### PR TITLE
Instant Search: Add support for simple, private WPCOM sites.

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -57,7 +57,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 */
 	public function load_assets() {
 		$script_relative_path = '_inc/build/instant-search/jp-search.bundle.js';
-		$style_relative_path  = '_inc/build/instant-search/instant-search.min.css';
+		$style_relative_path  = '_inc/build/instant-search/jp-search.bundle.css';
 		if ( ! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) || ! file_exists( JETPACK__PLUGIN_DIR . $style_relative_path ) ) {
 			return;
 		}

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -140,6 +140,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'postsPerPage'          => $posts_per_page,
 			'siteId'                => $this->jetpack_blog_id,
 			'postTypes'             => $post_type_labels,
+			'webpackPublicPath'     => plugins_url( '_inc/build/instant-search/', JETPACK__PLUGIN_FILE ),
+
+			// config values related to private site support.
+			'apiRoot'               => esc_url_raw( rest_url() ),
+			'apiNonce'              => wp_create_nonce( 'wp_rest' ),
+			'isPrivateSite'         => '-1' === get_option( 'blog_public' ),
+			'isWpcom'               => defined( 'IS_WPCOM' ) && IS_WPCOM,
 
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -163,7 +163,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$options = apply_filters( 'jetpack_instant_search_options', $options );
 
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
-		wp_add_inline_script( 'jetpack-instant-search', 'var JetpackInstantSearchOptions=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $options ) ) . '"));' );
+		wp_add_inline_script( 'jetpack-instant-search', 'var JetpackInstantSearchOptions=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $options ) ) . '"));', 'before' );
 	}
 
 	/**

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -1,5 +1,9 @@
 /** @jsx h */
 
+// NOTE: This must be imported first before any other imports.
+// See: https://github.com/webpack/webpack/issues/2776#issuecomment-233208623
+import './set-webpack-public-path';
+
 /**
  * External dependencies
  */

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -11,7 +11,7 @@ import Cache from 'cache';
  * Internal dependencies
  */
 import { getFilterKeys } from './filters';
-import { MINUTE_IN_MILLISECONDS } from './constants';
+import { MINUTE_IN_MILLISECONDS, SERVER_OBJECT_NAME } from './constants';
 
 const isLengthyArray = array => Array.isArray( array ) && array.length > 0;
 // Cache contents evicted after fixed time-to-live
@@ -144,33 +144,17 @@ function mapSortToApiValue( sort ) {
 	return SORT_QUERY_MAP.get( sort, 'score_default' );
 }
 
-export function search( {
+function generateApiQueryString( {
 	aggregations,
 	excludedPostTypes,
 	filter,
 	pageHandle,
 	query,
 	resultFormat,
-	siteId,
 	sort,
 	postsPerPage = 10,
 	adminQueryFilter,
 } ) {
-	const key = stringify( Array.from( arguments ) );
-
-	// Use cached value from the last 30 minutes if browser is offline
-	if ( ! navigator.onLine && backupCache.get( key ) ) {
-		return backupCache
-			.get( key )
-			.then( data => ( { _isCached: true, _isError: false, _isOffline: true, ...data } ) );
-	}
-	// Use cached value from the last 5 minutes
-	if ( cache.get( key ) ) {
-		return cache
-			.get( key )
-			.then( data => ( { _isCached: true, _isError: false, _isOffline: false, ...data } ) );
-	}
-
 	let fields = [
 		'date',
 		'permalink.url.raw',
@@ -188,7 +172,7 @@ export function search( {
 			fields = fields.concat( [ 'wc.price' ] );
 	}
 
-	const queryString = encode(
+	return encode(
 		flatten( {
 			aggregations,
 			fields,
@@ -200,23 +184,91 @@ export function search( {
 			size: postsPerPage,
 		} )
 	);
+}
 
-	return fetch(
-		`https://public-api.wordpress.com/rest/v1.3/sites/${ siteId }/search?${ queryString }`
-	)
-		.catch( error => {
-			// TODO: Display a message about falling back to a cached value in the interface
-			// Fallback to either cache if we run into any errors
-			const fallbackValue = cache.get( key ) || backupCache.get( key );
-			if ( fallbackValue ) {
-				return { _isCached: true, _isError: true, _isOffline: false, ...fallbackValue };
+function promiseifedProxyRequest( proxyRequest, path, query ) {
+	return new Promise( function ( resolve, reject ) {
+		proxyRequest( { path, query, apiVersion: '1.3' }, function ( err, body, headers ) {
+			if ( err ) {
+				reject( err );
 			}
-			throw error;
-		} )
-		.then( response => {
-			const json = response.json();
-			cache.put( key, json );
-			backupCache.put( key, json );
-			return json;
+			resolve( body, headers );
 		} );
+	} );
+}
+
+function errorHandlerFactory( cacheKey ) {
+	return function errorHandler( error ) {
+		// TODO: Display a message about falling back to a cached value in the interface
+		// Fallback to either cache if we run into any errors
+		const fallbackValue = cache.get( cacheKey ) || backupCache.get( cacheKey );
+		if ( fallbackValue ) {
+			return { _isCached: true, _isError: true, _isOffline: false, ...fallbackValue };
+		}
+		throw error;
+	};
+}
+
+function responseHandlerFactory( cacheKey ) {
+	return function responseHandler( responseJson ) {
+		cache.put( cacheKey, responseJson );
+		backupCache.put( cacheKey, responseJson );
+		return responseJson;
+	};
+}
+
+export function search( options ) {
+	const key = stringify( Array.from( arguments ) );
+
+	// Use cached value from the last 30 minutes if browser is offline
+	if ( ! navigator.onLine && backupCache.get( key ) ) {
+		return Promise.resolve( backupCache.get( key ) ).then( data => ( {
+			_isCached: true,
+			_isError: false,
+			_isOffline: true,
+			...data,
+		} ) );
+	}
+	// Use cached value from the last 5 minutes
+	if ( cache.get( key ) ) {
+		return Promise.resolve( cache.get( key ) ).then( data => ( {
+			_isCached: true,
+			_isError: false,
+			_isOffline: false,
+			...data,
+		} ) );
+	}
+
+	const queryString = generateApiQueryString( options );
+	const errorHandler = errorHandlerFactory( key );
+	const responseHandler = responseHandlerFactory( key );
+
+	const pathForPublicApi = `/sites/${ options.siteId }/search?${ queryString }`;
+
+	// TODO: Remove eslint exception when adding atomic private site support
+	// eslint-disable-next-line no-unused-vars
+	const { apiNonce, apiRoot, isPrivateSite, isWpcom } = window[ SERVER_OBJECT_NAME ];
+	if ( isPrivateSite && isWpcom ) {
+		return import( 'wpcom-proxy-request' ).then( ( { default: proxyRequest } ) => {
+			return promiseifedProxyRequest( proxyRequest, pathForPublicApi, options.query )
+				.catch( errorHandler )
+				.then( responseHandler );
+		} );
+	}
+
+	// NOTE: This urlForPrivateApi will be enabled once locally proxied API route for private sites is complete.
+	const urlForPublicApi = `https://public-api.wordpress.com/rest/v1.3${ pathForPublicApi }`;
+	// const urlForPrivateApi = `${ apiRoot }wpcom/v2/search?${ queryString }`;
+	const url = urlForPublicApi;
+
+	return fetch( url, { headers: isPrivateSite ? { 'X-WP-Nonce': apiNonce } : {} } )
+		.then( response => {
+			if ( ! response.ok || response.status !== 200 ) {
+				throw new Error( `Unexpected response from API with status code ${ response.status }.` );
+			}
+			return response;
+		} )
+		.catch( errorHandler )
+		.then( r => r.json() )
+		.then( responseHandler );
 }

--- a/modules/search/instant-search/set-webpack-public-path.js
+++ b/modules/search/instant-search/set-webpack-public-path.js
@@ -1,0 +1,6 @@
+// NOTE: Setting this free variable allows us to modify Webpack's public path, enabling us to use
+//       dynamic imports. Also note that we don't import any other file to ensure that this operation is
+//       completed before any other module imports. See:
+//       https://github.com/webpack/webpack/issues/2776#issuecomment-233208623
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = window.JetpackInstantSearchOptions.webpackPublicPath;

--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
 		"unfetch": "4.1.0",
 		"url-polyfill": "1.1.10",
 		"webpack": "4.44.1",
-		"webpack-cli": "3.3.12"
+		"webpack-cli": "3.3.12",
+		"wpcom-proxy-request": "5.0.2"
 	},
 	"optionalDependencies": {
 		"react": "16.13.1",

--- a/tools/builder/sass.js
+++ b/tools/builder/sass.js
@@ -62,7 +62,7 @@ gulp.task( 'sass:instant-search', function ( done ) {
 			prepend.prependText( '/* Do not modify this file directly.  It is compiled SASS code. */\n' )
 		)
 		.pipe( autoprefixer() )
-		.pipe( rename( { suffix: '.min' } ) )
+		.pipe( rename( { basename: 'jp-search.bundle' } ) )
 		.pipe( gulp.dest( './_inc/build/instant-search' ) )
 		.on( 'end', function () {
 			log( 'Instant Search CSS finished.' );

--- a/webpack.config.search.js
+++ b/webpack.config.search.js
@@ -35,8 +35,9 @@ module.exports = [
 		entry: { search: path.join( __dirname, './modules/search/instant-search/index.jsx' ) },
 		output: {
 			...sharedWebpackConfig.output,
-			path: path.join( __dirname, '_inc/build/instant-search' ),
+			chunkFilename: 'jp-search.chunk-[name]-[hash].js',
 			filename: 'jp-search.bundle.js',
+			path: path.join( __dirname, '_inc/build/instant-search' ),
 		},
 		performance: isDevelopment
 			? {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,6 +4727,11 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+builtin-status-codes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz#6f22003baacf003ccd287afe6872151fddc58579"
+  integrity sha1-byIAO6rPADzNKHr+aHIVH93FhXk=
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -4859,6 +4864,11 @@ camelcase-keys@^2.0.0:
   dependencies:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
+
+camelcase@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+  integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
 
 camelcase@^2.0.0:
   version "2.1.1"
@@ -5494,7 +5504,7 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-component-event@^0.1.4:
+component-event@0.1.4, component-event@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/component-event/-/component-event-0.1.4.tgz#3de78fc28782381787e24bf2a7c536bf0142c9b4"
   integrity sha1-PeePwoeCOBeH4kvyp8U2vwFCybQ=
@@ -14140,6 +14150,11 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress-event@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/progress-event/-/progress-event-1.0.0.tgz#1146df4b61849ddbe93ee81f9365af91b8901c51"
+  integrity sha1-EUbfS2GEndvpPugfk2WvkbiQHFE=
+
 progress@^2.0.0, progress@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -17073,6 +17088,11 @@ uglify-save-license@0.4.1:
   resolved "https://registry.yarnpkg.com/uglify-save-license/-/uglify-save-license-0.4.1.tgz#95726c17cc6fd171c3617e3bf4d8d82aa8c4cce1"
   integrity sha1-lXJsF8xv0XHDYX479NjYKqjEzOE=
 
+uid@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/uid/-/uid-0.0.2.tgz#5e4a5d4b78138b4f70f89fd3c76fc59aa9d2f103"
+  integrity sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM=
+
 unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -17217,6 +17237,13 @@ upath@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
+
+uppercamelcase@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/uppercamelcase/-/uppercamelcase-1.1.0.tgz#324d98a6b3afc7e8a8953e10641509b0e4e23f97"
+  integrity sha1-Mk2YprOvx+iolT4QZBUJsOTiP5c=
+  dependencies:
+    camelcase "^1.2.1"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -17836,6 +17863,25 @@ workerpool@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.0.tgz#85aad67fa1a2c8ef9386a1b43539900f61d03d58"
   integrity sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==
+
+wp-error@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/wp-error/-/wp-error-1.3.0.tgz#720247aa326424991c58775cb2fedc9bfd885420"
+  integrity sha1-cgJHqjJkJJkcWHdcsv7cm/2IVCA=
+  dependencies:
+    builtin-status-codes "^2.0.0"
+    uppercamelcase "^1.1.0"
+
+wpcom-proxy-request@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/wpcom-proxy-request/-/wpcom-proxy-request-5.0.2.tgz#7ee07001ae4d92f96692002e63038444c4cb8bc6"
+  integrity sha512-2MTJNiadTdZIaobhv9XJiPa/7eS1CIF4Zzp0HUKee27lhCfdoMktrjF/K+WSj7LkFZvWVR37Qh7DWfRDUiNGNQ==
+  dependencies:
+    uid "0.0.2"
+    component-event "0.1.4"
+    debug "^3.1.0"
+    progress-event "~1.0.0"
+    wp-error "^1.3.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Spun off from #16938.

#### Changes proposed in this Pull Request:
* Adjusts Webpack configuration for Jetpack Search to handle chunks generated by dynamic imports.
* Adjusts Jetpack Search to use `wpcom-proxy-request` when it detects that it's running on a private WPCOM site.
* Tweaks the name of the Search stylesheet for consistency (`instant-search.min.css` -> `jp-search.bundle.css`).

#### Jetpack product discussion
See p1HpG7-a1g-p2 and p9dueE-1Nq-p2.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
For Jetpack sites:
1. Apply these changes to your Jetpack site with Instant Search enabled.
2. Search your site; ensure that the API request works as expected. There should be zero changes for Jetpack sites.

For Atomic sites:
1. Apply these changes to your Atomic site with Instant Search enabled. The site must be set to public visibility; private Atomic sites are not yet supported.
2. Search your site and ensure that it works as expected.

For Simple sites:
- Follow the test instructions in D49009-code.

#### Proposed changelog entry for your changes:
* None.
