### PR TITLE
Instant Search: Adjust "immediate" trigger so it doesn't use focus

### DIFF
--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -109,12 +109,12 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_control(
 			$id,
 			array(
-				'label'       => __( 'Search Overlay Trigger', 'jetpack' ),
+				'label'       => __( 'Search Input Overlay Trigger', 'jetpack' ),
 				'description' => __( 'Select when your overlay should appear.', 'jetpack' ),
 				'section'     => $section_id,
 				'type'        => 'select',
 				'choices'     => array(
-					'immediate' => __( 'Open immediately', 'jetpack' ),
+					'immediate' => __( 'Open when the user starts typing', 'jetpack' ),
 					'results'   => __( 'Open when results are available', 'jetpack' ),
 				),
 			)

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -70,7 +70,16 @@ class SearchApp extends Component {
 		window.addEventListener( 'popstate', this.onPopstate );
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 
-		this.updateEventListeners();
+		// Add listeners for input and submit
+		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
+			input.form.addEventListener( 'submit', this.handleSubmit );
+			input.addEventListener( 'input', this.handleInput );
+		} );
+
+		document.querySelectorAll( this.props.themeOptions.overlayTriggerSelector ).forEach( button => {
+			button.addEventListener( 'click', this.handleOverlayTriggerClick, true );
+		} );
+
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.addEventListener( 'click', this.handleFilterInputClick );
 		} );
@@ -85,6 +94,10 @@ class SearchApp extends Component {
 			input.removeEventListener( 'input', this.handleInput );
 		} );
 
+		document.querySelectorAll( this.props.themeOptions.overlayTriggerSelector ).forEach( button => {
+			button.removeEventListener( 'click', this.handleOverlayTriggerClick, true );
+		} );
+
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.removeEventListener( 'click', this.handleFilterInputClick );
 		} );
@@ -94,14 +107,6 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.setAttribute( 'autocomplete', 'off' );
 			input.form.setAttribute( 'autocomplete', 'off' );
-		} );
-	}
-
-	updateEventListeners() {
-		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
-			// Add listeners for input and submit
-			input.form.addEventListener( 'submit', this.handleSubmit );
-			input.addEventListener( 'input', this.handleInput );
 		} );
 	}
 
@@ -154,11 +159,15 @@ class SearchApp extends Component {
 		this.showResults();
 	};
 
+	handleOverlayTriggerClick = event => {
+		event.stopImmediatePropagation();
+		this.showResults();
+	};
+
 	handleOverlayOptionsUpdate = newOverlayOptions => {
 		this.setState(
 			state => ( { overlayOptions: { ...state.overlayOptions, ...newOverlayOptions } } ),
 			() => {
-				this.updateEventListeners();
 				this.showResults();
 			}
 		);

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -70,7 +70,7 @@ class SearchApp extends Component {
 		window.addEventListener( 'popstate', this.onPopstate );
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 
-		this.updateEventListeners( this.state.overlayOptions.overlayTrigger );
+		this.updateEventListeners();
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.addEventListener( 'click', this.handleFilterInputClick );
 		} );
@@ -83,7 +83,6 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.removeEventListener( 'submit', this.handleSubmit );
 			input.removeEventListener( 'input', this.handleInput );
-			input.removeEventListener( 'focus', this.handleInputFocus );
 		} );
 
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
@@ -98,22 +97,11 @@ class SearchApp extends Component {
 		} );
 	}
 
-	updateEventListeners( type ) {
+	updateEventListeners() {
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
-			if ( type === 'results' ) {
-				// Remove focus event listener
-				input.removeEventListener( 'focus', this.handleInputFocus );
-				// Add listeners for input and submit
-				input.form.addEventListener( 'submit', this.handleSubmit );
-				input.addEventListener( 'input', this.handleInput );
-			}
-			if ( type === 'immediate' ) {
-				// Remove listeners for input and submit
-				input.form.removeEventListener( 'submit', this.handleSubmit );
-				input.removeEventListener( 'input', this.handleInput );
-				// Add focus event listener
-				input.addEventListener( 'focus', this.handleInputFocus );
-			}
+			// Add listeners for input and submit
+			input.form.addEventListener( 'submit', this.handleSubmit );
+			input.addEventListener( 'input', this.handleInput );
 		} );
 	}
 
@@ -145,10 +133,13 @@ class SearchApp extends Component {
 		if ( event.inputType.includes( 'delete' ) || event.inputType.includes( 'format' ) ) {
 			return;
 		}
+
+		if ( this.state.overlayOptions.overlayTrigger === 'immediate' ) {
+			this.showResults();
+		}
+
 		setSearchQuery( event.target.value );
 	}, 200 );
-
-	handleInputFocus = () => this.showResults();
 
 	handleFilterInputClick = event => {
 		event.preventDefault();
@@ -167,7 +158,7 @@ class SearchApp extends Component {
 		this.setState(
 			state => ( { overlayOptions: { ...state.overlayOptions, ...newOverlayOptions } } ),
 			() => {
-				this.updateEventListeners( this.state.overlayOptions.overlayTrigger );
+				this.updateEventListeners();
 				this.showResults();
 			}
 		);
@@ -177,6 +168,7 @@ class SearchApp extends Component {
 		this.setState( { showResults: true } );
 		this.preventBodyScroll();
 	};
+
 	hideResults = () => {
 		this.restoreBodyScroll();
 		restorePreviousHref( this.props.initialHref, () => {

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -64,7 +64,7 @@ class SearchForm extends Component {
 						onChangeQuery={ this.onChangeQuery }
 						onChangeSort={ this.onChangeSort }
 						query={ getSearchQuery() }
-						shouldRestoreFocus={ this.props.overlayTrigger !== 'immediate' }
+						shouldRestoreFocus
 						showFilters={ this.state.showFilters }
 						sort={ this.props.sort }
 						toggleFilters={ this.toggleFilters }

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -32,3 +32,8 @@ $grid-size-large: 16px;
 .jetpack-search-filters-widget__filter-list {
 	list-style-type: none;
 }
+
+// Hide the search modal in the TwentyTwenty theme
+.theme-twentytwenty .cover-modal.show-modal.search-modal {
+	display: none;
+}

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -13,6 +13,10 @@ export function getThemeOptions( searchOptions ) {
 			'.searchform input.search-field:not(.jetpack-instant-search__box-input)',
 		].join( ', ' ),
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],
+		overlayTriggerSelector: [
+			'.jetpack-instant-search__open-overlay-button',
+			'header#site-header .search-toggle[data-toggle-target]', // TwentyTwenty theme's search button
+		].join( ',' ),
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15923.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The overlay trigger "immediate", which is the current default setting, breaks keyboard navigation because the overlay is triggered as soon as you focus the input element.

In a previous PR we suggested removing this setting entirely (https://github.com/Automattic/jetpack/pull/16754). In this PR, I've instead tried to redefine what immediate means. 

Before:

Any interaction at all with the input field (focus, click or typing) opens the overlay immediately.

After:

Any typing in the input field opens the overlay immediately, without waiting for results to be ready.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply this change to your local Jetpack installation.
2. Navigate to the customizer -> Jetpack Search. Ensure that the 'Search Overlay Trigger' setting is set to 'Immediately'.
3. Navigate to your site and trying tabbing into your search widget's input.
4. Ensure that the overlay has not been spawned. 
5. Start typing in the input. This should immediately open the overlay.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Jetpack Search: Trigger the search overlay upon typing into the search input.