### PR TITLE
Form Block: remove newsletter variation on wpcom simple sites

### DIFF
--- a/extensions/blocks/contact-form/variations.js
+++ b/extensions/blocks/contact-form/variations.js
@@ -8,9 +8,10 @@ import { getIconColor } from '../../shared/block-icons';
 /**
  * Internal dependencies
  */
+import { isSimpleSite } from '../../shared/site-type-utils';
 import renderMaterialIcon from '../../shared/render-material-icon';
 
-const variations = [
+const availableVariations = [
 	{
 		name: 'contact-form',
 		title: __( 'Contact Form', 'jetpack' ),
@@ -37,35 +38,37 @@ const variations = [
 			],
 		],
 	},
-	{
-		name: 'newsletter-form',
-		title: __( 'Newsletter Sign-up', 'jetpack' ),
-		description: __(
-			'A simple way to collect information from folks visiting your site.',
-			'jetpack'
-		),
-		icon: {
-			src: renderMaterialIcon(
-				<Path d="M37.9999 7.59998C49.3999 7.59998 68.3999 26.6 68.3999 26.6V68.4H7.59985V26.6C7.59985 26.6 26.5999 7.59998 37.9999 7.59998ZM64.5999 63.536L50.4259 52.44L64.5999 41.8L62.9659 40.394L54.3779 45.334L55.2899 28.956L21.9639 26.98L20.2159 44.232L12.6539 40.622L11.3999 41.8L25.5739 52.44L12.5019 63.27L14.0219 64.904L37.9999 49.4L62.8139 65.17L64.5999 63.536Z" />,
-				48,
-				48,
-				'-6 -6 92 92'
-			),
-			foreground: getIconColor(),
-		},
-		innerBlocks: [
-			[ 'jetpack/field-name', { required: true } ],
-			[ 'jetpack/field-email', { required: true } ],
-			[ 'jetpack/field-consent', {} ],
-			[
-				'jetpack/button',
-				{
-					text: __( 'Subscribe', 'jetpack' ),
-					element: 'button',
+	! isSimpleSite()
+		? {
+				name: 'newsletter-form',
+				title: __( 'Newsletter Sign-up', 'jetpack' ),
+				description: __(
+					'A simple way to collect information from folks visiting your site.',
+					'jetpack'
+				),
+				icon: {
+					src: renderMaterialIcon(
+						<Path d="M37.9999 7.59998C49.3999 7.59998 68.3999 26.6 68.3999 26.6V68.4H7.59985V26.6C7.59985 26.6 26.5999 7.59998 37.9999 7.59998ZM64.5999 63.536L50.4259 52.44L64.5999 41.8L62.9659 40.394L54.3779 45.334L55.2899 28.956L21.9639 26.98L20.2159 44.232L12.6539 40.622L11.3999 41.8L25.5739 52.44L12.5019 63.27L14.0219 64.904L37.9999 49.4L62.8139 65.17L64.5999 63.536Z" />,
+						48,
+						48,
+						'-6 -6 92 92'
+					),
+					foreground: getIconColor(),
 				},
-			],
-		],
-	},
+				innerBlocks: [
+					[ 'jetpack/field-name', { required: true } ],
+					[ 'jetpack/field-email', { required: true } ],
+					[ 'jetpack/field-consent', {} ],
+					[
+						'jetpack/button',
+						{
+							text: __( 'Subscribe', 'jetpack' ),
+							element: 'button',
+						},
+					],
+				],
+		  }
+		: null,
 	{
 		name: 'rsvp-form',
 		title: __( 'RSVP Form', 'jetpack' ),
@@ -229,5 +232,7 @@ const variations = [
 		},
 	},
 ];
+
+const variations = availableVariations.filter( Boolean );
 
 export default variations;

--- a/extensions/blocks/contact-form/variations.js
+++ b/extensions/blocks/contact-form/variations.js
@@ -1,6 +1,11 @@
 /**
  * External dependencies
  */
+import { compact } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Path } from '@wordpress/components';
 import { getIconColor } from '../../shared/block-icons';
@@ -11,7 +16,7 @@ import { getIconColor } from '../../shared/block-icons';
 import { isSimpleSite } from '../../shared/site-type-utils';
 import renderMaterialIcon from '../../shared/render-material-icon';
 
-const availableVariations = [
+const variations = compact( [
 	{
 		name: 'contact-form',
 		title: __( 'Contact Form', 'jetpack' ),
@@ -38,37 +43,35 @@ const availableVariations = [
 			],
 		],
 	},
-	! isSimpleSite()
-		? {
-				name: 'newsletter-form',
-				title: __( 'Newsletter Sign-up', 'jetpack' ),
-				description: __(
-					'A simple way to collect information from folks visiting your site.',
-					'jetpack'
-				),
-				icon: {
-					src: renderMaterialIcon(
-						<Path d="M37.9999 7.59998C49.3999 7.59998 68.3999 26.6 68.3999 26.6V68.4H7.59985V26.6C7.59985 26.6 26.5999 7.59998 37.9999 7.59998ZM64.5999 63.536L50.4259 52.44L64.5999 41.8L62.9659 40.394L54.3779 45.334L55.2899 28.956L21.9639 26.98L20.2159 44.232L12.6539 40.622L11.3999 41.8L25.5739 52.44L12.5019 63.27L14.0219 64.904L37.9999 49.4L62.8139 65.17L64.5999 63.536Z" />,
-						48,
-						48,
-						'-6 -6 92 92'
-					),
-					foreground: getIconColor(),
+	! isSimpleSite() && {
+		name: 'newsletter-form',
+		title: __( 'Newsletter Sign-up', 'jetpack' ),
+		description: __(
+			'A simple way to collect information from folks visiting your site.',
+			'jetpack'
+		),
+		icon: {
+			src: renderMaterialIcon(
+				<Path d="M37.9999 7.59998C49.3999 7.59998 68.3999 26.6 68.3999 26.6V68.4H7.59985V26.6C7.59985 26.6 26.5999 7.59998 37.9999 7.59998ZM64.5999 63.536L50.4259 52.44L64.5999 41.8L62.9659 40.394L54.3779 45.334L55.2899 28.956L21.9639 26.98L20.2159 44.232L12.6539 40.622L11.3999 41.8L25.5739 52.44L12.5019 63.27L14.0219 64.904L37.9999 49.4L62.8139 65.17L64.5999 63.536Z" />,
+				48,
+				48,
+				'-6 -6 92 92'
+			),
+			foreground: getIconColor(),
+		},
+		innerBlocks: [
+			[ 'jetpack/field-name', { required: true } ],
+			[ 'jetpack/field-email', { required: true } ],
+			[ 'jetpack/field-consent', {} ],
+			[
+				'jetpack/button',
+				{
+					text: __( 'Subscribe', 'jetpack' ),
+					element: 'button',
 				},
-				innerBlocks: [
-					[ 'jetpack/field-name', { required: true } ],
-					[ 'jetpack/field-email', { required: true } ],
-					[ 'jetpack/field-consent', {} ],
-					[
-						'jetpack/button',
-						{
-							text: __( 'Subscribe', 'jetpack' ),
-							element: 'button',
-						},
-					],
-				],
-		  }
-		: null,
+			],
+		],
+	},
 	{
 		name: 'rsvp-form',
 		title: __( 'RSVP Form', 'jetpack' ),
@@ -231,8 +234,6 @@ const availableVariations = [
 			subject: __( 'New feedback received from your website', 'jetpack' ),
 		},
 	},
-];
-
-const variations = availableVariations.filter( Boolean );
+] );
 
 export default variations;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Related: #17051

On WordPress.com Simple sites, it is not yet possible to easily take advantage of the new form variation, as you cannot install plugins to integrate form submissions with a newsletter solution.
Let's consequently remove that variation for now, to avoid confusion.

#### Jetpack product discussion

* p93VbO-gZ-p2
* p1599066361020000-slack-C0160HSMDQV

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a Jetpack site, when adding a form to a new post, the "Newsletter sign-up" option should still available.
* On WordPress.com Simple sites (when applying D49020-code), you should not see that option.

<img width="738" alt="screenshot 2020-09-03 at 11 00 40" src="https://user-images.githubusercontent.com/426388/92097873-d88c1780-edd8-11ea-990a-71249fceaa7c.png">

#### Proposed changelog entry for your changes:

* N/A
