### PR TITLE
Don't render stats tracking code if in Staging Mode

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -18,6 +18,7 @@ use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\XMLRPC_Async_Call;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 
 if ( defined( 'STATS_VERSION' ) ) {
 	return;
@@ -175,6 +176,12 @@ function stats_template_redirect() {
 	global $current_user;
 
 	if ( is_feed() || is_robots() || is_trackback() || is_preview() || jetpack_is_dnt_enabled() ) {
+		return;
+	}
+
+	// Staging Sites should not generate tracking stats.
+	$status = new Status();
+	if ( $status->is_staging_site() ) {
 		return;
 	}
 


### PR DESCRIPTION
Stats Module shouldn't render if the site is in Staging Mode.

Fixes #17052

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update Stats Module so it doesn't track visits if the site is in Staging Mode.


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

1. On your testing site confirm that your site sends visits information by confirming that the following script gets loaded:
```
<script type='text/javascript' src='https://stats.wp.com/e-202036.js' async='async' defer='defer'></script>
<script type='text/javascript'>
	_stq = window._stq || [];
	_stq.push([ 'view', {v:'ext',j:'1:9.0-alpha',blog:'YOURBLOGID',post:'POSTID',tz:'3',srv:'YOURDOMAIN'} ]);
	_stq.push([ 'clickTrackerInit', 'YOURBLOGID', 'POSTID' ]);
</script>
```
This script is for tracking a blog, a page view can be different. Keep in mind that stats are not sent for logged in administrators by default.
2. Add a constant to enable staging mode `define('JETPACK_STAGING_MODE', true );`
3. Try to load a page that sent visit information in step 1 again.
4. Verify no tracking code is rendered. ( Note that you may need to bust any caching enabled on your test site :) )

#### Proposed changelog entry for your changes:
* Bug Fix :: Update Stats module so it doesn't track visits if the site is in Staging Mode.
