### PR TITLE
Jetpack_WPES_Search_Query_Parser: add method to retrieve lang suffix

### DIFF
--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
@@ -151,6 +151,15 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 		return array_keys( $lst );
 	}
 
+	public function get_lang_field_suffix() {
+		if ( ! is_array( $this->langs ) || empty( $this->langs ) ) {
+			return;
+		}
+
+		// Returns the first language only
+		return $this->langs[0];
+	}
+
 	/*
 	 * Take a list of field prefixes and expand them for multi-lingual
 	 * with the provided boostings.


### PR DESCRIPTION
In D48544-code, we added a new method `get_lang_field_suffix()` to `Jetpack_WPES_Search_Query_Parser`. This PR syncs the change back to Jetpack.

Differential Revision: D48544-code

This commit syncs r213167-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Jetpack_WPES_Search_Query_Parser normalizes the languages handed to it with the `norm_langs()` method, which is called from the constructor. However, there is no way to retrieve the normalized language back from the parser. This PR adds a new method `get_lang_field_suffix()` to retrieve the first normalized language from the parser.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Request the WP.com endpoint https://public-api.wordpress.com/wpcom/v2/read/tags/cards?tags=dogs&_locale=fr&_envelope=1. It should return 'lang: fr' in the response. This has been obtained from Jetpack_WPES_Search_Query_Parser->get_lang_field_suffix().

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
This does not change a user-facing feature, so changelog probably isn't required.
