### PR TITLE
Story block: Improve static fallback

### DIFF
--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -307,7 +307,6 @@
 		border-radius: 0;
 		box-shadow: none !important;
 		transition: none !important;
-		margin-bottom: 20px;
 
 		.wp-story-wrapper {
 			border-radius: 15px;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -8,6 +8,7 @@
 	width: 180px;
 	margin-left: auto;
 	margin-right: auto;
+	margin-bottom: 24px;
 	position: relative;
 	list-style: none;
 	padding: 0;

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -349,7 +349,7 @@ function render_block( $attributes ) {
 		esc_attr( get_site_icon_url( 32, includes_url( 'images/w-logo-blue.png' ) ) ),
 		esc_html( get_the_title() ),
 		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : '',
-		get_permalink(),
+		get_permalink() . '?wp-story-load-in-fullscreen=true&amp;wp-story-play-on-load=true',
 		render_top_right_icon( $settings ),
 		render_pagination( $settings )
 	);


### PR DESCRIPTION
Updates the permalink used when JS is not present to load the story in fullscreen.

@Tug this seems to generally work but doesn't trigger fullscreen mode on Android Chrome. It seems like the two params aren't enough to trigger that?

#### Changes proposed in this Pull Request:
* Auto-fullscreen permalink when JS isn't loaded
* Add bottom margin to story container (affects posts with multiple blocks and the Android Reader)

#### Does this pull request change what data or activity we track or use?
No change

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Style change:
* Create a post with a story and a paragraph block right underneath.
* Observe the story is a bit too close to the paragraph (might be theme-dependent). (This is also a problem on the WPAndroid Reader.)
* Apply this change and confirm the spacing is better.

Permalink change:
* Apply this change to a Jetpack site, and follow that site in the Reader
* Apply the corresponding Calypso patch (https://github.com/Automattic/wp-calypso/pull/45397) and open a story post from the site in the reader
* Confirm that story post previews open the story in fullscreen and autoplay.

#### Proposed changelog entry for your changes:
No changelog entry needed.
