### PR TITLE
Added 2 options to sync wc whitelist

### DIFF
--- a/packages/sync/src/modules/class-woocommerce.php
+++ b/packages/sync/src/modules/class-woocommerce.php
@@ -401,6 +401,8 @@ class WooCommerce extends Module {
 		'woocommerce_currency_pos',
 		'woocommerce_api_enabled',
 		'woocommerce_allow_tracking',
+		'woocommerce_task_list_hidden',
+		'woocommerce_onboarding_profile',
 	);
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes the [issue 554](https://github.com/Automattic/wc-calypso-bridge/issues/554)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds the options `woocommerce_task_list_hidden` and `woocommerce_onboarding_profile` to sync wc whitelist.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify that the values of `woocommerce_task_list_hidden` and `woocommerce_onboarding_profile` are synchronized.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Added the options `woocommerce_task_list_hidden` and `woocommerce_onboarding_profile` to sync wc whitelist.