### PR TITLE
Tracking: add a should_enable_tracking() method

### DIFF
--- a/packages/tracking/composer.json
+++ b/packages/tracking/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-options": "@dev",
+		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-terms-of-service": "@dev"
 	},
 	"require-dev": {

--- a/packages/tracking/phpunit.xml.dist
+++ b/packages/tracking/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<directory suffix=".php">.</directory>
+			<exclude>
+				<directory suffix=".php">tests</directory>
+				<directory suffix=".php">vendor</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/packages/tracking/src/class-tracking.php
+++ b/packages/tracking/src/class-tracking.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack;
 
-use Automattic\Jetpack\Terms_Of_Service;
-
 /**
  * The Tracking class, used to record events in wpcom
  */
@@ -103,11 +101,9 @@ class Tracking {
 			return false;
 		}
 		$terms_of_service = new Terms_Of_Service();
-		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
-		if (
-			! $terms_of_service->has_agreed()
-			|| ! $this->connection->is_user_connected()
-		) {
+		$status           = new Status();
+		// Don't track users who have not agreed to our TOS.
+		if ( ! $this->should_enable_tracking( $terms_of_service, $status ) ) {
 			return false;
 		}
 
@@ -118,6 +114,22 @@ class Tracking {
 		}
 
 		return $event_obj->record();
+	}
+
+	/**
+	 * Determines whether tracking should be enabled.
+	 *
+	 * @param Automattic\Jetpack\Terms_Of_Service $terms_of_service A Terms_Of_Service object.
+	 * @param Automattic\Jetpack\Status           $status A Status object.
+	 *
+	 * @return boolean True if tracking should be enabled, else false.
+	 */
+	public function should_enable_tracking( $terms_of_service, $status ) {
+		if ( $status->is_offline_mode() ) {
+			return false;
+		}
+
+		return $terms_of_service->has_agreed() || $this->connection->is_user_connected();
 	}
 
 	/**

--- a/packages/tracking/tests/php/bootstrap.php
+++ b/packages/tracking/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/jetpack-tracking
+ */
+
+/**
+ * Includes the Composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/packages/tracking/tests/php/test-tracking.php
+++ b/packages/tracking/tests/php/test-tracking.php
@@ -1,0 +1,106 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests for Automattic\Jetpack\Tracking methods
+ *
+ * @package automattic/jetpack-tracking
+ */
+
+namespace Automattic\Jetpack;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tracking test suite.
+ */
+class Test_Tracking extends TestCase {
+
+	/**
+	 * Test setup.
+	 */
+	public function setUp() {
+		$this->connection = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->setMethods( array( 'is_user_connected' ) )
+			->getMock();
+		$this->tracking   = new Tracking( 'jetpack', $this->connection );
+	}
+
+	/**
+	 * Tests the  Automattic\Jetpack\Tracking::should_enabled_tracking() method.
+	 *
+	 * @param array   $inputs The test input values.
+	 * @param boolean $expected_output The expected output of Automattic\Jetpack\Tracking::should_enabled_tracking().
+	 *
+	 * @covers Automattic\Jetpack\Tracking::should_enabled_tracking
+	 * @dataProvider data_provider_test_should_enable_tracking
+	 */
+	public function test_should_enable_tracking( $inputs, $expected_output ) {
+		$tos = $this->getMockBuilder( 'Automattic\Jetpack\Terms_Of_Service' )
+			->setMethods( array( 'has_agreed' ) )
+			->getMock();
+
+		$tos->method( 'has_agreed' )
+			->will( $this->returnValue( $inputs['has_agreed'] ) );
+
+		$status = $this->getMockBuilder( 'Automattic\Jetpack\Status' )
+			->setMethods( array( 'is_offline_mode' ) )
+			->getMock();
+
+		$status->method( 'is_offline_mode' )
+			->will( $this->returnValue( $inputs['offline'] ) );
+
+		$this->connection->method( 'is_user_connected' )
+			->will( $this->returnValue( $inputs['connected'] ) );
+
+		$this->assertEquals( $expected_output, $this->tracking->should_enable_tracking( $tos, $status ) );
+	}
+
+	/**
+	 * Data provider for test_should_enable_tracking.
+	 *
+	 * @return array
+	 */
+	public function data_provider_test_should_enable_tracking() {
+		return array(
+			'offline: true, has agreed: true, connected: true' => array(
+				array(
+					'offline'    => true,
+					'has_agreed' => true,
+					'connected'  => true,
+				),
+				false,
+			),
+			'offline: false, has agreed: true, connected: true' => array(
+				array(
+					'offline'    => false,
+					'has_agreed' => true,
+					'connected'  => true,
+				),
+				true,
+			),
+			'offline: false, has agreed: true, connected: false' => array(
+				array(
+					'offline'    => false,
+					'has_agreed' => true,
+					'connected'  => false,
+				),
+				true,
+			),
+			'offline: false, has agreed: false, connected: true' => array(
+				array(
+					'offline'    => false,
+					'has_agreed' => false,
+					'connected'  => true,
+				),
+				true,
+			),
+			'offline: false, has agreed: false, connected: false' => array(
+				array(
+					'offline'    => false,
+					'has_agreed' => false,
+					'connected'  => false,
+				),
+				false,
+			),
+		);
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add a new method, `Tracking::should_enable_tracking()`, which replicates the original logic in the `Terms_Of_Service::has_agreed()` method [before the changes](https://github.com/Automattic/jetpack/pull/16967/files#diff-70716275c6e734611a8a24650646c4fbL62) in PR #16967.
* Add unit tests for the new `Tracking::should_enable_tracking()` method.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* No.

#### Testing instructions:
1. Install and activate Jetpack.
2. In your `wp-config.php` file, set the `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME` constant to true. This will force the Calypso connection process to be used.
3. On the Jetpack dashboard, click the `Set up Jetpack` button.
4. Go to the Tracks live view and verify that the `jetpack_jpc_register_success` event was recorded.

#### Proposed changelog entry for your changes:
* tbd
