### PR TITLE
Earn: Stripe Connection Feedback Message

### DIFF
--- a/extensions/shared/stripe-connection-notification.js
+++ b/extensions/shared/stripe-connection-notification.js
@@ -17,7 +17,7 @@ if ( undefined !== typeof window && window.location ) {
 		dispatch( 'core/notices' ).createNotice(
 			'success',
 			__(
-				'Congrats! Your site is now connected to Stripe. You can now start making money!',
+				'Congrats! Your site is now connected to Stripe. You can now start accepting funds!',
 				'jetpack'
 			)
 		);


### PR DESCRIPTION
Fixes #16975 

#### Changes proposed in this Pull Request:
* Previously, when a user was in their block editor and used a Donations block (or similar, which required a Stripe connection) and was not previously connected, after connecting to Stripe, the feedback message would be specific to receiving payments. This change makes the feedback read to be more generic so that it can be applicable for payments, or donations.

#### Jetpack product discussion
pbMlHh-dW-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

1. [Run Jetpack locally](https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md#standard-developmentdebug-tools) with this branch
2. Navigate to `http://localhost/wp-admin` in your browser
3. Go to a Post or Page and edit it
4. Append `&stripe_connect_success=true`
5. You should see a banner with the message `Congrats! Your site is now connected to Stripe. You can now start accepting funds!`

#### Screenshots:

Before | After
--- | ---
<img width="1184" alt="Screen Shot 2020-08-25 at 11 03 48 AM" src="https://user-images.githubusercontent.com/349751/91211449-a20d1900-e6c3-11ea-936f-29a2e7568e7f.png"> |<img width="1458" alt="Screen Shot 2020-09-04 at 6 01 39 PM" src="https://user-images.githubusercontent.com/66652282/92289773-ab765c80-eedf-11ea-9151-e976422ee30d.png">

#### Proposed changelog entry for your changes:
Donations / Payments: Fix feedback message after successfully connecting to Stripe from a payments block in the block editor.