### PR TITLE
Add AMP compatibility for OpenTable block

### DIFF
--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -68,11 +68,6 @@ function load_assets( $attributes ) {
 		$classes[] = sprintf( 'is-style-%s', $style );
 	}
 
-	$is_multi = false; // @todo Temp.
-	if ( array_key_exists( 'rid', $attributes ) && is_array( $attributes['rid'] ) && count( $attributes['rid'] ) > 1 ) {
-		$classes[] = 'is-multi';
-		$is_multi  = true; // @todo Temp.
-	}
 	if ( array_key_exists( 'negativeMargin', $attributes ) && $attributes['negativeMargin'] ) {
 		$classes[] = 'has-no-margin';
 	}
@@ -87,24 +82,13 @@ function load_assets( $attributes ) {
 
 		$src = "https://www.opentable.com/widget/reservation/canvas?$url_query";
 
-		// @todo This is temporary workaround! The height should not be needed, and otherwise it should just have layout=fill. To replace once https://github.com/ampproject/amphtml/issues/29398 fixed.
-		$height = $is_multi ? 361 : 301;
 		$params = array();
 		wp_parse_str( $url_query, $params );
-		if ( 'tall' === $params['theme'] ) {
-			$height = $is_multi ? 550 : 490;
-		} elseif ( 'wide' === $params['theme'] ) {
-			$height = 150;
-		} elseif ( 'button' === $params['theme'] ) {
-			$height = 113;
-		}
-		$layout_attrs = sprintf( 'layout="fixed-height" height="%d"', $height );
 
 		// Note an iframe is similarly constructed in the block edit function.
 		$content .= sprintf(
-			'<amp-iframe src="%s" %s sandbox="allow-scripts allow-forms allow-same-origin allow-popups">%s</amp-iframe>',
+			'<amp-iframe src="%s" layout="fill" sandbox="allow-scripts allow-forms allow-same-origin allow-popups">%s</amp-iframe>',
 			esc_url( $src ),
-			$layout_attrs,
 			sprintf(
 				'<a placeholder href="%s">%s</a>',
 				esc_url(

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -102,7 +102,7 @@ function load_assets( $attributes ) {
 
 		// Note an iframe is similarly constructed in the block edit function.
 		$content .= sprintf(
-			'<amp-iframe src="%s" %s sandbox="allow-scripts allow-forms allow-same-origin">%s</amp-iframe>',
+			'<amp-iframe src="%s" %s sandbox="allow-scripts allow-forms allow-same-origin allow-popups">%s</amp-iframe>',
 			esc_url( $src ),
 			$layout_attrs,
 			sprintf(

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -68,6 +68,9 @@ function load_assets( $attributes ) {
 		$classes[] = sprintf( 'is-style-%s', $style );
 	}
 
+	if ( array_key_exists( 'rid', $attributes ) && is_array( $attributes['rid'] ) && count( $attributes['rid'] ) > 1 ) {
+		$classes[] = 'is-multi';
+	}
 	if ( array_key_exists( 'negativeMargin', $attributes ) && $attributes['negativeMargin'] ) {
 		$classes[] = 'has-no-margin';
 	}

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -11,7 +11,6 @@ namespace Automattic\Jetpack\Extensions\OpenTable;
 
 use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
-use Jetpack_AMP_Support;
 
 const FEATURE_NAME = 'opentable';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
@@ -79,7 +78,7 @@ function load_assets( $attributes ) {
 
 	$script_url = build_embed_url( $attributes );
 
-	if ( Jetpack_AMP_Support::is_amp_request() ) {
+	if ( Blocks::is_amp_request() ) {
 		// Extract params from URL since it had jetpack_opentable_block_url filters applied.
 		$url_query = \wp_parse_url( $script_url, PHP_URL_QUERY ) . '&overlay=false&disablega=false';
 

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -1,6 +1,10 @@
 .wp-block-jetpack-opentable {
 	position: relative; /* For sake of amp-iframe with layout=fill */
 
+	.wp-block-jetpack-opentable iframe {
+		background: transparent; /* Override AMP Reader mode gray background for iframes in legacy post templates  */
+	}
+
 	&.aligncenter iframe {
 		margin: 0 auto;
 	}

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -1,4 +1,5 @@
 .wp-block-jetpack-opentable {
+	position: relative; /* For sake of amp-iframe with layout=fill */
 
 	&.aligncenter iframe {
 		margin: 0 auto;

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -1,8 +1,9 @@
 .wp-block-jetpack-opentable {
 	position: relative; /* For sake of amp-iframe with layout=fill */
 
-	.wp-block-jetpack-opentable iframe {
-		background: transparent; /* Override AMP Reader mode gray background for iframes in legacy post templates  */
+	> iframe {
+		background: transparent; /* Override AMP Reader mode gray background for iframes in legacy post templates. */
+		margin: 0; /* Override margins in AMP legacy Reader mode. */
 	}
 
 	&.aligncenter iframe {


### PR DESCRIPTION
See #14395

This fixes AMP compatibility for the OpenTable block by rendering an `amp-iframe` as opposed to the embed `script` on AMP pages. Note that the block edit function similarly constructs and iframe for preview purposes, so manually constructing the iframe is not unprecedented.

~👉  Note this is currently blocked by an AMP bug which has been fixed upstream but is not yet in production. See https://github.com/ampproject/amphtml/issues/29398. In order to test this PR, you need to first opt-in to to the `beta-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page. The fix should be rolled out to AMP's production channel by September 22nd.~  _The fix is now live._

Given this HTML content:

```html
<!-- wp:jetpack/opentable {"rid":["150220"]} -->
<div class="wp-block-jetpack-opentable"><a href="https://www.opentable.com/restref/client/?rid=150220">https://www.opentable.com/restref/client/?rid=150220</a></div>
<!-- /wp:jetpack/opentable -->

<!-- wp:jetpack/opentable {"rid":["150220"],"style":"tall","className":"is-style-tall"} -->
<div class="wp-block-jetpack-opentable is-style-tall"><a href="https://www.opentable.com/restref/client/?rid=150220">https://www.opentable.com/restref/client/?rid=150220</a></div>
<!-- /wp:jetpack/opentable -->

<!-- wp:jetpack/opentable {"rid":["150220"],"style":"wide","align":"wide","className":"is-style-wide"} -->
<div class="wp-block-jetpack-opentable alignwide is-style-wide"><a href="https://www.opentable.com/restref/client/?rid=150220">https://www.opentable.com/restref/client/?rid=150220</a></div>
<!-- /wp:jetpack/opentable -->

<!-- wp:jetpack/opentable {"rid":["150220"],"style":"button","align":"","className":"is-style-button"} -->
<div class="wp-block-jetpack-opentable is-style-button"><a href="https://www.opentable.com/restref/client/?rid=150220">https://www.opentable.com/restref/client/?rid=150220</a></div>
<!-- /wp:jetpack/opentable -->

<!-- wp:paragraph -->
<p>Multi:</p>
<!-- /wp:paragraph -->

<!-- wp:jetpack/opentable {"rid":["150220","1076311"]} -->
<div class="wp-block-jetpack-opentable"><a href="https://www.opentable.com/restref/client/?rid=150220">https://www.opentable.com/restref/client/?rid=150220</a><a href="https://www.opentable.com/restref/client/?rid=1076311">https://www.opentable.com/restref/client/?rid=1076311</a></div>
<!-- /wp:jetpack/opentable -->
```

Non-AMP | AMP Before 👎  | AMP After 👍 
----------|-------------|-----------
![image](https://user-images.githubusercontent.com/134745/92321789-af8aa300-efe1-11ea-9cea-0a1f868ab99a.png) | ![image](https://user-images.githubusercontent.com/134745/92321821-f6789880-efe1-11ea-9a79-a01cfadec4aa.png) | ![image](https://user-images.githubusercontent.com/134745/92321795-bf09ec00-efe1-11ea-87eb-251172158f44.png)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add AMP compatibility for OpenTable block by using `amp-iframe` on AMP pages as opposed to OpenTable embed script.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post with OpenTable blocks
* Compare non-AMP and AMP
* The two should be identical

#### Proposed changelog entry for your changes:

* Add AMP compatibility for OpenTable block
