### PR TITLE
use current (not deprecated) API for getting product id for prop on purchase event

### DIFF
--- a/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -284,7 +284,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 
 			$this->record_event(
 				'woocommerceanalytics_product_purchase',
-				$product ? $product->get_id() : -1,
+				$product_id,
 				array(
 					'oi' => $order->get_order_number(),
 					'pq' => $order_item->get_quantity(),

--- a/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -280,7 +280,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 
 		// loop through products in the order and queue a purchase event.
 		foreach ( $order->get_items() as $order_item_id => $order_item ) {
-			$product = is_callable( array( $order_item, 'get_product' ) ) ? $order_item->get_product() : null;
+			$product_id = is_callable( array( $order_item, 'get_product_id' ) ) ? $order_item->get_product_id() : -1;
 
 			$this->record_event(
 				'woocommerceanalytics_product_purchase',

--- a/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -280,11 +280,11 @@ class Jetpack_WooCommerce_Analytics_Universal {
 
 		// loop through products in the order and queue a purchase event.
 		foreach ( $order->get_items() as $order_item_id => $order_item ) {
-			$product = $order->get_product_from_item( $order_item );
+			$product = is_callable( array( $order_item, 'get_product' ) ) ? $order_item->get_product() : null;
 
 			$this->record_event(
 				'woocommerceanalytics_product_purchase',
-				$product->get_id(),
+				$product ? $product->get_id() : -1,
 				array(
 					'oi' => $order->get_order_number(),
 					'pq' => $order_item->get_quantity(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #17071

#### Changes proposed in this Pull Request:
* Uses `WC_Order_Item_Product::get_product_id()` to get product ID for `woocommerceanalytics_product_purchase` event. 

Previously was using `$order->get_product_from_item` which is [deprecated](https://github.com/woocommerce/woocommerce/blob/master/includes/legacy/abstract-wc-legacy-order.php#L319) in WooCommerce 4.4+.

`WC_Order_Item_Product::get_product_id()` is [available in WooCommerce 3.0+](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-order-item-product.php#L237); WooCommerce Analytics is [gated for 3.0+ and newer](https://github.com/Automattic/jetpack/blob/master/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php#L62).

#### Jetpack product discussion
Not a product change - just a bug fix 👍 

#### Does this pull request change what data or activity we track or use?
No changes to tracking, just fixes a bug affecting an existing event.

#### Testing instructions:
To test this you will need WooCommerce Analytics module enabled and sending events. 

* Clone this branch and ensure Jetpack is built.
* Ensure Jetpack is activated and connected; if you're on a local dev site, you can use ngrok to set up an http(s) tunnel to get connected (you'll need to set options `siteurl` and `home` to the tunnel url).
* This requires WooCommerce to be installed and set up on the site, with some products. Recommend setting up `Cash on delivery` payment method for fast checkout.
* Ensure you are [opted in to WooCommerce tracking](https://woocommerce.com/usage-tracking/). (Note you may need to [manually navigate to that settings page on Atomic / WPCOM platform](https://github.com/Automattic/wc-calypso-bridge/issues/598).)
* Ensure [`WooCommerce Analytics` module is not deactivated](https://jetpack.com/support/control-jetpack-features-on-one-page/).
* The events are disabled for development sites. Use an incognito window, or hack this by adding `return true;` at the start of [`Jetpack_WooCommerce_Analytics::shouldTrackStore()`](https://github.com/Automattic/jetpack/blob/master/modules/woocommerce-analytics/wp-woocommerce-analytics.php#L40).

##### To test the issue
* Open browser dev tools and filter for host `pixel.wp.com` so you can see analytics events requests.
* Visit a product or shop page and add something to cart.
* Navigate to checkout and complete purchase.
* On order complete page you should see a network request to `pixel.wp.com` with param `_en=woocommerceanalytics_product_purchase`. Check the other parameters are correct, in particular confirm the `pi` param is the product id. There should be one event for each product purchased. 

#### Proposed changelog entry for your changes:
* Fix: WooCommerce Analytics purchase event no longer uses `get_product_from_item` (deprecated in WooCommerce 4.4).
