### PR TITLE
Form block: Update icon property on all form variations

### DIFF
--- a/extensions/blocks/contact-form/variations.js
+++ b/extensions/blocks/contact-form/variations.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Path } from '@wordpress/components';
-import { getIconColor } from '../../shared/block-icons';
 
 /**
  * Internal dependencies

--- a/extensions/blocks/contact-form/variations.js
+++ b/extensions/blocks/contact-form/variations.js
@@ -15,15 +15,12 @@ const variations = [
 		name: 'contact-form',
 		title: __( 'Contact Form', 'jetpack' ),
 		description: __( 'Add a contact form to your page.', 'jetpack' ),
-		icon: {
-			src: renderMaterialIcon(
-				<Path d="M21.99 8c0-.72-.37-1.35-.94-1.7l-8.04-4.71c-.62-.37-1.4-.37-2.02 0L2.95 6.3C2.38 6.65 2 7.28 2 8v10c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2l-.01-10zm-11.05 4.34l-7.2-4.5 7.25-4.25c.62-.37 1.4-.37 2.02 0l7.25 4.25-7.2 4.5c-.65.4-1.47.4-2.12 0z" />,
-				48,
-				48,
-				'-4 -4 32 32'
-			),
-			foreground: getIconColor(),
-		},
+		icon: renderMaterialIcon(
+			<Path d="M21.99 8c0-.72-.37-1.35-.94-1.7l-8.04-4.71c-.62-.37-1.4-.37-2.02 0L2.95 6.3C2.38 6.65 2 7.28 2 8v10c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2l-.01-10zm-11.05 4.34l-7.2-4.5 7.25-4.25c.62-.37 1.4-.37 2.02 0l7.25 4.25-7.2 4.5c-.65.4-1.47.4-2.12 0z" />,
+			48,
+			48,
+			'-4 -4 32 32'
+		),
 		innerBlocks: [
 			[ 'jetpack/field-name', { required: true } ],
 			[ 'jetpack/field-email', { required: true } ],
@@ -44,15 +41,12 @@ const variations = [
 			'A simple way to collect information from folks visiting your site.',
 			'jetpack'
 		),
-		icon: {
-			src: renderMaterialIcon(
-				<Path d="M37.9999 7.59998C49.3999 7.59998 68.3999 26.6 68.3999 26.6V68.4H7.59985V26.6C7.59985 26.6 26.5999 7.59998 37.9999 7.59998ZM64.5999 63.536L50.4259 52.44L64.5999 41.8L62.9659 40.394L54.3779 45.334L55.2899 28.956L21.9639 26.98L20.2159 44.232L12.6539 40.622L11.3999 41.8L25.5739 52.44L12.5019 63.27L14.0219 64.904L37.9999 49.4L62.8139 65.17L64.5999 63.536Z" />,
-				48,
-				48,
-				'-6 -6 92 92'
-			),
-			foreground: getIconColor(),
-		},
+		icon: renderMaterialIcon(
+			<Path d="M37.9999 7.59998C49.3999 7.59998 68.3999 26.6 68.3999 26.6V68.4H7.59985V26.6C7.59985 26.6 26.5999 7.59998 37.9999 7.59998ZM64.5999 63.536L50.4259 52.44L64.5999 41.8L62.9659 40.394L54.3779 45.334L55.2899 28.956L21.9639 26.98L20.2159 44.232L12.6539 40.622L11.3999 41.8L25.5739 52.44L12.5019 63.27L14.0219 64.904L37.9999 49.4L62.8139 65.17L64.5999 63.536Z" />,
+			48,
+			48,
+			'-6 -6 92 92'
+		),
 		innerBlocks: [
 			[ 'jetpack/field-name', { required: true } ],
 			[ 'jetpack/field-email', { required: true } ],
@@ -70,15 +64,12 @@ const variations = [
 		name: 'rsvp-form',
 		title: __( 'RSVP Form', 'jetpack' ),
 		description: __( 'Add an RSVP form to your page', 'jetpack' ),
-		icon: {
-			src: renderMaterialIcon(
-				<Path d="M10 9V7.41c0-.89-1.08-1.34-1.71-.71L3.7 11.29c-.39.39-.39 1.02 0 1.41l4.59 4.59c.63.63 1.71.19 1.71-.7V14.9c5 0 8.5 1.6 11 5.1-1-5-4-10-11-11z" />,
-				48,
-				48,
-				'-4 -3 32 32'
-			),
-			foreground: getIconColor(),
-		},
+		icon: renderMaterialIcon(
+			<Path d="M10 9V7.41c0-.89-1.08-1.34-1.71-.71L3.7 11.29c-.39.39-.39 1.02 0 1.41l4.59 4.59c.63.63 1.71.19 1.71-.7V14.9c5 0 8.5 1.6 11 5.1-1-5-4-10-11-11z" />,
+			48,
+			48,
+			'-4 -3 32 32'
+		),
 		innerBlocks: [
 			[ 'jetpack/field-name', { required: true } ],
 			[ 'jetpack/field-email', { required: true } ],
@@ -107,15 +98,12 @@ const variations = [
 		name: 'registration-form',
 		title: __( 'Registration Form', 'jetpack' ),
 		description: __( 'Add a Registration form to your page', 'jetpack' ),
-		icon: {
-			src: renderMaterialIcon(
-				<Path d="M11.34 15.02c.39.39 1.02.39 1.41 0l6.36-6.36c.39-.39.39-1.02 0-1.41L14.16 2.3c-.38-.4-1.01-.4-1.4-.01L6.39 8.66c-.39.39-.39 1.02 0 1.41l4.95 4.95zm2.12-10.61L17 7.95l-4.95 4.95-3.54-3.54 4.95-4.95zm6.95 11l-2.12-2.12c-.18-.18-.44-.29-.7-.29h-.27l-2 2h1.91L19 17H5l1.78-2h2.05l-2-2h-.42c-.27 0-.52.11-.71.29l-2.12 2.12c-.37.38-.58.89-.58 1.42V20c0 1.1.9 2 2 2h14c1.1 0 2-.89 2-2v-3.17c0-.53-.21-1.04-.59-1.42z" />,
-				48,
-				48,
-				'-4 -3 32 32'
-			),
-			foreground: getIconColor(),
-		},
+		icon: renderMaterialIcon(
+			<Path d="M11.34 15.02c.39.39 1.02.39 1.41 0l6.36-6.36c.39-.39.39-1.02 0-1.41L14.16 2.3c-.38-.4-1.01-.4-1.4-.01L6.39 8.66c-.39.39-.39 1.02 0 1.41l4.95 4.95zm2.12-10.61L17 7.95l-4.95 4.95-3.54-3.54 4.95-4.95zm6.95 11l-2.12-2.12c-.18-.18-.44-.29-.7-.29h-.27l-2 2h1.91L19 17H5l1.78-2h2.05l-2-2h-.42c-.27 0-.52.11-.71.29l-2.12 2.12c-.37.38-.58.89-.58 1.42V20c0 1.1.9 2 2 2h14c1.1 0 2-.89 2-2v-3.17c0-.53-.21-1.04-.59-1.42z" />,
+			48,
+			48,
+			'-4 -3 32 32'
+		),
 		innerBlocks: [
 			[ 'jetpack/field-name', { required: true } ],
 			[ 'jetpack/field-email', { required: true } ],
@@ -150,15 +138,12 @@ const variations = [
 		name: 'appointment-form',
 		title: __( 'Appointment Form', 'jetpack' ),
 		description: __( 'Add an Appointment booking form to your page', 'jetpack' ),
-		icon: {
-			src: renderMaterialIcon(
-				<Path d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V8c0-.55-.45-1-1-1s-1 .45-1 1v2H2c-.55 0-1 .45-1 1s.45 1 1 1h2v2c0 .55.45 1 1 1s1-.45 1-1v-2h2c.55 0 1-.45 1-1s-.45-1-1-1H6zm9 4c-2.67 0-8 1.34-8 4v1c0 .55.45 1 1 1h14c.55 0 1-.45 1-1v-1c0-2.66-5.33-4-8-4z" />,
-				48,
-				48,
-				'-4 -3 32 32'
-			),
-			foreground: getIconColor(),
-		},
+		icon: renderMaterialIcon(
+			<Path d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V8c0-.55-.45-1-1-1s-1 .45-1 1v2H2c-.55 0-1 .45-1 1s.45 1 1 1h2v2c0 .55.45 1 1 1s1-.45 1-1v-2h2c.55 0 1-.45 1-1s-.45-1-1-1H6zm9 4c-2.67 0-8 1.34-8 4v1c0 .55.45 1 1 1h14c.55 0 1-.45 1-1v-1c0-2.66-5.33-4-8-4z" />,
+			48,
+			48,
+			'-4 -3 32 32'
+		),
 		innerBlocks: [
 			[ 'jetpack/field-name', { required: true } ],
 			[ 'jetpack/field-email', { required: true } ],
@@ -189,15 +174,12 @@ const variations = [
 		name: 'feedback-form',
 		title: __( 'Feedback Form', 'jetpack' ),
 		description: __( 'Add a Feedback form to your page', 'jetpack' ),
-		icon: {
-			src: renderMaterialIcon(
-				<Path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm3.5-9c.83 0 1.5-.67 1.5-1.5S16.33 8 15.5 8 14 8.67 14 9.5s.67 1.5 1.5 1.5zm-7 0c.83 0 1.5-.67 1.5-1.5S9.33 8 8.5 8 7 8.67 7 9.5 7.67 11 8.5 11zm3.5 6.5c2.03 0 3.8-1.11 4.75-2.75.19-.33-.05-.75-.44-.75H7.69c-.38 0-.63.42-.44.75.95 1.64 2.72 2.75 4.75 2.75z" />,
-				48,
-				48,
-				'-4 -3 32 32'
-			),
-			foreground: getIconColor(),
-		},
+		icon: renderMaterialIcon(
+			<Path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm3.5-9c.83 0 1.5-.67 1.5-1.5S16.33 8 15.5 8 14 8.67 14 9.5s.67 1.5 1.5 1.5zm-7 0c.83 0 1.5-.67 1.5-1.5S9.33 8 8.5 8 7 8.67 7 9.5 7.67 11 8.5 11zm3.5 6.5c2.03 0 3.8-1.11 4.75-2.75.19-.33-.05-.75-.44-.75H7.69c-.38 0-.63.42-.44.75.95 1.64 2.72 2.75 4.75 2.75z" />,
+			48,
+			48,
+			'-4 -3 32 32'
+		),
 		innerBlocks: [
 			[ 'jetpack/field-name', { required: true } ],
 			[ 'jetpack/field-email', { required: true } ],

--- a/extensions/blocks/send-a-message/variations.js
+++ b/extensions/blocks/send-a-message/variations.js
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
  */
 import whatsAppIcon from './whatsapp-button/icon';
 import { extendWithPaidIcon } from '../../extended-blocks/paid-blocks/render-paid-icon';
-import { getIconColor } from '../../shared/block-icons';
 
 const variations = [
 	{
@@ -19,10 +18,7 @@ const variations = [
 			'Let your visitors send you messages on WhatsApp with the tap of a button.',
 			'jetpack'
 		),
-		icon: {
-			src: extendWithPaidIcon( 'send-a-message', whatsAppIcon ),
-			foreground: getIconColor(),
-		},
+		icon: extendWithPaidIcon( 'send-a-message', whatsAppIcon ),
 		innerBlocks: [ [ 'jetpack/whatsapp-button', {} ] ],
 	},
 ];


### PR DESCRIPTION
- Fixes a bug introduced in https://github.com/Automattic/jetpack/pull/15311.
- Closes https://github.com/Automattic/jetpack/issues/17089.

#### Changes proposed in this Pull Request:

Simplifies the icon property to have just a single value instead of an object where `src` and `foreground` were being passed onto. This formatting is not supported, nor are color changes in the variations selections (yet?).

#### Testing instructions:

* Go to Posts > New Post.
* Add the Form block.
* Confirm no errors are thrown, validate that the variation selection works, as well as all variations.

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/426388/92373431-9a576680-f0fe-11ea-8f09-2dfcded7f2a8.png)

After

![image](https://user-images.githubusercontent.com/390760/92379815-fbcc0500-f0ff-11ea-84b0-b07e9745c288.png)


#### Proposed changelog entry for your changes:

* None
