### PR TITLE
Photon: Fix PHP warning when Photonizing some URLs

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -542,7 +542,7 @@ class Jetpack_Photon {
 
 						// If present, replace the link href with a Photoned URL for the full-size image.
 						if ( ! empty( $images['link_url'][ $index ] ) && self::validate_image_url( $images['link_url'][ $index ] ) ) {
-							$new_tag = preg_replace( '#(href=["|\'])' . $images['link_url'][ $index ] . '(["|\'])#i', '\1' . jetpack_photon_url( $images['link_url'][ $index ] ) . '\2', $new_tag, 1 );
+							$new_tag = preg_replace( '#(href=["|\'])' . preg_quote( $images['link_url'][ $index ], '#' ) . '(["|\'])#i', '\1' . jetpack_photon_url( $images['link_url'][ $index ] ) . '\2', $new_tag, 1 );
 						}
 
 						// Supplant the original source value with our Photon URL.
@@ -600,7 +600,7 @@ class Jetpack_Photon {
 						$content = str_replace( $tag, $new_tag, $content );
 					}
 				} elseif ( preg_match( '#^http(s)?://i[\d]{1}.wp.com#', $src ) && ! empty( $images['link_url'][ $index ] ) && self::validate_image_url( $images['link_url'][ $index ] ) ) {
-					$new_tag = preg_replace( '#(href=["|\'])' . $images['link_url'][ $index ] . '(["|\'])#i', '\1' . jetpack_photon_url( $images['link_url'][ $index ] ) . '\2', $tag, 1 );
+					$new_tag = preg_replace( '#(href=["|\'])' . preg_quote( $images['link_url'][ $index ], '#' ) . '(["|\'])#i', '\1' . jetpack_photon_url( $images['link_url'][ $index ] ) . '\2', $tag, 1 );
 
 					$content = str_replace( $tag, $new_tag, $content );
 				}

--- a/tests/php/modules/photon/sample-content/a-tags-with-hash-href.html
+++ b/tests/php/modules/photon/sample-content/a-tags-with-hash-href.html
@@ -1,0 +1,5 @@
+<a href="https://test.com/foo.jpg#d" ><img src="http://test.com/8.jpg"/></a>
+<a href="https://test.com/foo.jpg#d" ><img src="http://i0.wp.com/8.jpg"/></a>
+--RESULTS--
+<a href="https://i2.wp.com/test.com/foo.jpg?ssl=1" ><img src="https://i0.wp.com/test.com/8.jpg?w=640" data-recalc-dims="1"/></a>
+<a href="https://i2.wp.com/test.com/foo.jpg?ssl=1" ><img src="http://i0.wp.com/8.jpg"/></a>

--- a/tests/php/modules/photon/sample-content/a-tags-with-hash-href.html
+++ b/tests/php/modules/photon/sample-content/a-tags-with-hash-href.html
@@ -1,5 +1,5 @@
 <a href="https://test.com/foo.jpg#d" ><img src="http://test.com/8.jpg"/></a>
 <a href="https://test.com/foo.jpg#d" ><img src="http://i0.wp.com/8.jpg"/></a>
 --RESULTS--
-<a href="https://i2.wp.com/test.com/foo.jpg?ssl=1" ><img src="https://i0.wp.com/test.com/8.jpg?w=640" data-recalc-dims="1"/></a>
+<a href="https://i2.wp.com/test.com/foo.jpg?ssl=1" ><img src="https://i0.wp.com/test.com/8.jpg" data-recalc-dims="1"/></a>
 <a href="https://i2.wp.com/test.com/foo.jpg?ssl=1" ><img src="http://i0.wp.com/8.jpg"/></a>

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -232,6 +232,19 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	/**
 	 * Tests Photon's HTML parsing.
 	 *
+	 * @author biskobe
+	 * @covers Jetpack_Photon::filter_the_content
+	 * @since 3.2
+	 */
+	public function test_photon_parse_images_from_html_a_tags_with_hash_in_href() {
+		list( $sample_html, $expected ) = $this->get_photon_sample_content( 'a-tags-with-hash-href.html' );
+
+		$this->assertEquals( trim( $expected ), trim( Jetpack_Photon::filter_the_content( $sample_html ) ) );
+	}
+
+	/**
+	 * Tests Photon's HTML parsing.
+	 *
 	 * @author scotchfield
 	 * @covers Jetpack_Photon::parse_images_from_html
 	 * @since 3.2

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -252,7 +252,7 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		};
 		add_filter( 'jetpack_photon_post_image_args', $args_reset_callback, 10, 0 );
 
-		$this->assertEquals( trim( $expected ), trim( ( Jetpack_Photon::instance() )->filter_the_content( $sample_html ) ) );
+		$this->assertEquals( trim( $expected ), trim( Jetpack_Photon::instance()->filter_the_content( $sample_html ) ) );
 
 		remove_filter( 'jetpack_photon_post_image_args', $args_reset_callback );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fix an issue where some URLs would generate a PHP warning when trying to replace them with their Photon counterpart. 
* Fix failing `Jetpack_Photon` unit tests.

#### Jetpack product discussion

N/a

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

The quickest way to test is via `wp shell` on the local Jetpack instance.

If you have a local Jetpack Docker instance: 

* `yarn docker:wp shell --url=http://<your test site URL>`
* Then in the shell context run: 
   ```
   \Jetpack_Photon::filter_the_content("<a href=\"https://test.com/foo.jpg#d\" ><img src=\"http://test.com/8.jpg\"/></a>\n\n\n<a href=\"https://test.com/foo.jpg#d\" ><img src=\"http://i0.wp.com/8.jpg\"/></a>");
   ```
* In the output you should see two photonized image `src` and links (`a href`), similar to:
   ```
   <a href="https://i2.wp.com/test.com/foo.jpg?ssl=1" ><img src="https://i0.wp.com/test.com/8.jpg?w=580" data-recalc-dims="1"/></a>\n
   <a href="https://i2.wp.com/test.com/foo.jpg?ssl=1" ><img src="http://i0.wp.com/8.jpg"/></a>
   ```

If you don't have a local Docker instance:

* Enable Photon
* Try to publish a post with the following content:
   ```
   <a href="https://test.com/foo.jpg#d" ><img src="http://test.com/8.jpg"/></a>
   <a href="https://test.com/foo.jpg#d" ><img src="http://i0.wp.com/8.jpg"/></a>
   ```
* Make sure the output is similar to the Docker case above.

Unit Testing - if you have the local Docker Instance, as above:

```
yarn docker:phpunit --filter photon_
```

This will run all the `Jetpack_Photon` unit tests. They should all pass.

#### Proposed changelog entry for your changes:

* Fix PHP warning when replacing URL with their Photon counterpart
