### PR TITLE
Embeds: update song.link oEmbed to support more formats.

### DIFF
--- a/modules/shortcodes/others.php
+++ b/modules/shortcodes/others.php
@@ -14,4 +14,4 @@ wp_oembed_add_provider( '#https?://(www\.)?gfycat\.com/.*#i', 'https://api.gfyca
 wp_oembed_add_provider( '#https?://[^.]+\.(wistia\.com|wi\.st)/(medias|embed)/.*#', 'https://fast.wistia.com/oembed', true );
 wp_oembed_add_provider( '#https?://sketchfab\.com/.*#i', 'https://sketchfab.com/oembed', true );
 wp_oembed_add_provider( '#https?://(www\.)?icloud\.com/keynote/.*#i', 'https://iwmb.icloud.com/iwmb/oembed', true );
-wp_oembed_add_provider( 'https://song.link/*', 'https://song.link/oembed', false );
+wp_oembed_add_provider( '#https?://((song|album|artist|pods|playlist)\.link|odesli\.com?|mylink\.page)/.*#', 'https://odesli.co/oembed', true );

--- a/tests/php/modules/shortcodes/test-class.others.php
+++ b/tests/php/modules/shortcodes/test-class.others.php
@@ -18,15 +18,19 @@ class WP_Test_Jetpack_Shortcodes_Others extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test a post including a song.link link.
+	 * Test a post including an Odesli link.
+	 *
+	 * @dataProvider get_odesli_data
 	 *
 	 * @since 8.4.0
+	 *
+	 * @param string $embed_link The link we're trying to embed, as pasted in the editor.
+	 * @param string $expected   The expected return value of the function.
 	 */
-	public function test_shortcodes_songlink() {
+	public function test_shortcodes_songlink( $embed_link, $expected ) {
 		global $post;
 
-		$url  = 'https://song.link/hu/i/1051332387';
-		$post = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+		$post = $this->factory()->post->create_and_get( array( 'post_content' => $embed_link ) );
 
 		setup_postdata( $post );
 
@@ -37,10 +41,73 @@ class WP_Test_Jetpack_Shortcodes_Others extends WP_UnitTestCase {
 
 		$this->assertContains(
 			sprintf(
-				'src="https://embed.song.link/?url=%s" frameborder="0" allowtransparency allowfullscreen sandbox="allow-same-origin allow-scripts allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>',
-				rawurlencode( $url )
+				'src="%s" frameborder="0" allowtransparency allowfullscreen sandbox="allow-same-origin allow-scripts allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>',
+				$expected
 			),
 			$actual
 		);
+	}
+
+	/**
+	 * Test embeds for the Odesli service.
+	 *
+	 * @since 9.0.0
+	 */
+	public function get_odesli_data() {
+		$variations = array(
+			'https://song.link/hello',
+			'https://album.link/hello',
+			'https://pods.link/hello',
+			'https://odesli.com/hello',
+			'https://odesli.co/hello',
+			'https://artist.link/hello',
+			'https://playlist.link/hello',
+			'https://mylink.page/hello',
+			'https://song.link/ca/i/1288547996',
+			'https://album.link/song/ca/i/1288547996',
+			'https://song.link/i/1288547996',
+			'https://odesli.com/song/i/1288547996',
+			'https://odesli.co/song/s/6r1siiMXYLrao42oiqQrgj',
+			'https://artist.link/song/y/UUDjpNpETzo',
+			'https://playlist.link/song/y/6366dxFf-Os',
+			'https://mylink.page/song/y/H8tLS_NOWLs',
+			'https://song.link/song/g/Tg6zuj3cjgwcgrdi6ewlqdjk6iq',
+			'https://album.link/song/d/138241229',
+			'https://odesli.com/song/t/72268642',
+			'https://odesli.co/song/a/B01NAE38YO',
+			'https://artist.link/song/n/tra.246588040',
+			'https://playlist.link/song/sc/347741803',
+			'https://playlist.link/song/ya/32504596',
+			'https://mylink.page/song/p/TR:5791220',
+			'https://song.link/sp/1767083',
+			'https://album.link/ca/i/1279947491',
+			'https://song.link/album/i/1279947491',
+			'https://album.link/album/s/6JckISQKS5IwOH4YrFrfIB',
+			'https://odesli.com/album/y/OLAK5uy_nErvzigwPVzj76NSzpte5pmiViP_F0gNE',
+			'https://odesli.co/album/g/B7xsarspqwsinxzont6zdvd2hny',
+			'https://artist.link/album/d/14843037',
+			'https://playlist.link/album/t/67784530',
+			'https://mylink.page/album/a/B01N48U32A',
+			'https://album.link/n/alb.246588025',
+			'https://song.link/album/sc/228667052',
+			'https://odesli.com/album/ya/297720',
+			'https://odesli.co/album/p/AL:668238',
+			'https://artist.link/album/sp/145895',
+			'https://pods.link/us/i/360084272',
+			'https://mylink.page/podcast/i/360084272',
+		);
+
+		$test_data = array();
+
+		// Loop through each possible embed variation, and create a test case for it.
+		foreach ( $variations as $variation ) {
+			$test_name               = esc_attr( $variation );
+			$test_data[ $test_name ] = array(
+				$variation,
+				sprintf( 'https://embed.song.link/?url=%s', rawurlencode( $variation ) ),
+			);
+		}
+
+		return $test_data;
 	}
 }


### PR DESCRIPTION
Replaces #14998 

#### Changes proposed in this Pull Request:

* This PR updates the song.link oEmbed provider to support more formats.
* I extended the existing test to test for more potential formats, but did not use the full list provided [here](https://github.com/Automattic/jetpack/pull/14998#issuecomment-600367587) to avoid slowing down our tests too much. I picked one domain for each variation instead.

#### Jetpack product discussion

* Internal reference: D49210-code

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Do the tests pass?
* Try to add some of the links provided [here](https://github.com/Automattic/jetpack/pull/14998#issuecomment-600367587) and see that they get displayed properly.

#### Proposed changelog entry for your changes:

* Embeds: update song.link oEmbed to support more formats.
