### PR TITLE
Pinterest: avoid errors when Jetpack_AMP_Support isn't available

### DIFF
--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -180,7 +180,7 @@ function render_amp_pin( $attr ) {
  * @return string
  */
 function load_assets( $attr, $content ) {
-	if ( Jetpack_AMP_Support::is_amp_request() ) {
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		return render_amp_pin( $attr );
 	} else {
 		wp_enqueue_script( 'pinterest-pinit', 'https://assets.pinterest.com/js/pinit.js', array(), JETPACK__VERSION, true );


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Follow-up from #17086. In some environments (on WordPress.com for example), `Jetpack_AMP_Support` is not always available by the time we load the block.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:

* Apply WordPress.com patch.
* Notice no Fatals.

#### Proposed changelog entry for your changes:
* N/A
