### PR TITLE
Blocks: add AMP and CSS Classes methods to the new package

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -6,6 +6,7 @@
  * @package Jetpack
  */
 
+use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
 
@@ -649,7 +650,7 @@ class Jetpack_Gutenberg {
 			$script_dependencies = array_unique( array_merge( $script_dependencies, $asset_manifest['dependencies'] ) );
 		}
 
-		if ( ( ! class_exists( 'Jetpack_AMP_Support' ) || ! Jetpack_AMP_Support::is_amp_request() ) && self::block_has_asset( $script_relative_path ) ) {
+		if ( ! Blocks::is_amp_request() && self::block_has_asset( $script_relative_path ) ) {
 			$script_version = self::get_asset_version( $script_relative_path );
 			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $script_dependencies, $script_version, false );
@@ -841,34 +842,8 @@ class Jetpack_Gutenberg {
 	 * @return string $classes List of CSS classes for a block.
 	 */
 	public static function block_classes( $slug = '', $attr, $extra = array() ) {
-		if ( empty( $slug ) ) {
-			return '';
-		}
-
-		// Basic block name class.
-		$classes = array(
-			'wp-block-jetpack-' . $slug,
-		);
-
-		// Add alignment if provided.
-		if (
-			! empty( $attr['align'] )
-			&& in_array( $attr['align'], array( 'left', 'center', 'right', 'wide', 'full' ), true )
-		) {
-			array_push( $classes, 'align' . $attr['align'] );
-		}
-
-		// Add custom classes if provided in the block editor.
-		if ( ! empty( $attr['className'] ) ) {
-			array_push( $classes, $attr['className'] );
-		}
-
-		// Add any extra classes.
-		if ( is_array( $extra ) && ! empty( $extra ) ) {
-			$classes = array_merge( $classes, array_filter( $extra ) );
-		}
-
-		return implode( ' ', $classes );
+		_deprecated_function( __METHOD__, '9.0.0', 'Automattic\\Jetpack\\Blocks::classes' );
+		return Blocks::classes( $slug, $attr, $extra );
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-backup": "@dev",
+		"automattic/jetpack-blocks": "@dev",
 		"automattic/jetpack-compat": "@dev",
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-connection": "@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47b37ad7ddee294cec6da18fcee814dc",
+    "content-hash": "d99f2087c792c7d1102844480e714c30",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/a8c-mc-stats",
@@ -39,7 +39,7 @@
         },
         {
             "name": "automattic/jetpack-abtest",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/abtest",
@@ -75,7 +75,7 @@
         },
         {
             "name": "automattic/jetpack-assets",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/assets",
@@ -111,11 +111,11 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
-                "reference": "557195e755ff951fe3f8544056c5696eecc4d2cb"
+                "reference": "b9eb7c8e38782d3715568382ea97462c5608bd92"
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0"
@@ -128,9 +128,9 @@
                 "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin"
             },
             "autoload": {
-			    "classmap": [
-				  "src/AutoloadGenerator.php"
-				],
+                "classmap": [
+                    "src/AutoloadGenerator.php"
+                ],
                 "psr-4": {
                     "Automattic\\Jetpack\\Autoloader\\": "src"
                 }
@@ -151,7 +151,7 @@
         },
         {
             "name": "automattic/jetpack-backup",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/backup",
@@ -175,8 +175,43 @@
             }
         },
         {
+            "name": "automattic/jetpack-blocks",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "./packages/blocks",
+                "reference": "057e0ecae8c03cbc335bb5ea488f67b51603fd7a"
+            },
+            "require-dev": {
+                "automattic/wordbless": "dev-master",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "post-update-cmd": [
+                    "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Register and manage blocks within a plugin. Used to manage block registration, enqueues, and more.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-compat",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/compat",
@@ -211,7 +246,7 @@
         },
         {
             "name": "automattic/jetpack-config",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/config",
@@ -233,14 +268,15 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "bb68aeb045a837fe2fe4784ca41ac667fe5b6fa5"
+                "reference": "ccbf1b70e17ee389082c8aaa1cf625582fd9b373"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-heartbeat": "@dev",
                 "automattic/jetpack-options": "@dev",
                 "automattic/jetpack-roles": "@dev",
                 "automattic/jetpack-status": "@dev",
@@ -280,7 +316,7 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
@@ -312,7 +348,7 @@
         },
         {
             "name": "automattic/jetpack-device-detection",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/device-detection",
@@ -344,7 +380,7 @@
         },
         {
             "name": "automattic/jetpack-error",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/error",
@@ -375,7 +411,7 @@
         },
         {
             "name": "automattic/jetpack-heartbeat",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/heartbeat",
@@ -410,7 +446,7 @@
         },
         {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
@@ -454,13 +490,14 @@
         },
         {
             "name": "automattic/jetpack-lazy-images",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/lazy-images",
-                "reference": "16409fc61cce65c8b914b08c80cae2cc0662ca2d"
+                "reference": "b42d4c093ea12c89dd16c713c07e5a2c15c8ff5d"
             },
             "require": {
+                "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-constants": "@dev"
             },
             "require-dev": {
@@ -492,7 +529,7 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
@@ -524,7 +561,7 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
@@ -553,7 +590,7 @@
         },
         {
             "name": "automattic/jetpack-partner",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/partner",
@@ -587,7 +624,7 @@
         },
         {
             "name": "automattic/jetpack-redirect",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/redirect",
@@ -618,7 +655,7 @@
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/roles",
@@ -650,7 +687,7 @@
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/status",
@@ -683,7 +720,7 @@
         },
         {
             "name": "automattic/jetpack-sync",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
@@ -712,14 +749,13 @@
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/terms-of-service",
-                "reference": "f97241d09352c4ca44eab26520cac4c1903d08d3"
+                "reference": "723788a4aa7c508746f7c425f99c645c2a057598"
             },
             "require": {
-                "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-options": "@dev",
                 "automattic/jetpack-status": "@dev"
             },
@@ -749,7 +785,7 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-add/jetpack-lazy-images-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",
@@ -1220,6 +1256,7 @@
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-backup": 20,
+        "automattic/jetpack-blocks": 20,
         "automattic/jetpack-compat": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-connection": 20,

--- a/extensions/blocks/button/button.php
+++ b/extensions/blocks/button/button.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Button;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'button';
@@ -38,7 +39,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function render_block( $attributes, $content ) {
 	$save_in_post_content = get_attribute( $attributes, 'saveInPostContent' );
 
-	if ( class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request() ) {
+	if ( Blocks::is_amp_request() ) {
 		Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
 	}
 
@@ -50,7 +51,7 @@ function render_block( $attributes, $content ) {
 	$text      = get_attribute( $attributes, 'text' );
 	$unique_id = get_attribute( $attributes, 'uniqueId' );
 	$url       = get_attribute( $attributes, 'url' );
-	$classes   = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
+	$classes   = Blocks::classes( FEATURE_NAME, $attributes );
 
 	$button_classes = get_button_classes( $attributes );
 	$button_styles  = get_button_styles( $attributes );

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Calendly;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'calendly';
@@ -61,9 +62,9 @@ function load_assets( $attr, $content ) {
 	$background_color        = get_attribute( $attr, 'backgroundColor' );
 	$text_color              = get_attribute( $attr, 'textColor' );
 	$primary_color           = get_attribute( $attr, 'primaryColor' );
-	$classes                 = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr, array( 'calendly-style-' . $style ) );
+	$classes                 = Blocks::classes( FEATURE_NAME, $attr, array( 'calendly-style-' . $style ) );
 	$block_id                = wp_unique_id( 'calendly-block-' );
-	$is_amp_request          = class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request();
+	$is_amp_request          = Blocks::is_amp_request();
 
 	if ( ! wp_script_is( 'jetpack-calendly-external-js' ) && ! $is_amp_request ) {
 		enqueue_calendly_js();
@@ -103,7 +104,7 @@ function load_assets( $attr, $content ) {
 		if ( $is_amp_request ) {
 			$content = sprintf(
 				'<div class="%1$s" id="%2$s"><a href="%3$s" role="button" target="_blank">%4$s</a></div>',
-				esc_attr( Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr ) ),
+				esc_attr( Blocks::classes( FEATURE_NAME, $attr ) ),
 				esc_attr( $block_id ),
 				esc_js( $url ),
 				wp_kses_post( get_attribute( $attr, 'submitButtonText' ) )

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Eventbrite;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'eventbrite';
@@ -66,7 +67,7 @@ function render_block( $attr, $content ) {
 
 		// $content contains a fallback link to the event that's saved in the post_content.
 		// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
-		$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
+		$classes = Blocks::classes( FEATURE_NAME, $attr );
 
 		$content .= sprintf(
 			'<div id="%1$s" class="%2$s"></div>',

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -9,7 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Gif;
 
-use Jetpack_AMP_Support;
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'gif';
@@ -48,7 +48,7 @@ function render_block( $attr ) {
 		return null;
 	}
 
-	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
+	$classes = Blocks::classes( FEATURE_NAME, $attr );
 
 	$placeholder = sprintf( '<a href="%s">%s</a>', esc_url( $giphy_url ), esc_attr( $search_text ) );
 
@@ -56,7 +56,7 @@ function render_block( $attr ) {
 	?>
 	<div class="<?php echo esc_attr( $classes ); ?>">
 		<figure>
-			<?php if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) : ?>
+			<?php if ( Blocks::is_amp_request() ) : ?>
 				<amp-iframe src="<?php echo esc_url( $giphy_url ); ?>" width="100" height="<?php echo absint( $padding_top ); ?>" sandbox="allow-scripts allow-same-origin" layout="responsive">
 					<div placeholder>
 						<?php echo wp_kses_post( $placeholder ); ?>

--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -9,7 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Google_Calendar;
 
-use Jetpack_AMP_Support;
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'google-calendar';
@@ -41,7 +41,7 @@ function load_assets( $attr ) {
 	$url     = isset( $attr['url'] )
 		? Jetpack_Gutenberg::validate_block_embed_url( $attr['url'], array( 'calendar.google.com' ) ) :
 		'';
-	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
+	$classes = Blocks::classes( FEATURE_NAME, $attr );
 
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
@@ -49,7 +49,7 @@ function load_assets( $attr ) {
 		return;
 	}
 
-	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+	if ( Blocks::is_amp_request() ) {
 		return sprintf(
 			'<div class="%1$s"><amp-iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" height="%3$d" sandbox="allow-scripts allow-same-origin" layout="responsive"></amp-iframe></div>',
 			esc_attr( $classes ),

--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -9,7 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\ImageCompare;
 
-use Jetpack_AMP_Support;
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'image-compare';
@@ -38,7 +38,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  */
 function load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
-	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+	if ( Blocks::is_amp_request() ) {
 		return render_amp( $attr );
 	}
 

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -9,8 +9,8 @@
 
 namespace Automattic\Jetpack\Extensions\Instagram_Gallery;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack;
-use Jetpack_AMP_Support;
 use Jetpack_Gutenberg;
 use Jetpack_Instagram_Gallery_Helper;
 
@@ -51,7 +51,7 @@ function render_block( $attributes, $content ) {
 	$is_stacked_on_mobile = get_instagram_gallery_attribute( 'isStackedOnMobile', $attributes );
 	$spacing              = get_instagram_gallery_attribute( 'spacing', $attributes );
 
-	$grid_classes = Jetpack_Gutenberg::block_classes(
+	$grid_classes = Blocks::classes(
 		FEATURE_NAME,
 		$attributes,
 		array(
@@ -83,7 +83,7 @@ function render_block( $attributes, $content ) {
 		$message = $error_message
 			. '<br />'
 			. esc_html__( '(Only administrators and the post author will see this message.)', 'jetpack' );
-		return Jetpack_Gutenberg::notice( $message, 'error', Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes ) );
+		return Jetpack_Gutenberg::notice( $message, 'error', Blocks::classes( FEATURE_NAME, $attributes ) );
 	}
 
 	if ( empty( $gallery->images ) ) {
@@ -92,13 +92,11 @@ function render_block( $attributes, $content ) {
 
 	$images = array_slice( $gallery->images, 0, $count );
 
-	$is_amp_request = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
-
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	ob_start();
 	?>
-	<?php if ( $is_amp_request ) : ?>
+	<?php if ( Blocks::is_amp_request() ) : ?>
 		<style>
 			.wp-block-jetpack-instagram-gallery__grid .wp-block-jetpack-instagram-gallery__grid-post amp-img img {
 				object-fit: cover;

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -9,8 +9,8 @@
 
 namespace Automattic\Jetpack\Extensions\Mailchimp;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack;
-use Jetpack_AMP_Support;
 use Jetpack_Gutenberg;
 use Jetpack_Options;
 
@@ -56,9 +56,9 @@ function load_assets( $attr, $content ) {
 		? get_current_blog_id()
 		: Jetpack_Options::get_option( 'id' );
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
-	$classes         = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
+	$classes         = Blocks::classes( FEATURE_NAME, $attr );
 	$amp_form_action = sprintf( 'https://public-api.wordpress.com/rest/v1.1/sites/%s/email_follow/amp/subscribe/', $blog_id );
-	$is_amp_request  = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
+	$is_amp_request  = Blocks::is_amp_request();
 
 	ob_start();
 	?>

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -9,9 +9,9 @@
 
 namespace Automattic\Jetpack\Extensions\Map;
 
+use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Tracking;
 use Jetpack;
-use Jetpack_AMP_Support;
 use Jetpack_Gutenberg;
 use Jetpack_Mapbox_Helper;
 use Jetpack_Options;
@@ -71,7 +71,7 @@ function load_assets( $attr, $content ) {
 
 	wpcom_load_event( $access_token['source'] );
 
-	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+	if ( Blocks::is_amp_request() ) {
 		static $map_block_counter = array();
 
 		$id = get_the_ID();

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\OpenTable;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'opentable';
@@ -72,7 +73,7 @@ function load_assets( $attributes ) {
 	if ( array_key_exists( 'negativeMargin', $attributes ) && $attributes['negativeMargin'] ) {
 		$classes[] = 'has-no-margin';
 	}
-	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, $classes );
+	$classes = Blocks::classes( FEATURE_NAME, $attributes, $classes );
 	$content = '<div class="' . esc_attr( $classes ) . '">';
 
 	// The OpenTable script uses multiple `rid` paramters,

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -9,7 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Pinterest;
 
-use Jetpack_AMP_Support;
+use Automattic\Jetpack\Blocks;
 use WP_Error;
 
 const FEATURE_NAME = 'pinterest';
@@ -180,7 +180,7 @@ function render_amp_pin( $attr ) {
  * @return string
  */
 function load_assets( $attr, $content ) {
-	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+	if ( Blocks::is_amp_request() ) {
 		return render_amp_pin( $attr );
 	} else {
 		wp_enqueue_script( 'pinterest-pinit', 'https://assets.pinterest.com/js/pinit.js', array(), JETPACK__VERSION, true );

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -9,10 +9,10 @@
 
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
+use Automattic\Jetpack\Blocks;
 use WP_Error;
 use Jetpack_Gutenberg;
 use Jetpack_Podcast_Helper;
-use Jetpack_AMP_Support;
 
 const FEATURE_NAME = 'podcast-player';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
@@ -138,8 +138,8 @@ function render_player( $player_data, $attributes ) {
 	$player_inline_style  = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
 	$player_inline_style .= get_css_vars( $attributes );
 
-	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
-	$is_amp          = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
+	$block_classname = Blocks::classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
+	$is_amp          = Blocks::is_amp_request();
 
 	ob_start();
 	?>

--- a/extensions/blocks/repeat-visitor/repeat-visitor.php
+++ b/extensions/blocks/repeat-visitor/repeat-visitor.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Repeat_Visitor;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'repeat-visitor';
@@ -38,7 +39,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function render_block( $attributes, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
-	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
+	$classes = Blocks::classes( FEATURE_NAME, $attributes );
 
 	$count     = isset( $_COOKIE['jp-visit-counter'] ) ? intval( $_COOKIE['jp-visit-counter'] ) : 0;
 	$criteria  = isset( $attributes['criteria'] ) ? $attributes['criteria'] : 'after-visits';

--- a/extensions/blocks/revue/revue.php
+++ b/extensions/blocks/revue/revue.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Revue;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'revue';
@@ -49,8 +50,8 @@ function render_block( $attributes, $content ) {
 	$last_name_placeholder  = get_revue_attribute( 'lastNamePlaceholder', $attributes );
 	$last_name_show         = get_revue_attribute( 'lastNameShow', $attributes );
 	$url                    = sprintf( 'https://www.getrevue.co/profile/%s/add_subscriber', $attributes['revueUsername'] );
-	$base_class             = Jetpack_Gutenberg::block_classes( FEATURE_NAME, array() ) . '__';
-	$classes                = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
+	$base_class             = Blocks::classes( FEATURE_NAME, array() ) . '__';
+	$classes                = Blocks::classes( FEATURE_NAME, $attributes );
 
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -9,7 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Slideshow;
 
-use Jetpack_AMP_Support;
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'slideshow';
@@ -38,7 +38,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  */
 function load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
-	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+	if ( Blocks::is_amp_request() ) {
 		return render_amp( $attr );
 	}
 	return $content;
@@ -66,7 +66,7 @@ function render_amp( $attr ) {
 		$autoplay ? 'wp-block-jetpack-slideshow__autoplay' : null,
 		$autoplay ? 'wp-block-jetpack-slideshow__autoplay-playing' : null,
 	);
-	$classes  = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr, $extras );
+	$classes  = Blocks::classes( FEATURE_NAME, $attr, $extras );
 
 	return sprintf(
 		'<div class="%1$s" id="wp-block-jetpack-slideshow__%2$d"><div class="wp-block-jetpack-slideshow_container swiper-container">%3$s%4$s%5$s</div></div>',

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Story;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'story';
@@ -343,7 +344,7 @@ function render_block( $attributes ) {
 				</div>
 			</div>
 		</div>',
-		esc_attr( Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'wp-story', 'aligncenter' ) ) ),
+		esc_attr( Blocks::classes( FEATURE_NAME, $attributes, array( 'wp-story', 'aligncenter' ) ) ),
 		filter_var( wp_json_encode( $settings ), FILTER_SANITIZE_SPECIAL_CHARS ),
 		__( 'Site icon', 'jetpack' ),
 		esc_attr( get_site_icon_url( 32, includes_url( 'images/w-logo-blue.png' ) ) ),


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* This PR starts adding methods to the new Blocks package we'll use for all Jetpack blocks from now on.

#### Jetpack product discussion

* Internal reference: p9dueE-1BH-p2
* Primary issue: #17099 

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Install the AMP Plugin on your site.
* Connect Jetpack to WordPress.com, and try to add all the blocks added as labels to this PR.
* View them in AMP views as well.
* Ensure all blocks are displayed properly.
* Ensure that blocks that include a `view.js` file (such as the Map block) still load it on non-AMP views.

#### Proposed changelog entry for your changes:

* N/A

