### PR TITLE
Docker MySQL: Slow Queries Log

### DIFF
--- a/docker/config/mysql.conf
+++ b/docker/config/mysql.conf
@@ -1,0 +1,4 @@
+[mysqld]
+slow_query_log = 1
+slow_query_log_file = /var/log/mysql/slow.log
+long_query_time = 0.5

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     image: mysql:5.7
     volumes:
       - ./data/mysql:/var/lib/mysql
+      - ./logs/mysql:/var/log/mysql
+      - ./config/mysql.conf:/etc/mysql/conf.d/docker.cnf
     restart: always
     env_file:
       - default.env


### PR DESCRIPTION
Enabling [slow query log](https://dev.mysql.com/doc/refman/5.7/en/slow-query-log.html) for the Jetpack MySQL docker container.

#### Changes proposed in this Pull Request:
- logging of MySQL queries slower than 0.5 second into the file `docker/logs/mysql/slow.log`
- `docker/config/mysql.conf` config file makes changing the MySQL server configuration easier

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Run `yarn docker:up -d` to rebuild the MySQL container.
2. Use `yarn docker:db` to log into the MySQL client.
3. Run `SELECT SLEEP(0.5);`.
4. Go to `docker/logs/mysql/slow.log`, confirm that the query **was logged**.
5. Run `SELECT SLEEP(0.4);`, confirm that it has run for less than 0.5 second: `1 row in set (0.40 sec)`
6. Go to `docker/logs/mysql/slow.log` and make sure that the query **was not logged**.

#### Proposed changelog entry for your changes:
* Logging of slow MySQL queries for the Jetpack docker environment.