### PR TITLE
Partial reconnect: Cleanup redundant actions

### DIFF
--- a/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
+++ b/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
@@ -18,8 +18,6 @@ export default class JetpackConnectionErrors extends React.Component {
 	getAction( action, message, code ) {
 		switch ( action ) {
 			case 'reconnect':
-			case 'refresh_blog_token':
-			case 'refresh_user_token':
 				return <ErrorNoticeCycleConnection text={ message } errorCode={ code } action={ action } />;
 			case 'display':
 				return (

--- a/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
+++ b/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
@@ -62,7 +62,9 @@ export default connect(
 	},
 	dispatch => {
 		return {
-			reconnectSite: action => dispatch( reconnectSite( action ) ),
+			reconnectSite: () => {
+				return dispatch( reconnectSite() );
+			},
 		};
 	}
 )( NoticeActionReconnect );

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -104,10 +104,8 @@ function JetpackRestApiClient( root, nonce ) {
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 
-		reconnect: action =>
-			postRequest( `${ apiRoot }jetpack/v4/connection/reconnect`, postParams, {
-				body: JSON.stringify( { action: action } ),
-			} )
+		reconnect: () =>
+			postRequest( `${ apiRoot }jetpack/v4/connection/reconnect`, postParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 

--- a/_inc/client/state/connection/actions.js
+++ b/_inc/client/state/connection/actions.js
@@ -258,7 +258,7 @@ export const authorizeUserInPlaceSuccess = () => {
 	};
 };
 
-export const reconnectSite = ( action = 'reconnect' ) => {
+export const reconnectSite = () => {
 	return ( dispatch, getState ) => {
 		dispatch( {
 			type: SITE_RECONNECT,
@@ -269,7 +269,7 @@ export const reconnectSite = ( action = 'reconnect' ) => {
 			} )
 		);
 		return restApi
-			.reconnect( action )
+			.reconnect()
 			.then( connectionStatusData => {
 				const status = connectionStatusData.status;
 				const authorizeUrl = connectionStatusData.authorizeUrl;

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -99,12 +99,6 @@ class REST_Connector {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'connection_reconnect' ),
-				'args'                => array(
-					'action' => array(
-						'type'     => 'string',
-						'required' => true,
-					),
-				),
 				'permission_callback' => __CLASS__ . '::jetpack_reconnect_permission_check',
 			)
 		);
@@ -251,42 +245,21 @@ class REST_Connector {
 	 *
 	 * @since 8.8.0
 	 *
-	 * @param WP_REST_Request $request The request sent to the WP REST API.
-	 *
 	 * @return \WP_REST_Response|WP_Error
 	 */
-	public function connection_reconnect( WP_REST_Request $request ) {
-		$params = $request->get_json_params();
-
+	public function connection_reconnect() {
 		$response = array();
 
 		$next = null;
 
-		switch ( $params['action'] ) {
-			case 'reconnect':
-				$result = $this->connection->restore();
+		$result = $this->connection->restore();
 
-				if ( is_wp_error( $result ) ) {
-					$response = $result;
-				} elseif ( is_string( $result ) ) {
-					$next = $result;
-				} else {
-					$next = true === $result ? 'completed' : 'failed';
-				}
-
-				break;
-			case 'reconnect_force':
-				$result = $this->connection->reconnect();
-
-				if ( true === $result ) {
-					$next = 'authorize';
-				} elseif ( is_wp_error( $result ) ) {
-					$response = $result;
-				}
-				break;
-			default:
-				$response = new WP_Error( 'Unknown action' );
-				break;
+		if ( is_wp_error( $result ) ) {
+			$response = $result;
+		} elseif ( is_string( $result ) ) {
+			$next = $result;
+		} else {
+			$next = true === $result ? 'completed' : 'failed';
 		}
 
 		switch ( $next ) {

--- a/packages/connection/tests/php/test-rest-endpoints.php
+++ b/packages/connection/tests/php/test-rest-endpoints.php
@@ -519,7 +519,6 @@ class Test_REST_Endpoints extends TestCase {
 	private function build_reconnect_request() {
 		$this->request = new WP_REST_Request( 'POST', '/jetpack/v4/connection/reconnect' );
 		$this->request->set_header( 'Content-Type', 'application/json' );
-		$this->request->set_body( wp_json_encode( array( 'action' => 'reconnect' ) ) );
 
 		return $this->request;
 	}


### PR DESCRIPTION
This PR mainly cleans up the `action` parameter, used in the `reconnect` endpoint.
This parameter was introduced based on the assumption that the client will be aware of the type of reconnect we need to trigger, eg full or partial and send it along with the `reconnect` request.
Based on the current implementation, this logic is handled backend and the client is not aware of it, therefore we are cleaning up any references to the specific `action` we were meaning to send on the client side.

#### Changes proposed in this Pull Request:
* Removes the required `action` param from the `reconnect` endpoint and updates the corresponding unit tests
* Removes the `action` param from the client rest-api request implementation
* Removes the `action` redundant references from the client notices component
* Removes the `action` argument from the `reconnectSite` function in connection state.

#### Jetpack product discussion
p9dueE-1LL-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Nothing should be changed in the existing reconnect flow.
* Break your blog or user token (using the Broken Token plugin) 
* Make sure you see the "Restore connection" alert and 
* can successfully restore your connection by clicking on the corresponding button.

#### Proposed changelog entry for your changes:
* N/A