### PR TITLE
Sync: stop trying to check for edit_comment capability

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -165,7 +165,7 @@ class Defaults {
 		'jetpack_publicize_options',
 		'jetpack_connection_active_plugins',
 		'jetpack_sync_non_blocking', // is non-blocking Jetpack Sync flow enabled.
-		'ce4wp_referred_by', // Creative Mail. See pbtFPC-H5-p2
+		'ce4wp_referred_by', // Creative Mail. See pbtFPC-H5-p2 .
 	);
 
 	/**
@@ -894,7 +894,7 @@ class Defaults {
 		'promote_users',
 		'delete_themes',
 		'export',
-		'edit_comment',
+		'moderate_comments',
 		'upload_plugins',
 		'upload_themes',
 	);

--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -894,7 +894,6 @@ class Defaults {
 		'promote_users',
 		'delete_themes',
 		'export',
-		'moderate_comments',
 		'upload_plugins',
 		'upload_themes',
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Checking for edit_comment can only be used to check for the cap for one specific comment, which does not match our needs here.

More dicussion: p1599656662345700-slack-jetpack-crew

This did not come up in the past, and was triggered by a core change (r48961-core) that revealed the problem.

**Note**: in a future PR, we should consider making `Automattic\Jetpack\Sync\Modules\Users::get_real_user_capabilities()` more future-proof by ensuring it does not include caps that are not relevant or require extra arguments.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Do the tests pass?

#### Proposed changelog entry for your changes:

* N/A