### PR TITLE
Sync: check our whitelisted caps against all caps the user has

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -165,7 +165,7 @@ class Defaults {
 		'jetpack_publicize_options',
 		'jetpack_connection_active_plugins',
 		'jetpack_sync_non_blocking', // is non-blocking Jetpack Sync flow enabled.
-		'ce4wp_referred_by', // Creative Mail. See pbtFPC-H5-p2
+		'ce4wp_referred_by', // Creative Mail. See pbtFPC-H5-p2 .
 	);
 
 	/**
@@ -894,7 +894,7 @@ class Defaults {
 		'promote_users',
 		'delete_themes',
 		'export',
-		'edit_comment',
+		'moderate_comments',
 		'upload_plugins',
 		'upload_themes',
 	);

--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -894,7 +894,6 @@ class Defaults {
 		'promote_users',
 		'delete_themes',
 		'export',
-		'moderate_comments',
 		'upload_plugins',
 		'upload_themes',
 	);

--- a/packages/sync/src/modules/class-users.php
+++ b/packages/sync/src/modules/class-users.php
@@ -239,11 +239,15 @@ class Users extends Module {
 
 		$user_caps = $user->allcaps;
 
-		foreach ( Defaults::get_capabilities_whitelist() as $capability ) {
-			if ( in_array( $capability, $user_caps, true ) ) {
-				$user_capabilities[ $capability ] = true;
+		foreach ( $user_caps as $cap => $enabled ) {
+			if (
+				in_array( $cap, Defaults::get_capabilities_whitelist(), true )
+				&& true === $enabled
+			) {
+				$user_capabilities[ $cap ] = true;
 			}
 		}
+
 		return $user_capabilities;
 	}
 

--- a/packages/sync/src/modules/class-users.php
+++ b/packages/sync/src/modules/class-users.php
@@ -233,11 +233,14 @@ class Users extends Module {
 	 */
 	public function get_real_user_capabilities( $user ) {
 		$user_capabilities = array();
-		if ( is_wp_error( $user ) ) {
+		if ( is_wp_error( $user ) || ! is_a( $user, 'WP_User' ) ) {
 			return $user_capabilities;
 		}
+
+		$user_caps = $user->allcaps;
+
 		foreach ( Defaults::get_capabilities_whitelist() as $capability ) {
-			if ( user_can( $user, $capability ) ) {
+			if ( in_array( $capability, $user_caps, true ) ) {
 				$user_capabilities[ $capability ] = true;
 			}
 		}


### PR DESCRIPTION
Follow-up from #17114 

#### Changes proposed in this Pull Request:

Checking for edit_comment can only be used to check for the cap for one specific comment, which does not match our needs here. moderate_comments will allow us to check for the ability to edit all comments on the site.

More dicussion: p1599656662345700-slack-jetpack-crew

#### Jetpack product discussion
* N/A
#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:

* Not quite sure.
* Do the tests pass?

#### Proposed changelog entry for your changes:
* N/A
