### PR TITLE
Config: remove tos and tracking features

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -792,8 +792,6 @@ class Jetpack {
 		foreach (
 			array(
 				'sync',
-				'tracking',
-				'tos',
 			)
 			as $feature
 		) {
@@ -849,6 +847,15 @@ class Jetpack {
 			add_action( 'init', array( 'Jetpack_Iframe_Embed', 'init' ), 9, 0 );
 			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.jetpack-keyring-service-helper.php';
 			add_action( 'init', array( 'Jetpack_Keyring_Service_Helper', 'init' ), 9, 0 );
+		}
+
+		if ( ( new Tracking( $this->connection_manager ) )->should_enable_tracking( new Terms_Of_Service(), new Status() ) ) {
+			add_action( 'init', array( new Plugin_Tracking(), 'init' ) );
+		} else {
+			/**
+			 * Initialize tracking right after the user agrees to the terms of service.
+			 */
+			add_action( 'jetpack_agreed_to_terms_of_service', array( new Plugin_Tracking(), 'init' ) );
 		}
 	}
 

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -16,7 +16,6 @@ use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\JITMS\JITM as JITMS_JITM;
 use Automattic\Jetpack\JITM as JITM;
 use Automattic\Jetpack\Connection\Plugin;
-use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
 use Automattic\Jetpack\Sync\Main as Sync_Main;
 
 /**
@@ -37,8 +36,6 @@ class Config {
 		'jitm'       => false,
 		'connection' => false,
 		'sync'       => false,
-		'tracking'   => false,
-		'tos'        => false,
 	);
 
 	/**
@@ -83,12 +80,6 @@ class Config {
 		if ( $this->config['connection'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\Connection\Manager' )
 				&& $this->ensure_feature( 'connection' );
-		}
-
-		if ( $this->config['tracking'] ) {
-			$this->ensure_class( 'Automattic\Jetpack\Terms_Of_Service' )
-				&& $this->ensure_class( 'Automattic\Jetpack\Tracking' )
-				&& $this->ensure_feature( 'tracking' );
 		}
 
 		if ( $this->config['sync'] ) {
@@ -165,40 +156,6 @@ class Config {
 		do_action( 'jetpack_feature_' . $feature . '_enabled' );
 
 		return self::FEATURE_ENSURED;
-	}
-
-	/**
-	 * Dummy method to enable Terms of Service.
-	 */
-	protected function enable_tos() {
-		return true;
-	}
-
-	/**
-	 * Enables the tracking feature.
-	 * Depends on the Terms of Service package and the Connection package,
-	 * so enables them too.
-	 */
-	protected function enable_tracking() {
-
-		// Enabling dependencies.
-		$this->ensure_feature( 'tos' );
-		$this->ensure_feature( 'connection' );
-
-		$terms_of_service = new Terms_Of_Service();
-		$connection       = new Manager();
-		$tracking         = new Plugin_Tracking( $connection );
-
-		if ( $terms_of_service->has_agreed() && $connection->is_user_connected() ) {
-			add_action( 'init', array( $tracking, 'init' ) );
-		} else {
-			/**
-			 * Initialize tracking right after the user agrees to the terms of service.
-			 */
-			add_action( 'jetpack_agreed_to_terms_of_service', array( $tracking, 'init' ) );
-		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
We should consider removing the TOS and Tracking features from the Config package for three reasons:

* These features depend on the `Automattic\Jetpack\Plugin\Tracking` class, which is [located in the Jetpack plugin](https://github.com/Automattic/jetpack/blob/master/src/class-tracking.php#L23). Therefore, it's not possible for other consumer plugins to enable these features using the Config package.

* The Config package does not have any package dependencies, so we need to be extremely careful when making changes to this package. There's no way to guarantee which version of other packages will be installed. Therefore, I think we need to keep this package as small and stable as possible.

* I can't think of a need to configure the Tracking and TOS packages in the Config class. Consumer plugins and other packages will need to set up their own hooks for their specific tracking requirements, similar to Jetpack's `Automattic\Jetpack\Plugin\Tracking::init()` method.


#### Changes proposed in this Pull Request:
* Remove the TOS and Tracking features from the Config package.
* Add the `init` and `jetpack_agreed_to_terms_of_service` action hooks in the `Jetpack::configure()` method.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
##### Verify that connection events are still properly tracked.
1. Install and activate Jetpack.
2. Connect Jetpack.
3. Verify that the `jetpack_jpc_register_success` Tracks event has been recorded.
4. Verify that the `jetpack_wpa_user_linked` Tracks event has been recorded.

#### Proposed changelog entry for your changes:
tbd
