### PR TITLE
Docs: Adding Data Mocker and MySQL info

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -227,6 +227,12 @@ You can also see your database files via local file system at `./docker/data/mys
 
 You can also access it via phpMyAdmin at [http://localhost:8181](http://localhost:8181).
 
+Another way to accessing the database is MySQL client using the following command:
+```sh
+yarn docker:db
+```  
+This command utilizes credentials from the config file (`~/.my.cnf`) to log you into MySQL without entering any connection information.
+
 ## SFTP access
 
 You can access WordPress and Jetpack files via SFTP server container.
@@ -379,6 +385,14 @@ To `tail -f` the PHP error log, run:
 ```sh
 yarn docker:tail
 ```
+
+#### MySQL Slow Query Log
+
+The MySQL Server is configured to log any queries that take longer than 0.5 second to execute.
+
+Path to the slow query log: `docker/logs/mysql/slow.log`.
+
+We recommend to regularly review the log to make sure performance issues don't go unnoticed.
 
 ### Debugging emails
 

--- a/packages/debug-helper/README.md
+++ b/packages/debug-helper/README.md
@@ -26,3 +26,14 @@ REST API tester lets you send custom requests to Jetpack REST API and review the
 Adds some debugging to sync
 
 **Note:** This module is not currently being maintained. 
+
+### Data Mocker
+The tool allows you to mock data in the database for performance testing.
+
+There are two mockers implemented:
+- Options to generate random options.
+- Nonces, to create Jetpack Nonces with random timestamps.
+
+#### Adding a Custom Mocker
+1. Create a class implementing `Automattic\Jetpack\Debug_Helper\Mocker\Runner_Interface` that mocks the data.
+2. Add it into the list in `Automattic\Jetpack\Debug_Helper\Mocker::$runners`.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Added the info about `yarn docker:db` and slow query log into the Docker readme file.
- Described the Data Mocker in the readme of the Jetpack Debug Helper plugin.

#### Jetpack product discussion
`p9dueE-1QC-p2`

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Any mistakes?
- Is it more or less clear?

#### Proposed changelog entry for your changes:
n/a
