### PR TITLE
Calendly Block: Fixes Widget Not Loading on P2 Front End

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -115,27 +115,28 @@ function load_assets( $attr, $content ) {
 				esc_attr( $classes ),
 				esc_attr( $block_id )
 			);
-
-			$init_calendly_widget_js = "Calendly.initInlineWidget({
-				url: '%s',
-				parentElement: document.getElementById('%s'),
-				inlineStyles: false,
-			});";
-
-			if ( $is_p2_site ) {
-				// For P2s only: wait until after o2 has
-				// replaced main#content to initialize widget.
-				$script = <<<JS_END
-jQuery('body').on( 'ready.o2', function( event, domRef ) {
-	$init_calendly_widget_js
-} );
+			$script  = <<<JS_END
+// Give each Calendly init function a unique ID.
+calendlyBlockId = '%s';
+var jetpackInitCalendly = {
+	'calendlyBlockId': function jetpackInitCalendly() {
+						Calendly.initInlineWidget({
+							url: '%s',
+							parentElement: document.getElementById('%s'),
+							inlineStyles: false,
+						})
+					}
+}
+// For P2s only: wait until after o2 has
+// replaced main#content to initialize widget.
+if ( window.jQuery && window.o2 ) {
+	jQuery( 'body' ).on( 'ready.o2', jetpackInitCalendly['calendlyBlockId'] );
+// Else initialize widget without waiting.
+} else {
+	jetpackInitCalendly['calendlyBlockId']();
+}
 JS_END;
-			} else {
-				$script = <<<JS_END
-$init_calendly_widget_js
-JS_END;
-			}
-			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
+			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_js( $block_id ), esc_url( $url ), esc_js( $block_id ) ) );
 		}
 	}
 
@@ -201,7 +202,9 @@ function enqueue_calendly_js() {
 					}
 				} );
 			}
-		}"
+		}
+		// Declare unique ID variable for multiple instances.
+		var calendlyBlockId;"
 	);
 }
 

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -136,6 +136,7 @@ if ( window.jQuery && window.o2 ) {
 } else {
 	jetpackInitCalendly[0]();
 }
+
 JS_END;
 			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
 		}

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -136,7 +136,6 @@ if ( window.jQuery && window.o2 ) {
 } else {
 	jetpackInitCalendly[0]();
 }
-
 JS_END;
 			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
 		}

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -135,6 +135,7 @@ if ( window.jQuery && window.o2 ) {
 } else {
 	jetpackInitCalendly{$escaped_block_id}();
 }
+
 JS_END;
 			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $html_id ) ) );
 		}

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -126,14 +126,14 @@ function load_assets( $attr, $content ) {
 				// For P2s only: wait until after o2 has
 				// replaced main#content to initialize widget.
 				$script = <<<JS_END
-				jQuery('body').on( 'ready.o2', function( event, domRef ) {
-					$init_calendly_widget_js
-				} );
-				JS_END;
+jQuery('body').on( 'ready.o2', function( event, domRef ) {
+	$init_calendly_widget_js
+} );
+JS_END;
 			} else {
 				$script = <<<JS_END
-					$init_calendly_widget_js
-				JS_END;
+$init_calendly_widget_js
+JS_END;
 			}
 			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
 		}

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -135,7 +135,6 @@ if ( window.jQuery && window.o2 ) {
 } else {
 	jetpackInitCalendly{$escaped_block_id}();
 }
-
 JS_END;
 			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $html_id ) ) );
 		}

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -116,27 +116,28 @@ function load_assets( $attr, $content ) {
 				esc_attr( $classes ),
 				esc_attr( $html_id )
 			);
-			$escaped_block_id = esc_js( $block_id );
-			$script           = <<<JS_END
-// Call function with block id in name
+			$script  = <<<JS_END
+// Initialize function as an array object
 // to allow for multiple widgets.
-function jetpackInitCalendly{$escaped_block_id}() {
-	Calendly.initInlineWidget({
-		url: '%s',
-		parentElement: document.getElementById('%s'),
-		inlineStyles: false,
-	});
-};
+var jetpackInitCalendly = [
+	function() {
+		Calendly.initInlineWidget({
+			url: '%s',
+			parentElement: document.getElementById('%s'),
+			inlineStyles: false,
+		})
+	}
+];
 // For P2s only: wait until after o2 has
 // replaced main#content to initialize widget.
 if ( window.jQuery && window.o2 ) {
-	jQuery( 'body' ).on( 'ready.o2', jetpackInitCalendly{$escaped_block_id} );
+	jQuery( 'body' ).on( 'ready.o2', jetpackInitCalendly[0] );
 // Else initialize widget without waiting.
 } else {
-	jetpackInitCalendly{$escaped_block_id}();
+	jetpackInitCalendly[0]();
 }
 JS_END;
-			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $html_id ) ) );
+			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
 		}
 	}
 

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -116,27 +116,27 @@ function load_assets( $attr, $content ) {
 				esc_attr( $block_id )
 			);
 			$script  = <<<JS_END
-// Give each Calendly init function a unique ID.
-calendlyBlockId = '%s';
-var jetpackInitCalendly = {
-	'calendlyBlockId': function jetpackInitCalendly() {
-						Calendly.initInlineWidget({
-							url: '%s',
-							parentElement: document.getElementById('%s'),
-							inlineStyles: false,
-						})
-					}
-}
+// Initialize function as an array object
+// to allow for multiple widgets.
+var jetpackInitCalendly = [
+	function() {
+		Calendly.initInlineWidget({
+			url: '%s',
+			parentElement: document.getElementById('%s'),
+			inlineStyles: false,
+		})
+	}
+];
 // For P2s only: wait until after o2 has
 // replaced main#content to initialize widget.
 if ( window.jQuery && window.o2 ) {
-	jQuery( 'body' ).on( 'ready.o2', jetpackInitCalendly['calendlyBlockId'] );
+	jQuery( 'body' ).on( 'ready.o2', jetpackInitCalendly[0] );
 // Else initialize widget without waiting.
 } else {
-	jetpackInitCalendly['calendlyBlockId']();
+	jetpackInitCalendly[0]();
 }
 JS_END;
-			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_js( $block_id ), esc_url( $url ), esc_js( $block_id ) ) );
+			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
 		}
 	}
 
@@ -202,9 +202,7 @@ function enqueue_calendly_js() {
 					}
 				} );
 			}
-		}
-		// Declare unique ID variable for multiple instances.
-		var calendlyBlockId;"
+		}"
 	);
 }
 

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -115,13 +115,26 @@ function load_assets( $attr, $content ) {
 				esc_attr( $classes ),
 				esc_attr( $block_id )
 			);
-			$script  = <<<JS_END
-Calendly.initInlineWidget({
-	url: '%s',
-	parentElement: document.getElementById('%s'),
-	inlineStyles: false,
-});
-JS_END;
+
+			$init_calendly_widget_js = "Calendly.initInlineWidget({
+				url: '%s',
+				parentElement: document.getElementById('%s'),
+				inlineStyles: false,
+			})";
+
+			if ( $is_p2_site ) {
+				// For P2s only: wait until after o2 has
+				// replaced main#content to initialize widget.
+				$script = <<<JS_END
+				jQuery('body').on( 'ready.o2', function( event, domRef ) {
+					_.defer( $init_calendly_widget_js );
+				} );
+				JS_END;
+			} else {
+				$script = <<<JS_END
+					$init_calendly_widget_js;
+				JS_END;
+			}
 			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
 		}
 	}

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -120,19 +120,19 @@ function load_assets( $attr, $content ) {
 				url: '%s',
 				parentElement: document.getElementById('%s'),
 				inlineStyles: false,
-			})";
+			});";
 
 			if ( $is_p2_site ) {
 				// For P2s only: wait until after o2 has
 				// replaced main#content to initialize widget.
 				$script = <<<JS_END
 				jQuery('body').on( 'ready.o2', function( event, domRef ) {
-					_.defer( $init_calendly_widget_js );
+					$init_calendly_widget_js
 				} );
 				JS_END;
 			} else {
 				$script = <<<JS_END
-					$init_calendly_widget_js;
+					$init_calendly_widget_js
 				JS_END;
 			}
 			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -105,13 +105,8 @@ function load_assets( $attr, $content ) {
 		if ( $is_amp_request ) {
 			$content = sprintf(
 				'<div class="%1$s" id="%2$s"><a href="%3$s" role="button" target="_blank">%4$s</a></div>',
-<<<<<<< HEAD
 				esc_attr( Blocks::classes( FEATURE_NAME, $attr ) ),
-				esc_attr( $block_id ),
-=======
-				esc_attr( Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr ) ),
 				esc_attr( $html_id ),
->>>>>>> Add the unique block id to each Calendly call to call a different function for each Calendly block on the page
 				esc_js( $url ),
 				wp_kses_post( get_attribute( $attr, 'submitButtonText' ) )
 			);

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -111,7 +111,7 @@ function load_assets( $attr, $content ) {
 				wp_kses_post( get_attribute( $attr, 'submitButtonText' ) )
 			);
 		} else {
-			$content = sprintf(
+			$content          = sprintf(
 				'<div class="%1$s" id="%2$s"></div>',
 				esc_attr( $classes ),
 				esc_attr( $html_id )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15935 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* If jQuery and o2 are available, bind the `ready.o2` [event](https://backbonejs.org/#Events-on) to the body element and initialize the Calendly widget in the callback. This loads the Calendly widget _after_ the o2 plugin has replaced main#content.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See 426-gh-p2tenberg

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Only a12s can test this fix.
* Apply D49317 to your sandbox with a premium plan.
* Activate the P2020 theme with wp cli: `wp theme activate pub/p2020 --url=[siteurl]`
* Enable Calendly blocks by commenting out wp-content/plugins/p2tenberg-wpcom/p2tenberg-wpcom.php line 159 (`'jetpack/calendly',`)
* Create a post and insert the Calendly block, and add a Calendly link.
* The block should embed a Calendly widget in the editor.
* Save the post and preview/view it in the front end.
* Check that the index can display multiple Calendly widgets.
* Regression test that the Calendly widget still displays correctly on Atomic, self-hosted, and simple non-P2 paid plan sites.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Update the Calendly block to work with a8c P2s.