### PR TITLE
Instant Search: Proxy requests for searching private Atomic sites

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\Connection\Client;
  * Jetpack Search: Makes authenticated requests to the site search API using blog tokens.
  * This endpoint will only be used when trying to search private Jetpack and WordPress.com sites.
  *
- * @since 8.10
+ * @since 9.0.0
  */
 class WPCOM_REST_API_V2_Endpoint_Search extends WP_REST_Controller {
 	/**

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Proxy endpoint for Jetpack Search
+ *
+ * @package Jetpack
+ */
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Jetpack Search: Makes authenticated requests to the site search API using blog tokens.
+ * This endpoint will only be used when trying to search private Jetpack and WordPress.com sites.
+ *
+ * @since 8.10
+ */
+class WPCOM_REST_API_V2_Endpoint_Search extends WP_REST_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'search';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Called automatically on `rest_api_init()`.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_search_results' ),
+					'permission_callback' => 'is_user_logged_in',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Returns search results for the current blog.
+	 *
+	 * @param WP_REST_Request $request The REST API request data.
+	 * @return mixed The REST API response from public-api.
+	 */
+	public function get_search_results( $request ) {
+		$is_wpcom = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
+		$site_id  = $is_wpcom ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return new WP_Error(
+				'unavailable_site_id',
+				__( 'Sorry, something is wrong with your Jetpack connection.', 'jetpack' ),
+				403
+			);
+		}
+
+		$path    = add_query_arg(
+			$request->get_query_params(),
+			sprintf( '/sites/%d/search', absint( $site_id ) )
+		);
+		$request = Client::wpcom_json_api_request_as_blog( $path, '1.3' );
+		$body    = json_decode( wp_remote_retrieve_body( $request ) );
+		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
+			return $body;
+		}
+
+		return new WP_Error(
+			$body->error,
+			$body->message,
+			array( 'status' => wp_remote_retrieve_response_code( $request ) )
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Search' );

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -34,6 +34,7 @@ module.exports = [
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php',
+	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php',
 	'_inc/lib/core-api/wpcom-endpoints/memberships.php',
 	'_inc/lib/debugger/',

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -245,8 +245,6 @@ export function search( options ) {
 
 	const pathForPublicApi = `/sites/${ options.siteId }/search?${ queryString }`;
 
-	// TODO: Remove eslint exception when adding atomic private site support
-	// eslint-disable-next-line no-unused-vars
 	const { apiNonce, apiRoot, isPrivateSite, isWpcom } = window[ SERVER_OBJECT_NAME ];
 	if ( isPrivateSite && isWpcom ) {
 		return import( 'wpcom-proxy-request' ).then( ( { default: proxyRequest } ) => {
@@ -256,11 +254,12 @@ export function search( options ) {
 		} );
 	}
 
-	// NOTE: This urlForPrivateApi will be enabled once locally proxied API route for private sites is complete.
+	// NOTE: Both atomic and Jetpack sites can be set to "private".
 	const urlForPublicApi = `https://public-api.wordpress.com/rest/v1.3${ pathForPublicApi }`;
-	// const urlForPrivateApi = `${ apiRoot }wpcom/v2/search?${ queryString }`;
-	const url = urlForPublicApi;
+	const urlForPrivateApi = `${ apiRoot }wpcom/v2/search?${ queryString }`;
+	const url = isPrivateSite ? urlForPrivateApi : urlForPublicApi;
 
+	// NOTE: API Nonce is necessary to authenticate requests to class-wpcom-rest-api-v2-endpoint-search.php.
 	return fetch( url, { headers: isPrivateSite ? { 'X-WP-Nonce': apiNonce } : {} } )
 		.then( response => {
 			if ( ! response.ok || response.status !== 200 ) {


### PR DESCRIPTION
Spun off from #16938.

#### Changes proposed in this Pull Request:
* Creates a new endpoint for proxying authenticated requests to the WordPress.com API. This change is only compatible with Atomic sites with `blog_public === '-1'`.

#### Jetpack product discussion
See p1HpG7-a1g-p2 and p9dueE-1Nq-p2.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Spin up a new Atomic site and use the [Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/) to enable this branch. For the sake of indexing, keep the site visible to the public.
* Purchase Jetpack Search and ensure that instant search has been enabled automatically.
* Try a site search. 
  * Ensure that your site has been properly indexed and shows valid search results. 
  * Verify that the API requests are made to `https://public-api.wordpress.com/rest/v1.3/sites/<siteId>/search`.
* Change the site visibility to private by setting `blog_public` to `"-1"`. Ensure that your current browser session is logged in by checking that you can access `/wp-admin/`.
* Repeat a site search. 
  * Ensure that you see valid search results.
  * Verify that the API requests are made to `/wp-json/wpcom/v2/search` (which then proxies your search requests to WPCOM API on the user's behalf).

#### Proposed changelog entry for your changes:
* None.
