### PR TITLE
Instant Search: Fix bugs preventing search results from rendering

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -123,6 +123,20 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		}
 
 		$excluded_post_types   = get_option( $prefix . 'excluded_post_types' ) ? explode( ',', get_option( $prefix . 'excluded_post_types', '' ) ) : array();
+		$post_types            = array_values(
+			get_post_types(
+				array(
+					'exclude_from_search' => false,
+					'public'              => true,
+				)
+			)
+		);
+		$unexcluded_post_types = array_diff( $post_types, $excluded_post_types );
+		// NOTE: If all post types are being excluded, ignore the option value.
+		if ( count( $unexcluded_post_types ) === 0 ) {
+			$excluded_post_types = array();
+		}
+
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -122,6 +122,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$posts_per_page = 20;
 		}
 
+		$excluded_post_types   = get_option( $prefix . 'excluded_post_types' ) ? explode( ',', get_option( $prefix . 'excluded_post_types', '' ) ) : array();
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
@@ -150,7 +151,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),
-			'excludedPostTypes'     => explode( ',', get_option( $prefix . 'excluded_post_types', '' ) ),
+			'excludedPostTypes'     => $excluded_post_types,
 
 			// widget info.
 			'hasOverlayWidgets'     => count( $overlay_widget_ids ) > 0,

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -256,10 +256,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * Run the aggregations API query for any filtering
 	 *
 	 * @since 8.3.0
-	 *
-	 * @param WP_Query $query The WP_Query being filtered.
 	 */
-	public function action__parse_query( $query ) {
+	public function action__parse_query() {
 		if ( ! empty( $this->search_result ) ) {
 			return;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
* Fixes handling of `explode` to ensure that `[ '' ]` is never returned to the JavaScript application. When this is passed through as an excluded post types value, the search API returns zero results.
* Fixes handling of instances where all post types have been accidentally excluded. In these cases, the option value is ignored altogether.

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
None.

#### Testing instructions:
* Apply this patch to your Jetpack site that has already been indexed by Jetpack Search.
* Ensure that no post types have been excluded in the Jetpack Search section of the customizer.
* Try a search; ensure that you receive the expected search results.
* Try excluding some post types in the customizer. Repeat the search and ensure that the results are as expected.
* Try excluding all post types in the customizer. Repeat the search and ensure that the results are the same as when you've excluded no post types.

#### Proposed changelog entry for your changes:
* Fixes a bug where no results would appear for Jetpack Search.
