### PR TITLE
Build: Ensure that production builds are valid ES5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,11 @@
 		"build-search:styles": "gulp sass:instant-search",
 		"build-php": "composer install --ignore-platform-reqs",
 		"build-production-php": "COMPOSER_MIRROR_PATH_REPOS=1 composer install -o --no-dev --classmap-authoritative --prefer-dist",
-		"build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client",
-		"build-production": "yarn distclean && yarn install --production=false && yarn build-production-client && yarn build-production-php && NODE_ENV=production yarn build-extensions && NODE_ENV=production yarn build-search && NODE_ENV=production yarn build-packages",
+		"build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client && yarn validate-es5 -- ./_inc/build/",
+		"build-production-extensions": "NODE_ENV=production BABEL_ENV=production yarn build-extensions",
+		"build-production-packages": "NODE_ENV=production BABEL_ENV=production yarn build-packages && yarn validate-es5 -- ./packages/lazy-images/",
+		"build-production-search": "NODE_ENV=production BABEL_ENV=production yarn build-search && yarn validate-es5 -- ./_inc/build/instant-search/",
+		"build-production": "yarn distclean && yarn install --production=false && yarn build-production-client && yarn build-production-php && yarn build-production-extensions && yarn build-production-search && yarn build-production-packages",
 		"build-production-concurrently": "yarn distclean && yarn install --production=false && yarn concurrently 'yarn build-production-client' 'yarn build-production-php' 'NODE_ENV=production yarn build-extensions' 'NODE_ENV=production yarn build-search' 'NODE_ENV=production yarn build-packages'",
 		"docker:compose": "yarn docker:env && yarn docker:compose-volumes && yarn docker:compose-extras && docker-compose -f docker/docker-compose.yml -f docker/compose-volumes.built.yml -f docker/compose-extras.yml",
 		"docker:up": "yarn docker:compose up",
@@ -83,6 +86,7 @@
 		"test-dangerci-and-adminpage-and-extensions-and-search": "yarn concurrently 'yarn danger ci' 'yarn test-adminpage' 'yarn test-extensions' 'yarn test-search'",
 		"test-search": "jest modules/search",
 		"reformat-files": "./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json}\"",
+		"validate-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore",
 		"version-packages": "bash ./bin/version-packages.sh"
 	},
 	"husky": {

--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -90,10 +90,6 @@ const extensionsWebpackConfig = getBaseWebpackConfig(
 	}
 );
 
-const transpileConfig = extensionsWebpackConfig.module.rules.find( rule =>
-	rule.use.some( loader => loader.options.presets )
-);
-
 const componentsWebpackConfig = getBaseWebpackConfig(
 	{ WP: false },
 	{
@@ -112,15 +108,6 @@ const componentsWebpackConfig = getBaseWebpackConfig(
 module.exports = [
 	{
 		...extensionsWebpackConfig,
-		// The `module` override fixes https://github.com/Automattic/jetpack/issues/12511.
-		// @TODO Remove once there's a fix in `@automattic/calypso-build`
-		module: {
-			...extensionsWebpackConfig.module,
-			rules: [
-				{ ...transpileConfig, exclude: /node_modules\/(?!punycode)/ },
-				..._.without( extensionsWebpackConfig.module.rules, transpileConfig ),
-			],
-		},
 		plugins: [
 			...extensionsWebpackConfig.plugins,
 			new CopyWebpackPlugin( [


### PR DESCRIPTION
Fixes #13693.

#### Changes proposed in this Pull Request:

Add ES5 validation to production builds.

Inspired by https://github.com/Automattic/wp-calypso/pull/36596.

Can't currently add it to the `extension` build, since there are non-ES5 constructs in them.

#### Jetpack product discussion
Code quality.

#### Does this pull request change what data or activity we track or use?
Nah.

#### Testing instructions:
Run `yarn build-production`, and verify that eslint doesn't report any errors at the end.

#### Proposed changelog entry for your changes:
Add ES5 validation to production builds.