### PR TITLE
Infinite Scroll: Set the number of posts for the 'click' option to the global setting

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -249,14 +249,15 @@ class The_Neverending_Home_Page {
 	 * @return int
 	 */
 	static function posts_per_page() {
-		$posts_per_page = self::get_settings()->posts_per_page ? self::get_settings()->posts_per_page : self::wp_query()->get( 'posts_per_page' );
+		$posts_per_page             = self::get_settings()->posts_per_page ? self::get_settings()->posts_per_page : self::wp_query()->get( 'posts_per_page' );
+		$posts_per_page_core_option = get_option( 'posts_per_page' );
 
 		// If Infinite Scroll is set to click, and if the site owner changed posts_per_page, let's use that.
 		if (
 			'click' === self::get_settings()->type
-				&& ( '10' !== get_option( 'posts_per_page' ) )
+				&& ( '10' !== $posts_per_page_core_option )
 		) {
-			$posts_per_page = get_option( 'posts_per_page' );
+			$posts_per_page = $posts_per_page_core_option;
 		}
 
 		// Take JS query into consideration here.

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -251,7 +251,15 @@ class The_Neverending_Home_Page {
 	static function posts_per_page() {
 		$posts_per_page = self::get_settings()->posts_per_page ? self::get_settings()->posts_per_page : self::wp_query()->get( 'posts_per_page' );
 
-		// Take JS query into consideration here
+		// If Infinite Scroll is set to click, and if the site owner changed posts_per_page, let's use that.
+		if (
+			'click' === self::get_settings()->type
+				&& ( '10' !== get_option( 'posts_per_page' ) )
+		) {
+			$posts_per_page = get_option( 'posts_per_page' );
+		}
+
+		// Take JS query into consideration here.
 		if ( true === isset( $_REQUEST['query_args']['posts_per_page'] ) ) {
 			$posts_per_page = $_REQUEST['query_args']['posts_per_page'];
 		}


### PR DESCRIPTION
#9120 made a change to Infinite Scroll which changed the behaviour for the "click" option.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This reinstates only behaviour in Infinite Sroll thus:

If infinite scroll is set to `click` and the user has a `posts_per_page` setting which is different from the default (10) then use that instead of the theme value.

cc @mikejolley

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16471


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Choose a theme that supports infinite scroll (e.g. Pictorico)
* Turn on Infinite Scroll with this setting: "Load more posts in page with a button"
* Change the posts per page setting on wp-admin/options-reading.php to a number that isn't 10
* Check that this number of posts loads on the frontend.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Load the user's setting for posts per page in Infinite Scroll if it's not the default
