### PR TITLE
E2E Tests: Fix WPORG login failures

### DIFF
--- a/tests/e2e/lib/page-helper.js
+++ b/tests/e2e/lib/page-helper.js
@@ -74,7 +74,7 @@ export async function waitAndClick( page, selector, options = { visible: true } 
  * @param {string} value Value to type into
  * @param {Object} options Custom options to modify function behavior. The same object passes in two different functions. Use with caution!
  */
-export async function waitAndType( page, selector, value, options = { visible: true } ) {
+export async function waitAndType( page, selector, value, options = { visible: true, delay: 1 } ) {
 	const el = await waitForSelector( page, selector, options );
 
 	try {

--- a/tests/e2e/lib/pages/wp-admin/login.js
+++ b/tests/e2e/lib/pages/wp-admin/login.js
@@ -27,7 +27,9 @@ export default class WPLoginPage extends Page {
 		await waitAndType( this.page, '#user_login', username );
 		await waitAndType( this.page, '#user_pass', password );
 
-		await this.page.click( '#wp-submit' );
+		const navigationPromise = this.page.waitForNavigation();
+		await waitAndClick( this.page, '#wp-submit' );
+		await navigationPromise;
 
 		try {
 			await waitForSelector( this.page, this.expectedSelector, {


### PR DESCRIPTION
Sometimes, WPORG login fails due (probably) invalid login/password typed in. I guess it might happen because the puppeteer logs in too fast

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
-
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
-
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This issue is hard to test since it happens quite rarely. 
* Looking through code should be enough

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
