### PR TITLE
infinity: remove spinner when request completes but response is empty

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -374,6 +374,9 @@
 				responseCheck = 'undefined' !== typeof response.html;
 
 			if ( ! response || ! httpCheck || ! responseCheck ) {
+				if ( self.click_handle ) {
+					loader.parentNode.removeChild( loader );
+				}
 				return;
 			}
 


### PR DESCRIPTION
Summary:
Reported in 1014-gh-p2

Current code clears the spinner when the infinity xhr call responds with an error, or when the request succeeds and the payload is processed completely.

When two xhr calls are made in quick succession, and one of the calls returns first with the final payload batch, the second call will also succeed but with a payload of `{"type":"empty"}`, which can result in the infinity spinner never being cleared.

 In this changeset, we cover the case described above.

Test Plan:
1. Test on a P2020 site with only a few posts -- i.e. not enough posts to fill the screen when in compact view.
2. Scroll your browser to the very bottom, and reload.
3. After the very last post (oldest) is loaded, the spinner should clear.
4. Test on Default/Expanded view, and also on non-P2 sites with infinite scroll-enabled themes, e.g. pub/twentytwenty. Infinite scroll should still behave well.

Reviewers: #lighthouse_team, undemian

Reviewed By: #lighthouse_team, undemian

Subscribers: undemian

Tags: #touches_jetpack_files

Differential Revision: D49344-code

This commit syncs r213450-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Clears the infinite scroll loader when response returns and payload is empty.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Test on a P2020 site with only a few posts -- i.e. not enough posts to fill the screen when in compact view.
2. Scroll your browser to the very bottom, and reload.
3. After the very last post (oldest) is loaded, the spinner should clear.
4. Test on Default/Expanded view, and also on non-P2 sites with infinite scroll-enabled themes, e.g. pub/twentytwenty. Infinite scroll should still behave well.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* infinity: clear spinner when response completes and payload is empty
