### PR TITLE
Fix slideshow images not appearing

### DIFF
--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -40,7 +40,7 @@
 			margin: 0;
 			line-height: normal;
 		}
-		.wp-block-jetpack-slideshow_swiper-wrapper {
+		ul.wp-block-jetpack-slideshow_swiper-wrapper {
 			display: flex;
 		}
 	}

--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -40,6 +40,9 @@
 			margin: 0;
 			line-height: normal;
 		}
+		.wp-block-jetpack-slideshow_swiper-wrapper {
+			display: flex;
+		}
 	}
 
 	.wp-block-jetpack-slideshow_slide {


### PR DESCRIPTION
#### Summary
In a few themes, the slideshow images are not appearing in view due to the theme CSS superseding the display.

#### Before
[![Screenshot](https://d.pr/i/tAhrGP+)](https://d.pr/i/tAhrGP)

#### After
[![Screenshot](https://d.pr/i/FmhjnW+)](https://d.pr/i/FmhjnW)

#### Test Page
https://business-plan.blog/sample-page/

Fixes #17133 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a more specific styling to the slideshow display to prevent theme overrides

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Swell theme
* Add Slideshow Block to a page or posts with images.
* Publish the changes and view the page/post from the front end

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry needed
