### PR TITLE
Jetpack Debugger: Fixing the user token health check.

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -410,7 +410,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$name = __FUNCTION__;
 
 		$m                = new Connection_Manager();
-		$validated_tokens = $m->validate_tokens();
+		$validated_tokens = $m->validate_tokens( get_current_user_id() ? get_current_user_id() : $m->get_connection_owner_id() );
 
 		if ( ! is_array( $validated_tokens ) || count( array_diff_key( array_flip( array( 'blog_token', 'user_token' ) ), $validated_tokens ) ) ) {
 			return self::skipped_test(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The token check was introduced in the PR #17028.
Unfortunately, it's breaking the Jetpack Debugger (the one on `tools.jetpack.com`) because there is no user logged into WP when it runs.
This commit fixes the problem by checking the connection owner's token by default.

<img width="867" alt="Screen Shot 2020-09-10 at 3 37 41 PM" src="https://user-images.githubusercontent.com/1341249/92801847-98e6a200-f37b-11ea-991a-77ba3f99f837.png">

#### Jetpack product discussion
`p9dueE-1NT-p2`

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Go to https://tools.jetpack.com/debug/ and debug your site. All tests should pass.
2. Go to the Debugging Center (`/wp-admin/admin.php?page=jetpack-debugger`) and confirm that there are no errors.
3. Go break the user token via the Broken Token plugin.
4. Go back to https://tools.jetpack.com/debug/ and debug your site. You should see an error: `server error. requested method jetpack.testConnection does not exist`. This is fine for now, we'll need to make it validate the user token separately.
5. Go back to the Debugging Center (`/wp-admin/admin.php?page=jetpack-debugger`), you should see an error: `Connection test failed: Invalid Jetpack tokens`.

#### Proposed changelog entry for your changes:
n/a.
