### PR TITLE
API: Remove the constant `JETPACK_CLIENT__HTTPS`.

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -173,7 +173,7 @@ class Jetpack_Provision { //phpcs:ignore
 
 		$blog_id = Jetpack_Options::get_option( 'id' );
 		$url     = esc_url_raw( sprintf(
-			'https://%s/rest/v1.3/jpphp/%d/partner-provision',
+			'%s/rest/v1.3/jpphp/%d/partner-provision',
 			self::get_api_host(),
 			$blog_id
 		) );
@@ -253,7 +253,7 @@ class Jetpack_Provision { //phpcs:ignore
 			'body'    => ''
 		);
 
-		$url = sprintf( 'https://%s/rest/v1.3/jpphp/partner-keys/verify', self::get_api_host() );
+		$url    = sprintf( '%s/rest/v1.3/jpphp/partner-keys/verify', self::get_api_host() );
 		$result = Client::_wp_remote_request( $url, $request );
 
 		if ( is_wp_error( $result ) ) {
@@ -276,6 +276,6 @@ class Jetpack_Provision { //phpcs:ignore
 
 	private static function get_api_host() {
 		$env_api_host = getenv( 'JETPACK_START_API_HOST', true ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.getenv_local_onlyFound
-		return $env_api_host ? $env_api_host : JETPACK__WPCOM_JSON_API_HOST;
+		return $env_api_host ? 'https://' . $env_api_host : JETPACK__WPCOM_JSON_API_BASE;
 	}
 }

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -827,7 +827,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		$self_xml_rpc_url = site_url( 'xmlrpc.php' );
 
-		$testsite_url = Connection_Utils::fix_url_for_bad_hosts( JETPACK__API_BASE . 'testsite/1/?url=' );
+		$testsite_url = JETPACK__API_BASE . 'testsite/1/?url=';
 
 		// Using PHP_INT_MAX - 1 so that there is still a way to override this if needed and since it only impacts this one call.
 		add_filter( 'http_request_timeout', array( 'Jetpack_Cxn_Tests', 'increase_timeout' ), PHP_INT_MAX - 1 );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1131,7 +1131,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			'method'  => 'POST',
 		);
 
-		$url = sprintf( 'https://%s/rest/v1.3/jpphp/%s/partner-cancel', $this->get_api_host(), $site_identifier );
+		$url = sprintf( '%s/rest/v1.3/jpphp/%s/partner-cancel', $this->get_api_host(), $site_identifier );
 		if ( ! empty( $named_args ) && ! empty( $named_args['partner_tracking_id'] ) ) {
 			$url = esc_url_raw( add_query_arg( 'partner_tracking_id', $named_args['partner_tracking_id'], $url ) );
 		}
@@ -1790,7 +1790,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 	private function get_api_host() {
 		$env_api_host = getenv( 'JETPACK_START_API_HOST', true );
-		return $env_api_host ? $env_api_host : JETPACK__WPCOM_JSON_API_HOST;
+		return $env_api_host ? 'https://' . $env_api_host : JETPACK__WPCOM_JSON_API_BASE;
 	}
 
 	private function partner_provision_error( $error ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6520,6 +6520,10 @@ endif;
 				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
+			'jetpack_can_make_outbound_https'   => array(
+				'replacement' => null,
+				'version'     => 'jetpack-9.1.0',
+			),
 		);
 
 		foreach ( $filter_deprecated_list as $tag => $args ) {

--- a/functions.global.php
+++ b/functions.global.php
@@ -268,7 +268,7 @@ function jetpack_render_tos_blurb() {
  * @return array|bool|WP_Error
  */
 function jetpack_theme_update( $preempt, $r, $url ) {
-	if ( false !== stripos( $url, JETPACK__WPCOM_JSON_API_HOST . '/rest/v1/themes/download' ) ) {
+	if ( 0 === stripos( $url, JETPACK__WPCOM_JSON_API_BASE . '/rest/v1/themes/download' ) ) {
 		$file = $r['filename'];
 		if ( ! $file ) {
 			return new WP_Error( 'problem_creating_theme_file', esc_html__( 'Problem creating file for theme download', 'jetpack' ) );

--- a/jetpack.php
+++ b/jetpack.php
@@ -24,11 +24,30 @@ define( 'JETPACK__PLUGIN_FILE', __FILE__ );
 
 defined( 'JETPACK__RELEASE_POST_BLOG_SLUG' ) || define( 'JETPACK__RELEASE_POST_BLOG_SLUG', 'jetpackreleaseblog.wordpress.com' );
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
+
+/**
+ * WP.com API no longer supports `http://` protocol.
+ * This means Jetpack can't function properly on servers that can't send outbound HTTPS requests.
+ * The constant is no longer used.
+ *
+ * @deprecated 9.0.0
+ */
 defined( 'JETPACK_CLIENT__HTTPS' ) || define( 'JETPACK_CLIENT__HTTPS', 'AUTO' );
+
 defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) || define( 'JETPACK__GLOTPRESS_LOCALES_PATH', JETPACK__PLUGIN_DIR . 'locales.php' );
 defined( 'JETPACK__API_BASE' ) || define( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
 defined( 'JETPACK_PROTECT__API_HOST' ) || define( 'JETPACK_PROTECT__API_HOST', 'https://api.bruteprotect.com/' );
+defined( 'JETPACK__WPCOM_JSON_API_BASE' ) || define( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+/**
+ * WP.com API no longer supports `http://` protocol.
+ * Use `JETPACK__WPCOM_JSON_API_BASE` instead, which has the protocol hardcoded.
+ *
+ * @deprecated 9.0.0
+ */
 defined( 'JETPACK__WPCOM_JSON_API_HOST' ) || define( 'JETPACK__WPCOM_JSON_API_HOST', 'public-api.wordpress.com' );
+
+
 defined( 'JETPACK__SANDBOX_DOMAIN' ) || define( 'JETPACK__SANDBOX_DOMAIN', '' );
 defined( 'JETPACK__DEBUGGER_PUBLIC_KEY' ) || define(
 	'JETPACK__DEBUGGER_PUBLIC_KEY',

--- a/jetpack.php
+++ b/jetpack.php
@@ -30,7 +30,7 @@ defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCA
  * This means Jetpack can't function properly on servers that can't send outbound HTTPS requests.
  * The constant is no longer used.
  *
- * @deprecated 9.0.0
+ * @deprecated 9.1.0
  */
 defined( 'JETPACK_CLIENT__HTTPS' ) || define( 'JETPACK_CLIENT__HTTPS', 'AUTO' );
 
@@ -43,7 +43,7 @@ defined( 'JETPACK__WPCOM_JSON_API_BASE' ) || define( 'JETPACK__WPCOM_JSON_API_BA
  * WP.com API no longer supports `http://` protocol.
  * Use `JETPACK__WPCOM_JSON_API_BASE` instead, which has the protocol hardcoded.
  *
- * @deprecated 9.0.0
+ * @deprecated 9.1.0
  */
 defined( 'JETPACK__WPCOM_JSON_API_HOST' ) || define( 'JETPACK__WPCOM_JSON_API_HOST', 'public-api.wordpress.com' );
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -864,6 +864,8 @@ class Jetpack_Protect_Module {
 	 * @deprecated 9.0.0 Use constant `JETPACK_PROTECT__API_HOST` instead.
 	 */
 	function get_api_host() {
+		_deprecated_function( __METHOD__, 'jetpack-9.0.0' );
+
 		return JETPACK_PROTECT__API_HOST;
 	}
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -861,10 +861,10 @@ class Jetpack_Protect_Module {
 	 *
 	 * @return string
 	 *
-	 * @deprecated 9.0.0 Use constant `JETPACK_PROTECT__API_HOST` instead.
+	 * @deprecated 9.1.0 Use constant `JETPACK_PROTECT__API_HOST` instead.
 	 */
 	function get_api_host() {
-		_deprecated_function( __METHOD__, 'jetpack-9.0.0' );
+		_deprecated_function( __METHOD__, 'jetpack-9.1.0' );
 
 		return JETPACK_PROTECT__API_HOST;
 	}

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -25,9 +25,7 @@ class Jetpack_Protect_Module {
 	public $whitelist;
 	public $whitelist_error;
 	public $whitelist_saved;
-	private $user_ip;
 	private $local_host;
-	private $api_endpoint;
 	public $last_request;
 	public $last_response_raw;
 	public $last_response;
@@ -750,7 +748,7 @@ class Jetpack_Protect_Module {
 			'timeout'     => absint( $timeout )
 		);
 
-		$response_json           = wp_remote_post( $this->get_api_host(), $args );
+		$response_json           = wp_remote_post( JETPACK_PROTECT__API_HOST, $args );
 		$this->last_response_raw = $response_json;
 
 		$transient_name = $this->get_transient_name();
@@ -858,15 +856,15 @@ class Jetpack_Protect_Module {
 		return get_transient( $transient );
 	}
 
+	/**
+	 * Get the API host.
+	 *
+	 * @return string
+	 *
+	 * @deprecated 9.0.0 Use constant `JETPACK_PROTECT__API_HOST` instead.
+	 */
 	function get_api_host() {
-		if ( isset( $this->api_endpoint ) ) {
-			return $this->api_endpoint;
-		}
-
-		//Check to see if we can use SSL
-		$this->api_endpoint = Connection_Utils::fix_url_for_bad_hosts( JETPACK_PROTECT__API_HOST );
-
-		return $this->api_endpoint;
+		return JETPACK_PROTECT__API_HOST;
 	}
 
 	function get_local_host() {

--- a/modules/videopress/class.videopress-edit-attachment.php
+++ b/modules/videopress/class.videopress-edit-attachment.php
@@ -152,9 +152,8 @@ class VideoPress_Edit_Attachment {
 	 */
 	public function make_video_api_path( $guid ) {
 		return sprintf(
-			'%s://%s/rest/v%s/videos/%s',
-			'https',
-			'public-api.wordpress.com', // JETPACK__WPCOM_JSON_API_HOST,
+			'%s/rest/v%s/videos/%s',
+			JETPACK__WPCOM_JSON_API_BASE,
 			Client::WPCOM_JSON_API_VERSION,
 			$guid
 		);
@@ -295,11 +294,11 @@ class VideoPress_Edit_Attachment {
 <div class="misc-pub-section misc-pub-shortcode">
 	<strong>Shortcode</strong><br>
 	{$shortcode}
-</div> 
+</div>
 <div class="misc-pub-section misc-pub-url">
 	<strong>Url</strong>
 	{$url}
-</div> 
+</div>
 <div class="misc-pub-section misc-pub-poster">
 	<strong>Poster</strong>
 	{$poster}
@@ -317,10 +316,10 @@ class VideoPress_Edit_Attachment {
 			jQuery.ajax( {
 				type: 'post',
 				url: 'admin-ajax.php',
-				data: { 
+				data: {
 					action: 'videopress-update-transcoding-status',
 					post_id: '{$post_id}',
-					_ajax_nonce: '{$nonce}' 
+					_ajax_nonce: '{$nonce}'
 				},
 				complete: function( response ) {
 					if ( 200 === response.status ) {

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -492,9 +492,8 @@ function is_videopress_attachment( $post_id ) {
  */
 function videopress_make_video_get_path( $guid ) {
 	return sprintf(
-		'%s://%s/rest/v%s/videos/%s',
-		'https',
-		JETPACK__WPCOM_JSON_API_HOST,
+		'%s/rest/v%s/videos/%s',
+		JETPACK__WPCOM_JSON_API_BASE,
 		Client::WPCOM_JSON_API_VERSION,
 		$guid
 	);

--- a/packages/compat/legacy/class-jetpack-client.php
+++ b/packages/compat/legacy/class-jetpack-client.php
@@ -76,7 +76,6 @@ class Jetpack_Client {
 	 * The option is checked on each request.
 	 *
 	 * @internal
-	 * @see Utils::fix_url_for_bad_hosts()
 	 *
 	 * @param String  $url the request URL.
 	 * @param array   $args request arguments.

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -311,9 +311,7 @@ class Jetpack_XMLRPC_Server {
 		$nonce = sanitize_text_field( $request['nonce'] );
 		unset( $request['nonce'] );
 
-		$api_url  = Connection_Utils::fix_url_for_bad_hosts(
-			$this->connection->api_url( 'partner_provision_nonce_check' )
-		);
+		$api_url  = $this->connection->api_url( 'partner_provision_nonce_check' );
 		$response = Client::_wp_remote_request(
 			esc_url_raw( add_query_arg( 'nonce', $nonce, $api_url ) ),
 			array( 'method' => 'GET' ),

--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -446,6 +446,8 @@ class Client {
 	 * @deprecated 9.0.0 WP.com API no longer supports requests using `http://`.
 	 */
 	public static function protocol() {
+		_deprecated_function( __METHOD__, 'jetpack-9.0.0' );
+
 		return 'https';
 	}
 }

--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -138,7 +138,6 @@ class Client {
 		}
 
 		$url = add_query_arg( urlencode_deep( $url_args ), $args['url'] );
-		$url = Utils::fix_url_for_bad_hosts( $url );
 
 		$signature = $jetpack_signature->sign_request( $token_key, $timestamp, $nonce, $body_hash, $method, $url, $body, false );
 
@@ -178,7 +177,6 @@ class Client {
 	 * The option is checked on each request.
 	 *
 	 * @internal
-	 * @see Utils::fix_url_for_bad_hosts()
 	 *
 	 * @param String  $url the request URL.
 	 * @param array   $args request arguments.
@@ -333,9 +331,8 @@ class Client {
 		$args['user_id'] = get_current_user_id();
 		$args['method']  = isset( $args['method'] ) ? strtoupper( $args['method'] ) : 'GET';
 		$args['url']     = sprintf(
-			'%s://%s/%s/v%s/%s',
-			self::protocol(),
-			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_HOST' ),
+			'%s/%s/v%s/%s',
+			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 			$base_api_path,
 			$version,
 			$path
@@ -389,9 +386,8 @@ class Client {
 		$request_method = ( isset( $filtered_args['method'] ) ) ? $filtered_args['method'] : 'GET';
 
 		$url = sprintf(
-			'%s://%s/%s/v%s/%s',
-			self::protocol(),
-			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_HOST' ),
+			'%s/%s/v%s/%s',
+			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 			$base_api_path,
 			$version,
 			$_path
@@ -445,18 +441,11 @@ class Client {
 	/**
 	 * Gets protocol string.
 	 *
-	 * @return string `https` (if possible), else `http`.
+	 * @return string Always 'https'.
+	 *
+	 * @deprecated 9.0.0 WP.com API no longer supports requests using `http://`.
 	 */
 	public static function protocol() {
-		/**
-		 * Determines whether Jetpack can send outbound https requests to the WPCOM api.
-		 *
-		 * @since 3.6.0
-		 *
-		 * @param bool $proto Defaults to true.
-		 */
-		$https = apply_filters( 'jetpack_can_make_outbound_https', true );
-
-		return $https ? 'https' : 'http';
+		return 'https';
 	}
 }

--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -443,10 +443,10 @@ class Client {
 	 *
 	 * @return string Always 'https'.
 	 *
-	 * @deprecated 9.0.0 WP.com API no longer supports requests using `http://`.
+	 * @deprecated 9.1.0 WP.com API no longer supports requests using `http://`.
 	 */
 	public static function protocol() {
-		_deprecated_function( __METHOD__, 'jetpack-9.0.0' );
+		_deprecated_function( __METHOD__, 'jetpack-9.1.0' );
 
 		return 'https';
 	}

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1540,9 +1540,8 @@ class Manager {
 			return new WP_Error( 'site_not_registered', 'Site not registered.' );
 		}
 		$url = sprintf(
-			'%s://%s/%s/v%s/%s',
-			Client::protocol(),
-			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_HOST' ),
+			'%s/%s/v%s/%s',
+			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 			'wpcom',
 			'2',
 			'sites/' . $blog_id . '/jetpack-token-health'
@@ -1814,7 +1813,7 @@ class Manager {
 		);
 
 		add_filter( 'http_request_timeout', array( $this, 'increase_timeout' ), PHP_INT_MAX - 1 );
-		$response = Client::_wp_remote_request( Utils::fix_url_for_bad_hosts( $this->api_url( 'token' ) ), $args );
+		$response = Client::_wp_remote_request( $this->api_url( 'token' ), $args );
 		remove_filter( 'http_request_timeout', array( $this, 'increase_timeout' ), PHP_INT_MAX - 1 );
 
 		if ( is_wp_error( $response ) ) {
@@ -2572,9 +2571,8 @@ class Manager {
 		}
 
 		$url     = sprintf(
-			'%s://%s/%s/v%s/%s',
-			Client::protocol(),
-			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_HOST' ),
+			'%s/%s/v%s/%s',
+			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 			'wpcom',
 			'2',
 			'sites/' . $blog_id . '/jetpack-refresh-blog-token'

--- a/packages/connection/src/class-utils.php
+++ b/packages/connection/src/class-utils.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\Connection;
 
-use Automattic\Jetpack\Constants;
-
 /**
  * Provides utility methods for the Connection package.
  */

--- a/packages/connection/src/class-utils.php
+++ b/packages/connection/src/class-utils.php
@@ -24,10 +24,10 @@ class Utils {
 	 * @param string $url The url.
 	 * @return string The exact same url.
 	 *
-	 * @deprecated 9.0.0 Jetpack can't function properly on servers that don't support outbound HTTPS requests.
+	 * @deprecated 9.1.0 Jetpack can't function properly on servers that don't support outbound HTTPS requests.
 	 */
 	public static function fix_url_for_bad_hosts( $url ) {
-		_deprecated_function( __METHOD__, 'jetpack-9.0.0' );
+		_deprecated_function( __METHOD__, 'jetpack-9.1.0' );
 		return $url;
 	}
 

--- a/packages/connection/src/class-utils.php
+++ b/packages/connection/src/class-utils.php
@@ -18,24 +18,16 @@ class Utils {
 	const DEFAULT_JETPACK__API_BASE    = 'https://jetpack.wordpress.com/jetpack.';
 
 	/**
-	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requests.
-	 * This method sets the URL scheme to HTTP when HTTPS requests can't be made.
+	 * This method used to set the URL scheme to HTTP when HTTPS requests can't be made.
+	 * Now it returns the exact same URL you pass as an argument.
 	 *
 	 * @param string $url The url.
-	 * @return string The url with the required URL scheme.
+	 * @return string The exact same url.
+	 *
+	 * @deprecated 9.0.0 Jetpack can't function properly on servers that don't support outbound HTTPS requests.
 	 */
 	public static function fix_url_for_bad_hosts( $url ) {
-		// If we receive an http url, return it.
-		if ( 'http' === wp_parse_url( $url, PHP_URL_SCHEME ) ) {
-			return $url;
-		}
-
-		// If the url should never be https, ensure it isn't https.
-		if ( 'NEVER' === Constants::get_constant( 'JETPACK_CLIENT__HTTPS' ) ) {
-			return set_url_scheme( $url, 'http' );
-		}
-
-		// Otherwise, return the https url.
+		_deprecated_function( __METHOD__, 'jetpack-9.0.0' );
 		return $url;
 	}
 

--- a/packages/connection/tests/php/test-rest-endpoints.php
+++ b/packages/connection/tests/php/test-rest-endpoints.php
@@ -58,8 +58,8 @@ class Test_REST_Endpoints extends TestCase {
 		$user = wp_get_current_user();
 		$user->add_cap( 'jetpack_reconnect' );
 
-		$this->api_host_original                                  = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_HOST' );
-		Constants::$set_constants['JETPACK__WPCOM_JSON_API_HOST'] = 'public-api.wordpress.com';
+		$this->api_host_original                                  = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
 
 		Constants::$set_constants['JETPACK__API_BASE'] = 'https://jetpack.wordpress.com/jetpack.';
 
@@ -77,7 +77,7 @@ class Test_REST_Endpoints extends TestCase {
 		$user = wp_get_current_user();
 		$user->remove_cap( 'jetpack_reconnect' );
 
-		Constants::$set_constants['JETPACK__WPCOM_JSON_API_HOST'] = $this->api_host_original;
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = $this->api_host_original;
 
 		delete_transient( 'jetpack_assumed_site_creation_date' );
 


### PR DESCRIPTION
Fixes #16980

#### Changes proposed in this Pull Request:
Constant `JETPACK_CLIENT__HTTPS` is used to explicitly switch outbound HTTPS requests to HTTP.
`public-api.wordpress.com` no longer supports HTTP requests, so Jetpack cannot function if outbound HTTPS requests do not work.

We introduce a new constant `JETPACK__WPCOM_JSON_API_BASE` which has the protocol (`https://`) hardcoded into it, and deprecates the existing `JETPACK__WPCOM_JSON_API_HOST` which requires the protocol to be attached to it separately.
We also clean up the code accordingly, and deprecate functions that are no longer needed.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
This is a janitorial PR, meaning we only need to confirm that everything works as intended.
1. Connect Jetpack, make sure Jetpack Dashboard and Settings load correctly.
2. Activate Jetpack, try to logout of WP and login back again.
3. Go to https://wordpress.com/themes/, choose your site, and install a Jetpack theme.
4. Open the theme's `style.css` and downgrade the theme's point version (e.g. `1.2.3` to `1.2.2`).
5. Go to your site's `/wp-admin/themes.php` and make sure that you're suggested to update the theme. Update it.
6. If everything of the above went smoothly, check the `/wp-content/debug.log` and make sure there are no deprecated errors: `grep deprecated wp-content/debug.log`

#### Proposed changelog entry for your changes:
* Cleaning up outdated code that allows non-secure requests to WP.com API, because WP.com no longer accepts such requests.
