### PR TITLE
Adding 'review' to whitelisted comment types

### DIFF
--- a/packages/sync/src/modules/class-comments.php
+++ b/packages/sync/src/modules/class-comments.php
@@ -190,7 +190,7 @@ class Comments extends Module {
 		 */
 		return apply_filters(
 			'jetpack_sync_whitelisted_comment_types',
-			array( '', 'comment', 'trackback', 'pingback' )
+			array( '', 'comment', 'trackback', 'pingback', 'review' )
 		);
 	}
 


### PR DESCRIPTION
'review' comment_type added as a default Comment Type. This is used by Woo and other plugins and already is being sent to WP.com.

#### Changes proposed in this Pull Request:
* Updating the default jetpack_sync_whitelisted_comment_types values to include review.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Apply PR to your test site
* Insert comment with type "review" that is unapproved
* Approve comment
* Verify via kibana that a comment_approved_review sync action was sent for the site.

#### Proposed changelog entry for your changes:
* Jetpack Sync - review comment_type now trigger the comment_approved_* comment_unapproved_* actions.
