### PR TITLE
Fix early returns in Jetpack.

### DIFF
--- a/_inc/lib/class.media-extractor.php
+++ b/_inc/lib/class.media-extractor.php
@@ -59,6 +59,9 @@ class Jetpack_Media_Meta_Extractor {
 
 		$post = get_post( $post_id );
 		if ( ! $post instanceof WP_Post ) {
+			if ( function_exists( 'restore_current_blog' ) ) {
+				restore_current_blog();
+			}
 			return array();
 		}
 		$content  = $post->post_title . "\n\n" . $post->post_content;
@@ -79,7 +82,7 @@ class Jetpack_Media_Meta_Extractor {
 			$what_to_extract = $what_to_extract - self::IMAGES;
 		}
 
-		if ( function_exists( 'switch_to_blog' ) ) {
+		if ( function_exists( 'restore_current_blog' ) ) {
 			restore_current_blog();
 		}
 

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -94,6 +94,9 @@ class Jetpack_Media_Summary {
 		$extract = Jetpack_Media_Meta_Extractor::extract( $blog_id, $post_id, Jetpack_Media_Meta_Extractor::ALL );
 
 		if ( empty( $extract['has'] ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
 			return $return;
 		}
 


### PR DESCRIPTION
Follow-up from #16506 

Fixes a problem with early return when still in another blog context.

#### Changes proposed in this Pull Request:
* Adds a statement to switch back to the original blog before returning.

Barry: "Summary: We can't call switch_to_blog() and then return without also calling restore_current_blog(). One of these seems very old and the other one seems relatively new in class.media-extractor.php. It seems like we should be able to do some static or dynamic analysis to detect these cases and prevent new ones from being committed." Props @bazza  for the fix.

This commit syncs r213537-wpcom.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* TBA

#### Proposed changelog entry for your changes:
* N/A
