### PR TITLE
Autoloader: add PSR-0 support

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -80,7 +80,9 @@ You may run unit tests locally for any given package by running `composer phpuni
 via Jetpack Docker with the command `yarn docker:phpunit:package` for all package unit tests or 
 `yarn docker:phpunit:package packagename` for a specific one. 
 
-## Should my code be in a Package? 
+## Creating a New Package
+
+### Should my code be in a Package?
 
 Not sure if your code should be in a Package? Here are some general guidelines we follow when deciding: 
 
@@ -92,3 +94,8 @@ Not sure if your code should be in a Package? Here are some general guidelines w
 | ✅ | Other plugins will find this code useful. |
 | ✅ | You are building a completely new plugin. |
 | ✅ | Your code has dependencies that are only within itself or other Packages. |
+
+
+### Package Autoloading
+
+All new Jetpack package development should use classmap autoloading, which allows the class and file names to comply with the WordPress Coding Standards.

--- a/packages/autoloader/README.md
+++ b/packages/autoloader/README.md
@@ -43,9 +43,27 @@ Working with Development Versions of Packages
 
 The autoloader will attempt to use the package with the latest semantic version.
 
-During development, you can force the autoloader to use development package versions by setting the `JETPACK_AUTOLOAD_DEV` constant to true. When `JETPACK_AUTOLOAD_DEV` is true, the autoloader will prefer the following versions over semantic version:
+During development, you can force the autoloader to use development package versions by setting the `JETPACK_AUTOLOAD_DEV` constant to true. When `JETPACK_AUTOLOAD_DEV` is true, the autoloader will prefer the following versions over semantic versions:
   - `9999999-dev`
   - Versions with a `dev-` prefix.
+
+
+Autoloading Standards
+----
+
+All new Jetpack package development should use classmap autoloading, which allows the class and file names to comply with the WordPress Coding Standards.
+
+### Optimized Autoloader
+
+An optimized autoloader is generated when:
+ * `composer install` or `composer update` is called with `-o` or `--optimize-autoloader`
+ * `composer dump-autoload` is called with `-o` or `--optimize`
+
+PSR-4 and PSR-0 namespaces are converted to classmaps.
+
+### Unoptimized Autoloader
+
+Supports PSR-4 autoloading. PSR-0 namespaces are converted to classmaps.
 
 
 Autoloader Limitations

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -110,10 +110,10 @@ AUTOLOADER_COMMENT;
 	 * This function differs from the composer parseAutoloadsType in that beside returning the path.
 	 * It also return the path and the version of a package.
 	 *
-	 * Currently supports only psr-4 and clasmap parsing.
+	 * Supports PSR-4, PSR-0, and classmap parsing.
 	 *
 	 * @param array            $packageMap Map of all the packages.
-	 * @param string           $type Type of autoloader to use, currently not used, since we only support psr-4.
+	 * @param string           $type Type of autoloader to use.
 	 * @param PackageInterface $mainPackage Instance of the Package Object.
 	 *
 	 * @return array
@@ -182,8 +182,13 @@ AUTOLOADER_COMMENT;
 	/**
 	 * Given Composer's autoloads this will convert them to a version that we can use to generate the manifests.
 	 *
+	 * When the $scanPsrPackages argument is true, PSR-4 namespaces are converted to classmaps. When $scanPsrPackages
+	 * is false, PSR-4 namespaces are not converted to classmaps.
+	 *
+	 * PSR-0 namespaces are always converted to classmaps.
+	 *
 	 * @param array  $autoloads The autoloads we want to process.
-	 * @param bool   $scanPsrPackages Whether or not PSR packages should be converted to a classmap.
+	 * @param bool   $scanPsrPackages Whether or not PSR-4 packages should be converted to a classmap.
 	 * @param string $vendorPath The path to the vendor directory.
 	 * @param string $basePath The path to the current directory.
 	 *

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -121,7 +121,7 @@ AUTOLOADER_COMMENT;
 	protected function parseAutoloadsType( array $packageMap, $type, PackageInterface $mainPackage ) {
 		$autoloads = array();
 
-		if ( 'psr-4' !== $type && 'classmap' !== $type && 'files' !== $type ) {
+		if ( 'psr-4' !== $type && 'classmap' !== $type && 'files' !== $type && 'psr-0' !== $type ) {
 			return parent::parseAutoloadsType( $packageMap, $type, $mainPackage );
 		}
 
@@ -137,8 +137,8 @@ AUTOLOADER_COMMENT;
 				$installPath = substr( $installPath, 0, -strlen( '/' . $package->getTargetDir() ) );
 			}
 
-			if ( 'psr-4' === $type && isset( $autoload['psr-4'] ) && is_array( $autoload['psr-4'] ) ) {
-				foreach ( $autoload['psr-4'] as $namespace => $paths ) {
+			if ( in_array( $type, array( 'psr-4', 'psr-0' ), true ) && isset( $autoload[ $type ] ) && is_array( $autoload[ $type ] ) ) {
+				foreach ( $autoload[ $type ] as $namespace => $paths ) {
 					$paths = is_array( $paths ) ? $paths : array( $paths );
 					foreach ( $paths as $path ) {
 						$relativePath              = empty( $installPath ) ? ( empty( $path ) ? '.' : $path ) : $installPath . '/' . $path;

--- a/packages/autoloader/src/AutoloadProcessor.php
+++ b/packages/autoloader/src/AutoloadProcessor.php
@@ -88,6 +88,22 @@ class AutoloadProcessor {
 			}
 		}
 
+		if ( ! empty( $autoloads['psr-0'] ) ) {
+			foreach ( $autoloads['psr-0'] as $namespace => $sources ) {
+				$namespace = empty( $namespace ) ? null : $namespace;
+
+				foreach ( $sources as $source ) {
+					$classmap = call_user_func( $this->classmapScanner, $source['path'], $excludedClasses, $namespace );
+					foreach ( $classmap as $class => $path ) {
+						$processed[ $class ] = array(
+							'version' => $source['version'],
+							'path'    => call_user_func( $this->pathCodeTransformer, $path ),
+						);
+					}
+				}
+			}
+		}
+
 		if ( ! empty( $autoloads['classmap'] ) ) {
 			foreach ( $autoloads['classmap'] as $package ) {
 				$classmap = call_user_func( $this->classmapScanner, $package['path'], $excludedClasses, null );

--- a/packages/autoloader/src/AutoloadProcessor.php
+++ b/packages/autoloader/src/AutoloadProcessor.php
@@ -88,6 +88,7 @@ class AutoloadProcessor {
 			}
 		}
 
+		// PSR-0 namespaces are converted to classmaps for both optimized and unoptimized autoloaders.
 		if ( ! empty( $autoloads['psr-0'] ) ) {
 			foreach ( $autoloads['psr-0'] as $namespace => $sources ) {
 				$namespace = empty( $namespace ) ? null : $namespace;

--- a/packages/autoloader/src/AutoloadProcessor.php
+++ b/packages/autoloader/src/AutoloadProcessor.php
@@ -88,7 +88,10 @@ class AutoloadProcessor {
 			}
 		}
 
-		// PSR-0 namespaces are converted to classmaps for both optimized and unoptimized autoloaders.
+		/*
+		 * PSR-0 namespaces are converted to classmaps for both optimized and unoptimized autoloaders because any new
+		 * development should use classmap or PSR-4 autoloading.
+		 */
 		if ( ! empty( $autoloads['psr-0'] ) ) {
 			foreach ( $autoloads['psr-0'] as $namespace => $sources ) {
 				$namespace = empty( $namespace ) ? null : $namespace;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add PSR-0 support to the autoloader. PR #16699 needs to use a composer package that uses the PSR-0 autoloading standard.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Checkout this branch.
2. Add a package that uses PSR-0 to the list of required packages in the `composer.json` file. For example, add `"nojimage/twitter-text-php": "3.1.0"`.
3. Run `composer update`.
4. Open the `vendor/composer/jetpack_autoload_classmap.php` file and confirm that it includes the file paths for the `Twitter\\Text` classes: `EmojiRegex`, `Validator`, etc.
5. Run `composer update -o`.
6. Repeat step 4.

#### Proposed changelog entry for your changes:
* Autoloader: add PSR-0 support.
