### PR TITLE
Build Artifacts: fix `nvm` not found issue

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -17,7 +17,7 @@ jobs:
           commit_message: 'Automated production build from master'
   build_beta:
     name: Beta
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
     - name: Checkout Jetpack

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -33,9 +33,9 @@ jobs:
       shell: bash -l -eo pipefail {0}
       run: nvm ls
 
-    # - name: test nvm command
-    #   shell: bash -l -eo pipefail {0}
-    #   run: which nvm
+    - name: test nvm command
+      shell: bash -l -eo pipefail {0}
+      run: type -a nvm
     # - name: test nvm command
     #   shell: bash -l -eo pipefail {0}
     #   run: nvm use

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -23,7 +23,9 @@ jobs:
     - name: Checkout Jetpack
       uses: actions/checkout@master
     - name: install nvm
-      run: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+      run: |
+        export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
     - name: Build jetpack
       shell: bash -l -eo pipefail {0}
       run: |

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,7 +22,13 @@ jobs:
     steps:
     - name: Checkout Jetpack
       uses: actions/checkout@master
-    - run: nvm install
+    - name: check nvm location
+      shell: bash -l -eo pipefail {0}
+      run: echo $NVM_DIR
+
+    - name: test nvm command
+      shell: bash -l -eo pipefail {0}
+      run: nvm ls
     - name: Build jetpack
       run: |
         BRANCH=${GITHUB_REF:11}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -23,6 +23,12 @@ jobs:
     - name: Checkout Jetpack
       uses: actions/checkout@master
 
+    - run: |
+        node -v
+        command -v nvm
+        which nvm
+        nvm -v
+
     - name: Build jetpack
       run: |
         export NVM_DIR="$HOME/.nvm"

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -35,9 +35,6 @@ jobs:
 
     - name: test nvm command
       shell: bash -l -eo pipefail {0}
-      run: nvm -v
-    - name: test nvm command
-      shell: bash -l -eo pipefail {0}
       run: which nvm
     - name: test nvm command
       shell: bash -l -eo pipefail {0}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -46,7 +46,7 @@ jobs:
         nvm install
 
         BRANCH=${GITHUB_REF:11}
-        ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev
+        bash ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev
     - name: Upload jetpack build
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
     - name: Checkout Jetpack
       uses: actions/checkout@master
+    - run: nvm install
     - name: Build jetpack
       run: |
         BRANCH=${GITHUB_REF:11}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -43,7 +43,6 @@ jobs:
     - name: Build jetpack
       shell: bash -l -eo pipefail {0}
       run: |
-
         nvm install
 
         BRANCH=${GITHUB_REF:11}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -23,30 +23,10 @@ jobs:
     - name: Checkout Jetpack
       uses: actions/checkout@master
 
-    - run: node -v
-
-    - name: check nvm location
-      shell: bash -l -eo pipefail {0}
-      run: echo $NVM_DIR
-
-    - name: test nvm command
-      shell: bash -l -eo pipefail {0}
-      run: nvm ls
-
-    - name: test nvm command
-      shell: bash -l -eo pipefail {0}
-      run: type -a nvm
-    # - name: test nvm command
-    #   shell: bash -l -eo pipefail {0}
-    #   run: nvm use
-
     - name: Build jetpack
-      shell: bash -l -eo pipefail {0}
       run: |
-        nvm install
-
         BRANCH=${GITHUB_REF:11}
-        bash ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev
+        . ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev
     - name: Upload jetpack build
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Build jetpack
       shell: bash -l -eo pipefail {0}
       run: |
-        export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+        export NVM_DIR="$HOME/.nvm"
+        source "$NVM_DIR/nvm.sh"
         BRANCH=${GITHUB_REF:11}
         ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev
     - name: Upload jetpack build

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -47,7 +47,7 @@ jobs:
         export NVM_DIR="$HOME/.nvm"
         source "$NVM_DIR/nvm.sh"
         nvm ls
-        which nvm
+        type -a nvm
 
         BRANCH=${GITHUB_REF:11}
         ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -27,9 +27,12 @@ jobs:
 
     - name: check nvm location
       shell: bash -l -eo pipefail {0}
-      run: which nvm
+      run: echo $NVM_DIR
 
-    - run:    which nvm
+    - name: test nvm command
+      shell: bash -l -eo pipefail {0}
+      run: nvm ls
+
     - run: nvm -v
 
     - name: Build jetpack

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/checkout@master
 
     - name: Build jetpack
-      shell: bash -l -eo pipefail {0}
       run: |
         export NVM_DIR="$HOME/.nvm"
         source "$NVM_DIR/nvm.sh"

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -33,9 +33,18 @@ jobs:
       shell: bash -l -eo pipefail {0}
       run: nvm ls
 
-    - run: nvm -v
+    - name: test nvm command
+      shell: bash -l -eo pipefail {0}
+      run: nvm -v
+    - name: test nvm command
+      shell: bash -l -eo pipefail {0}
+      run: which nvm
+    - name: test nvm command
+      shell: bash -l -eo pipefail {0}
+      run: nvm use
 
     - name: Build jetpack
+      shell: bash -l -eo pipefail {0}
       run: |
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
         export NVM_DIR="$HOME/.nvm"

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -46,6 +46,9 @@ jobs:
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
         export NVM_DIR="$HOME/.nvm"
         source "$NVM_DIR/nvm.sh"
+        nvm ls
+        which nvm
+
         BRANCH=${GITHUB_REF:11}
         ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev
     - name: Upload jetpack build

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,11 +22,10 @@ jobs:
     steps:
     - name: Checkout Jetpack
       uses: actions/checkout@master
-
     - name: Build jetpack
       run: |
         BRANCH=${GITHUB_REF:11}
-        . ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev
+        ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev
     - name: Upload jetpack build
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -33,12 +33,12 @@ jobs:
       shell: bash -l -eo pipefail {0}
       run: nvm ls
 
-    - name: test nvm command
-      shell: bash -l -eo pipefail {0}
-      run: which nvm
-    - name: test nvm command
-      shell: bash -l -eo pipefail {0}
-      run: nvm use
+    # - name: test nvm command
+    #   shell: bash -l -eo pipefail {0}
+    #   run: which nvm
+    # - name: test nvm command
+    #   shell: bash -l -eo pipefail {0}
+    #   run: nvm use
 
     - name: Build jetpack
       shell: bash -l -eo pipefail {0}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -47,7 +47,7 @@ jobs:
         export NVM_DIR="$HOME/.nvm"
         source "$NVM_DIR/nvm.sh"
         nvm ls
-        type -a nvm
+        nvm use
 
         BRANCH=${GITHUB_REF:11}
         ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -23,11 +23,10 @@ jobs:
     - name: Checkout Jetpack
       uses: actions/checkout@master
 
-    - run: |
-        node -v
-        command -v nvm
-        which nvm
-        nvm -v
+    - run: node -v
+    - run: command -v nvm
+    - run:    which nvm
+    - run: nvm -v
 
     - name: Build jetpack
       run: |

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -29,6 +29,9 @@ jobs:
     - name: test nvm command
       shell: bash -l -eo pipefail {0}
       run: nvm ls
+    - name: nvm install
+      shell: bash -l -eo pipefail {0}
+      run: nvm install
     - name: Build jetpack
       run: |
         BRANCH=${GITHUB_REF:11}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -33,6 +33,8 @@ jobs:
       shell: bash -l -eo pipefail {0}
       run: nvm install
     - name: Build jetpack
+      shell: bash -l -eo pipefail {0}
+
       run: |
         BRANCH=${GITHUB_REF:11}
         ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -17,7 +17,7 @@ jobs:
           commit_message: 'Automated production build from master'
   build_beta:
     name: Beta
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
     - name: Checkout Jetpack

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,19 +22,10 @@ jobs:
     steps:
     - name: Checkout Jetpack
       uses: actions/checkout@master
-    - name: check nvm location
-      shell: bash -l -eo pipefail {0}
-      run: echo $NVM_DIR
-
-    - name: test nvm command
-      shell: bash -l -eo pipefail {0}
-      run: nvm ls
-    - name: nvm install
-      shell: bash -l -eo pipefail {0}
-      run: nvm install
+    - name: install nvm
+      run: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
     - name: Build jetpack
       shell: bash -l -eo pipefail {0}
-
       run: |
         BRANCH=${GITHUB_REF:11}
         ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -24,7 +24,11 @@ jobs:
       uses: actions/checkout@master
 
     - run: node -v
-    - run: command -v nvm
+
+    - name: check nvm location
+      shell: bash -l -eo pipefail {0}
+      run: which nvm
+
     - run:    which nvm
     - run: nvm -v
 

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -43,11 +43,8 @@ jobs:
     - name: Build jetpack
       shell: bash -l -eo pipefail {0}
       run: |
-        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-        export NVM_DIR="$HOME/.nvm"
-        source "$NVM_DIR/nvm.sh"
-        nvm ls
-        nvm use
+
+        nvm install
 
         BRANCH=${GITHUB_REF:11}
         ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -34,6 +34,7 @@ jobs:
 
     - name: Build jetpack
       run: |
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
         export NVM_DIR="$HOME/.nvm"
         source "$NVM_DIR/nvm.sh"
         BRANCH=${GITHUB_REF:11}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,13 +22,12 @@ jobs:
     steps:
     - name: Checkout Jetpack
       uses: actions/checkout@master
-    - name: install nvm
-      run: |
-        export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+
     - name: Build jetpack
       shell: bash -l -eo pipefail {0}
       run: |
+        export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
         BRANCH=${GITHUB_REF:11}
         ./tools/build-jetpack.sh -d -b $BRANCH Automattic/jetpack /tmp/artifact/jetpack-dev
     - name: Upload jetpack build

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 RED='\033[0;31m'
 trap 'exit_build' ERR
 

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# set -eo pipefail
 RED='\033[0;31m'
 trap 'exit_build' ERR
 
@@ -64,12 +63,12 @@ hash composer 2>/dev/null || {
     exit 1;
 }
 
-# Using the version of Node that is required in .nvmrc
-# export NVM_DIR="$HOME/.nvm"
-# source "$NVM_DIR/nvm.sh"
+# Hack-ish way to resolve problem with nvm being not available in script context
+export NVM_DIR="$HOME/.nvm"
+source "$NVM_DIR/nvm.sh"
 
-# nvm install &&
-nvm use || {
+# Using the version of Node that is required in .nvmrc
+nvm install && nvm use || {
     echo >&2 "This script requires a certain Node version."
     echo >&2 "We could not use the Node version that is specified in the .nvmrc file."
     exit 1;

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -65,7 +65,11 @@ hash composer 2>/dev/null || {
 }
 
 # Using the version of Node that is required in .nvmrc
-nvm -v
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+source "$NVM_DIR/nvm.sh"
+nvm ls
+nvm install
 nvm use || {
     echo >&2 "This script requires a certain Node version."
     echo >&2 "We could not use the Node version that is specified in the .nvmrc file."

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -65,10 +65,11 @@ hash composer 2>/dev/null || {
 }
 
 # Using the version of Node that is required in .nvmrc
-export NVM_DIR="$HOME/.nvm"
-source "$NVM_DIR/nvm.sh"
+# export NVM_DIR="$HOME/.nvm"
+# source "$NVM_DIR/nvm.sh"
 
-nvm install && nvm use || {
+# nvm install &&
+nvm use || {
     echo >&2 "This script requires a certain Node version."
     echo >&2 "We could not use the Node version that is specified in the .nvmrc file."
     exit 1;

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 RED='\033[0;31m'
 trap 'exit_build' ERR
 
@@ -64,6 +65,7 @@ hash composer 2>/dev/null || {
 }
 
 # Using the version of Node that is required in .nvmrc
+nvm -v
 nvm use || {
     echo >&2 "This script requires a certain Node version."
     echo >&2 "We could not use the Node version that is specified in the .nvmrc file."

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+# set -eo pipefail
 RED='\033[0;31m'
 trap 'exit_build' ERR
 
@@ -65,11 +65,11 @@ hash composer 2>/dev/null || {
 }
 
 # Using the version of Node that is required in .nvmrc
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-export NVM_DIR="$HOME/.nvm"
-source "$NVM_DIR/nvm.sh"
-nvm ls
-nvm install
+# curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+# export NVM_DIR="$HOME/.nvm"
+# source "$NVM_DIR/nvm.sh"
+# nvm ls
+# nvm install
 nvm use || {
     echo >&2 "This script requires a certain Node version."
     echo >&2 "We could not use the Node version that is specified in the .nvmrc file."

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -65,12 +65,10 @@ hash composer 2>/dev/null || {
 }
 
 # Using the version of Node that is required in .nvmrc
-# curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 source "$NVM_DIR/nvm.sh"
-# nvm ls
-# nvm install
-nvm use || {
+
+nvm install && nvm use || {
     echo >&2 "This script requires a certain Node version."
     echo >&2 "We could not use the Node version that is specified in the .nvmrc file."
     exit 1;

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -66,8 +66,8 @@ hash composer 2>/dev/null || {
 
 # Using the version of Node that is required in .nvmrc
 # curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-# export NVM_DIR="$HOME/.nvm"
-# source "$NVM_DIR/nvm.sh"
+export NVM_DIR="$HOME/.nvm"
+source "$NVM_DIR/nvm.sh"
 # nvm ls
 # nvm install
 nvm use || {

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -eo pipefail
-
 RED='\033[0;31m'
 trap 'exit_build' ERR
 


### PR DESCRIPTION
In #14274 we introduced `nvm use` call into the `build-jetpack` script, which apparently wasn't working properly from the beginning. For some reason, `nvm` is not available in script context, which seems odd, but I guess this is how github action environment is set up 🤷 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* explicitly export `nvm` binary and run `nvm install` to pull `nvmrc`-defined node version

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a 
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check Beta builder action. it should be green
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
