### PR TITLE
Update Unit Tests to call restore_current_blog after switch_to_blog usage

### DIFF
--- a/tests/php/modules/shortcodes/test-class.slideshow.php
+++ b/tests/php/modules/shortcodes/test-class.slideshow.php
@@ -40,6 +40,17 @@ class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Sets up each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function tearDown() {
+		if ( ! defined( 'TESTING_IN_JETPACK' ) || ! TESTING_IN_JETPACK ) {
+			restore_current_blog();
+		}
+	}
+
+	/**
 	 * @author scotchfield
 	 * @covers Jetpack_Slideshow_Shortcode::shortcode_callback
 	 * @since 3.2

--- a/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -397,14 +397,23 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
+
+		$user_count             = $this->server_replica_storage->user_count();
+		$srs_added_mu_blog_user = $this->server_replica_storage->get_user( $added_mu_blog_user_id );
+		$srs_user               = $this->server_replica_storage->get_user( $user_id );
+		$srs_mu_blog_user       = $this->server_replica_storage->get_user( $mu_blog_user_id );
+
+		// restore context then run assertions.
 		restore_current_blog();
 
-		$this->assertEquals( 2, $this->server_replica_storage->user_count() );
+		$this->assertEquals( 2, $user_count );
 
 		// again, opposite users from previous sync
-		$this->assertNotNull( $this->server_replica_storage->get_user( $added_mu_blog_user_id ) );
-		$this->assertNull( $this->server_replica_storage->get_user( $user_id ) );
-		$this->assertNotNull( $this->server_replica_storage->get_user( $mu_blog_user_id ) );
+
+		$this->assertNotNull( $srs_added_mu_blog_user );
+		$this->assertNull( $srs_user );
+		$this->assertNotNull( $srs_mu_blog_user );
+
 	}
 
 	function record_full_synced_users( $user_ids ) {

--- a/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -397,6 +397,7 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
+		restore_current_blog();
 
 		$this->assertEquals( 2, $this->server_replica_storage->user_count() );
 

--- a/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -390,7 +390,7 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->assertNotNull( $this->server_replica_storage->get_user( $added_mu_blog_user_id ) );
 		$this->assertNull( $this->server_replica_storage->get_user( $mu_blog_user_id ) );
 
-		// now switch to the other site and sync, and ensure that only that site's users get synced
+		// now switch to the other site and sync, and ensure that only that site's users get synced.
 		switch_to_blog( $other_blog_id );
 		$this->server_replica_storage->reset();
 		$this->synced_user_ids = null;
@@ -408,8 +408,7 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 2, $user_count );
 
-		// again, opposite users from previous sync
-
+		// again, opposite users from previous sync.
 		$this->assertNotNull( $srs_added_mu_blog_user );
 		$this->assertNull( $srs_user );
 		$this->assertNotNull( $srs_mu_blog_user );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -583,6 +583,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( in_array( $mu_blog_user_id, $this->synced_user_ids ) );
 
 		$this->sender->do_full_sync();
+		restore_current_blog();
 
 		$this->assertEquals( 2, $this->server_replica_storage->user_count() );
 


### PR DESCRIPTION
Fixes https://wp.me/p9dueE-1Ry

#### Changes proposed in this Pull Request:
* Update Unit Tests so that restore_current_blog is called after each swtich_to_blog statement.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Verify Unit Tests are still fully functional

#### Proposed changelog entry for your changes:
* N/A Unit Test update
