### PR TITLE
Client admin page: Add reconnect route

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -19,6 +19,7 @@ import {
 	isStaging,
 	isInIdentityCrisis,
 	isCurrentUserLinked,
+	isReconnectingSite,
 	getConnectUrl as _getConnectUrl,
 } from 'state/connection';
 import {
@@ -214,6 +215,7 @@ class JetpackNotices extends React.Component {
 				<NoticesList />
 				{ this.props.siteConnectionStatus &&
 					this.props.userCanConnectSite &&
+					! this.props.isReconnectingSite &&
 					( this.props.connectionErrors.length > 0 || siteDataErrors.length > 0 ) && (
 						<JetpackConnectionErrors
 							errors={ this.props.connectionErrors.concat( siteDataErrors ) }
@@ -234,13 +236,15 @@ class JetpackNotices extends React.Component {
 				/>
 				<PlanConflictWarning />
 				<DismissableNotices />
-				{ ! siteDataErrors.length && ! this.props.connectionErrors.length && (
-					<UserUnlinked
-						connectUrl={ this.props.connectUrl }
-						siteConnected={ true === this.props.siteConnectionStatus }
-						isLinked={ this.props.isLinked }
-					/>
-				) }
+				{ ! this.props.isReconnectingSite &&
+					! siteDataErrors.length &&
+					! this.props.connectionErrors.length && (
+						<UserUnlinked
+							connectUrl={ this.props.connectUrl }
+							siteConnected={ true === this.props.siteConnectionStatus }
+							isLinked={ this.props.isLinked }
+						/>
+					) }
 				{ ! this.props.siteConnectionStatus && ! this.props.userCanConnectSite && (
 					<SimpleNotice
 						showDismiss={ false }
@@ -269,5 +273,6 @@ export default connect( state => {
 		isInIdentityCrisis: isInIdentityCrisis( state ),
 		connectionErrors: getConnectionErrors( state ),
 		siteDataErrors: getSiteDataErrors( state ),
+		isReconnectingSite: isReconnectingSite( state ),
 	};
 } )( JetpackNotices );

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -20,6 +20,7 @@ import {
 	isSiteConnected,
 	isAuthorizingUserInPlace,
 	isReconnectingSite,
+	reconnectSite,
 } from 'state/connection';
 import {
 	setInitialState,
@@ -89,6 +90,27 @@ class Main extends React.Component {
 				path: this.props.location.pathname,
 				current_version: this.props.currentVersion,
 			} );
+
+		// Handle 'reconnect' direct link.
+		const { history, location } = this.props;
+		const searchParams = new URLSearchParams( location.search );
+
+		if ( searchParams.has( 'reconnect' ) ) {
+			// Update the state object or URL of the current history entry
+			// in response to user 'reconnect' action.
+			// If we didn't do this, we'd get in an endless loop due to window reloading
+			// after reconnection.
+			searchParams.delete( 'reconnect' );
+			const search = searchParams.toString();
+			history.replace( {
+				pathname: location.pathname,
+				search: search.length ? '?' + search : '',
+			} );
+			// Trigger actual reconnect if is not already happening.
+			if ( ! this.props.isReconnectingSite ) {
+				this.props.reconnectSite();
+			}
+		}
 	}
 
 	componentDidMount() {
@@ -380,6 +402,9 @@ export default connect(
 		},
 		clearUnsavedSettingsFlag: () => {
 			return dispatch( clearUnsavedSettingsFlag() );
+		},
+		reconnectSite: () => {
+			return dispatch( reconnectSite() );
 		},
 	} )
 )( withRouter( Main ) );

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -61,7 +61,7 @@ const setupRoutes = [
 	'/setup/features',
 ];
 
-const dashboardRoutes = [ '/', '/dashboard', '/my-plan', '/plans' ];
+const dashboardRoutes = [ '/', '/dashboard', '/reconnect', '/my-plan', '/plans' ];
 const settingsRoutes = [
 	'/settings',
 	'/security',
@@ -90,27 +90,6 @@ class Main extends React.Component {
 				path: this.props.location.pathname,
 				current_version: this.props.currentVersion,
 			} );
-
-		// Handle 'reconnect' direct link.
-		const { history, location } = this.props;
-		const searchParams = new URLSearchParams( location.search );
-
-		if ( searchParams.has( 'reconnect' ) ) {
-			// Update the state object or URL of the current history entry
-			// in response to user 'reconnect' action.
-			// If we didn't do this, we'd get in an endless loop due to window reloading
-			// after reconnection.
-			searchParams.delete( 'reconnect' );
-			const search = searchParams.toString();
-			history.replace( {
-				pathname: location.pathname,
-				search: search.length ? '?' + search : '',
-			} );
-			// Trigger actual reconnect if is not already happening.
-			if ( ! this.props.isReconnectingSite ) {
-				this.props.reconnectSite();
-			}
-		}
 	}
 
 	componentDidMount() {
@@ -223,6 +202,18 @@ class Main extends React.Component {
 						rewindStatus={ this.props.rewindStatus }
 					/>
 				);
+				break;
+			case '/reconnect':
+				// Trigger actual reconnect if is not already happening.
+				if ( this.props.isSiteConnected && ! this.props.isReconnectingSite ) {
+					this.props.reconnectSite();
+				}
+				// Update the state object or URL of the current history entry
+				// in response to user 'reconnect' action.
+				// If we didn't do this, we'd get in an endless loop due to window reloading
+				// after reconnection.
+				this.props.history.replace( '/dashboard' );
+				pageComponent = this.getAtAGlance();
 				break;
 			case '/my-plan':
 				pageComponent = (

--- a/_inc/client/state/connection/actions.js
+++ b/_inc/client/state/connection/actions.js
@@ -286,9 +286,6 @@ export const reconnectSite = () => {
 					} );
 					dispatch( authorizeUserInPlace() );
 				} else {
-					dispatch( {
-						type: SITE_RECONNECT_SUCCESS,
-					} );
 					window.location.reload();
 				}
 			} )


### PR DESCRIPTION
This PR adds support for a direct reconnect link that automatically triggers the partial reconnection process.
Up to now, this was only triggered by clicking the "Restore Connection" button, found in the corresponding alert when connection (token related) errors occured. 

#### Changes proposed in this Pull Request:
* Adds a new `reconnect` dashboard route
* Triggers partial reconnection upon visiting the `reconnect` route seamlessly, while maintaining the same UX flow with clicking the "Restore connection" button, found in the corresponding alert when connection (token related) errors occur. 
* Hides the connection error and link-account notices while reconnecting


#### Jetpack product discussion
p9dueE-1NT-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
**Broken blog token:**
- Invalidate the blog token using the Broken Token plugin
- Visit `admin.php?page=jetpack#/reconnect`
- The partial reconnect flow should be triggered and you should be reconnected **without** re-linking your WP account

**Broken user token:**
- Invalidate the current user token using the Broken Token plugin
- Visit `admin.php?page=jetpack#/reconnect`
- The partial reconnect flow should be triggered and you should be reconnected **after** re-linking your WP account

**Healthy tokens:**
- Make sure your tokens are healthy, either by using the Broken Token plugin's restore functionality or testing your connection in the .org debugger: admin.php?page=jetpack-debugger`
- Visit `admin.php?page=jetpack#/reconnect`
- The full reconnect flow should be triggered and you should be reconnected **after** re-linking your WP account

**Demo (after):** https://d.pr/v/sS7T9M

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Client admin page: Add reconnect route