### PR TITLE
Update code paths to always call restore_current_blog if switch_to_blog was used.

### DIFF
--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -53,6 +53,9 @@ class Jetpack_Media_Summary {
 
 		$cache_key = "{$blog_id}_{$post_id}_{$args['max_words']}_{$args['max_chars']}";
 		if ( isset( self::$cache[ $cache_key ] ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
 			return self::$cache[ $cache_key ];
 		}
 

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -205,8 +205,9 @@ class Jetpack_Network {
 			if ( ! in_array( 'jetpack/jetpack.php', $active_plugins, true ) ) {
 				Jetpack::disconnect();
 			}
+			restore_current_blog();
 		}
-		restore_current_blog();
+
 	}
 
 	/**

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -684,6 +684,9 @@ class Jetpack_Carousel {
 		do_action( 'jp_carousel_check_blog_user_privileges' );
 
 		if ( ! comments_open( $_post_id ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
 			die( json_encode( array( 'error' => __( 'Comments on this post are closed.', 'jetpack' ) ) ) );
 		}
 
@@ -695,6 +698,9 @@ class Jetpack_Carousel {
 			$url          = $user->user_url;
 
 			if ( empty( $user_id ) ) {
+				if ( $switched ) {
+					restore_current_blog();
+				}
 				die( json_encode( array( 'error' => __( 'Sorry, but we could not authenticate your request.', 'jetpack' ) ) ) );
 			}
 		} else {
@@ -705,14 +711,23 @@ class Jetpack_Carousel {
 
 			if ( get_option( 'require_name_email' ) ) {
 				if ( empty( $display_name ) ) {
+					if ( $switched ) {
+						restore_current_blog();
+					}
 					die( json_encode( array( 'error' => __( 'Please provide your name.', 'jetpack' ) ) ) );
 				}
 
 				if ( empty( $email ) ) {
+					if ( $switched ) {
+						restore_current_blog();
+					}
 					die( json_encode( array( 'error' => __( 'Please provide an email address.', 'jetpack' ) ) ) );
 				}
 
 				if ( ! is_email( $email ) ) {
+					if ( $switched ) {
+						restore_current_blog();
+					}
 					die( json_encode( array( 'error' => __( 'Please provide a valid email address.', 'jetpack' ) ) ) );
 				}
 			}


### PR DESCRIPTION
Fixes https://wp.me/p9dueE-1Ry

#### Changes proposed in this Pull Request:
* Ensure restore_current_blog is called for all switch_to_blog usages.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Verify all Unit Tests Pass

1. Setup a Multi-site and connect several blogs with Jetpack.
2. perform a network wide deactivation -> ensure all blogs are disconnected

#### Proposed changelog entry for your changes:
* Bug - ensure restore_current_blog is called for all switch_to_blog usages.
