### PR TITLE
Connection: Initializing default constants for the REST authorization.

### DIFF
--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -23,12 +23,7 @@ class Client {
 	 * @return array|WP_Error WP HTTP response on success
 	 */
 	public static function remote_request( $args, $body = null ) {
-		add_filter(
-			'jetpack_constant_default_value',
-			__NAMESPACE__ . '\Utils::jetpack_api_constant_filter',
-			10,
-			2
-		);
+		Utils::init_default_constants();
 
 		$defaults = array(
 			'url'           => '',

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -79,12 +79,7 @@ class Manager {
 	public static function configure() {
 		$manager = new self();
 
-		add_filter(
-			'jetpack_constant_default_value',
-			__NAMESPACE__ . '\Utils::jetpack_api_constant_filter',
-			10,
-			2
-		);
+		Utils::init_default_constants();
 
 		$manager->setup_xmlrpc_handlers(
 			$_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/packages/connection/src/class-rest-authentication.php
+++ b/packages/connection/src/class-rest-authentication.php
@@ -73,6 +73,8 @@ class Rest_Authentication {
 			return $user;
 		}
 
+		Utils::init_default_constants();
+
 		if ( ! isset( $_GET['_for'] ) || 'jetpack' !== $_GET['_for'] ) {
 			// Nothing to do for this authentication method.
 			return null;

--- a/packages/connection/src/class-utils.php
+++ b/packages/connection/src/class-utils.php
@@ -82,4 +82,16 @@ class Utils {
 
 		return null;
 	}
+
+	/**
+	 * Add a filter to initialize default values of the constants.
+	 */
+	public static function init_default_constants() {
+		add_filter(
+			'jetpack_constant_default_value',
+			array( __CLASS__, 'jetpack_api_constant_filter' ),
+			10,
+			2
+		);
+	}
 }


### PR DESCRIPTION
When Jetpack plugin is not installed, REST Authentication requires defaults constants to function. In particular, `JETPACK__API_VERSION` is empty, making the WP Proxy request signature verification fail.

#### Changes proposed in this Pull Request:
- Extract the default constants initialization code into `Utils::init_default_constants()`.
- Replace the existing initialization with the new function call.
- Add a new initialization call for `Rest_Authentication` class so WP proxy requests signature could be properly verified.

#### Jetpack product discussion
`p1599852544000900-slack-CPBTESZMG`

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Install and connect Jetpack.
2. Open file `jetpack.php` and comment out two constants: `JETPACK__API_VERSION`, `JETPACK__API_BASE`.
3. Load the Dashboard, make sure it still works.
4. Go to the WordPress.com API Console and run an API request:
`WP.COM API`, `v1.1`, `GET`, `/sites/your-site-url.com`
5. Confirm that the response is a valid site info.

#### Proposed changelog entry for your changes:
n/a