### PR TITLE
Local Testing Suite: Skip the blog token test if site is not connected

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -142,6 +142,14 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 * @return array
 	 */
 	protected function test__blog_token_if_exists() {
+		if ( ! $this->helper_is_jetpack_connected() ) {
+			return self::skipped_test(
+				array(
+					'name'              => __FUNCTION__,
+					'short_description' => __( 'Jetpack is not connected. No blog token to check.', 'jetpack' ),
+				)
+			);
+		}
 		$blog_token = $this->helper_get_blog_token();
 
 		if ( $blog_token ) {


### PR DESCRIPTION
Skips a test if the site is not connected.

#### Changes proposed in this Pull Request:
* Skips a test if the site is not connected.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Before patch, set `JETPACK_DEV_DEBUG` to true.
* Load Site Health and see a critical error related to the blog token.
* Apply patch, repeat, see no error.

#### Proposed changelog entry for your changes:
* Site Health: Skip a test when in offline mode that assumed a connected site.
