### PR TITLE
Add AMP compatibility for Eventbrite block

### DIFF
--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -16,15 +16,6 @@ const FEATURE_NAME = 'eventbrite';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 
 /**
- * Determine whether the page will be AMP.
- *
- * @return bool
- */
-function is_amp_request() {
-	return class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request();
-}
-
-/**
  * Registers the block for use in Gutenberg
  * This is done via an action so that we can disable
  * registration if we need to.
@@ -76,13 +67,12 @@ function render_block( $attr, $content ) {
 	);
 
 	$widget_id = wp_unique_id( 'eventbrite-widget-' );
-	$is_amp    = is_amp_request();
 
 	// Show the embedded version.
 	if ( empty( $attr['useModal'] ) && ( empty( $attr['style'] ) || 'modal' !== $attr['style'] ) ) {
-		return render_embed_block( $widget_id, $is_amp, $attr );
+		return render_embed_block( $widget_id, Blocks::is_amp_request(), $attr );
 	} else {
-		return render_modal_block( $widget_id, $is_amp, $attr, $content );
+		return render_modal_block( $widget_id, Blocks::is_amp_request(), $attr, $content );
 	}
 }
 

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -49,9 +49,6 @@ function render_block( $attr, $content ) {
 
 	wp_enqueue_script( 'eventbrite-widget', 'https://www.eventbrite.com/static/widgets/eb_widgets.js', array(), JETPACK__VERSION, true );
 
-	// Add CSS to hide direct link.
-	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
-
 	// Show the embedded version.
 	if ( empty( $attr['useModal'] ) && ( empty( $attr['style'] ) || 'modal' !== $attr['style'] ) ) {
 		return render_embed_block( $attr, $content );
@@ -63,13 +60,14 @@ function render_block( $attr, $content ) {
 /**
  * Render block with embed style.
  *
- * @param array  $attr    Eventbrite block attributes.
- * @param string $content Rendered embed element (without scripts) from the block editor.
- *
+ * @param array $attr Eventbrite block attributes.
  * @return string Rendered block.
  */
-function render_embed_block( $attr, $content ) {
+function render_embed_block( $attr ) {
 	$widget_id = wp_unique_id( 'eventbrite-widget-' );
+
+	// Add CSS to hide direct link.
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	wp_add_inline_script(
 		'eventbrite-widget',
@@ -84,17 +82,15 @@ function render_embed_block( $attr, $content ) {
 	// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
 	$classes = Blocks::classes( FEATURE_NAME, $attr );
 
-	$content .= sprintf(
-		'<div id="%1$s" class="%2$s"></div>',
-		esc_attr( $widget_id ),
-		esc_attr( $classes )
-	);
-
 	return sprintf(
-		'%s<noscript><a href="%s" rel="noopener noreferrer" target="_blank">%s</a></noscript>',
-		$content,
-		esc_url( $attr['url'] ),
-		esc_html__( 'Register on Eventbrite', 'jetpack' )
+		'<div id="%1$s" class="%2$s">%3$s</div>',
+		esc_attr( $widget_id ),
+		esc_attr( $classes ),
+		sprintf(
+			'<a href="%s" rel="noopener noreferrer" target="_blank" class="eventbrite__direct-link">%s</a>',
+			esc_url( $attr['url'] ),
+			esc_html__( 'Register on Eventbrite', 'jetpack' )
+		)
 	);
 }
 
@@ -103,7 +99,6 @@ function render_embed_block( $attr, $content ) {
  *
  * @param array  $attr    Eventbrite block attributes.
  * @param string $content Rendered embed element (without scripts) from the block editor.
- *
  * @return string Rendered block.
  */
 function render_modal_block( $attr, $content ) {

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -106,7 +106,7 @@ function render_embed_block( $widget_id, $is_amp, $attr ) {
 		'<a href="%s" rel="noopener noreferrer" target="_blank" class="eventbrite__direct-link" %s>%s</a>',
 		esc_url( $attr['url'] ),
 		$is_amp ? 'placeholder fallback' : '',
-		esc_html__( 'Register on Eventbrite', 'jetpack' ),
+		esc_html__( 'Register on Eventbrite', 'jetpack' )
 	);
 
 	if ( $is_amp ) {

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -183,8 +183,9 @@ function render_modal_block( $widget_id, $is_amp, $attr, $content ) {
 		);
 
 		$lightbox = sprintf(
-			'<amp-lightbox id="%s" class="eventbrite__lightbox" layout="nodisplay">%s</amp-lightbox>',
+			'<amp-lightbox id="%1$s" on="%2$s" class="eventbrite__lightbox" layout="nodisplay">%3$s</amp-lightbox>',
 			esc_attr( $lightbox_id ),
+			esc_attr( "tap:{$lightbox_id}.close" ),
 			sprintf(
 				'
 					<div class="eventbrite__lighbox-inside">

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -11,10 +11,18 @@ namespace Automattic\Jetpack\Extensions\Eventbrite;
 
 use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
-use Jetpack_AMP_Support;
 
 const FEATURE_NAME = 'eventbrite';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Determine whether the page will be AMP.
+ *
+ * @return bool
+ */
+function is_amp_request() {
+	return class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request();
+}
 
 /**
  * Registers the block for use in Gutenberg
@@ -84,7 +92,7 @@ function render_block( $attr, $content ) {
 function render_embed_block( $attr ) {
 	$widget_id = wp_unique_id( 'eventbrite-widget-' );
 
-	$is_amp = Jetpack_AMP_Support::is_amp_request();
+	$is_amp = is_amp_request();
 
 	// $content contains a fallback link to the event that's saved in the post_content.
 	// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
@@ -150,7 +158,7 @@ function render_embed_block( $attr ) {
 function render_modal_block( $attr, $content ) {
 	$widget_id = wp_unique_id( 'eventbrite-widget-' );
 
-	$is_amp = Jetpack_AMP_Support::is_amp_request();
+	$is_amp = is_amp_request();
 
 	if ( $is_amp ) {
 		$lightbox_id = "{$widget_id}-lightbox";

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -75,24 +75,26 @@ function render_block( $attr, $content ) {
 		true
 	);
 
+	$widget_id = wp_unique_id( 'eventbrite-widget-' );
+	$is_amp    = is_amp_request();
+
 	// Show the embedded version.
 	if ( empty( $attr['useModal'] ) && ( empty( $attr['style'] ) || 'modal' !== $attr['style'] ) ) {
-		return render_embed_block( $attr );
+		return render_embed_block( $widget_id, $is_amp, $attr );
 	} else {
-		return render_modal_block( $attr, $content );
+		return render_modal_block( $widget_id, $is_amp, $attr, $content );
 	}
 }
 
 /**
  * Render block with embed style.
  *
- * @param array $attr Eventbrite block attributes.
+ * @param string $widget_id Widget ID to use.
+ * @param bool   $is_amp    Whether AMP page.
+ * @param array  $attr      Eventbrite block attributes.
  * @return string Rendered block.
  */
-function render_embed_block( $attr ) {
-	$widget_id = wp_unique_id( 'eventbrite-widget-' );
-
-	$is_amp = is_amp_request();
+function render_embed_block( $widget_id, $is_amp, $attr ) {
 
 	// $content contains a fallback link to the event that's saved in the post_content.
 	// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
@@ -151,14 +153,13 @@ function render_embed_block( $attr ) {
 /**
  * Render block with modal style.
  *
- * @param array  $attr    Eventbrite block attributes.
- * @param string $content Rendered embed element (without scripts) from the block editor.
+ * @param string $widget_id Widget ID to use.
+ * @param bool   $is_amp    Whether AMP page.
+ * @param array  $attr      Eventbrite block attributes.
+ * @param string $content   Rendered embed element (without scripts) from the block editor.
  * @return string Rendered block.
  */
-function render_modal_block( $attr, $content ) {
-	$widget_id = wp_unique_id( 'eventbrite-widget-' );
-
-	$is_amp = is_amp_request();
+function render_modal_block( $widget_id, $is_amp, $attr, $content ) {
 
 	if ( $is_amp ) {
 		$lightbox_id = "{$widget_id}-lightbox";

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -44,12 +44,12 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  */
 function get_current_url() {
 	if ( isset( $_SERVER['HTTP_HOST'] ) ) {
-		$host = wp_unslash( $_SERVER['HTTP_HOST'] );
+		$host = wp_unslash( $_SERVER['HTTP_HOST'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	} else {
 		$host = wp_parse_url( home_url(), PHP_URL_HOST );
 	}
 	if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-		$path = wp_unslash( $_SERVER['REQUEST_URI'] );
+		$path = wp_unslash( $_SERVER['REQUEST_URI'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	} else {
 		$path = '/';
 	}

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -123,5 +123,15 @@ function render_block( $attr, $content ) {
 	// Fallback for block version deprecated/v2.
 	$content = preg_replace( '/eventbrite-widget-\d+/', esc_attr( $widget_id ), $content );
 
+	// Inject URL to event in case the JS for the lightbox fails to load.
+	$content = preg_replace(
+		'/\shref="#"/',
+		sprintf(
+			' href="%s" rel="noopener noreferrer" target="_blank"',
+			esc_url( $attr['url'] )
+		),
+		$content
+	);
+
 	return $content;
 }

--- a/extensions/blocks/eventbrite/style.scss
+++ b/extensions/blocks/eventbrite/style.scss
@@ -1,4 +1,5 @@
-.eventbrite__direct-link {
+// Hide the link if an iframe got appended to the container.
+.eventbrite__direct-link:not(:only-child) {
 	display: none;
 }
 

--- a/extensions/blocks/eventbrite/style.scss
+++ b/extensions/blocks/eventbrite/style.scss
@@ -7,8 +7,9 @@
 // default/minimum value set by Eventbrite (425px), by overriding
 // the container's inline height (set by Eventbrite, sometimes incorrectly as 0px),
 // and setting the default height directly to the iframe.
-.wp-block-jetpack-eventbrite {
+.wp-block-jetpack-eventbrite--embed {
 	height: auto !important;
+
 	iframe {
 		height: 425px;
 	}
@@ -16,4 +17,51 @@
 	&.aligncenter {
 		text-align: center;
 	}
+}
+
+.eventbrite__lightbox {
+	background: rgba(57, 54, 79, .8);
+}
+
+.eventbrite__lighbox-inside {
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+@media (max-width: 660px) {
+	.eventbrite__lighbox-iframe-wrapper {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	}
+}
+
+@media (min-width: 661px) {
+	.eventbrite__lighbox-iframe-wrapper {
+	width: 95%;
+	height: 95%;
+	max-width: 1080px;
+	max-height: 720px;
+	margin: auto;
+	position: relative;
+	}
+}
+
+.eventbrite__lighbox-iframe {
+	margin: 0;
+}
+
+.eventbrite__lighbox-close {
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 40px;
+	height: 40px;
+	/* @todo More styling could be copied from Eventbrite */
 }


### PR DESCRIPTION
See #14395.

This PR adds AMP compatibility for the Eventbrite block.

Given a post with this content:

```html
<!-- wp:heading -->
<h2>In-Page Embed</h2>
<!-- /wp:heading -->

<!-- wp:jetpack/eventbrite {"url":"https://www.eventbrite.com/e/wordpress-diverse-speaker-workshops-october-2020-tickets-118559108485","eventId":118559108485} -->
<a class="wp-block-jetpack-eventbrite eventbrite__direct-link" href="https://www.eventbrite.com/e/wordpress-diverse-speaker-workshops-october-2020-tickets-118559108485">https://www.eventbrite.com/e/wordpress-diverse-speaker-workshops-october-2020-tickets-118559108485</a>
<!-- /wp:jetpack/eventbrite -->

<!-- wp:heading -->
<h2>Button and Modal</h2>
<!-- /wp:heading -->

<!-- wp:jetpack/eventbrite {"url":"https://www.eventbrite.com/e/wordpress-diverse-speaker-workshops-october-2020-tickets-118559108485","eventId":118559108485,"style":"modal"} -->
<div class="wp-block-jetpack-eventbrite"><!-- wp:jetpack/button {"element":"a","uniqueId":"eventbrite-widget-id","text":"Register","textColor":"background","backgroundColor":"primary","borderRadius":37,"className":"is-style-fill"} /--></div>
<!-- /wp:jetpack/eventbrite -->
```

State |  Non-AMP | JS Disabled Before 👎 | AMP Before 👎  | AMP After 👍 | JS Disabled After 👍 
------|-----------|-------------|-----------|--------------|-------------
Initial | ![image](https://user-images.githubusercontent.com/134745/93173267-1f371700-f6e1-11ea-8457-19a7fe9652fc.png) | ![image](https://user-images.githubusercontent.com/134745/93173529-7fc65400-f6e1-11ea-8d25-37516e26694c.png) (Misaligned link) |  ![image](https://user-images.githubusercontent.com/134745/93173338-3ece3f80-f6e1-11ea-8fb7-0226944d63c0.png) (Misaligned link) | ![image](https://user-images.githubusercontent.com/134745/93173837-efd4da00-f6e1-11ea-8b13-f73b9731d0e7.png) | ![image](https://user-images.githubusercontent.com/134745/93173875-011de680-f6e2-11ea-9dc3-3c083a7f6d1f.png)
Model Open | ![image](https://user-images.githubusercontent.com/134745/93173400-50174c00-f6e1-11ea-85fb-f1ea230ce489.png) | 🚫 Opens self in new window. | 🚫 Opens self in new window. | ![image](https://user-images.githubusercontent.com/134745/93174034-43472800-f6e2-11ea-8f3e-c1dea559b385.png) | ✅  Eventbrite link opens in new tab

#### Changes proposed in this Pull Request:

* Add AMP compatibility for Eventbrite block and improve fallback behavior when JS is disabled.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:

* Activate the AMP plugin and enable either Transitional or Reader mode (and in Reader mode, with Legacy theme or another theme active)
* Create a new post and supply the above post content
* Interact with the two Eventbrite blocks, including both the embed style and modal style.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add AMP compatibility for Eventbrite block and improve fallback behavior when JS is disabled.