### PR TITLE
Add nofollow to Jetpack.com links in Search colophon and Cookies widget

### DIFF
--- a/modules/search/instant-search/components/jetpack-colophon.jsx
+++ b/modules/search/instant-search/components/jetpack-colophon.jsx
@@ -44,7 +44,7 @@ const JetpackColophon = props => {
 		<div className="jetpack-instant-search__jetpack-colophon">
 			<a
 				href={ url }
-				rel="external noopener noreferrer"
+				rel="external noopener noreferrer nofollow"
 				target="_blank"
 				className="jetpack-instant-search__jetpack-colophon-link"
 			>

--- a/modules/widgets/eu-cookie-law/widget-amp.php
+++ b/modules/widgets/eu-cookie-law/widget-amp.php
@@ -26,11 +26,11 @@
 				echo esc_html( $instance['customtext'] );
 			}
 
-			$policy_link_text = 'default' === $instance['policy-url'] || empty( $instance['custom-policy-url'] )
-					? $instance['default-policy-url']
-					: $instance['custom-policy-url'];
+			$is_default_policy = 'default' === $instance['policy-url'] || empty( $instance['custom-policy-url'] );
+			$policy_link_url   = $is_default_policy ? $instance['default-policy-url'] : $instance['custom-policy-url'];
+			$policy_link_rel   = $is_default_policy ? 'nofollow' : '';
 			?>
-			<a href="<?php echo esc_url( $policy_link_text ); ?>">
+			<a href="<?php echo esc_url( $policy_link_url ); ?>" rel="<?php echo esc_attr( $policy_link_rel ); ?>">
 				<?php echo esc_html( $instance['policy-link-text'] ); ?>
 			</a>
 		</div>

--- a/modules/widgets/eu-cookie-law/widget.php
+++ b/modules/widgets/eu-cookie-law/widget.php
@@ -1,3 +1,11 @@
+<?php // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+/**
+ * Widget for Cookies and Consent.
+ *
+ * @package Jetpack
+ */
+?>
+
 <div
 	class="<?php echo implode( ' ', $classes ); ?>"
 	data-hide-timeout="<?php echo intval( $instance['hide-timeout'] ); ?>"
@@ -14,12 +22,12 @@
 		echo nl2br( esc_html( $instance['customtext'] ) );
 	} ?>
 
-	<a href="<?php
-		$policy_link_text = 'default' === $instance['policy-url'] || empty( $instance['custom-policy-url'] )
-			? $instance['default-policy-url']
-			: $instance['custom-policy-url'];
-		echo esc_url( $policy_link_text );
-	?>" >
+	<?php
+	$is_default_policy = 'default' === $instance['policy-url'] || empty( $instance['custom-policy-url'] );
+	$policy_link_url   = $is_default_policy ? $instance['default-policy-url'] : $instance['custom-policy-url'];
+	$policy_link_rel   = $is_default_policy ? 'nofollow' : '';
+	?>
+	<a href="<?php echo esc_url( $policy_link_url ); ?>" rel="<?php echo esc_attr( $policy_link_rel ); ?>">
 		<?php echo esc_html( $instance['policy-link-text'] ); ?>
 	</a>
 </div>


### PR DESCRIPTION
The goal is to avoid potential search engine penalties due to spammy-looking identical backlinks to Jetpack.com.

#### Changes proposed in this Pull Request:
* Add `rel="nofollow"` to Search Colophon link and Privacy & Cookies widget

#### Jetpack product discussion
pbNhbs-da-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Spin up a test site and enable Search and the extra Jetpack widgets.
* Add the Search (Jetpack) widget to any visible sidebar.
* Add the Cookies & Consent Banner (Jetpack) widget to any visible sidebar. Make sure "Privacy Policy Link" is set to "Default" and save the widget.
* Visit the site frontend.
* Make sure the "Privacy & Cookies" widget's "Cookie Policy" link has `rel="nofollow"`.
* Conduct a search so the instant search sidebar is visible.
* Make sure the "Search powered by Jetpack" colophon link has `rel="nofollow"`.

#### Proposed changelog entry for your changes:
No changelog entry necessary.
