### PR TITLE
Gutenboarding: save selected features as a site option

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -148,6 +148,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpforteams_site',
 		'site_creation_flow',
 		'is_cloud_eligible',
+		'selected_features',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -635,6 +636,12 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'is_cloud_eligible':
 					$options[ $key ] = $site->is_cloud_eligible();
+					break;
+				case 'selected_features':
+					$selected_features = $site->get_selected_features();
+					if ( $selected_features ) {
+						$options[ $key ] = $selected_features;
+					}
 					break;
 			}
 		}

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -689,4 +689,8 @@ abstract class SAL_Site {
 	function get_site_creation_flow() {
 		return get_option( 'site_creation_flow' );
 	}
+
+	public function get_selected_features() {
+		return get_option( 'selected_features' );
+	}
 }


### PR DESCRIPTION
Summary:
This patch is part of [[ 45148-gh-wp-calypso | #45148 ]]

This patch saves the `selected_features` as a site option.
We're looking to use this data during the Site setup flow (in editor) to recommend a plan based on the selected features.
The option will be available only for sites created using `site_creation_flow: 'gutenboarding'`.

Note: this change is a very similar to D42191-code

Test Plan: Follow testing instructions in [[ 45148-gh-wp-calypso | #45148 ]]

Reviewers: simison, mciampini, tomjcafferkey

Reviewed By: mciampini, tomjcafferkey

Tags: #touches_jetpack_files

Differential Revision: D49420-code

This commit syncs r213657-wpcom.

#### Does this pull request change what data or activity we track or use?
* We now save the user selection made during Features step in Gutenboarding (wordpress.com/new/features).

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to https://github.com/Automattic/wp-calypso/pull/45578

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Probably doesn't need a changelog entry
