### PR TITLE
Instant Search: Disable autocompletion for search inputs

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -20,7 +20,6 @@ import {
 	getFilterQuery,
 	getSearchQuery,
 	getSortQuery,
-	getResultFormatQuery,
 	hasFilter,
 	setSearchQuery,
 	setSortQuery,
@@ -53,6 +52,7 @@ class SearchApp extends Component {
 		this.getResults.flush();
 
 		this.addEventListeners();
+		this.disableAutocompletion();
 
 		if ( this.hasActiveQuery() ) {
 			this.showResults();
@@ -88,6 +88,13 @@ class SearchApp extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.removeEventListener( 'click', this.handleFilterInputClick );
+		} );
+	}
+
+	disableAutocompletion() {
+		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
+			input.setAttribute( 'autocomplete', 'off' );
+			input.form.setAttribute( 'autocomplete', 'off' );
 		} );
 	}
 

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -46,6 +46,7 @@ const SearchBox = props => {
 						<Gridicon icon="search" size={ 24 } />
 					</div>
 					<input
+						autocomplete="off"
 						id={ inputId }
 						className="search-field jetpack-instant-search__box-input"
 						onInput={ props.onChangeQuery }

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -55,7 +55,7 @@ class SearchForm extends Component {
 
 	render() {
 		return (
-			<form onSubmit={ noop } role="search" className={ this.props.className }>
+			<form autocomplete="off" onSubmit={ noop } role="search" className={ this.props.className }>
 				<div className="jetpack-instant-search__search-form">
 					<SearchBox
 						enableFilters={ this.hasSelectableFilters() || this.hasPreselectedFilters() }


### PR DESCRIPTION
Fixes #17162.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disables autocomplete functionality for all search inputs on the site.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Follow the reproduction steps from #17162:
>1. In Google Chrome, go to a site with Jetpack Instant Search enabled, using the 'when results are ready' overlay trigger
>2. Enter your search query and visit the results
>3. Try to repeat step 2 by attempting to summon the autocomplete dropdown. Ensure that the dropdown doesn't appear.

#### Proposed changelog entry for your changes:
* None.