### PR TITLE
Autoloader: Detect filtering of active_plugins

### DIFF
--- a/packages/autoloader/src/functions.php
+++ b/packages/autoloader/src/functions.php
@@ -45,11 +45,8 @@ function set_up_autoloader() {
 		$version_selector
 	);
 
+	// The autoloader must be reset when a plugin that was previously unknown is detected.
 	if ( $autoloader_handler->should_autoloader_reset() ) {
-		/*
-		 * The autoloader must be reset when an activating plugin that was
-		 * previously unknown is detected.
-		 */
 		$jetpack_autoloader_latest_version = null;
 		$jetpack_autoloader_loader         = null;
 	}

--- a/packages/autoloader/tests/php/tests/test_autoloader_handler.php
+++ b/packages/autoloader/tests/php/tests/test_autoloader_handler.php
@@ -61,6 +61,8 @@ class WP_Test_Autoloader_Handler extends TestCase {
 	 */
 	public function test_should_autoloader_reset_known_plugin() {
 		global $jetpack_autoloader_activating_plugins_paths;
+		global $jetpack_autoloader_cached_plugin_paths;
+		$jetpack_autoloader_cached_plugin_paths = array( TEST_DATA_PATH . '/plugins/plugin_current' );
 
 		$autoloader_handler = new Autoloader_Handler(
 			TEST_DATA_PATH . '/plugins/plugin_current',
@@ -89,6 +91,24 @@ class WP_Test_Autoloader_Handler extends TestCase {
 		$this->assertTrue( $autoloader_handler->should_autoloader_reset() );
 		$this->assertCount( 1, $jetpack_autoloader_activating_plugins_paths );
 		$this->assertEquals( TEST_DATA_PATH . '/plugins/plugin_current', $jetpack_autoloader_activating_plugins_paths[0] );
+	}
+
+	/**
+	 * Tests should_autoloader_reset() with an old cache set of plugin paths.
+	 */
+	public function test_should_autoloader_reset_invalid_cache() {
+		global $jetpack_autoloader_cached_plugin_paths;
+		$jetpack_autoloader_cached_plugin_paths = array();
+
+		$autoloader_handler = new Autoloader_Handler(
+			TEST_DATA_PATH . '/plugins/plugin_current',
+			array( TEST_DATA_PATH . '/plugins/plugin_current' ),
+			new Autoloader_Locator( new Version_Selector() ),
+			new Version_Selector()
+		);
+
+		$this->assertTrue( $autoloader_handler->should_autoloader_reset() );
+		$this->assertEquals( array( TEST_DATA_PATH . '/plugins/plugin_current' ), $jetpack_autoloader_cached_plugin_paths );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/issues/27608 it became apparent that plugins can filter `active_plugins` in a way that prevents some plugins from being detected by the autoloader. This PR addressed the issue by caching the list in `should_autoloader_reset()` as an additional means to evaluating whether or not manifests should be processed again.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Add this `autoloader-testing.php` file to `mu-plugin`. It sets up autoloader globals in a way that pretends the autoloader has been successfully loaded. Without this PR this will result in the entire site becoming inaccessible due to class loading errors, but with this PR, it will work as-expected.
```php
<?php
/**
 * Plugin Name: Autoloader Testing
 * Description: This plugin helps.
 * Version: 1.0
 */

 defined( 'ABSPATH' ) || exit;

// Set a version for the autoloader so that Jetpack won't attempt to
// reset the autoloader.
global $jetpack_autoloader_latest_version;
$jetpack_autoloader_latest_version = '2.2.0.0';
global $jetpack_autoloader_cached_plugin_paths;
$jetpack_autoloader_cached_plugin_paths = array();
```

#### Proposed changelog entry for your changes:
* Autoloader: Added handling for filtered `active_plugins` options that would otherwise have left classes out.