### PR TITLE
Adding clip-path property to supported CSS properties

### DIFF
--- a/modules/custom-css/csstidy/data.inc.php
+++ b/modules/custom-css/csstidy/data.inc.php
@@ -369,6 +369,7 @@ $GLOBALS['csstidy']['all_properties']['break-inside'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['caption-side'] = 'CSS2.0,CSS2.1,CSS3.0';
 $GLOBALS['csstidy']['all_properties']['clear'] = 'CSS1.0,CSS2.0,CSS2.1,CSS3.0';
 $GLOBALS['csstidy']['all_properties']['clip'] = 'CSS2.0,CSS2.1,CSS3.0';
+$GLOBALS['csstidy']['all_properties']['clip-path'] = 'CSS2.0,CSS2.1,CSS3.0';
 $GLOBALS['csstidy']['all_properties']['color'] = 'CSS1.0,CSS2.0,CSS2.1,CSS3.0';
 $GLOBALS['csstidy']['all_properties']['color-profile'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['column-count'] = 'CSS3.0';


### PR DESCRIPTION
Fixes #17106 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds support for the `clip-path` CSS property to the Customizer.

#### Jetpack product discussion

Raised as an issue here: [CSS Tidy: add clip-path · Issue #17106 · Automattic/jetpack](https://github.com/Automattic/jetpack/issues/17106) after initially suggesting Custom CSS to a user in 3294186-zen.

#### Does this pull request change what data or activity we track or use?

Not as far as I'm aware, no.

#### Testing instructions:

* Go to "My Sites → Design → Customize → Additional CSS"
* Create a CSS statement using the `clip-path` property, for example:

```
/* Add different circle crop to a larger images on the page */
.post-111 .wp-image-1020 {
    clip-path: circle(25%);
}
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Adds support for the `clip-path` CSS property for use in Additional CSS in the Customizer.
