### PR TITLE
Jetpack Debugger: Handle connection failing tests consistently

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -465,7 +465,8 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$name = __FUNCTION__;
 
 		$m                = new Connection_Manager();
-		$validated_tokens = $m->validate_tokens( get_current_user_id() ? get_current_user_id() : $m->get_connection_owner_id() );
+		$user_id          = get_current_user_id() ? get_current_user_id() : $m->get_connection_owner_id();
+		$validated_tokens = $m->validate_tokens( $user_id );
 
 		if ( ! is_array( $validated_tokens ) || count( array_diff_key( array_flip( array( 'blog_token', 'user_token' ) ), $validated_tokens ) ) ) {
 			return self::skipped_test(
@@ -559,10 +560,12 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$message      = $result->message . ': ' . wp_remote_retrieve_response_code( $response );
 
 		if ( $is_connected ) {
-			return self::passing_test( array( 'name' => $name ) );
+			$res = self::passing_test( array( 'name' => $name ) );
 		} else {
-			return self::connection_failing_test( $name, $message );
+			$res = self::connection_failing_test( $name, $message );
 		}
+
+		return $res;
 	}
 
 	/**

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -99,10 +99,73 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	}
 
 	/**
+	 * Returns the url to reconnect Jetpack.
+	 *
+	 * @return string The reconnect url.
+	 */
+	protected static function helper_get_reconnect_url() {
+		return admin_url( 'admin.php?page=jetpack#/reconnect' );
+	}
+
+	/**
 	 * Gets translated support text.
 	 */
 	protected function helper_get_support_text() {
 		return __( 'Please contact Jetpack support.', 'jetpack' );
+	}
+
+	/**
+	 * Returns the translated text to reconnect Jetpack.
+	 *
+	 * @return string The translated reconnect text.
+	 */
+	protected static function helper_get_reconnect_text() {
+		return __( 'Reconnect Jetpack now', 'jetpack' );
+	}
+
+	/**
+	 * Gets translated reconnect long description.
+	 *
+	 * @param string $connection_error The connection specific error.
+	 * @param string $recommendation The recommendation for resolving the connection error.
+	 *
+	 * @return string The translated long description for reconnection recommendations.
+	 */
+	protected static function helper_get_reconnect_long_description( $connection_error, $recommendation ) {
+
+		return sprintf(
+			'<p>%1$s</p>' .
+			'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s</p><p><strong>%4$s</strong></p>',
+			__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
+			/* translators: screen reader text indicating a test failed */
+			__( 'Error', 'jetpack' ),
+			$connection_error,
+			$recommendation
+		);
+	}
+
+	/**
+	 * Helper function to return consistent responses for a connection failing test.
+	 *
+	 * @param string $name The raw method name that runs the test. Default unnamed_test.
+	 * @param string $connection_error The connection specific error. Default 'Your site is not connected to Jetpack.'.
+	 * @param string $recommendation The recommendation for resolving the connection error. Default 'We recommend reconnecting Jetpack.'.
+	 *
+	 * @return array Test results.
+	 */
+	public static function connection_failing_test( $name, $connection_error = '', $recommendation = '' ) {
+		$connection_error = empty( $connection_error ) ? __( 'Your site is not connected to Jetpack.', 'jetpack' ) : $connection_error;
+		$recommendation   = empty( $recommendation ) ? __( 'We recommend reconnecting Jetpack.', 'jetpack' ) : $recommendation;
+
+		$args = array(
+			'name'              => $name,
+			'short_description' => $connection_error,
+			'action'            => self::helper_get_reconnect_url(),
+			'action_label'      => self::helper_get_reconnect_text(),
+			'long_description'  => self::helper_get_reconnect_long_description( $connection_error, $recommendation ),
+		);
+
+		return self::failing_test( $args );
 	}
 
 	/**
@@ -142,10 +205,12 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 * @return array
 	 */
 	protected function test__blog_token_if_exists() {
+		$name = __FUNCTION__;
+
 		if ( ! $this->helper_is_jetpack_connected() ) {
 			return self::skipped_test(
 				array(
-					'name'              => __FUNCTION__,
+					'name'              => $name,
 					'short_description' => __( 'Jetpack is not connected. No blog token to check.', 'jetpack' ),
 				)
 			);
@@ -153,16 +218,11 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$blog_token = $this->helper_get_blog_token();
 
 		if ( $blog_token ) {
-			$result = self::passing_test( array( 'name' => __FUNCTION__ ) );
+			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
-			$result = self::failing_test(
-				array(
-					'name'              => __FUNCTION__,
-					'short_description' => __( 'Blog token is missing.', 'jetpack' ),
-					'action'            => admin_url( 'admin.php?page=jetpack#/dashboard' ),
-					'action_label'      => __( 'Disconnect your site from WordPress.com, and connect it again.', 'jetpack' ),
-				)
-			);
+			$connection_error = __( 'Blog token is missing.', 'jetpack' );
+
+			$result = self::connection_failing_test( $name, $connection_error );
 		}
 
 		return $result;
@@ -206,23 +266,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				)
 			);
 		} else {
-			$result = self::failing_test(
-				array(
-					'name'              => $name,
-					'short_description' => __( 'Your site is not connected to Jetpack', 'jetpack' ),
-					'action'            => admin_url( 'admin.php?page=jetpack#/dashboard' ),
-					'action_label'      => __( 'Reconnect your site now', 'jetpack' ),
-					'long_description'  => sprintf(
-						'<p>%1$s</p>' .
-						'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s</strong></p>',
-						__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
-						/* translators: screen reader text indicating a test failed */
-						__( 'Error', 'jetpack' ),
-						__( 'Your site is not connected to Jetpack.', 'jetpack' ),
-						__( 'We recommend reconnecting Jetpack.', 'jetpack' )
-					),
-				)
-			);
+			$connection_error = __( 'Your site is not connected to Jetpack', 'jetpack' );
+
+			$result = self::connection_failing_test( $name, $connection_error );
 		}
 
 		return $result;
@@ -248,14 +294,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( $local_user->exists() ) {
 			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
-			$result = self::failing_test(
-				array(
-					'name'              => $name,
-					'short_description' => __( 'The user who setup the Jetpack connection no longer exists on this site.', 'jetpack' ),
-					'action_label'      => __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ),
-					'action'            => Redirect::get_url( 'jetpack-support-reconnecting-reinstalling-jetpack' ),
-				)
-			);
+			$connection_error = __( 'The user who setup the Jetpack connection no longer exists on this site.', 'jetpack' );
+
+			$result = self::connection_failing_test( $name, $connection_error );
 		}
 
 		return $result;
@@ -283,15 +324,12 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( user_can( $master_user, 'manage_options' ) ) {
 			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
-			$result = self::failing_test(
-				array(
-					'name'              => $name,
-					/* translators: a WordPress username */
-					'short_description' => sprintf( __( 'The user (%s) who setup the Jetpack connection is not an administrator.', 'jetpack' ), $master_user->user_login ),
-					'action_label'      => __( 'Either upgrade the user or disconnect and reconnect Jetpack.', 'jetpack' ),
-					'action'            => Redirect::get_url( 'jetpack-support-reconnecting-reinstalling-jetpack' ),
-				)
-			);
+			/* translators: a WordPress username */
+			$connection_error = sprintf( __( 'The user (%s) who setup the Jetpack connection is not an administrator.', 'jetpack' ), $master_user->user_login );
+			/* translators: a WordPress username */
+			$recommendation = sprintf( __( 'We recommend either upgrading the user (%s) or reconnecting Jetpack.', 'jetpack' ), $master_user->user_login );
+
+			$result = self::connection_failing_test( $name, $connection_error, $recommendation );
 		}
 
 		return $result;
@@ -414,7 +452,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 *
 	 * @return array Test results.
 	 */
-	protected function test__token_health() {
+	protected function test__connection_token_health() {
 		$name = __FUNCTION__;
 
 		$m                = new Connection_Manager();
@@ -441,14 +479,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			return self::passing_test( array( 'name' => $name ) );
 		}
 
-		return self::failing_test(
-			array(
-				'name'              => $name,
-				'short_description' => __( 'Connection test failed: Invalid Jetpack tokens', 'jetpack' ),
-				'action_label'      => __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ),
-				'action'            => Redirect::get_url( 'jetpack-support-reconnecting-reinstalling-jetpack' ),
-			)
-		);
+		$connection_error = __( 'Invalid Jetpack connection tokens.', 'jetpack' );
+
+		return self::connection_failing_test( $name, $connection_error );
 	}
 
 	/**
@@ -474,15 +507,19 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		remove_filter( 'http_request_timeout', array( 'Jetpack_Cxn_Tests', 'increase_timeout' ) );
 
 		if ( is_wp_error( $response ) ) {
-			return self::failing_test(
-				array(
-					'name'              => $name,
-					/* translators: %1$s is the error code, %2$s is the error message */
-					'short_description' => sprintf( __( 'Connection test failed (#%1$s: %2$s)', 'jetpack' ), $response->get_error_code(), $response->get_error_message() ),
-					'action_label'      => $this->helper_get_support_text(),
-					'action'            => $this->helper_get_support_url(),
-				)
-			);
+			if ( false !== strpos( $response->get_error_message(), 'cURL error 28' ) ) { // Timeout.
+				return self::skipped_test(
+					array(
+						'name'              => $name,
+						'short_description' => __( 'The test timed out which may sometimes indicate a failure or may be a false failure.', 'jetpack' ),
+					)
+				);
+			}
+
+			/* translators: %1$s is the error code, %2$s is the error message */
+			$message = sprintf( __( 'Connection test failed (#%1$s: %2$s)', 'jetpack' ), $response->get_error_code(), $response->get_error_message() );
+
+			return self::connection_failing_test( $name, $message );
 		}
 
 		$body = wp_remote_retrieve_body( $response );
@@ -513,14 +550,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( $is_connected ) {
 			return self::passing_test( array( 'name' => $name ) );
 		} else {
-			return self::failing_test(
-				array(
-					'name'              => $name,
-					'short_description' => $message,
-					'action_label'      => $this->helper_get_support_text(),
-					'action'            => $this->helper_get_support_url(),
-				)
-			);
+			return self::connection_failing_test( $name, $message );
 		}
 	}
 


### PR DESCRIPTION
Up to now, the Jetpack debugger (and correspondingly the Site Health tool) used to:

1. Report connection failing tests in a non-consistent format, aka sometimes an intro text about what a connection is, other times only the error that occurred and different recommendations to resolve the issue.
2. Provide links for resolving the connection issues either to the admin dashboard or to the Jetpack support page on reinstalling / reconnecting Jetpack

This PR aims to provide consistent handling of connection related failing tests while most importantly utilize the reconnect flow by providing direct links to the end users in order to reconnect Jetpack in one-click. 

#### Changes proposed in this Pull Request:
* Adds a `connection_failing_test` public static method in `Jetpack_Cxn_Tests` in order to return consistent responses for a connection failing test 
* Utilizes the reconnect flow by providing direct links to restore the Jetpack connection in one click (`helper_get_reconnect_url` and  `helper_get_reconnect_text` protected methods in `Jetpack_Cxn_Tests` )
* Fixes the `test__wpcom_connection_test` failing test on timeouts by marking it as skipped instead.

#### Jetpack product discussion
p9dueE-1NT-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
**Case 1: Blog token if exists**
- Using the Broken token plugin **clear the blog token**.
- Go to Tools->Site Health and verify you can see the **Blog Token If Exists** critical issue
- Click the **Reconnect Jetpack now** link and verify the reconnection process is triggered and the error disappears after reconnection

**Case 2 Master user exists**
- Link a secondary admin user to Jetpack
- Delete the master user from the database
- Go to Tools->Site Health and verify you can see the **Master User Exists On Site** critical issue
- Click the **Reconnect Jetpack now** link and verify the reconnection process is triggered and the error disappears after reconnection

**Case 3 Master user can manage options**
- Link a secondary admin user to Jetpack
- Update the master user's role to eg subscriber
- Go to Tools->Site Health and verify you can see the **Master User Can Manage Options** critical issue
- Click the **Reconnect Jetpack now** link and verify the reconnection process is triggered and the error disappears after reconnection

**Case 4/5: Token Health / Wpcom Connection**
- Using the Broken token plugin **invalidate the blog token**.
- Go to Tools->Site Health and verify you can see the **Connection Token Health** and  **Wpcom Connection Test** critical issues
- Click the **Reconnect Jetpack now** link and verify the reconnection process is triggered and the errors disappears after reconnection

**Before / After**
![Screenshot 2020-09-16 at 2 34 04 PM](https://user-images.githubusercontent.com/1758399/93331954-bb6c3580-f829-11ea-81ae-3ab38f143ddf.png)


#### Proposed changelog entry for your changes:
* Jetpack Debugger: Handle connection failing tests consistently