### PR TITLE
Pay with PayPal: Add alternative shortcode output for email notifications

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -241,7 +241,7 @@ class Jetpack_Simple_Payments {
 			);
 		} else {
 			$purchase_box = sprintf(
-				'<a href="%1$s" target="_blank">%2$s</a>',
+				'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
 				esc_url( get_permalink( get_the_ID() ) ),
 				__( 'Visit the site to purchase.', 'jetpack' )
 			);


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/17161
Fixes 190-gh-dotcom-manage

#### Changes proposed in this Pull Request:
The `simple-payment` shortcode renders a PayPal button that is initialized with a JS file. However, that doesn't work when rendered in a email, so this PR changes the output of the shortcode when used on an email notification. In those cases, we simply display now a textual call-to-action that links to the post so folks can purchase from the website directly.

Before | After
--- | ---
<img width="629" alt="Screen Shot 2020-09-16 at 15 38 16" src="https://user-images.githubusercontent.com/1233880/93345042-acd64c00-f832-11ea-9529-ba0659159fad.png"> | <img width="626" alt="Screen Shot 2020-09-16 at 15 39 49" src="https://user-images.githubusercontent.com/1233880/93345276-e7d87f80-f832-11ea-8ec6-05f6834ed1c0.png">

#### Jetpack product discussion
pbAPfg-OF-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

WordPress.com
- Switch to a site under a Premium plan.
- Publish a post that contains a "Pay with PayPal" block.
- Grab the IDs of the post and the site where the post has been published.
- In a WP.com sandbox run `php ./bin/subscriptions/send.php <BLOG_ID> post <POST_ID> <YOUR_EMAIL>`. 
- Check the email received and make sure it contains a "Visit the site to purchase" link replacing the non-functional PayPal button.
- Make sure the link redirects to the published post.
- Make sure the PayPal button is visible on the published post.

Jetpack
- [Spin a JN site running this branch](http://jurassic.ninja/create/?jetpack-beta&branch=fix/pay-with-paypal-fallback-context).
- Set up Jetpack and continue using the Free plan.
- Add a Jetpack Premium to the JN site plan through Store Admin.
- Subscribe to the site using the [Subscriptions module](https://jetpack.com/support/subscriptions/):
  - Go to Jetpack > Settings > Discussion.
  - Activate the "Let visitors subscribe to new posts and comments via email" option.
  - Visit an already published post (the "Hello World!" post automatically created by JN is fine).
  - Subscribe to the site by leaving a comment and checking the "Notify me of new posts by email." option.
  - Confirm the subscription by clicking on the confirmation email you've received.
- Publish a post that contains a "Pay with PayPal" block.
- Check the email subscription and make sure it contains a "Visit the site to purchase" link replacing the non-functional PayPal button.
- Make sure the link redirects to the published post.
- Make sure the PayPal button is visible on the published post.

#### Proposed changelog entry for your changes:
Pay with PayPal: Add alternative shortcode output for email notifications