### PR TITLE
Google Analytics: Move legacy code to head

### DIFF
--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -19,7 +19,7 @@ class Jetpack_Google_Analytics_Legacy {
 	public function __construct() {
 		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_anonymize_ip' ) );
 		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_track_purchases' ) );
-		add_action( 'wp_footer', array( $this, 'insert_code' ) );
+		add_action( 'wp_head', array( $this, 'insert_code' ), 999 );
 		add_action( 'wp_footer', array( $this, 'jetpack_wga_classic_track_add_to_cart' ) );
 	}
 
@@ -55,7 +55,7 @@ class Jetpack_Google_Analytics_Legacy {
 
 	/**
 	 * This injects the Google Analytics code into the footer of the page.
-	 * Called exclusively by wp_footer action
+	 * Called exclusively by wp_head action
 	 */
 	public function insert_code() {
 		$tracking_id = Jetpack_Google_Analytics_Options::get_tracking_code();


### PR DESCRIPTION
Fixes #9129

In 9129, I think we let it sit too long letting by figuring out how to fix a bigger issue—upgrading the GA code we use—instead of, in the mean time, fixing the immediately reported problem.

This fixes 9129 and we can continue figuring out the new code in #9335

#### Changes proposed in this Pull Request:
* Moves GA code from the wp_footer to wp_head hook.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p58i-9ss-p2


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a


#### Testing instructions:
* Enable GA (business plan, add via Calypso).
* Before patch, see the GA code in the end of the body.
* After patch, see the GA code in the head.
* Confirm in GA that both are recorded.

#### Proposed changelog entry for your changes:
* Google Analytics: Move the legacy variant from the HTML body to head.
