### PR TITLE
Embeds: Instagram: Allow setting own access token to bypass proxied requests

### DIFF
--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -10,7 +10,7 @@ class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 		// Note: This forces the tests below to use the WPCOM/legacy flow. This means that
 		// the call to the /oembed-proxy endpoint isn't covered with tests. We should create
 		// at least one test below that specifically covers that.
-		Constants::set_constant( 'IS_WPCOM', true );
+		Constants::set_constant( 'JETPACK_INSTAGRAM_EMBED_TOKEN', 'test' );
 
 		// Back compat for PHPUnit 3!
 		// @todo Remove this when WP's PHP version bumps.
@@ -40,7 +40,7 @@ class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 	}
 
 	public function pre_http_request( $response, $args, $url ) {
-		if ( 0 !== strpos( $url, 'https://api.instagram.com/oembed/?url=' ) ) {
+		if ( 0 !== strpos( $url, 'https://graph.facebook.com/v5.0/instagram_oembed/?url=' ) ) {
 			return $response;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

See p7H4VZ-2DU-p2 for context

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the ability for sites to bypass proxying the WP.com API for Instagram embeds requests by setting a token via constant or filter

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p7H4VZ-2DU-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout branch
* Ensure that `shortcodes` module is on
* Create a post with an Instagram embed in it (note: Right now, it's OK if the embed doesn't work in the editor).
* Set the access token via the `JETPACK_INSTAGRAM_EMBED_TOKEN` constant or `jetpack_instagram_embed_token` filter. Of note, you can use `app_ID|app_secret` as a token. If you Slack me, I can share this with you.
* Load the post on the front-end
* Ensure that the embed works

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add ability to set access token to bypass proxying WordPress.com API for Instagram embeds
