### PR TITLE
Instant Search: Improve mobile layout for expanded result type

### DIFF
--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -1,4 +1,6 @@
 $overlay-vertical-padding: 3.5em;
+$overlay-horizontal-padding: 1em;
+$overlay-horizontal-padding-small-viewport: 0.5em;
 
 .jetpack-instant-search__overlay {
 	position: fixed;
@@ -7,12 +9,16 @@ $overlay-vertical-padding: 3.5em;
 	z-index: 9999999999999;
 	width: 100vw;
 	height: 100vh;
-	padding: $overlay-vertical-padding 1em;
+	padding: $overlay-vertical-padding $overlay-horizontal-padding-small-viewport;
 	background: rgba( 255, 255, 255, 0.975 );
 	overflow-y: auto;
 	overflow-x: hidden;
 	transition: opacity 0.15s ease-in-out;
 	box-sizing: border-box;
+
+	@include break-small() {
+		padding: $overlay-vertical-padding $overlay-horizontal-padding;
+	}
 
 	&.is-hidden {
 		transform: translateX( 100vw );

--- a/modules/search/instant-search/components/search-result-expanded.scss
+++ b/modules/search/instant-search/components/search-result-expanded.scss
@@ -8,8 +8,12 @@ $min-height: 190px;
 
 .jetpack-instant-search__result-expanded {
 	display: flex;
-	flex-direction: row;
+	flex-flow: column wrap;
 	margin: 2em 0;
+
+	@include break-small() {
+		flex-flow: row nowrap;
+	}
 
 	&:last-child {
 		margin-right: 0;
@@ -27,10 +31,7 @@ $min-height: 190px;
 	overflow-x: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	max-width: 40em;
-	.jetpack-instant-search__result-expanded--no-image & {
-		max-width: 46em;
-	}
+	max-width: calc( 100vw - 2em );
 }
 
 .jetpack-instant-search__result-expanded__path-link {
@@ -48,8 +49,10 @@ $min-height: 190px;
 }
 
 .jetpack-instant-search__result-expanded__copy-container {
-	min-height: $min-height;
-	width: 70%;
+	@include break-small() {
+		min-height: $min-height;
+		width: 70%;
+	}
 
 	.jetpack-instant-search__result-expanded--no-image & {
 		width: initial;
@@ -61,8 +64,13 @@ $min-height: 190px;
 }
 
 .jetpack-instant-search__result-expanded__image-container {
-	margin-left: 1em;
-	width: 30%;
+	margin-top: 0.5em;
+
+	@include break-small() {
+		margin-top: 0;
+		margin-left: 1em;
+		width: 30%;
+	}
 
 	.jetpack-instant-search__result-expanded--no-image & {
 		display: none;
@@ -74,9 +82,13 @@ $min-height: 190px;
 	border-radius: 5px;
 }
 .jetpack-instant-search__result-expanded__image {
-	background-size: cover;
+	background-size: contain;
 	background-position: center;
 	background-repeat: no-repeat;
+
+	@include break-small() {
+		background-size: cover;
+	}
 }
 
 .jetpack-instant-search__result-expanded__img {


### PR DESCRIPTION
Fixes #17157.

#### Changes proposed in this Pull Request:
* Improves visual spacing for expanded result format in mobile viewports.

Before: 
> <img width="245" alt="Screen Shot 2020-09-16 at 2 46 33 PM" src="https://user-images.githubusercontent.com/4044428/93390794-806b0180-f82b-11ea-9b69-1e8d57d1a98b.png">

After:
> <img width="245" alt="Screen Shot 2020-09-16 at 2 46 09 PM" src="https://user-images.githubusercontent.com/4044428/93390810-8660e280-f82b-11ea-8b6c-9b9423f1ce52.png">


#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply these changes to your Jetpack installation.
* Search your site. Try changing your viewport; ensure that the results maintain visual consistency. 

#### Proposed changelog entry for your changes:
* Improved mobile layout for Instant Search results.