### PR TITLE
Custom CSS: add rebeccapurple color

### DIFF
--- a/modules/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/modules/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -2229,6 +2229,7 @@ class lessc {
 		'plum' => '221,160,221',
 		'powderblue' => '176,224,230',
 		'purple' => '128,0,128',
+		'rebeccapurple' => '102,51,153',
 		'red' => '255,0,0',
 		'rosybrown' => '188,143,143',
 		'royalblue' => '65,105,225',

--- a/modules/custom-css/custom-css/preprocessors/scss.inc.php
+++ b/modules/custom-css/custom-css/preprocessors/scss.inc.php
@@ -2380,7 +2380,7 @@ class scssc {
 	/**
 	 * CSS Colors
 	 *
-	 * @see https://www.w3.org/TR/css-color-3/
+	 * @see https://www.w3.org/TR/css-color-4/
 	 */
 	static protected $cssColors = array(
 		'aliceblue' => '240,248,255',

--- a/modules/custom-css/custom-css/preprocessors/scss.inc.php
+++ b/modules/custom-css/custom-css/preprocessors/scss.inc.php
@@ -2502,6 +2502,7 @@ class scssc {
 		'plum' => '221,160,221',
 		'powderblue' => '176,224,230',
 		'purple' => '128,0,128',
+		'rebeccapurple' => '102,51,153',
 		'red' => '255,0,0',
 		'rosybrown' => '188,143,143',
 		'royalblue' => '65,105,225',


### PR DESCRIPTION
Fixes #17190

#### Changes proposed in this Pull Request:

* Add `rebeccapurple` to our 2 CSS preprocessors. 
* See https://www.w3.org/TR/css-color-4/#valdef-color-rebeccapurple

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Jetpack > Settings and enable the Custom CSS feature.
* Go to Appearance > Customize > Additional CSS.
* Add the following:
```scss
a:hover { 
	background: lighten(rebeccapurple, 40%);
}
```
* Pick the SCSS preprocessor
* Save
* Visit your site's frontend
* View source
* Ensure the SCSS was compiled into:
```css
a:hover {
	background: #ccb3e6;
}

```

#### Proposed changelog entry for your changes:

Custom CSS: add rebeccapurple color to the list of colors that can be processed by the SCSS and LESS preprocessors.
