### PR TITLE
Filter only specific Wikimedia subdomains in Photon API

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -352,7 +352,7 @@ function jetpack_photon_banned_domains( $skip, $image_url ) {
 		'/\.paypalobjects\.com$/',
 		'/\.dropbox\.com$/',
 		'/\.cdninstagram\.com$/',
-		'/\.wikimedia\.org$/',
+		'/^(commons|upload)\.wikimedia\.org$/',
 	);
 
 	$host = wp_parse_url( $image_url, PHP_URL_HOST );


### PR DESCRIPTION
The following PR: https://github.com/Automattic/jetpack/pull/15774 has introduced a ban/filter in the Photon API for Wikimedia.org domain as images have a very specific URL.

Unfortunately, some Wikimedia.org subdomains are hosted on WordPress VIP and need to be able to use the Photon API.

Fixes #

#### Changes proposed in this Pull Request:

* I have modified the  wikimedia.org pattern in the `jetpack_photon_banned_domains()` function to only ban subdomains starting with `commons` and `upload`. To my knowledge, only those 2 subdomains are meant to be skipped in the Photon API. Multiple Wikimedia subdomains like `diff`, `techblog`, `policy`, ... need to use the Photon API.

#### Jetpack product discussion
115353-zd-wordpressvip


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
The following blog post: https://diff.wikimedia.org/2019/10/23/my-life-as-a-strategy-liaison-for-the-french-language/  
has a resized/intermediate image: https://diff.wikimedia.org/wp-content/uploads/2019/10/Siffli_weekly_meeting-748x1024.jpg 

The intermediate images are not available at the URL as they are not uploaded to the VIP Go Files Service but [are instead processed by Jetpack/VIP GO Files Service](https://github.com/Automattic/vip-go-mu-plugins/blob/f42df6112572bf2084997bc589fe6efe24cf64b8/a8c-files.php#L1024-L1042) to be resized.

In this example, the image should have been converted to something like `https://diff.wikimedia.org/wp-content/uploads/2019/10/Siffli_weekly_meeting.jpg?resize=328%2C449`


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Reduce the range of banned Wikimedia domains in the Photon API
