### PR TITLE
Story block: Post Images support

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -859,6 +859,18 @@ class Jetpack_PostImages {
 			foreach ( $block['attrs']['ids'] as $img_id ) {
 				$images[] = self::get_attachment_data( $img_id, $html_info['post_url'], $width, $height );
 			}
+		} elseif (
+			/**
+			 * Parse content from Jetpack's Story block.
+			 */
+			'jetpack/story' === $block['blockName']
+			&& ! empty( $block['attrs']['mediaFiles'] )
+		) {
+			foreach ( $block['attrs']['mediaFiles'] as $media_file ) {
+				if ( ! empty( $media_file['id'] ) ) {
+					$images[] = self::get_attachment_data( $media_file['id'], $html_info['post_url'], $width, $height );
+				}
+			}
 		}
 
 		return $images;

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -834,7 +834,8 @@ class Jetpack_PostImages {
 			$meta_width  = $meta['videopress']['width'];
 			$meta_height = $meta['videopress']['height'];
 		} elseif ( ! empty( $meta['thumb'] ) ) {
-			// Use the thumbnail path if it's set.
+			// On WordPress.com, VideoPress videos have a 'thumb' property with the
+			// poster image filename instead.
 			$media_url   = wp_get_attachment_url( $attachment_id );
 			$url         = str_replace( wp_basename( $media_url ), $meta['thumb'], $media_url );
 			$meta_width  = $meta['width'];

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -783,6 +783,10 @@ class Jetpack_PostImages {
 			return false;
 		}
 
+		if ( wp_attachment_is( 'video', $attachment_id ) || wp_attachment_is( 'audio', $attachment_id ) ) {
+			return false;
+		}
+
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
 		// The image must be larger than 200x200.

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -833,6 +833,12 @@ class Jetpack_PostImages {
 			$url         = $meta['videopress']['poster'];
 			$meta_width  = $meta['videopress']['width'];
 			$meta_height = $meta['videopress']['height'];
+		} elseif ( ! empty( $meta['thumb'] ) ) {
+			// Use the thumbnail path if it's set.
+			$media_url   = wp_get_attachment_url( $attachment_id );
+			$url         = str_replace( wp_basename( $media_url ), $meta['thumb'], $media_url );
+			$meta_width  = $meta['width'];
+			$meta_height = $meta['height'];
 		} elseif ( wp_attachment_is( 'video', $attachment_id ) ) {
 			// We don't have thumbnail images for non-VideoPress videos - skip them.
 			return false;

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -785,45 +785,6 @@ class Jetpack_PostImages {
 
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
-		// The image must be larger than 200x200.
-		if ( ! isset( $meta['width'] ) || $meta['width'] < $width ) {
-			return false;
-		}
-		if ( ! isset( $meta['height'] ) || $meta['height'] < $height ) {
-			return false;
-		}
-
-		$url = wp_get_attachment_url( $attachment_id );
-
-		return array(
-			'type'       => 'image',
-			'from'       => 'attachment',
-			'src'        => $url,
-			'src_width'  => $meta['width'],
-			'src_height' => $meta['height'],
-			'href'       => $post_url,
-			'alt_text'   => self::get_alt_text( $attachment_id ),
-		);
-	}
-
-	/**
-	 * Get info about a WordPress attachment in a Story block.
-	 *
-	 * @since 9.1.0
-	 *
-	 * @param int    $attachment_id Attachment ID.
-	 * @param string $post_url      URL of the post, if we have one.
-	 * @param int    $width         Minimum Image width.
-	 * @param int    $height        Minimum Image height.
-	 * @return array|bool           Image data or false if unavailable.
-	 */
-	public static function get_attachment_data_for_story( $attachment_id, $post_url = '', $width, $height ) {
-		if ( empty( $attachment_id ) ) {
-			return false;
-		}
-
-		$meta = wp_get_attachment_metadata( $attachment_id );
-
 		if ( empty( $meta ) ) {
 			return false;
 		}
@@ -858,7 +819,7 @@ class Jetpack_PostImages {
 
 		return array(
 			'type'       => 'image',
-			'from'       => 'story',
+			'from'       => 'attachment',
 			'src'        => $url,
 			'src_width'  => $meta_width,
 			'src_height' => $meta_height,
@@ -929,7 +890,7 @@ class Jetpack_PostImages {
 		) {
 			foreach ( $block['attrs']['mediaFiles'] as $media_file ) {
 				if ( ! empty( $media_file['id'] ) ) {
-					$images[] = self::get_attachment_data_for_story( $media_file['id'], $html_info['post_url'], $width, $height );
+					$images[] = self::get_attachment_data( $media_file['id'], $html_info['post_url'], $width, $height );
 				}
 			}
 		}

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -783,6 +783,45 @@ class Jetpack_PostImages {
 			return false;
 		}
 
+		$meta = wp_get_attachment_metadata( $attachment_id );
+
+		// The image must be larger than 200x200.
+		if ( ! isset( $meta['width'] ) || $meta['width'] < $width ) {
+			return false;
+		}
+		if ( ! isset( $meta['height'] ) || $meta['height'] < $height ) {
+			return false;
+		}
+
+		$url = wp_get_attachment_url( $attachment_id );
+
+		return array(
+			'type'       => 'image',
+			'from'       => 'attachment',
+			'src'        => $url,
+			'src_width'  => $meta['width'],
+			'src_height' => $meta['height'],
+			'href'       => $post_url,
+			'alt_text'   => self::get_alt_text( $attachment_id ),
+		);
+	}
+
+	/**
+	 * Get info about a WordPress attachment in a Story block.
+	 *
+	 * @since 9.1.0
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $post_url      URL of the post, if we have one.
+	 * @param int    $width         Minimum Image width.
+	 * @param int    $height        Minimum Image height.
+	 * @return array|bool           Image data or false if unavailable.
+	 */
+	public static function get_attachment_data_for_story( $attachment_id, $post_url = '', $width, $height ) {
+		if ( empty( $attachment_id ) ) {
+			return false;
+		}
+
 		if ( wp_attachment_is( 'video', $attachment_id ) || wp_attachment_is( 'audio', $attachment_id ) ) {
 			return false;
 		}
@@ -801,7 +840,7 @@ class Jetpack_PostImages {
 
 		return array(
 			'type'       => 'image',
-			'from'       => 'attachment',
+			'from'       => 'story',
 			'src'        => $url,
 			'src_width'  => $meta['width'],
 			'src_height' => $meta['height'],
@@ -872,7 +911,7 @@ class Jetpack_PostImages {
 		) {
 			foreach ( $block['attrs']['mediaFiles'] as $media_file ) {
 				if ( ! empty( $media_file['id'] ) ) {
-					$images[] = self::get_attachment_data( $media_file['id'], $html_info['post_url'], $width, $height );
+					$images[] = self::get_attachment_data_for_story( $media_file['id'], $html_info['post_url'], $width, $height );
 				}
 			}
 		}

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -822,28 +822,39 @@ class Jetpack_PostImages {
 			return false;
 		}
 
-		if ( wp_attachment_is( 'video', $attachment_id ) || wp_attachment_is( 'audio', $attachment_id ) ) {
-			return false;
-		}
-
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
-		// The image must be larger than 200x200.
-		if ( ! isset( $meta['width'] ) || $meta['width'] < $width ) {
-			return false;
-		}
-		if ( ! isset( $meta['height'] ) || $meta['height'] < $height ) {
+		if ( empty( $meta ) ) {
 			return false;
 		}
 
-		$url = wp_get_attachment_url( $attachment_id );
+		if ( ! empty( $meta['videopress'] ) ) {
+			// Use poster image for VideoPress videos.
+			$url         = $meta['videopress']['poster'];
+			$meta_width  = $meta['videopress']['width'];
+			$meta_height = $meta['videopress']['height'];
+		} elseif ( wp_attachment_is( 'video', $attachment_id ) ) {
+			// We don't have thumbnail images for non-VideoPress videos - skip them.
+			return false;
+		} else {
+			if ( ! isset( $meta['width'] ) || ! isset( $meta['height'] ) ) {
+				return false;
+			}
+			$url         = wp_get_attachment_url( $attachment_id );
+			$meta_width  = $meta['width'];
+			$meta_height = $meta['height'];
+		}
+
+		if ( $meta_width < $width || $meta_height < $height ) {
+			return false;
+		}
 
 		return array(
 			'type'       => 'image',
 			'from'       => 'story',
 			'src'        => $url,
-			'src_width'  => $meta['width'],
-			'src_height' => $meta['height'],
+			'src_width'  => $meta_width,
+			'src_height' => $meta_height,
 			'href'       => $post_url,
 			'alt_text'   => self::get_alt_text( $attachment_id ),
 		);

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -316,21 +316,23 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 
 		// Attempt to find something good for this post using our generalized PostImages code.
 		if ( empty( $image ) && class_exists( 'Jetpack_PostImages' ) ) {
-			$post_image = Jetpack_PostImages::get_image(
+			$post_images = Jetpack_PostImages::get_images(
 				get_the_ID(),
 				array(
 					'width'  => $width,
 					'height' => $height,
 				)
 			);
-			if ( ! empty( $post_image ) && is_array( $post_image ) ) {
-				$image['src'] = $post_image['src'];
-				if ( isset( $post_image['src_width'], $post_image['src_height'] ) ) {
-					$image['width']  = $post_image['src_width'];
-					$image['height'] = $post_image['src_height'];
-				}
-				if ( ! empty( $post_image['alt_text'] ) ) {
-					$image['alt_text'] = $post_image['alt_text'];
+			if ( $post_images && ! is_wp_error( $post_images ) ) {
+				foreach ( (array) $post_images as $post_image ) {
+					$image['src'] = $post_image['src'];
+					if ( isset( $post_image['src_width'], $post_image['src_height'] ) ) {
+						$image['width']  = $post_image['src_width'];
+						$image['height'] = $post_image['src_height'];
+					}
+					if ( ! empty( $post_image['alt_text'] ) ) {
+						$image['alt_text'] = $post_image['alt_text'];
+					}
 				}
 			}
 		}

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -316,23 +316,21 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 
 		// Attempt to find something good for this post using our generalized PostImages code.
 		if ( empty( $image ) && class_exists( 'Jetpack_PostImages' ) ) {
-			$post_images = Jetpack_PostImages::get_images(
+			$post_image = Jetpack_PostImages::get_image(
 				get_the_ID(),
 				array(
 					'width'  => $width,
 					'height' => $height,
 				)
 			);
-			if ( $post_images && ! is_wp_error( $post_images ) ) {
-				foreach ( (array) $post_images as $post_image ) {
-					$image['src'] = $post_image['src'];
-					if ( isset( $post_image['src_width'], $post_image['src_height'] ) ) {
-						$image['width']  = $post_image['src_width'];
-						$image['height'] = $post_image['src_height'];
-					}
-					if ( ! empty( $post_image['alt_text'] ) ) {
-						$image['alt_text'] = $post_image['alt_text'];
-					}
+			if ( ! empty( $post_image ) && is_array( $post_image ) ) {
+				$image['src'] = $post_image['src'];
+				if ( isset( $post_image['src_width'], $post_image['src_height'] ) ) {
+					$image['width']  = $post_image['src_width'];
+					$image['height'] = $post_image['src_height'];
+				}
+				if ( ! empty( $post_image['alt_text'] ) ) {
+					$image['alt_text'] = $post_image['alt_text'];
 				}
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds support for the Story block to `Jetpack_PostImages`, allowing the Open Graph image tags (`og:image` and `twitter:image`) to be set for posts containing the story block. This also enables themes that support it (e.g. Cubic) to have a preview image for story posts in the post gallery, without requiring a featured image.

~I'm also proposing a tweak to the open graph image selection logic, so it selects the first 'good' image in a post instead of the last (the Twitter card tag logic already does this).~ Extracted that part to #17598.

The image tags can be inspected by viewing the source of a post page, they look like this:

```html
<!-- Jetpack Open Graph Tags -->
<meta property="og:type" content="article" />
<meta property="og:title" content="A story post" />
<meta property="og:url" content="https://example.com/2020/10/20/a-story-post/" />
<meta property="og:description" content="Visit the post for more." />
<meta property="article:published_time" content="2020-10-20T06:39:37+00:00" />
<meta property="article:modified_time" content="2020-10-20T06:39:37+00:00" />
<meta property="og:site_name" content="alexforcier" />
<meta property="og:image" content="https://i2.wp.com/example.com/wp-content/uploads/2020/10/cropped-WP-Icon.png?fit=512%2C512&amp;ssl=1" />
<meta property="og:image:width" content="512" />
<meta property="og:image:height" content="512" />
<meta property="og:locale" content="en_US" />
<meta name="twitter:text:title" content="A story post" />
<meta name="twitter:image" content="https://i2.wp.com/example.com/wp-content/uploads/2020/10/cropped-WP-Icon.png?fit=240%2C240&amp;ssl=1" />
<meta name="twitter:card" content="summary" />
<meta name="twitter:description" content="Visit the post for more." />
```

TODO:
* [x] ~Currently incorrectly sets a VideoPress video as the social media image when that's the first slide of a story~
  * --> Fixed to extract the poster image for VideoPress videos
* [x] ~Fixing the above relies on using VideoPress poster images, and there's currently an issue where we either need to Photon-wrap them or make a server-side change - TBD~
   * --> This was patched server-side - I'll open a separate PR soon to propose some broader changes, but all that matters for this PR is that the `w=....` parameter automatically appended to `twitter:image` links no longer 404s for VideoPress poster images

I had to add special logic for supporting WordPress.com, for whatever reason the media metadata doesn't contain VideoPress data, but instead the `thumb` parameter is available. If I missed something here I'm very happy to correct it.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

On a Jetpack site, and on a WordPress.com simple site (the code path is different between the two):

Inspect the image tags for various kinds of stories and verify that the correct image is used:

(These apply to the `twitter:image` tag - the `og:image` tag will follow the same logic but use the _last_ slide with a valid image. #17598 will change the og tag to be in line with the twitter tag.)

* A story where the first slide is an image -> the image tag should have that image
* A story where the first slide is a VideoPress video -> the image tag should have that video's poster
* A story where the first slide is a non-VideoPress video -> the first slide that is an image (or a VideoPress video) should be used - otherwise no image if all slides are non-VideoPress videos
