### PR TITLE
Crowdsignal: Don't call mktime() in a deprecated manner.

### DIFF
--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -388,7 +388,7 @@ if (
 						return $this->get_async_code( $settings, $poll_link, $poll_url );
 					} else {
 						if ( 1 === $attributes['cb'] ) {
-							$attributes['cb'] = '?cb=' . mktime();
+							$attributes['cb'] = '?cb=' . time();
 						} else {
 							$attributes['cb'] = false;
 						}


### PR DESCRIPTION
Crowdsignal: Don't call mktime() in a deprecated manner.
This has been deprecated since PHP 5.1 and removed in PHP 8.0.

This is untested, but the behaviour of `mktime()` is to simply return the same value as `time()` for such calls.

This was detected via PHP Code Sniffer:
```
FILE: jetpack/modules/shortcodes/crowdsignal.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 391 | ERROR | The "hour" parameter for function mktime() is missing.
     |       | Passing this parameter is no longer optional. The
     |       | optional nature of the parameter is deprecated since
     |       | PHP 5.1 and removed since PHP 8.0
     |       | (PHPCompatibility.FunctionUse.OptionalToRequiredFunctionParameters.mktime_hourSoftRequiredHardRequired)
----------------------------------------------------------------------
```

#### Changes proposed in this Pull Request:
* Function change from `mktime()` to `time()`. Should have no impact.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improved PHP 8.0 support
