### PR TITLE
PHP Warning: All PHP Magic methods should be public, as of PHP8 __wakeup() causes a warning

### DIFF
--- a/sal/class.json-api-links.php
+++ b/sal/class.json-api-links.php
@@ -22,7 +22,9 @@ class WPCOM_JSON_API_Links {
 		$this->api = WPCOM_JSON_API::init();
 	}
 	private function __clone() { }
-	private function __wakeup() { }
+	public function __wakeup() {
+		die( "Please don't __wakeup WPCOM_JSON_API_Links" );
+	}
 
 	/**
 	 * Generate a URL to an endpoint


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
* Defined `__wakeup()` as public, added a `die()` for safety.

All PHP Magic methods should be public, as of PHP8 __wakeup() causes a PHP Warning if it's defined as non-public.

Technically, `__clone()` and `__construct()` should also be public, but PHP doesn't yet trigger warnings for those methods, so I'm submitting the bare minimal PR.

This is untested, but shouldn't cause an issue.

This was detected via PHP 8 Lint checking:
```
php -l jetpack/sal/class.json-api-links.php

PHP Warning:  The magic method WPCOM_JSON_API_Links::__wakeup() must have public visibility in jetpack/sal/class.json-api-links.php on line 25
```

#### Jetpack product discussion

* Primary issue: #17166 

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site runnning this branch
* Connect the site to WordPress.com
* Upload some media
* Go to https://developer.wordpress.com/docs/api/console/
* Run queries for media against the site
* Ensure no errors are logged on the site.
* Check that the response includes the proper links field.

#### Proposed changelog entry for your changes:
* WordPress.com REST API: improved PHP 8.0 support
