### PR TITLE
Admin: Request user confirmation before triggering reconnect by url

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -4,7 +4,7 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { HashRouter, Route, Switch, Redirect } from 'react-router-dom';
+import { HashRouter, Route, Switch } from 'react-router-dom';
 import { assign } from 'lodash';
 import { _x } from '@wordpress/i18n';
 

--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -4,7 +4,7 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { HashRouter, Route, Switch } from 'react-router-dom';
+import { HashRouter, Route, Switch, Redirect } from 'react-router-dom';
 import { assign } from 'lodash';
 import { _x } from '@wordpress/i18n';
 
@@ -46,6 +46,9 @@ function render() {
 					<Switch>
 						<Route path="/dashboard">
 							<Main routeName={ getRouteName( '/dashboard' ) } />
+						</Route>
+						<Route path="/reconnect">
+							<Main routeName={ getRouteName( '/reconnect' ) } />
 						</Route>
 						<Route path="/setup">
 							<Main routeName={ getRouteName( '/setup' ) } />

--- a/_inc/client/components/reconnect-modal/README.md
+++ b/_inc/client/components/reconnect-modal/README.md
@@ -1,0 +1,17 @@
+# Reconnect Modal
+
+This modal is used to confirm with the user if they want to reconnect Jetpack.
+
+
+## How to use:
+
+```jsx
+import ReconnectModal from 'components/reconnect-modal';
+
+<Button onClick={ this.setState( { showModal: true } ) } />
+
+<ReconnectModal
+	show={ this.state.showModal }
+	onHide={ this.setState( { showModal: false } ) }
+/>
+```

--- a/_inc/client/components/reconnect-modal/index.jsx
+++ b/_inc/client/components/reconnect-modal/index.jsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { __, _x } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import Card from 'components/card';
+import { isSiteConnected, isReconnectingSite, reconnectSite } from 'state/connection';
+import Modal from 'components/modal';
+
+import './style.scss';
+
+export class ReconnectModal extends React.Component {
+	static displayName = 'ReconnectModal';
+
+	static propTypes = {
+		show: PropTypes.bool,
+		onHide: PropTypes.func,
+	};
+
+	static defaultProps = {
+		show: false,
+	};
+
+	shouldShowModal = () => {
+		const { show } = this.props;
+
+		return show && this.props.isSiteConnected && ! this.props.isReconnectingSite;
+	};
+
+	closeModal = () => {
+		this.props.onHide();
+	};
+
+	clickReconnectSite = e => {
+		e.preventDefault();
+		analytics.tracks.recordJetpackClick( 'confirm_reconnect_modal' );
+		this.props.reconnectSite();
+		this.closeModal();
+	};
+
+	render() {
+		return (
+			this.shouldShowModal() && (
+				<Modal className="reconnect__modal" onRequestClose={ this.closeModal }>
+					<Card className="reconnect__modal__body">
+						<h2>{ __( 'Reconnect Jetpack', 'jetpack' ) }</h2>
+						<h4>
+							{ __( 'You’ve clicked a link to restore your Jetpack connection.', 'jetpack' ) }
+						</h4>
+						<h4>
+							<strong>
+								{ __(
+									'You should only do this if advised by Site Health tests or Jetpack Support.',
+									'jetpack'
+								) }
+							</strong>
+						</h4>
+						<h4>{ __( 'Click below to reconnect Jetpack', 'jetpack' ) }</h4>
+						<div className="reconnect__modal-actions">
+							<Button className="reconnect__modal-cancel" onClick={ this.closeModal }>
+								{ _x( 'Cancel', 'A caption for a button to cancel an action.', 'jetpack' ) }
+							</Button>
+							<Button
+								className="reconnect__modal-reconnect"
+								onClick={ this.clickReconnectSite }
+								primary
+							>
+								{ _x(
+									'Reconnect Jetpack',
+									'A caption for a button to reconnect Jetpack.',
+									'jetpack'
+								) }
+							</Button>
+						</div>
+					</Card>
+				</Modal>
+			)
+		);
+	}
+}
+
+export default connect(
+	state => {
+		return {
+			isSiteConnected: isSiteConnected( state ),
+			isReconnectingSite: isReconnectingSite( state ),
+		};
+	},
+	dispatch => ( {
+		reconnectSite: () => {
+			return dispatch( reconnectSite() );
+		},
+	} )
+)( ReconnectModal );

--- a/_inc/client/components/reconnect-modal/style.scss
+++ b/_inc/client/components/reconnect-modal/style.scss
@@ -1,0 +1,32 @@
+@import "../../scss/variables/colors";
+
+.reconnect__modal__body {
+	margin: 0;
+	padding: rem( 24px ) rem( 32px );
+	font-size: rem( 14px );
+	color: $blue-dark-text;
+	text-align: center;
+
+	h2 {
+		margin: rem( 32px ) 0 rem( 24px );
+		font-size: rem( 32px );
+		font-weight: 300;
+		color: $blue-dark-text;
+	}
+
+	h4 {
+		margin: rem( 16px ) rem( 24px ) 0;
+		font-size: rem( 16px );
+		font-weight: 400;
+		line-height: 1.5em;
+		color: $blue-heading;
+	}
+}
+
+.reconnect__modal-actions {
+	margin: 2rem 0;
+
+	.reconnect__modal-cancel {
+		margin-right: 1em;
+	}
+}

--- a/_inc/client/components/reconnect-modal/test/component.js
+++ b/_inc/client/components/reconnect-modal/test/component.js
@@ -14,16 +14,22 @@ import { ReconnectModal } from '../index';
 
 describe( 'ReconnectModal', () => {
 
-	let testProps = {
-		show:               true,
-		onHide:             noop,
-		isSiteConnected:    true,
-		isReconnectingSite: false,
-	};
+	let defaultTestProps, wrapper = {};
+
+	before( () => {
+		defaultTestProps = {
+			show:               true,
+			onHide:             noop,
+			isSiteConnected:    true,
+			isReconnectingSite: false,
+		};
+	} );
 
 	describe( 'Initially', () => {
 
-		const wrapper = shallow( <ReconnectModal { ...testProps } /> );
+		before( () => {
+			wrapper = shallow( <ReconnectModal { ...defaultTestProps } /> );
+		} );		
 
 		it( 'renders the modal', () => {
 			expect( wrapper.find( 'Modal' ) ).to.have.length( 1 );
@@ -42,12 +48,6 @@ describe( 'ReconnectModal', () => {
 		} );
 
 		it( 'when clicked, closeModal() is called once', () => {
-			const currentTestProps = {
-				show:               true,
-				isSiteConnected:    true,
-				isReconnectingSite: false,
-			};
-
 			const closeModal = sinon.spy();
 
 			class ReconnectModalMock extends ReconnectModal {
@@ -56,12 +56,9 @@ describe( 'ReconnectModal', () => {
 					this.closeModal = closeModal;
 				}
 			}
-			// We need to set the testProps again here, to make sure they are not affected by
-			// other tests running in between.
-			Object.assign( testProps, currentTestProps );
-			const wrapper = shallow( <ReconnectModalMock { ...testProps } /> );
+			const mockWrapper = shallow( <ReconnectModalMock { ...defaultTestProps } /> );
 
-			wrapper.find( '.reconnect__modal-cancel'  ).simulate('click', { preventDefault: () => undefined });
+			mockWrapper.find( '.reconnect__modal-cancel'  ).simulate('click', { preventDefault: () => undefined });
 			expect( closeModal.calledOnce ).to.be.true;
 		} );
 
@@ -78,12 +75,6 @@ describe( 'ReconnectModal', () => {
 		} );
 
 		it( 'when clicked, clickReconnectSite() is called once', () => {
-			const currentTestProps = {
-				show:               true,
-				isSiteConnected:    true,
-				isReconnectingSite: false,
-			};
-
 			const clickReconnectSite = sinon.spy();
 
 			class ReconnectModalMock extends ReconnectModal {
@@ -92,23 +83,22 @@ describe( 'ReconnectModal', () => {
 					this.clickReconnectSite = clickReconnectSite;
 				}
 			}
-			// We need to set the testProps again here, to make sure they are not affected by
-			// other tests running in between.
-			Object.assign( testProps, currentTestProps );
-			const wrapper = shallow( <ReconnectModalMock { ...testProps } /> );
+			const mockWrapper = shallow( <ReconnectModalMock { ...defaultTestProps } /> );
 
-			wrapper.find( '.reconnect__modal-reconnect'  ).simulate('click', { preventDefault: () => undefined });
+			mockWrapper.find( '.reconnect__modal-reconnect'  ).simulate('click', { preventDefault: () => undefined });
 			expect( clickReconnectSite.calledOnce ).to.be.true;
 		} );
 	} );
 
 	describe( 'When the site is not connected', () => {
 
-		Object.assign( testProps, {
-			isSiteConnected: false,
+		before( () => {
+			const testProps = {
+				isSiteConnected: false,
+			};
+			const props = { ...defaultTestProps, ...testProps };
+			wrapper = shallow( <ReconnectModal { ...props } /> );
 		} );
-
-		const wrapper = shallow( <ReconnectModal { ...testProps } /> );
 
 		it( 'doesn\'t render the modal', () => {
 			expect( wrapper.find( 'Modal' ) ).to.have.length( 0 );
@@ -118,11 +108,13 @@ describe( 'ReconnectModal', () => {
 
 	describe( 'When a reconnect is already in progress', () => {
 
-		Object.assign( testProps, {
-			isReconnectingSite: true,
+		before( () => {
+			const testProps = {
+				isReconnectingSite: true,
+			};
+			const props = { ...defaultTestProps, ...testProps };
+			wrapper = shallow( <ReconnectModal { ...props } /> );
 		} );
-
-		const wrapper = shallow( <ReconnectModal { ...testProps } /> );
 
 		it( 'doesn\'t render the modal', () => {
 			expect( wrapper.find( 'Modal' ) ).to.have.length( 0 );
@@ -132,11 +124,13 @@ describe( 'ReconnectModal', () => {
 
 	describe( 'When `show` is false', () => {
 
-		Object.assign( testProps, {
-			show: false,
+		before( () => {
+			const testProps = {
+				show: false,
+			} ;
+			const props = { ...defaultTestProps, ...testProps };
+			wrapper = shallow( <ReconnectModal { ...props } /> );
 		} );
-
-		const wrapper = shallow( <ReconnectModal { ...testProps } /> );
 
 		it( 'doesn\'t render the modal', () => {
 			expect( wrapper.find( 'Modal' ) ).to.have.length( 0 );

--- a/_inc/client/components/reconnect-modal/test/component.js
+++ b/_inc/client/components/reconnect-modal/test/component.js
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { ReconnectModal } from '../index';
+
+describe( 'ReconnectModal', () => {
+
+	let testProps = {
+		show:               true,
+		onHide:             noop,
+		isSiteConnected:    true,
+		isReconnectingSite: false,
+	};
+
+	describe( 'Initially', () => {
+
+		const wrapper = shallow( <ReconnectModal { ...testProps } /> );
+
+		it( 'renders the modal', () => {
+			expect( wrapper.find( 'Modal' ) ).to.have.length( 1 );
+		} );
+
+		it( 'has a Cancel button', () => {
+			expect( wrapper.find( '.reconnect__modal-cancel' ) ).to.have.length( 1 );
+		} );
+
+		it( 'its text is: Cancel', () => {
+			expect( wrapper.find( '.reconnect__modal-cancel' ).first().render().text() ).to.be.equal( 'Cancel' );
+		} );
+
+		it( 'has an onClick method', () => {
+			expect( wrapper.find( '.reconnect__modal-cancel' ).first().props().onClick ).to.exist; 
+		} );
+
+		it( 'when clicked, closeModal() is called once', () => {
+			const currentTestProps = {
+				show:               true,
+				isSiteConnected:    true,
+				isReconnectingSite: false,
+			};
+
+			const closeModal = sinon.spy();
+
+			class ReconnectModalMock extends ReconnectModal {
+				constructor( props ) {
+					super( props );
+					this.closeModal = closeModal;
+				}
+			}
+			// We need to set the testProps again here, to make sure they are not affected by
+			// other tests running in between.
+			Object.assign( testProps, currentTestProps );
+			const wrapper = shallow( <ReconnectModalMock { ...testProps } /> );
+
+			wrapper.find( '.reconnect__modal-cancel'  ).simulate('click', { preventDefault: () => undefined });
+			expect( closeModal.calledOnce ).to.be.true;
+		} );
+
+		it( 'has a Reconnect button', () => {
+			expect( wrapper.find( '.reconnect__modal-reconnect' ) ).to.have.length( 1 );
+		} );
+
+		it( 'its text is: Reconnect Jetpack', () => {
+			expect( wrapper.find( '.reconnect__modal-reconnect' ).first().render().text() ).to.be.equal( 'Reconnect Jetpack' );
+		} );
+
+		it( 'has an onClick method', () => {
+			expect( wrapper.find( '.reconnect__modal-reconnect' ).first().props().onClick ).to.exist; 
+		} );
+
+		it( 'when clicked, clickReconnectSite() is called once', () => {
+			const currentTestProps = {
+				show:               true,
+				isSiteConnected:    true,
+				isReconnectingSite: false,
+			};
+
+			const clickReconnectSite = sinon.spy();
+
+			class ReconnectModalMock extends ReconnectModal {
+				constructor( props ) {
+					super( props );
+					this.clickReconnectSite = clickReconnectSite;
+				}
+			}
+			// We need to set the testProps again here, to make sure they are not affected by
+			// other tests running in between.
+			Object.assign( testProps, currentTestProps );
+			const wrapper = shallow( <ReconnectModalMock { ...testProps } /> );
+
+			wrapper.find( '.reconnect__modal-reconnect'  ).simulate('click', { preventDefault: () => undefined });
+			expect( clickReconnectSite.calledOnce ).to.be.true;
+		} );
+	} );
+
+	describe( 'When the site is not connected', () => {
+
+		Object.assign( testProps, {
+			isSiteConnected: false,
+		} );
+
+		const wrapper = shallow( <ReconnectModal { ...testProps } /> );
+
+		it( 'doesn\'t render the modal', () => {
+			expect( wrapper.find( 'Modal' ) ).to.have.length( 0 );
+		} );
+
+	} );
+
+	describe( 'When a reconnect is already in progress', () => {
+
+		Object.assign( testProps, {
+			isReconnectingSite: true,
+		} );
+
+		const wrapper = shallow( <ReconnectModal { ...testProps } /> );
+
+		it( 'doesn\'t render the modal', () => {
+			expect( wrapper.find( 'Modal' ) ).to.have.length( 0 );
+		} );
+
+	} );
+
+	describe( 'When `show` is false', () => {
+
+		Object.assign( testProps, {
+			show: false,
+		} );
+
+		const wrapper = shallow( <ReconnectModal { ...testProps } /> );
+
+		it( 'doesn\'t render the modal', () => {
+			expect( wrapper.find( 'Modal' ) ).to.have.length( 0 );
+		} );
+
+	} );
+
+} );

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -75,9 +75,10 @@ const settingsRoutes = [
 ];
 
 class Main extends React.Component {
-	state = {
-		showReconnectModal: false,
-	};
+	constructor( props ) {
+		super( props );
+		this.closeReconnectModal = this.closeReconnectModal.bind( this );
+	}
 
 	UNSAFE_componentWillMount() {
 		this.props.setInitialState();
@@ -105,11 +106,6 @@ class Main extends React.Component {
 		if ( connectReactContainer && fullScreenContainer.length > 0 ) {
 			fullScreenContainer.prependTo( connectReactContainer );
 		}
-
-		//Handle reconnect
-		if ( '/reconnect' === this.props.location.pathname ) {
-			this.handleReconnect();
-		}
 	}
 
 	/*
@@ -128,26 +124,6 @@ class Main extends React.Component {
 			return true;
 		}
 		return false;
-	};
-
-	/*
-	 * Shows the confirmation dialog to reconnect Jetpack and replaces
-	 * the current history entry in response to user 'reconnect' action.
-	 */
-	handleReconnect = () => {
-		this.setState( {
-			showReconnectModal: true,
-		} );
-
-		// Update the state object or URL of the current history entry
-		// in response to user 'reconnect' action.
-		// If we didn't do this, we'd get in an endless loop due to window reloading
-		// after reconnection.
-		// This needs to happen outside an existing state transition (such as within `render`).
-		this.props.history.replace( {
-			pathname: '/dashboard',
-			state: { showReconnectModal: true },
-		} );
 	};
 
 	initializeAnalytics = () => {
@@ -354,27 +330,18 @@ class Main extends React.Component {
 	}
 
 	shouldShowReconnectModal() {
-		const { showReconnectModal } = this.state;
-		return showReconnectModal;
+		return '/reconnect' === this.props.location.pathname;
 	}
 
 	closeReconnectModal() {
-		this.setState( {
-			showReconnectModal: false,
-		} );
+		this.props.history.replace( '/dashboard' );
 	}
 
 	render() {
 		return (
 			<div>
 				{ this.shouldShowReconnectModal() && (
-					<ReconnectModal
-						show={ true }
-						// eslint-disable-next-line react/jsx-no-bind, semi
-						onHide={ () => {
-							this.closeReconnectModal();
-						} }
-					/>
+					<ReconnectModal show={ true } onHide={ this.closeReconnectModal } />
 				) }
 				{ this.shouldShowMasthead() && <Masthead location={ this.props.location } /> }
 				<div className="jp-lower">


### PR DESCRIPTION
This PR adds a confirmation dialog so that the user can confirm their intention before triggering the reconnect process by url.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a new `ReconnectModal` with corresponding unit tests and usage instructions
* Handles `reconnect` routing using a more declarative approach, per React guidelines, by adding it to Routes in `admin.js`
* Displays the reconnect confirmation modal on `reconnect` route and redirects to `dashboard` upon dismissal or when reconnection is triggered in `main.js`.
* Upon reconnect modal confirmation the `confirm_reconnect_modal` click action is tracked.

#### Jetpack product discussion
p9dueE-1NT-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
**Unit tests**
* Run `yarn test-client && yarn test-gui` and verify all tests pass

**Reconnect flow with confirmation modal**
* Setup Jetpack in your testing site
* Visit `admin.php?page=jetpack#/reconnect` and verify the reconnect modal shows up
* Click `Cancel` and verify the reconnect modal hides and the current route is `admin.php?page=jetpack#/dashboard`
* Visit `admin.php?page=jetpack#/reconnect` and verify the reconnect modal shows up
* Click `Reconnect Jetpack` and verify the reconnect process is triggered, the current route is `admin.php?page=jetpack#/dashboard` and the modal is hidden

#### Proposed changelog entry for your changes:
* Admin: Request user confirmation before triggering reconnect by url