### PR TITLE
Add full AMP compatibility for Calendly block

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -140,6 +140,7 @@ function load_assets( $attr, $content ) {
 				esc_attr__( 'Close', 'jetpack' )
 			);
 
+			$content .= $lightbox_button;
 			$content .= sprintf(
 				'<amp-lightbox id="%s" on="%s" tabindex="0" layout="nodisplay" class="wp-block-jetpack-calendly__lightbox"><div class="calendly-lightbox-iframe-wrapper">%s%s</div></amp-lightbox>',
 				esc_attr( $lightbox_id ),
@@ -148,7 +149,6 @@ function load_assets( $attr, $content ) {
 				$close_button
 			);
 
-			$content .= $lightbox_button;
 			$content .= '</div>';
 
 		} else {

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -129,8 +129,9 @@ function load_assets( $attr, $content ) {
 			}
 
 			$iframe = sprintf(
-				'<amp-iframe src="%s" layout="fill" class="wp-block-jetpack-calendly__lightbox-iframe" sandbox="allow-scripts allow-forms allow-same-origin"><span placeholder></span></amp-iframe>',
-				esc_url( $src )
+				'<amp-iframe src="%s" layout="fill" class="wp-block-jetpack-calendly__lightbox-iframe" sandbox="allow-scripts allow-forms allow-same-origin"><em placeholder>%s</em></amp-iframe>',
+				esc_url( $src ),
+				esc_html__( 'Loading...', 'jetpack' )
 			);
 
 			$close_button = sprintf(

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -32,6 +32,7 @@
 	max-width: 1000px;
 	height: 90%;
 	max-height: 680px;
+	margin: 0;
 }
 
 .calendly-popup-close {

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -1,7 +1,3 @@
-.admin-bar .calendly-overlay .calendly-popup-close {
-	top: 47px;
-}
-
 .wp-block-jetpack-calendly.calendly-style-inline {
 	height: 630px;
 	position: relative;
@@ -17,4 +13,63 @@
 
 .wp-block-jetpack-calendly .wp-block-jetpack-button {
 	color: #ffffff;
+}
+
+.wp-block-jetpack-calendly__lightbox {
+	background: rgba(31, 31, 31, 0.4);
+}
+
+.wp-block-jetpack-calendly__lightbox-iframe {
+	/* Styles adapted from https://assets.calendly.com/assets/external/widget.css */
+	box-sizing: border-box;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	-webkit-transform: translateY(-50%) translateX(-50%);
+	transform: translateY(-50%) translateX(-50%);
+	width: 80%;
+	min-width: 900px;
+	max-width: 1000px;
+	height: 90%;
+	max-height: 680px;
+}
+
+.calendly-popup-close {
+	/* Styles adapted from https://assets.calendly.com/assets/external/widget.css */
+	position: absolute;
+	top: 25px;
+	right: 25px;
+	color: #fff;
+	width: 19px;
+	height: 19px;
+	cursor: pointer;
+	background: url(https://assets.calendly.com/assets/external/close-icon.svg) no-repeat;
+	background-size: contain;
+}
+
+.admin-bar .calendly-popup-close {
+	top: 47px
+}
+
+@media (max-width: 975px) {
+	.wp-block-jetpack-calendly__lightbox-iframe {
+		/* Styles adapted from https://assets.calendly.com/assets/external/widget.css */
+		position: fixed;
+		top: 50px;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		-webkit-transform: none;
+		transform: none;
+		width: 100%;
+		height: auto;
+		min-width: 0;
+		max-height: none;
+	}
+
+	.calendly-popup-close,
+	.admin-bar .calendly-popup-close {
+		top: 15px;
+		right: 15px;
+	}
 }


### PR DESCRIPTION
See #14395.

~👉  Note this is currently blocked by an AMP bug which has been fixed upstream but is not yet in production. See https://github.com/ampproject/amphtml/issues/29398. In order to test this PR, you need to first opt-in to to the `beta-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page. The fix should be rolled out to AMP's production channel by September 22nd.~ _The fix is now live._

Given `post_content` as follows:

```html
<!-- wp:heading -->
<h2>Link Style</h2>
<!-- /wp:heading -->

<!-- wp:jetpack/calendly {"style":"link","url":"https://calendly.com/aldrich-andrea"} -->
<div class="wp-block-jetpack-calendly"><!-- wp:jetpack/button {"element":"a","uniqueId":"calendly-widget-id","passthroughAttributes":{"url":"url"},"text":"Schedule time with me","url":"https://calendly.com/aldrich-andrea"} /--></div>
<!-- /wp:jetpack/calendly -->

<!-- wp:heading -->
<h2>Inline Style</h2>
<!-- /wp:heading -->

<!-- wp:jetpack/calendly {"url":"https://calendly.com/aldrich-andrea"} -->
<div class="wp-block-jetpack-calendly"></div>
<!-- /wp:jetpack/calendly -->
```

The Calendly link I obtained by doing a search, found on a [Yale faculty page](https://politicalscience.yale.edu/people/faculty-office-hours).

The blocks appear in the editor as:

![image](https://user-images.githubusercontent.com/134745/93719914-866a2680-fb3a-11ea-842e-e7e5e90eddd4.png)

The behavior of the block is made to have full parity with non-AMP, and the fallback behavior for when JS is disabled is also improved as seen in the following table:

State | Non-AMP | Non-AMP No JS 👎  | AMP Before 👎  | AMP After 👍  | Non-AMP No JS After 👍 
------|-----------|---------------------|----------------|--------------|--------------------------
Closed | ![Non-AMP Closed](https://user-images.githubusercontent.com/134745/93719980-fd072400-fb3a-11ea-88eb-ec3ac17891bb.png) | ![Non-AMP no-JS](https://user-images.githubusercontent.com/134745/93720042-671fc900-fb3b-11ea-82a9-7d977c069e10.png) | ![AMP Before](https://user-images.githubusercontent.com/134745/93720065-8dddff80-fb3b-11ea-9a42-420ea38bb169.png) | ![AMP After](https://user-images.githubusercontent.com/134745/93720113-d0074100-fb3b-11ea-822d-f72d69526ce7.png) | ![image](https://user-images.githubusercontent.com/134745/93720148-13fa4600-fb3c-11ea-8fa9-75b6e6687fab.png)
Opened | ![Non-AMP Opened](https://user-images.githubusercontent.com/134745/93719991-1c05b600-fb3b-11ea-9cc2-0a3c8c919260.png) | (Opens in new window; inline embed missing) | (Both links open new window) | ![image](https://user-images.githubusercontent.com/134745/93720143-03e26680-fb3c-11ea-9842-e362b55b1c35.png) | (Both links open new window)

#### Changes proposed in this Pull Request:

* Add full AMP compatibility for the Calendly block, and improve fallback behavior for when JavaScript is disabled.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:

1. Activate AMP plugin.
1. In AMP settings, select Transitional mode or Reader mode.
1. Create post with the above `post_content`.
1. Compare block in AMP and non-AMP. 

#### Proposed changelog entry for your changes:

* Add full AMP compatibility for the Calendly block, and improve fallback behavior for when JavaScript is disabled.
