### PR TITLE
Gathering Tweetstorms: Add support for Gutenberg 8.8+

### DIFF
--- a/extensions/blocks/gathering-tweetstorms/editor.js
+++ b/extensions/blocks/gathering-tweetstorms/editor.js
@@ -22,12 +22,18 @@ import { BlockControls } from '@wordpress/editor';
  * @returns {object} The blockSettings, with our extra functionality inserted.
  */
 const addTweetstormToTweets = blockSettings => {
-	// Bail if this is not the Twitter embed block, or if the hook has been triggered by a deprecation.
-	if ( 'core-embed/twitter' !== blockSettings.name || blockSettings.isDeprecation ) {
+	// Bail if the hook has been triggered by a deprecation.
+	if ( blockSettings.isDeprecation ) {
 		return blockSettings;
 	}
 
-	const { edit: CoreTweetEdit } = blockSettings;
+	// Allow hooking into the Twitter embed block pre and post Gutenberg 8.8.
+	// @todo The 'core-embed/twitter' check can be removed when WordPress 5.6 is the minimum version.
+	if ( 'core-embed/twitter' !== blockSettings.name && 'core/embed' !== blockSettings.name ) {
+		return blockSettings;
+	}
+
+	const { edit: CoreEdit } = blockSettings;
 
 	return {
 		...blockSettings,
@@ -37,6 +43,15 @@ const addTweetstormToTweets = blockSettings => {
 			const { isGatheringStorm, unleashStorm } = useGatherTweetstorm( {
 				onReplace,
 			} );
+
+			// Only wrap the Twitter variant of the core/embed block.
+			// @todo The core/embed' check can be removed when WordPress 5.6 is the minimum version.
+			if (
+				'core/embed' === blockSettings.name &&
+				'twitter' !== props.attributes.providerNameSlug
+			) {
+				return <CoreEdit { ...props } />;
+			}
 
 			return (
 				<>
@@ -58,7 +73,7 @@ const addTweetstormToTweets = blockSettings => {
 							{ isGatheringStorm && <Spinner /> }
 						</ToolbarGroup>
 					</BlockControls>
-					<CoreTweetEdit { ...props } />
+					<CoreEdit { ...props } />
 				</>
 			);
 		} ),

--- a/extensions/blocks/gathering-tweetstorms/editor.js
+++ b/extensions/blocks/gathering-tweetstorms/editor.js
@@ -81,3 +81,5 @@ const addTweetstormToTweets = blockSettings => {
 };
 
 addFilter( 'blocks.registerBlockType', 'jetpack/gathering-tweetstorms', addTweetstormToTweets );
+
+export default addTweetstormToTweets;

--- a/extensions/blocks/gathering-tweetstorms/test/editor.js
+++ b/extensions/blocks/gathering-tweetstorms/test/editor.js
@@ -31,6 +31,17 @@ describe( 'addTweetstormToTweets', () => {
 		expect( wrappedBlock ).toEqual( block );
 	} );
 
+	it( 'should not add the wrapper when passed an unsupported block type', () => {
+		const block = {
+			name: 'core/paragraph',
+			edit: baseEditFunction,
+		};
+
+		const wrappedBlock = addTweetstormToTweets( block );
+
+		expect( wrappedBlock ).toEqual( block );
+	} );
+
 	it( 'should add the wrapper when passed core-embed/twitter block definition', () => {
 		const block = {
 			name: 'core-embed/twitter',

--- a/extensions/blocks/gathering-tweetstorms/test/editor.js
+++ b/extensions/blocks/gathering-tweetstorms/test/editor.js
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import './match-media.mock';
+import addTweetstormToTweets from '../editor';
+
+describe( 'addTweetstormToTweets', () => {
+	const baseEditFunction = ( props ) => { return <div id='baseEdit'>Base Edit </div> };
+
+	it( 'should expose the function', () => {
+		expect( addTweetstormToTweets ).toBeDefined();
+	} );
+
+	it( 'should not add the wrapper when passed a deprecated block definition', () => {
+		const block = {
+			isDeprecation: true,
+			edit: baseEditFunction,
+		};
+
+		const wrappedBlock = addTweetstormToTweets( block );
+
+		expect( wrappedBlock ).toEqual( block );
+	} );
+
+	it( 'should add the wrapper when passed core-embed/twitter block definition', () => {
+		const block = {
+			name: 'core-embed/twitter',
+			edit: baseEditFunction,
+			props: {
+				attributes: {
+					url: 'https://twitter.com/GaryPendergast/status/934003415507546112',
+				},
+			},
+		};
+
+		const wrappedBlock = addTweetstormToTweets( block );
+
+		expect( wrappedBlock ).not.toEqual( block );
+		expect( wrappedBlock.edit.name ).toEqual( 'WrappedBlockEdit' );
+
+		const wrapper = mount( <wrappedBlock.edit { ...block.props } /> );
+
+		expect( wrapper.find( '#baseEdit' ) ).toHaveLength( 1 );
+		expect( wrapper.find( 'IfBlockEditSelected(BlockControlsFill)' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'should add the wrapper when passed core/embed block definition', () => {
+		const block = {
+			name: 'core/embed',
+			edit: baseEditFunction,
+			props: {
+				attributes: {
+					url: 'https://twitter.com/GaryPendergast/status/934003415507546112',
+					providerNameSlug: 'twitter',
+				},
+				isSelected: true,
+			},
+		};
+
+		const wrappedBlock = addTweetstormToTweets( block );
+
+		expect( wrappedBlock ).not.toEqual( block );
+		expect( wrappedBlock.edit.name ).toEqual( 'WrappedBlockEdit' );
+
+		const wrapper = mount( <wrappedBlock.edit { ...block.props } /> );
+
+		expect( wrapper.find( '#baseEdit' ) ).toHaveLength( 1 );
+		expect( wrapper.find( 'IfBlockEditSelected(BlockControlsFill)' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'should not add block controls when passed a core/embed block definition with a different providerNameSlug', () => {
+		const block = {
+			name: 'core/embed',
+			edit: baseEditFunction,
+			props: {
+				attributes: {
+					url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+					providerNameSlug: 'youtube',
+				},
+				isSelected: true,
+			},
+		};
+
+		const wrappedBlock = addTweetstormToTweets( block );
+
+		expect( wrappedBlock ).not.toEqual( block );
+		expect( wrappedBlock.edit.name ).toEqual( 'WrappedBlockEdit' );
+
+		const wrapper = mount( <wrappedBlock.edit { ...block.props } /> );
+
+		expect( wrapper.find( '#baseEdit' ) ).toHaveLength( 1 );
+		expect( wrapper.find( 'IfBlockEditSelected(BlockControlsFill)' ) ).toHaveLength( 0 );
+	} );
+} );

--- a/extensions/blocks/gathering-tweetstorms/test/match-media.mock
+++ b/extensions/blocks/gathering-tweetstorms/test/match-media.mock
@@ -1,0 +1,13 @@
+Object.defineProperty( window, 'matchMedia', {
+	writable: true,
+	value: jest.fn().mockImplementation( query => ( {
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: jest.fn(), // deprecated
+		removeListener: jest.fn(), // deprecated
+		addEventListener: jest.fn(),
+		removeEventListener: jest.fn(),
+		dispatchEvent: jest.fn(),
+	} ) ),
+} );


### PR DESCRIPTION
Gutenberg 8.8 changed how the Twitter embed block is registered (WordPress/gutenberg#24090), which caused our checks before adding the "Unroll" button to fail.

This PR adds support for GB 8.8+, and maintains back compat with the older method.

Fixes #17201.

#### Changes proposed in this Pull Request:
* Add support for Gutenberg 8.8+ to the Twitter thread unroller.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No Change.

#### Testing instructions:
Run through these tests with the Gutenberg plugin enabled and disabled.

* Paste a Twitter link in the block editor.
* Confirm that the Unroll button appears, and works as expected.

#### Proposed changelog entry for your changes:
* Twitter Threads: Add support for unrolling threads when Gutenberg 8.8+ is activated.
