### PR TITLE
Connection: Add success message on completed partial reconnection

### DIFF
--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -235,7 +235,18 @@ class JetpackStateNotices extends React.Component {
 					</NoticeAction>
 				);
 				break;
-
+			case 'reconnection_completed':
+				message = jetpackCreateInterpolateElement(
+					__(
+						'Jetpack successfully reconnected! You can check your Jetpack Connection health by visiting the <a>Site Health tool</a>.',
+						'jetpack'
+					),
+					{
+						a: <a href="site-health.php" />,
+					}
+				);
+				status = 'is-success';
+				break;
 			default:
 				message = key;
 		}

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -9,7 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getCurrentVersion } from 'state/initial-state';
+import { getCurrentVersion, getSiteAdminUrl } from 'state/initial-state';
 import {
 	getJetpackStateNoticesErrorCode,
 	getJetpackStateNoticesMessageCode,
@@ -242,7 +242,7 @@ class JetpackStateNotices extends React.Component {
 						'jetpack'
 					),
 					{
-						a: <a href="site-health.php" />,
+						a: <a href={ this.props.siteAdminUrl + 'site-health.php' } />,
 					}
 				);
 				status = 'is-success';
@@ -316,5 +316,6 @@ export default connect( state => {
 		jetpackStateNoticesMessageCode: getJetpackStateNoticesMessageCode( state ),
 		jetpackStateNoticesErrorDescription: getJetpackStateNoticesErrorDescription( state ),
 		jetpackStateNoticesMessageContent: getJetpackStateNoticesMessageContent( state ),
+		siteAdminUrl: getSiteAdminUrl( state ),
 	};
 } )( JetpackStateNotices );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -780,6 +780,9 @@ class Jetpack {
 		add_filter( 'jetpack_token_processing_url', array( __CLASS__, 'filter_connect_processing_url' ) );
 		add_filter( 'jetpack_token_redirect_url', array( __CLASS__, 'filter_connect_redirect_url' ) );
 		add_filter( 'jetpack_token_request_body', array( __CLASS__, 'filter_token_request_body' ) );
+
+		// Actions for successful reconnect.
+		add_action( 'jetpack_reconnection_completed', array( $this, 'reconnection_completed' ) );
 	}
 
 	/**
@@ -4941,6 +4944,17 @@ endif;
 		$do_redirect_on_error = ( 'client' === $data['auth_type'] );
 
 		self::handle_post_authorization_actions( $activate_sso, $do_redirect_on_error );
+	}
+
+	/**
+	 * This action fires at the end of the REST_Connector connection_reconnect method when the
+	 * reconnect process is completed.
+	 * Note that this currently only happens when we don't need the user to re-authorize
+	 * their WP.com account, eg in cases where we are restoring a connection with
+	 * unhealthy blog token.
+	 */
+	public static function reconnection_completed() {
+		self::state( 'message', esc_html__( 'Jetpack successfully reconnected.', 'jetpack' ) );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4954,7 +4954,7 @@ endif;
 	 * unhealthy blog token.
 	 */
 	public static function reconnection_completed() {
-		self::state( 'message', esc_html__( 'Jetpack successfully reconnected.', 'jetpack' ) );
+		self::state( 'message', 'reconnection_completed' );
 	}
 
 	/**

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -269,6 +269,11 @@ class REST_Connector {
 				break;
 			case 'completed':
 				$response['status'] = 'completed';
+				/**
+				 * Action fired when reconnection has completed successfully.
+				 *
+				 * @since 9.0.0
+				 */
 				do_action( 'jetpack_reconnection_completed' );
 				break;
 			case 'failed':

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -269,6 +269,7 @@ class REST_Connector {
 				break;
 			case 'completed':
 				$response['status'] = 'completed';
+				do_action( 'jetpack_reconnection_completed' );
 				break;
 			case 'failed':
 				$response = new WP_Error( 'Reconnect failed' );


### PR DESCRIPTION
This PR adds a success message when a partial reconnection has been completed.
Note that this currently only happens when we don't need the user to re-authorize their WP.com account, eg in cases where we are restoring a connection with unhealthy blog token.

#### Changes proposed in this Pull Request:
* Adds a new hook in Connection's `REST_Connector` `connection_reconnect` endpoint, named `jetpack_reconnection_completed` when the response from connection restore is `completed`.
* Adds a new action in `Jetpack` that logs a re-connection success message to state cookie for later display in Admin.

#### Jetpack product discussion
p9dueE-1SB-p2#comment-3254

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Setup Jetpack in your testing site
* Invalidate the **blog** token using the Broken Token plugin
* Visit `admin.php?page=jetpack#/reconnect` 
* Verify that after successful reconnection you see the following success message in Admin:
![Screenshot 2020-09-21 at 1 38 59 PM](https://user-images.githubusercontent.com/1758399/93757997-568d5280-fc10-11ea-9897-3c87386a3237.png)


* Invalidate the **user** token using the Broken Token plugin
* Visit `admin.php?page=jetpack#/reconnect`
* Verify that the auth flow is triggered (you'll be asked to link your WP.com account again) and the above success message is **not** displayed.

Extra bonus points for testing all suggested cases by `test-case-reminder` bot!

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Connection: Add success message on completed partial reconnection