### PR TITLE
Premium Blocks: Fix Upgrade Button Redirect in Safari

### DIFF
--- a/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/extensions/extended-blocks/paid-blocks/editor.scss
@@ -67,6 +67,10 @@ $icon-background-color: #fff;
 	}
 }
 
+.jetpack-upgrade-plan__hidden {
+	opacity: 0;
+}
+
 // Tweak Banner depending on the context.
 // Tweak Banner: Inspector Controls.
 .editor-styles-wrapper [data-block].is-upgradable,

--- a/extensions/extended-blocks/paid-blocks/upgrade-plan-banner.jsx
+++ b/extensions/extended-blocks/paid-blocks/upgrade-plan-banner.jsx
@@ -29,13 +29,11 @@ const UpgradePlanBanner = ( {
 		requiredPlan,
 		onRedirect
 	);
-	if ( ! visible ) {
-		return null;
-	}
 
 	const cssClasses = classNames( className, 'jetpack-upgrade-plan-banner', {
 		'wp-block': context === 'editor-canvas',
 		'block-editor-block-list__block': context === 'editor-canvas',
+		'jetpack-upgrade-plan__hidden': ! visible,
 	} );
 
 	const redirectingText = __( 'Redirecting…', 'jetpack' );
@@ -51,19 +49,23 @@ const UpgradePlanBanner = ( {
 					</strong>
 				) }
 				{ description && (
-					<span className={ `${ className }__description banner-description` }>{ description }</span>
+					<span className={ `${ className }__description banner-description` }>
+						{ description }
+					</span>
 				) }
-				{ checkoutUrl && (
+				{
 					<Button
 						href={ isRedirecting ? null : checkoutUrl } // Only for server-side rendering, since onClick doesn't work there.
 						onClick={ goToCheckoutPage }
 						target="_top"
-						className="is-primary"
+						className={ classNames( 'is-primary', {
+							'jetpack-upgrade-plan__hidden': ! checkoutUrl,
+						} ) }
 						isBusy={ isRedirecting }
 					>
 						{ isRedirecting ? redirectingText : buttonText }
 					</Button>
-				) }
+				}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* In the Safari browser, when users on a free plan are in the block editor and decide to use a Premium Block, they are prompted with an "Upgrade" banner. Clicking the "Upgrade" button on the banner does nothing. Note this is specific to Safari.
* It seems that for some reason, the `onClick` to the button does not propagate, the `onClick` handler is not bound to the element, or the visual element is not actually indicative of the element state. A hint by @blackjackkent was that keeping the banner always visible ensured that the `onClick` handler, and therefore the redirect link always worked. Therefore, instead of removing the element from the DOM completely, we decided to use `opacity`, and keep the element in the DOM.
* Note, that this is a workaround to ensure users are not experiencing this, since this is a high priority bug. The additional elements placed in the DOM are considered insignificant relative to the negative effect this has on users. The experience is not perfect. Sometimes the banner disappears without showing "Redirecting" but eventually redirects the user. Lastly, I had to hardcode some variables to get the banner to show up, so I was never able to get it to a dynamic checkout screen because I hardcoded the URL. For some reason, my checkoutURL was never defined because my `plan` wasn't defined in `extensions/shared/use-upgrade-flow/index.js`. I also made `unavailableReason` to be `missing_plan`. `details.required_plan` to be `true` and `available` to be `false` for the `recurring-payments` block. This is not required for testing; it is just required for my local development, for some reason.

#### Jetpack product discussion
None, perhaps see https://github.com/Automattic/jetpack/issues/17181

#### Does this pull request change what data or activity we track or use?
No. 

#### Testing instructions:
1. Set up Jetpack locally following these steps: PCYsg-efV-p2
2. Open your Safari browser
3. Use a site with a Free Plan
4. Go to `/wp-admin`
5. Go to an existing post or create a new post
6. Click on an existing premium block, or add a new premium block
7. Note that there is a "Upgrade" banner. Click the "Upgrade" button. You should be redirected to the checkout page to enter your payment information to upgrade.

#### GIFs
Previously created Premium Blocks
![2020-09-21 23 17 25](https://user-images.githubusercontent.com/66652282/93843142-04c3e700-fc67-11ea-9b3e-b9125315daae.gif)

New Premium Block before completely loaded
![2020-09-21 23 18 04](https://user-images.githubusercontent.com/66652282/93843159-15745d00-fc67-11ea-920a-4e45610e165e.gif)

New Premium Block completely loaded
![2020-09-21 23 19 21](https://user-images.githubusercontent.com/66652282/93843189-28872d00-fc67-11ea-977a-993303ce46f2.gif)


#### Proposed changelog entry for your changes:
* Premium Blocks: Fix Upgrade Button Redirect in Safari

Fixes #17181 
