### PR TITLE
Instant Search: don't use Photon on private sites

### DIFF
--- a/modules/search/instant-search/components/photon-image.jsx
+++ b/modules/search/instant-search/components/photon-image.jsx
@@ -17,9 +17,23 @@ function stripQueryString( url ) {
 	return url.split( '?', 1 )[ 0 ];
 }
 
-const PhotonImage = ( { useDiv, src, maxWidth = 300, maxHeight = 300, alt, ...otherProps } ) => {
-	const photonSrc = photon( stripQueryString( src ), { resize: `${ maxWidth },${ maxHeight }` } );
-	const srcToDisplay = photonSrc !== null ? photonSrc : src;
+const PhotonImage = ( {
+	useDiv,
+	src,
+	maxWidth = 300,
+	maxHeight = 300,
+	alt,
+	isPrivateSite,
+	...otherProps
+} ) => {
+	let srcToDisplay = src;
+
+	if ( ! isPrivateSite ) {
+		const photonSrc = photon( stripQueryString( src ), { resize: `${ maxWidth },${ maxHeight }` } );
+		if ( photonSrc !== null ) {
+			srcToDisplay = photonSrc;
+		}
+	}
 
 	return useDiv ? (
 		<div

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -280,6 +280,7 @@ class SearchApp extends Component {
 					hasNextPage={ this.hasNextPage() }
 					highlightColor={ this.state.overlayOptions.highlightColor }
 					isLoading={ this.state.isLoading }
+					isPrivateSite={ this.props.options.isPrivateSite }
 					isVisible={ this.state.showResults }
 					locale={ this.props.options.locale }
 					onChangeSort={ this.onChangeSort }

--- a/modules/search/instant-search/components/search-result-expanded.jsx
+++ b/modules/search/instant-search/components/search-result-expanded.jsx
@@ -98,6 +98,7 @@ export default function SearchResultExpanded( props ) {
 						<PhotonImage
 							alt=""
 							className="jetpack-instant-search__result-expanded__image"
+							isPrivateSite={ this.props.isPrivateSite }
 							src={ `//${ firstImage }` }
 							useDiv
 						/>

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -37,9 +37,10 @@ class SearchResultProduct extends Component {
 				</h3>
 				{ firstImage && (
 					<PhotonImage
-						className="jetpack-instant-search__search-result-product-img"
-						src={ `//${ firstImage }` }
 						alt=""
+						className="jetpack-instant-search__search-result-product-img"
+						isPrivateSite={ this.props.isPrivateSite }
+						src={ `//${ firstImage }` }
 					/>
 				) }
 				<div

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -111,6 +111,7 @@ class SearchResults extends Component {
 						{ results.map( ( result, index ) => (
 							<SearchResult
 								index={ index }
+								isPrivateSite={ this.props.isPrivateSite }
 								locale={ this.props.locale }
 								query={ this.props.query }
 								railcar={ this.props.isVisible ? result.railcar : null }

--- a/modules/search/instant-search/components/test/photon-image.test.js
+++ b/modules/search/instant-search/components/test/photon-image.test.js
@@ -1,0 +1,29 @@
+/** @jsx h
+ * @jest-environment jsdom
+ */
+/* global expect */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+import { render } from '@testing-library/preact';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import PhotonImage from '../photon-image';
+
+test( 'returns a Photon URL for a public site', () => {
+	const { getByRole } = render(
+		<PhotonImage src={ 'http://example.com/okapi.jpg' } isPrivateSite={ false } />
+	);
+	expect( getByRole( 'img' ).src ).toMatch( /i[0-9]\.wp\.com/ );
+} );
+
+test( 'returns the original URL for a private site', () => {
+	const imageUrl = 'http://example.com/okapi.jpg';
+	const { getByRole } = render( <PhotonImage src={ imageUrl } isPrivateSite={ true } /> );
+	expect( getByRole( 'img' ).src ).toEqual( imageUrl );
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/17217.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Photon doesn't work unless the image being used is public. On private sites, we should not attempt to use it.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Short version:
* On a private site with Instant Search enabled and the expanded result format selected, make sure that images display correctly and do not use Photon.
* On a public site with Instant Search enabled and the expanded result format selected, make sure that images display correctly and _do_ use Photon.

Detailed instructions:


* Spin up a new Atomic site and use the Jetpack Beta plugin to enable this branch. For the sake of indexing, keep the site visible to the public.
 * Purchase Jetpack Search and ensure that instant search has been enabled automatically.
 * Create a new post on the site that contains at least one image.
 * Try a site search. Ensure that images use Photon (URLs start with *.wp.com)
 * Change the site visibility to private by setting blog_public to "-1". Ensure that your current browser session is logged in by checking that you can access /wp-admin/.
 * Repeat a site search. Ensure that images do not use Photon and display correctly.

<img width="1236" alt="Screen Shot 2020-09-23 at 14 31 28" src="https://user-images.githubusercontent.com/17325/93958195-119d2380-fdaa-11ea-80f8-e2f2f8576e9c.png">
<img width="775" alt="Screen Shot 2020-09-23 at 14 31 24" src="https://user-images.githubusercontent.com/17325/93958200-14981400-fdaa-11ea-960d-267aefaa1423.png">

You can also run the tests with `yarn test-search`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Not required. 