### PR TITLE
Module List: filter all items using existing filter

### DIFF
--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -17,16 +17,16 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			array_push( $this->compat_fields, 'all_items' );
 		}
 
-		$this->items = $this->all_items = Jetpack_Admin::init()->get_modules();
-		$this->items = $this->filter_displayed_table_items( $this->items );
 		/**
 		 * Filters the list of modules available to be displayed in the Jetpack Settings screen.
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param array $this->items Array of Jetpack modules.
+		 * @param array $modules Array of Jetpack modules.
 		 */
-		$this->items           = apply_filters( 'jetpack_modules_list_table_items', $this->items );
+		$this->all_items       = apply_filters( 'jetpack_modules_list_table_items', Jetpack_Admin::init()->get_modules() );
+		$this->items           = $this->all_items;
+		$this->items           = $this->filter_displayed_table_items( $this->items );
 		$this->_column_headers = array( $this->get_columns(), array(), array(), 'name' );
 		$modal_info            = isset( $_GET['info'] ) ? $_GET['info'] : false;
 
@@ -132,7 +132,8 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	}
 
 	function get_views() {
-		$modules              = Jetpack_Admin::init()->get_modules();
+		/** This filter is already documented in class.jetpack-modules-list-table.php */
+		$modules              = apply_filters( 'jetpack_modules_list_table_items', Jetpack_Admin::init()->get_modules() );
 		$array_of_module_tags = wp_list_pluck( $modules, 'module_tags' );
 		$module_tags          = call_user_func_array( 'array_merge', $array_of_module_tags );
 		$module_tags_unique   = array_count_values( $module_tags );


### PR DESCRIPTION
Fixes #17229

#### Changes proposed in this Pull Request:

The existing `jetpack_modules_list_table_items` filter ended up
not being very useful until now. It was only filtering the items
displayed, not the whole list of items available on the page.
The filter consequently could not be used to stop a specific item
from being displayed.

With this change, one can now filter an item out entirely.
I also took the opportunity to apply the filter to the views as well,
so when you filter an item out, the total count of items is updated.

It's worth noting that the filter is not currently being used in any theme or plugin in the plugin directory.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

Before to apply this branch, add the following snippet to your site:
```php
/**
 * Remove Masterbar from the old Module list.
 *
 * @param array $items Array of Jetpack modules.
 */
function jeherve_rm_masterbar_module_list( $items ) {
        if ( isset( $items['masterbar'] ) ) {
                unset( $items['masterbar'] );
        }
        return $items;
}
add_filter( 'jetpack_modules_list_table_items', 'jeherve_rm_masterbar_module_list' );
```

* Head over to Jetpack > Modules (link at the bottom of Jetpack > Dashboard) on a site connected to WordPress.com 
* Notice that the WordPress.com toolbar item is still there.
* Check out this branch.
* The feature disappears from the list, and the count of items (in the sidebar) is updated.

#### Proposed changelog entry for your changes:

* N/A

