### PR TITLE
Packages: avoid PHPCS warnings

### DIFF
--- a/packages/autoloader/src/class-plugins-handler.php
+++ b/packages/autoloader/src/class-plugins-handler.php
@@ -81,7 +81,9 @@ class Plugins_Handler {
 	 */
 	private function get_plugins_activating_via_request() {
 
-		 // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		$action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : false;
 		$plugin = isset( $_REQUEST['plugin'] ) ? $_REQUEST['plugin'] : false;
@@ -109,6 +111,8 @@ class Plugins_Handler {
 		}
 
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		return array();
 	}
 

--- a/packages/sync/src/modules/class-module.php
+++ b/packages/sync/src/modules/class-module.php
@@ -273,6 +273,7 @@ abstract class Module {
 	 * @return array|object|null
 	 */
 	public function get_next_chunk( $config, $status, $chunk_size ) {
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		global $wpdb;
 		return $wpdb->get_col(
 			<<<SQL
@@ -284,6 +285,7 @@ ORDER BY {$this->id_field()}
 DESC LIMIT {$chunk_size}
 SQL
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Fix some PHPCS warnings that stop us from updating packages on WordPress.com

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Not much to test here.

#### Proposed changelog entry for your changes:

* N/A
