### PR TITLE
fix spelling error in docblock

### DIFF
--- a/3rd-party/class.jetpack-modules-overrides.php
+++ b/3rd-party/class.jetpack-modules-overrides.php
@@ -7,7 +7,7 @@
  */
 class Jetpack_Modules_Overrides {
 	/**
-	 * Used to cache module overrides so that we minimize how many times we appy the
+	 * Used to cache module overrides so that we minimize how many times we apply the
 	 * option_jetpack_active_modules filter.
 	 *
 	 * @var null|array


### PR DESCRIPTION
Correctly spell "apply" in the `Jetpack_Modules_Overrides` class.