### PR TITLE
Contact From: Newsletter integration error handling fix

### DIFF
--- a/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
+++ b/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
@@ -4,6 +4,8 @@
 import { Button, ExternalLink, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { installAndActivatePlugin, activatePlugin } from './../../../shared/plugin-management';
+import getJetpackData from './../../../shared/get-jetpack-data';
+import { get } from 'lodash';
 
 const pluginPathWithoutPhp = 'creative-mail-by-constant-contact/creative-mail-plugin';
 const pluginSlug = 'creative-mail-by-constant-contact';
@@ -15,7 +17,7 @@ export const pluginStateEnum = Object.freeze( {
 } );
 
 const CreativeMailPluginIsInstalling = ( { isActivating } ) => {
-	const btnTxt = isActivating ? __( 'Installing…', 'jetpack' ) : __( 'Activating…', 'jetpack' );
+	const btnTxt = isActivating ? __( 'Activating…', 'jetpack' ) : __( 'Installing…', 'jetpack' );
 	return (
 		<Button
 			isSecondary
@@ -71,13 +73,18 @@ const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalli
 	);
 };
 
+const getCreativeMailPluginUrl = () => {
+	const adminUrl = get( getJetpackData(), 'adminUrl', false );
+	return `${ adminUrl }admin.php?page=creativemail`;
+};
+
 const CreativeMailPluginIsActive = () => {
 	return (
 		<p>
 			<em>
 				{ __( 'You’re all setup for email marketing with Creative Mail.', 'jetpack' ) }
 				<br />
-				<ExternalLink href="/wp-admin/admin.php?page=creativemail">
+				<ExternalLink href={ getCreativeMailPluginUrl() }>
 					{ __( 'Open Creative Mail settings', 'jetpack' ) }
 				</ExternalLink>
 			</em>


### PR DESCRIPTION
## Support WordPress instances installed in the subdirecty
https://github.com/Automattic/jetpack/pull/16964#pullrequestreview-494478771

#### Fixes #
* Support WordPress instances installed in a subdirectory
* show the correct Activating vs Installing caption.

#### Changes proposed in this Pull Request:
N/A

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

## test case 1
* Go to Posts > Add New
* Search for ‘Newsletter Sign-up’.
* Select the form block in the Gutenberg editor.
* Collapse the "Newsletter Integration" on the right side
<img width="303" alt="Screenshot 2020-08-25 at 11 07 56" src="https://user-images.githubusercontent.com/47211808/91158448-ed74f680-e6c6-11ea-9e8d-d339ef6e052c.png">
* Click install plugin creative mail plugin

![image](https://user-images.githubusercontent.com/47211808/91158563-1b5a3b00-e6c7-11ea-9c44-ec77a1385640.png)

* Click open creative mail, this should open the creative mail plugin in a new tab.

## test case 2
* Make sure that the Creative Mail plugin is *installed but deactivated*
* Go to Posts > Add New
* Search for ‘Newsletter Sign-up’.
* Select the form block in the Gutenberg editor.
* Collapse the "Newsletter Integration" on the right side
![image](https://user-images.githubusercontent.com/47211808/91158676-4e043380-e6c7-11ea-9aca-5f14ef6a6c1c.png)

* Click active plugin
![image](https://user-images.githubusercontent.com/47211808/90694105-577d3e00-e278-11ea-8672-0cd3f70452ae.png)
* Click open creative mail, this should open the creative mail plugin in a new tab.

## test case 3
* Make sure that you break your WP instance, (no write access on the plugin folder)
* Go to Posts > Add New
* Search for ‘Newsletter Sign-up’.
* Select the form block in the Gutenberg editor.
* Collapse the "Newsletter Integration" on the right side
![image](https://user-images.githubusercontent.com/47211808/91158773-6ffdb600-e6c7-11ea-85a3-8562c3bdb28e.png)
* Click install plugin
![image](https://user-images.githubusercontent.com/47211808/91158958-b18e6100-e6c7-11ea-8766-24651abaaf39.png)



#### Proposed changelog entry for your changes:
* TBD
