### PR TITLE
Debug Helper: Added WP Error object handling.

### DIFF
--- a/packages/debug-helper/modules/class-jetpack-sync-debug-helper.php
+++ b/packages/debug-helper/modules/class-jetpack-sync-debug-helper.php
@@ -81,6 +81,20 @@ class Jetpack_Sync_Debug_Helper {
 	 * @return array
 	 */
 	public static function store_sync_error( $data, $codec_name, $sent_timestamp, $queue_id ) {
+		if ( is_wp_error( $data ) ) {
+			update_option(
+				self::LAST_SYNC_ERROR,
+				array(
+					'error_code' => $data->get_error_code(),
+					'queue'      => $queue_id,
+					'timestamp'  => $sent_timestamp,
+					'codec'      => $codec_name,
+				)
+			);
+
+			// Not going any further to avoid fatal errors if $data is an object.
+			return $data;
+		}
 		if ( isset( $data['error_code'] ) && ! self::$saved_error ) {
 			update_option(
 				self::LAST_SYNC_ERROR,


### PR DESCRIPTION
In case of an error that contains object data, like in case of a disconnection, on shutdown this filter receives a WP_Error. This additional condition helps avoid a fatal error when trying to resolve an object as an array.

#### Changes proposed in this Pull Request:
* Added a condition that checks for a WP_Error in the last Sync error filter.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
* Enable the debug helper by clicking all checkboxes in the "Jetpack Debug" menu.
* Disconnect Jetpack by using the Dashboard disconnect link near the bottom of the page.
* See the fatal error in the log because of an attempt to access an array index on an object.

#### Proposed changelog entry for your changes:
* N/A
