### PR TITLE
Remove background color from slideshow block

### DIFF
--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -46,7 +46,6 @@
 	}
 
 	.wp-block-jetpack-slideshow_slide {
-		background: rgba( 0, 0, 0, 0.1 );
 		display: flex;
 		height: 100%;
 		width: 100%;


### PR DESCRIPTION
Fixes #17160

#### Changes proposed in this Pull Request:

* Removes the default background color from the slideshow block. This background currently displays when different size images are included in the slideshow.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

- Add a slideshow block with images of different sizes
- Notice that a grey background displays around the images
- Apply this PR
- Grey background should be gone and slideshow should inherit default page background color

before:

<img width="575" alt="Screen Shot 2020-09-24 at 11 34 01 AM" src="https://user-images.githubusercontent.com/3629020/94084789-92b3f380-fe5a-11ea-8000-46fd0cca2a71.png">

after:

<img width="582" alt="Screen Shot 2020-09-24 at 11 34 38 AM" src="https://user-images.githubusercontent.com/3629020/94084780-8af44f00-fe5a-11ea-87ff-fc51a7be8a38.png">


#### Proposed changelog entry for your changes:
* Default background color removed from the slideshow block
