### PR TITLE
Fix AMP compatibility for Google Calendar block

### DIFF
--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -46,22 +46,22 @@ function load_assets( $attr ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	if ( empty( $url ) ) {
-		return;
+		return '';
 	}
 
-	if ( Blocks::is_amp_request() ) {
-		return sprintf(
-			'<div class="%1$s"><amp-iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" height="%3$d" sandbox="allow-scripts allow-same-origin" layout="responsive"></amp-iframe></div>',
-			esc_attr( $classes ),
-			esc_url( $url ),
-			absint( $height )
-		);
-	} else {
-		return sprintf(
-			'<div class="%1$s"><iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" height="%3$d"></iframe></div>',
-			esc_attr( $classes ),
-			esc_url( $url ),
-			absint( $height )
-		);
-	}
+	$placeholder = sprintf(
+		'<a href="%s" %s>%s</a>',
+		esc_url( $url ),
+		Blocks::is_amp_request() ? 'placeholder' : '',
+		esc_html__( 'Google Calendar', 'jetpack' )
+	);
+
+	$iframe = sprintf(
+		'<iframe src="%1$s" frameborder="0" style="border:0" scrolling="no" height="%2$d" width="100%%">%3$s</iframe>',
+		esc_url( $url ),
+		absint( $height ),
+		$placeholder
+	);
+
+	return sprintf( '<div class="%s">%s</div>', esc_attr( $classes ), $iframe );
 }

--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -49,19 +49,38 @@ function load_assets( $attr ) {
 		return '';
 	}
 
-	$placeholder = sprintf(
-		'<a href="%s" %s>%s</a>',
-		esc_url( $url ),
-		Blocks::is_amp_request() ? 'placeholder' : '',
-		esc_html__( 'Google Calendar', 'jetpack' )
-	);
+	$sandbox = 'allow-scripts allow-same-origin';
+	if ( Blocks::is_amp_request() ) {
+		$noscript_src = str_replace(
+			'//calendar.google.com/calendar/embed',
+			'//calendar.google.com/calendar/htmlembed',
+			$url
+		);
 
-	$iframe = sprintf(
-		'<iframe src="%1$s" frameborder="0" style="border:0" scrolling="no" height="%2$d" width="100%%">%3$s</iframe>',
-		esc_url( $url ),
-		absint( $height ),
-		$placeholder
-	);
+		$iframe = sprintf(
+			'<amp-iframe src="%1$s" frameborder="0" scrolling="no" height="%2$d" layout="fixed-height" sandbox="%3$s">%4$s%5$s</amp-iframe>',
+			esc_url( $url ),
+			absint( $height ),
+			esc_attr( $sandbox ),
+			sprintf(
+				'<a href="%s" placeholder>%s</a>',
+				esc_url( $url ),
+				esc_html__( 'Google Calendar', 'jetpack' )
+			),
+			sprintf(
+				'<noscript><iframe src="%1$s" frameborder="0" scrolling="no" sandbox="%2$s"></iframe></noscript>',
+				esc_url( $noscript_src ),
+				esc_attr( $sandbox )
+			)
+		);
+	} else {
+		$iframe = sprintf(
+			'<iframe src="%1$s" frameborder="0" style="border:0" scrolling="no" height="%2$d" width="100%%" sandbox="%3$s"></iframe>',
+			esc_url( $url ),
+			absint( $height ),
+			esc_attr( $sandbox )
+		);
+	}
 
 	return sprintf( '<div class="%s">%s</div>', esc_attr( $classes ), $iframe );
 }

--- a/extensions/blocks/google-calendar/view.scss
+++ b/extensions/blocks/google-calendar/view.scss
@@ -6,4 +6,36 @@
 	iframe {
 		width: 100%;
 	}
+
+	/**
+	 * The following rules are purely enhancements for when JS is turned when an AMP page is viewed. Granted this will be
+	 * a very rare scenario. Also, the rules here should eventually be merged into ampshared.css in AMP itself, at which
+	 * point they can be removed from the block. They are included here as a proof of concept to show how the noscript
+	 * fallback experience can be improved on AMP pages.
+	 */
+
+	> amp-iframe > [placeholder] {
+		/* Overrides https://github.com/ampproject/amphtml/blob/8fb1a06a49088fb87de9b24646dee2058d910a87/css/ampshared.css#L303 */
+		line-height: 1;
+	}
+
+	> amp-iframe > noscript {
+		/*
+		 * Overrides https://github.com/ampproject/amphtml/blob/8fb1a06a49088fb87de9b24646dee2058d910a87/css/ampshared.css#L283
+		 * Won't be necessary after https://github.com/ampproject/amphtml/pull/29846
+		 */
+		display: inline-block !important;
+	}
+
+	> amp-iframe > noscript > iframe {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		z-index: 1; /* Match sibling [placeholder] z-index: https://github.com/ampproject/amphtml/blob/8fb1a06a49088fb87de9b24646dee2058d910a87/css/ampshared.css#L354 */
+	}
+
 }


### PR DESCRIPTION
See #14395

Given this `post_content`:

```html
<!-- wp:separator -->
<hr class="wp-block-separator"/>
<!-- /wp:separator -->

<!-- wp:jetpack/google-calendar {"url":"https://calendar.google.com/calendar/embed?src=askenergy%40oregon.gov\u0026ctz=America/Los_Angeles"} -->
<a href="https://calendar.google.com/calendar/embed?src=askenergy%40oregon.gov&amp;ctz=America/Los_Angeles" class="wp-block-jetpack-google-calendar">https://calendar.google.com/calendar/embed?src=askenergy%40oregon.gov&amp;ctz=America/Los_Angeles</a>
<!-- /wp:jetpack/google-calendar -->

<!-- wp:separator -->
<hr class="wp-block-separator"/>
<!-- /wp:separator -->
```

Google Calendar is currently not rendering at all on an AMP page. This is because it is getting removed due to not having a `width` defined on the `amp-iframe`:

> ![image](https://user-images.githubusercontent.com/134745/94099028-cd784600-fdde-11ea-87e7-9e40b38b2f85.png)

This PR fixes that issue by supplying the proper `layout` of `fixed-height` rather than `responsive`, since the width is intended to be `100%`. (This appears to be a regression introduced in #14835.) Also missing in the previous implementation was the `placeholder` child which is required for `amp-iframe` elements appearing in the initial viewport. So a link to the Google Calendar was supplied as a placeholder in this case.

This PR also goes beyond just fixing AMP compatibility in that the page is actually _better_ than the non-AMP version when JS is turned off, by supplying a the plain HTML calendar view to visitors with JS turned off. Some additional AMP-specific CSS was included here, but that will eventually not be needed once those are accounted for in AMP itself. See https://github.com/ampproject/amphtml/pull/29846.

##### Before

Non-AMP w/ JS | Non-AMP w/o JS  | AMP 👎  | AMP w/o JS 👎 
----------------|-------------------|---------|---------------
![image](https://user-images.githubusercontent.com/134745/94098516-9d7c7300-fddd-11ea-90ee-a5f3e9a1912d.png) | ![image](https://user-images.githubusercontent.com/134745/94098576-c270e600-fddd-11ea-897e-87e53497d3d4.png) | ![image](https://user-images.githubusercontent.com/134745/94098604-d583b600-fddd-11ea-9ac9-e7ab628835d1.png) (Removed by plugin sanitizer) | ![image](https://user-images.githubusercontent.com/134745/94098604-d583b600-fddd-11ea-9ac9-e7ab628835d1.png) (Removed by plugin sanitizer)

##### After

Non-AMP w/ JS | Non-AMP w/o JS  | AMP 👍   | AMP w/o JS 👍  
----------------|-------------------|---------|---------------
![image](https://user-images.githubusercontent.com/134745/94098735-209dc900-fdde-11ea-82b7-84bca943c316.png)  (No change) | ![image](https://user-images.githubusercontent.com/134745/94098757-2e534e80-fdde-11ea-8e27-8c77b5b3f252.png)  (No change) | ![image](https://user-images.githubusercontent.com/134745/94098775-39a67a00-fdde-11ea-8927-4315152d59b3.png) | ![image](https://user-images.githubusercontent.com/134745/94098789-43c87880-fdde-11ea-95ba-c29502a4ba26.png) (No-JS fallback!)


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix AMP compatibility in Google Calendar block.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Copy the above `post_content` into a new post.
2. Activate the AMP plugin and enable Transitional mode.
3. Compare the post in AMP and non-AMP (e.g. via Paired Browsing).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix AMP compatibility in Google Calendar block.
