### PR TITLE
Fix styling of Contact Forms on the legacy AMP post template in Reader mode

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -149,6 +149,7 @@ class Grunion_Contact_Form_Plugin {
 		}
 
 		add_action( 'loop_start', array( 'Grunion_Contact_Form', '_style_on' ) );
+		add_action( 'pre_amp_render_post', array( 'Grunion_Contact_Form', '_style_on' ) );
 
 		add_action( 'wp_ajax_grunion-contact-form', array( $this, 'ajax_request' ) );
 		add_action( 'wp_ajax_nopriv_grunion-contact-form', array( $this, 'ajax_request' ) );


### PR DESCRIPTION
Fixes #15981
See #14395

Fixes styling of Contact Forms on the legacy AMP post template in Reader mode. This is only an issue in legacy Reader mode because the old post templates do not have The Loop, and thus `loop_start` does not fire.

Before | After
-------|------
![contact-form-before](https://user-images.githubusercontent.com/134745/94101373-8c833000-fde4-11ea-9a27-b718a687e787.png) | ![contact-form-after](https://user-images.githubusercontent.com/134745/94101378-8f7e2080-fde4-11ea-84f8-bb3e1163b872.png)


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix styling of Contact Forms in legacy AMP Reader mode post templates.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a contact form to a post.
2. Activate the AMP plugin.
3. Switch to Reader mode and select the "AMP Legacy" Reader theme.
4. View the post as AMP.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix styling of Contact Forms in legacy AMP Reader mode post templates.
