### PR TITLE
Fix Image Compare block in AMP when width/height are not available

### DIFF
--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -57,10 +57,19 @@ function render_amp( $attr ) {
 	$img_before = $attr['imageBefore'];
 	$img_after  = $attr['imageAfter'];
 
+	$width  = ! empty( $img_before['width'] ) ? absint( $img_before['width'] ) : 0;
+	$height = ! empty( $img_before['height'] ) ? absint( $img_before['height'] ) : 0;
+
+	// As fallback, give 1:1 aspect ratio.
+	if ( ! $width || ! $height ) {
+		$width  = 1;
+		$height = 1;
+	}
+
 	return sprintf(
-		'<amp-image-slider layout="responsive"%1$s%2$s> <amp-img id="%3$d" src="%4$s" alt="%5$s" layout="fill"></amp-img> <amp-img id="%6$d" src="%7$s" alt="%8$s" layout="fill"></amp-img></amp-image-slider>',
-		! empty( $img_before['width'] ) ? ' width="' . absint( $img_before['width'] ) . '"' : '',
-		! empty( $img_before['height'] ) ? ' height="' . absint( $img_before['height'] ) . '"' : '',
+		'<amp-image-slider layout="responsive" width="%1$s" height="%2$s"> <amp-img id="%3$d" src="%4$s" alt="%5$s" layout="fill"></amp-img> <amp-img id="%6$d" src="%7$s" alt="%8$s" layout="fill"></amp-img></amp-image-slider>',
+		esc_attr( $width ),
+		esc_attr( $height ),
 		absint( $img_before['id'] ),
 		esc_url( $img_before['url'] ),
 		esc_attr( $img_before['alt'] ),


### PR DESCRIPTION
Fixes #16093
See #14395

All elements in AMP need to have dimensions defined up-front so that the page will have static layout to avoid [CLS](https://web.dev/cls/) (Cumulative Layout Shift). When no `width` or `height` is available for the Image Compare block, instead of omitting the `width`/`height` for the `amp-image-slider` component, the correct AMP fallback is to provide fallback dimensions. Since we don't know what the image dimension is, providing an aspect ratio of 1:1 seems to make sense.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Ensure fallback dimensions are provided to Image Compare block when image size is not available

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add an Image Compare block to a post and view that post on an AMP page.

I'm not sure entirely why the `width` or `height` weren't available when calling `render_amp()`, so the only way I know to test this is to forcibly unset them when calling the function:

```php
unset( $img_before['width'], $img_before['height'] );
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix AMP implementation of Image Compare block
