### PR TITLE
Preserve block wrapper and caption for Image Compare block in AMP

### DIFF
--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -39,7 +39,11 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 	if ( Blocks::is_amp_request() ) {
-		return render_amp( $attr );
+		$content = preg_replace(
+			'#<div class="juxtapose".+?</div>#s',
+			render_amp( $attr ),
+			$content
+		);
 	}
 
 	return $content;
@@ -51,7 +55,7 @@ function load_assets( $attr, $content ) {
  *
  * @param array $attr Array containing the image-compare block attributes.
  *
- * @return string
+ * @return string Markup for amp-image-slider.
  */
 function render_amp( $attr ) {
 	$img_before = $attr['imageBefore'];


### PR DESCRIPTION
Fixes #16858
See #14395

The Image Compare block on AMP pages was not including not only the caption but also the containing `figure.wp-block-jetpack-image-compare` wrapper element. This PR fixes that problem by just replacing the `div.juxtapose` element inside the block `$content` with the `amp-image-slider` element, rather than just rendering just the `amp-image-slider` alone.

##### Before

![image](https://user-images.githubusercontent.com/134745/94105373-f6ec9e00-fded-11ea-9d35-1b34390362d8.png)

AMP markup for block:

```html
<amp-image-slider layout="responsive" width="1536" height="2048">
    <amp-img id="4175" src="https://wordpressdev.lndo.site/content/uploads/2020/09/fire-before.jpg" alt="" layout="fill"></amp-img>
    <amp-img id="4176" src="https://wordpressdev.lndo.site/content/uploads/2020/09/fire-after.jpg" alt="" layout="fill"></amp-img>
</amp-image-slider>
```

##### After

![image](https://user-images.githubusercontent.com/134745/94105390-feac4280-fded-11ea-9fc0-4cc94040850a.png)

AMP markup for block:

```html
<figure class="wp-block-jetpack-image-compare">
    <amp-image-slider layout="responsive" width="1536" height="2048"> 
        <amp-img id="4175" src="https://wordpressdev.lndo.site/content/uploads/2020/09/fire-before.jpg" alt="" layout="fill"></amp-img>
        <amp-img id="4176" src="https://wordpressdev.lndo.site/content/uploads/2020/09/fire-after.jpg" alt="" layout="fill"></amp-img>
    </amp-image-slider>
    <figcaption>Before and after the wildfire smoke in Portland, Oregon</figcaption>
</figure>
```

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Include caption and original block wrapper element for Image Compare block on AMP pages.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add an Image Compare block to a post, along with a caption.
2. View the post on an AMP page.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Preserve caption for Image Compare blocks on AMP pages.
