### PR TITLE
Pay with PayPal block: Save fallback into post content

### DIFF
--- a/extensions/blocks/simple-payments/depecrated/v1/index.js
+++ b/extensions/blocks/simple-payments/depecrated/v1/index.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+
+export default {
+	attributes: {
+		currency: {
+			type: 'string',
+			default: 'USD',
+		},
+		content: {
+			type: 'string',
+			default: '',
+		},
+		email: {
+			type: 'string',
+			default: '',
+		},
+		featuredMediaId: {
+			type: 'number',
+			default: 0,
+		},
+		featuredMediaUrl: {
+			type: 'string',
+			default: null,
+		},
+		featuredMediaTitle: {
+			type: 'string',
+			default: null,
+		},
+		multiple: {
+			type: 'boolean',
+			default: false,
+		},
+		price: {
+			type: 'number',
+		},
+		productId: {
+			type: 'number',
+		},
+		title: {
+			type: 'string',
+			default: '',
+		},
+	},
+	supports: {
+		className: false,
+		customClassName: false,
+		html: false,
+		reusable: false,
+	},
+	save: ( { attributes } ) => {
+		const { productId } = attributes;
+		return productId ? <RawHTML>{ `[simple-payment id="${ productId }"]` }</RawHTML> : null;
+	},
+};

--- a/extensions/blocks/simple-payments/depecrated/v1/index.js
+++ b/extensions/blocks/simple-payments/depecrated/v1/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { RawHTML } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 export default {
 	attributes: {
@@ -54,4 +55,8 @@ export default {
 		const { productId } = attributes;
 		return productId ? <RawHTML>{ `[simple-payment id="${ productId }"]` }</RawHTML> : null;
 	},
+	migrate: attributes => ( {
+		...attributes,
+		postLinkText: __( 'Visit the site to purchase.', 'jetpack' ),
+	} ),
 };

--- a/extensions/blocks/simple-payments/depecrated/v1/index.js
+++ b/extensions/blocks/simple-payments/depecrated/v1/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { RawHTML } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 export default {
 	attributes: {

--- a/extensions/blocks/simple-payments/depecrated/v1/index.js
+++ b/extensions/blocks/simple-payments/depecrated/v1/index.js
@@ -55,8 +55,4 @@ export default {
 		const { productId } = attributes;
 		return productId ? <RawHTML>{ `[simple-payment id="${ productId }"]` }</RawHTML> : null;
 	},
-	migrate: attributes => ( {
-		...attributes,
-		postLinkText: __( 'Visit the site to purchase.', 'jetpack' ),
-	} ),
 };

--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -59,12 +59,16 @@ class SimplePaymentsEdit extends Component {
 			this.saveProduct();
 		}
 
-		if ( postLinkUrl && postLinkUrl !== attributes.postLinkUrl ) {
-			setAttributes( { postLinkUrl } );
-		}
-
-		if ( ! attributes.postLinkText ) {
-			setAttributes( { postLinkText: __( 'Visit the site to purchase.', 'jetpack' ) } );
+		const shouldUpdatePostLinkUrl =
+			postLinkUrl && postLinkUrl !== this.props.attributes.postLinkUrl;
+		const shouldUpdatePostLinkText = ! this.props.attributes.postLinkText;
+		if ( shouldUpdatePostLinkUrl || shouldUpdatePostLinkText ) {
+			setAttributes( {
+				...( shouldUpdatePostLinkUrl && { postLinkUrl } ),
+				...( shouldUpdatePostLinkText && {
+					postLinkText: __( 'Visit the site to purchase.', 'jetpack' ),
+				} ),
+			} );
 		}
 	}
 
@@ -88,12 +92,16 @@ class SimplePaymentsEdit extends Component {
 			this.validateAttributes();
 		}
 
-		if ( postLinkUrl && postLinkUrl !== this.props.attributes.postLinkUrl ) {
-			setAttributes( { postLinkUrl } );
-		}
-
-		if ( ! this.props.attributes.postLinkText ) {
-			setAttributes( { postLinkText: __( 'Visit the site to purchase.', 'jetpack' ) } );
+		const shouldUpdatePostLinkUrl =
+			postLinkUrl && postLinkUrl !== this.props.attributes.postLinkUrl;
+		const shouldUpdatePostLinkText = ! this.props.attributes.postLinkText;
+		if ( shouldUpdatePostLinkUrl || shouldUpdatePostLinkText ) {
+			setAttributes( {
+				...( shouldUpdatePostLinkUrl && { postLinkUrl } ),
+				...( shouldUpdatePostLinkText && {
+					postLinkText: __( 'Visit the site to purchase.', 'jetpack' ),
+				} ),
+			} );
 		}
 	}
 

--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -122,7 +122,7 @@ class SimplePaymentsEdit extends Component {
 			email: get( simplePayment, [ 'meta', 'spay_email' ], email ),
 			featuredMediaId: get( simplePayment, [ 'featured_media' ], featuredMediaId ),
 			featuredMediaUrl: get( featuredMedia, 'url', featuredMediaUrl ),
-			featuredMediaTitle: get( featuredMedia, 'titleckcc', featuredMediaTitle ),
+			featuredMediaTitle: get( featuredMedia, 'title', featuredMediaTitle ),
 			multiple: Boolean( get( simplePayment, [ 'meta', 'spay_multiple' ], Boolean( multiple ) ) ),
 			price: get( simplePayment, [ 'meta', 'spay_price' ], price || undefined ),
 			title: get( simplePayment, [ 'title', 'raw' ], title ),

--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -50,7 +50,7 @@ class SimplePaymentsEdit extends Component {
 		// Try to get the simplePayment loaded into attributes if possible.
 		this.injectPaymentAttributes();
 
-		const { attributes, hasPublishAction, postLink, setAttributes } = this.props;
+		const { attributes, hasPublishAction, postLinkUrl, setAttributes } = this.props;
 		const { productId } = attributes;
 
 		// If the user can publish save an empty product so that we have an ID and can save
@@ -59,13 +59,13 @@ class SimplePaymentsEdit extends Component {
 			this.saveProduct();
 		}
 
-		if ( postLink && postLink !== attributes.postLink ) {
-			setAttributes( { postLink } );
+		if ( postLinkUrl && postLinkUrl !== attributes.postLinkUrl ) {
+			setAttributes( { postLinkUrl } );
 		}
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { hasPublishAction, isSelected, postLink, setAttributes } = this.props;
+		const { hasPublishAction, isSelected, postLinkUrl, setAttributes } = this.props;
 
 		if ( ! isEqual( prevProps.simplePayment, this.props.simplePayment ) ) {
 			this.injectPaymentAttributes();
@@ -84,8 +84,8 @@ class SimplePaymentsEdit extends Component {
 			this.validateAttributes();
 		}
 
-		if ( postLink && postLink !== this.props.attributes.postLink ) {
-			setAttributes( { postLink } );
+		if ( postLinkUrl && postLinkUrl !== this.props.attributes.postLinkUrl ) {
+			setAttributes( { postLinkUrl } );
 		}
 	}
 
@@ -577,7 +577,7 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 		isSaving: !! isSavingPost(),
 		simplePayment,
 		featuredMedia: featuredMediaId ? getMedia( featuredMediaId ) : null,
-		postLink: post.link,
+		postLinkUrl: post.link,
 	};
 } );
 

--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -62,6 +62,10 @@ class SimplePaymentsEdit extends Component {
 		if ( postLinkUrl && postLinkUrl !== attributes.postLinkUrl ) {
 			setAttributes( { postLinkUrl } );
 		}
+
+		if ( ! attributes.postLinkText ) {
+			setAttributes( { postLinkText: __( 'Visit the site to purchase.', 'jetpack' ) } );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -86,6 +90,10 @@ class SimplePaymentsEdit extends Component {
 
 		if ( postLinkUrl && postLinkUrl !== this.props.attributes.postLinkUrl ) {
 			setAttributes( { postLinkUrl } );
+		}
+
+		if ( ! this.props.attributes.postLinkText ) {
+			setAttributes( { postLinkText: __( 'Visit the site to purchase.', 'jetpack' ) } );
 		}
 	}
 

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -105,7 +105,7 @@ export const settings = {
 			default: false,
 		},
 		postLink: {
-			type: 'number',
+			type: 'string',
 		},
 		price: {
 			type: 'number',

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -13,6 +13,7 @@ import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import { getIconColor } from '../../shared/block-icons';
 import edit from './edit';
 import save from './save';
+import deprecatedV1 from './depecrated/v1';
 
 /**
  * Example image
@@ -181,4 +182,6 @@ export const settings = {
 		// https://github.com/Automattic/jetpack/issues/11789
 		reusable: false,
 	},
+
+	deprecated: [ deprecatedV1 ],
 };

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -82,6 +82,8 @@ export const settings = {
 		},
 		content: {
 			type: 'string',
+			source: 'html',
+			selector: '.jetpack-simple-payments-description p',
 			default: '',
 		},
 		email: {
@@ -94,10 +96,16 @@ export const settings = {
 		},
 		featuredMediaUrl: {
 			type: 'string',
+			source: 'attribute',
+			selector: '.jetpack-simple-payments-image img',
+			attribute: 'src',
 			default: null,
 		},
 		featuredMediaTitle: {
 			type: 'string',
+			source: 'attribute',
+			selector: '.jetpack-simple-payments-image img',
+			attribute: 'alt',
 			default: null,
 		},
 		multiple: {
@@ -106,6 +114,9 @@ export const settings = {
 		},
 		postLink: {
 			type: 'string',
+			source: 'attribute',
+			selector: '.jetpack-simple-payments-purchase',
+			attribute: 'href',
 		},
 		price: {
 			type: 'number',
@@ -115,6 +126,8 @@ export const settings = {
 		},
 		title: {
 			type: 'string',
+			source: 'html',
+			selector: '.jetpack-simple-payments-title p',
 			default: '',
 		},
 	},

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -104,6 +104,9 @@ export const settings = {
 			type: 'boolean',
 			default: false,
 		},
+		postLink: {
+			type: 'number',
+		},
 		price: {
 			type: 'number',
 		},

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -113,11 +113,17 @@ export const settings = {
 			type: 'boolean',
 			default: false,
 		},
-		postLink: {
+		postLinkUrl: {
 			type: 'string',
 			source: 'attribute',
 			selector: '.jetpack-simple-payments-purchase',
 			attribute: 'href',
+		},
+		postLinkText: {
+			type: 'string',
+			source: 'html',
+			selector: '.jetpack-simple-payments-purchase',
+			default: __( 'Visit the site to purchase.', 'jetpack' ),
 		},
 		price: {
 			type: 'number',

--- a/extensions/blocks/simple-payments/save.js
+++ b/extensions/blocks/simple-payments/save.js
@@ -43,7 +43,12 @@ export default function Save( { attributes } ) {
 					<div className="jetpack-simple-payments-price">
 						<p>{ formatPrice( price, currency ) }</p>
 					</div>
-					<a href={ postLink } target="_blank" rel="noopener noreferrer">
+					<a
+						className="jetpack-simple-payments-purchase"
+						href={ postLink }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
 						{ __( 'Visit the site to purchase.', 'jetpack' ) }
 					</a>
 				</div>

--- a/extensions/blocks/simple-payments/save.js
+++ b/extensions/blocks/simple-payments/save.js
@@ -1,9 +1,53 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import { RawHTML } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { formatPrice } from './utils';
 
 export default function Save( { attributes } ) {
-	const { productId } = attributes;
-	return productId ? <RawHTML>{ `[simple-payment id="${ productId }"]` }</RawHTML> : null;
+	const {
+		content,
+		currency,
+		featuredMediaUrl,
+		featuredMediaTitle,
+		postLink,
+		price,
+		productId,
+		title,
+	} = attributes;
+	if ( ! productId ) {
+		return null;
+	}
+
+	return (
+		<div className={ `jetpack-simple-payments-wrapper jetpack-simple-payments-${ productId }` }>
+			<div className="jetpack-simple-payments-product">
+				<div className="jetpack-simple-payments-product-image">
+					<div className="jetpack-simple-payments-image">
+						<figure>
+							<img src={ featuredMediaUrl } alt={ featuredMediaTitle } />
+						</figure>
+					</div>
+				</div>
+				<div className="jetpack-simple-payments-details">
+					<div className="jetpack-simple-payments-title">
+						<p>{ title }</p>
+					</div>
+					<div className="jetpack-simple-payments-description">
+						<p>{ content }</p>
+					</div>
+					<div className="jetpack-simple-payments-price">
+						<p>{ formatPrice( price, currency ) }</p>
+					</div>
+					<a href={ postLink } target="_blank" rel="noopener noreferrer">
+						{ __( 'Visit the site to purchase.', 'jetpack' ) }
+					</a>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/extensions/blocks/simple-payments/save.js
+++ b/extensions/blocks/simple-payments/save.js
@@ -14,7 +14,8 @@ export default function Save( { attributes } ) {
 		currency,
 		featuredMediaUrl,
 		featuredMediaTitle,
-		postLink,
+		postLinkUrl,
+		postLinkText,
 		price,
 		productId,
 		title,
@@ -47,11 +48,11 @@ export default function Save( { attributes } ) {
 					</div>
 					<a
 						className="jetpack-simple-payments-purchase"
-						href={ postLink }
+						href={ postLinkUrl }
 						target="_blank"
 						rel="noopener noreferrer"
 					>
-						{ __( 'Visit the site to purchase.', 'jetpack' ) }
+						{ postLinkText }
 					</a>
 				</div>
 			</div>

--- a/extensions/blocks/simple-payments/save.js
+++ b/extensions/blocks/simple-payments/save.js
@@ -26,13 +26,15 @@ export default function Save( { attributes } ) {
 	return (
 		<div className={ `jetpack-simple-payments-wrapper jetpack-simple-payments-${ productId }` }>
 			<div className="jetpack-simple-payments-product">
-				<div className="jetpack-simple-payments-product-image">
-					<div className="jetpack-simple-payments-image">
-						<figure>
-							<img src={ featuredMediaUrl } alt={ featuredMediaTitle } />
-						</figure>
+				{ featuredMediaUrl && (
+					<div className="jetpack-simple-payments-product-image">
+						<div className="jetpack-simple-payments-image">
+							<figure>
+								<img src={ featuredMediaUrl } alt={ featuredMediaTitle } />
+							</figure>
+						</div>
 					</div>
-				</div>
+				) }
 				<div className="jetpack-simple-payments-details">
 					<div className="jetpack-simple-payments-title">
 						<p>{ title }</p>

--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -54,7 +54,7 @@ function render_block( $attr, $content ) {
 
 	// Augment block UI with a PayPal button if rendered on the frontend.
 	$product_id  = $attr['productId'];
-	$dom_id      = uniqid( "jetpack-simple-payments-{$product_id}_", true );
+	$dom_id      = wp_unique_id( "jetpack-simple-payments-{$product_id}_" );
 	$is_multiple = get_post_meta( $product_id, 'spay_multiple', true ) || '0';
 
 	$simple_payments->setup_paypal_checkout_button( $product_id, $dom_id, $is_multiple );

--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -39,8 +39,8 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  * @return string
  */
 function render_block( $attr, $content ) {
-	// Do nothing if block content has been generated from the `simple-payments` shortcode.
-	if ( false !== strpos( $content, 'jetpack-simple-payments-shortcode' ) ) {
+	// Do nothing if block content is a `simple-payment` shortcode.
+	if ( preg_match( '/\[simple-payment(.*)]/', $content ) ) {
 		return $content;
 	}
 

--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -39,9 +39,15 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  * @return string
  */
 function render_block( $attr, $content ) {
+	// Do nothing if block content has been generated from the `simple-payments` shortcode.
+	if ( false !== strpos( $content, 'jetpack-simple-payments-shortcode' ) ) {
+		return $content;
+	}
+
 	$simple_payments = Jetpack_Simple_Payments::getInstance();
 	$simple_payments->enqueue_frontend_assets();
 
+	// Keep content as-is if rendered in other contexts than frontend (i.e. feed, emails, API, etc.).
 	if ( ! jetpack_is_frontend() ) {
 		return $content;
 	}

--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -44,13 +44,13 @@ function render_block( $attr, $content ) {
 		return $content;
 	}
 
-	$simple_payments = Jetpack_Simple_Payments::getInstance();
-	$simple_payments->enqueue_frontend_assets();
-
 	// Keep content as-is if rendered in other contexts than frontend (i.e. feed, emails, API, etc.).
 	if ( ! jetpack_is_frontend() ) {
 		return $content;
 	}
+
+	$simple_payments = Jetpack_Simple_Payments::getInstance();
+	$simple_payments->enqueue_frontend_assets();
 
 	// Augment block UI with a PayPal button if rendered on the frontend.
 	$product_id  = $attr['productId'];

--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Pay with PayPal block (aka Simple Payments).
+ *
+ * @since 9.0.0
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\SimplePayments;
+
+use Jetpack_Simple_Payments;
+
+const FEATURE_NAME = 'simple-payments';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_block',
+			'plan_check'      => true,
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Pay with PayPal block dynamic rendering.
+ *
+ * @param array  $attr    Array containing the block attributes.
+ * @param string $content String containing the block content.
+ *
+ * @return string
+ */
+function render_block( $attr, $content ) {
+	$simple_payments = Jetpack_Simple_Payments::getInstance();
+	$simple_payments->enqueue_frontend_assets();
+
+	if ( ! jetpack_is_frontend() ) {
+		return $content;
+	}
+
+	// Augment block UI with a PayPal button if rendered on the frontend.
+	$product_id  = $attr['productId'];
+	$dom_id      = uniqid( "jetpack-simple-payments-{$product_id}_", true );
+	$is_multiple = get_post_meta( $product_id, 'spay_multiple', true ) || '0';
+
+	$simple_payments->setup_paypal_checkout_button( $product_id, $dom_id, $is_multiple );
+
+	$purchase_box = $simple_payments->output_purchase_box( $dom_id, $is_multiple );
+	$content      = preg_replace( '#<a class="jetpack-simple-payments-purchase(.*)</a>#i', $purchase_box, $content );
+
+	return $content;
+}

--- a/functions.global.php
+++ b/functions.global.php
@@ -484,3 +484,35 @@ function jetpack_is_mobile( $kind = 'any', $return_matched_agent = false ) {
 	 */
 	return apply_filters( 'jetpack_is_mobile', $return, $kind, $return_matched_agent );
 }
+
+/**
+ * Determine whether the current request is for accessing the frontend.
+ *
+ * @return bool True if it's a frontend request, false otherwise.
+ */
+function jetpack_is_frontend() {
+	$is_frontend = true;
+
+	if (
+		is_admin() ||
+		wp_doing_ajax() ||
+		wp_doing_cron() ||
+		wp_is_json_request() ||
+		wp_is_jsonp_request() ||
+		wp_is_xml_request() ||
+		is_feed() ||
+		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
+		( defined( 'WP_CLI' ) && WP_CLI )
+	) {
+		$is_frontend = false;
+	}
+
+	/**
+	 * Filter whether the current request is for accessing the frontend.
+	 *
+	 * @since  9.0.0
+	 *
+	 * @param bool|string $is_frontend Whether the current request is for accessing the frontend.
+	 */
+	return apply_filters( 'jetpack_is_frontend', $is_frontend );
+}

--- a/functions.global.php
+++ b/functions.global.php
@@ -512,7 +512,7 @@ function jetpack_is_frontend() {
 	 *
 	 * @since  9.0.0
 	 *
-	 * @param bool|string $is_frontend Whether the current request is for accessing the frontend.
+	 * @param bool $is_frontend Whether the current request is for accessing the frontend.
 	 */
-	return apply_filters( 'jetpack_is_frontend', $is_frontend );
+	return (bool) apply_filters( 'jetpack_is_frontend', $is_frontend );
 }

--- a/functions.global.php
+++ b/functions.global.php
@@ -502,6 +502,7 @@ function jetpack_is_frontend() {
 		wp_is_xml_request() ||
 		is_feed() ||
 		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
+		( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST ) ||
 		( defined( 'WP_CLI' ) && WP_CLI )
 	) {
 		$is_frontend = false;

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -26,7 +26,7 @@ body .jetpack-simple-payments-wrapper .jetpack-simple-payments-details p {
 }
 
 /* Higher specificity in order to trump theme's style */
-body .jetpack-simple-payments-wrapper .jetpack-simple-payments-product-image .jetpack-simple-payments-image img.size-full {
+body .jetpack-simple-payments-wrapper .jetpack-simple-payments-product-image .jetpack-simple-payments-image img {
 	border: 0;
 	border-radius: 0;
 	height: auto;

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -267,7 +267,7 @@ class Jetpack_Simple_Payments {
 	</div>
 </div>
 ',
-			esc_attr( "{$data['class']} ${css_prefix}-wrapper ${css_prefix}-shortcode" ),
+			esc_attr( "{$data['class']} ${css_prefix}-wrapper" ),
 			esc_attr( "${css_prefix}-product" ),
 			$image,
 			esc_attr( "${css_prefix}-details" ),

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -267,7 +267,7 @@ class Jetpack_Simple_Payments {
 	</div>
 </div>
 ',
-			esc_attr( "{$data['class']} ${css_prefix}-wrapper" ),
+			esc_attr( "{$data['class']} ${css_prefix}-wrapper ${css_prefix}-shortcode" ),
 			esc_attr( "${css_prefix}-product" ),
 			$image,
 			esc_attr( "${css_prefix}-details" ),

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -245,15 +245,6 @@ class Jetpack_Simple_Payments {
 		$items = '';
 		$css_prefix = self::$css_classname_prefix;
 
-		$is_paypal_button_visible = true;
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			require_once WP_CONTENT_DIR . '/lib/display-context.php';
-			$context = \A8C\Display_Context\get_current_context();
-			if ( \A8C\Display_Context\EMAIL === $context ) {
-				$is_paypal_button_visible = false;
-			}
-		}
-
 		if ( $data['multiple'] ) {
 			$items = sprintf( '
 				<div class="%1$s">
@@ -275,21 +266,13 @@ class Jetpack_Simple_Payments {
 			);
 		}
 
-		if ( $is_paypal_button_visible ) {
-			$purchase_box = sprintf(
-				'<div class="%1$s">%2$s<div class="%3$s" id="%4$s"></div></div>',
-				esc_attr( "${css_prefix}-purchase-box" ),
-				$items,
-				esc_attr( "${css_prefix}-button" ),
-				esc_attr( "{$data['dom_id']}_button" )
-			);
-		} else {
-			$purchase_box = sprintf(
-				'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
-				esc_url( get_permalink( get_the_ID() ) ),
-				__( 'Visit the site to purchase.', 'jetpack' )
-			);
-		}
+		$purchase_box = sprintf(
+			'<div class="%1$s">%2$s<div class="%3$s" id="%4$s"></div></div>',
+			esc_attr( "${css_prefix}-purchase-box" ),
+			$items,
+			esc_attr( "${css_prefix}-button" ),
+			esc_attr( "{$data['dom_id']}_button" )
+		);
 		return sprintf( '
 <div class="%1$s">
 	<div class="%2$s">


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/17246
Fixes https://github.com/Automattic/jetpack/issues/17161
Fixes https://github.com/Automattic/jetpack/issues/15591

#### Changes proposed in this Pull Request:
As @mtias noted in paYKcK-FI-p2#comment-831, the `save` function of a block is conceptually the proper fallback while `render_callback` is instead intended for augmenting the content dynamically.

In other words, the `save` function should return an output that works well enough in any context (email, notifications, feed, as well as unknown clients getting post content from an API, etc). Then, for cases where we want to provide a richer UI (such in the site frontend), the `render_callback` function should be used for manipulating the block content.

This PR modifies the Pay with PayPal block implementation so it follows the approach above:
- The block saves now a fallback output into the post content. That fallback includes a textual call-to-action linking to the post so folks can purchase from the website. This means that the block no longer saves a `[simple-payment]` shortcode.
- The block also sets a render callback that augments the UI replacing the link to the post with a PayPal button when the block is rendered in the frontend (determined with a new `jetpack_is_frontend` function).
- Changes from https://github.com/Automattic/jetpack/pull/17180 have been reverted so the fallback is only saved when saving posts from now on. Contexts where the fallback output is going to be rendered are usually timely streamers, so we don't need to worry about using the fallback in existing posts.

#### Jetpack product discussion
paYKcK-FI-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

_Web_
- [Spin up a JN site running `master`](https://jurassic.ninja/create/?jetpack-beta).
- Set up Jetpack and purchase any paid plan.
- Go to WP Admin > Posts > Add new.
- Insert a Pay with PayPal block.
- Fill it with data.
- Publish the post.
- Go to WP Admin > Jetpack > Jetpack Beta.
- Switch to the branch of this PR (`update/pay-with-paypal-save-fallback`).
- Visit the frontend of the post you published before.
- Make sure there are no regressions in the Pay with PayPal block.
- Go to WP Admin > Posts.
- Edit the post you published before.
- Make sure there are no regressions in the Pay with PayPal block.
- Open the "More" menu and activate the "Code editor" view.
- Make sure the HTML markup is the fallback output (the one with a "Visit the site to purchase" link).
- Switch back to the "Visual editor" view.
- Click on the "Update" button.
- Visit the frontend of the post.
- Make sure the augmented UI is displayed (the one with a "PayPal" button).

_API_
- [Go to the WP.com API console](https://developer.wordpress.com/docs/api/console/).
- Make a `GET` request to `/sites/:site/posts/:post-id` (where `:post-id` is the ID of a post that contains a Pay with PayPal block).
- Make sure the post content uses the fallback.
<img width="1278" alt="Screen Shot 2020-09-28 at 17 29 28" src="https://user-images.githubusercontent.com/1233880/94452816-3cbfb280-01b0-11eb-844d-77b8f87df64a.png">

_Email, notifications, and reader (only testable in WP.com)_
- Apply D50134-code to your WP.com sandbox.
- Sandbox the API and the URL of a WP.com site under a Premium plan.
- Go to https://wordpress.com/following/manage.
- Make sure to follow the site under a Premium plan you sandboxed above.
- Enable the "Notify me of new posts" option.
<img width="330" alt="Screen Shot 2020-09-28 at 16 25 18" src="https://user-images.githubusercontent.com/1233880/94444997-3b3dbc80-01a7-11eb-850f-47e87d259098.png">

- Go to https://wordpress.com/block-editor.
- Select the site under a Premium plan you sandboxed above.
- Publish a post that contains a "Pay with PayPal" block.
- Grab the IDs of the post and the site where the post has been published.
- In a WP.com sandbox run `php ./bin/subscriptions/send.php <BLOG_ID> post <POST_ID> <YOUR_EMAIL>`.
- Check the email received and make sure it contains a "Visit the site to purchase" link.
<img width="626" alt="Screen Shot 2020-09-28 at 16 27 26" src="https://user-images.githubusercontent.com/1233880/94445254-85bf3900-01a7-11eb-84a1-7ec66d8b322d.png">

- Open the masterbar notifications.
- Make sure it includes the "Visit the site to purchase" link.
<img width="401" alt="Screen Shot 2020-09-28 at 16 26 35" src="https://user-images.githubusercontent.com/1233880/94445152-67f1d400-01a7-11eb-9b37-5debf7302d0b.png">

- Go to Reader.
- Open the post you just published above.
- Make sure it includes the "Visit the site to purchase" link.
<img width="1012" alt="Screen Shot 2020-09-28 at 16 33 29" src="https://user-images.githubusercontent.com/1233880/94446067-6e348000-01a8-11eb-8c1f-ad524103370a.png">

#### Proposed changelog entry for your changes:
Pay with PayPal block: Save fallback into post content