### PR TITLE
Admin Page: do not display upgrade banners when in Offline mode

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -27,6 +27,7 @@ import {
 	getPlanClass,
 } from 'lib/plans/constants';
 
+import { isOfflineMode } from 'state/connection';
 import {
 	getSiteAdminUrl,
 	getUpgradeUrl,
@@ -342,7 +343,8 @@ export const SettingsCard = props => {
 	};
 
 	const children = showChildren() && props.children;
-	const banner = ! props.fetchingSiteData && ! featureIsOverriden() && getBanner();
+	const banner =
+		! props.fetchingSiteData && ! featureIsOverriden() && ! props.inOfflineMode && getBanner();
 
 	if ( ! children && ! banner ) {
 		return null;
@@ -417,5 +419,6 @@ export default connect( state => {
 		spamUpgradeUrl: getUpgradeUrl( state, 'settings-spam' ),
 		multisite: isMultisite( state ),
 		hasActiveSearchPurchase: hasActiveSearchPurchase( state ),
+		inOfflineMode: isOfflineMode( state ),
 	};
 } )( SettingsCard );

--- a/_inc/client/performance/search.jsx
+++ b/_inc/client/performance/search.jsx
@@ -71,6 +71,7 @@ function Search( props ) {
 	return (
 		<SettingsCard { ...props } module="search" feature={ FEATURE_SEARCH_JETPACK } hideButton>
 			<SettingsGroup
+				disableInOfflineMode
 				hasChild
 				module={ { module: 'search' } }
 				support={ {

--- a/_inc/client/performance/search.jsx
+++ b/_inc/client/performance/search.jsx
@@ -13,6 +13,7 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
 import { FEATURE_SEARCH_JETPACK, getPlanClass } from 'lib/plans/constants';
 import { FormFieldset } from 'components/forms';
 import getRedirectUrl from 'lib/jp-redirect';
+import { isOfflineMode } from 'state/connection';
 import {
 	getSitePlan,
 	hasActiveSearchPurchase as selectHasActiveSearchPurchase,
@@ -77,7 +78,11 @@ function Search( props ) {
 					link: getRedirectUrl( 'jetpack-support-search' ),
 				} }
 			>
-				<p>{ SEARCH_DESCRIPTION } </p>
+				<p>
+					{ props.inOfflineMode
+						? __( 'Unavailable in Offline Mode', 'jetpack' )
+						: SEARCH_DESCRIPTION }
+				</p>
 				{ props.isLoading && __( 'Loading…', 'jetpack' ) }
 				{ ! props.isLoading && ( props.isBusinessPlan || props.hasActiveSearchPurchase ) && (
 					<Fragment>
@@ -141,6 +146,7 @@ export default connect( state => {
 	const planClass = getPlanClass( getSitePlan( state ).product_slug );
 	return {
 		isLoading: isFetchingSitePurchases( state ),
+		inOfflineMode: isOfflineMode( state ),
 		hasActiveSearchPurchase: selectHasActiveSearchPurchase( state ),
 		isBusinessPlan: 'is-business-plan' === planClass,
 		failedToEnableSearch:


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Do not display Upgrade banners in Offline mode, where folks will not be able to purchase a plan or product for their site.

This PR removes those banners: 

<img width="1086" alt="screenshot 2020-09-24 at 18 00 14" src="https://user-images.githubusercontent.com/426388/94170109-ee4ca400-fe8f-11ea-87d0-f9988de2da3e.png">
<img width="1094" alt="screenshot 2020-09-24 at 18 00 09" src="https://user-images.githubusercontent.com/426388/94170114-ef7dd100-fe8f-11ea-9d51-ed6c6a91ce21.png">
<img width="1100" alt="screenshot 2020-09-24 at 18 00 06" src="https://user-images.githubusercontent.com/426388/94170119-f0166780-fe8f-11ea-96ce-7dd3caaa482f.png">

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Start with a site [in Offline mode](https://jetpack.com/support/development-mode/) (in JN, you can go to Settings > Jetpack Constants and enable that option)
* Go to Jetpack > Dashboard and Jetpack > Settings
* You should not see banners inviting you to upgrade. The Anti-Spam banner should be the only one remaining (since Akismet can still be used).

#### Proposed changelog entry for your changes:

* Dashboard: do not display option to purchase a plan when in Offline mode.
