### PR TITLE
Avoid version "dev-master" for monorepo packages in composer.lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ php:
 - "7.4snapshot"
 
 env:
-  # Global variable is re-defined in matrix-include -list
   global:
+  # Global variable is re-defined in matrix-include -list
   - WP_TRAVISCI=phpunit
+  # Tell Composer that the version is "dev-master" to avoid it guessing for the monorepo packages.
+  - COMPOSER_ROOT_VERSION=dev-master
   # Run phpunit in Travis matrix for these combinations
   matrix:
   - WP_BRANCH=master SIMPLE_AND_MULTISITE=1 # SIMPLE_AND_MULTISITE is just a way to explicitly mention that we run both suites

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -148,10 +148,10 @@ function runPHPCSChanged( phpFilesToCheck ) {
  * Check that composer.lock doesn't refer to monorepo packages as "dev-master"
  */
 function checkComposerLock() {
-	var obj = JSON.parse( fs.readFileSync( 'composer.lock', 'utf8' ) );
-	var changed = [];
+	const obj = JSON.parse( fs.readFileSync( 'composer.lock', 'utf8' ) );
+	const changed = [];
 
-	var checkPackage = function ( p ) {
+	const checkPackage = function ( p ) {
 		if (
 			p.dist.type === 'path' &&
 			p.dist.url.startsWith( './packages/' ) &&

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -145,6 +145,47 @@ function runPHPCSChanged( phpFilesToCheck ) {
 }
 
 /**
+ * Check that composer.lock doesn't refer to monorepo packages as "dev-master"
+ */
+function checkComposerLock() {
+	var obj = JSON.parse( fs.readFileSync( 'composer.lock', 'utf8' ) );
+	var changed = [];
+
+	var checkPackage = function ( p ) {
+		if (
+			p.dist.type === 'path' &&
+			p.dist.url.startsWith( './packages/' ) &&
+			p.version === 'dev-master'
+		) {
+			p.version = 'dev-monorepo';
+			changed.push( p.name );
+		}
+	};
+
+	obj.packages.forEach( checkPackage );
+	obj[ 'packages-dev' ].forEach( checkPackage );
+
+	if ( changed.length > 0 ) {
+		if ( checkFileAgainstDirtyList( 'composer.lock', dirtyFiles ) ) {
+			fs.writeFileSync( 'composer.lock', JSON.stringify( obj, null, 4 ) + '\n' );
+			execSync( `git add composer.lock` );
+			console.log(
+				chalk.yellow( 'Monorepo package versions automatically fixed.' ),
+				'\n\nAffected packages: ' + changed.join( ', ' )
+			);
+		} else {
+			console.log(
+				chalk.red( 'COMMIT ABORTED:' ),
+				'composer.lock must not refer to packages in the monorepo with version "dev-master".\n' +
+					'This could not be fixed automatically because composer.lock is dirty.',
+				'\n\nAffected packages: ' + changed.join( ', ' )
+			);
+			exitCode = 1;
+		}
+	}
+}
+
+/**
  * Exit
  *
  * @param {Number} exitCodePassed Shell exit code.
@@ -231,4 +272,5 @@ if ( phpcsResult && phpcsResult.status ) {
 }
 
 runPHPCSChanged( phpFiles );
+checkComposerLock();
 exit( exitCode );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,9 @@
 		<testsuite name="php-lint">
 			<file>tests/php/test_php-lint.php</file>
 		</testsuite>
+		<testsuite name="composer-lint">
+			<file>tests/php/test-composer-lint.php</file>
+		</testsuite>
 		<testsuite name="core-api">
 			<directory prefix="test" suffix=".php">tests/php/core-api</directory>
 		</testsuite>

--- a/tests/php/test-composer-lint.php
+++ b/tests/php/test-composer-lint.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Test suite to lint composer.lock
+ *
+ * @package Jetpack
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test suite to lint composer.lock
+ */
+class WP_Test_Jetpack_Composer_Lint extends TestCase {
+
+	/**
+	 * Test that monorepo packages are correctly referred to from composer.lock.
+	 */
+	public function test_monorepo_package_locks() {
+		$basedir = dirname( dirname( __DIR__ ) );
+
+		// First, find the available packages.
+		$monorepo_packages = array();
+		foreach ( scandir( "$basedir/packages/" ) as $dir ) {
+			$file = "$basedir/packages/$dir/composer.json";
+			if ( file_exists( $file ) ) {
+				$obj                               = json_decode( file_get_contents( $file ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$monorepo_packages[ $obj['name'] ] = "./packages/$dir";
+			}
+		}
+
+		$obj      = json_decode( file_get_contents( "$basedir/composer.lock" ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$packages = array_merge( $obj['packages'], $obj['packages-dev'] );
+
+		foreach ( $packages as $p ) {
+			$name = $p['name'];
+			if ( ! isset( $monorepo_packages[ $name ] ) ) {
+				continue;
+			}
+
+			$this->assertNotSame( 'dev-master', $p['version'], "$name: Monorepo packages must not be version \"dev-master\"" );
+			$this->assertSame( 'path', $p['dist']['type'], "$name: Monorepo packages must have dist.type = 'path'" );
+			$this->assertSame(
+				$monorepo_packages[ $name ],
+				$p['dist']['url'],
+				"$name: Monorepo packages must have dist.url pointing to the monorepo"
+			);
+		}
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

If composer.lock has a monorepo package as version "dev-master", this can easily confuse Composer into switching the package from the monorepo to the versions in the Packagist repository, which in turn will break Travis testing.
    
We avoid this in a few ways:
    
* A git pre-commit hook will attempt to switch them from "dev-master" to "dev-monorepo", and will fail the commit if it can't.
* A CI test has been added to avoid such changes being merged if they somehow get past the above.
 * Our Travis setup has been adjusted to pretend to Composer that the monorepo version is "dev-master" instead of the default based on the commit ID, which should hopefully prevent it from getting confused.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
none, but see https://github.com/Automattic/jetpack/pull/17030#issuecomment-697804890

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Reset all changes between tests.

Test 1:
* Edit composer.lock to change `"version": "dev-add/jetpack-lazy-images-package"` to `"version": "dev-master"` on line 11. Do not `git add` it at this time.
* Make some other arbitrary change, and `git add` it.
* Attempt to commit your change. The commit should fail because `composer.lock` is dirty.
* Now do `git add composer.lock`
* Attempt to commit your change. The commit should succeed, with "dev-master" on line 11 changed to "dev-monorepo".

Test 2:
* Execute `composer require automattic/jetpack-autoloader=dev-master`. Verify that composer.lock reflects this package being installed from git rather than from the monorepo.
* Run `yarn docker:phpunit --testsuite composer-lint`.
* The test should fail, complaining that version "dev-master" is not allowed.

Test 3:
* Execute `composer require automattic/jetpack-autoloader=v2.3.0`. Verify that composer.lock reflects this package being installed from git rather than from the monorepo.
* Run `yarn docker:phpunit --testsuite composer-lint`.
* The test should fail, complaining that monorepo packages must have dist.type = 'path'.

Test 4:
* Edit composer.lock to change `"url": "./packages/a8c-mc-stats"` to `"url": "/tmp/something"` on line 14.
* Run `yarn docker:phpunit --testsuite composer-lint`.
* The test should fail, complaining that monorepo packages must have a url pointing to the monorepo.

Test 5:
* Edit composer.lock to change one or more monorepo packages to version "dev-master", and commit this.
* Push it as a PR to Github.
* Once Travis runs, see that test runs for PHP 5.6 and 7.0 actually ran correctly, and only failed because of the composer-lint test.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
This change only affects developers, so it's probably not necessary.
