### PR TITLE
Jetpack Setup Wizard: Add Tracks event to Creative Mail install

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/index.jsx
+++ b/_inc/client/setup-wizard/feature-toggle/index.jsx
@@ -94,8 +94,11 @@ let FeatureToggle = props => {
 		setIsInstalling( true );
 		onInstallClick().then( () => {
 			setIsInstalling( false );
+			analytics.tracks.recordEvent( 'jetpack_wizard_feature_install', {
+				feature,
+			} );
 		} );
-	} );
+	}, [ feature ] );
 
 	let buttonContent;
 	if ( ! checked && upgradeLink ) {

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -330,9 +330,11 @@ const features = {
 		},
 		mapDispatchToProps: dispatch => {
 			const installAndRefreshPluginData = () => {
-				restApi.installPlugin( 'creative-mail-by-constant-contact', 'setup-wizard' ).then( () => {
-					dispatch( fetchPluginsData() );
-				} );
+				return restApi
+					.installPlugin( 'creative-mail-by-constant-contact', 'setup-wizard' )
+					.then( () => {
+						dispatch( fetchPluginsData() );
+					} );
 			};
 
 			return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR adds a Tracks event to the Creative Mail install button in the setup wizard.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. On a Jetpack site without Creative Mail installed add the following to then end of the wp-config.php file in order to make the Setup Wizard show:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit `/wp-admin/admin.php?page=jetpack#/setup/features`.
3. Open the network tab in your browser's dev tools and filter for `t.gif`.
4. Click "Install now" on the Creative Mail recommendation. 
5. Verify that a request for `t.gif` is made with `feature=creative-mail` and `_en=jetpack_wizard_feature_install`.
6. Wait 5 minutes and then verify in Tracks Live View that the `jetpack_wizard_feature_install` event displays for your user.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Added missing Tracks event on setup wizard install links
