### PR TITLE
Blocks: switch all blocks to be registered using new package

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -13,53 +13,20 @@ use Automattic\Jetpack\Status;
 /**
  * Wrapper function to safely register a gutenberg block type
  *
- * @param string $slug Slug of the block.
- * @param array  $args Arguments that are passed into register_block_type.
+ * @deprecated 9.1.0 Use Automattic\\Jetpack\\Blocks::Blocks::jetpack_register_block instead
  *
  * @see register_block_type
  *
  * @since 6.7.0
  *
+ * @param string $slug Slug of the block.
+ * @param array  $args Arguments that are passed into register_block_type.
+ *
  * @return WP_Block_Type|false The registered block type on success, or false on failure.
  */
 function jetpack_register_block( $slug, $args = array() ) {
-	if ( 0 !== strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
-		_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', '7.1.0' );
-		$slug = 'jetpack/' . $slug;
-	}
-
-	if ( isset( $args['version_requirements'] )
-		&& ! Jetpack_Gutenberg::is_gutenberg_version_available( $args['version_requirements'], $slug ) ) {
-		return false;
-	}
-
-	// Checking whether block is registered to ensure it isn't registered twice.
-	if ( Jetpack_Gutenberg::is_registered( $slug ) ) {
-		return false;
-	}
-
-	$feature_name = Jetpack_Gutenberg::remove_extension_prefix( $slug );
-	// If the block is dynamic, and a Jetpack block, wrap the render_callback to check availability.
-	if (
-		isset( $args['plan_check'] )
-		&& true === $args['plan_check']
-	) {
-		if ( isset( $args['render_callback'] ) ) {
-			$args['render_callback'] = Jetpack_Gutenberg::get_render_callback_with_availability_check( $feature_name, $args['render_callback'] );
-		}
-		$method_name = 'set_availability_for_plan';
-	} else {
-		$method_name = 'set_extension_available';
-	}
-
-	add_action(
-		'jetpack_register_gutenberg_extensions',
-		function() use ( $feature_name, $method_name ) {
-			call_user_func( array( 'Jetpack_Gutenberg', $method_name ), $feature_name );
-		}
-	);
-
-	return register_block_type( $slug, $args );
+	_deprecated_function( __METHOD__, '9.1.0', 'Automattic\\Jetpack\\Blocks::jetpack_register_block' );
+	return Blocks::jetpack_register_block( $slug, $args );
 }
 
 /**
@@ -207,20 +174,6 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Register a block
-	 *
-	 * @deprecated 7.1.0 Use jetpack_register_block() instead
-	 *
-	 * @param string $slug Slug of the block.
-	 * @param array  $args Arguments that are passed into register_block_type().
-	 */
-	public static function register_block( $slug, $args ) {
-		_deprecated_function( __METHOD__, '7.1', 'jetpack_register_block' );
-
-		jetpack_register_block( 'jetpack/' . $slug, $args );
-	}
-
-	/**
 	 * Register a plugin
 	 *
 	 * @deprecated 7.1.0 Use Jetpack_Gutenberg::set_extension_available() instead
@@ -231,25 +184,6 @@ class Jetpack_Gutenberg {
 		_deprecated_function( __METHOD__, '7.1', 'Jetpack_Gutenberg::set_extension_available' );
 
 		self::set_extension_available( $slug );
-	}
-
-	/**
-	 * Register a block
-	 *
-	 * @deprecated 7.0.0 Use jetpack_register_block() instead
-	 *
-	 * @param string $slug Slug of the block.
-	 * @param array  $args Arguments that are passed into the register_block_type.
-	 * @param array  $availability array containing if a block is available and the reason when it is not.
-	 */
-	public static function register( $slug, $args, $availability ) {
-		_deprecated_function( __METHOD__, '7.0', 'jetpack_register_block' );
-
-		if ( isset( $availability['available'] ) && ! $availability['available'] ) {
-			self::set_extension_unavailability_reason( $slug, $availability['unavailable_reason'] );
-		} else {
-			self::register_block( $slug, $args );
-		}
 	}
 
 	/**
@@ -502,7 +436,7 @@ class Jetpack_Gutenberg {
 		/**
 		 * Fires before Gutenberg extensions availability is computed.
 		 *
-		 * In the function call you supply, use `jetpack_register_block()` to set a block as available.
+		 * In the function call you supply, use `Blocks::jetpack_register_block()` to set a block as available.
 		 * Alternatively, use `Jetpack_Gutenberg::set_extension_available()` (for a non-block plugin), and
 		 * `Jetpack_Gutenberg::set_extension_unavailable()` (if the block or plugin should not be registered
 		 * but marked as unavailable).

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -13,7 +13,7 @@ use Automattic\Jetpack\Status;
 /**
  * Wrapper function to safely register a gutenberg block type
  *
- * @deprecated 9.1.0 Use Automattic\\Jetpack\\Blocks::Blocks::jetpack_register_block instead
+ * @deprecated 9.1.0 Use Automattic\\Jetpack\\Blocks::jetpack_register_block instead
  *
  * @see register_block_type
  *

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -156,11 +156,12 @@ To test extensions for a Simple site in Calypso, sandbox the simple site URL (`e
 
 ## Paid blocks
 
-Blocks can be restricted to specific paid plans in both WordPress.com and Jetpack. When registering a block using `jetpack_register_block`, pass `plan_check => true` as a key in the second argument. When the block is registered we check the plan data to see if the user's plan supports this block. For example:
+Blocks can be restricted to specific paid plans in both WordPress.com and Jetpack. When registering a block using `Blocks::jetpack_register_block`, pass `plan_check => true` as a key in the second argument. When the block is registered we check the plan data to see if the user's plan supports this block. For example:
 
 ```php
+use Automattic\Jetpack\Blocks;
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\load_assets',

--- a/extensions/blocks/amazon/amazon.php
+++ b/extensions/blocks/amazon/amazon.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Amazon;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'amazon';
@@ -20,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
 	);

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Business_Hours;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'business-hours';
@@ -20,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\render' )
 	);

--- a/extensions/blocks/button/button.php
+++ b/extensions/blocks/button/button.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 	);

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\load_assets',

--- a/extensions/blocks/contact-info/contact-info.php
+++ b/extensions/blocks/contact-info/contact-info.php
@@ -7,14 +7,16 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
+use Automattic\Jetpack\Blocks;
+
+Blocks::jetpack_register_block(
 	'jetpack/contact-info',
 	array(
 		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render' ),
 	)
 );
 
-jetpack_register_block(
+Blocks::jetpack_register_block(
 	'jetpack/address',
 	array(
 		'parent'          => array( 'jetpack/contact-info' ),
@@ -22,7 +24,7 @@ jetpack_register_block(
 	)
 );
 
-jetpack_register_block(
+Blocks::jetpack_register_block(
 	'jetpack/email',
 	array(
 		'parent'          => array( 'jetpack/contact-info' ),
@@ -30,7 +32,7 @@ jetpack_register_block(
 	)
 );
 
-jetpack_register_block(
+Blocks::jetpack_register_block(
 	'jetpack/phone',
 	array(
 		'parent'          => array( 'jetpack/contact-info' ),

--- a/extensions/blocks/donations/donations.php
+++ b/extensions/blocks/donations/donations.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Donations;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'donations';
@@ -20,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_block',

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 	);

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 	);

--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\load_assets',

--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
 	);

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -24,7 +24,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  */
 function register_block() {
 	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
-		jetpack_register_block(
+		Blocks::jetpack_register_block(
 			BLOCK_NAME,
 			array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 		);

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -27,7 +27,7 @@ function register_block() {
 		( defined( 'IS_WPCOM' ) && IS_WPCOM )
 		|| Jetpack::is_active()
 	) {
-		jetpack_register_block(
+		Blocks::jetpack_register_block(
 			BLOCK_NAME,
 			array(
 				'render_callback' => __NAMESPACE__ . '\load_assets',

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'Jetpack_Mapbox_Helper' ) ) {
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\load_assets',

--- a/extensions/blocks/markdown/markdown.php
+++ b/extensions/blocks/markdown/markdown.php
@@ -9,6 +9,8 @@
 
 namespace Automattic\Jetpack\Extensions\Markdown;
 
+use Automattic\Jetpack\Blocks;
+
 const FEATURE_NAME = 'markdown';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 
@@ -18,6 +20,6 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block( BLOCK_NAME );
+	Blocks::jetpack_register_block( BLOCK_NAME );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\load_assets',

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -22,7 +22,7 @@ const URL_PATTERN  = '#^https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.[a-z.]+/pin
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
 	);

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'Jetpack_Podcast_Helper' ) ) {
  * we can disable registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'attributes'      => array(

--- a/extensions/blocks/rating-star/rating-star.php
+++ b/extensions/blocks/rating-star/rating-star.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Rating_Star;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'rating-star';
@@ -23,7 +24,7 @@ require_once __DIR__ . '/rating-meta.php';
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_block',

--- a/extensions/blocks/repeat-visitor/repeat-visitor.php
+++ b/extensions/blocks/repeat-visitor/repeat-visitor.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 	);

--- a/extensions/blocks/revue/revue.php
+++ b/extensions/blocks/revue/revue.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 	);

--- a/extensions/blocks/send-a-message/send-a-message.php
+++ b/extensions/blocks/send-a-message/send-a-message.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Extensions\Send_A_Message;
 
 require_once dirname( __FILE__ ) . '/whatsapp-button/whatsapp-button.php';
 
+use Automattic\Jetpack\Blocks;
 use Jetpack;
 use Jetpack_Gutenberg;
 
@@ -21,7 +22,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_block',

--- a/extensions/blocks/send-a-message/whatsapp-button/whatsapp-button.php
+++ b/extensions/blocks/send-a-message/whatsapp-button/whatsapp-button.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Extensions\WhatsApp_Button;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack;
 use Jetpack_Gutenberg;
 
@@ -20,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 	);

--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\SimplePayments;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Simple_Payments;
 
 const FEATURE_NAME = 'simple-payments';
@@ -20,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_block',

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
 	);

--- a/extensions/blocks/social-previews/social-previews.php
+++ b/extensions/blocks/social-previews/social-previews.php
@@ -9,7 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\Social_Previews;
 
-use Jetpack_Gutenberg;
+use Automattic\Jetpack\Blocks;
 
 const FEATURE_NAME = 'social-previews';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
@@ -18,7 +18,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * Registers the Social Previews feature with the block editor.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'plan_check' => true,

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -25,7 +25,7 @@ const IMAGE_BREAKPOINTS = '(max-width: 460px) 576w, (max-width: 614px) 768w, 120
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 	);

--- a/extensions/blocks/subscriptions/subscriptions.php
+++ b/extensions/blocks/subscriptions/subscriptions.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Extensions\Subscriptions;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack;
 use Jetpack_Gutenberg;
 
@@ -23,7 +24,7 @@ function register_block() {
 		( defined( 'IS_WPCOM' ) && IS_WPCOM )
 		|| ( Jetpack::is_active() && Jetpack::is_module_active( 'subscriptions' ) )
 	) {
-		jetpack_register_block(
+		Blocks::jetpack_register_block(
 			BLOCK_NAME,
 			array( 'render_callback' => __NAMESPACE__ . '\render_block' )
 		);

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -10,6 +10,7 @@
 
 namespace Automattic\Jetpack\Extensions;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack;
 use Jetpack_Gutenberg;
 use Jetpack_Plan;
@@ -36,7 +37,7 @@ class Tiled_Gallery {
 			( defined( 'IS_WPCOM' ) && IS_WPCOM )
 			|| Jetpack::is_active()
 		) {
-			jetpack_register_block(
+			Blocks::jetpack_register_block(
 				self::BLOCK_NAME,
 				array(
 					'render_callback' => array( __CLASS__, 'render' ),

--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions;
 
+use Automattic\Jetpack\Blocks;
 use Jetpack;
 use Jetpack_Gutenberg;
 
@@ -56,7 +57,7 @@ class WordAds {
 	 */
 	public static function register() {
 		if ( self::is_available() ) {
-			jetpack_register_block(
+			Blocks::jetpack_register_block(
 				self::BLOCK_NAME,
 				array(
 					'render_callback' => array( __CLASS__, 'gutenblock_render' ),

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -8,6 +8,7 @@
  */
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Sync\Settings;
 
 define( 'GRUNION_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
@@ -244,56 +245,92 @@ class Grunion_Contact_Form_Plugin {
 	}
 
 	private static function register_contact_form_blocks() {
-		jetpack_register_block( 'jetpack/contact-form', array(
-			'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
-		) );
+		Blocks::jetpack_register_block(
+			'jetpack/contact-form',
+			array(
+				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
+			)
+		);
 
 		// Field render methods.
-		jetpack_register_block( 'jetpack/field-text', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
-		) );
-		jetpack_register_block( 'jetpack/field-name', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
-		) );
-		jetpack_register_block( 'jetpack/field-email', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
-		) );
-		jetpack_register_block( 'jetpack/field-url', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
-		) );
-		jetpack_register_block( 'jetpack/field-date', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
-		) );
-		jetpack_register_block( 'jetpack/field-telephone', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
-		) );
-		jetpack_register_block( 'jetpack/field-textarea', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
-		) );
-		jetpack_register_block( 'jetpack/field-checkbox', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
-		) );
-		jetpack_register_block( 'jetpack/field-checkbox-multiple', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
-		) );
-		jetpack_register_block( 'jetpack/field-radio', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
-		) );
-		jetpack_register_block( 'jetpack/field-select', array(
-			'parent'          => array( 'jetpack/contact-form' ),
-			'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
-		) );
-		jetpack_register_block(
+		Blocks::jetpack_register_block(
+			'jetpack/field-text',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_text' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-name',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_name' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-email',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_email' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-url',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_url' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-date',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_date' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-telephone',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_telephone' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-textarea',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_textarea' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-checkbox',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-checkbox-multiple',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_checkbox_multiple' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-radio',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_radio' ),
+			)
+		);
+		Blocks::jetpack_register_block(
+			'jetpack/field-select',
+			array(
+				'parent'          => array( 'jetpack/contact-form' ),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_field_select' ),
+			)
+		);
+		Blocks::jetpack_register_block(
 			'jetpack/field-consent',
 			array(
 				'parent'          => array( 'jetpack/contact-form' ),

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -6,6 +6,8 @@
  * @since      7.3.0
  */
 
+use Automattic\Jetpack\Blocks;
+
 /**
  * Class Jetpack_Memberships
  * This class represents the Memberships functionality.
@@ -359,7 +361,7 @@ class Jetpack_Memberships {
 		}
 
 		if ( self::is_enabled_jetpack_recurring_payments() ) {
-			jetpack_register_block(
+			Blocks::jetpack_register_block(
 				'jetpack/recurring-payments',
 				array(
 					'render_callback' => array( $this, 'render_button' ),

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Sync\Settings;
 
 class Jetpack_RelatedPosts {
@@ -72,7 +73,7 @@ class Jetpack_RelatedPosts {
 		// Add Related Posts to the REST API Post response.
 		add_action( 'rest_api_init', array( $this, 'rest_register_related_posts' ) );
 
-		jetpack_register_block(
+		Blocks::jetpack_register_block(
 			'jetpack/related-posts',
 			array(
 				'render_callback' => array( $this, 'render_block' ),

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -1,9 +1,17 @@
-<?php
-/*
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
  * Simple Payments lets users embed a PayPal button fully integrated with wpcom to sell products on the site.
  * This is not a proper module yet, because not all the pieces are in place. Until everything is shipped, it can be turned
  * into module that can be enabled/disabled.
-*/
+ *
+ * @package Jetpack
+ */
+
+use Automattic\Jetpack\Blocks;
+
+/**
+ * Jetpack_Simple_Payments
+ */
 class Jetpack_Simple_Payments {
 	// These have to be under 20 chars because that is CPT limit.
 	static $post_type_order = 'jp_pay_order';

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Blocks;
 
 /**
  * Register a VideoPress extension to replace the default Core Video block.
@@ -108,7 +109,7 @@ class VideoPress_Gutenberg {
 	 * It defines a server-side rendering that adds VideoPress support to the core video block.
 	 */
 	public function register_video_block_with_videopress() {
-		jetpack_register_block(
+		Blocks::jetpack_register_block(
 			'core/video',
 			array(
 				'render_callback' => array( $this, 'render_video_block_with_videopress' ),

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Blocks;
+
 class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	public $master_user_id = false;
@@ -77,11 +79,11 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function register_block() {
-		jetpack_register_block( 'jetpack/apple' );
+		Blocks::jetpack_register_block( 'jetpack/apple' );
 	}
 
 	function test_registered_block_is_available() {
-		jetpack_register_block( 'jetpack/apple' );
+		Blocks::jetpack_register_block( 'jetpack/apple' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertTrue( $availability['apple']['available'] );
 	}
@@ -94,7 +96,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_registered_block_is_not_available_when_not_defined_in_whitelist() {
-		jetpack_register_block( 'jetpack/durian' );
+		Blocks::jetpack_register_block( 'jetpack/durian' );
 		$availability = Jetpack_Gutenberg::get_availability();
 		$this->assertArrayNotHasKey( 'durian', $availability, 'durian is available!' );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Functions;
@@ -63,7 +64,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		add_filter( 'jetpack_set_available_extensions',  array( $this, 'add_test_block' ) );
 		Jetpack_Gutenberg::init();
-		jetpack_register_block( 'jetpack/test' );
+		Blocks::jetpack_register_block( 'jetpack/test' );
 
 		$callables = array(
 			'wp_max_upload_size'               => wp_max_upload_size(),

--- a/wp-cli-templates/block-register-php.mustache
+++ b/wp-cli-templates/block-register-php.mustache
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Extensions\{{ underscoredTitle }};
 
+use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = '{{ slug }}';
@@ -20,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_block(
+	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
 	);


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Following #17167, we can now switch all blocks to use the method introduced in the Blocks package.
* We can also deprecate the old method.
* There were old registration methods in `Jetpack_Gutenberg` that have been deprecated for more than a year already, and are not used in Jetpack anymore. I've removed them for good.
* I've updated the template used when creating new blocks via WP Cli, so it uses the new method as well.

#### Jetpack product discussion

* See Primary issue: #17099 

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Posts > Add New
* In your browser console, check `Jetpack_Editor_Initial_State.available_blocks`: it should return all expected blocks, and no errors should appear in your logs.
* Tests should pass.
* You should be able to use blocks just like before.

#### Proposed changelog entry for your changes:

* N/A
