### PR TITLE
Calypsoify: Remove style that accidentally hides "Code editor" option

### DIFF
--- a/modules/calypsoify/style-gutenberg.scss
+++ b/modules/calypsoify/style-gutenberg.scss
@@ -4,11 +4,6 @@
 /* CORE UI */
 @import 'gutenberg-styles/button.scss';
 
-/* Hides the Fullscreen option from the View modes */
-.edit-post-more-menu__content .components-menu-group:first-child .components-menu-item__button:last-child {
-  display: none;
-}
-
 .edit-post-sidebar__panel-tab {
 	&.is-active {
 		border-color: $color-primary;


### PR DESCRIPTION
Gutenberg [hides the "View" menu for small screens now](https://github.com/WordPress/gutenberg/commit/f4300ff87ea9a8e5d2aed155f180c76b83a54c4a#diff-84d6cf5cfecefd4e711bd9d50e8fa5f6R14-R18). It's is causing our selector to miss the target and hide the "Code editor" item instead. Thankfully, since what we want is handled natively now we can safely remove our patch.

#### Changes proposed in this Pull Request:
Bugfix

#### Additional context:
- p1601030097044000-slack-C015AL3QL7M
- https://github.com/WordPress/gutenberg/pull/18816
- https://github.com/Automattic/jetpack/pull/10368

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Open iframed editor in mobile view (width < 782px)
* Open the `Options` menu (three vertical dots in the top-right corner)
* Confirm that the `Code editor` item is available

| Before  | After |
| ------------- | ------------- |
| <img width="431" alt="Screenshot 2020-09-25 at 15 35 05" src="https://user-images.githubusercontent.com/1451471/94273492-c9663880-ff44-11ea-8cd5-43c926ebbf26.png"> | <img width="435" alt="Screenshot 2020-09-25 at 15 35 22" src="https://user-images.githubusercontent.com/1451471/94273499-ccf9bf80-ff44-11ea-9196-50088e5ea515.png"> |


#### Proposed changelog entry for your changes:
* Calypsoify: Fix a bug that's making "Code editor" unreachable on mobile devices