### PR TITLE
Autoloader: remove the plugins_loaded bullet point from the README

### DIFF
--- a/packages/autoloader/README.md
+++ b/packages/autoloader/README.md
@@ -12,7 +12,6 @@ It diverges from the default Composer autoloader setup in the following ways:
 * It creates `jetpack_autoload_classmap.php` and `jetpack_autoload_filemap.php` files in the `vendor/composer` directory.
 * This file includes the version numbers from each package that is used. 
 * The autoloader will only load the latest version of the library no matter what plugin loads the library. 
-* Only call the library classes after all the plugins have loaded and the `plugins_loaded` action has fired.
 
 
 Usage


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The v2.x version of the autoloader allows package classes to be loaded before the `plugins_loaded` action has fired. Remove the bullet point that states that package classes should be loaded only after all plugins have loaded.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* n/a

#### Testing instructions:
* n/a. This is documentation change.

#### Proposed changelog entry for your changes:
* n/a
