### PR TITLE
Instant Search: Break line instead of overflowing result copy

### DIFF
--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -32,3 +32,7 @@
 .jetpack-instant-search__search-result-minimal-cats {
 	padding-left: 10px;
 }
+
+.jetpack-instant-search__search-result-minimal-content {
+	word-break: break-word;
+}

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -89,6 +89,7 @@
 	padding-left: 16px;
 	font-size: 0.9em;
 	border-left: 2px solid #eee;
+	word-break: break-word;
 
 	.gridicon {
 		margin-right: 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds line breaks to search results instead of overflowing out of the minimal results layout.

> Before (note how text overflows off-screen):
> <img width="235" alt="Screen Shot 2020-09-25 at 3 51 21 PM" src="https://user-images.githubusercontent.com/4044428/94319072-1814d200-ff47-11ea-8415-219f99fb2a64.png">

> After:
> <img width="235" alt="Screen Shot 2020-09-25 at 3 51 36 PM" src="https://user-images.githubusercontent.com/4044428/94319077-1945ff00-ff47-11ea-8d56-882acca3c874.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this PR to your Jetpack site.
* Apply the minimal result format in the Customizer.
* Try a search while emulating a small viewport, like that of the iPhone X.
* Ensure no results overflow off-screen.

#### Proposed changelog entry for your changes:
* Improved mobile layout for Jetpack Search.
