### PR TITLE
At-A-Glance: Only show the Scan card for multisites if they're connected to VaultPress

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -91,7 +91,7 @@ class AtAGlance extends Component {
 		const hasVaultPressScanning =
 			! this.props.fetchingScanStatus && this.props.scanStatus?.reason === 'vp_active_on_site';
 		if ( ! this.props.multisite || hasVaultPressScanning ) {
-			securityCards.push( <DashScan { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } /> );
+			securityCards.push( <DashScan { ...settingsProps } { ...urls } /> );
 		}
 
 		if ( ! this.props.multisite ) {

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -24,6 +24,7 @@ import DashSearch from './search';
 import DashConnections from './connections';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import QuerySite from 'components/data/query-site';
+import QueryScanStatus from 'components/data/query-scan-status';
 import {
 	isMultisite,
 	userCanManageModules,
@@ -32,6 +33,7 @@ import {
 } from 'state/initial-state';
 import { isOfflineMode } from 'state/connection';
 import { getModuleOverride } from 'state/modules';
+import { getScanStatus, isFetchingScanStatus } from 'state/scan';
 
 const renderPairs = layout =>
 	layout.map( ( item, layoutIndex ) => [
@@ -84,7 +86,14 @@ class AtAGlance extends Component {
 		// Status can be unavailable, active, provisioning, awaiting_credentials
 		const rewindStatus = get( this.props.rewindStatus, [ 'state' ], '' );
 		const securityCards = [];
-		securityCards.push( <DashScan { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } /> );
+
+		// Backup won't work with multi-sites, but Scan does if VaultPress is enabled
+		const hasVaultPressScanning =
+			! this.props.fetchingScanStatus && this.props.scanStatus?.reason === 'vp_active_on_site';
+		if ( ! this.props.multisite || hasVaultPressScanning ) {
+			securityCards.push( <DashScan { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } /> );
+		}
+
 		if ( ! this.props.multisite ) {
 			securityCards.push(
 				<DashBackups
@@ -138,6 +147,7 @@ class AtAGlance extends Component {
 				<div className="jp-at-a-glance">
 					<QuerySitePlugins />
 					<QuerySite />
+					<QueryScanStatus />
 					<DashStats { ...settingsProps } { ...urls } />
 					{ renderPairs( pairs ) }
 					{ connections }
@@ -185,5 +195,7 @@ export default connect( state => {
 		isOfflineMode: isOfflineMode( state ),
 		getModuleOverride: module_name => getModuleOverride( state, module_name ),
 		multisite: isMultisite( state ),
+		scanStatus: getScanStatus( state ),
+		fetchingScanStatus: isFetchingScanStatus( state ),
 	};
 } )( withModuleSettingsFormHelpers( AtAGlance ) );

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -111,6 +111,24 @@ class DashScan extends Component {
 	getVPContent() {
 		const { vaultPressData } = this.props;
 
+		// The VaultPress plugin is active but not registered, or we can't connect
+		if ( vaultPressData?.code === 'not_registered' ) {
+			return renderCard( {
+				className: 'jp-dash-item__is-inactive',
+				status: 'not-registered',
+				content: jetpackCreateInterpolateElement(
+					__(
+						"VaultPress is having trouble connecting. Make sure you've <keyLink>entered your registration key</keyLink>, or <supportLink>contact support</supportLink> if you still need help.",
+						'jetpack'
+					),
+					{
+						keyLink: <a href="admin.php?page=vaultpress" />,
+						supportLink: <a href={ getRedirectUrl( 'vaultpress-help' ) } />,
+					}
+				),
+			} );
+		}
+
 		// The VaultPress plugin is active and we received scanning data
 		const scanEnabled = get( vaultPressData, [ 'data', 'features', 'security' ], false );
 		if ( scanEnabled ) {
@@ -128,16 +146,12 @@ class DashScan extends Component {
 					content: __( "No threats found, you're good to go!", 'jetpack' ),
 				} );
 			}
-
-			// NOTE: Not sure how to handle other cases here; if everything is active and enabled,
-			// but `vaultPressData.code` is a non-success, what should we do?
 		}
 
 		// At this point, either the plugin isn't active/installed, or we're not receiving scan data.
 		// We need to know this site's current plan for decision-making past this point.
 		if ( this.props.fetchingSiteData ) {
 			return renderCard( {
-				status: '',
 				content: __( 'Loading…', 'jetpack' ),
 			} );
 		}

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -119,7 +119,7 @@ class DashScan extends Component {
 				status: 'not-registered',
 				content: jetpackCreateInterpolateElement(
 					__(
-						"VaultPress is having trouble connecting. Make sure you've <keyLink>entered your registration key</keyLink>, or <supportLink>contact support</supportLink> if you still need help.",
+						'VaultPress is having difficulties scanning. Please make sure your <keyLink>registration key is entered</keyLink>. If you require further assistance please <supportLink>contact support</supportLink>.',
 						'jetpack'
 					),
 					{
@@ -172,17 +172,37 @@ class DashScan extends Component {
 			} );
 		}
 
-		// We know this site has a plan with scanning included, so the plugin must not be active;
-		// show the corresponding status for whether it's not installed or just not activated
-		const status = this.props.isVaultPressInstalled ? 'pro-inactive' : 'pro-uninstalled';
+		// VaultPress is installed, just not activated
+		if ( this.props.isVaultPressInstalled ) {
+			return renderCard( {
+				className: 'jp-dash-item__is-inactive',
+				status: 'pro-inactive',
+				content: [
+					<p className="jp-dash-item__description" key="inactive-scanning">
+						{ jetpackCreateInterpolateElement(
+							__(
+								'VaultPress is not active, <a>please activate</a> to enable automatic scanning for security for threats.',
+								'jetpack'
+							),
+							{
+								a: <a href={ this.props.siteAdminUrl + 'plugins.php' } />,
+							}
+						) }
+					</p>,
+				],
+			} );
+		}
+
+		// By the process of elimination, we can assume now
+		// that VaultPress isn't installed at all
 		return renderCard( {
 			className: 'jp-dash-item__is-inactive',
-			status,
+			status: 'pro-uninstalled',
 			content: [
 				<p className="jp-dash-item__description" key="inactive-scanning">
 					{ jetpackCreateInterpolateElement(
 						__(
-							'For automated, comprehensive scanning of security threats, please <a>install and activate</a> VaultPress.',
+							'VaultPress is not installed, <a>please install</a> to enable automatic scanning for security for threats.',
 							'jetpack'
 						),
 						{
@@ -205,7 +225,7 @@ class DashScan extends Component {
 			<JetpackBanner
 				callToAction={ __( 'Upgrade', 'jetpack' ) }
 				title={ __(
-					'Automated scanning and one-click fixes keep your site ahead of security threats.',
+					'Purchase Jetpack Scan to protect your site from security threats with automated scanning.',
 					'jetpack'
 				) }
 				disableHref="false"
@@ -225,8 +245,8 @@ class DashScan extends Component {
 					<p className="jp-dash-item__description">
 						{ jetpackCreateInterpolateElement(
 							_n(
-								'Security threat found. Please <a>fix it</a> as soon as possible.',
-								'Security threats found. Please <a>fix these</a> as soon as possible.',
+								'Security threat found. <a>Click here</a> to fix them immediately.',
+								'Security threats found. <a>Click here</a> to fix them immediately.',
 								numberOfThreats,
 								'jetpack'
 							),
@@ -256,7 +276,7 @@ class DashScan extends Component {
 			return (
 				<>
 					{ renderActiveCard(
-						__( "You need to enter your server's credentials to finish the setup.", 'jetpack' )
+						__( 'Please finish your setup by entering your server’s credentials.', 'jetpack' )
 					) }
 					{ renderAction(
 						getRedirectUrl( 'calypso-settings-security', { site: siteRawUrl } ),
@@ -277,7 +297,7 @@ class DashScan extends Component {
 					<>
 						{ renderActiveCard(
 							__(
-								'We are making sure your site stays free of security threats. You will be notified if we find one.',
+								'No security threats found. Your site will continue to be monitored for future threats.',
 								'jetpack'
 							)
 						) }

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -86,6 +86,7 @@ const renderActiveCard = message => {
 class DashScan extends Component {
 	static propTypes = {
 		siteRawUrl: PropTypes.string.isRequired,
+		siteAdminUrl: PropTypes.string.isRequired,
 
 		// Connected props
 		vaultPressData: PropTypes.any.isRequired,
@@ -99,6 +100,7 @@ class DashScan extends Component {
 
 	static defaultProps = {
 		siteRawUrl: '',
+		siteAdminUrl: '',
 		vaultPressData: '',
 		scanThreats: 0,
 		sitePlan: '',
@@ -121,7 +123,7 @@ class DashScan extends Component {
 						'jetpack'
 					),
 					{
-						keyLink: <a href="admin.php?page=vaultpress" />,
+						keyLink: <a href={ this.props.siteAdminUrl + 'admin.php?page=vaultpress' } />,
 						supportLink: <a href={ getRedirectUrl( 'vaultpress-help' ) } />,
 					}
 				),

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -12,7 +12,6 @@ import { __, _n } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Card from 'components/card';
-import QueryVaultPressData from 'components/data/query-vaultpress-data';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
 import { getScanStatus, isFetchingScanStatus } from 'state/scan';
 import { isPluginInstalled } from 'state/site/plugins';
@@ -330,12 +329,13 @@ class DashScan extends Component {
 
 		// Wait until we know everything about the site's VaultPress/Rewind scan
 		// status before showing any "real" content
+
+		// ASSUMPTION: QueryVaultPressData and QueryScanStatus have been invoked
+		//             elsewhere on the page.
 		const isLoading = this.props.fetchingScanStatus || this.props.fetchingVaultPressData;
 		return (
 			<div>
-				<QueryVaultPressData />
-				{ isLoading && renderCard( { content: __( 'Loading…', 'jetpack' ) } ) }
-				{ ! isLoading && this.getContent() }
+				{ isLoading ? renderCard( { content: __( 'Loading…', 'jetpack' ) } ) : this.getContent() }
 			</div>
 		);
 	}

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -162,6 +162,13 @@ function JetpackRestApiClient( root, nonce ) {
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 
+		activateVaultPress: () =>
+			postRequest( `${ apiRoot }jetpack/v4/plugins`, postParams, {
+				body: JSON.stringify( { slug: 'vaultpress', status: 'active' } ),
+			} )
+				.then( checkStatus )
+				.then( parseJsonResponse ),
+
 		getVaultPressData: () =>
 			getRequest( `${ apiRoot }jetpack/v4/module/vaultpress/data`, getParams )
 				.then( checkStatus )


### PR DESCRIPTION
Fixes #17220.

#### Changes proposed in this Pull Request:

* Significantly refactor the `DashScan` component to make the VaultPress/Rewind switching logic more straightforward
* Add copy and handling to the Scan card for states where VaultPress is active but not registered/connected
* Use Rewind status to determine whether the site uses VaultPress or Rewind, instead of checking VaultPress data directly (doesn't appear to be as reliable?)
* Hide the At-A-Glance Scan card entirely for multi-sites that don't use VaultPress, since Rewind doesn't currently support multi-site networks

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

Nope 👍 

#### Testing instructions:

##### All scenarios

Monitor the **Network** panel in your browser's developer console. Verify that outgoing requests eventually stop once the page is fully loaded; or, to rephrase, ensure that network calls to get VaultPress/Rewind status don't infinitely repeat.

##### Scenario 1: Multi-site with Jetpack Scan via Rewind

**NOTE:** These instructions should be true whether or not the VaultPress plugin is currently installed or active.

* Open wp-admin for the primary site in a multi-site network. This site should have a purchase that would normally give access to Jetpack Scan (i.e., Jetpack Premium, Jetpack Security, etc.), and it should be set to use Rewind instead of VaultPress.
* Verify that on the **Jetpack > Dashboard** page, the Scan card is not visible.

<img width="1052" alt="Screen Shot 2020-09-29 at 10 41 32" src="https://user-images.githubusercontent.com/670067/94581163-5e687a80-0240-11eb-815f-5d47c1d71a50.png">

##### Scenario 2: Multi-site with Jetpack Scan via VaultPress

* Open wp-admin for the primary site in a multi-site network. This site should have a purchase that would normally give access to Jetpack Scan (i.e., Jetpack Premium, Jetpack Security, etc.), and it should be set to use VaultPress.
* Starting **without** the VaultPress plugin installed, go through and verify the following behaviors on the **Jetpack > Dashboard** page:
  * Plugin not installed: Scan card prompts user to install/activate the plugin
  * Plugin installed but not active: Scan card prompts user to install/activate the plugin (verify link goes to VaultPress install page)
  * Plugin installed and active, site not registered with VaultPress: Scan card prompts the user to register the site with VaultPress (verify links to go VaultPress admin page and VaultPress help page)
  * Plugin active and VaultPress registered, has threats: Scan card shows that threats were found
  * Plugin active and VaultPress registered, no threats: Scan card shows no threats were found

<img width="524" alt="Screen Shot 2020-09-29 at 10 37 40" src="https://user-images.githubusercontent.com/670067/94580704-d5514380-023f-11eb-93c7-65c9925505da.png">
<img width="525" alt="Screen Shot 2020-09-29 at 10 35 17" src="https://user-images.githubusercontent.com/670067/94580511-a33fe180-023f-11eb-99eb-613c0b398edf.png">
<img width="519" alt="Screen Shot 2020-09-29 at 13 35 19" src="https://user-images.githubusercontent.com/670067/94601159-ae533b80-0258-11eb-8151-8339503aea77.png">
<img width="523" alt="Screen Shot 2020-09-29 at 10 36 21" src="https://user-images.githubusercontent.com/670067/94580513-a33fe180-023f-11eb-8385-cd313831a67f.png">

##### Scenario 3: Single site with Jetpack Scan via Rewind

**NOTE:** These instructions should be true whether or not the VaultPress plugin is currently installed or active.

* Open wp-admin for a site that's not part of any multi-site network. This site should be set to use Rewind instead of VaultPress.
* Verify the following behaviors on the **Jetpack > Dashboard** page:
  * Jetpack Scan not purchased or included via another purchase: Scan card shows a prompt to purchase Scan
  * Jetpack Scan purchased but credentials not entered: Scan card asks the user to enter their credentials to complete the process
  * Jetpack Scan purchased and credentials entered, no threats: Scan card shows "no threats found"
  * Jetpack Scan purchased and credentials entered, threats found: Scan card shows how many threats were found

<img width="521" alt="Screen Shot 2020-09-29 at 10 29 27" src="https://user-images.githubusercontent.com/670067/94579639-ab4b5180-023e-11eb-8538-490bf3d8a1a9.png">
<img width="520" alt="Screen Shot 2020-09-29 at 10 22 56" src="https://user-images.githubusercontent.com/670067/94579497-835bee00-023e-11eb-9952-75aab766f006.png">
<img width="519" alt="Screen Shot 2020-09-29 at 10 24 15" src="https://user-images.githubusercontent.com/670067/94579500-83f48480-023e-11eb-8769-644fb39754a6.png">
<img width="520" alt="Screen Shot 2020-09-29 at 10 27 59" src="https://user-images.githubusercontent.com/670067/94579504-83f48480-023e-11eb-93c3-83f34ef8734f.png">

##### Scenario 4: Single site with Jetpack Scan via VaultPress

* Open wp-admin for a site that's not part of any multi-site network. This site should have a purchase that would normally give access to Jetpack Scan (i.e., Jetpack Premium, Jetpack Security, etc.), and it should be set to use VaultPress.
* Follow instructions for **Scenario 2**.

#### Proposed changelog entry for your changes:

* On the Dashboard, hide the Scan card for non-VaultPress multi-site networks (as they're not currently supported), and add copy to handle when VaultPress is not connected/registered.