### PR TITLE
Feedback: Allow Calypso to change menu icon color

### DIFF
--- a/modules/contact-form/css/editor-ui.css
+++ b/modules/contact-form/css/editor-ui.css
@@ -1,21 +1,12 @@
 i.mce-i-grunion {
 	font-size: 20px;
+	font-family: dashicons;
 }
 
 i.mce-i-grunion:before,
 .jetpack-contact-form-icon:before {
-	width: 24px;
+	content: '\f175';
 	vertical-align: top;
-	content: '';
-	display: block;
-	height: 24px;
-	background-size: 24px;
-	background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="rgb(85, 93, 102)" d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z"/></svg>');
-	margin-top: -4px;
-}
-i.mce-i-grunion:before {
-	margin-top: -2px;
-	margin-left: -2px;
 }
 
 .jetpack-contact-form-icon {
@@ -23,4 +14,5 @@ i.mce-i-grunion:before {
 	vertical-align: text-top;
 	display: inline-block;
 	height: 18px;
+	font: 18px/1 dashicons;
 }

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -177,8 +177,8 @@ class Grunion_Contact_Form_Plugin {
 					'not_found'          => __( 'No feedback found', 'jetpack' ),
 					'not_found_in_trash' => __( 'No feedback found', 'jetpack' ),
 				),
-				// Matrial Ballot icon
-				'menu_icon'             => 'data:image/svg+xml;base64,' . base64_encode('<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z"/></svg>'),
+				// Material Ballot icon.
+				'menu_icon'             => 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z"/></svg>' ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 				'show_ui'               => true,
 				'show_in_admin_bar'     => false,
 				'public'                => false,

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -177,7 +177,6 @@ class Grunion_Contact_Form_Plugin {
 					'not_found'          => __( 'No feedback found', 'jetpack' ),
 					'not_found_in_trash' => __( 'No feedback found', 'jetpack' ),
 				),
-				// Material Ballot icon.
 				'menu_icon'             => 'dashicons-feedback',
 				'show_ui'               => true,
 				'show_in_admin_bar'     => false,

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -178,7 +178,7 @@ class Grunion_Contact_Form_Plugin {
 					'not_found_in_trash' => __( 'No feedback found', 'jetpack' ),
 				),
 				// Material Ballot icon.
-				'menu_icon'             => 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z"/></svg>' ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'menu_icon'             => 'dashicons-feedback',
 				'show_ui'               => true,
 				'show_in_admin_bar'     => false,
 				'public'                => false,

--- a/scss/jetpack-icons.scss
+++ b/scss/jetpack-icons.scss
@@ -3,24 +3,33 @@
 // ==========================================================================
 
 @font-face {
-	font-family: "jetpack";
-	src: url("../_inc/fonts/jetpack/jetpack.eot");
-	src: url("../_inc/fonts/jetpack/jetpack.eot?#iefix") format("embedded-opentype"),
-		url("../_inc/fonts/jetpack/jetpack.woff") format("woff"),
-		url("../_inc/fonts/jetpack/jetpack.ttf") format("truetype"),
-		url("../_inc/fonts/jetpack/jetpack.svg#jetpack") format("svg");
+	font-family: 'jetpack';
+	src: url( '../_inc/fonts/jetpack/jetpack.eot' );
+	src: url( '../_inc/fonts/jetpack/jetpack.eot?#iefix' ) format( 'embedded-opentype' ),
+		url( '../_inc/fonts/jetpack/jetpack.woff' ) format( 'woff' ),
+		url( '../_inc/fonts/jetpack/jetpack.ttf' ) format( 'truetype' ),
+		url( '../_inc/fonts/jetpack/jetpack.svg#jetpack' ) format( 'svg' );
 	font-weight: normal;
 	font-style: normal;
 }
 
-@media screen and (-webkit-min-device-pixel-ratio:0) {
+@media screen and ( -webkit-min-device-pixel-ratio: 0 ) {
 	@font-face {
-		font-family: "jetpack";
-		src: url("../_inc/fonts/jetpack/jetpack.svg#jetpack") format("svg");
+		font-family: 'jetpack';
+		src: url( '../_inc/fonts/jetpack/jetpack.svg#jetpack' ) format( 'svg' );
 	}
 }
 
 li.toplevel_page_jetpack .wp-menu-image:before {
 	font-family: 'jetpack' !important;
 	content: '\f100';
+}
+
+#menu-posts-feedback .wp-menu-image:before {
+	font-family: dashicons !important;
+	content: '\f175';
+}
+#adminmenu #menu-posts-feedback div.wp-menu-image {
+	background: none !important;
+	background-repeat: no-repeat;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Introduced in #10670.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Reverts feedback menu icon to dashicon

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before | After
-------|------
![](https://cln.sh/z3BLul+) | ![](https://cln.sh/zH0Hmj+)
* Apply the diff and make sure the Feedback menu item in wp-admin's sidebar menu has changed to a dashicon

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
