### PR TITLE
Make XMLRPC methods available for blog token

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -7,7 +7,7 @@ class Publicize extends Publicize_Base {
 	function __construct() {
 		parent::__construct();
 
-		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'register_update_publicize_connections_xmlrpc_method' ) );
+		add_filter( 'jetpack_xmlrpc_unauthenticated_methods', array( $this, 'register_update_publicize_connections_xmlrpc_method' ) );
 
 		add_action( 'load-settings_page_sharing', array( $this, 'admin_page_load' ), 9 );
 

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -58,7 +58,7 @@ function stats_load() {
 		add_action( 'admin_init', 'stats_merged_widget_admin_init' );
 	}
 
-	add_filter( 'jetpack_xmlrpc_methods', 'stats_xmlrpc_methods' );
+	add_filter( 'jetpack_xmlrpc_unauthenticated_methods', 'stats_xmlrpc_methods' );
 
 	add_filter( 'pre_option_db_version', 'stats_ignore_db_version' );
 

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -602,6 +602,8 @@ class Jetpack_XMLRPC_Server {
 			return false;
 		}
 
+		wp_set_current_user( $user->ID );
+
 		return $user;
 	}
 

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -100,7 +100,7 @@ class Jetpack_XMLRPC_Server {
 		}
 
 		/**
-		 * Filters the XML-RPC methods available to Jetpack for unauthenticated users.
+		 * Filters the XML-RPC methods available to Jetpack for requests signed only with a blog token and without an authenticated user.
 		 *
 		 * @since 3.0.0
 		 *
@@ -734,13 +734,15 @@ class Jetpack_XMLRPC_Server {
 	/**
 	 * Unlink a user from WordPress.com
 	 *
-	 * If $user_id is not informed, it will try to disconnect the current logged in user. This will fail if called by the Master User.
+	 * When the request is done without any parameter, this XMLRPC callback gets an empty array as input.
 	 *
-	 * If $user_id is informed, it will try to disconnect the informed user, even if it's the Master User.
+	 * If $user_id is not an integer, it will try to disconnect the current logged in user. This will fail if called by the Master User.
 	 *
-	 * @param integer $user_id The user ID to disconnect from this site.
+	 * If $user_id is an integer, it will try to disconnect the informed user, even if it's the Master User.
+	 *
+	 * @param int|array $user_id The user ID to disconnect from this site.
 	 */
-	public function unlink_user( $user_id = null ) {
+	public function unlink_user( $user_id = array() ) {
 		/**
 		 * Fired when we want to log an event to the Jetpack event log.
 		 *
@@ -751,8 +753,8 @@ class Jetpack_XMLRPC_Server {
 		 */
 		do_action( 'jetpack_event_log', 'unlink' );
 		return Connection_Manager::disconnect_user(
-			empty( $user_id ) ? null : $user_id,
-			empty( $user_id ) ? false : true
+			$user_id,
+			! (bool) $user_id
 		);
 	}
 

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -100,7 +100,7 @@ class Jetpack_XMLRPC_Server {
 		}
 
 		/**
-		 * Filters the XML-RPC methods available to Jetpack for requests signed only with a blog token and without an authenticated user.
+		 * Filters the XML-RPC methods available to Jetpack for requests signed only with a blog token.
 		 *
 		 * @since 3.0.0
 		 *
@@ -736,13 +736,17 @@ class Jetpack_XMLRPC_Server {
 	 *
 	 * When the request is done without any parameter, this XMLRPC callback gets an empty array as input.
 	 *
-	 * If $user_id is not an integer, it will try to disconnect the current logged in user. This will fail if called by the Master User.
+	 * If $user_id is not provided, it will try to disconnect the current logged in user. This will fail if called by the Master User.
 	 *
-	 * If $user_id is an integer, it will try to disconnect the informed user, even if it's the Master User.
+	 * If $user_id is is provided, it will try to disconnect the informed user, even if it's the Master User.
 	 *
-	 * @param int|array $user_id The user ID to disconnect from this site.
+	 * @param mixed $user_id The user ID to disconnect from this site.
 	 */
 	public function unlink_user( $user_id = array() ) {
+		$user_id = (int) $user_id;
+		if ( $user_id < 1 ) {
+			$user_id = null;
+		}
 		/**
 		 * Fired when we want to log an event to the Jetpack event log.
 		 *
@@ -754,7 +758,7 @@ class Jetpack_XMLRPC_Server {
 		do_action( 'jetpack_event_log', 'unlink' );
 		return Connection_Manager::disconnect_user(
 			$user_id,
-			! (bool) $user_id
+			(bool) $user_id
 		);
 	}
 

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -748,7 +748,10 @@ class Jetpack_XMLRPC_Server {
 		 * @param string $data Optional data about the event.
 		 */
 		do_action( 'jetpack_event_log', 'unlink' );
-		return Connection_Manager::disconnect_user( $user_id, is_null( $user_id ) ? false : true );
+		return Connection_Manager::disconnect_user(
+			empty( $user_id ) ? null : $user_id,
+			is_null( $user_id ) ? false : true
+		);
 	}
 
 	/**

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -752,7 +752,7 @@ class Jetpack_XMLRPC_Server {
 		do_action( 'jetpack_event_log', 'unlink' );
 		return Connection_Manager::disconnect_user(
 			empty( $user_id ) ? null : $user_id,
-			is_null( $user_id ) ? false : true
+			empty( $user_id ) ? false : true
 		);
 	}
 

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -60,7 +60,6 @@ class Jetpack_XMLRPC_Server {
 			'jetpack.getUser'          => array( $this, 'get_user' ),
 			'jetpack.remoteRegister'   => array( $this, 'remote_register' ),
 			'jetpack.remoteProvision'  => array( $this, 'remote_provision' ),
-			'jetpack.testAPIUserCode'  => array( $this, 'test_api_user_code' ),
 			'jetpack.idcUrlValidation' => array( $this, 'validate_urls_for_idc_mitigation' ),
 			'jetpack.unlinkUser'       => array( $this, 'unlink_user' ),
 		);
@@ -78,7 +77,8 @@ class Jetpack_XMLRPC_Server {
 			$jetpack_methods = array_merge(
 				$jetpack_methods,
 				array(
-					'jetpack.disconnectBlog' => array( $this, 'disconnect_blog' ),
+					'jetpack.disconnectBlog'  => array( $this, 'disconnect_blog' ),
+					'jetpack.testAPIUserCode' => array( $this, 'test_api_user_code' ),
 				)
 			);
 

--- a/packages/heartbeat/src/class-heartbeat.php
+++ b/packages/heartbeat/src/class-heartbeat.php
@@ -67,7 +67,7 @@ class Heartbeat {
 			wp_schedule_event( time(), 'daily', $this->cron_name );
 		}
 
-		add_filter( 'jetpack_xmlrpc_methods', array( __CLASS__, 'jetpack_xmlrpc_methods' ) );
+		add_filter( 'jetpack_xmlrpc_unauthenticated_methods', array( __CLASS__, 'jetpack_xmlrpc_methods' ) );
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'jetpack-heartbeat', array( $this, 'cli_callback' ) );

--- a/packages/sync/src/class-sender.php
+++ b/packages/sync/src/class-sender.php
@@ -187,7 +187,7 @@ class Sender {
 	private function init() {
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_set_user_from_token' ), 1 );
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_clear_user_from_token' ), 20 );
-		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'register_jetpack_xmlrpc_methods' ) );
+		add_filter( 'jetpack_xmlrpc_unauthenticated_methods', array( $this, 'register_jetpack_xmlrpc_methods' ) );
 		foreach ( Modules::get_modules() as $module ) {
 			$module->init_before_send();
 		}

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -931,10 +931,19 @@ EXPECTED;
 			'jetpack.remoteRegister',
 			'jetpack.remoteProvision',
 			'jetpack.jsonAPI',
+			'jetpack.idcUrlValidation',
+			'jetpack.unlinkUser',
+			'jetpack.testConnection',
+			'jetpack.featuresAvailable',
+			'jetpack.featuresEnabled',
 		);
 
-		// Nothing else is allowed.
-		$allowed = array();
+		$allowed = array(
+			'jetpack.getHeartbeatData',
+			'jetpack.syncObject',
+			'jetpack.updatePublicizeConnections',
+			'jetpack.getBlog',
+		);
 
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR opens the possibility make request to some XMLRPC methods using the Blog Token as well as the user token.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1VI-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See 26a46-pb/#php

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*