### PR TITLE
Pre-Connection JITMs: Fix connection button links

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -116,7 +116,7 @@ jQuery( document ).ready( function ( $ ) {
 				$.ajax( {
 					url: window.jitm_config.api_root + 'jetpack/v4/jitm',
 					method: 'POST', // using DELETE without permalinks is broken in default nginx configuration
-					beforeSend: function( xhr ) {
+					beforeSend: function ( xhr ) {
 						xhr.setRequestHeader( 'X-WP-Nonce', window.jitm_config.nonce );
 					},
 					data: {
@@ -134,7 +134,10 @@ jQuery( document ).ready( function ( $ ) {
 			template = 'default';
 		}
 
-		response.url = response.url + '&redirect=' + redirect;
+		// Check for pre-existing redirect query var.
+		if ( response.url.indexOf( '&redirect' ) < 0 ) {
+			response.url = response.url + '&redirect=' + redirect;
+		}
 
 		var $template = templates[ template ]( response );
 		$template.find( '.jitm-banner__dismiss' ).click( render( $template ) );

--- a/packages/jitm/src/class-pre-connection-jitm.php
+++ b/packages/jitm/src/class-pre-connection-jitm.php
@@ -24,7 +24,7 @@ class Pre_Connection_JITM extends JITM {
 				'message_path'   => '/wp:edit-post:admin_notices/',
 				'message'        => __( 'Do you know which of these posts gets the most traffic?', 'jetpack' ),
 				'description'    => __( 'Set up Jetpack to get in-depth stats about your content and visitors.', 'jetpack' ),
-				'button_link'    => \Jetpack::admin_url( '#/setup' ),
+				'button_link'    => $this->build_setup_url( admin_url( 'edit.php' ), 'connect-jitm-posts' ),
 				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
 			),
 			array(
@@ -32,7 +32,7 @@ class Pre_Connection_JITM extends JITM {
 				'message_path'   => '/wp:upload:admin_notices/',
 				'message'        => __( 'Do you want lightning-fast images?', 'jetpack' ),
 				'description'    => __( 'Set up Jetpack, enable Site Accelerator, and start serving your images lightning fast, for free.', 'jetpack' ),
-				'button_link'    => \Jetpack::admin_url( '#/setup' ),
+				'button_link'    => $this->build_setup_url( admin_url( 'upload.php' ), 'connect-jitm-media' ),
 				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
 			),
 			array(
@@ -40,10 +40,23 @@ class Pre_Connection_JITM extends JITM {
 				'message_path'   => '/wp:widgets:admin_notices/',
 				'message'        => __( 'Looking for even more widgets?', 'jetpack' ),
 				'description'    => __( 'Set up Jetpack for great additional widgets that display business contact info and maps, blog stats, and top posts.', 'jetpack' ),
-				'button_link'    => \Jetpack::admin_url( '#/setup' ),
+				'button_link'    => $this->build_setup_url( admin_url( 'widgets.php' ), 'connect-jitm-widgets' ),
 				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
 			),
 		);
+	}
+
+	/**
+	 * Builds JITM Jetpack connection URL.
+	 */
+	private function build_setup_url( $redirect, $from = 'connect-jitm' ) {
+		$register_url = \Jetpack::init()->build_connect_url(
+			true,
+			$redirect,
+			$from,
+			true
+		);
+		return add_query_arg( 'auth_approved', 'true', $register_url );
 	}
 
 	/**


### PR DESCRIPTION
# Fixes

Currently, the "Set Up Jetpack" buttons on the Pre-Connection JITMs simply take the user to the `jetpack/#setup` page and do not pass on any query vars, making it impossible to track these connections or to properly redirect the user afterwards. This patch fixes these links such that the user is automatically connected after clicking and then redirected to the page they were on after success.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a method `Pre_Connection_JITM::build_setup_url()` that uses `Jetpack::build_connect_url()` to create the link for the buttons.
* Adds a `from` parameter to each JITM for source tracking purposes.
* Adds a check in `jetpack-jitm.js` to look for an existing `redirect` query var instead of blindly appending a new one.

#### Jetpack product discussion

* pbtFPC-nZ-p2

#### Does this pull request change what data or activity we track or use?
Adds a `from` parameter to each Pre-Connection JITM button link for source tracking for general analytics purposes.

#### Testing instructions:
* Add the following to your `debug.php` to allow Pre-Connection JITMs to display: `add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );` 
* I also recommend disabling the JITM cache: `add_filter( 'jetpack_just_in_time_msg_cache', '__return_false', 1000 );`
* Ensure the Jetpack plugin is Activated, but not connected.
* Visit `wp-admin/upload.php` and ensure the JITM appears and that the link has proper `from` and `redirect` query vars.
* Click the button and ensure Jetpack automatically connects successfully, returning the user back to `wp-admin/upload.php` afterward.
* Deactivate the Jetpack plugin to reset the connection, and repeat this process for:
  * `wp-admin/widgets.php` and
  * `wp-admin/edit.php` (Note: This JITM will not display until there are at least 5 posts.)

#### Proposed changelog entry for your changes:
* Fixes Pre-Connection JITM links to include a "from" parameter and the correct "redirect" parameter.
