### PR TITLE
Instant Search: improve accessibility of close button

### DIFF
--- a/modules/search/instant-search/components/gridicon/index.jsx
+++ b/modules/search/instant-search/components/gridicon/index.jsx
@@ -16,6 +16,10 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 
 class Gridicon extends Component {
+	static defaultProps = {
+		'aria-hidden': false,
+	};
+
 	needsOffset( icon, size ) {
 		const iconNeedsOffset = [
 			'gridicons-calendar',
@@ -200,6 +204,7 @@ class Gridicon extends Component {
 				viewBox="0 0 24 24"
 				width={ size }
 				xmlns="http://www.w3.org/2000/svg"
+				aria-hidden={ this.props[ 'aria-hidden' ] }
 			>
 				{ this.getSVGTitle( icon ) }
 				{ this.renderIcon( icon ) }

--- a/modules/search/instant-search/components/gridicon/index.jsx
+++ b/modules/search/instant-search/components/gridicon/index.jsx
@@ -17,7 +17,8 @@ import './style.scss';
 
 class Gridicon extends Component {
 	static defaultProps = {
-		'aria-hidden': false,
+		'aria-hidden': 'false',
+		focusable: 'true',
 	};
 
 	needsOffset( icon, size ) {
@@ -197,7 +198,7 @@ class Gridicon extends Component {
 		return (
 			<svg
 				className={ iconClass }
-				focusable="false"
+				focusable={ this.props.focusable }
 				height={ size }
 				onClick={ this.props.onClick }
 				style={ { height: size, width: size } }

--- a/modules/search/instant-search/components/gridicon/index.jsx
+++ b/modules/search/instant-search/components/gridicon/index.jsx
@@ -46,7 +46,7 @@ class Gridicon extends Component {
 			case 'gridicons-comment':
 				return <title>{ __( 'Matching comment.', 'jetpack' ) }</title>;
 			case 'gridicons-cross':
-				return <title>{ __( 'Close search overlay', 'jetpack' ) }</title>;
+				return <title>{ __( 'Close search results', 'jetpack' ) }</title>;
 			case 'gridicons-filter':
 				return <title>{ __( 'Toggle search filters.', 'jetpack' ) }</title>;
 			case 'gridicons-folder':
@@ -193,6 +193,7 @@ class Gridicon extends Component {
 		return (
 			<svg
 				className={ iconClass }
+				focusable="false"
 				height={ size }
 				onClick={ this.props.onClick }
 				style={ { height: size, width: size } }

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -38,28 +38,3 @@ $overlay-horizontal-padding-small-viewport: 0.5em;
 		box-sizing: inherit;
 	}
 }
-
-.jetpack-instant-search__overlay-close {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	position: fixed;
-	top: 0;
-	right: 0;
-	z-index: 20;
-	width: 40px;
-	height: 40px;
-	margin: 0;
-	padding: 0;
-	line-height: 1;
-	cursor: pointer;
-
-	@include break-medium() {
-		position: absolute;
-		top: -$overlay-vertical-padding;
-		right: 8px;
-		width: 64px;
-		height: 64px;
-		padding: 20px;
-	}
-}

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -1,4 +1,4 @@
-$overlay-vertical-padding: 3.5em;
+$overlay-vertical-padding: 4em;
 $overlay-horizontal-padding: 1em;
 $overlay-horizontal-padding-small-viewport: 0.5em;
 

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -166,15 +166,15 @@ class SearchResults extends Component {
 				aria-live="polite"
 				className="jetpack-instant-search__search-results"
 			>
-				<a
+				<button
 					className="jetpack-instant-search__overlay-close"
 					onClick={ this.closeOverlay }
 					onKeyPress={ this.onKeyPressHandler }
-					role="button"
 					tabIndex="0"
+					aria-label={ __( 'Close search results', 'jetpack' ) }
 				>
 					<Gridicon icon="cross" size="24" />
-				</a>
+				</button>
 				<div className="jetpack-instant-search__search-results-primary">
 					{ this.renderPrimarySection() }
 				</div>

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -173,7 +173,7 @@ class SearchResults extends Component {
 					tabIndex="0"
 					aria-label={ __( 'Close search results', 'jetpack' ) }
 				>
-					<Gridicon icon="cross" size="24" aria-hidden="true" />
+					<Gridicon icon="cross" size="24" aria-hidden="true" focusable="false" />
 				</button>
 				<div className="jetpack-instant-search__search-results-primary">
 					{ this.renderPrimarySection() }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -173,7 +173,7 @@ class SearchResults extends Component {
 					tabIndex="0"
 					aria-label={ __( 'Close search results', 'jetpack' ) }
 				>
-					<Gridicon icon="cross" size="24" />
+					<Gridicon icon="cross" size="24" aria-hidden="true" />
 				</button>
 				<div className="jetpack-instant-search__search-results-primary">
 					{ this.renderPrimarySection() }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -141,6 +141,6 @@
     -moz-appearance: none;
 
     &:focus {
-    	outline: 1px solid;
+    	outline: 1px dotted;
     }
 }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -137,8 +137,7 @@
     margin: 0;
     text-decoration: none;
     cursor: pointer;
-    -webkit-appearance: none;
-    -moz-appearance: none;
+    appearance: none;
 
     &:focus {
     	outline: 1px dotted;

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -22,6 +22,10 @@
 		.jetpack-instant-search__overlay-close svg {
 			fill: #000;
 		}
+
+		.jetpack-instant-search__overlay-close:focus {
+			outline-color: #000;
+		}
 	}
 
 	.jetpack-instant-search__overlay--dark & {
@@ -33,6 +37,10 @@
 
 		.jetpack-instant-search__overlay-close svg {
 			fill: #fff;
+		}
+
+		.jetpack-instant-search__overlay-close:focus {
+			outline-color: #fff;
 		}
 	}
 
@@ -120,4 +128,19 @@
 	.jetpack-instant-search__sort-select {
 		font-size: 0.9em;
 	}
+}
+
+.jetpack-instant-search__overlay-close {
+    background: none;
+    border: none;
+    display: inline-block;
+    margin: 0;
+    text-decoration: none;
+    cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+
+    &:focus {
+    	outline: 1px solid;
+    }
 }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -131,15 +131,34 @@
 }
 
 .jetpack-instant-search__overlay-close {
-    background: none;
-    border: none;
-    display: inline-block;
-    margin: 0;
-    text-decoration: none;
-    cursor: pointer;
-    appearance: none;
+	appearance: none;
+	background: none;
+	border: none;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	position: fixed;
+	top: 0;
+	right: 0;
+	z-index: 20;
+	width: 40px;
+	height: 40px;
+	margin: 0;
+	padding: 0;
+	line-height: 1;
+	cursor: pointer;
+	text-decoration: none;
 
-    &:focus {
+	@include break-medium() {
+		position: absolute;
+		top: -$overlay-vertical-padding;
+		right: 8px;
+		width: 64px;
+		height: 64px;
+		padding: 20px;
+	}
+
+	&:focus {
     	outline: 1px dotted;
     }
 }

--- a/modules/search/instant-search/components/test/__snapshots__/notice.test.js.snap
+++ b/modules/search/instant-search/components/test/__snapshots__/notice.test.js.snap
@@ -6,7 +6,9 @@ exports[`returns a notice if the type is warning 1`] = `
     class="jetpack-instant-search__notice jetpack-instant-search__notice--warning"
   >
     <svg
+      aria-hidden="false"
       class="gridicon gridicons-info "
+      focusable="true"
       height="20"
       style="height: 20px; width: 20px;"
       viewBox="0 0 24 24"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make sure the overlay close button is a real `<button>` to support the associated keyboard events.
* Add a focus outline style for the close button.
* Make sure the button is appropriately labelled for screen readers.
* Make sure the SVG is not focusable.

References:
- https://www.sarasoueidan.com/blog/accessible-icon-buttons/ (used technique #3 here)
- https://codepen.io/andybelldesign/pen/Vxpjvo (button style reset)

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Test the overlay in a selection of themes and check that the visual appearance of the close button has not changed.

Inspect the button with your browser's accessibility tools and ensure that you can see the correct label:

<img width="854" alt="Screen Shot 2020-09-29 at 16 35 31" src="https://user-images.githubusercontent.com/17325/94509888-e0bd6280-0271-11eb-824f-d077d4adc353.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Not required.
