### PR TITLE
Improve Comments module's AMP compatibility

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -345,7 +345,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 						height="<?php echo esc_attr( $height ); ?>"
 					<?php else : ?>
 						name="jetpack_remote_comment"
-						style="width:100%; height: <?php echo $height; ?>px; border:0;"
+						style="width:100%; height: <?php echo esc_attr( $height ); ?>px; border:0;"
 					<?php endif; ?>
 					class="jetpack_remote_comment"
 					id="jetpack_remote_comment"

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -364,6 +364,11 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 * @since JetpackComments (1.4)
 	 */
 	public function watch_comment_parent() {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			// @todo Implement AMP support.
+			return;
+		}
+
 		$url_origin = 'https://jetpack.wordpress.com';
 		?>
 

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -325,6 +325,8 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		$show_greeting = apply_filters( 'jetpack_comment_form_display_greeting', true );
 
 		// The actual iframe (loads comment form from Jetpack server)
+
+		$is_amp = Jetpack_AMP_Support::is_amp_request();
 		?>
 
 		<div id="respond" class="comment-respond">
@@ -334,8 +336,26 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 				</h3>
 			<?php endif; ?>
 			<form id="commentform" class="comment-form">
-				<iframe title="<?php esc_attr_e( 'Comment Form', 'jetpack' ); ?>" src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment" sandbox="allow-same-origin allow-top-navigation allow-scripts allow-forms allow-popups"></iframe>
-				<?php if ( ! Jetpack_AMP_Support::is_amp_request() ) : ?>
+				<iframe
+					title="<?php esc_attr_e( 'Comment Form', 'jetpack' ); ?>"
+					src="<?php echo esc_url( $url ); ?>"
+					<?php if ( $is_amp ) : ?>
+						resizable
+						layout="fixed-height"
+						height="<?php echo esc_attr( $height ); ?>"
+					<?php else : ?>
+						name="jetpack_remote_comment"
+						style="width:100%; height: <?php echo $height; ?>px; border:0;"
+					<?php endif; ?>
+					class="jetpack_remote_comment"
+					id="jetpack_remote_comment"
+					sandbox="allow-same-origin allow-top-navigation allow-scripts allow-forms allow-popups"
+				>
+					<?php if ( $is_amp ) : ?>
+						<button overflow><?php esc_html_e( 'Show more', 'jetpack' ); ?></button>
+					<?php endif; ?>
+				</iframe>
+				<?php if ( ! $is_amp ) : ?>
 					<!--[if !IE]><!-->
 					<script>
 						document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

See #9730.

When validating an post permalink that has comments enabled and the Jetpack Comments module active, two validation errors are raised:

Invalid `name` attribute on iframe | Invalid `script` output by `watch_comment_parent`
----------------------------------|-----------------------------------------------------
<img width="1173" alt="Screen Shot 2020-09-28 at 23 18 36" src="https://user-images.githubusercontent.com/134745/94520958-0ef36180-01e2-11eb-9639-48d12ba745df.png"> | <img width="1174" alt="Screen Shot 2020-09-28 at 23 18 52" src="https://user-images.githubusercontent.com/134745/94520964-1155bb80-01e2-11eb-861d-a11ba4e487b8.png">

This PR removes the invalid `name` attribute on the `iframe`. It also uses AMP's built-in `layout=fixed-height` rather than using inline styles.

Additionally, I noticed that when I enter a long comment that is higher than 400px, the iframe begins to scroll when it should resize itself:

> ![image](https://user-images.githubusercontent.com/134745/94521104-52e66680-01e2-11eb-9ca0-95f3cd856117.png)

In order for an iframe to resize itself in AMP, it needs to be marked as `resizable` and to have an `overflow` button. See [`amp-iframe` docs](https://amp.dev/documentation/components/amp-iframe/#iframe-resizing). This PR only implements half of the resizing, however. In order for the iframe to resize on AMP pages, the page at `https://jetpack.wordpress.com/jetpack-comment/?blogid=...` will need to incorporate this JS snippet when its height changes:

```js
window.parent.postMessage(
  {
    sentinel: 'amp',
    type: 'embed-size',
    height: document.body.scrollHeight,
  },
  '*'
);
```

Lastly, this PR suppresses outputting the JS in the `watch_comment_parent` method. For now it falls back to behave as if JS is disabled in the browser, but I've left a TODO to revisit. At least it is not reporting a validation error anymore.

#### Changes proposed in this Pull Request:

* Prevent AMP validation errors from being reported from using Comments module. Prepare for iframe to be resizable.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Activate AMP plugin.
2. Enable Transitional mode.
3. View a post in AMP with the Jetpack Comments module active.
4. Look for AMP validation errors being reported.
5. Try submitting a comment.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve AMP compatibility for Comments module.
