### PR TITLE
Pay with PayPal: Add email styles

### DIFF
--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -148,7 +148,7 @@ body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message 
 		margin: 0;
 	}
 
-	.jetpack-simple-payments-details {
+	.jetpack-simple-payments-product-image + .jetpack-simple-payments-details {
 		display: table-cell;
 		width: 70%;
 	}

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -127,3 +127,25 @@ body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message 
 		padding-left: 1em;
 	}
 }
+
+@media only email {
+	.jetpack-simple-payments-product {
+		display: table;
+		width: 100%;
+	}
+
+	.jetpack-simple-payments-product-image {
+		display: table-cell;
+		width: 30%;
+		vertical-align: top;
+	}
+
+	.jetpack-simple-payments-image {
+		padding-top: 0;
+	}
+
+	.jetpack-simple-payments-details {
+		display: table-cell;
+		width: 70%;
+	}
+}

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -144,6 +144,10 @@ body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message 
 		padding-top: 0;
 	}
 
+	.jetpack-simple-payments-image figure {
+		margin: 0;
+	}
+
 	.jetpack-simple-payments-details {
 		display: table-cell;
 		width: 70%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The flexbox grid is unfortunately not compatible with many email clients (such as Gmail) so this PR defines alternative email-friendly styles for the Pay with PayPal block under a custom media query `@media only email` (which is ignored on the fronted but processed by the WP.com mailer when sending an email, see D50003-code).

Before | After
--- | ---
<img width="623" alt="Screen Shot 2020-09-29 at 17 55 23" src="https://user-images.githubusercontent.com/1233880/94582899-1b78c800-027d-11eb-9ba0-d1e6414291c8.png"> | <img width="626" alt="Screen Shot 2020-09-29 at 18 56 14" src="https://user-images.githubusercontent.com/1233880/94589377-7b736c80-0285-11eb-87d9-c8d5c92dba9d.png">

#### Jetpack product discussion
paYKcK-GA-p2

#### Does this pull request change what data or activity we track or use?
No
#### Testing instructions:

_Only testable in a WP.com sandbox_
- Apply D50351-code, D50003-code and D49730-code.
- Go to https://wordpress.com/block-editor and select a WP.com simple site.
- Publish a post that contains a Pay with PayPal block.
- Grab the IDs of the post and the site where the post has been published.
- Run `php ./bin/subscriptions/send.php <BLOG_ID> post <POST_ID> <YOUR_EMAIL>` from your sandbox.
- Check the email and make sure the look-and-feel matches with what's rendered in the frontend (2-columns layout, title and price in bold).

#### Proposed changelog entry for your changes:
Pay with PayPal: Add email styles