### PR TITLE
Photon: Remove broken support for HTML4 img percentage width/height

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -369,19 +369,14 @@ class Jetpack_Photon {
 					$width  = false;
 					$height = false;
 
-					// First, check the image tag.
+					// First, check the image tag. Note we only check for pixel sizes now; HTML4 percentages have never been correctly
+					// supported, so we stopped pretending to support them in JP 9.1.0.
 					if ( preg_match( '#[\s|"|\']width=["|\']?([\d%]+)["|\']?#i', $images['img_tag'][ $index ], $width_string ) ) {
-						$width = $width_string[1];
+						$width = false === strpos( $width_string[1], '%' ) ? $width_string[1] : false;
 					}
 
 					if ( preg_match( '#[\s|"|\']height=["|\']?([\d%]+)["|\']?#i', $images['img_tag'][ $index ], $height_string ) ) {
-						$height = $height_string[1];
-					}
-
-					// Can't pass both a relative width and height, so unset the height in favor of not breaking the horizontal layout.
-					if ( false !== strpos( $width, '%' ) && false !== strpos( $height, '%' ) ) {
-						$width  = false;
-						$height = false;
+						$height = false === strpos( $height_string[1], '%' ) ? $height_string[1] : false;
 					}
 
 					// Detect WP registered image size from HTML class.
@@ -466,13 +461,11 @@ class Jetpack_Photon {
 					$transform_orig = $transform;
 
 					// If width is available, constrain to $content_width.
-					if ( false !== $width && false === strpos( $width, '%' ) && is_numeric( $content_width ) ) {
-						if ( $width > $content_width && false !== $height && false === strpos( $height, '%' ) ) {
+					if ( false !== $width && is_numeric( $content_width ) && $width > $content_width ) {
+						if ( false !== $height ) {
 							$height = round( ( $content_width * $height ) / $width );
-							$width  = $content_width;
-						} elseif ( $width > $content_width ) {
-							$width = $content_width;
 						}
+						$width = $content_width;
 					}
 
 					// Set a width if none is found and $content_width is available.
@@ -498,7 +491,7 @@ class Jetpack_Photon {
 					// Build array of Photon args and expose to filter before passing to Photon URL function.
 					$args = array();
 
-					if ( false !== $width && false !== $height && false === strpos( $width, '%' ) && false === strpos( $height, '%' ) ) {
+					if ( false !== $width && false !== $height ) {
 						$args[ $transform ] = $width . ',' . $height;
 					} elseif ( false !== $width ) {
 						$args['w'] = $width;
@@ -561,8 +554,9 @@ class Jetpack_Photon {
 						}
 
 						// If we are not transforming the image with resize, fit, or letterbox (lb), then we should remove
-						// the width and height arguments from the image to prevent distortion. Even if $args['w'] and $args['h']
-						// are present, Photon does not crop to those dimensions. Instead, it appears to favor height.
+						// the width and height arguments (including HTML4 percentages) from the image to prevent distortion.
+						// Even if $args['w'] and $args['h'] are present, Photon does not crop to those dimensions. Instead,
+						// it appears to favor height.
 						//
 						// If we are transforming the image via one of those methods, let's update the width and height attributes.
 						if ( empty( $args['resize'] ) && empty( $args['fit'] ) && empty( $args['lb'] ) ) {
@@ -584,7 +578,7 @@ class Jetpack_Photon {
 
 							// (?<=\s)         - Ensure width or height attribute is preceded by a space
 							// (width=["|\']?) - Matches, and captures, width=, width=", or width='
-							// [\d%]+          - Matches 1 or more digits
+							// [\d%]+          - Matches 1 or more digits or percent signs
 							// (["|\']?)       - Matches, and captures, ", ', or empty string
 							// \s              - Ensures there's a space after the attribute
 							$new_tag = preg_replace( '#(?<=\s)(width=["|\']?)[\d%]+(["|\']?)\s?#i', sprintf( '${1}%d${2} ', $resize_args[0] ), $new_tag );

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -1145,6 +1145,27 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	}
 
 	/**
+	 * Tests that Photon ignores percentage dimensions. It should fall back to e.g. a "size-foo" class.
+	 *
+	 * @covers Jetpack_Photon::filter_the_content
+	 */
+	public function test_photon_filter_the_content_percentage_width_and_height() {
+		$sample_html      = '<img src="http://example.com/test.png" class="test size-large" width="45%" height="55%" />';
+		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
+		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
+		$query_str        = wp_parse_url( $attributes['src']['value'], PHP_URL_QUERY );
+		parse_str( $query_str, $query_params );
+
+		$this->assertArrayHasKey( 'width', $attributes );
+		$this->assertEquals( '1024', $attributes['width']['value'] );
+		$this->assertArrayHasKey( 'height', $attributes );
+		$this->assertEquals( '1024', $attributes['height']['value'] );
+
+		$this->assertArrayHasKey( 'fit', $query_params );
+		$this->assertEquals( '1024,1024', $query_params['fit'] );
+	}
+
+	/**
 	 * Tests that Photon will filter for an AMP response.
 	 *
 	 * @author westonruter


### PR DESCRIPTION
Fixes #9833

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the attempted support for HTML4 percentage width/height in the Photon code. It has never conformed to HTML4 semantics, and since 2016 it hasn't even correctly implemented the "percentage of the image's native width/height" semantics.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See #9833 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable Photon, if necessary.
* Using the code editor, attempt to add an `<img>` tag with percentage values for width and/or height.
* The resulting HTML should ignore the supplied percentage width/height, acting the same as if you had omitted the attribute entirely.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Perhaps something like "Jetpack's image accelerator (Photon) will now ignore attempts to specify percentages for width or height in an `<img>` tag. This hasn't worked correctly since 2016, and even before that did not follow HTML4 semantics."?
