### PR TITLE
Shortcodes: Enable FB and IG embed whenever connected

### DIFF
--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -19,7 +19,9 @@ $tools = array(
 	'custom-post-types/nova.php',
 	'geo-location.php',
 	// Those oEmbed providers are always available.
+	'shortcodes/facebook.php',
 	'shortcodes/others.php',
+	// Theme Tools.
 	'theme-tools.php',
 	'theme-tools/social-links.php',
 	'theme-tools/random-redirect.php',
@@ -52,7 +54,6 @@ $connected_tools = array(
 	// These oEmbed providers are available when connected to WordPress.com.
 	// Starting from 2020-10-24, they need an authentication token, and that token is stored on WordPress.com.
 	// More information: https://developers.facebook.com/docs/instagram/oembed/.
-	'shortcodes/facebook.php',
 	'shortcodes/instagram.php',
 );
 

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -49,6 +49,11 @@ $connected_tools = array(
 	'simple-payments/simple-payments.php',
 	'wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 	'wpcom-tos/wpcom-tos.php',
+	// These oEmbed providers are available when connected to WordPress.com.
+	// Starting from 2020-10-24, they need an authentication token, and that token is stored on WordPress.com.
+	// More information: https://developers.facebook.com/docs/instagram/oembed/.
+	'shortcodes/facebook.php',
+	'shortcodes/instagram.php',
 );
 
 // Add connected features to our existing list if the site is currently connected.


### PR DESCRIPTION
Enable the Facebook and Instagram embeds whenever JP is connected to WP.com, rather than only enabling them when the `shortcodes` module is enabled.

#### Changes proposed in this Pull Request:

Decouple the Facebook and Instagram embed handlers from the `shortcodes` module, in order to always provide those embeds (as long as Jetpack is connected to WP.com), rather than only when the `shortcodes` module is active.

Quoting some rational from the discussion (p1601385813135300-slack-CBG1CP4EN):

> I think it may help some site owners, since the shortcodes module:
> 1. is not enabled by default in Jetpack
> 2. does not have a UI in the settings page; you need to search for it to be able to activate it.

(p1601385994137700-slack-CBG1CP4EN?thread_ts=1601385813.135300&cid=CBG1CP4EN)

> Also, we're now stating that
>> This feature is no longer necessary as the editor now handles media embeds rather gracefully.
> 
> https://github.com/Automattic/jetpack/blob/1527e0be4d25312d5fb4672a3f856e11ad6d84db/modules/shortcodes.php#L5

(p1601386021138100-slack-CBG1CP4EN?thread_ts=1601385813.135300&cid=CBG1CP4EN)

Furthermore, we expect that with this change, things will be less disruptive for our users, once FB and IG embeds require an access token (which is why we proxy through WP.com, where we add that token).

#### Jetpack product discussion
p1601385813135300-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Note that JP's IG embed handler also is in charge of _un_registering Core's IG handler (which will continue to be around until WP 5.6 is released, see https://core.trac.wordpress.org/ticket/50861). This means that IG embeds _will work_ even without the JP IG embed handler active -- they will just use the Core handler instead.

However, the JP handler does a few things differently. For example, it enqueues the following JS: https://github.com/Automattic/jetpack/blob/1527e0be4d25312d5fb4672a3f856e11ad6d84db/modules/shortcodes/instagram.php#L189-L195

We will thus base our testing on the presence of that script's handle (the `jetpack-instagram-embed` string) in the page source.

1. On `master`, make sure that you're connected to WP.com, and that the `shortcodes` module is enabled (`yarn docker:wp jetpack module activate shortcodes`).
1. Start a new post and insert the URL of an Instagram post.
1. Publish that post, and view it on the frontend. Check the page source. Search for the `jetpack-instagram-embed` string -- it should be present (it's the `id` of a `<script />` tag).
1. Deactivate the `shortcodes` module (`yarn docker:wp jetpack module deactivate shortcodes`), and reload that post (still on the frontend). The page source should no longer contain the `jetpack-instagram-embed` string.
1. Switch to this PR's branch. Reload the post (frontend, still). The `jetpack-instagram-embed` string should be back in the page source.

#### Proposed changelog entry for your changes:
Enable the Facebook and Instagram embeds whenever JP is connected to WP.com, rather than only enabling them when the `shortcodes` module is enabled.