### PR TITLE
WhatsApp Block: Add alignment controls

### DIFF
--- a/extensions/blocks/send-a-message/editor.scss
+++ b/extensions/blocks/send-a-message/editor.scss
@@ -1,11 +1,7 @@
 .wp-block-jetpack-send-a-message {
 	.block-editor-block-list__layout {
-		display: inline-flex;
-
 		.wp-block {
-			margin-top: 0px;
-			margin-bottom: 0px;
-			margin-right: 10px;
+			margin: 0;
 		}
 	}
 

--- a/extensions/blocks/send-a-message/whatsapp-button/edit.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/edit.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { __, _x } from '@wordpress/i18n';
 import { useEffect, useState, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
@@ -191,8 +192,12 @@ export default function WhatsAppButtonEdit( { attributes, setAttributes, classNa
 		);
 	};
 
+	const getBlockClassNames = () => {
+		return classnames( className, colorClass ? 'is-color-' + colorClass : undefined );
+	};
+
 	return (
-		<div className={ className + ' is-color-' + colorClass }>
+		<div className={ getBlockClassNames() }>
 			{ ToolbarGroup && (
 				<BlockControls>
 					<ToolbarGroup>

--- a/extensions/blocks/send-a-message/whatsapp-button/editor.scss
+++ b/extensions/blocks/send-a-message/whatsapp-button/editor.scss
@@ -43,3 +43,9 @@
 		padding: 12px;
 	}
 }
+
+.wp-block[data-align="center"] {
+	.wp-block-jetpack-whatsapp-button {
+		justify-content: center;
+	}
+}

--- a/extensions/blocks/send-a-message/whatsapp-button/index.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/index.js
@@ -43,6 +43,7 @@ export const settings = {
 	supports: {
 		html: false,
 		reusable: false,
+		align: [ 'left', 'center', 'right' ],
 	},
 	attributes,
 	edit,

--- a/extensions/blocks/send-a-message/whatsapp-button/view.scss
+++ b/extensions/blocks/send-a-message/whatsapp-button/view.scss
@@ -1,11 +1,11 @@
 div.wp-block-jetpack-whatsapp-button {
-	display: inline-block;
 	margin-right: 5px;
+	display: flex;
 
 	a.whatsapp-block__button {
 		background: #25D366;
 		color: #fff;
-		display: inline-block;
+		display: block;
 		padding: 8px 16px 8px 56px;
 		border-radius: 8px;
 		text-decoration: none;
@@ -28,12 +28,16 @@ div.wp-block-jetpack-whatsapp-button {
 		}
 	}
 
+	&.alignleft {
+		justify-content: flex-start;
+	}
+
 	&.aligncenter {
-		text-align: center;
+		justify-content: center;
 	}
 
 	&.alignright {
-		text-align: right;
+		justify-content: flex-end;
 	}
 
 	&.has-no-text {

--- a/extensions/blocks/send-a-message/whatsapp-button/view.scss
+++ b/extensions/blocks/send-a-message/whatsapp-button/view.scss
@@ -29,6 +29,7 @@ div.wp-block-jetpack-whatsapp-button {
 	}
 
 	&.alignleft {
+		float: none;
 		justify-content: flex-start;
 	}
 
@@ -37,6 +38,7 @@ div.wp-block-jetpack-whatsapp-button {
 	}
 
 	&.alignright {
+		float: none;
 		justify-content: flex-end;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add WhatsApp button alignment controls to provide better support for including this button in block patterns.

Fixes #16660
![2020-09-29 13 53 59](https://user-images.githubusercontent.com/1464705/94614587-4520f780-025b-11eb-85f3-6c6d688cf27e.gif)

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Insert a WhatsApp Button block in a post or page
* Change the alignment
* Confirm this works in the editor and in the front end.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add ability to change the alignment of the WhatsApp button.
