### PR TITLE
Sync: Seperate theme data ( name, version, slug and uri) from theme support data 

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -804,7 +804,14 @@ class Defaults {
 		'custom-logo',
 		'menus',
 		'automatic-feed-links',
-		'editor-style',
+		'align-wide',
+		'wp-block-styles',
+		'responsive-embeds',
+		'disable-custom-gradients',
+		'disable-custom-font-sizes',
+		'disable-custom-colors',
+		'dark-editor-style',
+		'customize-selective-refresh-widgets',
 		'widgets',
 		'html5',
 		'title-tag',
@@ -814,6 +821,9 @@ class Defaults {
 		'site-logo',
 		'editor-color-palette',
 		'editor-gradient-presets',
+		'editor-font-sizes',
+		'editor-styles',
+		'editor-style', // deprecated.
 	);
 
 	/**

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -630,18 +630,29 @@ class Functions {
 	 * Return the theme's supported features.
 	 * Used for syncing the supported feature that we care about.
 	 *
+	 * @param WP_Theme $theme Theme Object.
+	 *
 	 * @return array List of features that the theme supports.
 	 */
-	public static function get_theme_support() {
+	public static function get_theme_support( $theme = null ) {
 		global $_wp_theme_features;
 
 		$theme_support = array();
+
+		if ( ! $theme instanceof WP_Theme ) {
+			$theme = wp_get_theme();
+		}
 		foreach ( Defaults::$default_theme_support_whitelist as $theme_feature ) {
 			$has_support = current_theme_supports( $theme_feature );
 			if ( $has_support ) {
 				$theme_support[ $theme_feature ] = $_wp_theme_features[ $theme_feature ];
 			}
 		}
+
+		$theme_support['name']    = $theme->get( 'Name' );
+		$theme_support['version'] = $theme->get( 'Version' );
+		$theme_support['slug']    = $theme->get_stylesheet();
+		$theme_support['uri']     = $theme->get( 'ThemeURI' );
 
 		return $theme_support;
 	}

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -630,29 +630,18 @@ class Functions {
 	 * Return the theme's supported features.
 	 * Used for syncing the supported feature that we care about.
 	 *
-	 * @param WP_Theme $theme Theme Object.
-	 *
 	 * @return array List of features that the theme supports.
 	 */
-	public static function get_theme_support( $theme = null ) {
+	public static function get_theme_support() {
 		global $_wp_theme_features;
 
 		$theme_support = array();
-
-		if ( ! $theme instanceof WP_Theme ) {
-			$theme = wp_get_theme();
-		}
 		foreach ( Defaults::$default_theme_support_whitelist as $theme_feature ) {
 			$has_support = current_theme_supports( $theme_feature );
 			if ( $has_support ) {
 				$theme_support[ $theme_feature ] = $_wp_theme_features[ $theme_feature ];
 			}
 		}
-
-		$theme_support['name']    = $theme->get( 'Name' );
-		$theme_support['version'] = $theme->get( 'Version' );
-		$theme_support['slug']    = $theme->get_stylesheet();
-		$theme_support['uri']     = $theme->get( 'ThemeURI' );
 
 		return $theme_support;
 	}

--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -150,7 +150,7 @@ class Replicastore implements Replicastore_Interface {
 	 * @param int    $max_id Maximum post ID.
 	 * @return array Array of posts.
 	 */
-	public function get_posts( $status = null, $min_id = null, $max_id = null ) {
+	public function get_posts( $status = null, $min_id = null, $max_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$args = array(
 			'orderby'        => 'ID',
 			'posts_per_page' => -1,
@@ -185,7 +185,7 @@ class Replicastore implements Replicastore_Interface {
 	 * @param \WP_Post $post   Post object.
 	 * @param bool     $silent Whether to perform a silent action. Not used in this implementation.
 	 */
-	public function upsert_post( $post, $silent = false ) {
+	public function upsert_post( $post, $silent = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $wpdb;
 
 		// Reject the post if it's not a \WP_Post.
@@ -358,7 +358,7 @@ class Replicastore implements Replicastore_Interface {
 	 * @param int    $max_id Maximum comment ID.
 	 * @return array Array of comments.
 	 */
-	public function get_comments( $status = null, $min_id = null, $max_id = null ) {
+	public function get_comments( $status = null, $min_id = null, $max_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$args = array(
 			'orderby' => 'ID',
 			'status'  => 'all',
@@ -576,14 +576,13 @@ class Replicastore implements Replicastore_Interface {
 	}
 
 	/**
-	 * Change the features that the current theme supports.
-	 * Intentionally not implemented in this replicastore.
+	 * Change the info of the current theme.
 	 *
 	 * @access public
 	 *
-	 * @param array $theme_support Features that the theme supports.
+	 * @param array $theme_info Theme info array.
 	 */
-	public function set_theme_support( $theme_support ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function set_theme_info( $theme_info ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// Noop.
 	}
 
@@ -884,7 +883,7 @@ class Replicastore implements Replicastore_Interface {
 	 * @param bool   $is_term_id Whether this is a `term_id` or a `term_taxonomy_id`.
 	 * @return \WP_Term|\WP_Error Term object on success, \WP_Error object on failure.
 	 */
-	public function get_term( $taxonomy, $term_id, $is_term_id = true ) {
+	public function get_term( $taxonomy, $term_id, $is_term_id = true ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$t = $this->ensure_taxonomy( $taxonomy );
 		if ( ! $t || is_wp_error( $t ) ) {
 			return $t;

--- a/packages/sync/src/interface-replicastore.php
+++ b/packages/sync/src/interface-replicastore.php
@@ -249,13 +249,13 @@ interface Replicastore_Interface {
 	public function delete_option( $option );
 
 	/**
-	 * Change the features that the current theme supports.
+	 * Change the info of the current theme.
 	 *
 	 * @access public
 	 *
-	 * @param array $theme_support Features that the theme supports.
+	 * @param array $theme_info Theme info array.
 	 */
-	public function set_theme_support( $theme_support );
+	public function set_theme_info( $theme_info );
 
 	/**
 	 * Whether the current theme supports a certain feature.

--- a/packages/sync/src/modules/class-themes.php
+++ b/packages/sync/src/modules/class-themes.php
@@ -459,18 +459,17 @@ class Themes extends Module {
 	 * @param \WP_Theme $old_theme The previous theme.
 	 */
 	public function sync_theme_support( $new_name, $new_theme = null, $old_theme = null ) {
-		$previous_theme = $this->get_theme_support_info( $old_theme );
+		$previous_theme = $this->get_theme_info( $old_theme );
 
 		/**
 		 * Fires when the client needs to sync theme support info
-		 * Only sends theme support attributes whitelisted in Defaults::$default_theme_support_whitelist
 		 *
 		 * @since 4.2.0
 		 *
 		 * @param array the theme support array
 		 * @param array the previous theme since Jetpack 6.5.0
 		 */
-		do_action( 'jetpack_sync_current_theme_support', $this->get_theme_support_info(), $previous_theme );
+		do_action( 'jetpack_sync_current_theme_support', $this->get_theme_info(), $previous_theme );
 	}
 
 	/**
@@ -556,7 +555,7 @@ class Themes extends Module {
 	 * @return array Theme data.
 	 */
 	public function expand_theme_data() {
-		return array( $this->get_theme_support_info( null, true ) );
+		return array( $this->get_theme_info() );
 	}
 
 	/**
@@ -784,19 +783,15 @@ class Themes extends Module {
 	 * @access private
 	 *
 	 * @param \WP_Theme $theme Theme object. Optional, will default to the current theme.
-	 * @param boolean   $send_full_theme_data Should send additional theme data.
+	 *
 	 * @return array Theme data.
 	 */
-	private function get_theme_support_info( $theme = null, $send_full_theme_data = false ) {
+	private function get_theme_info( $theme = null ) {
 		$theme_support = array();
 
 		// We are trying to get the current theme info.
 		if ( null === $theme ) {
 			$theme = wp_get_theme();
-		}
-
-		if ( $send_full_theme_data ) {
-			return Functions::get_theme_support( $theme );
 		}
 
 		$theme_support['name']    = $theme->get( 'Name' );

--- a/packages/sync/src/modules/class-themes.php
+++ b/packages/sync/src/modules/class-themes.php
@@ -795,13 +795,15 @@ class Themes extends Module {
 			$theme = wp_get_theme();
 		}
 
+		if ( $send_full_theme_data ) {
+			return Functions::get_theme_support( $theme );
+		}
+
 		$theme_support['name']    = $theme->get( 'Name' );
 		$theme_support['version'] = $theme->get( 'Version' );
 		$theme_support['slug']    = $theme->get_stylesheet();
 		$theme_support['uri']     = $theme->get( 'ThemeURI' );
-		if ( $send_full_theme_data ) {
-			return array_merge( Functions::get_theme_support(), $theme_support );
-		}
+
 		return $theme_support;
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -88,7 +88,7 @@ class Jetpack_Sync_Server_Replicator {
 			case 'jetpack_sync_current_theme_support':
 			case 'jetpack_full_sync_theme_data':
 				list( $theme_options ) = $args;
-				$this->store->set_theme_support( $theme_options );
+				$this->store->set_theme_info( $theme_options );
 				break;
 
 			// metadata - actions

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -14,7 +14,13 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 	private $comments;
 	private $comment_status;
 	private $options;
-	private $theme_support;
+
+	/**
+	 * Stores info related to the theme.
+	 *
+	 * @var array $theme_info stores theme info.
+	 */
+	private $theme_info;
 	private $meta;
 	private $meta_filter;
 	private $constants;
@@ -37,7 +43,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		$this->posts[ get_current_blog_id() ]           = array();
 		$this->comments[ get_current_blog_id() ]        = array();
 		$this->options[ get_current_blog_id() ]         = array();
-		$this->theme_support[ get_current_blog_id() ]   = array();
+		$this->theme_info[ get_current_blog_id() ]         = array();
 		$this->meta[ get_current_blog_id() ]            = array( 'post' => array(), 'comment' => array() );
 		$this->constants[ get_current_blog_id() ]       = array();
 		$this->updates[ get_current_blog_id() ]         = array();
@@ -214,13 +220,20 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		return $carry ^ ( array_key_exists( $option_name, $this->options[ get_current_blog_id() ] ) ? ( sprintf( '%u', crc32( $option_name . $this->options[ get_current_blog_id() ][ $option_name ] ) ) + 0 ) : 0 );
 	}
 
-	// theme functions
-	function set_theme_support( $theme_support ) {
-		$this->theme_support[ get_current_blog_id() ] = (object) $theme_support;
+	/**
+	 * Change the info of the current theme.
+	 *
+	 * @access public
+	 *
+	 * @param array $theme_info Theme info array.
+	 */
+	public function set_theme_info( $theme_info ) {
+		$this->theme_info[ get_current_blog_id() ] = (object) $theme_info;
 	}
 
 	function current_theme_supports( $feature ) {
-		return isset( $this->theme_support[ get_current_blog_id() ]->{$feature} );
+		$theme_supports = $this->get_callable( 'theme_support' );
+		return isset( $theme_supports[ $feature ] );
 	}
 
 	// meta

--- a/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -719,9 +719,17 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $local_option, $remote_option );
 
 		$synced_theme_caps_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_theme_data' );
-		$synced_theme_caps       = $synced_theme_caps_event->args[0];
+		$synced_theme_info       = $synced_theme_caps_event->args[0];
 
-		$this->assertTrue( $synced_theme_caps['post-thumbnails'] );
+		$this->assertTrue( isset( $synced_theme_info['name'] ) );
+		$this->assertTrue( isset( $synced_theme_info['slug'] ) );
+		$this->assertTrue( isset( $synced_theme_info['uri'] ) );
+		$this->assertTrue( isset( $synced_theme_info['version'] ) );
+
+		$theme_support = $this->server_replica_storage->get_callable( 'theme_support' );
+		$this->assertTrue( isset( $theme_support['post-thumbnails'] ) );
+
+		$this->assertTrue( $theme_support['post-thumbnails'] );
 
 		$this->assertTrue( $this->server_replica_storage->current_theme_supports( 'post-thumbnails' ) );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -887,11 +887,15 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $local_option, $remote_option );
 
 		$synced_theme_caps_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_theme_data' );
-		$synced_theme_caps = $synced_theme_caps_event->args[0];
+		$synced_theme_info       = $synced_theme_caps_event->args[0];
 
-		$this->assertTrue( $synced_theme_caps['post-thumbnails'] );
+		$this->assertTrue( isset( $synced_theme_info['name'] ) );
+		$this->assertTrue( isset( $synced_theme_info['slug'] ) );
+		$this->assertTrue( isset( $synced_theme_info['uri'] ) );
+		$this->assertTrue( isset( $synced_theme_info['version'] ) );
 
-		$this->assertTrue( $this->server_replica_storage->current_theme_supports( 'post-thumbnails' ) );
+		$theme_support = $this->server_replica_storage->get_callable( 'theme_support' );
+		$this->assertTrue( isset( $theme_support['post-thumbnails'] ) );
 	}
 
 	function check_for_updates_to_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -88,6 +88,19 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$theme_supports = $this->server_replica_storage->get_callable( 'theme_support' );
 
+		foreach ( Defaults::$default_theme_support_whitelist as $theme_feature ) {
+			$this->assertEquals(
+				current_theme_supports( $theme_feature ),
+				isset( $theme_supports[ $theme_feature ] ),
+				'Default Feature(s) not synced ' . $theme_feature
+			);
+		}
+
+		if ( ! function_exists( 'get_registered_theme_features' ) ) {
+			// get_registered_theme_features got intorduced in WP 5.5 so any tests that use the previous version of WP fail.
+			return;
+		}
+
 		// Sync all registered theme features.
 		$registered_theme_features = array_keys( get_registered_theme_features() );
 		$not_synced_theme_features = array_diff( $registered_theme_features, Defaults::$default_theme_support_whitelist );
@@ -96,14 +109,6 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			empty( $not_synced_theme_features ),
 			'Theme Sync Error. Please add the following ' . implode( ', ', $not_synced_theme_features ) . ' to Defaults::$default_theme_support_whitelist'
 		);
-
-		foreach ( Defaults::$default_theme_support_whitelist as $theme_feature ) {
-			$this->assertEquals(
-				current_theme_supports( $theme_feature ),
-				isset( $theme_supports[ $theme_feature ] ),
-				'Default Feature(s) not synced ' . $theme_feature
-			);
-		}
 	}
 
 	public function test_network_enable_disable_theme_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Sync\Defaults;
+
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 //Mock object requiered for test_theme_update()
@@ -85,31 +88,19 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$theme_supports = $this->server_replica_storage->get_callable( 'theme_support' );
 
-		$theme_features = array(
-			'post-thumbnails',
-			'post-formats',
-			'custom-header',
-			'custom-background',
-			'custom-logo',
-			'menus',
-			'automatic-feed-links',
-			'editor-style',
-			'widgets',
-			'html5',
-			'title-tag',
-			'jetpack-social-menu',
-			'jetpack-responsive-videos',
-			'infinite-scroll',
-			'site-logo',
-			'editor-color-palette',
-			'editor-gradient-presets',
+		// Sync all registered theme features.
+		$registered_theme_features = array_keys( get_registered_theme_features() );
+		$not_synced_theme_features = array_diff( $registered_theme_features, Defaults::$default_theme_support_whitelist );
+		$this->assertTrue(
+			empty( $not_synced_theme_features ),
+			'Theme Sync error, please add the following ' . implode( ', ', $not_synced_theme_features )
 		);
 
-		foreach ( $theme_features as $theme_feature ) {
+		foreach ( Defaults::$default_theme_support_whitelist as $theme_feature ) {
 			$this->assertEquals(
 				current_theme_supports( $theme_feature ),
 				isset( $theme_supports[ $theme_feature ] ),
-				'Feature(s) not synced' . $theme_feature
+				'Default Feature(s) not synced ' . $theme_feature
 			);
 		}
 	}

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -91,9 +91,10 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		// Sync all registered theme features.
 		$registered_theme_features = array_keys( get_registered_theme_features() );
 		$not_synced_theme_features = array_diff( $registered_theme_features, Defaults::$default_theme_support_whitelist );
+		// We want to make sure we keep up with the latest theme_supports data that gets registered.
 		$this->assertTrue(
 			empty( $not_synced_theme_features ),
-			'Theme Sync error, please add the following ' . implode( ', ', $not_synced_theme_features )
+			'Theme Sync Error. Please add the following ' . implode( ', ', $not_synced_theme_features ) . ' to Defaults::$default_theme_support_whitelist'
 		);
 
 		foreach ( Defaults::$default_theme_support_whitelist as $theme_feature ) {

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -182,8 +182,8 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		// temporary hack due to missing post_meta_checksum implementation in the test replicastore
 		if ( 'Jetpack_Sync_Test_Replicastore' != get_class( $store ) ) {
 			$this->assertEquals( $store->post_meta_checksum( 1, 2 ), $histogram['1-2'] );
-			$this->assertEquals( $store->post_meta_checksum( 5, 10 ), $histogram['5-10'] );	
-		}		
+			$this->assertEquals( $store->post_meta_checksum( 5, 10 ), $histogram['5-10'] );
+		}
 
 		// test comments checksum with ID range
 		$histogram = $store->checksum_histogram( 'comments', 2 );
@@ -644,7 +644,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 				),
 		);
 
-		$store->set_theme_support( $theme_features );
+		$store->set_callable( 'theme_support', $theme_features );
 
 		// the "current_theme_supports" API is only supposed to return "true" if there's a setting
 		foreach ( $theme_features as $theme_feature => $theme_feature_value ) {


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/pull/16827

We introduces a new way of syncing the theme supports data while doing that we missed adding additional theme date that is currently registered. 

This PR also seperates the theme data and theme supports information. 

So that theme data ( name, version, slug and uri) doesn't contain any theme support data. Since this info should be stored different places on .com side.

This PR also adds additional theme supports data so that we would be able to provide the same data as the /themes?status=active endpoint. 

#### Does this pull request change what data or activity we track or use?
We sync more theme related data. 

#### Testing instructions:
* Switch the theme. Make sure that this works as expected. Apply the D50465-code to your .com sandbox. 
Does the data appear to be as you would expect it to be? 

#### Proposed changelog entry for your changes:
* Improved syncing of the theme related data. 
