### PR TITLE
WhatsApp Button: Fix incorrect button text color

### DIFF
--- a/extensions/blocks/send-a-message/whatsapp-button/deprecated.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/deprecated.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { whatsAppURL } from './index';
+
+export default {
+	save: function ( { attributes, className } ) {
+		const {
+			countryCode,
+			phoneNumber,
+			firstMessage,
+			colorClass,
+			buttonText,
+			backgroundColor,
+			openInNewTab,
+		} = attributes;
+
+		const target = openInNewTab ? '_blank' : '_self';
+
+		const fullPhoneNumber =
+			countryCode && phoneNumber
+				? countryCode.replace( /\D+/g, '' ) + phoneNumber.replace( /\D+/g, '' )
+				: '';
+
+		const getWhatsAppUrl = () => {
+			let url = whatsAppURL + fullPhoneNumber;
+
+			if ( '' !== firstMessage ) {
+				url += '&text=' + encodeURIComponent( firstMessage );
+			}
+
+			return url;
+		};
+
+		const cssClassNames = classnames(
+			className,
+			colorClass ? 'is-color-' + colorClass : undefined,
+			! buttonText.length ? 'has-no-text' : undefined
+		);
+
+		return (
+			<div className={ cssClassNames }>
+				<a
+					className="whatsapp-block__button"
+					href={ getWhatsAppUrl() }
+					style={ {
+						backgroundColor: backgroundColor,
+					} }
+					target={ target }
+					rel="noopener noreferrer"
+				>
+					<RichText.Content value={ buttonText } />
+				</a>
+			</div>
+		);
+	},
+};

--- a/extensions/blocks/send-a-message/whatsapp-button/deprecated/v1/index.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/deprecated/v1/index.js
@@ -8,15 +8,15 @@ import { RichText } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { whatsAppURL } from '../../index';
-import attributes from '../../attributes';
+import attr from '../../attributes';
 
 export default {
-	attributes,
+	attributes: attr,
 	supports: {
 		html: false,
 		reusable: false,
 	},
-	save: function ( { attr, className } ) {
+	save: function ( { attributes, className } ) {
 		const {
 			countryCode,
 			phoneNumber,
@@ -25,7 +25,7 @@ export default {
 			buttonText,
 			backgroundColor,
 			openInNewTab,
-		} = attr;
+		} = attributes;
 
 		const target = openInNewTab ? '_blank' : '_self';
 

--- a/extensions/blocks/send-a-message/whatsapp-button/deprecated/v1/index.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/deprecated/v1/index.js
@@ -7,10 +7,16 @@ import { RichText } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { whatsAppURL } from './index';
+import { whatsAppURL } from '../../index';
+import attributes from '../../attributes';
 
 export default {
-	save: function ( { attributes, className } ) {
+	attributes,
+	supports: {
+		html: false,
+		reusable: false,
+	},
+	save: function ( { attr, className } ) {
 		const {
 			countryCode,
 			phoneNumber,
@@ -19,7 +25,7 @@ export default {
 			buttonText,
 			backgroundColor,
 			openInNewTab,
-		} = attributes;
+		} = attr;
 
 		const target = openInNewTab ? '_blank' : '_self';
 

--- a/extensions/blocks/send-a-message/whatsapp-button/edit.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/edit.js
@@ -260,6 +260,7 @@ export default function WhatsAppButtonEdit( { attributes, setAttributes, classNa
 				preserveWhiteSpace={ false }
 				style={ {
 					backgroundColor: backgroundColor,
+					color: 'dark' === colorClass ? '#fff' : '#465B64',
 				} }
 			/>
 		</div>

--- a/extensions/blocks/send-a-message/whatsapp-button/index.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/index.js
@@ -10,6 +10,7 @@ import { getIconColor } from '../../../shared/block-icons';
 import attributes from './attributes';
 import edit from './edit';
 import save from './save';
+import deprecated from './deprecated';
 import icon from './icon';
 import './editor.scss';
 
@@ -53,4 +54,5 @@ export const settings = {
 			phoneNumber: '555-123-4567',
 		},
 	},
+	deprecated,
 };

--- a/extensions/blocks/send-a-message/whatsapp-button/index.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/index.js
@@ -10,7 +10,7 @@ import { getIconColor } from '../../../shared/block-icons';
 import attributes from './attributes';
 import edit from './edit';
 import save from './save';
-import deprecated from './deprecated';
+import deprecatedV1 from './deprecated/v1';
 import icon from './icon';
 import './editor.scss';
 
@@ -54,5 +54,5 @@ export const settings = {
 			phoneNumber: '555-123-4567',
 		},
 	},
-	deprecated,
+	deprecated: [ deprecatedV1 ],
 };

--- a/extensions/blocks/send-a-message/whatsapp-button/save.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/save.js
@@ -48,7 +48,10 @@ export default function SendAMessageSave( { attributes, className } ) {
 			<a
 				className="whatsapp-block__button"
 				href={ getWhatsAppUrl() }
-				style={ { backgroundColor: backgroundColor } }
+				style={ {
+					backgroundColor: backgroundColor,
+					color: 'dark' === colorClass ? '#fff' : '#465B64',
+				} }
 				target={ target }
 				rel="noopener noreferrer"
 			>


### PR DESCRIPTION
When the WhatsApp button block is added to a parent block with a set text color it can on certain themes (Mayland as an example) override the fixed button text color. To avoid this the text color is now set inline so it cannot be overridden by strong styles on any parent block.

See: https://github.com/Automattic/view-design/issues/82

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Activate the Mayland theme
* Insert a Group block and set the text color to red
* Insert a WhatsApp Button block inside the group block and confirm that the text in the button is not red
* Confirm the same is true on the front end of the site.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed issue with WhatsApp button where the incorrect text color would be used.
