### PR TITLE
Extensions: update webpack configuration to prevent plugin conflicts

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-activecampaign-js-error
+++ b/projects/plugins/jetpack/changelog/fix-activecampaign-js-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Updates the webpack configuration for extensions to prevent JS conflicts with other plugins

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -118,6 +118,7 @@ const extensionsWebpackConfig = getBaseWebpackConfig(
 		},
 		'output-chunk-filename': '[name].[chunkhash].js',
 		'output-path': path.join( path.dirname( __dirname ), '_inc', 'blocks' ),
+		'output-jsonp-function': 'webpackJsonpJetpack',
 	}
 );
 


### PR DESCRIPTION
Fixes #17289

#### Changes proposed in this Pull Request:

- Adds a custom setting for `output.jsonpFunction` to the webpack configuration for building extensions
- This prevents conflicts in the default `webpackJsonp` JavaScript global when other WordPress plugins also load JavaScript built with webpack

See https://v4.webpack.js.org/configuration/output/#outputjsonpfunction for more information about the webpack configuration.

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

I've only been able to replicate #17289 with the release build of Jetpack, not in development environments, so I'm not sure how to test that this definitely fixes the issue.

But more generally, you can test by

1. Build Jetpack extensions with `jetpack build plugin` and select `jetpack`.
1. Load a post or page in the editor with your local Jetpack development site. Look at the output JS for extensions (such as editor-beta.js). You should see `window["webpackJsonpJetpack"]` in the built JS, rather than `window["webpackJsonp"]`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Updates the webpack configuration for `jsonpFunction` when building JavaScript for extensions.
