### PR TITLE
Publicize: Fix race condition when loading wp-annotations

### DIFF
--- a/extensions/blocks/publicize/twitter/options.js
+++ b/extensions/blocks/publicize/twitter/options.js
@@ -9,6 +9,9 @@ import { __ } from '@wordpress/i18n';
 import { RadioControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
+// Because the wp-annotations script isn't loaded by default in the block editor, importing
+// it here tells webpack to add it as a dependency to be loaded before Jetpack blocks.
+import '@wordpress/annotations';
 
 /**
  * Internal dependencies

--- a/extensions/blocks/publicize/twitter/tweet-divider.js
+++ b/extensions/blocks/publicize/twitter/tweet-divider.js
@@ -6,6 +6,9 @@ import { Popover } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Component } from '@wordpress/element';
+// Because the wp-annotations script isn't loaded by default in the block editor, importing
+// it here tells webpack to add it as a dependency to be loaded before Jetpack blocks.
+import '@wordpress/annotations';
 
 /**
  * Internal dependencies

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 		"@babel/core": "7.8.4",
 		"@babel/preset-env": "7.8.4",
 		"@babel/register": "7.7.7",
+		"@wordpress/annotations": "1.12.2",
 		"@wordpress/base-styles": "2.0.1",
 		"@wordpress/browserslist-config": "2.6.0",
 		"@wordpress/compose": "3.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2896,6 +2896,20 @@
     "@babel/runtime" "^7.8.3"
     "@wordpress/dom-ready" "^2.7.0"
 
+"@wordpress/annotations@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/annotations/-/annotations-1.12.2.tgz#01593f73faeaed01355954d65066892525994f2a"
+  integrity sha512-CQ0dprLQT9MHfOMk1m86U2m2XX1h179cN1HmpY2a3rTXFsOp2ZBYjIhgsED1o1Mcdus6PSPS/Fdn021cZLAWdA==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    "@wordpress/data" "^4.14.2"
+    "@wordpress/hooks" "^2.7.0"
+    "@wordpress/i18n" "^3.9.0"
+    "@wordpress/rich-text" "^3.12.2"
+    lodash "^4.17.15"
+    rememo "^3.0.0"
+    uuid "^3.3.2"
+
 "@wordpress/api-fetch@^3.11.0":
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz#795e14b58d13f53284bfdf5ff875d0dbdbc8f53c"


### PR DESCRIPTION
After #16699, there appears to be a race condition when loading `wp-annotations`, which can cause it blocks to throw JavaScript errors.

While the `@wordpress/annotations` package doesn't actually export anything, adding `import '@wordpress/annotations'` is a signal to `@wordpress/dependency-extraction-webpack-plugin` that `wp-annotations` is a dependency, and needs to be added to the `editor*asset.php` files.

#### Changes proposed in this Pull Request:
* Fixes a sporadic JavaScript error that can occur in the post editor.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

This is tricky to reproduce. It appears to occur most consistently in a fresh `wp-env` based setup, before connecting Jetpack to a WPCOM account.

#### Proposed changelog entry for your changes:
* None needed.
