### PR TITLE
Composer: Ignore the ext-intl requirement of nojimage/twitter-text-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,9 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"sort-packages": true
+		"sort-packages": true,
+		"platform": {
+			"ext-intl": "0.0.0"
+		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ac5e4e05b7d798cbccd18d14ed8d40d",
+    "content-hash": "7b0199b97ad4a8ba90ec8ae3092b7add",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1390,5 +1390,8 @@
         "ext-openssl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "1.1.0",
+    "platform-overrides": {
+        "ext-intl": "0.0.0"
+    }
 }


### PR DESCRIPTION
The `nojimage/twitter-text-php` package requires `ext-intl` to be available. Unfortunately, the default PHP build on MacOS doesn't include `ext-intl`.

Since we're not making any use of the parts of `nojimage/twitter-text-php` that use `ext-intl`, we can override this requirement.

#### Changes proposed in this Pull Request:
* Add a platform override for `ext-intl` to `composer.json`.

#### Jetpack product discussion
p9dueE-1WN-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Check that the PHP version you're using doesn't have `ext-intl` enabled. (`php -m`)
* Run `composer install`, and confirm that it finishes without errors.

#### Proposed changelog entry for your changes:
* None needed.