### PR TITLE
Add centre alignment option to the jetpack/button block

### DIFF
--- a/extensions/blocks/button/editor.scss
+++ b/extensions/blocks/button/editor.scss
@@ -2,3 +2,10 @@
 	display: inline-block;
 	margin: 0 auto;
 }
+
+.wp-block[data-align="center"] {
+	.wp-block-jetpack-button {
+		display: flex;
+		justify-content: center;
+	}
+}

--- a/extensions/blocks/button/index.js
+++ b/extensions/blocks/button/index.js
@@ -22,7 +22,7 @@ export const settings = {
 	supports: {
 		html: false,
 		inserter: false,
-		align: [ 'left', 'right' ],
+		align: [ 'left', 'center', 'right'  ],
 	},
 	styles: [
 		{ name: 'fill', label: __( 'Fill', 'jetpack' ), isDefault: true },

--- a/extensions/blocks/button/index.js
+++ b/extensions/blocks/button/index.js
@@ -22,7 +22,7 @@ export const settings = {
 	supports: {
 		html: false,
 		inserter: false,
-		align: [ 'left', 'center', 'right'  ],
+		align: [ 'left', 'center', 'right' ],
 	},
 	styles: [
 		{ name: 'fill', label: __( 'Fill', 'jetpack' ), isDefault: true },


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This PR add a center alignment option to the button block, mainly at this stage to provide centring of the button in the payments block

#### Testing instructions:

* Apply this PR
* Add a Jetpack button block, or a block that contains the button, eg. payment block
* Check that the button can be centre aligned and that alignment applies correctly in editor and front end

![button](https://user-images.githubusercontent.com/3629020/94642083-aa4e1900-033f-11eb-9258-90e8c6a87a55.gif)

#### Proposed changelog entry for your changes:

* Option to center the button block added
