### PR TITLE
Admin Page: activate Publicize before to link to its settings

### DIFF
--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -726,34 +726,36 @@ class MyPlanBody extends React.Component {
 									) }
 								/>
 							</div>
-							<div className="jp-landing__plan-features-text">
-								<h3 className="jp-landing__plan-features-title">
-									{ __( 'Increase traffic to your site', 'jetpack' ) }
-								</h3>
-								<p>
-									{ __(
-										'Reach a wider audience by automatically sharing your posts on social media.',
-										'jetpack'
+							{ 'inactive' !== this.props.getModuleOverride( 'publicize' ) && (
+								<div className="jp-landing__plan-features-text">
+									<h3 className="jp-landing__plan-features-title">
+										{ __( 'Increase traffic to your site', 'jetpack' ) }
+									</h3>
+									<p>
+										{ __(
+											'Reach a wider audience by automatically sharing your posts on social media.',
+											'jetpack'
+										) }
+									</p>
+									{ this.props.isModuleActivated( 'publicize' ) ? (
+										<Button
+											onClick={ this.handleButtonClickForTracking( 'free_sharing' ) }
+											href={ getRedirectUrl( 'calypso-marketing-connections', {
+												site: this.props.siteRawUrl,
+											} ) }
+										>
+											{ __( 'Start sharing', 'jetpack' ) }
+										</Button>
+									) : (
+										<Button
+											onClick={ this.activatePublicize }
+											disabled={ this.props.isActivatingModule( 'publicize' ) }
+										>
+											{ __( 'Activate Publicize', 'jetpack' ) }
+										</Button>
 									) }
-								</p>
-								{ this.props.isModuleActivated( 'publicize' ) ? (
-									<Button
-										onClick={ this.handleButtonClickForTracking( 'free_sharing' ) }
-										href={ getRedirectUrl( 'calypso-marketing-connections', {
-											site: this.props.siteRawUrl,
-										} ) }
-									>
-										{ __( 'Start sharing', 'jetpack' ) }
-									</Button>
-								) : (
-									<Button
-										onClick={ this.activatePublicize }
-										disabled={ this.props.isActivatingModule( 'publicize' ) }
-									>
-										{ __( 'Activate Publicize', 'jetpack' ) }
-									</Button>
-								) }
-							</div>
+								</div>
+							) }
 						</div>
 
 						<div className="jp-landing__plan-features-card">

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -736,14 +736,23 @@ class MyPlanBody extends React.Component {
 										'jetpack'
 									) }
 								</p>
-								<Button
-									onClick={ this.handleButtonClickForTracking( 'free_sharing' ) }
-									href={ getRedirectUrl( 'calypso-marketing-connections', {
-										site: this.props.siteRawUrl,
-									} ) }
-								>
-									{ __( 'Start sharing', 'jetpack' ) }
-								</Button>
+								{ this.props.isModuleActivated( 'publicize' ) ? (
+									<Button
+										onClick={ this.handleButtonClickForTracking( 'free_sharing' ) }
+										href={ getRedirectUrl( 'calypso-marketing-connections', {
+											site: this.props.siteRawUrl,
+										} ) }
+									>
+										{ __( 'Start sharing', 'jetpack' ) }
+									</Button>
+								) : (
+									<Button
+										onClick={ this.activatePublicize }
+										disabled={ this.props.isActivatingModule( 'publicize' ) }
+									>
+										{ __( 'Activate Publicize', 'jetpack' ) }
+									</Button>
+								) }
 							</div>
 						</div>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* See https://github.com/Automattic/wp-calypso/issues/45288#issuecomment-701184609

After connecting a brand new site to your WordPress.com account, you are directed to Jetpack > My Plan when you want to go back to wp-admin. There, we offer a number of Jetpack features you can start using. One of those is Publicize. We suggest you "start sharing" by clicking a button that leads you to Publicize settings in Calypso. However, at that point Publicize is most likely not active yet; that Publicize settings screen is consequently not available yet.

In this PR, when the module is not active, instead of linking to Publicize settings we offer a button to activate the feature. If the feature is active, we then link to Publicize settings.

In addition to this change, I've also made sure we do not show the card if [someone deliberately chose to make Publicize unavailable on the site](https://jetpack.com/support/module-overrides/).

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No 

#### Testing instructions:

* On a brand new site, connect to WordPress.com and do not buy a plan.
* Head back to Jetpack > My Plan
* By then, the Publicize module has not been active yet. You should see an option to "activate publicize"
* Clicking it should activate the module
* You should then be able to click "start sharing"

#### Proposed changelog entry for your changes:

* N/A

