### PR TITLE
Licensing: use Oxford comma in error message

### DIFF
--- a/packages/licensing/src/class-licensing.php
+++ b/packages/licensing/src/class-licensing.php
@@ -199,7 +199,7 @@ class Licensing {
 			$this->log_error(
 				sprintf(
 					/* translators: %s is a comma-separated list of license keys. */
-					__( 'The following Jetpack licenses are invalid, already in use or revoked: %s', 'jetpack' ),
+					__( 'The following Jetpack licenses are invalid, already in use, or revoked: %s', 'jetpack' ),
 					implode( ', ', $failed )
 				)
 			);

--- a/packages/licensing/tests/php/class-test-licensing.php
+++ b/packages/licensing/tests/php/class-test-licensing.php
@@ -320,7 +320,7 @@ class Test_Licensing extends BaseTestCase {
 
 		$licensing->expects( $this->once() )
 			->method( 'log_error' )
-			->with( 'The following Jetpack licenses are invalid, already in use or revoked: foo, baz' );
+			->with( 'The following Jetpack licenses are invalid, already in use, or revoked: foo, baz' );
 
 		$licensing->attach_stored_licenses();
 	}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* This is a minor change, just ensuring we use [Oxford commas](https://en.wikipedia.org/wiki/Serial_comma) when possible.

**Before**

![image](https://user-images.githubusercontent.com/426388/94652276-07bf7700-02fa-11eb-88b9-ac109ef8c20f.png)

**After**

![image](https://user-images.githubusercontent.com/426388/94652309-1ad24700-02fa-11eb-914c-acb42c563516.png)


#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a brand new site, add an invalid license: `yarn docker:wp option update jetpack_licenses '["lorem_ipsum"]' --format=json`
* Connect your site to WordPress.com
* When back in the dashboard, notice the notice.

#### Proposed changelog entry for your changes:

* N/A
