### PR TITLE
Admin Page: switch to @wordpress/date in My plan page

### DIFF
--- a/_inc/client/components/product-expiration/index.jsx
+++ b/_inc/client/components/product-expiration/index.jsx
@@ -3,8 +3,8 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { moment } from 'i18n-calypso';
 import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n, isInTheFuture } from '@wordpress/date';
 
 class ProductExpiration extends React.PureComponent {
 	static propTypes = {
@@ -18,7 +18,7 @@ class ProductExpiration extends React.PureComponent {
 		expiryDate: '',
 		purchaseDate: '',
 		isRefundable: false,
-		dateFormat: 'LL',
+		dateFormat: 'F j, Y',
 	};
 
 	render() {
@@ -31,30 +31,31 @@ class ProductExpiration extends React.PureComponent {
 
 		// Return the subscription date if we don't have the expiry date or the plan is refundable.
 		if ( ! expiryDate || isRefundable ) {
-			const purchaseMoment = moment( purchaseDate );
-			if ( purchaseMoment.isValid() ) {
+			const purchaseDateObj = new Date( purchaseDate );
+			if ( purchaseDateObj.toString() !== 'Invalid Date' ) {
 				return sprintf(
 					/* translators: placeholder is a date. */
 					__( 'Purchased on %s.', 'jetpack' ),
-					purchaseMoment.format( dateFormat )
+					dateI18n( dateFormat, purchaseDateObj )
 				);
 			}
+
 			return null;
 		}
 
-		const expiryMoment = moment( expiryDate );
+		const expiryDateObj = new Date( expiryDate );
 
 		// Return null if date is not parsable.
-		if ( ! expiryMoment.isValid() ) {
+		if ( expiryDateObj.toString() === 'Invalid Date' ) {
 			return null;
 		}
 
 		// If the expiry date is in the past, show the expiration date.
-		if ( expiryMoment.diff( new Date() ) < 0 ) {
+		if ( ! isInTheFuture( expiryDateObj ) ) {
 			return sprintf(
 				/* translators: placeholder is a date. */
 				__( 'Expired on %s.', 'jetpack' ),
-				expiryMoment.format( dateFormat )
+				dateI18n( dateFormat, expiryDateObj )
 			);
 		}
 
@@ -62,7 +63,7 @@ class ProductExpiration extends React.PureComponent {
 		return sprintf(
 			/* translators: placeholder is a date. */
 			__( 'Renews on %s.', 'jetpack' ),
-			expiryMoment.format( dateFormat )
+			dateI18n( dateFormat, expiryDateObj )
 		);
 	}
 }

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -15,14 +15,14 @@ import Card from 'components/card';
 import ProductExpiration from 'components/product-expiration';
 import UpgradeLink from 'components/upgrade-link';
 import { getPlanClass } from 'lib/plans/constants';
-import { getUpgradeUrl, getSiteRawUrl, showBackups } from 'state/initial-state';
+import { getUpgradeUrl, getSiteRawUrl, getDateFormat, showBackups } from 'state/initial-state';
 import ChecklistCta from './checklist-cta';
 import ChecklistProgress from './checklist-progress-card';
 import MyPlanCard from '../my-plan-card';
 
 class MyPlanHeader extends React.Component {
 	getProductProps( productSlug ) {
-		const { displayBackups, purchases } = this.props;
+		const { displayBackups, dateFormat, purchases } = this.props;
 
 		const productProps = {
 			productSlug,
@@ -40,6 +40,7 @@ class MyPlanHeader extends React.Component {
 		if ( purchase ) {
 			expiration = (
 				<ProductExpiration
+					dateFormat={ dateFormat }
 					expiryDate={ purchase.expiry_date }
 					purchaseDate={ purchase.subscribed_date }
 					isRefundable={ purchase.is_refundable }
@@ -253,6 +254,7 @@ MyPlanHeader.propTypes = {
 
 	// From connect HoC
 	siteSlug: PropTypes.string,
+	dateFormat: PropTypes.string,
 	displayBackups: PropTypes.bool,
 	plansMainTopUpgradeUrl: PropTypes.string,
 	purchases: PropTypes.array,
@@ -261,6 +263,7 @@ MyPlanHeader.propTypes = {
 export default connect( state => {
 	return {
 		siteSlug: getSiteRawUrl( state ),
+		dateFormat: getDateFormat( state ),
 		displayBackups: showBackups( state ),
 		plansMainTopUpgradeUrl: getUpgradeUrl( state, 'plans-main-top' ),
 	};

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -289,6 +289,17 @@ export function isMultisite( state ) {
 }
 
 /**
+ * Get the site's date format, in format accepted by DateTimeInterface::format().
+ *
+ * @param {object} state Global state tree
+ *
+ * @return {string} Date format of the site.
+ */
+export function getDateFormat( state ) {
+	return get( state.jetpack.initialState.siteData, 'dateFormat', false );
+}
+
+/**
  * Returns the affiliate code, if it exists. Otherwise an empty string.
  *
  * @param {object} state Global state tree

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -309,6 +309,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'showBackups'                => Jetpack::show_backups_ui(),
 				'showSetupWizard'            => $this->show_setup_wizard(),
 				'isMultisite'                => is_multisite(),
+				'dateFormat'                 => get_option( 'date_format' ),
 			),
 			'themeData'                   => array(
 				'name'      => $current_theme->get( 'Name' ),

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
 		"@wordpress/browserslist-config": "2.6.0",
 		"@wordpress/compose": "3.11.0",
 		"@wordpress/data": "4.14.2",
+		"@wordpress/date": "3.11.1",
 		"@wordpress/element": "2.16.0",
 		"@wordpress/i18n": "3.9.0",
 		"@wordpress/url": "2.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3135,6 +3135,15 @@
     turbo-combine-reducers "^1.0.2"
     use-memo-one "^1.1.1"
 
+"@wordpress/date@3.11.1":
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-3.11.1.tgz#8b76ac138714d905a591eaac248149b02824f7bc"
+  integrity sha512-Vxt102uR0ptQ/ec5TPL/JEtqShBRCuYSkP+uj9TJ7DdK97+D698c8GQ/2VFnzJ3VMb2Xq+4VFCXSw1vC5M3NMg==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    moment "^2.22.1"
+    moment-timezone "^0.5.31"
+
 "@wordpress/date@^3.8.0":
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-3.8.0.tgz#beeedf0eaa995756f341b3e72c7fa9ee6e0002c0"
@@ -12190,6 +12199,13 @@ moment-timezone@^0.5.16:
   version "0.5.26"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.26.tgz#c0267ca09ae84631aa3dc33f65bedbe6e8e0d772"
   integrity sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==
+  dependencies:
+    moment ">= 2.9.0"
+
+moment-timezone@^0.5.31:
+  version "0.5.31"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"
+  integrity sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* In Jetpack > My Plan, switch from `moment` to `@wordpress/date` to display expiration dates for the current plan.

#### Jetpack product discussion

* Related issues: #16481, #16397 

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Connect your site to your WordPress.com account and purchase a plan.
* Head back to Jetpack > My Plan in wp-admin.
* The displayed expiration date should be correct.
* Try changing the date format in Settings > General, as well as the site language; the date should remain correct.

#### Proposed changelog entry for your changes:

* Admin Page: improve the display of dates in the Jetpack Plan screen.
