### PR TITLE
REST API: Site based authentication migration

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -2052,6 +2052,21 @@ abstract class WPCOM_JSON_API_Endpoint {
 		return 'GET' == $this->method || ( $this->allow_unauthorized_request && in_array( $origin, $complete_access_origins ) );
 	}
 
+	/**
+	 * Whether this endpoint allows site based authentication.
+	 * If we made it to this point, it means we have a signed request with a Jetpack token,
+	 * so all we need to do in order to determine that a blog token is used is check if a
+	 * logged-in user exists.
+	 *
+	 * @since 8.9.1
+	 *
+	 * @return bool true, if Jetpack blog token is used (aka no logged-in user exists) and `allow_jetpack_site_auth` is true, false otherwise.
+	 */
+	public function allows_site_based_authentication() {
+		return $this->allow_jetpack_site_auth &&
+			0 === get_current_user_id();
+	}
+
 	function get_platform() {
 		return wpcom_get_sal_platform( $this->api->token_details );
 	}

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -2055,7 +2055,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 	/**
 	 * Whether this endpoint allows site based authentication.
 	 *
-	 * @since 8.9.1
+	 * @since 9.1.0
 	 *
 	 * @return bool true, if Jetpack blog token is used and `allow_jetpack_site_auth` is true,
 	 * false otherwise.

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -2053,14 +2053,14 @@ abstract class WPCOM_JSON_API_Endpoint {
 	}
 
 	/**
-	 * Whether this endpoint allows site based authentication.
+	 * Whether this endpoint accepts site based authentication.
 	 *
 	 * @since 9.1.0
 	 *
 	 * @return bool true, if Jetpack blog token is used and `allow_jetpack_site_auth` is true,
 	 * false otherwise.
 	 */
-	public function allows_site_based_authentication() {
+	public function accepts_site_based_authentication() {
 		return $this->allow_jetpack_site_auth &&
 			$this->api->is_jetpack_authorized_for_site();
 	}

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -2054,17 +2054,15 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 	/**
 	 * Whether this endpoint allows site based authentication.
-	 * If we made it to this point, it means we have a signed request with a Jetpack token,
-	 * so all we need to do in order to determine that a blog token is used is check if a
-	 * logged-in user exists.
 	 *
 	 * @since 8.9.1
 	 *
-	 * @return bool true, if Jetpack blog token is used (aka no logged-in user exists) and `allow_jetpack_site_auth` is true, false otherwise.
+	 * @return bool true, if Jetpack blog token is used and `allow_jetpack_site_auth` is true,
+	 * false otherwise.
 	 */
 	public function allows_site_based_authentication() {
 		return $this->allow_jetpack_site_auth &&
-			0 === get_current_user_id();
+			$this->api->is_jetpack_authorized_for_site();
 	}
 
 	function get_platform() {

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -2053,7 +2053,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 	}
 
 	/**
-	 * Whether this endpoint accepts site based authentication.
+	 * Whether this endpoint accepts site based authentication for the current request.
 	 *
 	 * @since 9.1.0
 	 *

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -595,7 +595,7 @@ class WPCOM_JSON_API {
 		 * 1. In case of user based authentication, we need to check if the logged-in user has the 'read' capability.
 		 * 2. In case of site based authentication, make sure the endpoint allows it and no user is logged-in.
 		 */
-		if ( '-1' === get_option( 'blog_public' ) &&
+		if ( -1 === get_option( 'blog_public' ) &&
 			! current_user_can( 'read' ) &&
 			! $this->endpoint->allows_site_based_authentication()
 		) {

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -151,7 +151,7 @@ class WPCOM_JSON_API {
 	 *
 	 * @since 9.1.0
 	 *
-	 * @param  boolean|number $site_id The site id.
+	 * @param  boolean|int $site_id The site id.
 	 * @return boolean
 	 */
 	public function is_jetpack_authorized_for_site( $site_id = false ) {

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -627,11 +627,11 @@ class WPCOM_JSON_API {
 		/**
 		 * If this is a private site we check for 2 things:
 		 * 1. In case of user based authentication, we need to check if the logged-in user has the 'read' capability.
-		 * 2. In case of site based authentication, make sure the endpoint allows it and no user is logged-in.
+		 * 2. In case of site based authentication, make sure the endpoint accepts it.
 		 */
 		if ( -1 === (int) get_option( 'blog_public' ) &&
 			! current_user_can( 'read' ) &&
-			! $this->endpoint->allows_site_based_authentication()
+			! $this->endpoint->accepts_site_based_authentication()
 		) {
 			return new WP_Error( 'unauthorized', 'User cannot access this private blog.', 403 );
 		}

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -147,8 +147,9 @@ class WPCOM_JSON_API {
 
 	/**
 	 * Checks if the current request is authorized with a blog token.
+	 * This method is overridden by a child class in WPCOM.
 	 *
-	 * @since 8.9.1
+	 * @since 9.1.0
 	 *
 	 * @param  boolean|number $site_id The site id.
 	 * @return boolean

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -629,7 +629,7 @@ class WPCOM_JSON_API {
 		 * 1. In case of user based authentication, we need to check if the logged-in user has the 'read' capability.
 		 * 2. In case of site based authentication, make sure the endpoint allows it and no user is logged-in.
 		 */
-		if ( -1 === get_option( 'blog_public' ) &&
+		if ( -1 === (int) get_option( 'blog_public' ) &&
 			! current_user_can( 'read' ) &&
 			! $this->endpoint->allows_site_based_authentication()
 		) {

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -145,6 +145,39 @@ class WPCOM_JSON_API {
 		$this->token_details['blog_id'] = Jetpack_Options::get_option( 'id' );
 	}
 
+	/**
+	 * Checks if the current request is authorized with a blog token.
+	 *
+	 * @since 8.9.1
+	 *
+	 * @param  boolean|number $site_id The site id.
+	 * @return boolean
+	 */
+	public function is_jetpack_authorized_for_site( $site_id = false ) {
+		if ( ! $this->token_details ) {
+			return false;
+		}
+
+		$token_details = (object) $this->token_details;
+
+		$site_in_token = (int) $token_details->blog_id;
+
+		if ( $site_in_token < 1 ) {
+			return false;
+		}
+
+		if ( $site_id && $site_in_token !== (int) $site_id ) {
+			return false;
+		}
+
+		if ( (int) get_current_user_id() !== 0 ) {
+			// If Jetpack blog token is used, no logged-in user should exist.
+			return false;
+		}
+
+		return true;
+	}
+
 	function serve( $exit = true ) {
 		ini_set( 'display_errors', false );
 

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -590,8 +590,15 @@ class WPCOM_JSON_API {
 		if ( $this->is_restricted_blog( $blog_id ) ) {
 			return new WP_Error( 'unauthorized', 'User cannot access this restricted blog', 403 );
 		}
-
-		if ( -1 == get_option( 'blog_public' ) && ! current_user_can( 'read' ) ) {
+		/**
+		 * If this is a private site we check for 2 things:
+		 * 1. In case of user based authentication, we need to check if the logged-in user has the 'read' capability.
+		 * 2. In case of site based authentication, make sure the endpoint allows it and no user is logged-in.
+		 */
+		if ( '-1' === get_option( 'blog_public' ) &&
+			! current_user_can( 'read' ) &&
+			! $this->endpoint->allows_site_based_authentication()
+		) {
 			return new WP_Error( 'unauthorized', 'User cannot access this private blog.', 403 );
 		}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
@@ -116,11 +116,15 @@ abstract class Jetpack_JSON_API_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$failed[] = $cap;
 				}
 			}
-			// Check that must have conditions is less then
+			// Check if all conditions have passed.
 			if ( $passed < $must_pass ) {
-				return new WP_Error( 'unauthorized', sprintf( __( 'This user is not authorized to %s on this blog.', 'jetpack' ), implode( ', ', $failed ), 403 ) );
+				return new WP_Error(
+					'unauthorized',
+					/* translators: %s: comma-separated list of capabilities */
+					sprintf( __( 'This user is not authorized to %s on this blog.', 'jetpack' ), implode( ', ', $failed ) ),
+					403
+				);
 			}
-
 		} else {
 			if ( !current_user_can( $capability ) ) {
 				return new WP_Error( 'unauthorized', sprintf( __( 'This user is not authorized to %s on this blog.', 'jetpack' ), $capability ), 403 );

--- a/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
@@ -94,7 +94,7 @@ abstract class Jetpack_JSON_API_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @return bool|WP_Error
 	 */
 	protected function check_capability( $capability ) {
-		// If this endpoint accepts site based authentication capabilities check.
+		// If this endpoint accepts site based authentication, skip capabilities check.
 		if ( $this->accepts_site_based_authentication() ) {
 			return true;
 		}

--- a/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
@@ -94,6 +94,11 @@ abstract class Jetpack_JSON_API_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @return bool|WP_Error
 	 */
 	protected function check_capability( $capability ) {
+		// If this endpoint allows site based authentication (aka Jetpack blog token) skip
+		// capabilities check.
+		if ( $this->allows_site_based_authentication() ) {
+			return true;
+		}
 		if ( is_array( $capability ) ) {
 			// the idea is that the we can pass in an array of capabilitie that the user needs to have before we allowing them to do something
 			$capabilities = ( isset( $capability['capabilities'] ) ? $capability['capabilities'] : $capability );

--- a/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
@@ -94,9 +94,8 @@ abstract class Jetpack_JSON_API_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @return bool|WP_Error
 	 */
 	protected function check_capability( $capability ) {
-		// If this endpoint allows site based authentication (aka Jetpack blog token) skip
-		// capabilities check.
-		if ( $this->allows_site_based_authentication() ) {
+		// If this endpoint accepts site based authentication capabilities check.
+		if ( $this->accepts_site_based_authentication() ) {
 			return true;
 		}
 		if ( is_array( $capability ) ) {

--- a/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
@@ -7,6 +7,31 @@ if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && defined( 'JETPACK__PLUGIN_DIR'
 require_jetpack_file( 'class.json-api-endpoints.php' );
 
 class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
+	/**
+	 * An admin user_id.
+	 *
+	 * @var number $admin_user_id.
+	 */
+	private static $admin_user_id;
+	/**
+	 * The user_id of a user without read capabilities.
+	 *
+	 * @var number $no_read_user_id.
+	 */
+	private static $no_read_user_id;
+
+	/**
+	 * Create fixtures once, before any tests in the class have run.
+	 *
+	 * @param object $factory A factory object needed for creating fixtures.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id   = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$no_read_user_id = $factory->user->create();
+
+		$no_read_user = get_user_by( 'id', self::$no_read_user_id );
+		$no_read_user->add_cap( 'read', false );
+	}
 
 	/**
 	 * Inserts globals needed to initialize the endpoint.
@@ -18,6 +43,8 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 	}
 
 	public function setUp() {
+		global $blog_id;
+
 		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
 			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
 		}
@@ -25,6 +52,96 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->set_globals();
+
+		// Initialize some missing stuff for the API.
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
+	}
+
+	/**
+	 * Tests allows_site_based_authentication method.
+	 *
+	 * @author fgiannar
+	 * @covers WPCOM_JSON_API_Endpoint allows_site_based_authentication
+	 * @group json-api
+	 * @dataProvider data_provider_test_allows_site_based_authentication
+	 *
+	 * @param bool $allow_jetpack_site_auth The endpoint's `allow_jetpack_site_auth` value.
+	 * @param bool $is_user_logged_in If a user is logged in.
+	 * @param bool $result The expected result.
+	 */
+	public function test_allows_site_based_authentication( $allow_jetpack_site_auth, $is_user_logged_in, $result ) {
+
+		$endpoint = new Jetpack_JSON_API_Dummy_Endpoint(
+			array(
+				'stat'                    => 'dummy',
+				'allow_jetpack_site_auth' => $allow_jetpack_site_auth,
+			)
+		);
+
+		if ( $is_user_logged_in ) {
+			wp_set_current_user( self::$admin_user_id );
+		}
+
+		$this->assertEquals( $result, $endpoint->allows_site_based_authentication() );
+	}
+
+	/**
+	 * Tests api accessibility on a private site.
+	 *
+	 * @author fgiannar
+	 * @covers WPCOM_JSON_API switch_to_blog_and_validate_user
+	 * @group json-api
+	 * @dataProvider data_provider_test_private_site_accessibility
+	 *
+	 * @param bool            $allow_jetpack_site_auth The endpoint's `allow_jetpack_site_auth` value.
+	 * @param bool            $use_blog_token If we should simulate a blog token for this test.
+	 * @param bool            $user_can_read If the current user has read capability. When a blog token is used this has no effect.
+	 * @param WP_Error|string $result The expected result.
+	 */
+	public function test_private_site_accessibility( $allow_jetpack_site_auth, $use_blog_token, $user_can_read, $result ) {
+		// Private site.
+		update_option( 'blog_public', '-1' );
+
+		$endpoint = new Jetpack_JSON_API_Dummy_Endpoint(
+			array(
+				'stat'                    => 'dummy',
+				'allow_jetpack_site_auth' => $allow_jetpack_site_auth,
+			)
+		);
+
+		if ( ! $use_blog_token ) {
+			$user_id = $user_can_read ? self::$admin_user_id : self::$no_read_user_id;
+			wp_set_current_user( $user_id );
+		}
+		$this->assertEquals( $result, $endpoint->api->process_request( $endpoint, array() ) );
+	}
+
+	/**
+	 * Tests endpoint capabilities.
+	 *
+	 * @author fgiannar
+	 * @covers Jetpack_JSON_API_Endpoint validate_call
+	 * @group json-api
+	 * @dataProvider data_provider_test_endpoint_capabilities
+	 *
+	 * @param bool            $allow_jetpack_site_auth The endpoint's `allow_jetpack_site_auth` value.
+	 * @param bool            $use_blog_token If we should simulate a blog token for this test.
+	 * @param bool            $user_with_permissions If the current user has the needed capabilities to access the endpoint. When a blog token is used this has no effect.
+	 * @param WP_Error|string $result The expected result.
+	 */
+	public function test_endpoint_capabilities( $allow_jetpack_site_auth, $use_blog_token, $user_with_permissions, $result ) {
+		$endpoint = new Jetpack_JSON_API_Dummy_Endpoint(
+			array(
+				'stat'                    => 'dummy',
+				'allow_jetpack_site_auth' => $allow_jetpack_site_auth,
+			)
+		);
+
+		if ( ! $use_blog_token ) {
+			$user_id = $user_with_permissions ? self::$admin_user_id : self::$no_read_user_id;
+			wp_set_current_user( $user_id );
+		}
+		$this->assertEquals( $result, $endpoint->api->process_request( $endpoint, array() ) );
 	}
 
 	public function create_get_category_endpoint() {
@@ -60,8 +177,6 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 		$category = wp_insert_term( 'test_category', 'category' );
 
 		$endpoint = $this->create_get_category_endpoint();
-		// Initialize some missing stuff for the API
-		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
 
 		$response = $endpoint->callback(
 			sprintf( '/sites/%d/categories/slug:test_category', $blog_id ),
@@ -90,8 +205,6 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 		$category = wp_insert_term( 'test_category', 'category' );
 
 		$endpoint = $this->create_get_category_endpoint();
-		// Initialize some missing stuff for the API
-		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
 
 		$response = $endpoint->callback(
 			sprintf( '/sites/%d/categories/slug:test_category', $blog_id ),
@@ -103,5 +216,66 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 			'/?feed=rss2&amp;cat=' . $category['term_id'],
 			$response->feed_url
 		);
+	}
+
+	/**
+	 * Data provider for test_allows_site_based_authentication.
+	 */
+	public function data_provider_test_allows_site_based_authentication() {
+		return array(
+			'allow_jetpack_site_auth: true; logged_in_user: false;'  => array( true, false, true ),
+			'allow_jetpack_site_auth: false; logged_in_user: false;' => array( false, false, false ),
+			'allow_jetpack_site_auth: true; logged_in_user: true;'   => array( true, true, false ),
+		);
+	}
+
+	/**
+	 * Data provider for test_private_site_accessibility.
+	 */
+	public function data_provider_test_private_site_accessibility() {
+		$success = 'success';
+		$error   = new WP_Error( 'unauthorized', 'User cannot access this private blog.', 403 );
+
+		return array(
+			'allow_jetpack_site_auth: true; blog_token: true; can_read: null'   => array( true, true, null, $success ),
+			'allow_jetpack_site_auth: false; blog_token: true; can_read: null'   => array( false, true, null, $error ),
+			'allow_jetpack_site_auth: false; blog_token: false; can_read: false'   => array( false, false, false, $error ),
+			'allow_jetpack_site_auth: false; blog_token: false; can_read: true'   => array( false, false, true, $success ),
+		);
+	}
+
+	/**
+	 * Data provider for test_endpoint_capabilities.
+	 */
+	public function data_provider_test_endpoint_capabilities() {
+		$success = 'success';
+		$error   = new WP_Error( 'unauthorized', 'This user is not authorized to manage_options on this blog.', 403 );
+
+		return array(
+			'allow_jetpack_site_auth: true; blog_token: true; user_with_permissions: null'   => array( true, true, null, $success ),
+			'allow_jetpack_site_auth: false; blog_token: true; user_with_permissions: null'   => array( false, true, null, $error ),
+			'allow_jetpack_site_auth: false; blog_token: false; user_with_permissions: false'   => array( false, false, false, $error ),
+			'allow_jetpack_site_auth: false; blog_token: false; user_with_permissions: true'   => array( false, false, true, $success ),
+		);
+	}
+}
+
+/**
+ * Dummy endpoint for testing.
+ */
+class Jetpack_JSON_API_Dummy_Endpoint extends Jetpack_JSON_API_Endpoint {
+	/**
+	 * Only accessible to admins.
+	 *
+	 * @var array
+	 */
+	protected $needed_capabilities = 'manage_options';
+
+	/**
+	 * Dummy result.
+	 */
+	public function result() {
+
+		return 'success';
 	}
 }

--- a/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
@@ -58,18 +58,18 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests allows_site_based_authentication method.
+	 * Tests accepts_site_based_authentication method.
 	 *
 	 * @author fgiannar
-	 * @covers WPCOM_JSON_API_Endpoint allows_site_based_authentication
+	 * @covers WPCOM_JSON_API_Endpoint accepts_site_based_authentication
 	 * @group json-api
-	 * @dataProvider data_provider_test_allows_site_based_authentication
+	 * @dataProvider data_provider_test_accepts_site_based_authentication
 	 *
 	 * @param bool $allow_jetpack_site_auth The endpoint's `allow_jetpack_site_auth` value.
 	 * @param bool $is_user_logged_in If a user is logged in.
 	 * @param bool $result The expected result.
 	 */
-	public function test_allows_site_based_authentication( $allow_jetpack_site_auth, $is_user_logged_in, $result ) {
+	public function test_accepts_site_based_authentication( $allow_jetpack_site_auth, $is_user_logged_in, $result ) {
 
 		$endpoint = new Jetpack_JSON_API_Dummy_Endpoint(
 			array(
@@ -82,7 +82,7 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 			wp_set_current_user( self::$admin_user_id );
 		}
 
-		$this->assertEquals( $result, $endpoint->allows_site_based_authentication() );
+		$this->assertEquals( $result, $endpoint->accepts_site_based_authentication() );
 	}
 
 	/**
@@ -219,9 +219,9 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_allows_site_based_authentication.
+	 * Data provider for test_accepts_site_based_authentication.
 	 */
-	public function data_provider_test_allows_site_based_authentication() {
+	public function data_provider_test_accepts_site_based_authentication() {
 		return array(
 			'allow_jetpack_site_auth: true; logged_in_user: false;'  => array( true, false, true ),
 			'allow_jetpack_site_auth: false; logged_in_user: false;' => array( false, false, false ),
@@ -267,7 +267,7 @@ class Jetpack_JSON_API_Dummy_Endpoint extends Jetpack_JSON_API_Endpoint {
 	/**
 	 * Only accessible to admins.
 	 *
-	 * @var array
+	 * @var array|string
 	 */
 	protected $needed_capabilities = 'manage_options';
 


### PR DESCRIPTION
This PR updates the functionality of Jetpack JSON API endpoints by allowing them to support both site based authentication and also define needed capabilities that will only be checked if user based authentication is provided.

In short, if an endpoint allows site based authentication ( `allow_jetpack_site_auth` is `true` ) and the current authentication includes a blog token (no logged in user), then any needed capabilities defined by an endpoint will not be checked.
If though, the aforementioned endpoint is accessed with a user token, then the capabilities will be checked, same as before.

It's important to note that we will no longer need to set `$needed_capabilities = array()` in a Jetpack JSON API endpoint in order to support the blog token like we used to. 
We can have both the capabilities check (if a user token is used to access that endpoint) and support a blog token at the same time.

#### Changes proposed in this Pull Request:
* Adds `allows_site_based_authentication` method in `WPCOM_JSON_API` class. (see comments in code for a detailed explanation)
* Updates `switch_to_blog_and_validate_user` method to take into account if site based authentication is allowed when checking for private site's endpoint accessibility.
* Updates `check_capability` method to take into account if site based authentication is allowed when checking for the endpoint's needed capabilities.

#### Jetpack product discussion
p9dueE-1VI-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Make sure your site is sandboxed 
- Go to the Developer Console and pick a Jetpack Json Api endpoint with `allow_jetpack_site_auth` set (eg `GET
v1/sites/YOUR_SITE/options/backup?name=blogname`
- Make sure you get a 200 response
- Update the endpoint by setting `$needed_capabilities = 'manage_options'`
- Log in to the Console as a non admin user and make sure you get `403` response
- Repeat the request using a blog token and verify you get a `200` response
- Make your site private by setting `blog_public` as `'-1'`
- Repeat the request using a blog token and verify you get a `200` response
- Link a secondary user with no `read` permissions
- Log in to the console as that user and verify you get a `403 User cannot access this private blog.` response

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* REST API: Support needed capabilities in Jetpack REST API endpoints that allow site based authentication.