### PR TITLE
Latest Instagram Posts: fix PHP warning when checking cached gallery

### DIFF
--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -72,7 +72,10 @@ class Jetpack_Instagram_Gallery_Helper {
 		$cached_gallery = get_transient( $transient_key );
 		if ( $cached_gallery ) {
 			$decoded_cached_gallery = json_decode( $cached_gallery );
-			$cached_count           = count( $decoded_cached_gallery->images );
+			// `images` can be an array of images or a string 'ERROR'.
+			// 'ERROR' seems to be cached to limit the number of repeated API requests when there's a problem
+			// retrieving images.
+			$cached_count = is_array( $decoded_cached_gallery->images ) ? count( $decoded_cached_gallery->images ) : 0;
 			if ( $cached_count >= $count ) {
 				return $decoded_cached_gallery;
 			}

--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -73,8 +73,6 @@ class Jetpack_Instagram_Gallery_Helper {
 		if ( $cached_gallery ) {
 			$decoded_cached_gallery = json_decode( $cached_gallery );
 			// `images` can be an array of images or a string 'ERROR'.
-			// 'ERROR' seems to be cached to limit the number of repeated API requests when there's a problem
-			// retrieving images.
 			$cached_count = is_array( $decoded_cached_gallery->images ) ? count( $decoded_cached_gallery->images ) : 0;
 			if ( $cached_count >= $count ) {
 				return $decoded_cached_gallery;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Prevents the following PHP warning when there's an error from the Instagram API

```
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in .../_inc/lib/class-jetpack-instagram-gallery-helper.php on line 75
```

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1601478331363400-slack-CKZHG0QCR

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add the Latest Instagram Posts block to a page while tailing your site's PHP error logs
* You should not see the `count(): Parameter must be an array or an object` error when there's an error retrieving images.
* There's happens to be an [outage with the Instagram API](https://developers.facebook.com/status/issues/370520597643291/) if you test this soon, otherwise you can simulate this by sandboxing the wpcom API and returning `'ERROR'` for the `images`  property in `wp-content/rest-api-plugins/endpoints/sites-instagram.php`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Resolved a PHP warning when there's an error retrieving images from Instagram.