### PR TITLE
Add filters for modifying the max number of tags/categories fetched in widget visibility

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -45,7 +45,7 @@ class Jetpack_Widget_Conditions {
 
 		$categories = get_categories(
 			array(
-				'number'  => 1000,
+				'number'  => apply_filters( 'jetpack_widget_visibility_max_number_categories', 1000 ),
 				'orderby' => 'count',
 				'order'   => 'DESC',
 			)
@@ -88,7 +88,7 @@ class Jetpack_Widget_Conditions {
 
 		$tags = get_tags(
 			array(
-				'number'  => 1000,
+				'number'  => apply_filters( 'jetpack_widget_visibility_max_number_tags', 1000 ),
 				'orderby' => 'count',
 				'order'   => 'DESC',
 			)

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -45,6 +45,15 @@ class Jetpack_Widget_Conditions {
 
 		$categories = get_categories(
 			array(
+				/**
+				 * Specific a maximum number of categories to query for the Widget visibility UI.
+				 *
+				 * @module widget-visibility
+				 *
+				 * @since 9.1.0
+				 *
+				 * @param int $number Maximum number of categories displayed in the Widget visibility UI.
+				 */
 				'number'  => apply_filters( 'jetpack_widget_visibility_max_number_categories', 1000 ),
 				'orderby' => 'count',
 				'order'   => 'DESC',
@@ -88,6 +97,15 @@ class Jetpack_Widget_Conditions {
 
 		$tags = get_tags(
 			array(
+				/**
+				 * Specific a maximum number of tags to query for the Widget visibility UI.
+				 *
+				 * @module widget-visibility
+				 *
+				 * @since 9.1.0
+				 *
+				 * @param int $number Maximum number of tags displayed in the Widget visibility UI.
+				 */
 				'number'  => apply_filters( 'jetpack_widget_visibility_max_number_tags', 1000 ),
 				'orderby' => 'count',
 				'order'   => 'DESC',

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -54,7 +54,7 @@ class Jetpack_Widget_Conditions {
 				 *
 				 * @param int $number Maximum number of categories displayed in the Widget visibility UI.
 				 */
-				'number'  => apply_filters( 'jetpack_widget_visibility_max_number_categories', 1000 ),
+				'number'  => (int) apply_filters( 'jetpack_widget_visibility_max_number_categories', 1000 ),
 				'orderby' => 'count',
 				'order'   => 'DESC',
 			)
@@ -106,7 +106,7 @@ class Jetpack_Widget_Conditions {
 				 *
 				 * @param int $number Maximum number of tags displayed in the Widget visibility UI.
 				 */
-				'number'  => apply_filters( 'jetpack_widget_visibility_max_number_tags', 1000 ),
+				'number'  => (int) apply_filters( 'jetpack_widget_visibility_max_number_tags', 1000 ),
 				'orderby' => 'count',
 				'order'   => 'DESC',
 			)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds a couple filters for modifying the number of tags or categories fetched by the widget visibility settings. There isn't currently a good way of modifying that limit, and Newspack has a number of sites with more than 1000 tags. On those sites, some tags will be missing from the widget visibility list. 

An alternate approach could be to just do `number => 0` which would get all of the terms, but that may take so long that the request times out on sites with a lot of tags and poor infrastructure. I think a filter is the way to go because it doesn't affect the behavior unless something is hooked into the filter.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a - this doesn't modify the product in any way.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a - this doesn't affect any of that.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to Jetpack settings and enable widget visibility:

<img width="1054" alt="Screen Shot 2020-09-30 at 11 25 02 AM" src="https://user-images.githubusercontent.com/7317227/94726204-bfac4e80-0311-11eb-935e-65ab023f0473.png">

2. Go to Appearance > Widgets. Observe up to 1000 tags are in the tag visibility select:

<img width="426" alt="Screen Shot 2020-09-30 at 11 27 47 AM" src="https://user-images.githubusercontent.com/7317227/94726213-c4710280-0311-11eb-90ed-cc29effddbbc.png">

3. Add the following somewhere: 

```
add_filter( 'jetpack_widget_visibility_max_number_tags', function( $num_tags ) {
	return 5;
});
```

4. Go to Appearance > Widgets. Observe up to 5 tags are in the tag visibility select:

<img width="446" alt="Screen Shot 2020-09-30 at 11 28 54 AM" src="https://user-images.githubusercontent.com/7317227/94726221-c6d35c80-0311-11eb-9db2-37c63b05c7d1.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Added filters for modifying the maximum number of tags and categories fetched for widget visibility settings.
