### PR TITLE
Contact Form: Allow for commas and such in field labels, options, and values

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2330,6 +2330,34 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Escape a shortcode value.
+	 *
+	 * Shortcode attribute values have a number of unfortunate restrictions, which fortunately we
+	 * can get around by adding some extra HTML encoding.
+	 *
+	 * The output HTML will have a few extra escapes, but that makes no functional difference.
+	 *
+	 * @since 9.1.0
+	 * @param string $val Value to escape.
+	 * @return string
+	 */
+	private static function esc_shortcode_val( $val ) {
+		return strtr(
+			esc_html( $val ),
+			array(
+				// Brackets in attribute values break the shortcode parser.
+				'['  => '&#091;',
+				']'  => '&#093;',
+				// Shortcode parser screws up backslashes too, thanks to calls to `stripcslashes`.
+				'\\' => '&#092;',
+				// The existing code here represents arrays as comma-separated strings.
+				// Rather than trying to change representations now, just escape the commas in values.
+				','  => '&#044;',
+			)
+		);
+	}
+
+	/**
 	 * The contact-field shortcode processor
 	 * We use an object method here instead of a static Grunion_Contact_Form_Field class method to parse contact-field shortcodes so that we can tie them to the contact-form object.
 	 *
@@ -2347,18 +2375,18 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			}
 			foreach ( $attributes as $att => $val ) {
 				if ( is_numeric( $att ) ) { // Is a valueless attribute
-					$att_strs[] = esc_html( $val );
+					$att_strs[] = self::esc_shortcode_val( $val );
 				} elseif ( isset( $val ) ) { // A regular attr - value pair
 					if ( ( $att === 'options' || $att === 'values' ) && is_string( $val ) ) { // remove any empty strings
 						$val = explode( ',', $val );
 					}
- 					if ( is_array( $val ) ) {
+					if ( is_array( $val ) ) {
 						$val =  array_filter( $val, array( __CLASS__, 'remove_empty' ) ); // removes any empty strings
-						$att_strs[] = esc_html( $att ) . '="' . implode( ',', array_map( 'esc_html', $val ) ) . '"';
+						$att_strs[] = esc_html( $att ) . '="' . implode( ',', array_map( array( __CLASS__, 'esc_shortcode_val' ), $val ) ) . '"';
 					} elseif ( is_bool( $val ) ) {
-						$att_strs[] = esc_html( $att ) . '="' . esc_html( $val ? '1' : '' ) . '"';
+						$att_strs[] = esc_html( $att ) . '="' . self::esc_shortcode_val( $val ? '1' : '' ) . '"';
 					} else {
-						$att_strs[] = esc_html( $att ) . '="' . esc_html( $val ) . '"';
+						$att_strs[] = esc_html( $att ) . '="' . self::esc_shortcode_val( $val ) . '"';
 					}
 				}
 			}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2384,7 +2384,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 						$val =  array_filter( $val, array( __CLASS__, 'remove_empty' ) ); // removes any empty strings
 						$att_strs[] = esc_html( $att ) . '="' . implode( ',', array_map( array( __CLASS__, 'esc_shortcode_val' ), $val ) ) . '"';
 					} elseif ( is_bool( $val ) ) {
-						$att_strs[] = esc_html( $att ) . '="' . self::esc_shortcode_val( $val ? '1' : '' ) . '"';
+						$att_strs[] = esc_html( $att ) . '="' . ( $val ? '1' : '' ) . '"';
 					} else {
 						$att_strs[] = esc_html( $att ) . '="' . self::esc_shortcode_val( $val ) . '"';
 					}

--- a/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -531,6 +531,33 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests shortcode with commas and brackets.
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
+	public function test_array_values_with_commas_and_brackets() {
+		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
+		$shortcode = "[contact-field type='radio' options='\"foo\",bar&#044; baz,&#091;b&#092;rackets&#093;' label='fun &#093;&#091; times'/]";
+		$html      = do_shortcode( $shortcode );
+		$this->assertEquals( '[contact-field type="radio" options="&quot;foo&quot;,bar&#044; baz,&#091;b&#092;rackets&#093;" label="fun &#093;&#091; times"/]', $html );
+	}
+
+	/**
+	 * Tests Gutenblock input with commas and brackets.
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
+	public function test_array_values_with_commas_and_brackets_from_gutenblock() {
+		$attr = array(
+			'type'    => 'radio',
+			'options' => array( '"foo"', 'bar, baz', '[b\\rackets]' ),
+			'label'   => 'fun ][ times',
+		);
+		$html = Grunion_Contact_Form_Plugin::gutenblock_render_field_radio( $attr, '' );
+		$this->assertEquals( '[contact-field type="radio" options="&quot;foo&quot;,bar&#044; baz,&#091;b&#092;rackets&#093;" label="fun &#093;&#091; times"/]', $html );
+	}
+
+	/**
 	 * Test for text field_renders
 	 *
 	 * @covers Grunion_Contact_Form_Field
@@ -690,13 +717,13 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 */
 	public function test_make_sure_radio_field_renders_as_expected() {
 		$attributes = array(
-			'label' => 'fun',
-			'type' => 'radio',
-			'class' => 'lalala',
+			'label'   => 'fun',
+			'type'    => 'radio',
+			'class'   => 'lalala',
 			'default' => 'option 1',
-			'id' => 'funID',
-			'options' => array( 'option 1', 'option 2' ),
-			'values' => array( 'option 1', 'option 2' ),
+			'id'      => 'funID',
+			'options' => array( 'option 1', 'option 2', 'option 3, or 4' ),
+			'values'  => array( 'option 1', 'option 2', 'option [34]' ),
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'radio' ) );
@@ -710,13 +737,13 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 */
 	public function test_make_sure_select_field_renders_as_expected() {
 		$attributes = array(
-			'label' => 'fun',
-			'type' => 'select',
-			'class' => 'lalala',
+			'label'   => 'fun',
+			'type'    => 'select',
+			'class'   => 'lalala',
 			'default' => 'option 1',
-			'id' => 'funID',
-			'options' => array( 'option 1', 'option 2' ),
-			'values' => array( 'o1', 'o2' ),
+			'id'      => 'funID',
+			'options' => array( 'option 1', 'option 2', 'option 3, or 4' ),
+			'values'  => array( 'o1', 'o2', 'option [34]' ),
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'select' ) );
@@ -842,17 +869,17 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	public function assertValidFieldMultiField( $html, $attributes ) {
 
-		$wrapperDiv = $this->getCommonDiv( $html );
-		$this->assertCommonValidHtml( $wrapperDiv, $attributes );
+		$wrapper_div = $this->getCommonDiv( $html );
+		$this->assertCommonValidHtml( $wrapper_div, $attributes );
 
 		// Get label
-		$label = $this->getFirstElement( $wrapperDiv, 'label' );
+		$label = $this->getFirstElement( $wrapper_div, 'label' );
 
 		//Inputs
 		if ( $attributes['type'] === 'select' ) {
 			$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label select', 'label class doesn\'t match' );
 
-			$select = $this->getFirstElement( $wrapperDiv, 'select' );
+			$select = $this->getFirstElement( $wrapper_div, 'select' );
 			$this->assertEquals(
 				$label->getAttribute( 'for' ),
 				$select->getAttribute( 'id' ),
@@ -867,28 +894,49 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 			$this->assertEquals( $select->getAttribute( 'class' ), 'select '. $attributes['class'], ' select class does not match expected' );
 
-			// First Option
-			$option = $this->getFirstElement( $select, 'option' );
-			$this->assertEquals( $option->getAttribute( 'value' ), $attributes['values'][0], 'Input value doesn\'t match' );
-			$this->assertEquals( $option->getAttribute( 'selected' ), 'selected', 'Input is not selected' );
-			$this->assertEquals( $option->nodeValue, $attributes['options'][0], 'Input does not match the option' );
-
+			// Options.
+			$options = $select->getElementsByTagName( 'option' );
+			$n       = is_array( $options ) ? count( $options ) : $options->length;
+			$this->assertEquals( $n, count( $attributes['options'] ), 'Number of inputs doesn\'t match number of options' );
+			$this->assertEquals( $n, count( $attributes['values'] ), 'Number of inputs doesn\'t match number of values' );
+			for ( $i = 0; $i < $n; $i++ ) {
+				$option = is_array( $options ) ? $options[ $i ] : $options->item( $i );
+				$this->assertEquals( $option->getAttribute( 'value' ), $attributes['values'][ $i ], 'Input value doesn\'t match' );
+				if ( 0 === $i ) {
+					$this->assertEquals( $option->getAttribute( 'selected' ), 'selected', 'Input is not selected' );
+				} else {
+					$this->assertNotEquals( $option->getAttribute( 'selected' ), 'selected', 'Input is selected' );
+				}
+				//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$this->assertEquals( $option->nodeValue, $attributes['options'][ $i ], 'Input does not match the option' );
+			}
 		} else {
 			$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label', 'label class doesn\'t match' );
-			// Radio and Checkboxes
-			$second_label = $this->getFirstElement( $wrapperDiv, 'label', 1 );
-			$this->assertEquals( $second_label->nodeValue, ' ' . $attributes['options'][0] ); // extra space added for a padding
+			// Radio and Checkboxes.
+			$labels = $wrapper_div->getElementsByTagName( 'label' );
+			$n      = is_array( $labels ) ? count( $labels ) - 1 : $labels->length - 1;
+			$this->assertEquals( $n, count( $attributes['options'] ), 'Number of inputs doesn\'t match number of options' );
+			$this->assertEquals( $n, count( $attributes['values'] ), 'Number of inputs doesn\'t match number of values' );
+			for ( $i = 1; $i < $n; $i++ ) {
+				$item_label = is_array( $labels ) ? $labels[ $i + 1 ] : $labels->item( $i + 1 );
+				//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$this->assertEquals( $item_label->nodeValue, ' ' . $attributes['options'][ $i ] ); // extra space added for a padding.
 
-			$input = $this->getFirstElement( $second_label, 'input' );
-			$this->assertEquals( $input->getAttribute( 'type' ), $attributes['input_type'], 'Type doesn\'t match' );
-			if (  $attributes['input_type'] === 'radio' ) {
-				$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );
-			} else {
-				$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'] . '[]', 'Input name doesn\'t match' );
+				$input = $this->getFirstElement( $item_label, 'input' );
+				$this->assertEquals( $input->getAttribute( 'type' ), $attributes['input_type'], 'Type doesn\'t match' );
+				if ( 'radio' === $attributes['input_type'] ) {
+					$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );
+				} else {
+					$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'] . '[]', 'Input name doesn\'t match' );
+				}
+				$this->assertEquals( $input->getAttribute( 'value' ), $attributes['values'][ $i ], 'Input value doesn\'t match' );
+				$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' ' . $attributes['class'], 'Input class doesn\'t match' );
+				if ( 0 === $i ) {
+					$this->assertEquals( $input->getAttribute( 'checked' ), 'checked', 'Input checked doesn\'t match' );
+				} else {
+					$this->assertNotEquals( $input->getAttribute( 'checked' ), 'checked', 'Input checked doesn\'t match' );
+				}
 			}
-			$this->assertEquals( $input->getAttribute( 'value' ), $attributes['values'][0], 'Input value doesn\'t match' );
-			$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' '. $attributes['class'], 'Input class doesn\'t match' );
-			$this->assertEquals( $input->getAttribute( 'checked' ), 'checked', 'Input checked doesn\'t match' );
 		}
 	}
 

--- a/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -722,8 +722,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'class'   => 'lalala',
 			'default' => 'option 1',
 			'id'      => 'funID',
-			'options' => array( 'option 1', 'option 2', 'option 3, or 4' ),
-			'values'  => array( 'option 1', 'option 2', 'option [34]' ),
+			'options' => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
+			'values'  => array( 'option 1', 'option 2', 'option [34]', '\\' ),
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'radio' ) );
@@ -742,8 +742,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'class'   => 'lalala',
 			'default' => 'option 1',
 			'id'      => 'funID',
-			'options' => array( 'option 1', 'option 2', 'option 3, or 4' ),
-			'values'  => array( 'o1', 'o2', 'option [34]' ),
+			'options' => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
+			'values'  => array( 'option 1', 'option 2', 'option [34]', '\\' ),
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'select' ) );
@@ -917,7 +917,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			$n      = is_array( $labels ) ? count( $labels ) - 1 : $labels->length - 1;
 			$this->assertEquals( $n, count( $attributes['options'] ), 'Number of inputs doesn\'t match number of options' );
 			$this->assertEquals( $n, count( $attributes['values'] ), 'Number of inputs doesn\'t match number of values' );
-			for ( $i = 1; $i < $n; $i++ ) {
+			for ( $i = 0; $i < $n; $i++ ) {
 				$item_label = is_array( $labels ) ? $labels[ $i + 1 ] : $labels->item( $i + 1 );
 				//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$this->assertEquals( $item_label->nodeValue, ' ' . $attributes['options'][ $i ] ); // extra space added for a padding.


### PR DESCRIPTION
Fixes #7633

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add more HTML entity-encoding when converting Gutenblock input to shortcode text, to avoid a few problems:
    * Commas in "options" and "values" were conflicting with the use of commas as an array element separator.
    * Brackets broke shortcode parsing entirely.
    * Backslashes would get mangled too.
* A bit of incidental improvement to the tests.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No discussion, but see #7633

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a page with a contact form.
* Attempt to create radio buttons with commas in the labels.
* Save or preview, and see that your radio buttons are as intended rather than being broken on commas as in #7633.
* Do the same with brackets (`[` and `]`) and backslashes anywhere in the form.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Perhaps "Contact Form: Selection widgets, radio buttons, and checkboxes can now have commas in the labels and values without breaking the widget. Brackets and backslashes also can now be used in labels and values without breaking the form."
