### PR TITLE
Podcast player: Make it possible to hide the episode title

### DIFF
--- a/extensions/blocks/podcast-player/attributes.js
+++ b/extensions/blocks/podcast-player/attributes.js
@@ -25,6 +25,10 @@ export default {
 		type: 'boolean',
 		default: true,
 	},
+	showEpisodeTitle: {
+		type: 'boolean',
+		default: true,
+	},
 	showEpisodeDescription: {
 		type: 'boolean',
 		default: true,

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -21,6 +21,7 @@ const Header = memo(
 		link,
 		track,
 		children,
+		showEpisodeTitle,
 		showCoverArt,
 		showEpisodeDescription,
 		colors,
@@ -37,7 +38,7 @@ const Header = memo(
 					</div>
 				) }
 
-				{ !! ( title || ( track && track.title ) ) && (
+				{ showEpisodeTitle && !! ( title || ( track && track.title ) ) && (
 					<Title
 						playerId={ playerId }
 						title={ title }

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -212,6 +212,7 @@ export class PodcastPlayer extends Component {
 			customBackgroundColor,
 			hexBackgroundColor,
 			showCoverArt,
+			showEpisodeTitle,
 			showEpisodeDescription,
 		} = attributes;
 		const { playerState, currentTrack } = this.state;
@@ -268,6 +269,7 @@ export class PodcastPlayer extends Component {
 					cover={ cover }
 					track={ this.getTrack( currentTrack ) }
 					showCoverArt={ showCoverArt }
+					showEpisodeTitle={ showEpisodeTitle }
 					showEpisodeDescription={ showEpisodeDescription }
 					colors={ colors }
 				>
@@ -323,6 +325,7 @@ PodcastPlayer.defaultProps = {
 		url: null,
 		itemsToShow: 5,
 		showCoverArt: true,
+		showEpisodeTitle: true,
 		showEpisodeDescription: true,
 	},
 	tracks: [],

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -82,6 +82,7 @@ const PodcastPlayerEdit = ( {
 		url,
 		itemsToShow,
 		showCoverArt,
+		showEpisodeTitle,
 		showEpisodeDescription,
 		exampleFeedData,
 	} = validatedAttributes;
@@ -287,6 +288,12 @@ const PodcastPlayerEdit = ( {
 						label={ __( 'Show Cover Art', 'jetpack' ) }
 						checked={ showCoverArt }
 						onChange={ value => setAttributes( { showCoverArt: value } ) }
+					/>
+
+					<ToggleControl
+						label={ __( 'Show Episode Title', 'jetpack' ) }
+						checked={ showEpisodeTitle }
+						onChange={ value => setAttributes( { showEpisodeTitle: value } ) }
 					/>
 
 					<ToggleControl

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -41,6 +41,10 @@ function register_block() {
 					'type'    => 'boolean',
 					'default' => true,
 				),
+				'showEpisodeTitle'       => array(
+					'type'    => 'boolean',
+					'default' => true,
+				),
 				'showEpisodeDescription' => array(
 					'type'    => 'boolean',
 					'default' => true,

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -22,6 +22,7 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
  */
 $attributes               = (array) $template_props['attributes']; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 $show_cover_art           = (bool) $attributes['showCoverArt'];
+$show_episode_title       = (bool) $attributes['showEpisodeTitle'];
 $show_episode_description = (bool) $attributes['showEpisodeDescription'];
 
 // Current track.
@@ -38,6 +39,7 @@ $track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 		<?php endif; ?>
 
 		<?php
+		if ( $show_episode_title ) {
 			render(
 				'podcast-header-title',
 				array(
@@ -48,7 +50,8 @@ $track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 					'primary_colors' => $primary_colors,
 				)
 			);
-			?>
+		}
+		?>
 	</div>
 
 	<?php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
At present the block allows you to hide the episode description and cover art. This allows you to also hide the episode title.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add an attribute to toggle the visibility of the episode title.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post with a podcast player
* Add a podcast RSS feed
* Toggle the episode title off
* Load the post in the front end
* Confirm that the episode title doesn't show

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Podcast player: Make it possible to hide the episode title.
