### PR TITLE
Admin Page: switch to @wordpress/date in Stats dashboard

### DIFF
--- a/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -3,18 +3,23 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
-import { numberFormat, moment } from 'i18n-calypso';
+import { numberFormat } from 'i18n-calypso';
+
+/**
+ * WordPress dependencies
+ */
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import getRedirectUrl from 'lib/jp-redirect';
 import Button from 'components/button';
 import Card from 'components/card';
 import ConnectButton from 'components/connect-button';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 
 class DashStatsBottom extends Component {
 	statsBottom() {
@@ -74,7 +79,7 @@ class DashStatsBottom extends Component {
 								  ) }
 						</h3>
 						<p className="jp-at-a-glance__stat-details">
-							{ '-' === s.bestDay.day ? '-' : moment( s.bestDay.day ).format( 'MMMM Do, YYYY' ) }
+							{ '-' === s.bestDay.day ? '-' : dateI18n( this.props.dateFormat, s.bestDay.day ) }
 						</p>
 					</div>
 					<div className="jp-at-a-glance__stats-summary-alltime">
@@ -149,6 +154,7 @@ DashStatsBottom.propTypes = {
 	siteAdminUrl: PropTypes.string.isRequired,
 	statsData: PropTypes.object.isRequired,
 	isLinked: PropTypes.bool.isRequired,
+	dateFormat: PropTypes.string.isRequired,
 };
 
 DashStatsBottom.defaultProps = {
@@ -156,6 +162,7 @@ DashStatsBottom.defaultProps = {
 	siteAdminUrl: '',
 	statsData: {},
 	isLinked: false,
+	dateFormat: 'F j, Y',
 };
 
 export default DashStatsBottom;

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -5,9 +5,13 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { forEach, get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
-import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
-import { numberFormat, moment } from 'i18n-calypso';
+import { numberFormat } from 'i18n-calypso';
+
+/**
+ * WordPress dependencies
+ */
 import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -17,9 +21,10 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Chart from 'components/chart';
 import DashSectionHeader from 'components/dash-section-header';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import DashStatsBottom from './dash-stats-bottom';
 import { emptyStatsCardDismissed } from 'state/settings';
-import { getInitialStateStatsData } from 'state/initial-state';
+import { getInitialStateStatsData, getDateFormat } from 'state/initial-state';
 import getRedirectUrl from 'lib/jp-redirect';
 import { getStatsData, statsSwitchTab, fetchStatsData, getActiveStatsTab } from 'state/at-a-glance';
 import { imagePath } from 'constants/urls';
@@ -58,6 +63,15 @@ export class DashStats extends Component {
 
 		let totalViews = 0;
 
+		/* translators: short date format, such as: Jan 12. */
+		const shortMonthFormat = __( 'M j', 'jetpack' );
+
+		/* translators: long date format, such as: January 12th. */
+		const longMonthFormat = __( 'F jS', 'jetpack' );
+
+		/* translators: long month/year format, such as: January, 2021. */
+		const longMonthYearFormat = __( 'F, Y', 'jetpack' );
+
 		if ( 'object' !== typeof props.statsData[ unit ] ) {
 			return { chartData: s, totalViews: false };
 		}
@@ -72,19 +86,19 @@ export class DashStats extends Component {
 			totalViews += views;
 
 			if ( 'day' === unit ) {
-				chartLabel = moment( date ).format( 'MMM D' );
-				tooltipLabel = moment( date ).format( 'MMMM Do' );
+				chartLabel = dateI18n( shortMonthFormat, date );
+				tooltipLabel = dateI18n( longMonthFormat, date );
 			} else if ( 'week' === unit ) {
 				date = date.replace( /W/g, '-' );
-				chartLabel = moment( date ).format( 'MMM D' );
+				chartLabel = dateI18n( shortMonthFormat, date );
 				tooltipLabel = sprintf(
 					/* translators: placeholder is a date. */
 					__( 'Week of %s', 'jetpack' ),
-					moment( date ).format( 'MMMM Do' )
+					dateI18n( longMonthFormat, date )
 				);
 			} else if ( 'month' === unit ) {
-				chartLabel = moment( date ).format( 'MMM' );
-				tooltipLabel = moment( date ).format( 'MMMM, YYYY' );
+				chartLabel = dateI18n( 'M', date );
+				tooltipLabel = dateI18n( longMonthYearFormat, date );
 			}
 
 			s.push( {
@@ -139,6 +153,7 @@ export class DashStats extends Component {
 						siteAdminUrl={ this.props.siteAdminUrl }
 						isLinked={ this.props.isLinked }
 						connectUrl={ this.props.connectUrl }
+						dateFormat={ this.props.dateFormat }
 					/>
 				</div>
 			</div>
@@ -358,6 +373,7 @@ export default connect(
 	state => ( {
 		isModuleAvailable: isModuleAvailable( state, 'stats' ),
 		activeTab: getActiveStatsTab( state ),
+		dateFormat: getDateFormat( state ),
 		isOfflineMode: isOfflineMode( state ),
 		isLinked: isCurrentUserLinked( state ),
 		connectUrl: getConnectUrl( state ),

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -70,7 +70,7 @@ export class DashStats extends Component {
 		const longMonthFormat = __( 'F jS', 'jetpack' );
 
 		/* translators: long month/year format, such as: January, 2021. */
-		const longMonthYearFormat = __( 'F, Y', 'jetpack' );
+		const longMonthYearFormat = __( 'F Y', 'jetpack' );
 
 		if ( 'object' !== typeof props.statsData[ unit ] ) {
 			return { chartData: s, totalViews: false };


### PR DESCRIPTION
Follow-up to #17321


#### Changes proposed in this Pull Request:

* This should allow for better translations and date formatting in i18n languages for all date labels in the Stats graph of the Jetpack dashboard.

**Before (note the untranslated dates and months)**

<img width="575" alt="screenshot 2020-10-01 at 14 08 32" src="https://user-images.githubusercontent.com/426388/94807883-8b5b8f80-03f0-11eb-9f35-ed72cefc3c0c.png">
<img width="265" alt="screenshot 2020-10-01 at 14 08 24" src="https://user-images.githubusercontent.com/426388/94807886-8c8cbc80-03f0-11eb-9815-d78f6acceedc.png">

**After**

<img width="601" alt="screenshot 2020-10-01 at 14 14 29" src="https://user-images.githubusercontent.com/426388/94807924-97dfe800-03f0-11eb-80cb-7c0e6329d93e.png">
<img width="594" alt="screenshot 2020-10-01 at 14 14 08" src="https://user-images.githubusercontent.com/426388/94807925-99111500-03f0-11eb-930e-d1c1a59ade10.png">
<img width="302" alt="screenshot 2020-10-01 at 14 13 04" src="https://user-images.githubusercontent.com/426388/94807926-99111500-03f0-11eb-8f7d-fd7c9787e424.png">

#### Jetpack product discussion

* Related issues: #16481, #16397

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

You'll need an active site with some stats to be able to test things.

* Go to Jetpack > Dashboard
* Check the different views of the Stats graph (day / week / month)
* Check the dates in all labels and axis; they should be formatted properly.
* Check the "Best day" item at the bottom of the stats graph; that day should be formatted according to the settings under Settings > General.
* If you switch to a different language, that date should change to use the new language.

#### Proposed changelog entry for your changes:

* Dashboard: improve the display of dates in the Stats graph.
