### PR TITLE
Automatically adds current site url in getRedirectUrl

### DIFF
--- a/_inc/client/lib/jp-redirect/index.js
+++ b/_inc/client/lib/jp-redirect/index.js
@@ -1,3 +1,4 @@
+/* global jetpack_redirects */
 /**
  * Builds an URL using the jetpack.com/redirect/ service
  *
@@ -5,7 +6,7 @@
  *
  * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect/?url=https://wordpress.com
  *
- * Note: if using full URL, query parameters and anchor must be passed in $args. Any querystring of url fragment in the URL will be discarded.
+ * Note: if using full URL, query parameters and anchor must be passed in args. Any querystring of url fragment in the URL will be discarded.
  *
  * @since 8.5.0
  *
@@ -14,7 +15,7 @@
  *
  * 		Additional arguments to build the url
  *
- * 		@type {string} site URL of the current site.
+ * 		@type {string} site URL of the current site. Will default to the value of jetpack_redirects.currentSiteRawUrl, if available.
  * 		@type {string} path Additional path to be appended to the URL
  * 		@type {string} query Query parameters to be added to the URL
  * 		@type {string} anchor Anchor to be added to the URL
@@ -42,6 +43,14 @@ export default function getRedirectUrl( source, args = {} ) {
 			queryVars[ argName ] = encodeURIComponent( args[ argName ] );
 		}
 	} );
+
+	if (
+		! Object.keys( queryVars ).includes( 'site' ) &&
+		typeof jetpack_redirects !== 'undefined' &&
+		jetpack_redirects.hasOwnProperty( 'currentSiteRawUrl' )
+	) {
+		queryVars.site = jetpack_redirects.currentSiteRawUrl;
+	}
 
 	const queryString = Object.keys( queryVars )
 		.map( key => key + '=' + queryVars[ key ] )

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -187,6 +187,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		// Add objects to be passed to the initial state of the app.
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
 		wp_add_inline_script( 'react-plugin', 'var Initial_State=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $this->get_initial_state() ) ) . '"));', 'before' );
+
+		// This will set the default URL of the jp_redirects lib.
+		wp_add_inline_script( 'react-plugin', 'var jetpack_redirects = { currentSiteRawUrl: "' . Jetpack::build_raw_urls( get_home_url() ) . '" };', 'before' );
 	}
 
 	function get_initial_state() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Automatically append the current site in every link generated by the `getRedirectUrl` method of the `jp-redirects`lib.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a new global javascript variable to inform the jp-redirects lib about the current site url
* Changes the lib to 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1601493560050900-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `yarn docker build-client`
* Visit Jetpack Dashboard
* Confirm that the link to Support how includes a `site` parameter with the current site URL

![Captura de Tela 2020-10-01 às 11 55 57](https://user-images.githubusercontent.com/971483/94850152-e2676180-03fc-11eb-816b-c5f05763942d.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Automatically append the current site in every link generated by the `getRedirectUrl`