### PR TITLE
Connect button: Carry the "from" param when redirecting.

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -52,7 +52,8 @@ jQuery( document ).ready( function ( $ ) {
 		handleConnectInPlaceFlow: function () {
 			// Alternative connection buttons should redirect to the main one for the "connect in place" flow.
 			if ( connectButton.hasClass( 'jp-banner__alt-connect-button' ) ) {
-				window.location = jpConnect.connectInPlaceUrl;
+				// Make sure we don't lose the `from` parameter.
+				window.location = jpConnect.connectInPlaceUrl + '&from=' + connectButtonFrom;
 				return;
 			}
 
@@ -146,24 +147,24 @@ jQuery( document ).ready( function ( $ ) {
 
 			// Fetch plan type late to make sure any stored license keys have been
 			// attached to the site during the connection.
-			jetpackConnectButton.fetchPlanType()
-				.always( function () {
-					if ( ! jetpackConnectButton.isPaidPlan ) {
-						window.location.assign( jpConnect.plansPromptUrl );
-						return;
-					}
+			jetpackConnectButton.fetchPlanType().always( function () {
+				if ( ! jetpackConnectButton.isPaidPlan ) {
+					window.location.assign( jpConnect.plansPromptUrl );
+					return;
+				}
 
-					var parser = document.createElement('a');
-					parser.href = jpConnect.dashboardUrl;
-					var reload = window.location.pathname === parser.pathname && window.location.hash !== parser.hash;
+				var parser = document.createElement( 'a' );
+				parser.href = jpConnect.dashboardUrl;
+				var reload =
+					window.location.pathname === parser.pathname && window.location.hash !== parser.hash;
 
-					window.location.assign( jpConnect.dashboardUrl );
+				window.location.assign( jpConnect.dashboardUrl );
 
-					if ( reload ) {
-						// The Jetpack admin page has hashes in the URLs, so we need to reload the page after .assign()
-						window.location.reload( true );
-					}
-				} );
+				if ( reload ) {
+					// The Jetpack admin page has hashes in the URLs, so we need to reload the page after .assign()
+					window.location.reload( true );
+				}
+			} );
 		},
 		handleConnectionError: function ( error ) {
 			jetpackConnectButton.isRegistering = false;
@@ -172,7 +173,11 @@ jQuery( document ).ready( function ( $ ) {
 	};
 
 	// When we visit /wp-admin/admin.php?page=jetpack#/setup, immediately start the connection flow.
-	var hash = location.hash.replace( /#\//, '' );
+	var hash = location.hash.replace( /(#\/setup).*/, 'setup' );
+
+	// In case the parameter has been manually set in the URL after redirect.
+	connectButtonFrom = location.hash.split( '&from=' )[ 1 ];
+
 	if ( 'setup' === hash ) {
 		if ( connectionHelpSections.length ) {
 			connectionHelpSections.hide();

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -52,8 +52,9 @@ jQuery( document ).ready( function ( $ ) {
 		handleConnectInPlaceFlow: function () {
 			// Alternative connection buttons should redirect to the main one for the "connect in place" flow.
 			if ( connectButton.hasClass( 'jp-banner__alt-connect-button' ) ) {
-				// Make sure we don't lose the `from` parameter.
-				window.location = jpConnect.connectInPlaceUrl + '&from=' + connectButtonFrom;
+				// Make sure we don't lose the `from` parameter, if set.
+				var fromParam = ( connectButtonFrom && '&from=' + connectButtonFrom ) || '';
+				window.location = jpConnect.connectInPlaceUrl + fromParam;
 				return;
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #17344

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This change adds some logic that will manually carry over the `from` parameter from the original request, for cases such as #17344 where the flow starts in the wp-admin dashboard or plugins screen banner. 

One side effect of this approach is that the query parameter remains in the URL after the redirect happens `/wp-admin/admin.php?page=jetpack#/setup&from=connect-banner-72-dashboard`. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pbtFPC-PY-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes, we should be properly tracking the `from` if it's set in any connection flow. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Disconnect Jetpack
- From `/wp-admin/index.php`, click the "Set Up Jetpack" button in the banner at the top
- You should be redirected to the Jetpack dashboard as normal
- The registration step should still be done automatically
- You should end up landing on the user auth step
- When in the auth step, check the iframe source in the inspector, ensure that the `src` in the `<iframe class="jp-jetpack-connect__iframe"` element does not have an empty `from` parameter. 

- To verify the tracks was correctly recorded, visit the live view in MC, search for your wpcom username and the `wpcom_jpc_authorize_begin` event name. Expand that, and you should see the `from` param recorded correctly.

- Test with all other connection flows. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A
