### PR TITLE
Simple Payments: remove the duplicate use Automattic\Jetpack\Blocks

### DIFF
--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -11,7 +11,6 @@ namespace Automattic\Jetpack\Extensions\SimplePayments;
 
 use Automattic\Jetpack\Blocks;
 use Jetpack_Simple_Payments;
-use Automattic\Jetpack\Blocks;
 
 const FEATURE_NAME = 'simple-payments';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Remove the duplicate `use Automattic\Jetpack\Blocks` statement introduced in https://github.com/Automattic/jetpack/commit/f93ff480383680c0ad342fbdb14267952586e409#diff-7e876fff2a20f1ed2b54d7e106c0ff18R14

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* n/a
