### PR TITLE
Publicize: Add Twitter thread limits

### DIFF
--- a/extensions/blocks/publicize/index.js
+++ b/extensions/blocks/publicize/index.js
@@ -45,7 +45,7 @@ export const settings = {
 					</span>
 				}
 			>
-				<PublicizePanel />
+				<PublicizePanel prePublish={ true } />
 			</PluginPrePublishPanel>
 		</PostTypeSupportCheck>
 	),

--- a/extensions/blocks/publicize/panel.js
+++ b/extensions/blocks/publicize/panel.js
@@ -22,7 +22,7 @@ import PublicizeForm from './form';
 import PublicizeSettingsButton from './settings-button';
 import PublicizeTwitterOptions from './twitter/options';
 
-const PublicizePanel = ( { connections, refreshConnections } ) => (
+const PublicizePanel = ( { connections, refreshConnections, prePublish } ) => (
 	<Fragment>
 		{ connections && connections.some( connection => connection.enabled ) && (
 			<PublicizeConnectionVerify />
@@ -33,7 +33,7 @@ const PublicizePanel = ( { connections, refreshConnections } ) => (
 		{ connections && connections.length > 0 && (
 			<PublicizeForm refreshCallback={ refreshConnections } />
 		) }
-		<PublicizeTwitterOptions />
+		<PublicizeTwitterOptions prePublish={ prePublish } />
 		{ connections && 0 === connections.length && (
 			<PublicizeSettingsButton
 				className="jetpack-publicize-add-connection-wrapper"

--- a/extensions/blocks/publicize/store/selectors.js
+++ b/extensions/blocks/publicize/store/selectors.js
@@ -157,7 +157,7 @@ export function getLastTweet( state ) {
 	const message =
 		state.tweets.length > 100
 			? __( 'The rest of this thread can be read here:', 'jetpack' )
-			: __( 'This thread can also be read here:', 'jetpack' );
+			: __( 'This thread can be read here:', 'jetpack' );
 
 	return {
 		...getFirstTweet( state ),

--- a/extensions/blocks/publicize/store/selectors.js
+++ b/extensions/blocks/publicize/store/selectors.js
@@ -78,7 +78,7 @@ export function getTweetStorm( state ) {
 
 	const thread = [
 		getFirstTweet( state ),
-		...state.tweets.map( tweet => ( {
+		...state.tweets.slice( 0, 100 ).map( tweet => ( {
 			...tweetTemplate,
 			text: tweet.text,
 			media: tweet.media,
@@ -154,11 +154,16 @@ export function getLastTweet( state ) {
 	const { getEditedPostAttribute } = select( 'core/editor' );
 	const url = getEditedPostAttribute( 'link' );
 
+	const message =
+		state.tweets.length > 100
+			? __( 'The rest of this thread can be read here:', 'jetpack' )
+			: __( 'This thread can also be read here:', 'jetpack' );
+
 	return {
 		...getFirstTweet( state ),
 		// The URL is deliberately not included in the translatable string, as it must always
 		// be the last thing in the tweet text.
-		text: __( "I've also published this thread on my site:", 'jetpack' ) + ` ${ url }`,
+		text: `${ message } ${ url }`,
 	};
 }
 

--- a/extensions/blocks/publicize/twitter/editor.scss
+++ b/extensions/blocks/publicize/twitter/editor.scss
@@ -2,9 +2,17 @@ h3.jetpack-publicize-twitter-options__heading {
 	margin-top: 1em;
 }
 
-.jetpack-publicize-twitter-options__preview {
-	width: 100%;
-	justify-content: center;
+.jetpack-publicize-twitter-options__notices {
+	.components-notice {
+		margin-left: 0;
+		margin-right: 0;
+		padding: 0 0 0 8px;
+
+		.components-notice__content {
+			margin-top: 8px;
+			margin-bottom: 8px;
+		}
+	}
 }
 
 .jetpack-publicize-twitter__tweet-divider {

--- a/extensions/blocks/publicize/twitter/options.js
+++ b/extensions/blocks/publicize/twitter/options.js
@@ -6,7 +6,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RadioControl } from '@wordpress/components';
+import { NoticeList, RadioControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 // Because the wp-annotations script isn't loaded by default in the block editor, importing
@@ -18,7 +18,13 @@ import '@wordpress/annotations';
  */
 import './editor.scss';
 
-const PublicizeTwitterOptions = ( { connections, isTweetStorm, setTweetstorm } ) => {
+const PublicizeTwitterOptions = ( {
+	connections,
+	isTweetStorm,
+	tweetStormLength,
+	setTweetstorm,
+	prePublish,
+} ) => {
 	if ( ! connections.some( connection => 'twitter' === connection.service_name ) ) {
 		return null;
 	}
@@ -30,6 +36,37 @@ const PublicizeTwitterOptions = ( { connections, isTweetStorm, setTweetstorm } )
 			setTweetstorm( false );
 		}
 	};
+
+	const notices = [];
+
+	if ( tweetStormLength >= 102 ) {
+		notices.push( {
+			id: 'jetpack-publicize-twitter-tweetstorm-too-long',
+			status: 'error',
+			content: __(
+				'Only the first 100 tweets of this post will be published in the Twitter thread.',
+				'jetpack'
+			),
+			isDismissible: false,
+		} );
+	} else if ( tweetStormLength >= 22 ) {
+		notices.push( {
+			id: 'jetpack-publicize-twitter-tweetstorm-a-bit-long',
+			status: 'warning',
+			content: __( 'This post will create a Twitter thread more than 20 tweets long.', 'jetpack' ),
+			isDismissible: false,
+		} );
+	} else if ( prePublish && tweetStormLength <= 2 ) {
+		notices.push( {
+			id: 'jetpack-publicize-twitter-tweetstorm-too-short',
+			status: 'warning',
+			content: __(
+				'None of the content in this post could be transformed into tweets, it may be better to share as a single tweet.',
+				'jetpack'
+			),
+			isDismissible: false,
+		} );
+	}
 
 	return (
 		<>
@@ -53,15 +90,24 @@ const PublicizeTwitterOptions = ( { connections, isTweetStorm, setTweetstorm } )
 				] }
 				onChange={ tweetTypeChange }
 			/>
+			{ isTweetStorm && (
+				<NoticeList className="jetpack-publicize-twitter-options__notices" notices={ notices } />
+			) }
 		</>
 	);
 };
 
 export default compose( [
-	withSelect( select => ( {
-		connections: select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_connections' ),
-		isTweetStorm: select( 'jetpack/publicize' ).isTweetStorm(),
-	} ) ),
+	withSelect( select => {
+		const { isTweetStorm, getTweetStorm } = select( 'jetpack/publicize' );
+		return {
+			connections: select( 'core/editor' ).getEditedPostAttribute(
+				'jetpack_publicize_connections'
+			),
+			isTweetStorm: isTweetStorm(),
+			tweetStormLength: getTweetStorm().length,
+		};
+	} ),
 	withDispatch( dispatch => ( {
 		setTweetstorm: value => {
 			dispatch( 'core/editor' ).editPost( { meta: { jetpack_is_tweetstorm: value } } );

--- a/extensions/blocks/social-previews/modal.js
+++ b/extensions/blocks/social-previews/modal.js
@@ -125,6 +125,6 @@ export default withSelect( ( select, props ) => {
 	return {
 		...postData,
 		tweets,
-		isTweetStorm,
+		isTweetStorm: isTweetStorm(),
 	};
 } )( SocialPreviewsModal );


### PR DESCRIPTION
This PR adds warnings for Twitter threads with unusual lengths:

- Add a pre-publish warning-level notice when the post will produce zero tweets.
- Add a warning-level notice when the post will produce more than 20 tweets.
- Add an error-level notice when the post hits the 100 tweet limit.

The 20/100 tweet limits don't include the bookend tweets.

See #17149.

The 100 tweet limit is enforced on the server-side in D50541-code.

<img width="250" alt="" src="https://user-images.githubusercontent.com/352291/94893180-ead99e00-04c9-11eb-89e0-af06fcb212da.png"> <img width="250" alt="" src="https://user-images.githubusercontent.com/352291/94893179-e9a87100-04c9-11eb-8dda-af30bab54b4f.png"> <img width="250" alt="" src="https://user-images.githubusercontent.com/352291/94893172-e6ad8080-04c9-11eb-962d-c02ba41bf49c.png">

#### Changes proposed in this Pull Request:
* Adds thread length warnings to the Twitter options Publicize panel.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Create a new post.
* Test that the warning messages show.

#### Proposed changelog entry for your changes:
* None needed.
