### PR TITLE
Pay with PayPal: Check `amp_is_canonical` exists

### DIFF
--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -88,7 +88,7 @@ function render_block( $attr, $content ) {
 function amp_skip_post( $skip, $post_id, $post ) {
 	// When AMP is on standard mode, there are no non-AMP posts to link to where the purchase can be completed, so let's
 	// prevent the post from being available in AMP.
-	if ( Blocks::amp_is_canonical() && has_block( 'jetpack/simple-payments', $post->post_content ) ) {
+	if ( Blocks::is_amp_canonical() && has_block( 'jetpack/simple-payments', $post->post_content ) ) {
 		return true;
 	}
 	return $skip;

--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -88,7 +88,7 @@ function render_block( $attr, $content ) {
 function amp_skip_post( $skip, $post_id, $post ) {
 	// When AMP is on standard mode, there are no non-AMP posts to link to where the purchase can be completed, so let's
 	// prevent the post from being available in AMP.
-	if ( function_exists( 'amp_is_canonical' ) && amp_is_canonical() && has_block( 'jetpack/simple-payments', $post->post_content ) ) {
+	if ( function_exists( 'amp_is_canonical' ) && \amp_is_canonical() && has_block( 'jetpack/simple-payments', $post->post_content ) ) {
 		return true;
 	}
 	return $skip;

--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -88,7 +88,7 @@ function render_block( $attr, $content ) {
 function amp_skip_post( $skip, $post_id, $post ) {
 	// When AMP is on standard mode, there are no non-AMP posts to link to where the purchase can be completed, so let's
 	// prevent the post from being available in AMP.
-	if ( amp_is_canonical() && has_block( 'jetpack/simple-payments', $post->post_content ) ) {
+	if ( Blocks::amp_is_canonical() && has_block( 'jetpack/simple-payments', $post->post_content ) ) {
 		return true;
 	}
 	return $skip;

--- a/extensions/blocks/simple-payments/simple-payments.php
+++ b/extensions/blocks/simple-payments/simple-payments.php
@@ -88,7 +88,7 @@ function render_block( $attr, $content ) {
 function amp_skip_post( $skip, $post_id, $post ) {
 	// When AMP is on standard mode, there are no non-AMP posts to link to where the purchase can be completed, so let's
 	// prevent the post from being available in AMP.
-	if ( Blocks::is_amp_canonical() && has_block( 'jetpack/simple-payments', $post->post_content ) ) {
+	if ( function_exists( 'amp_is_canonical' ) && amp_is_canonical() && has_block( 'jetpack/simple-payments', $post->post_content ) ) {
 		return true;
 	}
 	return $skip;

--- a/packages/blocks/src/class-blocks.php
+++ b/packages/blocks/src/class-blocks.php
@@ -226,4 +226,14 @@ class Blocks {
 		/** This filter is documented in 3rd-party/class.jetpack-amp-support.php */
 		return apply_filters( 'jetpack_is_amp_request', $is_amp_request );
 	}
+
+	/**
+	 * Is the page in AMP 'canonical mode'.
+	 * Used when themes register support for AMP with `add_theme_support( 'amp' )`.
+	 *
+	 * @return bool is_amp_canonical
+	 */
+	public static function is_amp_canonical() {
+		return function_exists( 'amp_is_canonical' ) && amp_is_canonical();
+	}
 }

--- a/packages/blocks/src/class-blocks.php
+++ b/packages/blocks/src/class-blocks.php
@@ -226,14 +226,4 @@ class Blocks {
 		/** This filter is documented in 3rd-party/class.jetpack-amp-support.php */
 		return apply_filters( 'jetpack_is_amp_request', $is_amp_request );
 	}
-
-	/**
-	 * Is the page in AMP 'canonical mode'.
-	 * Used when themes register support for AMP with `add_theme_support( 'amp' )`.
-	 *
-	 * @return bool is_amp_canonical
-	 */
-	public static function is_amp_canonical() {
-		return function_exists( 'amp_is_canonical' ) && amp_is_canonical();
-	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds a safeguard check that ensures the `amp_is_canonical` function exists before calling to it.

This change shouldn't modify any behavior in Jetpack sites, but it should solve the fatals we were seeing in WP.com after landing the counterpart diff of https://github.com/Automattic/jetpack/pull/17298:
```
Uncaught Error: Call to undefined function Automattic\Jetpack\Extensions\SimplePayments\amp_is_canonical()
```

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- [Spin up a JN site running this branch](https://jurassic.ninja/create/?jetpack-beta&branch=add/blocks-amp-is-canonical).
- Set up Jetpack and purchase any paid plan.
- Go to WP Admin > Plugins > Add new.
- Install and activate the AMP plugin.
- Go to WP Admin > AMP.
- Switch to the "Standard" mode.
- Go to WP Admin > Posts > Add new.
- Insert a Pay with PayPal block.
- Open the sidebar.
- Change the purchase link text.
- Publish the post.
- Visit the AMP version of the published post by going to the post URL with a ?amp added at the end (e.g.: https://example.com/2020/09/29/post-slug/?amp).
- Make sure AMP is skipped and the non-AMP version is displayed (the one with a PayPal button).

#### Proposed changelog entry for your changes:
N/A.
