### PR TITLE
Fix `use` statement sorting

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -1,7 +1,7 @@
 <?php
 
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 
 // Shared logic between Jetpack admin pages
 abstract class Jetpack_Admin_Page {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,9 +1,9 @@
 <?php
-use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Connection\REST_Connector;
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Licensing;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Partner;
+use Automattic\Jetpack\Status;
 
 include_once( 'class.jetpack-admin-page.php' );
 

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -1,7 +1,7 @@
 <?php
 
-use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Tracking;
 
 include_once( 'class.jetpack-admin-page.php' );
 include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1,9 +1,9 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Jetpack_CRM_Data;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\REST_Connector;
+use Automattic\Jetpack\Jetpack_CRM_Data;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Tracking;

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -7,13 +7,13 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Connection\Utils as Connection_Utils;
-use Automattic\Jetpack\Sync\Modules;
-use Automattic\Jetpack\Sync\Settings as Sync_Settings;
-use Automattic\Jetpack\Sync\Health as Sync_Health;
-use Automattic\Jetpack\Sync\Sender as Sync_Sender;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Sync\Health as Sync_Health;
+use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Sender as Sync_Sender;
+use Automattic\Jetpack\Sync\Settings as Sync_Settings;
 
 /**
  * Class Jetpack_Cxn_Tests contains all of the actual tests.

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -5,12 +5,12 @@
  * @package jetpack
  */
 
-use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Sync\Modules;
-use Automattic\Jetpack\Sync\Functions;
-use Automattic\Jetpack\Sync\Sender;
-use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Sync\Functions;
+use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Sender;
 
 /**
  * Class Jetpack_Debug_Data

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -5,8 +5,8 @@
  * @package jetpack
  */
 
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 
 /**
  * Class Jetpack_Debugger

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -1,7 +1,7 @@
 <?php
 
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
+use Automattic\Jetpack\Status;
 
 // Build the Jetpack admin menu as a whole
 class Jetpack_Admin {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5,12 +5,15 @@ use Automattic\Jetpack\Config;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Nonce_Handler;
-use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Partner;
+use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Functions;
@@ -19,9 +22,6 @@ use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Users;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
-use Automattic\Jetpack\Redirect;
-use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 
 /*
 Options:

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -10,9 +10,9 @@
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 use Automattic\Jetpack\Blocks;
-use WP_Error;
 use Jetpack_Gutenberg;
 use Jetpack_Podcast_Helper;
+use WP_Error;
 
 const FEATURE_NAME = 'podcast-player';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;

--- a/functions.global.php
+++ b/functions.global.php
@@ -11,8 +11,8 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Device_Detection;
+use Automattic\Jetpack\Redirect;
 
 /**
  * Disable direct access.

--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -1,8 +1,8 @@
 <?php
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
+use Automattic\Jetpack\Redirect;
 
 class Jetpack_Custom_CSS {
 	static function init() {

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -3,9 +3,9 @@
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Scan\Admin_Bar_Notice;
-use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 
 require_once dirname( __FILE__ ) . '/rtl-admin-bar.php';
 

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -1,8 +1,8 @@
 <?php
 
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Tracking;
 
 /**
  * Disable direct access and execution.

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -12,8 +12,8 @@
  * Additional Search Queries: security, jetpack protect, secure, protection, botnet, brute force, protect, login, bot, password, passwords, strong passwords, strong password, wp-login.php,  protect admin
  */
 
-use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Connection\Utils as Connection_Utils;
+use Automattic\Jetpack\Constants;
 
 include_once JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php';
 

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -15,8 +15,8 @@
  * @package Jetpack
  */
 
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 
 if ( ! function_exists( 'sharing_init' ) ) {
 	require dirname( __FILE__ ) . '/sharedaddy/sharedaddy.php';

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1,9 +1,9 @@
 <?php
 
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\Redirect;
 
 require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' );
 require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-notices.php' );

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -14,11 +14,11 @@
  * @package Jetpack
  */
 
-use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\XMLRPC_Async_Call;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Tracking;
 
 if ( defined( 'STATS_VERSION' ) ) {
 	return;

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -8,8 +8,8 @@
  */
 
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 
 add_action( 'widgets_init', 'jetpack_search_widget_init' );
 

--- a/packages/abtest/tests/php/test-abtest.php
+++ b/packages/abtest/tests/php/test-abtest.php
@@ -8,9 +8,9 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Abtest;
-use PHPUnit\Framework\TestCase;
 use phpmock\Mock;
 use phpmock\MockBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Test_Abtest

--- a/packages/analyzer/src/Declarations/class-visitor.php
+++ b/packages/analyzer/src/Declarations/class-visitor.php
@@ -2,9 +2,9 @@
 
 namespace Automattic\Jetpack\Analyzer\Declarations;
 
-use PhpParser\NodeVisitorAbstract;
-use PhpParser\Node;
 use Automattic\Jetpack\Analyzer\Utils;
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
 
 class Visitor extends NodeVisitorAbstract {
 	private $current_class;

--- a/packages/analyzer/src/Differences/class-class-const-missing.php
+++ b/packages/analyzer/src/Differences/class-class-const-missing.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Const;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-class-const-moved.php
+++ b/packages/analyzer/src/Differences/class-class-const-moved.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Const;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-class-method-deprecated.php
+++ b/packages/analyzer/src/Differences/class-class-method-deprecated.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Call;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-class-method-missing.php
+++ b/packages/analyzer/src/Differences/class-class-method-missing.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Call;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-class-method-moved.php
+++ b/packages/analyzer/src/Differences/class-class-method-moved.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Call;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-class-missing.php
+++ b/packages/analyzer/src/Differences/class-class-missing.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\New_;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-class-moved.php
+++ b/packages/analyzer/src/Differences/class-class-moved.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\New_;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-class-property-missing.php
+++ b/packages/analyzer/src/Differences/class-class-property-missing.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Property;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-class-property-moved.php
+++ b/packages/analyzer/src/Differences/class-class-property-moved.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Property;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-function-deprecated.php
+++ b/packages/analyzer/src/Differences/class-function-deprecated.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Function_Call;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-function-missing.php
+++ b/packages/analyzer/src/Differences/class-function-missing.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Function_Call;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Differences/class-function-moved.php
+++ b/packages/analyzer/src/Differences/class-function-moved.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Function_Call;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**

--- a/packages/analyzer/src/Invocations/class-function-call.php
+++ b/packages/analyzer/src/Invocations/class-function-call.php
@@ -2,8 +2,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Declarations\Function_;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 
 /**
  * Invocations of a function

--- a/packages/analyzer/src/Invocations/class-new.php
+++ b/packages/analyzer/src/Invocations/class-new.php
@@ -2,8 +2,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Declarations\Class_;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 
 /**
  * Instantiation of a class

--- a/packages/analyzer/src/Invocations/class-static-call.php
+++ b/packages/analyzer/src/Invocations/class-static-call.php
@@ -2,8 +2,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Declarations\Class_Method;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 
 /**
  * Instantiation of a class

--- a/packages/analyzer/src/Invocations/class-static-const.php
+++ b/packages/analyzer/src/Invocations/class-static-const.php
@@ -2,8 +2,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Declarations\Class_Const;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 
 /**
  * Instantiation of a class

--- a/packages/analyzer/src/Invocations/class-static-property.php
+++ b/packages/analyzer/src/Invocations/class-static-property.php
@@ -2,8 +2,8 @@
 
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
-use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Declarations\Class_Property;
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 
 /**
  * Instantiation of a class

--- a/packages/analyzer/src/Invocations/class-visitor.php
+++ b/packages/analyzer/src/Invocations/class-visitor.php
@@ -2,9 +2,9 @@
 
 namespace Automattic\Jetpack\Analyzer\Invocations;
 
-use PhpParser\NodeVisitorAbstract;
-use PhpParser\Node;
 use Automattic\Jetpack\Analyzer\Utils;
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
 
 class Visitor extends NodeVisitorAbstract {
 	private $invocations;

--- a/packages/analyzer/src/class-declarations.php
+++ b/packages/analyzer/src/class-declarations.php
@@ -2,9 +2,9 @@
 
 namespace Automattic\Jetpack\Analyzer;
 
-use PhpParser\ParserFactory;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
 
 class Declarations extends PersistentList {
 

--- a/packages/analyzer/src/class-differences.php
+++ b/packages/analyzer/src/class-differences.php
@@ -2,10 +2,10 @@
 
 namespace Automattic\Jetpack\Analyzer;
 
-use PhpParser\ParserFactory;
-use PhpParser\NodeTraverser;
 use PhpParser\NodeDumper;
+use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
 
 class Differences extends PersistentList {
 

--- a/packages/analyzer/src/class-invocations.php
+++ b/packages/analyzer/src/class-invocations.php
@@ -2,10 +2,10 @@
 
 namespace Automattic\Jetpack\Analyzer;
 
-use PhpParser\ParserFactory;
-use PhpParser\NodeTraverser;
 use PhpParser\NodeDumper;
+use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
 
 
 /**

--- a/packages/assets/tests/php/test-assets.php
+++ b/packages/assets/tests/php/test-assets.php
@@ -7,10 +7,10 @@
 
 namespace Automattic\Jetpack;
 
-use PHPUnit\Framework\TestCase;
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Brain\Monkey;
 use Brain\Monkey\Filters;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Retrieves a URL within the plugins or mu-plugins directory.

--- a/packages/autoloader/src/CustomAutoloaderPlugin.php
+++ b/packages/autoloader/src/CustomAutoloaderPlugin.php
@@ -15,11 +15,11 @@
 namespace Automattic\Jetpack\Autoloader;
 
 use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
-use Composer\Plugin\PluginInterface;
-use Composer\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Class CustomAutoloaderPlugin.

--- a/packages/autoloader/tests/php/tests/test_AutoloadProcessor.php
+++ b/packages/autoloader/tests/php/tests/test_AutoloadProcessor.php
@@ -5,8 +5,8 @@
  * @package automattic/jetpack-autoloader
  */
 
-use PHPUnit\Framework\TestCase;
 use Automattic\Jetpack\Autoloader\AutoloadProcessor;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test suite class for the Autoload processor.

--- a/packages/autoloader/tests/php/tests/test_Autoloader.php
+++ b/packages/autoloader/tests/php/tests/test_Autoloader.php
@@ -5,8 +5,8 @@
  * @package automattic/jetpack-autoloader
  */
 
-use PHPUnit\Framework\TestCase;
 use Jetpack\AutoloaderTestData\Plugin\Test;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test suite class for the Autoloader.

--- a/packages/autoloader/tests/php/tests/test_ManifestGenerator.php
+++ b/packages/autoloader/tests/php/tests/test_ManifestGenerator.php
@@ -5,8 +5,8 @@
  * @package automattic/jetpack-autoloader
  */
 
-use PHPUnit\Framework\TestCase;
 use Automattic\Jetpack\Autoloader\ManifestGenerator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test suite class for the manifest generator

--- a/packages/autoloader/tests/php/tests/test_version_loader.php
+++ b/packages/autoloader/tests/php/tests/test_version_loader.php
@@ -5,9 +5,9 @@
  * @package automattic/jetpack-autoloader
  */
 
-use PHPUnit\Framework\TestCase;
-use \Jetpack\AutoloaderTestData\Plugin\Test;
 use \Jetpack\AutoloaderTestData\Plugin\Psr4\Test as Psr4Test;
+use \Jetpack\AutoloaderTestData\Plugin\Test;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test suite class for the Autoloader part that handles file loading.

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -13,9 +13,9 @@ namespace Automattic\Jetpack;
  * must require the corresponding packages to use these features.
  */
 use Automattic\Jetpack\Connection\Manager;
-use Automattic\Jetpack\JITMS\JITM as JITMS_JITM;
-use Automattic\Jetpack\JITM as JITM;
 use Automattic\Jetpack\Connection\Plugin;
+use Automattic\Jetpack\JITM as JITM;
+use Automattic\Jetpack\JITMS\JITM as JITMS_JITM;
 use Automattic\Jetpack\Sync\Main as Sync_Main;
 
 /**

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -9,8 +9,8 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Roles;
-use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Functions;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Sender;
 
 /**

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -8,13 +8,13 @@
 namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Heartbeat;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
 use WP_Error;
 use WP_User;
-use Automattic\Jetpack\Heartbeat;
 
 /**
  * The Jetpack Connection Manager class that is used as a single gateway between WordPress.com

--- a/packages/connection/tests/php/test-rest-endpoints.php
+++ b/packages/connection/tests/php/test-rest-endpoints.php
@@ -7,10 +7,10 @@ use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
 use Automattic\Jetpack\Constants;
 use phpmock\MockBuilder;
 use PHPUnit\Framework\TestCase;
+use Requests_Utility_CaseInsensitiveDictionary;
 use WorDBless\Options as WorDBless_Options;
 use WP_REST_Request;
 use WP_REST_Server;
-use Requests_Utility_CaseInsensitiveDictionary;
 use WP_User;
 
 /**

--- a/packages/device-detection/tests/php/test_DeviceDetection.php
+++ b/packages/device-detection/tests/php/test_DeviceDetection.php
@@ -7,8 +7,8 @@
  * @phpcs:disable WordPress.Files.FileName
  */
 
-use PHPUnit\Framework\TestCase;
 use Automattic\Jetpack\Device_Detection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for the Device_Detection class.

--- a/packages/heartbeat/src/class-heartbeat.php
+++ b/packages/heartbeat/src/class-heartbeat.php
@@ -8,8 +8,8 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\A8c_Mc_Stats;
-use WP_CLI;
 use Jetpack_Options;
+use WP_CLI;
 
 /**
  * Heartbeat sends a batch of stats to wp.com once a day

--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -9,9 +9,9 @@ namespace Automattic\Jetpack\JITMS;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
-use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\JITMS\Post_Connection_JITM;
 use Automattic\Jetpack\JITMS\Pre_Connection_JITM;
+use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\Status;
 
 /**

--- a/packages/jitm/src/class-post-connection-jitm.php
+++ b/packages/jitm/src/class-post-connection-jitm.php
@@ -9,10 +9,10 @@ namespace Automattic\Jetpack\JITMS;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\JITMS\JITM;
 
 /**
  * Jetpack just in time messaging through out the admin

--- a/packages/partner/tests/php/test-partner.php
+++ b/packages/partner/tests/php/test-partner.php
@@ -7,11 +7,11 @@
 
 namespace Automattic\Jetpack;
 
+use Brain\Monkey;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
 
-use Brain\Monkey;
-use Brain\Monkey\Functions;
-use Brain\Monkey\Filters;
 
 /**
  * Class Partner_Test

--- a/packages/roles/tests/php/test-roles.php
+++ b/packages/roles/tests/php/test-roles.php
@@ -8,9 +8,9 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Roles;
-use PHPUnit\Framework\TestCase;
 use phpmock\Mock;
 use phpmock\MockBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Test_Roles

--- a/packages/status/tests/php/test-status.php
+++ b/packages/status/tests/php/test-status.php
@@ -8,12 +8,12 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Status;
-use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
 use phpmock\Mock;
 use phpmock\MockBuilder;
-use Brain\Monkey;
-use Brain\Monkey\Functions;
-use Brain\Monkey\Filters;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Status test suite.

--- a/packages/sync/src/class-users.php
+++ b/packages/sync/src/class-users.php
@@ -8,8 +8,8 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
-use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Connection\XMLRPC_Async_Call;
+use Automattic\Jetpack\Roles;
 
 /**
  * Class Users.

--- a/packages/sync/src/modules/class-callables.php
+++ b/packages/sync/src/modules/class-callables.php
@@ -7,10 +7,10 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
-use Automattic\Jetpack\Sync\Functions;
-use Automattic\Jetpack\Sync\Defaults;
-use Automattic\Jetpack\Sync\Settings;
 use Automattic\Jetpack\Constants as Jetpack_Constants;
+use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Functions;
+use Automattic\Jetpack\Sync\Settings;
 
 /**
  * Class to handle sync for callables.

--- a/packages/sync/src/modules/class-comments.php
+++ b/packages/sync/src/modules/class-comments.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
-use Automattic\Jetpack\Sync\Settings;
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Settings;
 
 /**
  * Class to handle sync for comments.

--- a/packages/terms-of-service/tests/php/test-terms-of-service.php
+++ b/packages/terms-of-service/tests/php/test-terms-of-service.php
@@ -7,9 +7,9 @@
 
 namespace Automattic\Jetpack;
 
-use PHPUnit\Framework\TestCase;
 use phpmock\Mock;
 use phpmock\MockBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Test_Terms_Of_Service

--- a/src/class-tracking.php
+++ b/src/class-tracking.php
@@ -1,8 +1,8 @@
 <?php
 namespace Automattic\Jetpack\Plugin;
 
-use Automattic\Jetpack\Tracking as Tracks;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Tracking as Tracks;
 
 class Tracking {
 	/**

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -1,7 +1,7 @@
 <?php
 
-use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Constants;
 
 /**
  * @covers Jetpack_Data

--- a/tests/php/general/test_class.jetpack-xmlrpc-server.php
+++ b/tests/php/general/test_class.jetpack-xmlrpc-server.php
@@ -1,7 +1,7 @@
 <?php
 
-use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Connection\Utils as Connection_Utils;
+use Automattic\Jetpack\Sync\Sender;
 
 class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 	static $xmlrpc_admin = 0;

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -1,8 +1,8 @@
 <?php
 
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\Status;
 

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -1,7 +1,7 @@
 <?php
 
-use Automattic\Jetpack\Sync\Replicastore_Interface;
 use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Replicastore_Interface;
 
 /**
  * A simple in-memory implementation of iJetpack_Sync_Replicastore

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -1,14 +1,14 @@
 <?php
 
-use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
-use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Main;
+use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Modules\Constants;
+use Automattic\Jetpack\Sync\Modules\Posts;
 use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
-use Automattic\Jetpack\Sync\Modules\Posts;
 
 $sync_server_dir = dirname( __FILE__ ) . '/server/';
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1,7 +1,7 @@
 <?php
 
-use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Functions;

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -1,7 +1,7 @@
 <?php
 
-use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Constants;
 
 /**

--- a/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -1,10 +1,10 @@
 <?php
 
 use Automattic\Jetpack\Sync\Actions;
+use Automattic\Jetpack\Sync\Health;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Full_Sync;
 use Automattic\Jetpack\Sync\Settings;
-use Automattic\Jetpack\Sync\Health;
 
 if ( ! function_exists( 'jetpack_foo_full_sync_callable' ) ) {
 	function jetpack_foo_full_sync_callable() {

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -2,8 +2,8 @@
 
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Defaults;
-use Automattic\Jetpack\Sync\Settings;
 use Automattic\Jetpack\Sync\Health;
+use Automattic\Jetpack\Sync\Settings;
 
 class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 	function test_never_queues_if_development() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -2,8 +2,8 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Roles;
-use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Settings;
 
 /**

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -1,8 +1,8 @@
 <?php
 
-use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Lock;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Settings;
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -1,8 +1,8 @@
 <?php
 
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Sync\Users;
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Users;
 
 /**
  * Testing CRUD on Users

--- a/uninstall.php
+++ b/uninstall.php
@@ -5,8 +5,8 @@
  * @package Jetpack
  */
 
-use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Backup\Helper_Script_Manager;
+use Automattic\Jetpack\Sync\Sender;
 
 if (
 	!defined( 'WP_UNINSTALL_PLUGIN' )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This sorts the `use` statements to fix the sniff added in #17361. It should not change any functionality.

It was generated by executing `composer php:autofix -- --sniffs=Jetpack.Classes.UnsortedUseStatements`.

This patch is "not verified" because touching them makes phpcs start whining about all the *other* phpcs failures in those files. I'd rather keep this to fixing just the newly-added sniff.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure everything still works?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No functionality change, so no changelog entry should be needed.
