### PR TITLE
Content Options: filter to disable featured image removal for CPT

### DIFF
--- a/modules/theme-tools/content-options/featured-images.php
+++ b/modules/theme-tools/content-options/featured-images.php
@@ -5,8 +5,22 @@
 function jetpack_featured_images_remove_post_thumbnail( $metadata, $object_id, $meta_key, $single ) {
 	$opts = jetpack_featured_images_get_settings();
 
-	// Automatically return metadata if it's a PayPal product - we don't want to hide the Featured Image.
-	if ( 'jp_pay_product' === get_post_type( $object_id ) ) {
+	/**
+	 * Allow featured images to be displayed at all times for specific CPTs.
+	 *
+	 * @module theme-tools
+	 *
+	 * @since 9.1.0
+	 *
+	 * @param array $excluded_post_types Array of excluded post types.
+	 */
+	$excluded_post_types = apply_filters(
+		'jetpack_content_options_featured_image_exclude_cpt',
+		array( 'jp_pay_product' )
+	);
+
+	// Automatically return metadata for specific post types, when we don't want to hide the Featured Image.
+	if ( in_array( get_post_type( $object_id ), $excluded_post_types, true ) ) {
 		return $metadata;
 	}
 


### PR DESCRIPTION
Fixes #17345
Fixes #13107 


#### Changes proposed in this Pull Request:

This will give plugin and theme authors more control over Jetpack's content options settings and how they impact CPTs.


#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:

* On a site with the Jetpack plugin installed and active, activate the "Rebalance" theme.
* Go to Jetpack > Settings > Writing, and activate Jetpack's Portfolios. 
* Go to Portfolio > Add New, and publish a portfolio item, with Featured image
* View that Portfolio item, you should see the Featured Image at the top of the page.
* Go to Appearance > Customize > Content Options, and disable featured images for single projects.
* Refresh the page; the featured image should be gone.

#### Proposed changelog entry for your changes:

* Content Options: add new filter to allow theme and plugin authors to disable featured image removal for their Custom Post Types.