### PR TITLE
Publicize: avoid errors when Publicize isn't available

### DIFF
--- a/extensions/blocks/publicize/store/selectors.js
+++ b/extensions/blocks/publicize/store/selectors.js
@@ -288,7 +288,7 @@ export function getShareMessageMaxLength() {
  * @returns {boolean} Whether or not it's a tweetstorm.
  */
 export function isTweetStorm() {
-	return !! select( 'core/editor' ).getEditedPostAttribute( 'meta' ).jetpack_is_tweetstorm;
+	return !! select( 'core/editor' ).getEditedPostAttribute( 'meta' )?.jetpack_is_tweetstorm;
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Let's avoid block editor errors when Publicize isn't available for a Custom Post Type.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site that's connected to WordPress.com, and where Publicize is disabled.
* Go to Jetpack > Settings > Writing, and activate Jetpack's Portfolios.
* Go to Portfolio > Add New
* Start typing 
* You'll notice that you cannot add any blocks; you'll get an error instead.
* Switch to this branch
* Go back to the editor.
* See no errors when typing.

#### Proposed changelog entry for your changes:
* N/A

