### PR TITLE
Update Instagram helper from WPCOM

### DIFF
--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -79,29 +79,6 @@ class Jetpack_Instagram_Gallery_Helper {
 			}
 		}
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			if ( ! class_exists( 'WPCOM_Instagram_Gallery_Helper' ) ) {
-				\jetpack_require_lib( 'instagram-gallery-helper' );
-			}
-
-			$gallery = WPCOM_Instagram_Gallery_Helper::get_gallery( $access_token, $count );
-			if ( is_wp_error( $gallery ) ) {
-				return $gallery;
-			}
-
-			$encoded_gallery = wp_json_encode( $gallery );
-
-			// Make sure the gallery is an object.
-			$gallery_object = json_decode( $encoded_gallery );
-
-			// Avoid caching the gallery if the fetch failed for unknown reasons.
-			if ( property_exists( $gallery_object, 'images' ) && 'ERROR' !== $gallery_object->images ) {
-				set_transient( $transient_key, $encoded_gallery, HOUR_IN_SECONDS );
-			}
-
-			return $gallery_object;
-		}
-
 		$response = Client::wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/instagram/%s?count=%d', $site_id, $access_token, (int) $count ),
 			2,


### PR DESCRIPTION
In D50630-code I simplified this library to remove WPCOM specific code. This PR just syncs the files again.

To test, just make sure the Instagram Latest Posts block still works I guess.