### PR TITLE
Fixes PHP Warning in Verification Tools

### DIFF
--- a/modules/verification-tools/verification-tools-utils.php
+++ b/modules/verification-tools/verification-tools-utils.php
@@ -7,30 +7,32 @@
 
 if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	function jetpack_verification_validate( $verification_services_codes ) {
-		foreach ( $verification_services_codes as $key => $code ) {
-			// Parse html meta tag if it does not look like a valid code
-			if ( ! preg_match( '/^[a-z0-9_-]+$/i', $code ) ) {
-				$code = jetpack_verification_get_code( $code );
+		if ( is_array( $verification_services_codes ) ) {
+			foreach ( $verification_services_codes as $key => $code ) {
+				// Parse html meta tag if it does not look like a valid code
+				if ( ! preg_match( '/^[a-z0-9_-]+$/i', $code ) ) {
+					$code = jetpack_verification_get_code( $code );
+				}
+
+				$code = esc_attr( trim( $code ) );
+
+				// limit length to 100 chars.
+				$code = substr( $code, 0, 100 );
+
+				/**
+				 * Fire after each Verification code was validated.
+				 *
+				 * @module verification-tools
+				 *
+				 * @since 3.0.0
+				 *
+				 * @param string $key Verification service name.
+				 * @param string $code Verification service code provided in field in the Tools menu.
+				 */
+				do_action( 'jetpack_site_verification_validate', $key, $code );
+
+				$verification_services_codes[ $key ] = $code;
 			}
-
-			$code = esc_attr( trim( $code ) );
-
-			// limit length to 100 chars.
-			$code = substr( $code, 0, 100 );
-
-			/**
-			 * Fire after each Verification code was validated.
-			 *
-			 * @module verification-tools
-			 *
-			 * @since 3.0.0
-			 *
-			 * @param string $key Verification service name.
-			 * @param string $code Verification service code provided in field in the Tools menu.
-			 */
-			do_action( 'jetpack_site_verification_validate', $key, $code );
-
-			$verification_services_codes[ $key ] = $code;
 		}
 		return $verification_services_codes;
 	}


### PR DESCRIPTION
Fixes PHP warning when the `verification_services_codes` option is still [its default] and not an array.

Fixes #16386

#### Changes proposed in this Pull Request:

* Adds an `is_array()` check to `jetpack_verification_validate()` 

#### Does this pull request change what data or activity we track or use?

No, I don't believe so.

#### Testing instructions:

1. Have a fresh Jetpack install, or run `wp option set verification_services_codes 0` to set the option back to the default.
2. On a multisite install, visit `/wp-admin/network/site-settings.php?id=1` (or any other subsite) and make a change.
3. Verify the PHP warning shows up in the logs or output somewhere: `Warning: Invalid argument supplied for foreach() in wp-content/plugins/jetpack/modules/verification-tools/verification-tools-utils.php on line 10`
4. Update a site setting again (See 2)
5. Verify the PHP warning didn't show up.

#### Proposed changelog entry for your changes:

Verification Tools: avoid PHP warnings when updating site settings from the Network Admin of a multisite.
