### PR TITLE
Publicize: ensure that post meta can be saved for Portfolio CPT

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -288,6 +288,7 @@ class Jetpack_Portfolio {
 				'wpcom-markdown',
 				'revisions',
 				'excerpt',
+				'custom-fields',
 			),
 			'rewrite' => array(
 				'slug'       => 'portfolio',


### PR DESCRIPTION
Fixes #17322

#### Changes proposed in this Pull Request:

* The Portfolio Post Type needs to support custom fields so post meta can be saved by Publicize when the post is saved.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:

* Go to Jetpack > Settings > Writing and enable Portfolios.
* Go to Jetpack > Settings > Sharing and enable automatic sharing, then configure it (connect a test Twitter account)
* Go to Portfolio > Add New
* You should see the Publicize options in the Jetpack plugin sidebar.
* When making changes there (such as entering a custom message), and then saving as draft, your changes should remain.
* When publishing your portfolio, the custom message you've entered should get used on your Twitter message.

#### Proposed changelog entry for your changes:

* Publicize: ensure that custom messages can be saved when using the Portfolio Custom Post Type.
