### PR TITLE
API Nonces: Removing the "is locked" check

### DIFF
--- a/packages/connection/src/class-nonce-handler.php
+++ b/packages/connection/src/class-nonce-handler.php
@@ -120,7 +120,7 @@ class Nonce_Handler {
 	/**
 	 * Clean up the expired nonces on shutdown.
 	 *
-	 * @return bool True if the cleanup query has been run, false if the table is locked.
+	 * @return bool True if the cleanup query has been run.
 	 */
 	public static function clean_runtime() {
 		/**

--- a/packages/connection/src/class-nonce-handler.php
+++ b/packages/connection/src/class-nonce-handler.php
@@ -123,13 +123,6 @@ class Nonce_Handler {
 	 * @return bool True if the cleanup query has been run, false if the table is locked.
 	 */
 	public static function clean_runtime() {
-		// If the table is currently in use, we do nothing.
-		// We don't really care if the cleanup is occasionally skipped,
-		// as long as we can run the cleanup at least once every ten attempts.
-		if ( static::is_table_locked() ) {
-			return false;
-		}
-
 		/**
 		 * Adjust the number of old nonces that are cleaned up at shutdown.
 		 *
@@ -187,20 +180,6 @@ class Nonce_Handler {
 		static::$nonces_used_this_request = array();
 
 		return true;
-	}
-
-	/**
-	 * Check if the options table is locked.
-	 * Subject to race condition, the table may appear locked when a fast database query is performing.
-	 *
-	 * @return bool
-	 */
-	protected static function is_table_locked() {
-		global $wpdb;
-
-		$result = $wpdb->get_results( "SHOW OPEN TABLES WHERE In_use > 0 AND `Table` = '{$wpdb->options}'" );
-
-		return is_array( $result ) && count( $result );
 	}
 
 }

--- a/packages/connection/tests/php/test-class-nonce-handler.php
+++ b/packages/connection/tests/php/test-class-nonce-handler.php
@@ -145,28 +145,4 @@ class Test_Nonce_Handler extends TestCase {
 		self::assertTrue( $query_filter_delete_run, "The SQL query assertions haven't run." );
 	}
 
-	/**
-	 * Make sure the runtime cleanup doesn't get run when the table is locked, and gets run otherwise.
-	 */
-	public function test_cleanup_locked() {
-		$query_filter = function( $result, $query ) {
-			if ( 0 === strpos( $query, 'SHOW OPEN TABLES WHERE In_use > 0' ) ) {
-				return array( 'something' );
-			}
-
-			return $result;
-		};
-
-		add_filter( 'wordbless_wpdb_query_results', $query_filter, 10, 2 );
-
-		$cleanup_skipped = ! Nonce_Handler::clean_runtime();
-
-		remove_filter( 'wordbless_wpdb_query_results', $query_filter );
-
-		$cleanup_ran = Nonce_Handler::clean_runtime();
-
-		self::assertTrue( $cleanup_skipped, 'The cleanup was run over a locked table' );
-		self::assertTrue( $cleanup_ran, 'The cleanup was not run over an unlocked table' );
-	}
-
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The "is table locked" functionality is excessive and potentially unstable, removing it.

#### Jetpack product discussion
p1HpG7-ajF-p2#comment-42552

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Use the Jetpack Debug's "Mocker" tool to create a bunch of old nonces (a few dozens would be enough).
2. Count the nonces, write down how many are there:
```sql
SELECT COUNT(*) FROM wp_options WHERE option_name LIKE 'jetpack\_nonce\_%';
```
3. Go to the [Developer Console](https://developer.wordpress.com/docs/api/console/) and send an API request:
`WP.COM API`, `GET`, `v1.2`, `/sites/your-site.com`
4. Run the `COUNT` SQL query again and confirm that the number of nonces decreased by 9 (1 new nonce, 10 old removed).

#### Proposed changelog entry for your changes:
* Removing the potentially unstable check if the options table is locked.
