### PR TITLE
Fix visual bugs in Stripe warning nudge

### DIFF
--- a/extensions/shared/components/block-nudge/index.jsx
+++ b/extensions/shared/components/block-nudge/index.jsx
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * External dependencies
  */
 import { Button } from '@wordpress/components';
@@ -8,7 +13,15 @@ import { Warning } from '@wordpress/block-editor';
 
 import './style.scss';
 
-export const BlockNudge = ( { autosaveAndRedirect, buttonLabel, href, icon, subtitle, title } ) => (
+export const BlockNudge = ( {
+	autosaveAndRedirect,
+	buttonLabel,
+	href,
+	icon,
+	subtitle,
+	title,
+	className,
+} ) => (
 	<Warning
 		actions={
 			// Use href to determine whether or not to display the Upgrade button.
@@ -24,7 +37,7 @@ export const BlockNudge = ( { autosaveAndRedirect, buttonLabel, href, icon, subt
 				</Button>,
 			]
 		}
-		className="jetpack-block-nudge wp-block"
+		className={ classNames( className, 'jetpack-block-nudge wp-block' ) }
 	>
 		<span className="jetpack-block-nudge__info">
 			{ icon }

--- a/extensions/shared/components/stripe-nudge/index.jsx
+++ b/extensions/shared/components/stripe-nudge/index.jsx
@@ -39,6 +39,7 @@ export default ( { blockName, postId, stripeConnectUrl } ) => {
 
 	return (
 		<BlockNudge
+			className="jetpack-stripe-nudge__banner"
 			buttonLabel={ __( 'Connect', 'jetpack' ) }
 			icon={
 				<GridiconStar

--- a/extensions/shared/components/stripe-nudge/style.scss
+++ b/extensions/shared/components/stripe-nudge/style.scss
@@ -11,3 +11,7 @@
 	margin-right: 16px;
 	padding: 6px;
 }
+
+.jetpack-block-nudge.block-editor-warning .block-editor-warning__contents {
+	align-items: center;
+}

--- a/extensions/shared/components/stripe-nudge/style.scss
+++ b/extensions/shared/components/stripe-nudge/style.scss
@@ -15,8 +15,3 @@
 	margin-right: 16px;
 	padding: 6px;
 }
-
-.jetpack-block-nudge.block-editor-warning .block-editor-warning__contents {
-	align-items: center;
-}
-

--- a/extensions/shared/components/stripe-nudge/style.scss
+++ b/extensions/shared/components/stripe-nudge/style.scss
@@ -15,3 +15,4 @@
 .jetpack-block-nudge.block-editor-warning .block-editor-warning__contents {
 	align-items: center;
 }
+

--- a/extensions/shared/components/stripe-nudge/style.scss
+++ b/extensions/shared/components/stripe-nudge/style.scss
@@ -1,6 +1,6 @@
 @import '../../styles/gutenberg-base-styles.scss';
 
-.jetpack-stripe-nudge__banner {
+.jetpack-stripe-nudge__banner .block-editor-warning__contents {
 	align-items: center;
 }
 

--- a/extensions/shared/components/stripe-nudge/style.scss
+++ b/extensions/shared/components/stripe-nudge/style.scss
@@ -1,5 +1,9 @@
 @import '../../styles/gutenberg-base-styles.scss';
 
+.jetpack-stripe-nudge__banner {
+	align-items: center;
+}
+
 .jetpack-stripe-nudge__icon {
 	align-self: center;
 	background: var( --color-primary );


### PR DESCRIPTION
Fixes Automattic/wp-calypso#46010

#### Changes proposed in this Pull Request:

* Vertically center content in Stripe banner connection warning.

**Before**

<img width="811" alt="Screen Shot 2020-10-06 at 1 20 06 PM" src="https://user-images.githubusercontent.com/2124984/95237805-a9e9ce00-07d6-11eb-8dcf-d1863980ef59.png">

**After**

<img width="803" alt="Screen Shot 2020-10-06 at 1 18 47 PM" src="https://user-images.githubusercontent.com/2124984/95237642-7a3ac600-07d6-11eb-9352-1f0e6c3cc15e.png">

#### Does this pull request change what data or activity we track or use? No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Switch to this branch
* Add a premium block to a page or post on a site that does not have an established Stripe connection
* You should see the above banner and its contents should be vertically aligned to the center.

#### Proposed changelog entry for your changes:
* Fix visual bug with Stripe connection banner.
