### PR TITLE
Media Extractor: Ensure URL parts are present

### DIFF
--- a/_inc/lib/class.media-extractor.php
+++ b/_inc/lib/class.media-extractor.php
@@ -244,12 +244,12 @@ class Jetpack_Media_Meta_Extractor {
 					$url = wp_parse_url( $link_raw );
 
 					// Data URI links.
-					if ( isset( $url['scheme'] ) && 'data' === $url['scheme'] ) {
+					if ( ! isset( $url['scheme'] ) || 'data' === $url['scheme'] ) {
 						continue;
 					}
 
 					// Reject invalid URLs.
-					if ( ! isset( $url['scheme'] ) || ! isset( $url['host'] ) ) {
+					if ( ! isset( $url['host'] ) ) {
 						continue;
 					}
 

--- a/_inc/lib/class.media-extractor.php
+++ b/_inc/lib/class.media-extractor.php
@@ -248,6 +248,11 @@ class Jetpack_Media_Meta_Extractor {
 						continue;
 					}
 
+					// Reject invalid URLs.
+					if ( ! isset( $url['scheme'] ) || ! isset( $url['host'] ) ) {
+						continue;
+					}
+
 					// Remove large (and likely invalid) links.
 					if ( 4096 < strlen( $link_raw ) ) {
 						continue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes `E_NOTICE: /home/public_html/wp-content/plugins/jetpack/_inc/lib/class.media-extractor.php:267 - Trying to access array offset on value of type bool` (discovered in w.org logs)

#### Changes proposed in this Pull Request:
* Simple isset for URL parts.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unsure, but likely setting an image URL that's relative directly into the post.
*

#### Proposed changelog entry for your changes:
* Media Extractor: Prevent PHP notice for some URLs.
