### PR TITLE
Jetpack_Plan: don't update the option if the plan hasn't changed

### DIFF
--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -146,6 +146,13 @@ class Jetpack_Plan {
 			return false;
 		}
 
+		$current_plan = get_option( self::PLAN_OPTION, array() );
+
+		if ( ! empty( $current_plan ) && $current_plan === $results['plan'] ) {
+			// Bail if the plans array hasn't changed.
+			return false;
+		}
+
 		// Store the new plan in an option and return true if updated.
 		$result = self::store_data_in_option( self::PLAN_OPTION, $results['plan'] );
 

--- a/tests/php/general/test_class.jetpack-plan.php
+++ b/tests/php/general/test_class.jetpack-plan.php
@@ -38,22 +38,22 @@ class WP_Test_Jetpack_Plan extends WP_UnitTestCase {
 
 	public function get_update_from_sites_response_data() {
 		return array(
-			'is_errored_response'            => array(
+			'is_errored_response'                    => array(
 				$this->get_errored_sites_response(),
 				'jetpack_free',
 				false,
 			),
-			'response_is_empty'              => array(
+			'response_is_empty'                      => array(
 				$this->get_mocked_response( 200, '' ),
 				'jetpack_free',
 				false,
 			),
-			'response_does_not_have_body'    => array(
+			'response_does_not_have_body'            => array(
 				array( 'code' => 400 ),
 				'jetpack_free',
 				false,
 			),
-			'response_does_not_have_plan'    => array(
+			'response_does_not_have_plan'            => array(
 				array(
 					'code' => 200,
 					array(),
@@ -61,27 +61,39 @@ class WP_Test_Jetpack_Plan extends WP_UnitTestCase {
 				'jetpack_free',
 				false,
 			),
-			'initially_empty_option_to_free' => array(
+			'initially_empty_option_to_free'         => array(
 				$this->get_response_free_plan(),
 				'jetpack_free',
 				true,
 			),
-			'initially_empty_to_personal'    => array(
+			'initially_empty_to_personal'            => array(
 				$this->get_response_personal_plan(),
 				'jetpack_personal',
 				true,
 			),
-			'initially_free_to_personal'     => array(
+			'initially_free_to_personal'             => array(
 				$this->get_response_personal_plan(),
 				'jetpack_personal',
 				true,
 				$this->get_free_plan(),
 			),
-			'initially_personal_to_free'     => array(
+			'initially_personal_to_free'             => array(
 				$this->get_response_free_plan(),
 				'jetpack_free',
 				true,
 				$this->get_personal_plan(),
+			),
+			'initially_free_no_change'               => array(
+				$this->get_response_free_plan(),
+				'jetpack_free',
+				false,
+				$this->get_free_plan(),
+			),
+			'initially_personal_to_changed_personal' => array(
+				$this->get_response_changed_personal_plan(),
+				'jetpack_personal',
+				true,
+				$this->get_response_personal_plan(),
 			),
 		);
 	}
@@ -92,6 +104,10 @@ class WP_Test_Jetpack_Plan extends WP_UnitTestCase {
 
 	private function get_response_personal_plan() {
 		return $this->get_successful_plan_response( $this->get_personal_plan() );
+	}
+
+	private function get_response_changed_personal_plan() {
+		return $this->get_successful_plan_response( $this->get_changed_personal_plan() );
 	}
 
 	private function get_successful_plan_response( $plan_response ) {
@@ -187,6 +203,13 @@ class WP_Test_Jetpack_Plan extends WP_UnitTestCase {
 				),
 			),
 		);
+	}
+
+	private function get_changed_personal_plan() {
+		$changed_personal_plan = $this->get_personal_plan();
+
+		$changed_personal_plan['features']['available']['test_feature'] = array( 'jetpack_free' );
+		return $changed_personal_plan;
 	}
 
 	private function get_personal_plan() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* There's no need to update the `jetpack_active_plan` option if the plan hasn't changed. Compare the plan from the WPCOM response to the current plan and bail early if they're the same.
* Add two new data provider elements for the unit test:
   - The site starts with a free plan and WPCOM returns the free plan. In this case, the `jetpack_active_plan` option should not be updated.
   - The site starts with a personal plan and WPCOM returns the personal plan with an additional available feature. In this case, the `jetpack_active_plan` option needs to be updated.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install and activate this branch.
2. Connect Jetpack and select the Free plan.
3. Check that the free plan is in the `jetpack_active_plan` option:
   `wp option get jetpack_active_plan`

4. Upgrade the Jetpack plan. For example, upgrade to the Jetpack Security Plan.
5. Check that the plan you purchased is in the `jetpack_active_plan` option:
   `wp option get jetpack_active_plan`

6. Verify that the paid features for the plan are available. For example, if you purchased the Jetpack Security Plan, navigate to wp-admin -> Jetpack -> Settings -> Performance and verify that the Video setting can be enabled.

7. Manually change the array in the `jetpack_active_plan` option. For example, remove the akismet feature value:
   `wp option patch delete jetpack_active_plan features available akismet`

8. Verify that the `jetpack_active_plan` option was changed:
   `wp option get jetpack_active_plan`

9. Navigate to wp-admin -> Jetpack -> Dashboard -> At A Glance. (Refresh if you were already on the dashboard.)
10. Verify that the changes you made to the `jetpack_active_plan` option in step 6 were reverted. For example, if you deleted the `features->available->akismet` value, it should be restored.
   `wp option get jetpack_active_plan`

#### Proposed changelog entry for your changes:
* tbd
