### PR TITLE
Publicize: Improve the text/usability of Twitter thread options

### DIFF
--- a/extensions/blocks/publicize/twitter/editor.scss
+++ b/extensions/blocks/publicize/twitter/editor.scss
@@ -2,6 +2,17 @@ h3.jetpack-publicize-twitter-options__heading {
 	margin-top: 1em;
 }
 
+.jetpack-publicize-twitter-options__type {
+	.components-radio-control__option {
+		display: grid;
+		grid-template-columns: 24px auto;
+
+		input {
+			margin-top: 2px;
+		}
+	}
+}
+
 .jetpack-publicize-twitter-options__notices {
 	.components-notice {
 		margin-left: 0;

--- a/extensions/blocks/publicize/twitter/options.js
+++ b/extensions/blocks/publicize/twitter/options.js
@@ -25,7 +25,9 @@ const PublicizeTwitterOptions = ( {
 	setTweetstorm,
 	prePublish,
 } ) => {
-	if ( ! connections?.some( connection => 'twitter' === connection.service_name ) ) {
+	if (
+		! connections?.some( connection => 'twitter' === connection.service_name && connection.enabled )
+	) {
 		return null;
 	}
 

--- a/extensions/blocks/publicize/twitter/options.js
+++ b/extensions/blocks/publicize/twitter/options.js
@@ -74,16 +74,26 @@ const PublicizeTwitterOptions = ( {
 				{ __( 'Twitter settings', 'jetpack' ) }
 			</h3>
 			<RadioControl
+				className="jetpack-publicize-twitter-options__type"
 				selected={ isTweetStorm ? 'tweetstorm' : 'single' }
 				options={ [
 					{
-						label: __( 'Share your blog post as a link in a single tweet', 'jetpack' ),
+						label: (
+							<>
+								<strong>{ __( 'Single Tweet', 'jetpack' ) }</strong>
+								<br />
+								{ __( 'Share a link to this post to Twitter.', 'jetpack' ) }
+							</>
+						),
 						value: 'single',
 					},
 					{
-						label: __(
-							'Share your entire blog post as a Twitter thread in multiple Tweets',
-							'jetpack'
+						label: (
+							<>
+								<strong>{ __( 'Twitter Thread', 'jetpack' ) }</strong>
+								<br />
+								{ __( 'Share the content of this post as a Twitter thread.', 'jetpack' ) }
+							</>
 						),
 						value: 'tweetstorm',
 					},

--- a/extensions/blocks/publicize/twitter/options.js
+++ b/extensions/blocks/publicize/twitter/options.js
@@ -39,6 +39,16 @@ const PublicizeTwitterOptions = ( {
 		}
 	};
 
+	const generateLabel = ( label, help ) => {
+		return (
+			<>
+				<strong>{ label }</strong>
+				<br />
+				{ help }
+			</>
+		);
+	};
+
 	const notices = [];
 
 	if ( tweetStormLength >= 102 ) {
@@ -80,22 +90,16 @@ const PublicizeTwitterOptions = ( {
 				selected={ isTweetStorm ? 'tweetstorm' : 'single' }
 				options={ [
 					{
-						label: (
-							<>
-								<strong>{ __( 'Single Tweet', 'jetpack' ) }</strong>
-								<br />
-								{ __( 'Share a link to this post to Twitter.', 'jetpack' ) }
-							</>
+						label: generateLabel(
+							__( 'Single Tweet', 'jetpack' ),
+							__( 'Share a link to this post to Twitter.', 'jetpack' )
 						),
 						value: 'single',
 					},
 					{
-						label: (
-							<>
-								<strong>{ __( 'Twitter Thread', 'jetpack' ) }</strong>
-								<br />
-								{ __( 'Share the content of this post as a Twitter thread.', 'jetpack' ) }
-							</>
+						label: generateLabel(
+							__( 'Twitter Thread', 'jetpack' ),
+							__( 'Share the content of this post as a Twitter thread.', 'jetpack' )
 						),
 						value: 'tweetstorm',
 					},

--- a/extensions/blocks/publicize/twitter/test/options.js
+++ b/extensions/blocks/publicize/twitter/test/options.js
@@ -34,10 +34,22 @@ describe( 'PublicizeTwitterOptions', () => {
 		expect( wrapper.find( 'input' ) ).toHaveLength( 0 );
 	} );
 
+	it( 'should not render with only disabled twitter connections', () => {
+		useSelect.mockImplementation( () => {
+			return {
+				connections: [ { service_name: 'twitter', enabled: false } ],
+			}
+		} );
+		const wrapper = mount( <PublicizeTwitterOptions /> );
+
+		expect( wrapper.find( 'h3' ) ).toHaveLength( 0 );
+		expect( wrapper.find( 'input' ) ).toHaveLength( 0 );
+	} );
+
 	it( 'should render with a twitter connection', () => {
 		useSelect.mockImplementation( () => {
 			return {
-				connections: [ { service_name: 'twitter' } ],
+				connections: [ { service_name: 'twitter', enabled: true } ],
 			}
 		} );
 		const wrapper = mount( <PublicizeTwitterOptions /> );
@@ -51,7 +63,7 @@ describe( 'PublicizeTwitterOptions', () => {
 	it( 'should show the tweetstorm option selected when the isTweetStorm prop is set', () => {
 		useSelect.mockImplementation( () => {
 			return {
-				connections: [ { service_name: 'twitter' } ],
+				connections: [ { service_name: 'twitter', enabled: true } ],
 				isTweetStorm: true,
 			}
 		} );
@@ -64,7 +76,7 @@ describe( 'PublicizeTwitterOptions', () => {
 	it( 'should trigger change event when the selected option changes', () => {
 		useSelect.mockImplementation( () => {
 			return {
-				connections: [ { service_name: 'twitter' } ],
+				connections: [ { service_name: 'twitter', enabled: true } ],
 				isTweetStorm: false,
 			}
 		} );


### PR DESCRIPTION
This PR includes a couple of tweaks to the Twitter options panel, making it more usable.

- The style and copy has been tweaked to more closely match the post visibility radio options in Core.
- The panel is now hidden when there are no Twitter accounts selected.

<img width="279" alt="Screen Shot 2020-10-07 at 2 25 02 pm" src="https://user-images.githubusercontent.com/352291/95284229-6dd36d80-08a9-11eb-9747-6e165868e17a.png"> <img width="279" alt="Screen Shot 2020-10-07 at 2 25 10 pm" src="https://user-images.githubusercontent.com/352291/95284236-7166f480-08a9-11eb-838b-a045c1578aa3.png">

#### Changes proposed in this Pull Request:
* Tweaks to the Publicize Twitter options panel.

#### Jetpack product discussion
p58i-9vv-p2#comment-47632

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Open the Publicize panel in a post.
* Ensure that the options look correct.
* Ensure that the options are only visible when one or more Twitter accounts is enabled.

#### Proposed changelog entry for your changes:
* Publicize: Improve the usability of the Twitter thread options.
