### PR TITLE
Twenty Twenty: ensure Facebook videos are centered properly

### DIFF
--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -257,6 +257,11 @@
 	margin: 1em auto;
 }
 
+/* Facebook */
+.entry-content .fb-video {
+	display: block;
+}
+
 /**
  * Blocks
  */


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

When using the Twenty Twenty theme and inserting Facebook videos inside a classic block, videos used to be breaking out of the layout:

![image](https://user-images.githubusercontent.com/426388/95314103-2c36c880-0891-11eb-9e1a-bbba16e9c2d5.png)

This fixes that:

![image](https://user-images.githubusercontent.com/426388/95314153-3eb10200-0891-11eb-805b-d41e75725c3f.png)


#### Jetpack product discussion

Reported here:
p8oabR-y3-p2/#comment-4678

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site using the Twenty Twenty theme.
* Go to Posts > Add New
* Add some content.
* Insert a Classic block
* Inside that block, paste this on its own line: `https://www.facebook.com/WhiteHouse/videos/10153398464269238/`
* Publish your post
* Ensure it is displayed properly.

#### Proposed changelog entry for your changes:

* Embeds: ensure Facebook videos are centered properly with the Twenty Twenty theme.