### PR TITLE
Add checkout overlay action to upgrade flow

### DIFF
--- a/extensions/shared/use-upgrade-flow/index.js
+++ b/extensions/shared/use-upgrade-flow/index.js
@@ -70,10 +70,10 @@ export default function useUpgradeFlow( planSlug, onRedirect = noop ) {
 
 		setIsRedirecting( true );
 
-		/*
-		* If there are not unsaved values, redirect.
-		* If the post is not auto-savable, redirect.
-		*/
+		/**
+		 * If there are not unsaved values, redirect.
+		 * If the post is not auto-savable, redirect.
+		 */
 		if ( ! isDirtyPost || ! isAutosaveablePost ) {
 			return redirect( checkoutUrl, onRedirect );
 		}

--- a/extensions/shared/use-upgrade-flow/index.js
+++ b/extensions/shared/use-upgrade-flow/index.js
@@ -8,6 +8,7 @@ import { noop } from 'lodash';
  */
 import { useSelect, dispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { doAction, hasAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -22,14 +23,6 @@ function redirect( url, callback ) {
 		callback( url );
 	}
 	window.top.location.href = url;
-}
-
-function isCheckoutOverlayAvailable() {
-	try {
-		return window.wp.hooks.hasAction( 'a8c.wpcom-block-editor.openCheckoutModal' );
-	} catch ( err ) {
-		return false;
-	}
 }
 
 export default function useUpgradeFlow( planSlug, onRedirect = noop ) {
@@ -54,10 +47,11 @@ export default function useUpgradeFlow( planSlug, onRedirect = noop ) {
 	const savePost = dispatch( 'core/editor' ).savePost;
 
 	const goToCheckoutPage = async event => {
-		// If checkout overlay is enabled, use it. Otherwise contiue to redirect method.
-		if ( isCheckoutOverlayAvailable() ) {
+		// If this action is available, the feature is enabled to open the checkout
+		// in a modal rather than redirect the user there, away from the editor.
+		if ( hasAction( 'a8c.wpcom-block-editor.openCheckoutModal' ) ) {
 			event.preventDefault();
-			window.wp.hooks.doAction( 'a8c.wpcom-block-editor.openCheckoutModal', { products: [planData] } );
+			doAction( 'a8c.wpcom-block-editor.openCheckoutModal', { products: [planData] } );
 			return;
 		}
 

--- a/extensions/shared/use-upgrade-flow/index.js
+++ b/extensions/shared/use-upgrade-flow/index.js
@@ -18,6 +18,8 @@ import { doAction, hasAction } from '@wordpress/hooks';
 import '../components/upgrade-nudge/store';
 import { getUpgradeUrl } from '../plan-utils';
 
+const HOOK_OPEN_CHECKOUT_MODAL = 'a8c.wpcom-block-editor.openCheckoutModal';
+
 function redirect( url, callback ) {
 	if ( callback ) {
 		callback( url );
@@ -49,9 +51,9 @@ export default function useUpgradeFlow( planSlug, onRedirect = noop ) {
 	const goToCheckoutPage = async event => {
 		// If this action is available, the feature is enabled to open the checkout
 		// in a modal rather than redirect the user there, away from the editor.
-		if ( hasAction( 'a8c.wpcom-block-editor.openCheckoutModal' ) ) {
+		if ( hasAction( HOOK_OPEN_CHECKOUT_MODAL ) ) {
 			event.preventDefault();
-			doAction( 'a8c.wpcom-block-editor.openCheckoutModal', { products: [planData] } );
+			savePost( event ).then( () => doAction( HOOK_OPEN_CHECKOUT_MODAL, { products: [planData] } ) );
 			return;
 		}
 

--- a/extensions/shared/use-upgrade-flow/index.js
+++ b/extensions/shared/use-upgrade-flow/index.js
@@ -53,7 +53,8 @@ export default function useUpgradeFlow( planSlug, onRedirect = noop ) {
 		// in a modal rather than redirect the user there, away from the editor.
 		if ( hasAction( HOOK_OPEN_CHECKOUT_MODAL ) ) {
 			event.preventDefault();
-			savePost( event ).then( () => doAction( HOOK_OPEN_CHECKOUT_MODAL, { products: [planData] } ) );
+			savePost( event );
+			doAction( HOOK_OPEN_CHECKOUT_MODAL, { products: [planData] } );
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When block editor is running under Calypso, clicking on Upgrade Plan button should call the parent Calypso and display the checkout modal overlay.

This improves the user experience of the checkout flow by avoiding the need to exit block editor and redirect to the checkout page.

See related PRs and issues at https://github.com/Automattic/wp-calypso/milestone/322
Fixes: https://github.com/Automattic/wp-calypso/issues/46389

#### Testing instructions:
- On a FREE site, open up calypso block editor behind the feature flag `post-editor/checkout-overlay`, for example: https://wp_dot_com/block-editor/page/your_site_here.wordpress.com?flags=post-editor/checkout-overlay
- Add any jetpack premium blocks.
- Click on "Upgrade Plan" button.
- It should show checkout modal instead of redirecting.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry needed (internal for now).
