### PR TITLE
Dev: Add processor for lists on the require list for PHPCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ phpcs.xml
 /modules/**/*.min.css
 /modules/**/*-rtl.css
 /css
-_inc/jetpack-strings.php
 /modules/**/*/block.js
 /vendor/automattic/
 /vendor/composer/

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -46,7 +46,20 @@
 
 	<arg name="colors"/>
 
+	<!-- Ignore external libraries -->
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
+
+	<!-- Ignore WordPress and such checked out for Docker -->
+	<exclude-pattern>/docker/mu-plugins/0-sandbox.php</exclude-pattern>
+	<exclude-pattern>/docker/wordpress-develop/*</exclude-pattern>
+	<exclude-pattern>/docker/wordpress/*</exclude-pattern>
+
+	<!-- Ignore WordPress included in packages -->
 	<exclude-pattern>/packages/*/wordpress/*</exclude-pattern>
+
+	<!-- Ignore built files -->
+	<exclude-pattern>/_inc/blocks/*</exclude-pattern>
+	<exclude-pattern>/_inc/build/*</exclude-pattern>
+
 </ruleset>

--- a/bin/phpcs-requirelist-commands.js
+++ b/bin/phpcs-requirelist-commands.js
@@ -2,28 +2,19 @@
 
 /* eslint-disable no-console, no-process-exit */
 const spawnSync = require( 'child_process' ).spawnSync;
-const chalk = require( 'chalk' );
 const requirelist = require( './phpcs-requirelist' );
 
-requirelist.forEach( function ( fileToProcess ) {
-	console.log( chalk.yellow( 'Processing ' + fileToProcess ) );
-	spawnSync( 'vendor/bin/phpcbf', [ fileToProcess ], {
-		shell: true,
-		stdio: 'inherit',
-	} );
+console.log( 'PHPCBF... Please expect this to take minutes.' );
+spawnSync( 'vendor/bin/phpcbf', [ ...requirelist ], {
+	shell: true,
+	stdio: 'inherit',
 } );
 
-console.log(
-	chalk.yellow(
-		'PHPCBF completed. Now running PHPCS. Please be patient and thank you for developing Jetpack.'
-	)
-);
+console.log( 'PHPCS... Please expect this to take minutes.' );
 
-requirelist.forEach( function ( fileToProcess ) {
-	spawnSync( 'vendor/bin/phpcs', [ '-s', fileToProcess ], {
-		shell: true,
-		stdio: 'inherit',
-	} );
+spawnSync( 'vendor/bin/phpcs', [ '-s', ...requirelist ], {
+	shell: true,
+	stdio: 'inherit',
 } );
 
 process.exit();

--- a/bin/phpcs-requirelist-commands.js
+++ b/bin/phpcs-requirelist-commands.js
@@ -7,7 +7,7 @@ const requirelist = require( './phpcs-requirelist' );
 
 requirelist.forEach( function ( fileToProcess ) {
 	if ( 'docker/' === fileToProcess ) {
-		console.log( chalk.yellow( 'Skipping docker/. It takes forever.' ) );
+		console.log( chalk.yellow( 'Skipping docker/. It takes forever.' ) ); // Remove after #17405 is merged.
 		return;
 	}
 	console.log( chalk.yellow( 'Processing ' + fileToProcess ) );
@@ -15,8 +15,21 @@ requirelist.forEach( function ( fileToProcess ) {
 		shell: true,
 		stdio: 'inherit',
 	} );
+} );
 
-	spawnSync( 'composer', [ 'php:lint:errors', fileToProcess ], {
+console.log(
+	chalk.yellow(
+		'PHPCBF completed. Now running PHPCS. Please be patient and thank you for developing Jetpack.'
+	)
+);
+
+requirelist.forEach( function ( fileToProcess ) {
+	if ( 'docker/' === fileToProcess ) {
+		console.log( chalk.yellow( 'Skipping docker/. It takes forever.' ) ); // Remove after #17405 is merged.
+		return;
+	}
+
+	spawnSync( 'vendor/bin/phpcs', [ '-s', fileToProcess ], {
 		shell: true,
 		stdio: 'inherit',
 	} );

--- a/bin/phpcs-requirelist-commands.js
+++ b/bin/phpcs-requirelist-commands.js
@@ -6,10 +6,6 @@ const chalk = require( 'chalk' );
 const requirelist = require( './phpcs-requirelist' );
 
 requirelist.forEach( function ( fileToProcess ) {
-	if ( 'docker/' === fileToProcess ) {
-		console.log( chalk.yellow( 'Skipping docker/. It takes forever.' ) ); // Remove after #17405 is merged.
-		return;
-	}
 	console.log( chalk.yellow( 'Processing ' + fileToProcess ) );
 	spawnSync( 'vendor/bin/phpcbf', [ fileToProcess ], {
 		shell: true,
@@ -24,11 +20,6 @@ console.log(
 );
 
 requirelist.forEach( function ( fileToProcess ) {
-	if ( 'docker/' === fileToProcess ) {
-		console.log( chalk.yellow( 'Skipping docker/. It takes forever.' ) ); // Remove after #17405 is merged.
-		return;
-	}
-
 	spawnSync( 'vendor/bin/phpcs', [ '-s', fileToProcess ], {
 		shell: true,
 		stdio: 'inherit',

--- a/bin/phpcs-requirelist-commands.js
+++ b/bin/phpcs-requirelist-commands.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console, no-process-exit */
+const spawnSync = require( 'child_process' ).spawnSync;
+const chalk = require( 'chalk' );
+const requirelist = require( './phpcs-requirelist' );
+
+requirelist.forEach( function ( fileToProcess ) {
+	if ( 'docker/' === fileToProcess ) {
+		console.log( chalk.yellow( 'Skipping docker/. It takes forever.' ) );
+		return;
+	}
+	console.log( chalk.yellow( 'Processing ' + fileToProcess ) );
+	spawnSync( 'vendor/bin/phpcbf', [ fileToProcess ], {
+		shell: true,
+		stdio: 'inherit',
+	} );
+
+	spawnSync( 'composer', [ 'php:lint:errors', fileToProcess ], {
+		shell: true,
+		stdio: 'inherit',
+	} );
+} );
+
+process.exit();

--- a/bin/phpcs-requirelist-commands.js
+++ b/bin/phpcs-requirelist-commands.js
@@ -4,15 +4,15 @@
 const spawnSync = require( 'child_process' ).spawnSync;
 const requirelist = require( './phpcs-requirelist' );
 
-console.log( 'PHPCBF... Please expect this to take minutes.' );
-spawnSync( 'vendor/bin/phpcbf', [ ...requirelist ], {
+console.log( 'Running PHPCBF. Please standby as it makes code beautiful.' );
+spawnSync( 'vendor/bin/phpcbf', [ '-p', ...requirelist ], {
 	shell: true,
 	stdio: 'inherit',
 } );
 
-console.log( 'PHPCS... Please expect this to take minutes.' );
+console.log( 'Running PHPCS.' );
 
-spawnSync( 'vendor/bin/phpcs', [ '-s', ...requirelist ], {
+spawnSync( 'vendor/bin/phpcs', [ '-ps', ...requirelist ], {
 	shell: true,
 	stdio: 'inherit',
 } );

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -15,7 +15,7 @@ module.exports = [
 	'class.jetpack-twitter-cards.php',
 	'class-jetpack-wizard-banner.php',
 	'class.photon.php',
-	'docker',
+	'docker/',
 	'extensions/',
 	'functions.cookies.php',
 	'functions.global.php',
@@ -86,5 +86,5 @@ module.exports = [
 	'tests/php/general/test-class.jetpack-network.php',
 	'tests/php/test_class.jetpack_photon.php',
 	'views/admin/deactivation-dialog.php',
-	'bin/PHPCSSniffs',
+	'bin/PHPCSStandards',
 ];

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
 		"php:lint": "vendor/bin/phpcs -p -s",
 		"php:changed": "vendor/sirbrillig/phpcs-changed/bin/phpcs-changed --git",
 		"php:autofix": "vendor/bin/phpcbf",
-		"php:lint:errors": "vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1"
+		"php:lint:errors": "vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1",
+		"php:requirelist": "node bin/phpcs-requirelist-commands.js"
 	},
 	"repositories": [
 		{

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
 		"@wordpress/server-side-render": "1.8.6",
 		"babel-eslint": "10.0.2",
 		"chai": "4.2.0",
+		"chalk": "4.1.0",
 		"commander": "6.1.0",
 		"config": "3.3.2",
 		"css-loader": "4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5094,6 +5094,14 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@4.1.0, chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -5117,14 +5125,6 @@ chalk@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
   integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* As we eye adding PHPCS rules and whenever we update PHPCS versions, our "clean" files can be out of date. This adds a processor to run through the list to PHPCBF them all and run PHPCS.
* Adds chalk as a direct dev dep.

A first attempt of something to run whenever sniffs are updated—either our in-repo or upstream diffs.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?

#### Testing instructions:
* `composer php:requirelist`

#### Proposed changelog entry for your changes:
* n/a
