### PR TITLE
Publicize: URLs are sometimes counted incorrectly in Twitter threads.

### DIFF
--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -9,6 +9,7 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Status;
 use Twitter\Text\Regex as Twitter_Regex;
+use Twitter\Text\Validator as Twitter_Validator;
 
 /**
  * Class Jetpack_Tweetstorm_Helper
@@ -612,9 +613,12 @@ class Jetpack_Tweetstorm_Helper {
 
 		$current_tweet = self::get_current_tweet();
 
+		$reserved_characters  = count( $current_tweet['media'] ) * self::$characters_per_media;
+		$reserved_characters += 1 + self::$characters_per_url;
+
 		// We can only attach an embed to the previous tweet if it doesn't already
-		// have any URLs in it.
-		if ( preg_match( '/url-placeholder-\d+-*/', $current_tweet['text'] ) ) {
+		// have any URLs in it. Also, we can't attach it if it'll make the tweet too long.
+		if ( preg_match( '/url-placeholder-\d+-*/', $current_tweet['text'] ) || ! self::is_valid_tweet( $current_tweet['text'], $reserved_characters ) ) {
 			$current_tweet         = self::start_new_tweet();
 			$current_tweet['text'] = self::generate_url_placeholder( $block['embed'] );
 		} else {
@@ -1314,6 +1318,8 @@ class Jetpack_Tweetstorm_Helper {
 
 		$tokens = wp_html_split( $html );
 
+		$validator = new Twitter_Validator();
+
 		foreach ( $tags as $tag ) {
 			$values[ $tag ] = array();
 
@@ -1356,7 +1362,7 @@ class Jetpack_Tweetstorm_Helper {
 					// A link has opened, grab the URL for inserting later.
 					if ( 0 === strpos( $token, '<a ' ) ) {
 						$href_values = self::extract_attr_content_from_html( 'a', 'href', $token );
-						if ( ! empty( $href_values[0] ) ) {
+						if ( ! empty( $href_values[0] ) && $validator->isValidURL( $href_values[0] ) ) {
 							// Remember the URL.
 							$current_url = $href_values[0];
 						}
@@ -1413,8 +1419,16 @@ class Jetpack_Tweetstorm_Helper {
 						$offset += self::$characters_per_url - strlen( $url );
 
 						// If we're in a link with a URL set, there's no need to keep two copies of the same link.
-						if ( $url === $current_url ) {
-							$current_url = '';
+						if ( ! empty( $current_url ) ) {
+							if ( $url === $current_url ) {
+								$current_url = '';
+							}
+
+							// Check that the link text isn't just a shortened version of the href value.
+							$trimmed_current_url = preg_replace( '|^https://|', '', $current_url );
+							if ( $url === $trimmed_current_url || trim( $trimmed_current_url, '/' ) === $url ) {
+								$current_url = '';
+							}
 						}
 					}
 

--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -1420,13 +1420,16 @@ class Jetpack_Tweetstorm_Helper {
 
 						// If we're in a link with a URL set, there's no need to keep two copies of the same link.
 						if ( ! empty( $current_url ) ) {
-							if ( $url === $current_url ) {
+							$lower_url         = strtolower( $url );
+							$lower_current_url = strtolower( $current_url );
+
+							if ( $lower_url === $lower_current_url ) {
 								$current_url = '';
 							}
 
 							// Check that the link text isn't just a shortened version of the href value.
-							$trimmed_current_url = preg_replace( '|^https?://|', '', $current_url );
-							if ( $url === $trimmed_current_url || trim( $trimmed_current_url, '/' ) === $url ) {
+							$trimmed_current_url = preg_replace( '|^https?://|', '', $lower_current_url );
+							if ( $lower_url === $trimmed_current_url || trim( $trimmed_current_url, '/' ) === $lower_url ) {
 								$current_url = '';
 							}
 						}

--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -1425,7 +1425,7 @@ class Jetpack_Tweetstorm_Helper {
 							}
 
 							// Check that the link text isn't just a shortened version of the href value.
-							$trimmed_current_url = preg_replace( '|^https://|', '', $current_url );
+							$trimmed_current_url = preg_replace( '|^https?://|', '', $current_url );
 							if ( $url === $trimmed_current_url || trim( $trimmed_current_url, '/' ) === $url ) {
 								$current_url = '';
 							}

--- a/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
+++ b/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
@@ -2004,7 +2004,7 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 	public function test_links_handled() {
 		$test_urls = array(
 			'https://jetpack.com',
-			'https://wordpress.org/',
+			'https://WordPress.org/',
 			'https://jetpack.com',
 		);
 
@@ -2229,25 +2229,28 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 	 * that have been typed into text (but aren't necessarily linked) are counted correctly.
 	 */
 	public function test_text_urls_are_counted_correctly() {
-		$test_content = 'https://jetpack.com ';
+		$test_content = 'https://jetpack.com https://Jetpack.com jetpack.com ';
 
 		$blocks = array(
-			$this->generateParagraphData( trim( str_repeat( $test_content, 12 ) ) ),
+			$this->generateParagraphData( trim( str_repeat( $test_content, 4 ) ) ),
 		);
 
 		$expected_content = array(
 			array(
-				'text' => trim( str_repeat( $test_content, 11 ) ) . '…',
-				'urls' => array_fill( 0, 11, trim( $test_content ) ),
+				'text' => trim( str_repeat( $test_content, 3 ) ) . ' https://jetpack.com https://Jetpack.com…',
+				'urls' => array_merge(
+					array_merge( ...array_fill( 0, 3, array( 'https://jetpack.com', 'https://Jetpack.com', 'jetpack.com' ) ) ),
+					array( 'https://jetpack.com', 'https://Jetpack.com' )
+				),
 			),
 			array(
-				'text' => '…' . trim( $test_content ),
-				'urls' => array( trim( $test_content ) ),
+				'text' => '…jetpack.com',
+				'urls' => array( 'jetpack.com' ),
 			),
 		);
 
 		$expected_boundaries = array(
-			$this->generateNormalBoundary( 219, 220, 'content' ),
+			$this->generateNormalBoundary( 195, 196, 'content' ),
 			false,
 		);
 
@@ -2268,7 +2271,7 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 			'https://wordpress.org/',
 		);
 
-		$test_content = "Visiting <a href='$test_urls[0]'>$test_urls[0]</a> is good, so is visiting <a href='$test_urls[1]'>wordpress.org</a>.";
+		$test_content = "Visiting <a href='$test_urls[0]'>$test_urls[0]</a> is good, so is visiting <a href='$test_urls[1]'>WordPress.org</a>.";
 
 		$blocks = array(
 			$this->generateParagraphData( $test_content ),
@@ -2276,10 +2279,10 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 
 		$expected_content = array(
 			array(
-				'text' => "Visiting $test_urls[0] is good, so is visiting wordpress.org.",
+				'text' => "Visiting $test_urls[0] is good, so is visiting WordPress.org.",
 				'urls' => array(
 					$test_urls[0],
-					'wordpress.org',
+					'WordPress.org',
 				),
 			),
 		);


### PR DESCRIPTION
This PR fixes two errors in URL handling, that can cause invalid tweets to be generated:

- The `href` of a link tag should only be inserted into the text when it's a URL that Twitter considers to be valid. (For example, `mailto:foo@bar.com`. and `ftp://foo.com` are valid `href` values, but Twitter doesn't auto-link them, so they shouldn't be treated as URLs.)
- Before the URL from an embed block is appended to the tweet, it should check that the tweet has enough space for it.

Additionally, this PR extends handling of when link text is the same as the link `href`: it previously only checked if they were identical, but it now checks if the text is a shortened version of the `href`. (For example, having a `href` of `https://wordpress.org/` and a link text of `wordpress.org` will no longer cause the URL to be inserted twice into the tweet text.)

#### Changes proposed in this Pull Request:
* Publicize: Improve handling of URLs when generating Twitter threads.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Create a new post.
* Switch Publicize to Twitter threads.
* Check that content with URLs and embeds behaves as expected. (The Social Previews link will show the Twitter thread that is generated.)

Additionally, testing that the thread is then posted to Twitter correctly requires the following:

* Apply D50818-code to your sandbox.
* Set `JETPACK__SANDBOX_DOMAIN` on your Jetpack site to point to your sandbox.
* Add `add_filter( 'publicize_force_synchronous', '__return_true' );` to your sandbox.

#### Proposed changelog entry for your changes:
* Publicize: Improve handling of URLs when generating Twitter threads.