### PR TITLE
Widget Visibility: Disable in Block Editor

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -23,6 +23,7 @@ class Jetpack_Widget_Conditions {
 
 	public static function widget_admin_setup() {
 		$current_screen = get_current_screen();
+		// TODO: Replace `$current_screen->is_block_editor()` with `wp_should_load_block_editor_scripts_and_styles()` that is introduced in WP 5.6
 		if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
 			return;
 		}

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -22,6 +22,11 @@ class Jetpack_Widget_Conditions {
 	}
 
 	public static function widget_admin_setup() {
+		$current_screen = get_current_screen();
+		if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+			return;
+		}
+
 		wp_enqueue_style( 'widget-conditions', plugins_url( 'widget-conditions/widget-conditions.css', __FILE__ ) );
 		wp_style_add_data( 'widget-conditions', 'rtl', 'replace' );
 		wp_enqueue_script(


### PR DESCRIPTION
Currently, on `widget_admin_setup`, in the Widget Visibility module we'll run heavy operations to retrieve a bunch of entities, but we only really use those on the widgets page. Among those entities include all pages, categories, tags, custom taxonomy terms, all registered post types, users. For sites that don't leverage cache and have many pages with a lot of content, this can cause significant delays in TTFB and even end up in OOM errors.

The reason for this is that since Gutenberg 8.3 we call the `widget_admin_setup` hook on the block editor, too (see https://github.com/WordPress/gutenberg/pull/22807), but never actually use this data in the block editor. This means that we can disable the heavy logic on the block editor pages. This is what this PR does.

Note that this intentionally touches WP.com files. We'd like this improvement to be done there, too.

#### Changes proposed in this Pull Request:
* Widget Visibility: Disable in Block Editor

#### Jetpack product discussion
No related discussion. This is related to recent block editor perf improvements in p4TIVU-9uP-p2. See p7H4VZ-2KJ-p2 for more information.

#### Does this pull request change what data or activity we track or use?
Not at all.

#### Testing instructions:
* Go to the Widgets screen.
* Verify the Widget Visibility functionality still works well.

#### Proposed changelog entry for your changes:
* Disable Widget Visibility admin setup in Block Editor