### PR TITLE
REST API tests: Minor update in setUp method

### DIFF
--- a/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
@@ -43,13 +43,13 @@ class WP_Test_Jetpack_Json_Api_Endpoints extends WP_UnitTestCase {
 	}
 
 	public function setUp() {
+		parent::setUp();
+
 		global $blog_id;
 
 		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
 			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
 		}
-
-		parent::setUp();
 
 		$this->set_globals();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Not much, just moves the `parent::setUp` call to the top of `WP_Test_Jetpack_Json_Api_Endpoints` `setUp` method

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
n/a

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
n/a No functional changes
