### PR TITLE
Client: Extract `validate_args_for_wpcom_json_api_request` helper.

### DIFF
--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -297,15 +297,15 @@ class Client {
 	 * Validate and build arguments for a WordPress.com REST API request.
 	 *
 	 * @param  string $path             REST API path.
-	 * @param  string $version          REST API version.
+	 * @param  string $version          REST API version. Default is `2`.
 	 * @param  array  $args             Arguments to {@see WP_Http}. Default is `array()`.
-	 * @param  string $base_api_path    REST API root. Default is `wpcom`.
+	 * @param  string $base_api_path    REST API root. Default is `rest`.
 	 *
 	 * @return array|WP_Error $response Response data, else {@see WP_Error} on failure.
 	 */
 	public static function validate_args_for_wpcom_json_api_request(
 		$path,
-		$version,
+		$version = '2',
 		$args = array(),
 		$base_api_path = 'rest'
 	) {

--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -296,11 +296,12 @@ class Client {
 	/**
 	 * Validate and build arguments for a WordPress.com REST API request.
 	 *
-	 * @param String $path The API endpoint relative path.
-	 * @param String $version The API version.
-	 * @param array  $args Request arguments.
-	 * @param String $base_api_path (optional) the API base path override, defaults to 'rest'.
-	 * @return array|WP_Error $response Data.
+	 * @param  string $path             REST API path.
+	 * @param  string $version          REST API version.
+	 * @param  array  $args             Arguments to {@see WP_Http}. Default is `array()`.
+	 * @param  string $base_api_path    REST API root. Default is `wpcom`.
+	 *
+	 * @return array|WP_Error $response Response data, else {@see WP_Error} on failure.
 	 */
 	public static function validate_args_for_wpcom_json_api_request(
 		$path,

--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -299,7 +299,7 @@ class Client {
 	 * @param  string $path             REST API path.
 	 * @param  string $version          REST API version. Default is `2`.
 	 * @param  array  $args             Arguments to {@see WP_Http}. Default is `array()`.
-	 * @param  string $base_api_path    REST API root. Default is `rest`.
+	 * @param  string $base_api_path    REST API root. Default is `wpcom`.
 	 *
 	 * @return array|WP_Error $response Response data, else {@see WP_Error} on failure.
 	 */
@@ -307,7 +307,7 @@ class Client {
 		$path,
 		$version = '2',
 		$args = array(),
-		$base_api_path = 'rest'
+		$base_api_path = 'wpcom'
 	) {
 		$base_api_path = trim( $base_api_path, '/' );
 		$version       = ltrim( $version, 'v' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Extract some request validation code that's used both by `wpcom_json_api_request_as_user` and `wpcom_json_api_request_as_blog` into a newly created `validate_args_for_wpcom_json_api_request` helper.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Verify that authenticated requests to the WP.com API still work. (This is hopefully covered by unit tests.)

#### Proposed changelog entry for your changes:
Client: Extract `validate_args_for_wpcom_json_api_request` helper.
