### PR TITLE
Autoloader: remove the defined('JETPACK_AUTOLOAD_DEV') checks from the tests

### DIFF
--- a/packages/autoloader/tests/php/tests/test-version-selector.php
+++ b/packages/autoloader/tests/php/tests/test-version-selector.php
@@ -52,7 +52,7 @@ class VersionSelectorTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_is_version_update_required_with_dev_constant( $selected_version, $compare_version, $expected ) {
-		defined( 'JETPACK_AUTOLOAD_DEV' ) || define( 'JETPACK_AUTOLOAD_DEV', true );
+		define( 'JETPACK_AUTOLOAD_DEV', true );
 		$this->assertEquals( $expected, $this->version_selector->is_version_update_required( $selected_version, $compare_version ) );
 	}
 

--- a/packages/autoloader/tests/php/tests/test_manifest_handler.php
+++ b/packages/autoloader/tests/php/tests/test_manifest_handler.php
@@ -89,7 +89,7 @@ class WP_Test_Manifest_Handler extends TestCase {
 			),
 			new Version_Selector()
 		);
-		defined( 'JETPACK_AUTOLOAD_DEV' ) || define( 'JETPACK_AUTOLOAD_DEV', true );
+		define( 'JETPACK_AUTOLOAD_DEV', true );
 
 		$manifest_handler->register_plugin_manifests( 'vendor/composer/jetpack_autoload_classmap.php', $input_array );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* A few of the unit tests require that the `JETPACK_AUTOLOAD_DEV` constant be set to true. Currently, we're checking whether the constant is defined before setting it. If the constant is already defined, we can't guarantee that the constant is set to true, making the tests less reliable. Let's remove the `defined()` checks. If the constant is already defined when the unit tests are executed, an error should be generated.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* These changes affect the tests. Verify that the autoloader packages tests have passed.

#### Proposed changelog entry for your changes:
* n/a
