### PR TITLE
Publicize: avoid loading Twitter settings when not necessary

### DIFF
--- a/extensions/blocks/publicize/twitter/options.js
+++ b/extensions/blocks/publicize/twitter/options.js
@@ -25,7 +25,7 @@ const PublicizeTwitterOptions = ( {
 	setTweetstorm,
 	prePublish,
 } ) => {
-	if ( ! connections.some( connection => 'twitter' === connection.service_name ) ) {
+	if ( ! connections?.some( connection => 'twitter' === connection.service_name ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/46279

#### Changes proposed in this Pull Request:

* When we have no connections available (like in the page editor, where Publicize isn't available), we shouldn't need to load Publicize Twitter settings.

Related:
- https://github.com/Automattic/wp-calypso/issues/46278
- https://github.com/Automattic/wp-calypso/issues/46279

#### Jetpack product discussion

* p2EDhh-1aA-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Pages > Add New
* See no editor errors
* Go to Posts > Add New
* See Publicize Twitter options

#### Proposed changelog entry for your changes:

* Publicize: avoid block editor errors when no Publicize connections are available.
