### PR TITLE
Upgrade: Tracking WP.com connection status

### DIFF
--- a/_inc/client/components/banner/index.jsx
+++ b/_inc/client/components/banner/index.jsx
@@ -73,7 +73,7 @@ class Banner extends Component {
 				target: 'banner',
 				type: 'upgrade',
 				current_version: currentVersion,
-				wpcom_connected: this.props.wpcomUserLogin ? 'yes' : 'no',
+				is_user_wpcom_connected: this.props.wpcomUserLogin ? 'yes' : 'no',
 				is_connection_owner: this.props.isConnectionOwner ? 'yes' : 'no',
 				...eventFeatureProp,
 				...pathProp,

--- a/_inc/client/components/banner/index.jsx
+++ b/_inc/client/components/banner/index.jsx
@@ -21,7 +21,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import PlanIcon from 'components/plans/plan-icon';
-import { getCurrentVersion } from 'state/initial-state';
+import { getCurrentVersion, getUserWpComLogin, userIsMaster } from 'state/initial-state';
 
 import './style.scss';
 
@@ -41,6 +41,8 @@ class Banner extends Component {
 		plan: PropTypes.string,
 		siteSlug: PropTypes.string,
 		title: PropTypes.string.isRequired,
+		wpcomUserLogin: PropTypes.string,
+		isConnectionOwner: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -71,6 +73,8 @@ class Banner extends Component {
 				target: 'banner',
 				type: 'upgrade',
 				current_version: currentVersion,
+				wpcom_connected: this.props.wpcomUserLogin ? 'yes' : 'no',
+				is_connection_owner: this.props.isConnectionOwner ? 'yes' : 'no',
 				...eventFeatureProp,
 				...pathProp,
 			};
@@ -165,4 +169,6 @@ class Banner extends Component {
 
 export default connect( state => ( {
 	currentVersion: getCurrentVersion( state ),
+	wpcomUserLogin: getUserWpComLogin( state ),
+	isConnectionOwner: userIsMaster( state ),
 } ) )( Banner );

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -16,7 +16,13 @@ import Button from 'components/button';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
 import { getSiteConnectionStatus } from 'state/connection';
 import getRedirectUrl from 'lib/jp-redirect';
-import { isAtomicSite, isDevVersion as _isDevVersion, getUpgradeUrl } from 'state/initial-state';
+import {
+	isAtomicSite,
+	isDevVersion as _isDevVersion,
+	getUpgradeUrl,
+	getUserWpComLogin,
+	userIsMaster,
+} from 'state/initial-state';
 import JetpackBanner from 'components/jetpack-banner';
 import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
 import {
@@ -37,6 +43,8 @@ class SupportCard extends React.Component {
 			target: 'banner-click',
 			feature: 'support',
 			page: this.props.path,
+			wpcom_connected: this.props.wpcomUserLogin ? 'yes' : 'no',
+			is_connection_owner: this.props.isConnectionOwner ? 'yes' : 'no',
 		} );
 	};
 
@@ -131,6 +139,8 @@ class SupportCard extends React.Component {
 SupportCard.propTypes = {
 	siteConnectionStatus: PropTypes.any.isRequired,
 	className: PropTypes.string,
+	wpcomUserLogin: PropTypes.string,
+	isConnectionOwner: PropTypes.bool,
 };
 
 export default connect( state => {
@@ -141,5 +151,7 @@ export default connect( state => {
 		isAtomicSite: isAtomicSite( state ),
 		isDevVersion: _isDevVersion( state ),
 		supportUpgradeUrl: getUpgradeUrl( state, 'support' ),
+		wpcomUserLogin: getUserWpComLogin( state ),
+		isConnectionOwner: userIsMaster( state ),
 	};
 } )( SupportCard );

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -43,7 +43,7 @@ class SupportCard extends React.Component {
 			target: 'banner-click',
 			feature: 'support',
 			page: this.props.path,
-			wpcom_connected: this.props.wpcomUserLogin ? 'yes' : 'no',
+			is_user_wpcom_connected: this.props.wpcomUserLogin ? 'yes' : 'no',
 			is_connection_owner: this.props.isConnectionOwner ? 'yes' : 'no',
 		} );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR adds two properties for the existing event `jetpack_wpa_click`:

- `is_user_wpcom_connected`
- `is_connection_owner`

Clicks on the "Upgrade" banners in Jetpack Dashboard don't properly track if the user is connected to WP.com
The existing properties (`_ui`, `_ut`) get potentially overwritten by the ETL process, so we can't rely on them for this purpose.

The goal is to find out how many non-connected secondary users try to upgrade and end up in the broken connection flow.

#### Jetpack product discussion
p9dueE-1M4-p2

#### Does this pull request change what data or activity we track or use?
The PR slightly modifies the data we track in the Jetpack Dashboard by adding two new properties to the existing events:
- Is the user connected to WP.com?
- Is this the connection owner?

No new event tracking added.

#### Testing instructions:
1. Connect your site using Jetpack Free plan.
2. Open the "Network" browser dev tool and filter by `jetpack_wpa_click`.
3. Go to the Dashboard and click on the "Scan -> Upgrade".
4. Check the network tab and confirm that the event `jetpack_wpa_click` has been sent with two properties: `is_user_wpcom_connected: yes` and `is_connection_owner: yes`.
5. Log into your site as another admin user, not connected to WP.com
6. Go to Jetpack Dashboard, filter network tab by `jetpack_wpa_click`.
7. Click on "Get a faster resolution to your support questions -> Upgrade".
8. Check the network tab and confirm that the event `jetpack_wpa_click` has been sent with two properties: `is_user_wpcom_connected: no` and `is_connection_owner: no`.

You can use the "Tracks Live" and filter by the event `jetpack_wpa_click` to find your tracks and confirm that the data was recorded correctly.

#### Proposed changelog entry for your changes:
n/a