### PR TITLE
Jetpack: API: Add jetpack_instagram_embed_request action

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -282,6 +282,21 @@ function jetpack_instagram_fetch_embed( $args ) {
 			)
 		);
 		$response             = wp_remote_get( $url, array( 'redirection' => 0 ) );
+
+		// Unset before calling the action below.
+		unset( $args['access_token'] );
+
+		/**
+		 * Fires after making a request for an Instagram embed.
+		 *
+		 * @module shortcodes
+		 *
+		 * @since  9.1.0
+		 *
+		 * @param array $response The response from the embed request.
+		 * @param array $url      The arguments sent with the request.
+		 */
+		do_action( 'jetpack_instagram_embed_request', $response, $args );
 	} else {
 		if ( ! Jetpack::is_active_and_not_offline_mode() ) {
 			return new WP_Error(


### PR DESCRIPTION
See D50894-code. Note, this is already merged to WP.com

#### Changes proposed in this Pull Request:

* Because we have rate limiting for our Facebook access token, we need good logging/stats in place. This action makes it convenient to hook in any time an embed request is made to handle logging/stats.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See D50894-code and p7H4VZ-2DU-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

It does not change what logging that we have in the Jetpack core plugin. It does, however, allow us to better log requests with a standard retention rate on WordPress.com

#### Testing instructions:

See D50894-code

#### Proposed changelog entry for your changes:

* Add jetpack_instagram_embed_request action to allow for logging and stats since the Facebook embed API is rate limited.
