### PR TITLE
Connection Errors: Tracking additional error data

### DIFF
--- a/_inc/client/components/jetpack-notices/error-notice-cycle-connection.jsx
+++ b/_inc/client/components/jetpack-notices/error-notice-cycle-connection.jsx
@@ -20,6 +20,7 @@ export default class ErrorNoticeCycleConnection extends React.Component {
 	static propTypes = {
 		text: PropTypes.string.isRequired,
 		errorCode: PropTypes.string,
+		errorData: PropTypes.object,
 		action: PropTypes.string,
 	};
 
@@ -31,7 +32,11 @@ export default class ErrorNoticeCycleConnection extends React.Component {
 				status={ 'is-error' }
 				icon={ 'link-break' }
 			>
-				<NoticeActionReconnect errorCode={ this.props.errorCode } action={ this.props.action }>
+				<NoticeActionReconnect
+					errorCode={ this.props.errorCode }
+					errorData={ this.props.errorData }
+					action={ this.props.action }
+				>
 					{ __( 'Restore Connection', 'jetpack' ) }
 				</NoticeActionReconnect>
 			</SimpleNotice>

--- a/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
+++ b/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
@@ -15,10 +15,17 @@ export default class JetpackConnectionErrors extends React.Component {
 		errors: PropTypes.array.isRequired,
 	};
 
-	getAction( action, message, code ) {
+	getAction( action, message, code, errorData ) {
 		switch ( action ) {
 			case 'reconnect':
-				return <ErrorNoticeCycleConnection text={ message } errorCode={ code } action={ action } />;
+				return (
+					<ErrorNoticeCycleConnection
+						text={ message }
+						errorCode={ code }
+						errorData={ errorData }
+						action={ action }
+					/>
+				);
 			case 'display':
 				return (
 					<SimpleNotice
@@ -34,7 +41,12 @@ export default class JetpackConnectionErrors extends React.Component {
 	}
 
 	renderOne( error ) {
-		const action = this.getAction( error.action, error.message, error.code );
+		const action = this.getAction(
+			error.action,
+			error.message,
+			error.code,
+			error.hasOwnProperty( 'data' ) ? error.data : {}
+		);
 
 		return null === action ? null : (
 			<React.Fragment key={ error.action }>{ action }</React.Fragment>

--- a/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
+++ b/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
@@ -30,8 +30,13 @@ class NoticeActionReconnect extends React.Component {
 			eventProps.error_code = this.props.errorCode;
 		}
 
-		if ( this.props.errorData && this.props.errorData.api_error_code ) {
-			eventProps.api_error_code = this.props.errorData.api_error_code;
+		if ( this.props.errorData ) {
+			if ( this.props.errorData.api_error_code ) {
+				eventProps.api_error_code = this.props.errorData.api_error_code;
+			}
+			if ( this.props.errorData.api_http_code ) {
+				eventProps.api_http_code = this.props.errorData.api_http_code;
+			}
 		}
 
 		return eventProps;

--- a/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
+++ b/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
@@ -16,6 +16,7 @@ class NoticeActionReconnect extends React.Component {
 	static propTypes = {
 		icon: PropTypes.string,
 		errorCode: PropTypes.string,
+		errorData: PropTypes.object,
 		action: PropTypes.string,
 	};
 
@@ -28,6 +29,11 @@ class NoticeActionReconnect extends React.Component {
 		if ( this.props.errorCode ) {
 			eventProps.error_code = this.props.errorCode;
 		}
+
+		if ( this.props.errorData && this.props.errorData.api_error_code ) {
+			eventProps.api_error_code = this.props.errorData.api_error_code;
+		}
+
 		return eventProps;
 	};
 

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -159,6 +159,7 @@ export const errors = ( state = {}, action ) => {
 				code: action.error.hasOwnProperty( 'response' )
 					? action.error.response.code
 					: 'fetch_site_data_fail_other',
+				data: action.error.hasOwnProperty( 'response' ) ? action.error.response.data : {},
 			} );
 		default:
 			return state;

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1795,15 +1795,18 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$data     = $body ? json_decode( $body ) : null;
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$api_error_code = null;
+			$error_info = array(
+				'api_error_code' => null,
+				'api_http_code'  => wp_remote_retrieve_response_code( $response ),
+			);
 
 			if ( is_wp_error( $response ) ) {
-				$api_error_code = $response->get_error_code() ? wp_strip_all_tags( $response->get_error_code() ) : null;
+				$error_info['api_error_code'] = $response->get_error_code() ? wp_strip_all_tags( $response->get_error_code() ) : null;
 			} elseif ( $data && ! empty( $data->error ) ) {
-				$api_error_code = $data->error;
+				$error_info['api_error_code'] = $data->error;
 			}
 
-			return new WP_Error( 'site_data_fetch_failed', '', array( 'api_error_code' => $api_error_code ) );
+			return new WP_Error( 'site_data_fetch_failed', '', $error_info );
 		}
 
 		Jetpack_Plan::update_from_sites_response( $response );
@@ -1849,6 +1852,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			array(
 				'status'         => 400,
 				'api_error_code' => empty( $error_data['api_error_code'] ) ? null : $error_data['api_error_code'],
+				'api_http_code'  => empty( $error_data['api_http_code'] ) ? null : $error_data['api_http_code'],
 			)
 		);
 	}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1843,7 +1843,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 			$error_message = sprintf( esc_html__( 'Failed fetching site data from WordPress.com (%s). If the problem persists, try reconnecting Jetpack.', 'jetpack' ), $error_data['api_error_code'] );
 		}
 
-		return new WP_Error( $site_data->get_error_code(), $error_message, array( 'status' => 400 ) );
+		return new WP_Error(
+			$site_data->get_error_code(),
+			$error_message,
+			array(
+				'status'         => 400,
+				'api_error_code' => empty( $error_data['api_error_code'] ) ? null : $error_data['api_error_code'],
+			)
+		);
 	}
 
 	/**

--- a/packages/connection/src/class-error-handler.php
+++ b/packages/connection/src/class-error-handler.php
@@ -75,6 +75,15 @@ class Error_Handler {
 	 * @since 8.7.0
 	 */
 	const ERROR_LIFE_TIME = DAY_IN_SECONDS;
+
+	/**
+	 * The error code for event tracking purposes.
+	 * If there are many, only the first error code will be tracked.
+	 *
+	 * @var string
+	 */
+	private $error_code;
+
 	/**
 	 * List of known errors. Only error codes in this list will be handled
 	 *
@@ -92,7 +101,8 @@ class Error_Handler {
 		'token_malformed',
 		'user_id_mismatch',
 		'no_possible_tokens',
-		'no_valid_token',
+		'no_valid_user_token',
+		'no_valid_blog_token',
 		'unknown_token',
 		'could_not_sign',
 		'invalid_scheme',
@@ -145,14 +155,12 @@ class Error_Handler {
 	public function handle_verified_errors() {
 		$verified_errors = $this->get_verified_errors();
 		foreach ( array_keys( $verified_errors ) as $error_code ) {
-
-			$error_found = false;
-
 			switch ( $error_code ) {
 				case 'malformed_token':
 				case 'token_malformed':
 				case 'no_possible_tokens':
-				case 'no_valid_token':
+				case 'no_valid_user_token':
+				case 'no_valid_blog_token':
 				case 'unknown_token':
 				case 'could_not_sign':
 				case 'invalid_token':
@@ -163,11 +171,10 @@ class Error_Handler {
 				case 'no_token_for_user':
 					add_action( 'admin_notices', array( $this, 'generic_admin_notice_error' ) );
 					add_action( 'react_connection_errors_initial_state', array( $this, 'jetpack_react_dashboard_error' ) );
-					$error_found = true;
-			}
-			if ( $error_found ) {
-				// Since we are only generically handling errors, we don't need to trigger error messages for each one of them.
-				break;
+					$this->error_code = $error_code;
+
+					// Since we are only generically handling errors, we don't need to trigger error messages for each one of them.
+					break 2;
 			}
 		}
 	}
@@ -670,11 +677,11 @@ class Error_Handler {
 	 * @return array
 	 */
 	public function jetpack_react_dashboard_error( $errors ) {
-
 		$errors[] = array(
 			'code'    => 'xmlrpc_error',
 			'message' => __( 'Your connection with WordPress.com seems to be broken. If you\'re experiencing issues, please try reconnecting.', 'jetpack' ),
 			'action'  => 'reconnect',
+			'data'    => array( 'api_error_code' => $this->error_code ),
 		);
 		return $errors;
 	}

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2333,9 +2333,9 @@ class Manager {
 		if ( ! $valid_token ) {
 			if ( $user_id ) {
 				// translators: %d is the user ID.
-				return $suppress_errors ? false : new \WP_Error( 'no_valid_token', sprintf( __( 'Invalid token for user %d', 'jetpack' ), $user_id ) );
+				return $suppress_errors ? false : new \WP_Error( 'no_valid_user_token', sprintf( __( 'Invalid token for user %d', 'jetpack' ), $user_id ) );
 			} else {
-				return $suppress_errors ? false : new \WP_Error( 'no_valid_token', __( 'Invalid blog token', 'jetpack' ) );
+				return $suppress_errors ? false : new \WP_Error( 'no_valid_blog_token', __( 'Invalid blog token', 'jetpack' ) );
 			}
 		}
 


### PR DESCRIPTION
The goal of this PR is to get better understanding of the Jetpack connection errors.

#### Changes proposed in this Pull Request:
* Adding the WP.com API error codes and HTTP response codes into the `jetpack_termination_error_notice_*` tracks.

#### Does this pull request change what data or activity we track or use?
Yes.
We modify the existing `jetpack_termination_error_notice_click` and `jetpack_termination_error_notice_view` events by adding two new properties:
- `api_error_code` - contains the error code received from WP.com (if there is one).
- `api_http_code` - contains the HTTP response code received from WP.com

#### Testing instructions:
**REST Errors**
1. Use the "Broken Token" tool to set an invalid blog token.
2. Activate the "Network" browser dev tool, filter the log by `jetpack_termination_error_notice`.
3. Go to Jetpack Dashboard, the tracking request should appear for event `jetpack_termination_error_notice_view`. Confirm it sends the properties`api_error_code: unknown_token` and `api_http_code: 400`.
4. Click "Restore Connection". The tracking request should appear for the event `jetpack_termination_error_notice_click`. Confirm it sends the properties `api_error_code: unknown_token` and `api_http_code: 400`.
5. The Jetpack Dashboard should reload, the connection error notice should disappear, the blog token should be restored.
6. Restore the connection.

**XMLRPC Errors**
7. Head to "Jetpack Debug -> XML-RPC Errors" and click "Create Error" to generate an XMLRPC error.
8. Activate the "Network" browser dev tool, filter the log by `jetpack_termination_error_notice`.
9. Go to Jetpack Dashboard, the tracking request should appear for event `jetpack_termination_error_notice_view`. Confirm it sends the properties`error_code: xmlrpc_error` and `api_error_code: invalid_token`.
10. Click "Restore Connection". The tracking request should appear for the event `jetpack_termination_error_notice_click`. Confirm it sends the properties `error_code: xmlrpc_error` and `api_error_code: invalid_token`.

#### Proposed changelog entry for your changes:
n/a