### PR TITLE
Connection: add the constant filter hooks directly

### DIFF
--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -23,7 +23,12 @@ class Client {
 	 * @return array|WP_Error WP HTTP response on success
 	 */
 	public static function remote_request( $args, $body = null ) {
-		Utils::init_default_constants();
+		add_filter(
+			'jetpack_constant_default_value',
+			__NAMESPACE__ . '\Utils::jetpack_api_constant_filter',
+			10,
+			2
+		);
 
 		$defaults = array(
 			'url'           => '',

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -97,7 +97,12 @@ class Manager {
 	public static function configure() {
 		$manager = new self();
 
-		Utils::init_default_constants();
+		add_filter(
+			'jetpack_constant_default_value',
+			__NAMESPACE__ . '\Utils::jetpack_api_constant_filter',
+			10,
+			2
+		);
 
 		$manager->setup_xmlrpc_handlers(
 			$_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/packages/connection/src/class-rest-authentication.php
+++ b/packages/connection/src/class-rest-authentication.php
@@ -73,7 +73,12 @@ class Rest_Authentication {
 			return $user;
 		}
 
-		Utils::init_default_constants();
+		add_filter(
+			'jetpack_constant_default_value',
+			__NAMESPACE__ . '\Utils::jetpack_api_constant_filter',
+			10,
+			2
+		);
 
 		if ( ! isset( $_GET['_for'] ) || 'jetpack' !== $_GET['_for'] ) {
 			// Nothing to do for this authentication method.


### PR DESCRIPTION
A fatal error can occur under these conditions:
- Jetpack is updated from <=8.9.1 to >=9.0.
- The Dashboard -> Updates tool is used to update Jetpack.

The generated error is `Fatal error: Uncaught Error: Call to undefined method Automattic\Jetpack\Connection\Utils::init_default_constants()`

This PR prevents the fatal from occurring.

Thanks to @sergeymitr for suggesting this fix.

#### Changes proposed in this Pull Request:
* Call `add_filter( 'jetpack_constant_default_value'...)` directly rather than calling `Utils::init_default_constants()`.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Reproduce the error
1. Install, activate, and connect Jetpack 8.9.1.
2. Using the Dashboard -> Updates tool, update Jetpack to 9.0.1.
3. Observe the error.

##### Test this PR
1. Install, activate, and connect Jetpack 8.9.1.
2. Set up a snippet to force an update to this branch. See p9dueE-1AG-p2 for instructions. The branch url is https://betadownload.jetpack.me/branches/fix_set_constant_filters/jetpack-dev.zip.
3. Using the Dashboard -> Updates tool, update Jetpack to this branch.
4. Verify that the error did not occur.
5. Test other update methods (the plugins page, WP-CLI, autoupdate) to verify that the updates are successful and no errors are generated.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* tbd