### PR TITLE
Instagram: Clean query params and force URL and protocol

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -102,9 +102,6 @@ wp_embed_register_handler(
 function jetpack_instagram_handler( $matches, $atts, $url ) {
 	global $content_width;
 
-	// keep a copy of the passed-in URL since it's modified below.
-	$passed_url = $url;
-
 	$max_width = 698;
 	$min_width = 320;
 
@@ -144,17 +141,8 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 		$atts['width'] = $min_width;
 	}
 
-	// remove the modal param from the URL.
-	$url = remove_query_arg( 'modal', $url );
-
-	// force .com instead of .am for https support.
-	$url = str_replace( 'instagr.am', 'instagram.com', $url );
-
-	// The oembed endpoint expects HTTP, but HTTP requests 301 to HTTPS.
-	$instagram_http_url = str_replace( 'https://', 'http://', $url );
-
 	$url_args = array(
-		'url'        => $instagram_http_url,
+		'url'        => $url,
 		'maxwidth'   => $atts['width'],
 		'omitscript' => 1,
 	);
@@ -163,7 +151,7 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 		$url_args['hidecaption'] = 'true';
 	}
 
-	$use_cache     = jetpack_instagram_use_cache( $matches, $atts, $passed_url );
+	$use_cache     = jetpack_instagram_use_cache( $matches, $atts, $url );
 	$cache_key     = 'oembed_response_body_' . md5( add_query_arg( $url_args, 'https://api.instagram.com/oembed/' ) );
 	$response_body = $use_cache
 		? wp_cache_get( $cache_key, 'instagram_embeds' )
@@ -270,6 +258,13 @@ function jetpack_instagram_use_cache( $matches, $atts, $passed_url ) {
  */
 function jetpack_instagram_fetch_embed( $args ) {
 	$access_token = jetpack_instagram_get_access_token();
+
+	// Attempt to clean query params from the URL since Facebook's new API for Instagram
+	// embeds does not like query parameters. See p7H4VZ-2DU-p2.
+	$parsed_url = wp_parse_url( $args['url'] );
+	if ( $parsed_url ) {
+		$args['url'] = 'https://www.instagram.com' . $parsed_url['path'];
+	}
 
 	// If an access token exists, which will be the case for WPCOM, then we will call the Facebook API directly.
 	// Otherwise, proxy the request through the WordPress.com API using the blog token to sign the request.


### PR DESCRIPTION
Fixes #17424

#### Changes proposed in this Pull Request:

Ensure that when embedding Instagram posts, posts with query args can be embedded as well: `https://www.instagram.com/p/CGAWEzXnD-O/?utm_source=ig_web_copy_link` should work just as well as `https://www.instagram.com/p/CGAWEzXnD-O/` or `https://instagr.am/p/CGAWEzXnD-O/`

Differential Revision: D50902-code

This commit syncs r214945-wpcom.

#### Jetpack product discussion

* p7H4VZ-2DU-p2/#comment-8928

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

- Checkout patch
- Create JN site and connect
- Create post and add Instagram embed, adding a query arg
- Ensure that embed is successful
- Update URL to be something like http://instagr.am/p/CGBrMmPplaW/
- Ensure that URL works

#### Proposed changelog entry for your changes:

* Instagram Embeds: ensure that Instagram URLs with additional URL parameters can be embedded as well
