### PR TITLE
Fix memory and performance issues of the Widget Visibility module

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -230,7 +230,7 @@ class Jetpack_Widget_Conditions {
  	 *
  	 * @see https://core.trac.wordpress.org/ticket/51469
  	 *
- 	 * @return array List of all pages on the site (objects containing ID, post_title, and post_parent only).
+ 	 * @return array List of all pages on the site (stdClass objects containing ID, post_title, and post_parent only).
  	 */
 	public static function get_pages() {
 		global $wpdb;
@@ -243,7 +243,7 @@ class Jetpack_Widget_Conditions {
 			wp_cache_set( $cache_key, $pages, 'widget_conditions' );
 		}
 
-		// Copy-pasted from the get_pages function. For usage in the `get_pages` filter.
+		// Copy-pasted from the get_pages function. For usage in the `widget_conditions_get_pages` filter.
 		$parsed_args = array(
 			'child_of'     => 0,
 			'sort_order'   => 'ASC',

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -229,6 +229,28 @@ class Jetpack_Widget_Conditions {
 			$pages = $wpdb->get_results( "SELECT {$wpdb->posts}.ID, {$wpdb->posts}.post_parent, {$wpdb->posts}.post_title FROM {$wpdb->posts} WHERE {$wpdb->posts}.post_type = 'page' AND {$wpdb->posts}.post_status = 'publish' ORDER BY {$wpdb->posts}.post_title ASC" );
 			wp_cache_set( $cache_key, $pages, 'widget_conditions' );
 		}
+
+		// Copy-pasted from the get_pages function. For usage in the `get_pages` filter.
+		$parsed_args = array(
+			'child_of'     => 0,
+			'sort_order'   => 'ASC',
+			'sort_column'  => 'post_title',
+			'hierarchical' => 1,
+			'exclude'      => array(),
+			'include'      => array(),
+			'meta_key'     => '',
+			'meta_value'   => '',
+			'authors'      => '',
+			'parent'       => -1,
+			'exclude_tree' => array(),
+			'number'       => '',
+			'offset'       => 0,
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+		);
+		/** This filter is documented in wp-includes/post.php */
+		$pages = apply_filters( 'get_pages', $pages, $parsed_args );
+
 		return $pages;
 	}
 

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -226,7 +226,7 @@ class Jetpack_Widget_Conditions {
 		$cache_key    = "get_pages:$last_changed";
 		$pages        = wp_cache_get( $cache_key, 'widget_conditions' );
 		if ( false === $pages ) {
-			$pages = $wpdb->get_results( "SELECT {$wpdb->posts}.ID, {$wpdb->posts}.post_parent, {$wpdb->posts}.post_title FROM {$wpdb->posts} WHERE {$wpdb->posts}.post_type = 'page' AND {$wpdb->posts}.post_status = 'publish' ORDER BY {$wpdb->posts}.post_date DESC" );
+			$pages = $wpdb->get_results( "SELECT {$wpdb->posts}.ID, {$wpdb->posts}.post_parent, {$wpdb->posts}.post_title FROM {$wpdb->posts} WHERE {$wpdb->posts}.post_type = 'page' AND {$wpdb->posts}.post_status = 'publish' ORDER BY {$wpdb->posts}.post_title ASC" );
 			wp_cache_set( $cache_key, $pages, 'widget_conditions' );
 		}
 		return $pages;

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -261,8 +261,15 @@ class Jetpack_Widget_Conditions {
 			'post_type'    => 'page',
 			'post_status'  => 'publish',
 		);
-		/** This filter is documented in wp-includes/post.php */
-		$pages = apply_filters( 'get_pages', $pages, $parsed_args );
+
+		/**
+		 * Filters the retrieved list of pages.
+		 *
+		 *
+		 * @param stdClass[] $pages       Array of objects containing only the ID, post_parent, and post_title fields.
+		 * @param array      $parsed_args Array of get_pages() arguments.
+		*/
+		$pages = apply_filters( 'widget_conditions_get_pages', $pages, $parsed_args );
 
 		return $pages;
 	}

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -265,10 +265,14 @@ class Jetpack_Widget_Conditions {
 		/**
 		 * Filters the retrieved list of pages.
 		 *
+		 * @since 9.1.0
+		 *
+		 * @module widget-visibility
+		 *
 		 * @param stdClass[] $pages       Array of objects containing only the ID, post_parent, and post_title fields.
 		 * @param array      $parsed_args Array of get_pages() arguments.
 		 */
-		return apply_filters( 'widget_conditions_get_pages', $pages, $parsed_args );
+		return apply_filters( 'jetpack_widget_visibility_get_pages', $pages, $parsed_args );
 	}
 
 	/**

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -268,10 +268,8 @@ class Jetpack_Widget_Conditions {
 		 *
 		 * @param stdClass[] $pages       Array of objects containing only the ID, post_parent, and post_title fields.
 		 * @param array      $parsed_args Array of get_pages() arguments.
-		*/
-		$pages = apply_filters( 'widget_conditions_get_pages', $pages, $parsed_args );
-
-		return $pages;
+		 */
+		return apply_filters( 'widget_conditions_get_pages', $pages, $parsed_args );
 	}
 
 	/**

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -265,7 +265,6 @@ class Jetpack_Widget_Conditions {
 		/**
 		 * Filters the retrieved list of pages.
 		 *
-		 *
 		 * @param stdClass[] $pages       Array of objects containing only the ID, post_parent, and post_title fields.
 		 * @param array      $parsed_args Array of get_pages() arguments.
 		 */

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -219,6 +219,19 @@ class Jetpack_Widget_Conditions {
 		wp_localize_script( 'widget-conditions', 'widget_conditions_parent_pages', $all_parents );
 	}
 
+	/**
+ 	 * Retrieves a full list of all pages, containing just the IDs, post_parent, and post_title fields.
+ 	 *
+ 	 * Since the WordPress' `get_pages` function does not allow us to fetch only the fields mentioned
+ 	 * above, we need to introduce a custom method using a direct SQL query fetching those.
+ 	 *
+ 	 * By fetching only those 3 fields and not populating the object cache for all the pages, we can 
+ 	 * improve the performance of the query on sites having a lot of pages.
+ 	 *
+ 	 * @see https://core.trac.wordpress.org/ticket/51469
+ 	 *
+ 	 * @return array List of all pages on the site (objects containing ID, post_title, and post_parent only).
+ 	 */
 	public static function get_pages() {
 		global $wpdb;
 


### PR DESCRIPTION
The Widget Visibility feature requires a lot of data in order to provide a very flexible visibility settings for the widgets. For instance, it lists all the pages on a site in a dropdown, which may be an issue for sites with a huge amount of pages, or sites with very large pages, so they don't fit into a single memcache key=>value pair.

In order to preserve the current behaviour (listing all the pages), but optimize the loading times, this patch is introducing a custom direct SQL query for fetching only necessary data of all pages (ID, post_parent, and post_title). The direct SQL query is being cached under plugin's own group, and is taking advantage of the `wp_cache_get_last_changed( 'posts' )` value, which is being flushed whenever a new page is being added, so the listing should be always fresh (the `wp_cache_get_last_changed( 'posts' )` is being used also inside the `get_pages` function call, which the custom implementation is replacing).

The custom `get_pages` function does not trigger the memcache gets for all the pages, as we really don't need whole post objects here.

This changeset also limits the fields returned by the `get_users` call to `ID` and `display_name`, since that's really all we need here.

Fixes #6955

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Should not contain any functional changes, but rather optimise the performance of an existing feature, while keeping it working as it is now.

#### Jetpack product discussion
- p7H4VZ-2KJ-p2

#### Does this pull request change what data or activity we track or use?
Nope.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have a site with many users (authors) and/or with many pages.
* Go to '/wp-admin/widgets.php' and make sure you can see all the pages and authors in the dropdowns of the Visibility feature of a widget
* Check what related SQL queries are run, what memcache keys are being fetched (eg.: using the Debug Bar or any other similar plugin), and whether the page load was reasonably fast.

#### Proposed changelog entry for your changes:
* Improves performance of the Widget Visibility module
