### PR TITLE
Publicize: connections should always be an array

### DIFF
--- a/extensions/blocks/publicize/store/reducer.js
+++ b/extensions/blocks/publicize/store/reducer.js
@@ -17,7 +17,7 @@ export default function ( state = DEFAULT_STATE, action ) {
 		case 'SET_CONNECTION_TEST_RESULTS':
 			return {
 				...state,
-				connections: action.results,
+				connections: action.results || [],
 			};
 		case 'REFRESH_CONNECTION_TEST_RESULTS':
 			return {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

See https://github.com/Automattic/jetpack/pull/17420#pullrequestreview-505232376

`connections` really should be an empty array when there are no connections, rather than undefined.


#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A

#### Testing instructions:

* Go to Pages > Add New
* See no editor errors
* Go to Posts > Add New
* See Publicize Twitter options

#### Proposed changelog entry for your changes:
* N/A
