### PR TITLE
External Media: Enable for Cover block

### DIFF
--- a/extensions/shared/external-media/index.js
+++ b/extensions/shared/external-media/index.js
@@ -34,6 +34,7 @@ if ( isCurrentUserConnected() && 'function' === typeof useBlockEditContext ) {
 		'external-media/replace-media-upload',
 		OriginalComponent => props => {
 			const allowedBlocks = [
+				'core/cover',
 				'core/image',
 				'core/gallery',
 				'core/media-text',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Enables External Media feature for the Cover block.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `core/cover` to the list of blocks External Media is available to.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In the Editor, insert a Cover block and chose an External Media provider to insert a background image.
* Replace the image with a different one.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Makes External Media available to the Cover block.