### PR TITLE
External Media: Update source icons

### DIFF
--- a/extensions/shared/external-media/media-button/media-menu.js
+++ b/extensions/shared/external-media/media-button/media-menu.js
@@ -3,6 +3,7 @@
  */
 import { Button, MenuItem, MenuGroup, Dropdown, NavigableMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { media } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -59,7 +60,7 @@ function MediaButtonMenu( props ) {
 				renderContent={ () => (
 					<NavigableMenu aria-label={ label }>
 						<MenuGroup>
-							<MenuItem icon="admin-media" onClick={ open }>
+							<MenuItem icon={ media } onClick={ open }>
 								{ __( 'Media Library', 'jetpack' ) }
 							</MenuItem>
 

--- a/extensions/shared/external-media/sources/index.js
+++ b/extensions/shared/external-media/sources/index.js
@@ -16,13 +16,13 @@ export const mediaSources = [
 	{
 		id: SOURCE_GOOGLE_PHOTOS,
 		label: __( 'Google Photos', 'jetpack' ),
-		icon: <GooglePhotosIcon />,
+		icon: <GooglePhotosIcon className="components-menu-items__item-icon" />,
 		keyword: 'google photos',
 	},
 	{
 		id: SOURCE_PEXELS,
 		label: __( 'Pexels Free Photos', 'jetpack' ),
-		icon: <PexelsIcon />,
+		icon: <PexelsIcon className="components-menu-items__item-icon" />,
 		keyword: 'pexels',
 	},
 ];

--- a/extensions/shared/icons.js
+++ b/extensions/shared/icons.js
@@ -23,14 +23,14 @@ export const MediaLibraryIcon = () => (
 	</SVG>
 );
 
-export const GooglePhotosIcon = () => (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+export const GooglePhotosIcon = props => (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" { ...props }>
 		<Path d="M6.3 7l-4.4 4.5c0 .1-.1.2-.1.3-.1.1 0 .2.2.2h7c1.1 0 2-.9 2-2V7H6.3zM22 12h-7c-1.1 0-2 .9-2 2v3h4.7l4.4-4.5c0-.1.1-.2.1-.3.1-.1 0-.2-.2-.2zM12.5 1.9c-.1 0-.2-.1-.3-.1-.1-.1-.2 0-.2.2v7c0 1.1.9 2 2 2h3V6.3l-4.5-4.4zM10 13H7v4.7l4.5 4.4c.1 0 .2.1.3.1.2 0 .3-.1.3-.3v-7c-.1-1-1-1.9-2.1-1.9z" />
 	</SVG>
 );
 
-export const PexelsIcon = () => (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+export const PexelsIcon = props => (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" { ...props }>
 		<Path d="M14 7H9v10h3.9v-3.8H14c1.7 0 3.1-1.4 3.1-3.1C17.2 8.4 15.8 7 14 7z" />
 		<Path d="M20.5 2h-17C2.7 2 2 2.7 2 3.5v17c0 .8.7 1.5 1.5 1.5h17c.8 0 1.5-.7 1.5-1.5v-17c0-.8-.7-1.5-1.5-1.5zm-5.6 13.2V19H7V5h7c2.8 0 5.1 2.3 5.1 5.1.1 2.5-1.8 4.7-4.2 5.1z" />
 	</SVG>

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
 		"@wordpress/date": "3.11.1",
 		"@wordpress/element": "2.16.0",
 		"@wordpress/i18n": "3.9.0",
+		"@wordpress/icons": "2.7.0",
 		"@wordpress/url": "2.11.0",
 		"babel-jest": "26.3.0",
 		"babel-loader": "8.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1308,7 +1308,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.11.1":
+"@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -2520,10 +2520,30 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.2.tgz#5bb52ee68d0f8efa9cc0099920e56be6cc4e37f3"
   integrity sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/react-dom@^16.9.0":
+  version "16.9.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
+  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.9.0":
+  version "16.9.51"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.51.tgz#f8aa51ffa9996f1387f63686696d9b59713d2b60"
+  integrity sha512-lQa12IyO+DMlnSZ3+AGHRUiUcpK47aakMMoBG8f7HGxJT8Yfe+WE128HIXaHOHVPReAW0oDS3KAI0JI2DDe1PQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/responselike@*":
   version "1.0.0"
@@ -3315,6 +3335,19 @@
     react "^16.9.0"
     react-dom "^16.9.0"
 
+"@wordpress/element@^2.18.0":
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-2.18.0.tgz#6ccdaf05f49831058103ec111ab4744df030c335"
+  integrity sha512-aR1gOXFxIDcrLCSANe5PwOwYH40n29LzjqBascNkFo6f0LBekCZPbI3Bqq4EtoH/zjq2RKAO9PVPlQRDoQUlmA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@types/react" "^16.9.0"
+    "@types/react-dom" "^16.9.0"
+    "@wordpress/escape-html" "^1.10.0"
+    lodash "^4.17.19"
+    react "^16.13.1"
+    react-dom "^16.13.1"
+
 "@wordpress/env@1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@wordpress/env/-/env-1.6.0.tgz#db4846d9052e8f6b505c98ed2f437ee9b6180c2d"
@@ -3332,6 +3365,13 @@
     rimraf "^3.0.2"
     terminal-link "^2.0.0"
     yargs "^14.0.0"
+
+"@wordpress/escape-html@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-1.10.0.tgz#72e2b502e2f77a7feb32c8c4504f5cda9f4ea5f6"
+  integrity sha512-peG+Ypnw8L3YiUWSe/3Nmyzlaoqqbn5JaBaLpL0o6pBxFvGwKr00fFJoi+Yq2yZ3LEFDrHBHlVYAB6A2aYIbew==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
 
 "@wordpress/escape-html@^1.7.0":
   version "1.7.0"
@@ -3389,6 +3429,15 @@
     memize "^1.0.5"
     sprintf-js "^1.1.1"
     tannin "^1.1.0"
+
+"@wordpress/icons@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-2.7.0.tgz#0059fae7c0f4c9a8028b35bd6b1e9ff6e0723d39"
+  integrity sha512-UnFoieW6dZjYOpQTU+cIdoDTU2NNMiBQ5nUFP1RnNcNcwEiXVrhLqJS9ZXsy+mECeR0K1wT3UUUN7rTiMtITGw==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@wordpress/element" "^2.18.0"
+    "@wordpress/primitives" "^1.9.0"
 
 "@wordpress/icons@^1.1.0":
   version "1.1.0"
@@ -3468,6 +3517,15 @@
   dependencies:
     "@babel/runtime" "^7.8.3"
     "@wordpress/element" "^2.11.0"
+    classnames "^2.2.5"
+
+"@wordpress/primitives@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-1.9.0.tgz#584b9dadd175e09e82a08c9631879030cb42c1e3"
+  integrity sha512-dbYivYpHunYMTXBlY5Mxy/YSBY2RbMV+Z3/MgdkZJMkGL1k+C5/JFAsHSt8Y1UyvWR3lZnWpH+MeF+oq04TWYg==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@wordpress/element" "^2.18.0"
     classnames "^2.2.5"
 
 "@wordpress/priority-queue@^1.5.1":
@@ -6204,6 +6262,11 @@ csstype@^2.5.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
   integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+
+csstype@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
+  integrity sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -14607,7 +14670,7 @@ react-dates@^17.1.1:
     react-with-styles "^3.2.0"
     react-with-styles-interface-css "^4.0.2"
 
-react-dom@16.13.1, "react-dom@^0.14.3 || ^15.1.0 || ^16.0.0", react-dom@^16.9.0:
+react-dom@16.13.1, "react-dom@^0.14.3 || ^15.1.0 || ^16.0.0", react-dom@^16.13.1, react-dom@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -14773,7 +14836,7 @@ react-with-styles@^3.2.0:
     prop-types "^15.6.2"
     react-with-direction "^1.3.0"
 
-react@16.13.1, "react@^0.14.3 || ^15.1.0 || ^16.0.0", react@^16.8.3, react@^16.9.0:
+react@16.13.1, "react@^0.14.3 || ^15.1.0 || ^16.0.0", react@^16.13.1, react@^16.8.3, react@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
Fixes #17472 

Updates external media provider icons to be properly aligned in the latest Gutenberg version (without breaking existing versions). Also updates Media Library icon.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds html class for icons to be properly aligned
* Adds `@wordpress/icon` library to replace old media library Icon
* Updates `yarn.lock`, not sure if that's desired.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Editor
* Click to add a Featured Image in the right sidebar and make sure (1) the Icons are aligned to the right (or left, depending on Gutenberg version) and (2) the media library icon is updated (an SVG rather than dashicon)
* Insert a media & text block and add an image to the media part.
* Click on "Replace" and make sure the icons are aligned properly

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* External Media: updated iconography and better forward compatibility.

Before | After
--- | ---
![Screen Shot 2020-10-09 at 1 11 00 PM](https://user-images.githubusercontent.com/1398304/95629181-46f57280-0a34-11eb-9a69-9b893b04c079.png) | ![Screen Shot 2020-10-09 at 1 25 56 PM](https://user-images.githubusercontent.com/1398304/95629193-4ceb5380-0a34-11eb-9db0-421508282d5a.png)
![Screen Shot 2020-10-09 at 1 11 17 PM](https://user-images.githubusercontent.com/1398304/95629200-51177100-0a34-11eb-8787-c225a6d81493.png) | ![Screen Shot 2020-10-09 at 1 27 17 PM](https://user-images.githubusercontent.com/1398304/95629213-55dc2500-0a34-11eb-8166-9e501cfd7e24.png)

