### PR TITLE
Mobile Stories block (part 3): rename using BlockMediaUpdateProgress

### DIFF
--- a/extensions/blocks/story/edit.native.js
+++ b/extensions/blocks/story/edit.native.js
@@ -6,12 +6,8 @@ import { Text, View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import {
-	Image,
-} from '@wordpress/components';
-import {
-	StoryUpdateProgress,
-} from '@wordpress/block-editor';
+import { Image } from '@wordpress/components';
+import { BlockMediaUpdateProgress } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { getProtocol } from '@wordpress/url';
 import { doAction, hasAction } from '@wordpress/hooks';
@@ -21,7 +17,7 @@ import {
 	// requestImageUploadCancelDialog,
 	// requestImageFullscreenPreview,
 	mediaUploadSync,
-	storySaveSync,
+	mediaSaveSync,
 	requestStoryCreatorLoad,
 } from '@wordpress/react-native-bridge';
 
@@ -34,26 +30,18 @@ import StoryEditingButton from './story-editing-button';
 class StoryEdit extends React.Component {
 	constructor( props ) {
 		super( props );
-		
+
 		this.onEditButtonTapped = this.onEditButtonTapped.bind( this );
-		
+
 		this.mediaUploadStateReset = this.mediaUploadStateReset.bind( this );
-		this.finishMediaUploadWithSuccess = this.finishMediaUploadWithSuccess.bind(
-			this
-		);
-		this.finishMediaUploadWithFailure = this.finishMediaUploadWithFailure.bind(
-			this
-		);
+		this.finishMediaUploadWithSuccess = this.finishMediaUploadWithSuccess.bind( this );
+		this.finishMediaUploadWithFailure = this.finishMediaUploadWithFailure.bind( this );
 		this.updateMediaUploadProgress = this.updateMediaUploadProgress.bind( this );
 
 		// save progress bindings
 		this.mediaSaveStateReset = this.mediaSaveStateReset.bind( this );
-		this.finishMediaSaveWithSuccess = this.finishMediaSaveWithSuccess.bind(
-			this
-		);
-		this.finishMediaSaveWithFailure = this.finishMediaSaveWithFailure.bind(
-			this
-		);
+		this.finishMediaSaveWithSuccess = this.finishMediaSaveWithSuccess.bind( this );
+		this.finishMediaSaveWithFailure = this.finishMediaSaveWithFailure.bind( this );
 		this.updateMediaSaveProgress = this.updateMediaSaveProgress.bind( this );
 
 		this.onStorySaveResult = this.onStorySaveResult.bind( this );
@@ -71,16 +59,18 @@ class StoryEdit extends React.Component {
 	componentDidMount() {
 		const { attributes } = this.props;
 		if ( attributes.mediaFiles !== undefined ) {
-			for (i = 0; i < attributes.mediaFiles.length; i++) {
-				var protocolForUrl = getProtocol(attributes.mediaFiles[i].url);
-				if (attributes.mediaFiles[i].id && protocolForUrl !== 'http:'  || protocolForUrl !== 'https:') {
+			for ( let i = 0; i < attributes.mediaFiles.length; i++ ) {
+				const protocolForUrl = getProtocol( attributes.mediaFiles[ i ].url );
+				if (
+					( attributes.mediaFiles[ i ].id && protocolForUrl !== 'http:' ) ||
+					protocolForUrl !== 'https:'
+				) {
 					mediaUploadSync();
-					storySaveSync();
+					mediaSaveSync();
 					return;
 				}
 			}
 		}
-
 	}
 
 	componentWillUnmount() {
@@ -89,17 +79,17 @@ class StoryEdit extends React.Component {
 		// and ditch / fix if not
 		if (
 			hasAction( 'blocks.onRemoveBlockCheckUpload' ) &&
-			(this.state.isUploadInProgress || this.state.isSaveInProgress)
+			( this.state.isUploadInProgress || this.state.isSaveInProgress )
 		) {
 			const { attributes } = this.props;
 			if ( attributes.mediaFiles !== undefined ) {
-				for (i = 0; i < attributes.mediaFiles.length; i++) {
-					var protocolForUrl = getProtocol(attributes.mediaFiles[i].url);
-					if (attributes.mediaFiles[i].id && protocolForUrl !== 'http:'  || protocolForUrl !== 'https:') {
-						doAction(
-							'blocks.onRemoveBlockCheckUpload',
-							attributes.mediaFiles[i].id
-						);
+				for ( let i = 0; i < attributes.mediaFiles.length; i++ ) {
+					const protocolForUrl = getProtocol( attributes.mediaFiles[ i ].url );
+					if (
+						( attributes.mediaFiles[ i ].id && protocolForUrl !== 'http:' ) ||
+						protocolForUrl !== 'https:'
+					) {
+						doAction( 'blocks.onRemoveBlockCheckUpload', attributes.mediaFiles[ i ].id );
 					}
 				}
 			}
@@ -153,7 +143,11 @@ class StoryEdit extends React.Component {
 		// setAttributes( { src: payload.mediaUrl, id: payload.mediaServerId } );
 		// find the mediaFiles item that needs to change via its id, and apply the new URL
 		// var updatedMediaFiles = this.replaceMediaUrlInMediaFilesById( payload.mediaId, payload.mediaUrl);
-		var updatedMediaFiles = this.replaceNewIdInMediaFilesByOldId( payload.mediaId, payload.mediaServerId, payload.mediaUrl);
+		const updatedMediaFiles = this.replaceNewIdInMediaFilesByOldId(
+			payload.mediaId,
+			payload.mediaServerId,
+			payload.mediaUrl
+		);
 		setAttributes( { mediaFiles: updatedMediaFiles } );
 		this.setState( { isUploadInProgress: false } );
 	}
@@ -172,7 +166,6 @@ class StoryEdit extends React.Component {
 		this.setState( { isUploadInProgress: false } );
 	}
 
-
 	// save state handling methods
 	updateMediaSaveProgress( payload ) {
 		const { setAttributes } = this.props;
@@ -187,10 +180,10 @@ class StoryEdit extends React.Component {
 	replaceMediaUrlInMediaFilesById( mediaId, mediaUrl ) {
 		const { attributes } = this.props;
 		if ( mediaId !== undefined && attributes.mediaFiles !== undefined ) {
-			for (i = 0; i < attributes.mediaFiles.length; i++) {
-				if (attributes.mediaFiles[i].id === mediaId.toString()) {
-					attributes.mediaFiles[i].url = mediaUrl;
-					attributes.mediaFiles[i].link = mediaUrl;
+			for ( let i = 0; i < attributes.mediaFiles.length; i++ ) {
+				if ( attributes.mediaFiles[ i ].id === mediaId.toString() ) {
+					attributes.mediaFiles[ i ].url = mediaUrl;
+					attributes.mediaFiles[ i ].link = mediaUrl;
 				}
 			}
 		}
@@ -200,11 +193,11 @@ class StoryEdit extends React.Component {
 	replaceNewIdInMediaFilesByOldId( oldId, mediaId, mediaUrl ) {
 		const { attributes } = this.props;
 		if ( mediaId !== undefined && attributes.mediaFiles !== undefined ) {
-			for (i = 0; i < attributes.mediaFiles.length; i++) {
-				if (attributes.mediaFiles[i].id === oldId.toString()) {
-					attributes.mediaFiles[i].id = mediaId;
-					attributes.mediaFiles[i].url = mediaUrl;
-					attributes.mediaFiles[i].link = mediaUrl;
+			for ( let i = 0; i < attributes.mediaFiles.length; i++ ) {
+				if ( attributes.mediaFiles[ i ].id === oldId.toString() ) {
+					attributes.mediaFiles[ i ].id = mediaId;
+					attributes.mediaFiles[ i ].url = mediaUrl;
+					attributes.mediaFiles[ i ].link = mediaUrl;
 				}
 			}
 		}
@@ -214,7 +207,10 @@ class StoryEdit extends React.Component {
 	finishMediaSaveWithSuccess( payload ) {
 		const { setAttributes } = this.props;
 		// find the mediaFiles item that needs to change via its id, and apply the new URL
-		var updatedMediaFiles = this.replaceMediaUrlInMediaFilesById( payload.mediaId, payload.mediaUrl);
+		const updatedMediaFiles = this.replaceMediaUrlInMediaFilesById(
+			payload.mediaId,
+			payload.mediaUrl
+		);
 		setAttributes( { mediaFiles: updatedMediaFiles } );
 		this.setState( { isSaveInProgress: false } );
 	}
@@ -242,7 +238,11 @@ class StoryEdit extends React.Component {
 
 	onMediaModelCreated( payload ) {
 		const { setAttributes } = this.props;
-		var updatedMediaFiles = this.replaceNewIdInMediaFilesByOldId( payload.mediaId, payload.newId, payload.mediaUrl);
+		const updatedMediaFiles = this.replaceNewIdInMediaFilesByOldId(
+			payload.mediaId,
+			payload.newId,
+			payload.mediaUrl
+		);
 		setAttributes( { mediaFiles: updatedMediaFiles } );
 		this.setState( { isSaveInProgress: false } );
 	}
@@ -251,57 +251,31 @@ class StoryEdit extends React.Component {
 		const { attributes, isSelected } = this.props;
 		const { mediaFiles } = attributes;
 		const hasContent = !! mediaFiles.length;
-		const {
-			isUploadInProgress,
-			isSaveInProgress,
-			didUploadFail,
-			didSaveFail,
-		} = this.state;
-	
+		const { isUploadInProgress, isSaveInProgress, didUploadFail, didSaveFail } = this.state;
+
 		return (
-			<View style={ styles['wp-story-container'] }>
-				{!hasContent && 
-					<Text style={ styles['wp-story-wrapper'] }>
-							Empty Story placeholder here
-					</Text>
-				}	
-				{ hasContent && 
+			<View style={ styles[ 'wp-story-container' ] }>
+				{ ! hasContent && (
+					<Text style={ styles[ 'wp-story-wrapper' ] }>Empty Story placeholder here</Text>
+				) }
+				{ hasContent && (
 					<View style={ { flex: 1 } }>
-						{ !isUploadInProgress && !isSaveInProgress &&
-							isSelected && (
-							<StoryEditingButton
-								onEditButtonTapped={ this.onEditButtonTapped }
-							/>
+						{ ! isUploadInProgress && ! isSaveInProgress && isSelected && (
+							<StoryEditingButton onEditButtonTapped={ this.onEditButtonTapped } />
 						) }
-						<StoryUpdateProgress
-							coverUrl={ mediaFiles[0].url } // just select the first one // TODO see how to handle video
-							mediaFiles = { mediaFiles}
+						<BlockMediaUpdateProgress
+							coverUrl={ mediaFiles[ 0 ].url } // just select the first one // TODO see how to handle video
+							mediaFiles={ mediaFiles }
 							onUpdateMediaUploadProgress={ this.updateMediaUploadProgress }
-							onFinishMediaUploadWithSuccess={
-								this.finishMediaUploadWithSuccess
-							}
-							onFinishMediaUploadWithFailure={
-								this.finishMediaUploadWithFailure
-							}
-							onMediaUploadStateReset={
-								this.mediaUploadStateReset
-							}
+							onFinishMediaUploadWithSuccess={ this.finishMediaUploadWithSuccess }
+							onFinishMediaUploadWithFailure={ this.finishMediaUploadWithFailure }
+							onMediaUploadStateReset={ this.mediaUploadStateReset }
 							onUpdateMediaSaveProgress={ this.updateMediaSaveProgress }
-							onFinishMediaSaveWithSuccess={
-								this.finishMediaSaveWithSuccess
-							}
-							onFinishMediaUploadWithFailure={
-								this.finishMediaSaveWithFailure
-							}
-							onMediaSaveStateReset={
-								this.mediaSaveStateReset
-							}
-							onStorySaveResult={
-								this.onStorySaveResult
-							}
-							onMediaModelCreated={
-								this.onMediaModelCreated
-							}
+							onFinishMediaSaveWithSuccess={ this.finishMediaSaveWithSuccess }
+							onFinishMediaSaveWithFailure={ this.finishMediaSaveWithFailure }
+							onMediaSaveStateReset={ this.mediaSaveStateReset }
+							onFinalSaveResult={ this.onStorySaveResult }
+							onMediaModelCreated={ this.onMediaModelCreated }
 							renderContent={ ( {
 								isUploadInProgress,
 								isUploadFailed,
@@ -311,15 +285,14 @@ class StoryEdit extends React.Component {
 							} ) => {
 								return (
 									<Image
-											url={ mediaFiles[0].url } // just select the first one // TODO see how to handle video
-											style={ styles['wp-story-image'] }
+										url={ mediaFiles[ 0 ].url } // just select the first one // TODO see how to handle video
+										style={ styles[ 'wp-story-image' ] }
 									/>
 								);
 							} }
 						/>
-	
 					</View>
-				}
+				) }
 			</View>
 		);
 	}

--- a/extensions/blocks/story/edit.native.js
+++ b/extensions/blocks/story/edit.native.js
@@ -18,7 +18,7 @@ import {
 	// requestImageFullscreenPreview,
 	mediaUploadSync,
 	mediaSaveSync,
-	requestStoryCreatorLoad,
+	requestMediaFilesEditorLoad,
 } from '@wordpress/react-native-bridge';
 
 /**
@@ -122,9 +122,9 @@ class StoryEdit extends React.Component {
 		// } else if ( isImage && url ) {
 		// 	requestImageFullscreenPreview( url );
 		// }
-		// requestStoryCreatorLoad( id );
+		// requestMediaFilesEditorLoad( id );
 		// let's open the Story Creator and load this block in there
-		requestStoryCreatorLoad( attributes.mediaFiles, clientId );
+		requestMediaFilesEditorLoad( attributes.mediaFiles, clientId );
 	}
 
 	// upload state handling methods


### PR DESCRIPTION
This PR builds on top of https://github.com/Automattic/jetpack/pull/17222

This PR changes the `StoryUpdateProgress` component to the more generic abstraction `BlockMediaUpdateProgress` - this is mostly a renaming refactor

Related PRs:

Gutenberg: https://github.com/WordPress/gutenberg/pull/26005

Gutenberg mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2706

WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/13101

