### PR TITLE
Travis: Add slack notifications for failed master builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,10 @@ script: ./tests/run-travis.sh
 sudo: false
 
 notifications:
+   slack:
+     on_success: change # default: always
+     if: branch = master
+     secure: WWKijFuetJgC7Gam4RkZALUf5lhDPWOkXCD2ignA4qLzlATUbi8lNjkBxMEq0Y8wKBLdHdRostmZl1eBXdWF4J6PEX1pbKrTweBlEG0Ka7QEW+62/eMnCJzWazKmtZvr5ILKGz8zf7ig+q/URoEejWSmkbN1HMHvDCT2DtIZN7I=
    webhooks:
      urls:
        - https://betadownload.jetpack.me/travis.php
@@ -171,7 +175,6 @@ notifications:
        - beau@automattic.com
        # Encrypted Slack notification address
        - secure: "WQdTdmYuifSW0hiJGXpQGKystMASC50QvxHlyUL5SM3h5GP8aCgeSsHuXvKPe3dT3Pffhk0dSHBfDtdWFwSHW/upURhg0vs4dm7+nxxvGZiTPzKcuAIjgvCoqWM7teyda/XqFGNSnv+XsT34uoyPhhFgd45T3oS+QQ3aNCruFak="
-
 addons:
   code_climate:
     repo_token: 683bd559e5214ca3b721092af177893f05765ba90d2589fcf35d7e85c6ea01e8


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds automated slack notifications for failed master builds into #jetpack-r2d2

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a 
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not much to test here. 
* once merged, look for Travis failures for the master build, then check #jetpack-r2d2

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
