### PR TITLE
REST API: Add sync related endpoint capabilities

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -12,11 +12,12 @@ use Automattic\Jetpack\Sync\Settings;
 class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	/**
-	 * Sync endpoints allow authentication via a blog token therefore require no user capabilities.
+	 * This endpoint allows authentication both via a blog and a user token.
+	 * If a user token is used, that user should have `manage_options` capability.
 	 *
-	 * @var array
+	 * @var array|string
 	 */
-	protected $needed_capabilities = array();
+	protected $needed_capabilities = 'manage_options';
 
 	protected function validate_call( $_blog_id, $capability, $check_manage_active = true ) {
 		return parent::validate_call( $_blog_id, $capability, false );

--- a/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
+++ b/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
@@ -4,11 +4,12 @@ use Automattic\Jetpack\Sync\Defaults;
 
 class WPCOM_JSON_API_Get_Option_Endpoint extends Jetpack_JSON_API_Endpoint {
 	/**
-	 * This endpoint allows authentication via a blog token therefore requires no user capabilities.
+	 * This endpoint allows authentication both via a blog and a user token.
+	 * If a user token is used, that user should have `manage_options` capability.
 	 *
-	 * @var array
+	 * @var array|string
 	 */
-	protected $needed_capabilities = array();
+	protected $needed_capabilities = 'manage_options';
 
 	public $option_name;
 	public $site_option;

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -434,40 +434,44 @@ new Jetpack_JSON_API_Core_Endpoint( array(
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-sync-endpoint.php' );
 
 // POST /sites/%s/sync
-new Jetpack_JSON_API_Sync_Endpoint( array(
-	'description'     => 'Force sync of all options and constants',
-	'method'          => 'POST',
-	'path'            => '/sites/%s/sync',
-	'stat'            => 'sync',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'request_format' => array(
-		'modules'  => '(string) Comma-delimited set of sync modules to use (default: all of them)',
-		'posts'    => '(string) Comma-delimited list of post IDs to sync',
-		'comments' => '(string) Comma-delimited list of comment IDs to sync',
-		'users'    => '(string) Comma-delimited list of user IDs to sync',
-	),
-	'response_format' => array(
-		'scheduled' => '(bool) Whether or not the synchronisation was started'
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync'
-) );
+new Jetpack_JSON_API_Sync_Endpoint(
+	array(
+		'description'             => 'Force sync of all options and constants',
+		'method'                  => 'POST',
+		'path'                    => '/sites/%s/sync',
+		'stat'                    => 'sync',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'request_format'          => array(
+			'modules'  => '(string) Comma-delimited set of sync modules to use (default: all of them)',
+			'posts'    => '(string) Comma-delimited list of post IDs to sync',
+			'comments' => '(string) Comma-delimited list of comment IDs to sync',
+			'users'    => '(string) Comma-delimited list of user IDs to sync',
+		),
+		'response_format'         => array(
+			'scheduled' => '(bool) Whether or not the synchronisation was started',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync',
+	)
+);
 
 // GET /sites/%s/sync/status
 new Jetpack_JSON_API_Sync_Status_Endpoint(
 	array(
-		'description'      => 'Status of the current full sync or the previous full sync',
-		'method'           => 'GET',
-		'path'             => '/sites/%s/sync/status',
-		'stat'             => 'sync-status',
-		'path_labels'      => array(
+		'description'             => 'Status of the current full sync or the previous full sync',
+		'method'                  => 'GET',
+		'path'                    => '/sites/%s/sync/status',
+		'stat'                    => 'sync-status',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
 			'$site' => '(int|string) The site ID, The site domain',
 		),
-		'query_parameters' => array(
+		'query_parameters'        => array(
 			'fields' => '(string|null) List of comma-separated fields to return (see `response_format`).',
 		),
-		'response_format'  => array(
+		'response_format'         => array(
 			'posts_checksum'        => '(string|null) Posts checksum. Needs to be requested using the filter parameter.',
 			'comments_checksum'     => '(string|null) Comments checksum. Needs to be requested using the filter parameter.',
 			'post_meta_checksum'    => '(string|null) Post Meta checksum. Needs to be requested using the filter parameter.',
@@ -491,53 +495,59 @@ new Jetpack_JSON_API_Sync_Status_Endpoint(
 			'progress'              => '(array) Full Sync status by module',
 			'debug_details'         => '(array) Details as to why Sync is disabled.',
 		),
-		'example_request'  => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status',
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status',
 	)
 );
 
 
 // GET /sites/%s/data-checksums
-new Jetpack_JSON_API_Sync_Check_Endpoint( array(
-	'description'     => 'Check that cacheable data on the site is in sync with wordpress.com',
-	'group'           => '__do_not_document',
-	'method'          => 'GET',
-	'path'            => '/sites/%s/data-checksums',
-	'stat'            => 'data-checksums',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'response_format' => array(
-		'posts' => '(string) Posts checksum',
-		'comments' => '(string) Comments checksum',
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/data-checksums'
-) );
+new Jetpack_JSON_API_Sync_Check_Endpoint(
+	array(
+		'description'             => 'Check that cacheable data on the site is in sync with wordpress.com',
+		'group'                   => '__do_not_document',
+		'method'                  => 'GET',
+		'path'                    => '/sites/%s/data-checksums',
+		'stat'                    => 'data-checksums',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'response_format'         => array(
+			'posts'    => '(string) Posts checksum',
+			'comments' => '(string) Comments checksum',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/data-checksums',
+	)
+);
 
 // GET /sites/%s/data-histogram
-new Jetpack_JSON_API_Sync_Histogram_Endpoint( array(
-	'description'     => 'Get a histogram of checksums for certain synced data',
-	'group'           => '__do_not_document',
-	'method'          => 'GET',
-	'path'            => '/sites/%s/data-histogram',
-	'stat'            => 'data-histogram',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'query_parameters' => array(
-		'object_type' => '(string=posts) The type of object to checksum - posts, comments or options',
-		'buckets' => '(int=10) The number of buckets for the checksums',
-		'start_id' => '(int=0) Starting ID for the range',
-		'end_id' => '(int=null) Ending ID for the range',
-		'columns' => '(string) Columns to checksum',
-		'strip_non_ascii' => '(bool=true) Strip non-ascii characters from all columns',
-		'shared_salt' => '(string) Salt to reduce the collision and improve validation',
-	),
-	'response_format' => array(
-		'histogram' => '(array) Associative array of histograms by ID range, e.g. "500-999" => "abcd1234"',
-		'type'      => '(string) Type of checksum algorithm',
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/data-histogram'
-) );
+new Jetpack_JSON_API_Sync_Histogram_Endpoint(
+	array(
+		'description'             => 'Get a histogram of checksums for certain synced data',
+		'group'                   => '__do_not_document',
+		'method'                  => 'GET',
+		'path'                    => '/sites/%s/data-histogram',
+		'stat'                    => 'data-histogram',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'query_parameters'        => array(
+			'object_type'     => '(string=posts) The type of object to checksum - posts, comments or options',
+			'buckets'         => '(int=10) The number of buckets for the checksums',
+			'start_id'        => '(int=0) Starting ID for the range',
+			'end_id'          => '(int=null) Ending ID for the range',
+			'columns'         => '(string) Columns to checksum',
+			'strip_non_ascii' => '(bool=true) Strip non-ascii characters from all columns',
+			'shared_salt'     => '(string) Salt to reduce the collision and improve validation',
+		),
+		'response_format'         => array(
+			'histogram' => '(array) Associative array of histograms by ID range, e.g. "500-999" => "abcd1234"',
+			'type'      => '(string) Type of checksum algorithm',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/data-histogram',
+	)
+);
 
 $sync_settings_response = array(
 	'dequeue_max_bytes'        => '(int|bool=false) Maximum bytes to read from queue in a single request',
@@ -564,162 +574,186 @@ $sync_settings_response = array(
 );
 
 // GET /sites/%s/sync/settings
-new Jetpack_JSON_API_Sync_Get_Settings_Endpoint( array(
-	'description'     => 'Update sync settings',
-	'method'          => 'GET',
-	'group'           => '__do_not_document',
-	'path'            => '/sites/%s/sync/settings',
-	'stat'            => 'write-sync-settings',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'response_format' => $sync_settings_response,
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/settings'
-) );
+new Jetpack_JSON_API_Sync_Get_Settings_Endpoint(
+	array(
+		'description'             => 'Update sync settings',
+		'method'                  => 'GET',
+		'group'                   => '__do_not_document',
+		'path'                    => '/sites/%s/sync/settings',
+		'stat'                    => 'write-sync-settings',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'response_format'         => $sync_settings_response,
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/settings',
+	)
+);
 
 // POST /sites/%s/sync/settings
-new Jetpack_JSON_API_Sync_Modify_Settings_Endpoint( array(
-	'description'     => 'Update sync settings',
-	'method'          => 'POST',
-	'group'           => '__do_not_document',
-	'path'            => '/sites/%s/sync/settings',
-	'stat'            => 'write-sync-settings',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'request_format' => $sync_settings_response,
-	'response_format' => $sync_settings_response,
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/settings'
-) );
+new Jetpack_JSON_API_Sync_Modify_Settings_Endpoint(
+	array(
+		'description'             => 'Update sync settings',
+		'method'                  => 'POST',
+		'group'                   => '__do_not_document',
+		'path'                    => '/sites/%s/sync/settings',
+		'stat'                    => 'write-sync-settings',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'request_format'          => $sync_settings_response,
+		'response_format'         => $sync_settings_response,
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/settings',
+	)
+);
 
 // GET /sites/%s/sync/object
-new Jetpack_JSON_API_Sync_Object( array(
-	'description'     => 'Get an object by ID from one of the sync modules, in the format it would be synced in',
-	'group'           => '__do_not_document',
-	'method'          => 'GET',
-	'path'            => '/sites/%s/sync/object',
-	'stat'            => 'sync-object',
-	'path_labels' => array(
-		'$site'        => '(int|string) The site ID, The site domain'
-	),
-	'query_parameters' => array(
-		'module_name'    => '(string) The sync module ID, e.g. "posts"',
-		'object_type'    => '(string) An identified for the object type, e.g. "post"',
-		'object_ids'     => '(array) The IDs of the objects',
-	),
-	'response_format' => array(
-		'objects' => '(string) The encoded objects',
-		'codec'   => '(string) The codec used to encode the objects, deflate-json-array or simple'
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/object?module_name=posts&object_type=post&object_ids[]=1&object_ids[]=2&object_ids[]=3'
-) );
+new Jetpack_JSON_API_Sync_Object(
+	array(
+		'description'             => 'Get an object by ID from one of the sync modules, in the format it would be synced in',
+		'group'                   => '__do_not_document',
+		'method'                  => 'GET',
+		'path'                    => '/sites/%s/sync/object',
+		'stat'                    => 'sync-object',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'query_parameters'        => array(
+			'module_name' => '(string) The sync module ID, e.g. "posts"',
+			'object_type' => '(string) An identified for the object type, e.g. "post"',
+			'object_ids'  => '(array) The IDs of the objects',
+		),
+		'response_format'         => array(
+			'objects' => '(string) The encoded objects',
+			'codec'   => '(string) The codec used to encode the objects, deflate-json-array or simple',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/object?module_name=posts&object_type=post&object_ids[]=1&object_ids[]=2&object_ids[]=3',
+	)
+);
 
 // POST /sites/%s/sync/now
-new Jetpack_JSON_API_Sync_Now_Endpoint( array(
-	'description'     => 'Force immediate sync of top items on a queue',
-	'method'          => 'POST',
-	'path'            => '/sites/%s/sync/now',
-	'stat'            => 'sync-now',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'request_format' => array(
-		'queue'  => '(string) sync or full_sync',
-	),
-	'response_format' => array(
-		'response' => '(array) The response from the server'
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/now?queue=full_sync'
-) );
+new Jetpack_JSON_API_Sync_Now_Endpoint(
+	array(
+		'description'             => 'Force immediate sync of top items on a queue',
+		'method'                  => 'POST',
+		'path'                    => '/sites/%s/sync/now',
+		'stat'                    => 'sync-now',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'request_format'          => array(
+			'queue' => '(string) sync or full_sync',
+		),
+		'response_format'         => array(
+			'response' => '(array) The response from the server',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/now?queue=full_sync',
+	)
+);
 
 
 // POST /sites/%s/sync/unlock
-new Jetpack_JSON_API_Sync_Unlock_Endpoint( array(
-	'description'     => 'Unlock the queue in case it gets locked by a process.',
-	'method'          => 'POST',
-	'path'            => '/sites/%s/sync/unlock',
-	'group'           => '__do_not_document',
-	'stat'            => 'sync-unlock',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'request_format' => array(
-		'queue'      => '(string) sync or full_sync',
-	),
-	'response_format' => array(
-		'success' => '(bool) Unlocking the queue successful?'
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/unlock'
-) );
+new Jetpack_JSON_API_Sync_Unlock_Endpoint(
+	array(
+		'description'             => 'Unlock the queue in case it gets locked by a process.',
+		'method'                  => 'POST',
+		'path'                    => '/sites/%s/sync/unlock',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'sync-unlock',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'request_format'          => array(
+			'queue' => '(string) sync or full_sync',
+		),
+		'response_format'         => array(
+			'success' => '(bool) Unlocking the queue successful?',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/unlock',
+	)
+);
 
 // GET /sites/%s/sync/object-id-range
-new Jetpack_JSON_API_Sync_Object_Id_Range( array(
-	'description'     => 'Gets minimum and maximum object ids for each batch of given batch size.',
-	'method'          => 'GET',
-	'path'            => '/sites/%s/sync/object-id-range',
-	'group'           => '__do_not_document',
-	'stat'            => 'sync-object-id-range',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'query_parameters' => array(
-		'batch_size' => '(int=1000) The amount of objects per batch.',
-		'sync_module' => '(string=posts) The sync module used to enumerate the ranges.',
-	),
-	'response_format' => array(
-		'ranges' => '(array) An array of range objects with min and max properties for each batch.',
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/object-id-range?batch_size=100&sync_module=comments'
-) );
+new Jetpack_JSON_API_Sync_Object_Id_Range(
+	array(
+		'description'             => 'Gets minimum and maximum object ids for each batch of given batch size.',
+		'method'                  => 'GET',
+		'path'                    => '/sites/%s/sync/object-id-range',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'sync-object-id-range',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'query_parameters'        => array(
+			'batch_size'  => '(int=1000) The amount of objects per batch.',
+			'sync_module' => '(string=posts) The sync module used to enumerate the ranges.',
+		),
+		'response_format'         => array(
+			'ranges' => '(array) An array of range objects with min and max properties for each batch.',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/object-id-range?batch_size=100&sync_module=comments',
+	)
+);
 
 // POST /sites/%s/sync/checkout
-new Jetpack_JSON_API_Sync_Checkout_Endpoint( array(
-	'description'     => 'Locks the queue and returns items and the buffer ID.',
-	'method'          => 'POST',
-	'path'            => '/sites/%s/sync/checkout',
-	'group'           => '__do_not_document',
-	'stat'            => 'sync-checkout',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'request_format' => array(
-		'queue'             => '(string) sync or full_sync',
-		'number_of_items'   => '(int=10) Maximum number of items from the queue to be returned',
-		'encode'            => '(bool=true) Use the default encode method',
-		'force'             => '(bool=false) Force unlock the queue',
-		'pop'               => '(bool=false) Pop from the queue without checkout, use carefully 😱',
-	),
-	'response_format' => array(
-		'buffer_id' => '(string) Buffer ID that we are using',
-		'items'             => '(array) Items from the queue that are ready to be processed by the sync server',
-		'skipped_items'     => '(array) Skipped item ids',
-		'codec'             => '(string) The name of the codec used to encode the data',
-		'sent_timestamp'    => '(int) Current timestamp of the server',
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/checkout'
-) );
+new Jetpack_JSON_API_Sync_Checkout_Endpoint(
+	array(
+		'description'             => 'Locks the queue and returns items and the buffer ID.',
+		'method'                  => 'POST',
+		'path'                    => '/sites/%s/sync/checkout',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'sync-checkout',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'request_format'          => array(
+			'queue'           => '(string) sync or full_sync',
+			'number_of_items' => '(int=10) Maximum number of items from the queue to be returned',
+			'encode'          => '(bool=true) Use the default encode method',
+			'force'           => '(bool=false) Force unlock the queue',
+			'pop'             => '(bool=false) Pop from the queue without checkout, use carefully 😱',
+		),
+		'response_format'         => array(
+			'buffer_id'      => '(string) Buffer ID that we are using',
+			'items'          => '(array) Items from the queue that are ready to be processed by the sync server',
+			'skipped_items'  => '(array) Skipped item ids',
+			'codec'          => '(string) The name of the codec used to encode the data',
+			'sent_timestamp' => '(int) Current timestamp of the server',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/checkout',
+	)
+);
 
 // POST /sites/%s/sync/close
-new Jetpack_JSON_API_Sync_Close_Endpoint( array(
-	'description'     => 'Closes the buffer and delete the processed items from the queue.',
-	'method'          => 'POST',
-	'path'            => '/sites/%s/sync/close',
-	'group'           => '__do_not_document',
-	'stat'            => 'sync-close',
-	'path_labels' => array(
-		'$site' => '(int|string) The site ID, The site domain'
-	),
-	'request_format' => array(
-		'item_ids'  => '(array) Item IDs to delete from the queue.',
-		'queue'     => '(string) sync or full_sync',
-		'buffer_id' => '(string) buffer ID that was opened during the checkout step.',
-		'continue'  => '(bool=false) Perform another checkout from queue.',
-	),
-	'response_format' => array(
-		'success' => '(bool) Closed the buffer successfully?'
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/close'
-) );
+new Jetpack_JSON_API_Sync_Close_Endpoint(
+	array(
+		'description'             => 'Closes the buffer and delete the processed items from the queue.',
+		'method'                  => 'POST',
+		'path'                    => '/sites/%s/sync/close',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'sync-close',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'request_format'          => array(
+			'item_ids'  => '(array) Item IDs to delete from the queue.',
+			'queue'     => '(string) sync or full_sync',
+			'buffer_id' => '(string) buffer ID that was opened during the checkout step.',
+			'continue'  => '(bool=false) Perform another checkout from queue.',
+		),
+		'response_format'         => array(
+			'success' => '(bool) Closed the buffer successfully?',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/close',
+	)
+);
 
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-log-endpoint.php' );
 
@@ -831,58 +865,64 @@ new Jetpack_JSON_API_Translations_Modify_Endpoint( array(
 // Options
 require_once( $json_jetpack_endpoints_dir . 'class.wpcom-json-api-get-option-endpoint.php' );
 
-new WPCOM_JSON_API_Get_Option_Endpoint( array (
-	'method' => 'GET',
-	'description' => 'Fetches an option.',
-	'group' => '__do_not_document',
-	'stat' => 'option',
-	'path' => '/sites/%s/option',
-	'path_labels' => array(
-		'$site' => '(int|string) Site ID or domain',
-	),
-	'query_parameters' => array(
-		'option_name' => '(string) The name of the option to fetch.',
-		'site_option' => '(bool=false) True if the option is a site option.',
-	),
-	'response_format' => array(
-		'option_value' => '(string|object) The value of the option.',
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/option?option_name=blogname',
-	'example_request_data' => array(
-		'headers' => array( 'authorization' => 'Bearer YOUR_API_TOKEN' ),
-	),
-) );
+new WPCOM_JSON_API_Get_Option_Endpoint(
+	array(
+		'method'                  => 'GET',
+		'description'             => 'Fetches an option.',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'option',
+		'allow_jetpack_site_auth' => true,
+		'path'                    => '/sites/%s/option',
+		'path_labels'             => array(
+			'$site' => '(int|string) Site ID or domain',
+		),
+		'query_parameters'        => array(
+			'option_name' => '(string) The name of the option to fetch.',
+			'site_option' => '(bool=false) True if the option is a site option.',
+		),
+		'response_format'         => array(
+			'option_value' => '(string|object) The value of the option.',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/option?option_name=blogname',
+		'example_request_data'    => array(
+			'headers' => array( 'authorization' => 'Bearer YOUR_API_TOKEN' ),
+		),
+	)
+);
 
 require_once( $json_jetpack_endpoints_dir . 'class.wpcom-json-api-update-option-endpoint.php' );
 
-new WPCOM_JSON_API_Update_Option_Endpoint( array (
-	'method' => 'POST',
-	'description' => 'Updates an option.',
-	'group' => '__do_not_document',
-	'stat' => 'option:update',
-	'path' => '/sites/%s/option',
-	'path_labels' => array(
-		'$site' => '(int|string) Site ID or domain',
-	),
-	'query_parameters' => array(
-		'option_name' => '(string) The name of the option to fetch.',
-		'site_option' => '(bool=false) True if the option is a site option.',
-		'is_array' => '(bool=false) True if the value should be converted to an array before saving.',
-	),
-	'request_format' => array(
-		'option_value' => '(string|object) The new value of the option.',
-	),
-	'response_format' => array(
-		'option_value' => '(string|object) The value of the updated option.',
-	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/option',
-	'example_request_data' => array(
-		'headers' => array( 'authorization' => 'Bearer YOUR_API_TOKEN' ),
-		'body' => array(
-			'option_value' => 'My new blog name'
+new WPCOM_JSON_API_Update_Option_Endpoint(
+	array(
+		'method'                  => 'POST',
+		'description'             => 'Updates an option.',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'option:update',
+		'allow_jetpack_site_auth' => true,
+		'path'                    => '/sites/%s/option',
+		'path_labels'             => array(
+			'$site' => '(int|string) Site ID or domain',
 		),
-	),
-) );
+		'query_parameters'        => array(
+			'option_name' => '(string) The name of the option to fetch.',
+			'site_option' => '(bool=false) True if the option is a site option.',
+			'is_array'    => '(bool=false) True if the value should be converted to an array before saving.',
+		),
+		'request_format'          => array(
+			'option_value' => '(string|object) The new value of the option.',
+		),
+		'response_format'         => array(
+			'option_value' => '(string|object) The value of the updated option.',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/option',
+		'example_request_data'    => array(
+			'headers' => array( 'authorization' => 'Bearer YOUR_API_TOKEN' ),
+			'body'    => array(
+				'option_value' => 'My new blog name',
+			),
+		),
+	)
+);
 
 
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-cron-endpoint.php' );


### PR DESCRIPTION
This PR is part of our work towards migrating endpoints to allow blog tokens described in #17379 and covers the two sub-tasks under the Technical Debt section.
In more detail, in order to allow blog token usage in the past we had removed the Sync related endpoint capabilities in #16893 
With #17331 though, we can now both have needed capabilities defined for endpoints (if a user token is used) AND allow blog token usage, as long as the endpoint has the `allow_jetpack_site_auth` flag set.
So in this PR, we are adding again the needed capabilities we had removed from Sync related endpoints.

#### Changes proposed in this Pull Request:
* Sets the `allow_jetpack_site_auth` flag for Sync related endpoints (covers Options related endpoints as well as they are used by Sync).
* Re-adds the previously removed needed permissions in Sync related endpoints (covers Options related endpoints as well as they are used by Sync).

#### Jetpack product discussion


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Go to the [developer console](https://developer.wordpress.com/docs/api/console/) and perform the following requests as a site admin (checkout `json-api-jetpack-endpoints.php` for details on request parameters and sample requests):

1. `POST /sites/%s/sync`
2. `GET /sites/%s/sync/status`
3. `GET /sites/%s/sync/settings`
4. `POST /sites/%s/sync/settings`
5. `GET /sites/%s/sync/object`
6. `POST /sites/%s/sync/now`
7. `POST /sites/%s/sync/checkout`
8. `POST /sites/%s/sync/close`
9. `POST /sites/%s/sync/unlock`
10. `GET /sites/%s/data-checksums`
11. `GET /sites/%s/data-histogram`
12. `GET /sites/%s/sync/object-id-range`
13. `GET sites/%s/option?option_name=blogname`
14. `POST sites/%s/option`

- [x] Make sure you receive `20*` responses for endpoints 1-14:

* Repeat the above requests as a non-admin user of your site and confirm you get:

- [x] For endpoints 1-9: `403 Unauthorized` responses with message: "This endpoint needs more permissions from the user.".
- [x] For endpoints 10-14: `403 Unauthorized` responses with message: "This user is not authorized to manage_options on this blog.".

* Repeat the above requests as a non-user of your site and confirm you get:
- [x] For endpoints 1-9: `403 Unauthorized` responses with message: "This endpoint needs more permissions from the user.".
- [x] For endpoints 10-14: `400` responses with message: "Unknown Token.".

* Repeat the above requests without any authorization (outside of the console, eg using Postman) and confirm you get:
- [x] For endpoints 1-14: 
    - GET requests should return `403 Unauthorized` responses with message: "This endpoint needs more permissions from the user."
    - POST requests should return `405 Unauthorized` responses with message: "That method is not allowed."

* Repeat the above requests using a blog token and confirm you get:
- [x] For endpoints 1-14: `20*` responses.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A :: non functional change, hardening of Jetpack Connection and Sync.
