### PR TITLE
Subscription module: Add missing email input label

### DIFF
--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -358,8 +358,17 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 					$email_field_id = 'subscribe-field' . self::$instance_count > 1
 						? '-' . self::$instance_count
 						: '';
+					$label_field_id = $email_field_id . '-label';
 					?>
 					<p id="subscribe-email">
+						<label
+							id="<?php echo esc_attr( $label_field_id ); ?>"
+							for="<?php echo esc_attr( $email_field_id ); ?>"
+							class="screen-reader-text"
+						>
+							<?php echo esc_html__( 'Email Address:', 'jetpack' ); ?>
+						</label>
+
 						<?php
 						printf(
 							'<input

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -355,10 +355,11 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						</div>
 						<?php
 					}
-					$email_field_id = 'subscribe-field' . self::$instance_count > 1
+					$email_field_id  = 'subscribe-field';
+					$email_field_id .= self::$instance_count > 1
 						? '-' . self::$instance_count
 						: '';
-					$label_field_id = $email_field_id . '-label';
+					$label_field_id  = $email_field_id . '-label';
 					?>
 					<p id="subscribe-email">
 						<label


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a missing label for screen readers in Subscriptions form (wpcom)

#### Jetpack product discussion
5911-gh-jpop-issues

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Apply D51011-code to your sandbox
- Add a subscription form in your Wordpress.com sandboxed site
- Make sure a corresponding label for the `email` input exists but is not visible, with class `screen-reader-text`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A :: These changes do not affect the Jetpack plugin