### PR TITLE
Fix video (videopress) aspect-ratio in editor

### DIFF
--- a/extensions/blocks/videopress/constants.js
+++ b/extensions/blocks/videopress/constants.js
@@ -1,0 +1,11 @@
+export const ASPECT_RATIOS = [
+	// Common video resolutions.
+	{ ratio: '2.33', className: 'wp-embed-aspect-21-9' },
+	{ ratio: '2.00', className: 'wp-embed-aspect-18-9' },
+	{ ratio: '1.78', className: 'wp-embed-aspect-16-9' },
+	{ ratio: '1.33', className: 'wp-embed-aspect-4-3' },
+	// Vertical video and instagram square video support.
+	{ ratio: '1.00', className: 'wp-embed-aspect-1-1' },
+	{ ratio: '0.56', className: 'wp-embed-aspect-9-16' },
+	{ ratio: '0.50', className: 'wp-embed-aspect-1-2' },
+];

--- a/extensions/blocks/videopress/edit.js
+++ b/extensions/blocks/videopress/edit.js
@@ -33,6 +33,7 @@ import { get } from 'lodash';
  */
 import Loading from './loading';
 import { getVideoPressUrl } from './url';
+import { getClassNames } from './utils';
 
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
@@ -295,6 +296,11 @@ const VideoPressEdit = CoreVideoEdit =>
 			}
 
 			const { html, scripts } = preview;
+			const sandboxClassnames = getClassNames(
+				html,
+				classnames( className, 'wp-block-embed', 'is-type-video' ),
+				true
+			);
 
 			// Disabled because the overlay div doesn't actually have a role or functionality
 			// as far as the user is concerned. We're just catching the first click so that
@@ -303,11 +309,9 @@ const VideoPressEdit = CoreVideoEdit =>
 			return (
 				<Fragment>
 					{ blockSettings }
-					<BlockFigureWrapper
-						className={ classnames( className, 'wp-block-embed', 'is-type-video' ) }
-					>
+					<BlockFigureWrapper className={ sandboxClassnames }>
 						<div className="wp-block-embed__wrapper">
-							<SandBox html={ html } scripts={ scripts } />
+							<SandBox html={ html } scripts={ scripts } type={ sandboxClassnames } />
 						</div>
 
 						{

--- a/extensions/blocks/videopress/utils.js
+++ b/extensions/blocks/videopress/utils.js
@@ -1,0 +1,61 @@
+/**
+ * Internal dependencies
+ */
+import { ASPECT_RATIOS } from './constants';
+
+import classnames from 'classnames';
+
+/**
+ * Removes all previously set aspect ratio related classes and return the rest
+ * existing class names.
+ *
+ * @param {string} existingClassNames Any existing class names.
+ * @returns {string} The class names without any aspect ratio related class.
+ */
+export const removeAspectRatioClasses = existingClassNames => {
+	const aspectRatioClassNames = ASPECT_RATIOS.reduce(
+		( accumulator, { className } ) => {
+			accumulator[ className ] = false;
+			return accumulator;
+		},
+		{ 'wp-has-aspect-ratio': false }
+	);
+	return classnames( existingClassNames, aspectRatioClassNames );
+};
+
+/**
+ * Returns class names with any relevant responsive aspect ratio names.
+ *
+ * @param {string}  html               The preview HTML that possibly contains an iframe with width and height set.
+ * @param {string}  existingClassNames Any existing class names.
+ * @param {boolean} allowResponsive    If the responsive class names should be added, or removed.
+ * @returns {string} Deduped class names.
+ */
+export function getClassNames( html, existingClassNames = '', allowResponsive = true ) {
+	if ( ! allowResponsive ) {
+		return removeAspectRatioClasses( existingClassNames );
+	}
+
+	const previewDocument = document.implementation.createHTMLDocument( '' );
+	previewDocument.body.innerHTML = html;
+	const iframe = previewDocument.body.querySelector( 'iframe' );
+
+	// If we have a fixed aspect iframe, and it's a responsive embed block.
+	if ( iframe && iframe.height && iframe.width ) {
+		const aspectRatio = ( iframe.width / iframe.height ).toFixed( 2 );
+		// Given the actual aspect ratio, find the widest ratio to support it.
+		for ( let ratioIndex = 0; ratioIndex < ASPECT_RATIOS.length; ratioIndex++ ) {
+			const potentialRatio = ASPECT_RATIOS[ ratioIndex ];
+
+			if ( aspectRatio >= potentialRatio.ratio ) {
+				return classnames(
+					removeAspectRatioClasses( existingClassNames ),
+					potentialRatio.className,
+					'wp-has-aspect-ratio'
+				);
+			}
+		}
+	}
+
+	return existingClassNames;
+}

--- a/extensions/blocks/videopress/utils.js
+++ b/extensions/blocks/videopress/utils.js
@@ -1,4 +1,9 @@
 /**
+ * The code below is pulled from Gutenberg embed block, until we can use it directly from Gutenberg
+ * https://github.com/WordPress/gutenberg/blob/e4b6d70f129a745a0cc7dc556d41a44bdab7b0ca/packages/block-library/src/embed/util.js#L177
+ */
+
+/**
  * Internal dependencies
  */
 import { ASPECT_RATIOS } from './constants';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Relates to https://github.com/Automattic/jetpack/issues/17465

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In Video Block (`core/video`):
- adds utils to determine aspect ratio
- adds aspect ratio classes to preview

Code is pull from Gutenberg embed block which handles it correctly 
https://github.com/WordPress/gutenberg/blob/e4b6d70f129a745a0cc7dc556d41a44bdab7b0ca/packages/block-library/src/embed/util.js#L177

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* apply D51012-code
* Open the sandboxed site
* Edit a page / post
* Add a 30/30/30 columns block
* Add a video to 1 column
* Video should get full width of the current column
* Height should be adjusted according to the aspect ratio of the original video

Before | After
-------|------
![image](https://user-images.githubusercontent.com/12430020/95772648-c3eb4b00-0cc5-11eb-9e29-75b3c112920b.png)| ![](https://cln.sh/cB4z8e+)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix video block to respect video aspect-ratio in editor