### PR TITLE
Also use Core `wp_get_environment_type` for local

### DIFF
--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -143,6 +143,12 @@ class Status {
 			}
 		}
 
+		// @todo Remove function_exists when WP 5.5 is the minimum version.
+		// Use Core's environment check, if available.  Added in 5.5.0 / 5.5.1 (for `local` return value)
+		if ( function_exists( 'wp_get_environment_type' ) && 'local' === wp_get_environment_type() ) {
+			$is_local = true;
+		}
+
 		/**
 		 * Filters is_local_site check.
 		 *


### PR DESCRIPTION
Since being added recently in r48856-core we may as well listen for the environment declaring itself `local` explicitly.

https://core.trac.wordpress.org/ticket/51064

Relevant prior art: #16338

(apologies for the short nature of the pr description, was just a drive-by addition while I was in the neighborhood)

#### Changes proposed in this Pull Request:

* Extra way of detecting a local dev environment.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Better detect local development environments.
