### PR TITLE
E2E Tests: Don't pre-connect for suites where it is not needed

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -79,7 +79,7 @@ We use the following tools to write e2e tests:
 - [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) – provides all required configuration to run tests using Puppeteer
 - [expect-puppeteer](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer) – assertion library for Puppeteer
 
-Tests are kept in `tests/e2e/specs` folder. Every file represents a test suite, which is designed around specific feature under test. Most of the tests relies on active Jetpack Connection, so we do connect a site before running actual test suite. It's logic could be found in [`setup-env#maybePreConnect`](./lib/setup-env.js) function. For test suites where pre-connection is not need, it could be disabled by setting `SKIP_CONNECT` env var to false. Check [`connection.test.js`](./specs/connection.test.js) for example use.
+Tests are kept in `tests/e2e/specs` folder. Every file represents a test suite, which is designed around specific feature under test. Most of the tests rely on an active Jetpack Connection, so we connect a site before running the actual test suite. Its logic can be found in the [`setup-env#maybePreConnect`](./lib/setup-env.js) function. For test suites where pre-connection is not needed, it can be disabled by setting `SKIP_CONNECT` env var to false. Check [`connection.test.js`](./specs/connection.test.js) for example use.
 
 The following packages are being used to write tests:
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -79,7 +79,7 @@ We use the following tools to write e2e tests:
 - [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) – provides all required configuration to run tests using Puppeteer
 - [expect-puppeteer](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer) – assertion library for Puppeteer
 
-Tests are kept in `tests/e2e/specs` folder.
+Tests are kept in `tests/e2e/specs` folder. Every file represents a test suite, which is designed around specific feature under test. Most of the tests relies on active Jetpack Connection, so we do connect a site before running actual test suite. It's logic could be found in [`setup-env#maybePreConnect`](./lib/setup-env.js) function. For test suites where pre-connection is not need, it could be disabled by setting `SKIP_CONNECT` env var to false. Check [`connection.test.js`](./specs/connection.test.js) for example use.
 
 The following packages are being used to write tests:
 

--- a/tests/e2e/lib/pages/wpcom/pick-a-plan.js
+++ b/tests/e2e/lib/pages/wpcom/pick-a-plan.js
@@ -6,8 +6,7 @@ import { waitAndClick } from '../../page-helper';
 
 export default class PickAPlanPage extends Page {
 	constructor( page ) {
-		// const expectedSelector = '.plan-features__table button.is-premium-plan:not([disabled])';
-		const expectedSelector = '.plans-v2__columns .jetpack-product-card__price';
+		const expectedSelector = '.jetpack-product-card-alt .jetpack-product-card-alt__raw-price';
 		super( page, { expectedSelector } );
 	}
 

--- a/tests/e2e/lib/pages/wpcom/pick-a-plan.js
+++ b/tests/e2e/lib/pages/wpcom/pick-a-plan.js
@@ -23,22 +23,23 @@ export default class PickAPlanPage extends Page {
 	}
 
 	async selectFreePlan() {
-		const freePlanButton = 'a.jetpack-free-card__button';
+		const freePlanButton = '.jetpack-free-card-alt__main a';
 		return await waitAndClick( this.page, freePlanButton );
 	}
 
 	async selectComplete() {
-		const buttonSelector = 'div[data-icon="jetpack_complete_v2"] .jetpack-product-card__button';
+		const buttonSelector = 'div[data-icon="jetpack_complete_v2"] .jetpack-product-card-alt__button';
+		// [data-icon="jetpack_complete_v2"] .jetpack-product-card-alt__button
 		return await waitAndClick( this.page, buttonSelector );
 	}
 
 	async selectSecurity( type ) {
-		const buttonSelector = 'div[data-icon="jetpack_security_v2"] .jetpack-product-card__button';
+		const buttonSelector = 'div[data-icon="jetpack_security_v2"] .jetpack-product-card-alt__button';
 		await waitAndClick( this.page, buttonSelector );
 
 		// We actually redirecting to new view, so lets wait for a expected selector here.
 		await this.waitForPage();
-		const securityTypeSelector = `[data-icon="jetpack_security_${ type }_v2"] .jetpack-product-card__button`;
+		const securityTypeSelector = `[data-icon="jetpack_security_${ type }_v2"] .jetpack-product-card-alt__button`;
 		return await waitAndClick( this.page, securityTypeSelector );
 	}
 }

--- a/tests/e2e/specs/connection.test.js
+++ b/tests/e2e/specs/connection.test.js
@@ -7,6 +7,9 @@ import { execWpCommand } from '../lib/utils-helper';
 import Sidebar from '../lib/pages/wp-admin/sidebar';
 import JetpackPage from '../lib/pages/wp-admin/jetpack';
 
+// Disable pre-connect for this test suite
+process.env.SKIP_CONNECT = true;
+
 describe( 'Connection', () => {
 	catchBeforeAll( async () => {
 		await execWpCommand( 'wp option delete jetpack_private_options' );

--- a/tests/e2e/specs/plugin-updater.test.js
+++ b/tests/e2e/specs/plugin-updater.test.js
@@ -12,6 +12,9 @@ import {
 import Sidebar from '../lib/pages/wp-admin/sidebar';
 import PluginsPage from '../lib/pages/wp-admin/plugins';
 
+// Disable pre-connect for this test suite
+process.env.SKIP_CONNECT = true;
+
 describe( 'Jetpack updater', () => {
 	catchBeforeAll( async () => {
 		await prepareUpdaterTest();

--- a/tests/e2e/specs/pre-connection.test.js
+++ b/tests/e2e/specs/pre-connection.test.js
@@ -8,6 +8,9 @@ import JetpackPage from '../lib/pages/wp-admin/jetpack';
 import { catchBeforeAll } from '../lib/setup-env';
 import { execWpCommand } from '../lib/utils-helper';
 
+// Disable pre-connect for this test suite
+process.env.SKIP_CONNECT = true;
+
 describe( 'Jetpack pre-connection', () => {
 	catchBeforeAll( async () => {
 		await execWpCommand( 'wp option delete jetpack_private_options' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Don't pre-connect Jetpack when it is not needed

This PR saves around 1 minute for E2E tests run time.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Travis should be green
* E2E build time should be lower

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*n/a
