### PR TITLE
Stats: Insist on a WP_Post when trying to fetch a post ID

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -221,11 +221,15 @@ function stats_build_view_data() {
 		// 2. Set show_on_front = page
 		// 3. Set page_on_front = something
 		// 4. Visit https://example.com/ !
-		$queried_object = ( isset( $wp_the_query->queried_object ) ) ? $wp_the_query->queried_object : null;
-		$queried_object_id = ( isset( $wp_the_query->queried_object_id ) ) ? $wp_the_query->queried_object_id : null;
-		$post = $wp_the_query->get_queried_object_id();
-		$wp_the_query->queried_object = $queried_object;
-		$wp_the_query->queried_object_id = $queried_object_id;
+		$queried_object    = isset( $wp_the_query->queried_object ) ? $wp_the_query->queried_object : null;
+		$queried_object_id = isset( $wp_the_query->queried_object_id ) ? $wp_the_query->queried_object_id : null;
+		try {
+			$post_obj = $wp_the_query->get_queried_object();
+			$post     = $post_obj instanceof WP_Post ? $post_obj->ID : '0';
+		} finally {
+			$wp_the_query->queried_object    = $queried_object;
+			$wp_the_query->queried_object_id = $queried_object_id;
+		}
 	} else {
 		$post = '0';
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

It's completely unclear what might be happening in #15582 or how it
might be reproduced. But some static analysis (see the issue) seems to
indicate that Stats wants a WP_Post object and not anything else, so
perhaps we can cut the spaghetti knot and just check for that class
directly in Stats.

Also, since phpcs is making me touch the surrounding lines anyway for
alignment of `=`, remove some extraneous parens and throw in some
try-finally logic to make it a little more robust.

Fixes #15582

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None I'm aware of.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
It stops incorrectly reporting a term ID as a post ID in some existing tracking. Instead "0" will be used, as for other cases where no post ID is available.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that normal posts still have the post ID in the Stats footer as they did before.
* If you can figure out how to reproduce what was going wrong in #15582, check that that's fixed now too.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* If this is worth mentioning, maybe "Stats: No longer incorrectly report a term ID as a post ID in some rare cases."
