### PR TITLE
Editor Deprecation: Remove the Switch to Classic option

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -312,11 +312,6 @@ class Jetpack_WPCOM_Block_Editor {
 			'wpcom-block-editor-default-editor-script',
 			'wpcomGutenberg',
 			array(
-				'switchToClassic' => array(
-					'isVisible' => $this->is_iframed_block_editor() && ! isset( $_GET['in-editor-deprecation-group'] ), // phpcs:ignore WordPress.Security.NonceVerification
-					'label'     => __( 'Switch to Classic Editor', 'jetpack' ),
-					'url'       => Jetpack_Calypsoify::getInstance()->get_switch_to_classic_editor_url(),
-				),
 				'richTextToolbar' => array(
 					'justify'   => __( 'Justify', 'jetpack' ),
 					'underline' => __( 'Underline', 'jetpack' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

With the Calypso editor deprecated and the code to switch editors
removed from WPCOM, the code to trigger the inclusion of the 'Switch to
Classic' option is redundant. This change removes that code.

#### Testing instructions:

Testing is difficult in that there is no way to get the 'Switch to Classic' option to appear anymore. As this change affects the WPCOM Block Editor code, editing a post within the Gutenframe on a Jetpack site will mean that the code is run. Checking for errors in the browser dev tools, and on the server side is probably the best testing we can do. 

#### Proposed changelog entry for your changes:

N/A
