### PR TITLE
Connection: Add wp.com function

### DIFF
--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -419,6 +419,14 @@ class Client {
 	) {
 		$validated_args            = self::validate_args_for_wpcom_json_api_request( $path, $version, $args, $base_api_path );
 		$validated_args['blog_id'] = (int) \Jetpack_Options::get_option( 'id' );
+
+		// For Simple sites get the response directly without any HTTP requests.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			add_filter( 'is_jetpack_authorized_for_site', '__return_true' );
+			require_lib( 'wpcom-api-direct' );
+			return \WPCOM_API_Direct::do_request( $validated_args );
+		}
+
 		return self::remote_request( $validated_args, $body );
 	}
 


### PR DESCRIPTION
This takes the changes made in D49507-code and brings them back into Jetpack.

#### Internal references

- D51094-code
- p1602626775095500-slack-CDLH4C1UZ
- p1602665919113500-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

There should be no changes for Jetpack sites. Simple sites will now be able to call the WPCOM API directly rather than doing an HTTP request.

#### Proposed changelog entry for your changes:

* no changelog