### PR TITLE
E2E Tests: Disable pre-connection in some tests V2

### DIFF
--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -38,14 +38,9 @@ const cardCredentials = config.get( 'testCardCredentials' );
  * @param {boolean} o.mockPlanData
  */
 export async function connectThroughWPAdminIfNeeded( {
-	wpcomUser = 'defaultUser',
 	plan = 'complete',
 	mockPlanData = false,
 } = {} ) {
-	// await loginToWpcomIfNeeded( wpcomUser, mockPlanData );
-
-	// await loginToWpSite( mockPlanData );
-
 	if ( await isBlogTokenSet() ) {
 		return 'already_connected';
 	}

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -42,9 +42,9 @@ export async function connectThroughWPAdminIfNeeded( {
 	plan = 'complete',
 	mockPlanData = false,
 } = {} ) {
-	await loginToWpcomIfNeeded( wpcomUser, mockPlanData );
+	// await loginToWpcomIfNeeded( wpcomUser, mockPlanData );
 
-	await loginToWpSite( mockPlanData );
+	// await loginToWpSite( mockPlanData );
 
 	if ( await isBlogTokenSet() ) {
 		return 'already_connected';

--- a/tests/e2e/lib/setup-env.js
+++ b/tests/e2e/lib/setup-env.js
@@ -148,7 +148,7 @@ function observeConsoleLogging() {
 async function maybePreConnect() {
 	const wpcomUser = 'defaultUser';
 	const mockPlanData = true;
-	const plan = true;
+	const plan = 'free';
 
 	await loginToWpcomIfNeeded( wpcomUser, mockPlanData );
 	await loginToWpSite( mockPlanData );

--- a/tests/e2e/lib/setup-env.js
+++ b/tests/e2e/lib/setup-env.js
@@ -19,7 +19,7 @@ import {
 	loginToWpSite,
 } from './flows/jetpack-connect';
 
-const { PUPPETEER_TIMEOUT, E2E_DEBUG, CI, E2E_LOG_HTML, SKIP_CONNECT } = process.env;
+const { PUPPETEER_TIMEOUT, E2E_DEBUG, CI, E2E_LOG_HTML } = process.env;
 let currentBlock;
 
 const defaultErrorHandler = async ( error, name ) => {

--- a/tests/e2e/lib/setup-env.js
+++ b/tests/e2e/lib/setup-env.js
@@ -142,7 +142,7 @@ function observeConsoleLogging() {
 }
 
 async function maybePreConnect() {
-	if ( SKIP_CONNECT ) {
+	if ( process.env.SKIP_CONNECT ) {
 		return;
 	}
 

--- a/tests/e2e/lib/setup-env.js
+++ b/tests/e2e/lib/setup-env.js
@@ -13,7 +13,11 @@ import { takeScreenshot } from './reporters/screenshot';
 import { logHTML, logDebugLog } from './page-helper';
 import logger from './logger';
 import { execWpCommand } from './utils-helper';
-import { connectThroughWPAdminIfNeeded } from './flows/jetpack-connect';
+import {
+	connectThroughWPAdminIfNeeded,
+	loginToWpcomIfNeeded,
+	loginToWpSite,
+} from './flows/jetpack-connect';
 
 const { PUPPETEER_TIMEOUT, E2E_DEBUG, CI, E2E_LOG_HTML, SKIP_CONNECT } = process.env;
 let currentBlock;
@@ -142,14 +146,18 @@ function observeConsoleLogging() {
 }
 
 async function maybePreConnect() {
+	const wpcomUser = 'defaultUser';
+	const mockPlanData = true;
+	const plan = true;
+
+	await loginToWpcomIfNeeded( wpcomUser, mockPlanData );
+	await loginToWpSite( mockPlanData );
+
 	if ( process.env.SKIP_CONNECT ) {
 		return;
 	}
 
-	const status = await connectThroughWPAdminIfNeeded( {
-		mockPlanData: true,
-		plan: 'free',
-	} );
+	const status = await connectThroughWPAdminIfNeeded( { wpcomUser, mockPlanData, plan } );
 
 	if ( status !== 'already_connected' ) {
 		const result = await execWpCommand( 'wp option get jetpack_private_options --format=json' );

--- a/tests/e2e/specs/plugin-updater.test.js
+++ b/tests/e2e/specs/plugin-updater.test.js
@@ -34,7 +34,6 @@ describe( 'Jetpack updater', () => {
 
 	it( 'Plugin updater', async () => {
 		await step( 'Can login and navigate to Plugins page', async () => {
-			// await loginToWpSite();
 			await ( await Sidebar.init( page ) ).selectInstalledPlugins();
 			await PluginsPage.init( page );
 		} );

--- a/tests/e2e/specs/plugin-updater.test.js
+++ b/tests/e2e/specs/plugin-updater.test.js
@@ -34,7 +34,7 @@ describe( 'Jetpack updater', () => {
 
 	it( 'Plugin updater', async () => {
 		await step( 'Can login and navigate to Plugins page', async () => {
-			await loginToWpSite();
+			// await loginToWpSite();
 			await ( await Sidebar.init( page ) ).selectInstalledPlugins();
 			await PluginsPage.init( page );
 		} );

--- a/tests/e2e/specs/plugin-updater.test.js
+++ b/tests/e2e/specs/plugin-updater.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { catchBeforeAll, step } from '../lib/setup-env';
-import { loginToWpSite, connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
+import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
 import {
 	execWpCommand,
 	prepareUpdaterTest,


### PR DESCRIPTION
It is a follow-up to #17470 which did not properly disable pre-connect step.

The problem with the above PR is that it uses env var that was set in the build time, it would not reflect any runtime changes.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the tests are green :D 
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
