### PR TITLE
Add ability to push built block code to sandboxes for streamlined smoke-testing

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const program = require( 'commander' );
+
+program
+	.version( '0.0.1' )
+	.option( '-s, --sandbox <host>', 'Your WordPress.com sandbox host' )
+	.command(
+		'push',
+		'Upload source code to appropriate paths in your sandbox'
+	)
+	.command( 'pull', 'Pull source code from your sandbox' );
+
+program.on( 'option:sandbox', ( host ) => {
+	process.env.WPCOM_SANDBOX = host;
+} );
+
+program.parse( process.argv );

--- a/bin/sandbox-push
+++ b/bin/sandbox-push
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const { execSync } = require( 'child_process' );
+const program = require( 'commander' );
+
+// The sandbox host
+const host = process.env.WPCOM_SANDBOX;
+const destinations = [
+	{
+		name: 'Blocks',
+		id: 'blocks',
+		local: '_inc/blocks/',
+		remote: 'public_html/wp-content/mu-plugins/jetpack/_inc/blocks/',
+		isDirectory: true,
+	},
+];
+const excludes = [ '.DS_Store' ];
+
+if ( ! host ) {
+	throw new Error( 'Sandbox host is not set' );
+}
+
+program
+	.option(
+		'-k, --keep-deleted',
+		'Keep deleted files/folders in the target if they were deleted' + ' locally.'
+	)
+	.parse( process.argv );
+
+push( host, program.keepDeleted );
+
+process.stderr.write( '\nComplete\n' );
+
+function sync( origin, destination, isDirectory, keepDeleted ) {
+	const deleteFlag = keepDeleted ? '' : '--delete';
+	const excludeStr = excludes.map( item => `'${ item }'` ).join( ',' );
+
+	execSync( `rsync -azb --exclude={${ excludeStr }} ${ origin } ${ destination } ${ deleteFlag }` );
+}
+
+function push( host, keepDeleted ) {
+	destinations.forEach( item => {
+		//makeLocalDirectory( item );
+		process.stderr.write( `\nUploading ${ item.name } to sandbox ${ host }` );
+		sync( item.local, `${ host }:${ item.remote }`, keepDeleted );
+	} );
+}

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
 		"jest-puppeteer": "4.4.0",
 		"lodash": "4.17.20",
 		"markdown-spellcheck": "1.3.1",
+		"minimist": "1.2.5",
 		"mocha": "8.1.3",
 		"mockery": "2.1.0",
 		"nock": "13.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12200,7 +12200,7 @@ minimist@0.0.8, minimist@^0.2.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
   integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@1.2.5, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
The changes here extend the `yarn watch` script to allow pushing of code to sandboxes after being rebuilt.

Code cannibalized from the P2 codebase. 

#### Changes proposed in this Pull Request:

* Introducess `-s` parameter to `yarn watch`: `yarn watch -- -s comsandbox` for pushing built code to sandbox.
* Adds some scripts to extend npm start behaviour when passed the `-s` flag for providing a sandbox domaain to where push built code over SCP
* Introduces `minimist` into devDependencies for option parsing from inside `gulpfile.babel.js`

#### Jetpack product discussion

Doesn't affect the final product

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Checkout this branch
* Run `yarn build`.
* Run `bin/sandbox -s comsandbox push`. You can use an alias from your `.ssh/config` file or a domain like `myuser@mysandbox.wordpress.com`.
  ![image](https://user-images.githubusercontent.com/746152/96140719-9fb28880-0ed6-11eb-8aae-d747864428e0.png)

* Expect to have block files synced to your sandbox.
* Run `yarn watch -- -s comsandbox`.
* Expect to have `yarn watch` running, monitoring your local changes, and changes synced to your sandbox right away

#### Proposed changelog entry for your changes:

No need for changelog entry
