### PR TITLE
AMP: Use div.fb-post instead of fb:post to modernize and fix Facebook post embeds on AMP pages

### DIFF
--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -69,7 +69,7 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 			$width = min( $width, $content_width );
 		}
 
-		$embed = sprintf( '<fb:post href="%s" data-width="%s"></fb:post>', esc_url( $url ), esc_attr( $width ) );
+		$embed = sprintf( '<div class="fb-post" data-href="%s" data-width="%s"></div>', esc_url( $url ), esc_attr( $width ) );
 	}
 
 	// since Facebook is a faux embed, we need to load the JS SDK in the wpview embed iframe.

--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -50,9 +50,10 @@ wp_embed_register_handler( 'facebook-alternate-video', JETPACK_FACEBOOK_VIDEO_AL
 /**
  * Callback to modify output of embedded Facebook posts.
  *
- * @param array $matches Regex partial matches against the URL passed.
- * @param array $attr    Attributes received in embed response.
- * @param array $url     Requested URL to be embedded.
+ * @param array  $matches Regex partial matches against the URL passed.
+ * @param array  $attr    Attributes received in embed response.
+ * @param string $url     Requested URL to be embedded.
+ * @return string Facebook embed markup.
  */
 function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 	if (

--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -72,6 +72,11 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 		$embed = sprintf( '<div class="fb-post" data-href="%s" data-width="%s"></div>', esc_url( $url ), esc_attr( $width ) );
 	}
 
+	// Skip rendering scripts in an AMP context.
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		return $embed;
+	}
+
 	// since Facebook is a faux embed, we need to load the JS SDK in the wpview embed iframe.
 	if (
 		defined( 'DOING_AJAX' )


### PR DESCRIPTION
WIth the turning down of Facebook oEmbed support, Jetpack's internal oEmbed handler is now being used embedding Facebook posts. The way this is implemented, however, does not work with the AMP plugin's conversion of Facebook post embeds to `<amp-facebook>` components.

Given this `post_content`:

```html
<!-- wp:core-embed/facebook {"url":"https://www.facebook.com/aljazeera/posts/10159392848398690","type":"rich","providerNameSlug":"facebook","className":""} -->
<figure class="wp-block-embed-facebook wp-block-embed is-type-rich is-provider-facebook">
	<div class="wp-block-embed__wrapper">
		https://www.facebook.com/aljazeera/posts/10159392848398690
	</div>
</figure>
<!-- /wp:core-embed/facebook -->
```

This is resulting in the following markup added to the non-AMP page:

```html
<figure class="wp-block-embed-facebook wp-block-embed is-type-rich is-provider-facebook">
	<div class="wp-block-embed__wrapper">
		<fb:post href="https://www.facebook.com/aljazeera/posts/10159392848398690" data-width="552"></fb:post>
	</div>
</figure>
```

On an AMP page, however, the `fb:post` element here is getting stripped out as invalid AMP. This is because [`AMP_Facebook_Embed_Handler::sanitize_raw_embeds()`](https://github.com/ampproject/amp-wp/blob/b7bb7c53708be604a2fa59397d30540678480bbe/includes/embeds/class-amp-facebook-embed-handler.php#L51-L101) is only looking for `div` elements with the `fb-*` class names to convert into `amp-facebook` components. Indeed, the use of `div` is the current practice advised in Facebook's [Embedded Posts](https://developers.facebook.com/docs/plugins/embedded-posts/) documentation. The introduction of `fb:post` happened in 7 years ago via bfdfd8c8b1c43096ba49ee854eb4a316b46d83c7. The faux XML tags comes from XFBML which is for the [now-deprecated FBML](https://developers.facebook.com/blog/post/568/). I believe this has its roots in when XHTML was cool and HTML5 was not yet a thing. However, there's no need to use XFBML anymore and the `div` can be used instead.

This PR also prevents the `jetpack-facebook-embed` script from being printed on AMP pages.

Non-AMP | AMP Before 👎  | AMP After 👍 
----------|-----------------|--------------
![image](https://user-images.githubusercontent.com/134745/96170894-0afd5a00-0ed9-11eb-89fb-5fddb3bf3c73.png) | ![image](https://user-images.githubusercontent.com/134745/96171015-2bc5af80-0ed9-11eb-80bd-3b8ebe26b8c4.png) | ![image](https://user-images.githubusercontent.com/134745/96171140-5ca5e480-0ed9-11eb-9437-5cc873b2bf73.png)

The AMP Validated URL screen:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/96171076-44ce6080-0ed9-11eb-94b2-d07cde2022f3.png) | ![image](https://user-images.githubusercontent.com/134745/96171122-531c7c80-0ed9-11eb-99c2-2cdfa7dc2653.png)

#### Changes proposed in this Pull Request:

* Use HTML5 Facebook post embeds instead of XFBML to fix embedding on AMP pages. Prevent printing invalid (and unnecessary) scripts on AMP pages.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Embed a Facebook post like https://www.facebook.com/aljazeera/posts/10159392848398690
2. Look at the non-AMP version
3. Compare with the AMP version.
4. The appearance should be identical and no AMP validation errors should be detected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix AMP-compatibility for Facebook post embeds.
