### PR TITLE
External Media: Don't append to Coblocks replace button

### DIFF
--- a/extensions/shared/external-media/index.js
+++ b/extensions/shared/external-media/index.js
@@ -28,25 +28,29 @@ if ( isCurrentUserConnected() && 'function' === typeof useBlockEditContext ) {
 		props.unstableFeaturedImageFlow ||
 		( props.modalClass && props.modalClass.indexOf( 'featured-image' ) > -1 );
 
+	const isAllowedBlock = ( name, render ) => {
+		const allowedBlocks = [
+			'core/cover',
+			'core/image',
+			'core/gallery',
+			'core/media-text',
+			'jetpack/image-compare',
+			'jetpack/slideshow',
+			'jetpack/tiled-gallery',
+		];
+
+		return allowedBlocks.indexOf( name ) > -1 && render.toString().indexOf( 'coblocks' ) === -1;
+	};
+
 	// Register the new 'browse media' button.
 	addFilter(
 		'editor.MediaUpload',
 		'external-media/replace-media-upload',
 		OriginalComponent => props => {
-			const allowedBlocks = [
-				'core/cover',
-				'core/image',
-				'core/gallery',
-				'core/media-text',
-				'jetpack/image-compare',
-				'jetpack/slideshow',
-				'jetpack/tiled-gallery',
-			];
-
 			const { name } = useBlockEditContext();
 			let { render } = props;
 
-			if ( allowedBlocks.indexOf( name ) > -1 || isFeaturedImage( props ) ) {
+			if ( isAllowedBlock( name, render ) || isFeaturedImage( props ) ) {
 				const { allowedTypes, gallery = false, value = [] } = props;
 
 				// Only replace button for components that expect images, except existing galleries.


### PR DESCRIPTION
Fixes #17476.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Very rudimentarily checks if the media button render function contains the `coblocks` textdomain and doesn't append external media links if it does.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

Before | After
--- | ---
<img src="https://user-images.githubusercontent.com/4550351/95929295-619e6180-0e0f-11eb-93ca-535a6602ca82.png" width="300">  | ![image](https://user-images.githubusercontent.com/30462574/76105255-d5cb7980-5f91-11ea-930c-94ec47908f59.gif)


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Editor
* Insert an image block and select an image.
* Click on "Replace" in the block toolbar and make sure External Media is still available there.
* Check the sidebar and make sure External Media links are no longer there.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* External Media: Fixed a conflict with CoBlock's image replace feature.
