### PR TITLE
Instant Search: Fix event handler for filter links

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -148,12 +148,11 @@ class SearchApp extends Component {
 
 	handleFilterInputClick = event => {
 		event.preventDefault();
-
-		if ( event.target.dataset.filterType ) {
-			if ( event.target.dataset.filterType === 'taxonomy' ) {
-				setFilterQuery( event.target.dataset.taxonomy, event.target.dataset.val );
+		if ( event.currentTarget.dataset.filterType ) {
+			if ( event.currentTarget.dataset.filterType === 'taxonomy' ) {
+				setFilterQuery( event.currentTarget.dataset.taxonomy, event.currentTarget.dataset.val );
 			} else {
-				setFilterQuery( event.target.dataset.filterType, event.target.dataset.val );
+				setFilterQuery( event.currentTarget.dataset.filterType, event.currentTarget.dataset.val );
 			}
 		}
 		this.showResults();

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -143,7 +143,7 @@ class SearchApp extends Component {
 			this.showResults();
 		}
 
-		setSearchQuery( event.target.value );
+		setSearchQuery( event.currentTarget.value );
 	}, 200 );
 
 	handleFilterInputClick = event => {
@@ -184,7 +184,7 @@ class SearchApp extends Component {
 		} );
 	};
 
-	onChangeQuery = event => setSearchQuery( event.target.value );
+	onChangeQuery = event => setSearchQuery( event.currentTarget.value );
 
 	onPopstate = () => {
 		this.onChangeQueryString();

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -143,7 +143,7 @@ class SearchApp extends Component {
 			this.showResults();
 		}
 
-		setSearchQuery( event.currentTarget.value );
+		setSearchQuery( event.target.value );
 	}, 200 );
 
 	handleFilterInputClick = event => {
@@ -183,8 +183,6 @@ class SearchApp extends Component {
 			this.setState( { showResults: false } );
 		} );
 	};
-
-	onChangeQuery = event => setSearchQuery( event.currentTarget.value );
 
 	onPopstate = () => {
 		this.onChangeQueryString();

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -27,7 +27,7 @@ class SearchForm extends Component {
 		showFilters: !! this.props.widget,
 	};
 
-	onChangeQuery = event => setSearchQuery( event.target.value );
+	onChangeQuery = event => setSearchQuery( event.currentTarget.value );
 	onChangeSort = sort => {
 		this.props.onChangeSort( sort );
 		this.hideFilters();

--- a/modules/search/instant-search/components/search-sort.jsx
+++ b/modules/search/instant-search/components/search-sort.jsx
@@ -12,15 +12,15 @@ import { SORT_OPTIONS } from '../lib/constants';
 
 export default class SearchSort extends Component {
 	handleKeyPress = event => {
-		if ( this.props.value !== event.target.value && event.key === 'Enter' ) {
+		if ( this.props.value !== event.currentTarget.value && event.key === 'Enter' ) {
 			event.preventDefault();
-			this.props.onChange( event.target.dataset.value );
+			this.props.onChange( event.currentTarget.dataset.value );
 		}
 	};
 	handleClick = event => {
-		if ( this.props.value !== event.target.value ) {
+		if ( this.props.value !== event.currentTarget.value ) {
 			event.preventDefault();
-			this.props.onChange( event.target.dataset.value );
+			this.props.onChange( event.currentTarget.dataset.value );
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Fixes a bug where filter link clicks wouldn't apply the necessary filters due to nested elements within the filter link; the event handler was checking `event.target` instead of `event.currentTarget`.
* Pre-emptively changes usage of `event.target` to `event.currentTarget` where appropriate.

#### Jetpack product discussion
No.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Using a Custom HTML block, manually add a search filter link with a nested element inside like so: 
```html
<a class="jetpack-search-filter__link" href="#" data-filter-type="post_types" data-val="post"><span>Search</span></a>
```
* Click on this link before applying this patch. You'll notice that the `post` post type filter has not been applied.
* Click on this link with this patch. Ensure that the `post` post type filter has been applied.
* Ensure that entering a search query in the overlay works as expected.
* Ensure that manipulating the sort selector works as expected.

#### Proposed changelog entry for your changes:
* None.
