### PR TITLE
Fix implementation of Infinite Scroll in AMP

### DIFF
--- a/modules/infinite-scroll/class-jetpack-amp-infinite-scroll-sanitizer.php
+++ b/modules/infinite-scroll/class-jetpack-amp-infinite-scroll-sanitizer.php
@@ -15,6 +15,7 @@ final class Jetpack_AMP_Infinite_Scroll_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array {
 	 *     @type string   $footer_xpaths
 	 *     @type string[] $next_page_hide_xpaths
+	 *     @type string[] $hidden_xpaths
 	 * }
 	 */
 	protected $args;
@@ -67,6 +68,7 @@ final class Jetpack_AMP_Infinite_Scroll_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		$this->hide_next_page_elements();
+		$this->hide_hidden_elements();
 	}
 
 	/**
@@ -83,7 +85,25 @@ final class Jetpack_AMP_Infinite_Scroll_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $xpaths as $next_page_hide_xpath ) {
 			/** @var DOMElement $element */
 			foreach ( $this->xpath->query( $next_page_hide_xpath ) as $element ) {
-				$element->setAttribute( 'next-page-hide', '' ); // @todo Also hidden?
+				$element->setAttribute( 'next-page-hide', '' );
+			}
+		}
+	}
+
+	/**
+	 * Hide elements on initial load.
+	 */
+	private function hide_hidden_elements() {
+		if ( isset( $this->args['hidden_xpaths'] ) && is_array( $this->args['hidden_xpaths'] ) ) {
+			$xpaths = $this->args['hidden_xpaths'];
+		} else {
+			$xpaths = array();
+		}
+
+		foreach ( $xpaths as $hidden_xpath ) {
+			/** @var DOMElement $element */
+			foreach ( $this->xpath->query( $hidden_xpath ) as $element ) {
+				$element->setAttribute( 'hidden', '' );
 			}
 		}
 	}

--- a/modules/infinite-scroll/class-jetpack-amp-infinite-scroll-sanitizer.php
+++ b/modules/infinite-scroll/class-jetpack-amp-infinite-scroll-sanitizer.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Infinite scroll sanitizer for AMP pages.
+ *
+ * @package    Jetpack
+ * @since      9.1.0
+ */
+
+/**
+ * This class makes the necessary changes to an AMP page when making an amp-next-page request.
+ */
+final class Jetpack_AMP_Infinite_Scroll_Sanitizer extends AMP_Base_Sanitizer {
+
+	/**
+	 * @var array {
+	 *     @type string   $footer_xpaths
+	 *     @type string[] $next_page_hide_xpaths
+	 * }
+	 */
+	protected $args;
+
+	/**
+	 * XPath.
+	 *
+	 * @var DOMXPath
+	 */
+	private $xpath;
+
+	/**
+	 * Sanitize.
+	 */
+	public function sanitize() {
+		$this->xpath = new DOMXPath( $this->dom );
+
+		// Abort if there is no amp-next-page in the document.
+		$next_page_element = $this->xpath->query( '//amp-next-page[ @class = "jetpack-infinite-scroll" ]' )->item( 0 );
+		if ( ! $next_page_element instanceof DOMElement ) {
+			return;
+		}
+
+		// Abort amp-next-page if no footer element discovered.
+		$footer_elements = array();
+		if ( ! empty( $this->args['footer_xpaths'] ) ) {
+			foreach ( $this->args['footer_xpaths'] as $footer_xpath ) {
+				$footer_elements = array_merge( $footer_elements, iterator_to_array( $this->xpath->query( $footer_xpath ) ) );
+			}
+		}
+		if ( empty( $footer_elements ) ) {
+			return;
+		}
+
+		// Abort if the amp-next-page lacks a div[footer] element.
+		$footer_container = $this->xpath->query( './div[ @footer ]', $next_page_element )->item( 0 );
+		if ( ! $footer_container instanceof DOMElement ) {
+			return;
+		}
+
+		// Make sure amp-next-page is at the end of the body.
+		$body = $this->dom->getElementsByTagName( 'body' )->item( 0 );
+		$next_page_element->parentNode->removeChild( $next_page_element );
+		$body->appendChild( $next_page_element );
+
+		// Move the footer to be inside of <amp-next-page>.
+		foreach ( $footer_elements as $footer_element ) {
+			$footer_element->parentNode->removeChild( $footer_element );
+			$footer_container->appendChild( $footer_element );
+		}
+
+		$this->hide_next_page_elements();
+	}
+
+	/**
+	 * Hide next page elements.
+	 */
+	private function hide_next_page_elements() {
+		if ( isset( $this->args['next_page_hide_xpaths'] ) && is_array( $this->args['next_page_hide_xpaths'] ) ) {
+			$xpaths = $this->args['next_page_hide_xpaths'];
+		} else {
+			$xpaths = array();
+		}
+		$xpaths[] = '//div[ @id = "wpadminbar" ]';
+
+		foreach ( $xpaths as $next_page_hide_xpath ) {
+			/** @var DOMElement $element */
+			foreach ( $this->xpath->query( $next_page_hide_xpath ) as $element ) {
+				$element->setAttribute( 'next-page-hide', '' ); // @todo Also hidden?
+			}
+		}
+	}
+}

--- a/modules/theme-tools/compat/twentynineteen.php
+++ b/modules/theme-tools/compat/twentynineteen.php
@@ -156,6 +156,9 @@ function twentynineteen_filter_amp_infinite_scroll_sanitizers( $sanitizers ) {
 				'//*[ @id = "masthead" ]',
 				'//*[ contains( @class, "navigation pagination" ) ]',
 			),
+			'hidden_xpaths'         => array(
+				'//*[ contains( @class, "navigation pagination" ) ]',
+			),
 		)
 	);
 

--- a/modules/theme-tools/compat/twentynineteen.php
+++ b/modules/theme-tools/compat/twentynineteen.php
@@ -131,62 +131,37 @@ add_filter( 'body_class', 'twentynineteen_jetpack_body_classes' );
  * @return void
  */
 function amp_twentynineteen_infinite_scroll_render_hooks() {
-	add_filter( 'jetpack_amp_infinite_footers', 'twentynineteen_amp_infinite_footers', 10, 2 );
-	add_filter( 'jetpack_amp_infinite_output', 'twentynineteen_amp_infinite_output' );
 	add_filter( 'jetpack_amp_infinite_older_posts', 'twentynineteen_amp_infinite_older_posts' );
 }
 
 /**
- * Get the theme specific footers.
+ * Add arguments to the infinite scroll sanitizer.
  *
- * @param array  $footers The footers of the themes.
- * @param string $buffer  Contents of the output buffer.
- *
- * @return mixed
+ * @param array $sanitizers Sanitizers.
+ * @return array Sanitizers.
  */
-function twentynineteen_amp_infinite_footers( $footers, $buffer ) {
-	// Collect the footer wrapper.
-	preg_match(
-		'/<footer id="colophon".*<!-- #colophon -->/s',
-		$buffer,
-		$footer
-	);
-	$footers[] = reset( $footer );
+function twentynineteen_filter_amp_infinite_scroll_sanitizers( $sanitizers ) {
+	if ( ! array_key_exists( 'Jetpack_AMP_Infinite_Scroll_Sanitizer', $sanitizers ) ) {
+		return $sanitizers;
+	}
 
-	return $footers;
+	$sanitizers['Jetpack_AMP_Infinite_Scroll_Sanitizer'] = array_merge(
+		$sanitizers['Jetpack_AMP_Infinite_Scroll_Sanitizer'],
+		array(
+			// Formerly twentynineteen_amp_infinite_footers.
+			'footer_xpaths'         => array(
+				'//footer[ @id = "colophon" ]',
+			),
+			'next_page_hide_xpaths' => array(
+				'//*[ @id = "masthead" ]',
+				'//*[ contains( @class, "navigation pagination" ) ]',
+			),
+		)
+	);
+
+	return $sanitizers;
 }
-
-/**
- * Hide and remove various elements from next page load.
- *
- * @param string $buffer Contents of the output buffer.
- *
- * @return string
- */
-function twentynineteen_amp_infinite_output( $buffer ) {
-	// Hide site header on next page load.
-	$buffer = preg_replace(
-		'/id="masthead"/',
-		'$0 next-page-hide',
-		$buffer
-	);
-
-	// Hide pagination on next page load.
-	$buffer = preg_replace(
-		'/class=".*navigation pagination.*"/',
-		'$0 next-page-hide hidden',
-		$buffer
-	);
-
-	// Remove the footer as it will be added back to amp next page footer.
-	$buffer = preg_replace(
-		'/<footer id="colophon".*<!-- #colophon -->/s',
-		'',
-		$buffer
-	);
-
-	return $buffer;
-}
+add_filter( 'amp_content_sanitizers', 'twentynineteen_filter_amp_infinite_scroll_sanitizers' );
 
 /**
  * Filter the AMP infinite scroll older posts button

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -185,13 +185,16 @@ function twentytwenty_filter_amp_infinite_scroll_sanitizers( $sanitizers ) {
 	$sanitizers['Jetpack_AMP_Infinite_Scroll_Sanitizer'] = array_merge(
 		$sanitizers['Jetpack_AMP_Infinite_Scroll_Sanitizer'],
 		array(
-			// Formerly twentynineteen_amp_infinite_footers.
+			// Formerly twentytwenty_amp_infinite_footers.
 			'footer_xpaths'         => array(
 				'//div[ contains( @class, "footer-nav-widgets-wrapper" ) ]',
 				'//footer[ @id = "site-footer" ]',
 			),
 			'next_page_hide_xpaths' => array(
 				'//*[ @id = "site-header" ]',
+				'//*[ contains( @class, "pagination-wrapper" ) ]',
+			),
+			'hidden_xpaths'         => array(
 				'//*[ contains( @class, "pagination-wrapper" ) ]',
 			),
 		)

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -167,78 +167,39 @@ add_action( 'wp_enqueue_scripts', 'twentytwenty_infinity_accent_color_css' );
  * @return void
  */
 function amp_twentytwenty_infinite_scroll_render_hooks() {
-	add_filter( 'jetpack_amp_infinite_footers', 'twentytwenty_amp_infinite_footers', 10, 2 );
-	add_filter( 'jetpack_amp_infinite_output', 'twentytwenty_amp_infinite_output' );
 	add_filter( 'jetpack_amp_infinite_separator', 'twentytwenty_amp_infinite_separator' );
 	add_filter( 'jetpack_amp_infinite_older_posts', 'twentytwenty_amp_infinite_older_posts' );
 }
 
 /**
- * Get the theme specific footers.
+ * Add arguments to the infinite scroll sanitizer.
  *
- * @param array  $footers The footers of the themes.
- * @param string $buffer  Contents of the output buffer.
- *
- * @return mixed
+ * @param array $sanitizers Sanitizers.
+ * @return array Sanitizers.
  */
-function twentytwenty_amp_infinite_footers( $footers, $buffer ) {
-	// Collect the footer wrapper.
-	preg_match(
-		'/<div class="footer-nav-widgets-wrapper.*<!-- .footer-nav-widgets-wrapper -->/s',
-		$buffer,
-		$footer
-	);
-	$footers[] = reset( $footer );
+function twentytwenty_filter_amp_infinite_scroll_sanitizers( $sanitizers ) {
+	if ( ! array_key_exists( 'Jetpack_AMP_Infinite_Scroll_Sanitizer', $sanitizers ) ) {
+		return $sanitizers;
+	}
 
-	// Collect the footer wrapper.
-	preg_match(
-		'/<footer id="site-footer".*<!-- #site-footer -->/s',
-		$buffer,
-		$footer
+	$sanitizers['Jetpack_AMP_Infinite_Scroll_Sanitizer'] = array_merge(
+		$sanitizers['Jetpack_AMP_Infinite_Scroll_Sanitizer'],
+		array(
+			// Formerly twentynineteen_amp_infinite_footers.
+			'footer_xpaths'         => array(
+				'//div[ contains( @class, "footer-nav-widgets-wrapper" ) ]',
+				'//footer[ @id = "site-footer" ]',
+			),
+			'next_page_hide_xpaths' => array(
+				'//*[ @id = "site-header" ]',
+				'//*[ contains( @class, "pagination-wrapper" ) ]',
+			),
+		)
 	);
-	$footers[] = reset( $footer );
 
-	return $footers;
+	return $sanitizers;
 }
-
-/**
- * Hide and remove various elements from next page load.
- *
- * @param string $buffer Contents of the output buffer.
- *
- * @return string
- */
-function twentytwenty_amp_infinite_output( $buffer ) {
-	// Hide site header on next page load.
-	$buffer = preg_replace(
-		'/id="site-header"/',
-		'$0 next-page-hide',
-		$buffer
-	);
-
-	// Hide pagination on next page load.
-	$buffer = preg_replace(
-		'/class=".*pagination-wrapper.*"/',
-		'$0 next-page-hide hidden',
-		$buffer
-	);
-
-	// Remove the footer as it will be added back to amp next page footer.
-	$buffer = preg_replace(
-		'/<div class="footer-nav-widgets-wrapper.*<!-- .footer-nav-widgets-wrapper -->/s',
-		'',
-		$buffer
-	);
-
-	// Remove the footer as it will be added back to amp next page footer.
-	$buffer = preg_replace(
-		'/<footer id="site-footer".*<!-- #site-footer -->/s',
-		'',
-		$buffer
-	);
-
-	return $buffer;
-}
+add_filter( 'amp_content_sanitizers', 'twentytwenty_filter_amp_infinite_scroll_sanitizers' );
 
 /**
  * Filter the AMP infinite scroll separator


### PR DESCRIPTION
As reported in https://github.com/Automattic/newspack-theme/issues/1108#issuecomment-706444086 and https://github.com/Automattic/newspack-theme/issues/1107, the AMP implementation of Infinite Scroll is broken in Jetpack. For example, as also reported on an [AMP support forum topic](https://wordpress.org/support/topic/footer-on-footer-amp-page/), in the Twenty Seventeen theme the footer shows the text `%%footer%%`.

The implementation appears to do more work than it needs to, by starting its own output buffering for the entire page when the AMP plugin is already doing this. Instead of doing search/replace on the output buffered document to make the necessary 
changes, the better approach is to register an AMP plugin sanitizer which can make those changes on the DOM that is already being constructed from the output buffer by the AMP plugin.

This pull request is a _start_ at fixing the implementation. I admit that I am not well-versed in Infinite Scroll or `amp-next-page`. ~The behavior currently in production for Twenty Twenty and Twenty Nineteen doesn't even seem to work as expected: I scroll down to the footer and then scroll back upward in order to start seeing the additional pages inserted.~ (This may have been due to not choosing the right setting for Infinite Scroll.) 

#### Changes proposed in this Pull Request:

* Prevent `%%footer%%` from showing up in themes that don't support Infinite Scroll.
* Use an AMP sanitizer to inject the required markup for `amp-next-page` in the DOM, rather than creating a secondary output buffer and perform brittle string replacements.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
