### PR TITLE
Update size of input on Google Cal block

### DIFF
--- a/extensions/blocks/google-calendar/editor.scss
+++ b/extensions/blocks/google-calendar/editor.scss
@@ -16,7 +16,14 @@
 	}
 
 	&-embed-form-editor {
+		display: flex;
+		flex-direction: row;
+		width: 100%;
+		flex-wrap: wrap;
+
 		textarea {
+			margin-right: 1px;
+			flex: 1;
 			height: 36px;
 			padding-top: 9px;
 		}

--- a/extensions/blocks/google-calendar/editor.scss
+++ b/extensions/blocks/google-calendar/editor.scss
@@ -16,11 +16,6 @@
 	}
 
 	&-embed-form-editor {
-		display: flex;
-		flex-direction: row;
-		width: 100%;
-		flex-wrap: wrap;
-
 		textarea {
 			margin-right: 1px;
 			flex: 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Updates the Google Calender block UI to be more consistent with other blocks. 

Before:

![94680500-1de12d80-0322-11eb-98c2-bbcfca322f75](https://user-images.githubusercontent.com/411945/96239993-a7d6fa80-0fa0-11eb-986c-e9aeedf4d620.png)

After:

![Screenshot 2020-10-16 at 11 02 53](https://user-images.githubusercontent.com/411945/96240025-b1606280-0fa0-11eb-91a8-61ca6e916852.png)

with comparison to Calendly

Fixes #17326 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Style only

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Pull this PR
* Create a new Google Calendar block and check the UI 
* Compare it with the Calendly UI 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
