### PR TITLE
Remove smile stats toggle

### DIFF
--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -211,19 +211,6 @@ class SiteStatsComponent extends React.Component {
 									) }
 								</span>
 							</CompactFormToggle>
-							<CompactFormToggle
-								checked={ !! this.props.getOptionValue( 'hide_smile' ) }
-								disabled={ ! isStatsActive || unavailableInOfflineMode }
-								toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
-								onChange={ this.handleStatsOptionToggle( 'hide_smile' ) }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Hide the stats smiley face image', 'jetpack' ) }
-								</span>
-								<span className="jp-form-setting-explanation">
-									{ __( 'The image helps collect stats but should work when hidden.', 'jetpack' ) }
-								</span>
-							</CompactFormToggle>
 						</FormFieldset>
 						<FormFieldset>
 							<FormLegend>{ __( 'Count logged in page views from', 'jetpack' ) }</FormLegend>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Removes the hide smiley stats toggle.

Before:

![94591476-6cda8480-0288-11eb-8e7e-c9a3a3545181](https://user-images.githubusercontent.com/411945/96246050-621e3000-0fa8-11eb-98be-03bc773ad0fa.png)

After:

![Screenshot 2020-10-16 at 12 07 54](https://user-images.githubusercontent.com/411945/96246079-6c402e80-0fa8-11eb-9617-9b11719665c5.png)

The api endpoint in has been left for now: https://github.com/Automattic/jetpack/blob/fix/17304-hide-smile-ui/_inc/lib/class.core-rest-api-endpoints.php#L2610

Fixes #17304

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove UI control for stats smiley (hidden by default)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `wp-admin/admin.php?page=jetpack#/settings?term=site%20stats`
* Verify that the stats toggle has been removed from the UI

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
