### PR TITLE
Instagram Embed: Enable test on WP master

### DIFF
--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -186,9 +186,6 @@ BODY;
 	 * @covers ::jetpack_instagram_oembed_fetch_url
 	 */
 	public function test_instagram_replace_image_url_with_embed_and_remove_query_args() {
-		if ( 'master' === getenv( 'WP_BRANCH' ) ) {
-			$this->markTestSkipped( 'must be revisited.' );
-		}
 		global $post;
 
 		$instagram_url                 = 'https://www.instagram.com/p/BnMO9vRleEx/';


### PR DESCRIPTION
Leftover from #17356, where I enabled all other IG embed unit tests on WP master. I think this one fell through the cracks when I rebased :thinking: 

Related: #12918.

#### Changes proposed in this Pull Request:
Instagram Embed: Enable last missing unit test on WP master

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Verify that unit tests pass: CI goes green, or manually:

```
yarn docker:phpunit --filter=WP_Test_Jetpack_Shortcodes_Instagram
```

#### Proposed changelog entry for your changes:
Not needed.