### PR TITLE
Story block: minor UI fixes and improvements

### DIFF
--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -34,6 +34,7 @@ const defaultSettings = {
 	defaultAspectRatio: 720 / 1280,
 	cropUpTo: 0.2, // crop percentage allowed, after which media is displayed in letterbox
 	volume: 0.5,
+	renderInterval: 50, // in ms
 };
 
 export default function StoryPlayer( { slides, metadata, disabled, ...settings } ) {

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import { merge } from 'lodash';
-import classNames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-import { createElement, useLayoutEffect, useRef, useState } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,11 +14,6 @@ import { createElement, useLayoutEffect, useRef, useState } from '@wordpress/ele
 import './style.scss';
 import { Player } from './player';
 import ShadowRoot from './lib/shadow-root';
-import * as fullscreenAPI from './lib/fullscreen-api';
-
-const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-	window.navigator.userAgent
-);
 
 const defaultSettings = {
 	imageTime: 5000,
@@ -45,54 +39,9 @@ const defaultSettings = {
 export default function StoryPlayer( { slides, metadata, disabled, ...settings } ) {
 	const playerSettings = merge( {}, defaultSettings, settings );
 
-	const rootElementRef = useRef();
-	const [ fullscreen, setFullscreen ] = useState( false );
-	const [ lastScrollPosition, setLastScrollPosition ] = useState( null );
-
-	useLayoutEffect( () => {
-		if ( fullscreen ) {
-			if ( isMobile && fullscreenAPI.enabled() && ! playerSettings.loadInFullscreen ) {
-				fullscreenAPI.launch( rootElementRef.current );
-			} else {
-				// position: fixed does not work as expected on mobile safari
-				// To fix that we need to add a fixed positioning to body,
-				// retain the current scroll position and restore it when we exit fullscreen
-				setLastScrollPosition( [
-					document.documentElement.scrollLeft,
-					document.documentElement.scrollTop,
-				] );
-				document.body.classList.add( 'wp-story-in-fullscreen' );
-				document.getElementsByTagName( 'html' )[ 0 ].classList.add( 'wp-story-in-fullscreen' );
-			}
-		} else {
-			// eslint-disable-next-line no-lonely-if
-			if ( fullscreenAPI.element() ) {
-				fullscreenAPI.exit();
-			} else {
-				document.body.classList.remove( 'wp-story-in-fullscreen' );
-				if ( lastScrollPosition ) {
-					window.scrollTo( ...lastScrollPosition );
-				}
-				document.getElementsByTagName( 'html' )[ 0 ].classList.remove( 'wp-story-in-fullscreen' );
-			}
-		}
-	}, [ fullscreen ] );
-
 	return (
 		<ShadowRoot { ...playerSettings.shadowDOM }>
-			<div
-				ref={ rootElementRef }
-				className={ classNames( [ 'wp-story-app', { 'wp-story-fullscreen': fullscreen } ] ) }
-			>
-				<Player
-					fullscreen={ fullscreen }
-					setFullscreen={ setFullscreen }
-					slides={ slides }
-					metadata={ metadata }
-					disabled={ disabled }
-					{ ...playerSettings }
-				/>
-			</div>
+			<Player slides={ slides } metadata={ metadata } disabled={ disabled } { ...playerSettings } />
 		</ShadowRoot>
 	);
 }

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -26,18 +26,28 @@ import icon from '../icon';
 import ProgressBar from './progress-bar';
 import { Background, Controls, Header, Overlay } from './components';
 import useResizeObserver from './use-resize-observer';
+import * as fullscreenAPI from './lib/fullscreen-api';
 
-export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settings } ) => {
+const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+	window.navigator.userAgent
+);
+
+export const Player = ( { slides, disabled, ref, ...settings } ) => {
 	const [ currentSlideIndex, updateSlideIndex ] = useState( 0 );
 	const [ playing, setPlaying ] = useState( false );
 	const [ ended, setEnded ] = useState( false );
 	const [ muted, setMuted ] = useState( settings.startMuted );
 	const [ currentSlideProgress, setCurrentSlideProgress ] = useState( 0 );
 
-	const wrapperRef = useRef();
+	const slideContainerRef = useRef();
+	const appRef = useRef();
+
 	const [ maxSlideWidth, setMaxSlideWidth ] = useState( null );
 	const [ resizeListener, { width, height } ] = useResizeObserver();
 	const [ targetAspectRatio, setTargetAspectRatio ] = useState( settings.defaultAspectRatio );
+
+	const [ fullscreen, setFullscreen ] = useState( false );
+	const [ lastScrollPosition, setLastScrollPosition ] = useState( null );
 
 	const uploading = some( slides, media => isBlobURL( media.url ) );
 	const showProgressBar = fullscreen || ! settings.showSlideCount;
@@ -122,32 +132,66 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 		}
 	}, [] );
 
+	// Max slide width is used to display the story in portrait mode on desktop
 	useLayoutEffect( () => {
-		if ( ! fullscreen ) {
-			if ( ! wrapperRef.current ) {
-				return;
-			}
-			const wrapperHeight = wrapperRef.current.offsetHeight;
-			const ratioBasedWidth = Math.round( settings.defaultAspectRatio * wrapperHeight );
-			setMaxSlideWidth( ratioBasedWidth );
-		} else {
-			const wrapperHeight = ( wrapperRef.current && wrapperRef.current.offsetHeight ) || height;
-			const ratioBasedWidth = Math.round( settings.defaultAspectRatio * wrapperHeight );
-			const newMaxSlideWidth =
-				Math.abs( 1 - ratioBasedWidth / width ) < settings.cropUpTo ? width : ratioBasedWidth;
-			setMaxSlideWidth( newMaxSlideWidth );
+		if ( ! slideContainerRef.current ) {
+			return;
 		}
+		let ratioBasedWidth = Math.round(
+			settings.defaultAspectRatio * slideContainerRef.current.offsetHeight
+		);
+		if ( fullscreen ) {
+			ratioBasedWidth =
+				Math.abs( 1 - ratioBasedWidth / width ) < settings.cropUpTo ? width : ratioBasedWidth;
+		}
+		setMaxSlideWidth( ratioBasedWidth );
 	}, [ width, height, fullscreen ] );
 
 	useLayoutEffect( () => {
-		if ( wrapperRef.current && wrapperRef.current.offsetHeight > 0 ) {
-			setTargetAspectRatio( wrapperRef.current.offsetWidth / wrapperRef.current.offsetHeight );
+		if (
+			maxSlideWidth &&
+			slideContainerRef.current &&
+			slideContainerRef.current.offsetHeight > 0
+		) {
+			setTargetAspectRatio( maxSlideWidth / slideContainerRef.current.offsetHeight );
 		}
-	}, [ width, height ] );
+	}, [ maxSlideWidth ] );
+
+	useLayoutEffect( () => {
+		if ( fullscreen ) {
+			if ( isMobile && fullscreenAPI.enabled() && ! settings.loadInFullscreen ) {
+				fullscreenAPI.launch( appRef.current );
+			} else {
+				// position: fixed does not work as expected on mobile safari
+				// To fix that we need to add a fixed positioning to body,
+				// retain the current scroll position and restore it when we exit fullscreen
+				setLastScrollPosition( [
+					document.documentElement.scrollLeft,
+					document.documentElement.scrollTop,
+				] );
+				document.body.classList.add( 'wp-story-in-fullscreen' );
+				document.getElementsByTagName( 'html' )[ 0 ].classList.add( 'wp-story-in-fullscreen' );
+			}
+		} else {
+			// eslint-disable-next-line no-lonely-if
+			if ( fullscreenAPI.element() ) {
+				fullscreenAPI.exit();
+			} else {
+				document.body.classList.remove( 'wp-story-in-fullscreen' );
+				if ( lastScrollPosition ) {
+					window.scrollTo( ...lastScrollPosition );
+				}
+				document.getElementsByTagName( 'html' )[ 0 ].classList.remove( 'wp-story-in-fullscreen' );
+			}
+		}
+	}, [ fullscreen ] );
 
 	return (
 		/* eslint-disable jsx-a11y/click-events-have-key-events */
-		<>
+		<div
+			ref={ appRef }
+			className={ classNames( [ 'wp-story-app', { 'wp-story-fullscreen': fullscreen } ] ) }
+		>
 			{ resizeListener }
 			<div
 				role={ disabled ? 'presentation' : 'button' }
@@ -168,7 +212,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					fullscreen={ fullscreen }
 					onExitFullscreen={ onExitFullscreen }
 				/>
-				<div className="wp-story-wrapper" ref={ wrapperRef }>
+				<div ref={ slideContainerRef } className="wp-story-wrapper">
 					{ slides.map( ( media, index ) => (
 						<Slide
 							key={ index }
@@ -224,6 +268,6 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					}
 				/>
 			) }
-		</>
+		</div>
 	);
 };

--- a/extensions/blocks/story/player/slide.js
+++ b/extensions/blocks/story/player/slide.js
@@ -112,8 +112,8 @@ export const Slide = ( {
 	}, [ currentSlidePlaying, ended ] );
 
 	// Sync progressState with underlying media playback progress
-	useEffect( () => {
-		cancelAnimationFrame( progressState.timeout );
+	useLayoutEffect( () => {
+		clearTimeout( progressState.timeout );
 		if ( loading ) {
 			return;
 		}
@@ -123,8 +123,10 @@ export const Slide = ( {
 			if ( progressState.currentTime >= duration ) {
 				return;
 			}
-			progressState.timeout = requestAnimationFrame( () => {
-				const delta = progressState.lastUpdate ? Date.now() - progressState.lastUpdate : 0;
+			progressState.timeout = setTimeout( () => {
+				const delta = progressState.lastUpdate
+					? Date.now() - progressState.lastUpdate
+					: settings.renderInterval;
 				const currentTime = video ? video.currentTime : progressState.currentTime + delta;
 				updateProgressState( {
 					...progressState,
@@ -132,7 +134,7 @@ export const Slide = ( {
 					duration,
 					currentTime,
 				} );
-			} );
+			}, settings.renderInterval );
 		}
 		const paused = visible && ! playing;
 		if ( paused && progressState.lastUpdate ) {

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -348,7 +348,7 @@ function render_block( $attributes ) {
 		esc_attr( 'wp-story-' . get_the_ID() ),
 		filter_var( wp_json_encode( $settings ), FILTER_SANITIZE_SPECIAL_CHARS ),
 		__( 'Site icon', 'jetpack' ),
-		esc_attr( get_site_icon_url( 32, includes_url( 'images/w-logo-blue.png' ) ) ),
+		esc_attr( get_site_icon_url( 40, includes_url( 'images/w-logo-blue.png' ) ) ),
 		esc_html( get_the_title() ),
 		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : '',
 		get_permalink() . '?wp-story-load-in-fullscreen=true&amp;wp-story-play-on-load=true',


### PR DESCRIPTION
This PR fixes the latest bugs and UI feedback on the Story block:
- Media not cropped in fullscreen in iOS Safari
- Fix icon pixelated

### Testing Instructions

#### Media not cropped in fullscreen in iOS Safari
- Create a story, with its first image being a bit thinner than 9:16
- Load the post on Safari iOS (not the homepage)
- Don't scroll
- Use your first interaction with the page to tap on the story
- Make sure the image does not have black margins on the side

#### Fix icon pixelated
- Load a story in fullscreen
- Check that the site icon is not pixelated
- Inspect the image url loaded, make sure it ends with `?w=40`