### PR TITLE
Publicize: Remove tweets from threads that are only whitespace

### DIFF
--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -1265,7 +1265,7 @@ class Jetpack_Tweetstorm_Helper {
 				}
 
 				// Remove trailing whitespace from every line.
-				$tweet['text'] = preg_replace( '/\s+$/um', "\n", $tweet['text'] );
+				$tweet['text'] = preg_replace( '/\p{Z}+$/um', '', $tweet['text'] );
 
 				// Remove all trailing whitespace (including line breaks) from the end of the text.
 				$tweet['text'] = rtrim( $tweet['text'] );

--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -622,7 +622,8 @@ class Jetpack_Tweetstorm_Helper {
 			$current_tweet         = self::start_new_tweet();
 			$current_tweet['text'] = self::generate_url_placeholder( $block['embed'] );
 		} else {
-			$current_tweet['text'] .= ' ' . self::generate_url_placeholder( $block['embed'] );
+			$space                  = empty( $current_tweet['text'] ) ? '' : ' ';
+			$current_tweet['text'] .= $space . self::generate_url_placeholder( $block['embed'] );
 		}
 
 		self::save_current_tweet( $current_tweet, $block );
@@ -1070,7 +1071,7 @@ class Jetpack_Tweetstorm_Helper {
 		foreach ( $tag_values as $tag => $values ) {
 			// For single-line blocks, we need to squash all the values for this tag into a single value.
 			if ( 'multiline' !== $block_def['type'] ) {
-				$values = array( trim( implode( "\n", $values ) ) );
+				$values = array( implode( "\n", $values ) );
 			}
 
 			// Handle the special "content" tag.
@@ -1102,9 +1103,8 @@ class Jetpack_Tweetstorm_Helper {
 		// Join the lines together into a single string.
 		$text = implode( self::$line_separator, $lines );
 
-		// Trim off any extra whitespace that we no longer need.
-		$text = trim( $text );
-		$text = preg_replace( '/(' . self::$line_separator . ')+$/', '', $text );
+		// Trim off any trailing whitespace that we no longer need.
+		$text = preg_replace( '/(\s|' . self::$line_separator . ')+$/u', '', $text );
 
 		return $text;
 	}
@@ -1259,9 +1259,16 @@ class Jetpack_Tweetstorm_Helper {
 				// Remove any inline placeholders.
 				$tweet['text'] = str_replace( self::$inline_placeholder, '', $tweet['text'] );
 
-				// Tidy up the whitespace: using a regex instead of trim(), since the former catches more whitespace characters.
-				$tweet['text'] = preg_replace( '/^\s+|\s+$/u', '', $tweet['text'] );
-				$tweet['text'] = preg_replace( '/[ \t]+\n/', "\n", $tweet['text'] );
+				// If the tweet text consists only of whitespace, we can remove all of it.
+				if ( preg_match( '/^\s*$/u', $tweet['text'] ) ) {
+					$tweet['text'] = '';
+				}
+
+				// Remove trailing whitespace from every line.
+				$tweet['text'] = preg_replace( '/\s+$/um', "\n", $tweet['text'] );
+
+				// Remove all trailing whitespace (including line breaks) from the end of the text.
+				$tweet['text'] = rtrim( $tweet['text'] );
 
 				// Remove internal flags.
 				unset( $tweet['changed'] );

--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -1259,8 +1259,8 @@ class Jetpack_Tweetstorm_Helper {
 				// Remove any inline placeholders.
 				$tweet['text'] = str_replace( self::$inline_placeholder, '', $tweet['text'] );
 
-				// Tidy up the whitespace.
-				$tweet['text'] = trim( $tweet['text'] );
+				// Tidy up the whitespace: using a regex instead of trim(), since the former catches more whitespace characters.
+				$tweet['text'] = preg_replace( '/^\s+|\s+$/u', '', $tweet['text'] );
 				$tweet['text'] = preg_replace( '/[ \t]+\n/', "\n", $tweet['text'] );
 
 				// Remove internal flags.
@@ -1284,6 +1284,11 @@ class Jetpack_Tweetstorm_Helper {
 							unset( $tweet['blocks'][ $ii ][ $key ] );
 						}
 					}
+				}
+
+				// Once we've finished cleaning up, check if there's anything left to be tweeted.
+				if ( empty( $tweet['text'] ) && empty( $tweet['media'] ) && empty( $tweet['tweet'] ) ) {
+					return false;
 				}
 
 				return $tweet;

--- a/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
+++ b/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
@@ -894,12 +894,17 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 	 * Test that a basic verse maintains spacing.
 	 */
 	public function test_basic_verse() {
-		$test_content = " They say that code\n        is poetry.\n\n    Is indentation poetry,\n  too?";
-		$blocks       = array(
+		$test_content = " They say that code \n        is poetry.\n\n    Is indentation poetry,\n  too?";
+
+		$blocks = array(
 			$this->generateVerseData( $test_content ),
 		);
 
-		$this->assertTweetGenerated( $blocks, array( $test_content ), array( false ), array( $blocks ) );
+		$expected_text = array(
+			" They say that code\n        is poetry.\n\n    Is indentation poetry,\n  too?",
+		);
+
+		$this->assertTweetGenerated( $blocks, $expected_text, array( false ), array( $blocks ) );
 	}
 
 	/**

--- a/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
+++ b/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
@@ -894,7 +894,7 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 	 * Test that a basic verse maintains spacing.
 	 */
 	public function test_basic_verse() {
-		$test_content = "They say that code\n        is poetry.\n\n    Is indentation poetry,\n  too?";
+		$test_content = " They say that code\n        is poetry.\n\n    Is indentation poetry,\n  too?";
 		$blocks       = array(
 			$this->generateVerseData( $test_content ),
 		);

--- a/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
+++ b/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
@@ -494,6 +494,7 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 	public function test_no_content_no_tweets() {
 		$blocks = array(
 			$this->generateParagraphData( '' ),
+			$this->generateHeadingData( '&nbsp;' ),
 			$this->generateHeadingData( '' ),
 			$this->generateListData( '<li></li>' ),
 			$this->generateQuoteData( '', '' ),
@@ -757,7 +758,7 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 		$expected_text = array(
 			// The parser will decode the HTML entities.
 			html_entity_decode( str_repeat( $test_content, 12 ) . 'This&nbsp;is&nbsp;22…', ENT_QUOTES ),
-			html_entity_decode( '…characters&nbsp;', ENT_QUOTES ),
+			html_entity_decode( '…characters', ENT_QUOTES ),
 		);
 
 		$expected_boundaries = array(


### PR DESCRIPTION
By inserting a block that only contains non-breaking spaces, it's possible for a tweet consisting only of whitespace to be generated. This tweet will be rejected by Twitter's API, causing the thread to fail. This behaviour can be confirmed by trying to tweet only whitespace on twitter.com.

To prevent this from happening, this change expands the final thread checks to trim all whitespace, not just the whitespace characters that `trim()` catches.

#### Changes proposed in this Pull Request:
* Ensures the Twitter thread generator checks for tweets that only contain whitespace.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No change.

#### Testing instructions:
* Create a new post.
* Add some text.
* Add a final heading consisting of non-breaking spaces (on MacOS, type Option+Space).
* Check that the heading doesn't show in the parse REST API response, or in the thread preview.

#### Proposed changelog entry for your changes:
* Publicize: Ensure that tweets consisting only of whitespace aren't added to Twitter threads.
