### PR TITLE
Admin Page: remove i18n-calypso dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
 		"gulp-rtlcss": "1.4.1",
 		"gulp-sass": "4.1.0",
 		"gulp-sourcemaps": "2.6.5",
-		"i18n-calypso": "4.0.0",
 		"jsdom": "16.4.0",
 		"jsdom-global": "3.0.2",
 		"json-loader": "0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9364,7 +9364,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-i18n-calypso@4.0.0, i18n-calypso@^4.0.0-alpha.1:
+i18n-calypso@^4.0.0-alpha.1:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/i18n-calypso/-/i18n-calypso-4.0.0.tgz#4d07c0c0ff6a9a70171186778bbe0be09ce0eeec"
   integrity sha512-L1oMtViG/LtwWqGcLfA6FJN+ililsA6r/fPJswxvND8waJAWRONZEDmmjojs6MKratJ1E6cnFjTifiC75zuHHQ==


### PR DESCRIPTION
Fixes #16397


#### Changes proposed in this Pull Request:

Following the work we've done in #16481, we should not be needing this dependency anymore.

**Note**: the library is still loaded, as it's required as a dependency of `@automattic/format-currency`


#### Jetpack product discussion

* #16481

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Nothing should change, you should be to load the Jetpack dashboard pages with no errors.


#### Proposed changelog entry for your changes:

* N/A

