### PR TITLE
Publicize: Allow splitting Twitter thread text at line breaks

### DIFF
--- a/extensions/blocks/publicize/twitter/editor.scss
+++ b/extensions/blocks/publicize/twitter/editor.scss
@@ -95,6 +95,12 @@ h3.jetpack-publicize-twitter-options__heading {
 	margin: 1px;
 }
 
+.annotation-text-jetpack-tweetstorm-line-break {
+	background: #0009;
+	padding: 0 2.5px;
+	margin: 1px;
+}
+
 .blocks-gallery-grid .blocks-gallery-item:nth-child(5) figure::before {
 	content: "";
 	height: calc( 100% + 16px );

--- a/extensions/blocks/publicize/twitter/options.js
+++ b/extensions/blocks/publicize/twitter/options.js
@@ -134,6 +134,9 @@ export default compose( [
 				dispatch( 'core/annotations' ).__experimentalRemoveAnnotationsBySource(
 					'jetpack-tweetstorm'
 				);
+				dispatch( 'core/annotations' ).__experimentalRemoveAnnotationsBySource(
+					'jetpack-tweetstorm-line-break'
+				);
 			}
 		},
 	} ) ),

--- a/extensions/blocks/publicize/twitter/tweet-divider.js
+++ b/extensions/blocks/publicize/twitter/tweet-divider.js
@@ -55,7 +55,8 @@ class TweetDivider extends Component {
 
 		if (
 			currentAnnotations.length !==
-				boundaries.filter( boundary => 'normal' === boundary.type ).length ||
+				boundaries.filter( boundary => [ 'normal', 'line-break' ].includes( boundary.type ) )
+					.length ||
 			! isEqual( prevProps.boundaries, boundaries )
 		) {
 			updateAnnotations();
@@ -184,7 +185,9 @@ export default compose( [
 					childProps.clientId
 				);
 				annotations.forEach( annotation => {
-					if ( annotation.source === 'jetpack-tweetstorm' ) {
+					if (
+						[ 'jetpack-tweetstorm', 'jetpack-tweetstorm-line-break' ].includes( annotation.source )
+					) {
 						dispatch( 'core/annotations' ).__experimentalRemoveAnnotation( annotation.id );
 					}
 				} );
@@ -198,6 +201,13 @@ export default compose( [
 						dispatch( 'core/annotations' ).__experimentalAddAnnotation( {
 							blockClientId: childProps.clientId,
 							source: 'jetpack-tweetstorm',
+							richTextIdentifier: container,
+							range: { start, end },
+						} );
+					} else if ( 'line-break' === type ) {
+						dispatch( 'core/annotations' ).__experimentalAddAnnotation( {
+							blockClientId: childProps.clientId,
+							source: 'jetpack-tweetstorm-line-break',
 							richTextIdentifier: container,
 							range: { start, end },
 						} );

--- a/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
+++ b/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
@@ -45,7 +45,7 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 			),
 			'block'      => array(
 				'blockName' => 'core/paragraph',
-				'innerHTML' => "<p>$text</p>",
+				'innerHTML' => "\n<p>$text</p>\n",
 			),
 			'clientId'   => wp_generate_uuid4(),
 		);
@@ -65,7 +65,7 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 			),
 			'block'      => array(
 				'blockName' => 'core/heading',
-				'innerHTML' => "<h2>$text</h2>",
+				'innerHTML' => "\n<h2>$text</h2>\n",
 			),
 			'clientId'   => wp_generate_uuid4(),
 		);
@@ -356,6 +356,23 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper function. Generates a line break boundary marker.
+	 *
+	 * @param int    $start     The start position of the marker.
+	 * @param int    $end       The end position of the marker.
+	 * @param string $container The name of the RichText container this boundary is for.
+	 * @return array The boundary marker definition.
+	 */
+	public function generateLineBreakBoundary( $start, $end, $container ) {
+		return array(
+			'start'     => $start,
+			'end'       => $end,
+			'container' => $container,
+			'type'      => 'line-break',
+		);
+	}
+
+	/**
 	 * Helper function. Generates a normal boundary marker.
 	 *
 	 * @param int    $line      The line number of the marker.
@@ -586,6 +603,23 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 			$blocks,
 			array( trim( str_repeat( $test_content, 12 ) ), trim( $test_content ) ),
 			array( $this->generateNormalBoundary( 275, 276, 'content' ), false ),
+			array( $blocks, $blocks )
+		);
+	}
+
+	/**
+	 * Test that a single long paragraph is split into two tweets, breaking at the end of a line.
+	 */
+	public function test_single_long_paragraph_with_line_breaks() {
+		$test_content = 'This is 21 characters';
+		$blocks       = array(
+			$this->generateParagraphData( str_repeat( "$test_content\n", 7 ) . trim( str_repeat( "$test_content ", 7 ) ) . '.' ),
+		);
+
+		$this->assertTweetGenerated(
+			$blocks,
+			array( trim( str_repeat( "$test_content\n", 7 ) ), trim( str_repeat( "$test_content ", 7 ) ) . '.' ),
+			array( $this->generateLineBreakBoundary( 153, 154, 'content' ), false ),
 			array( $blocks, $blocks )
 		);
 	}


### PR DESCRIPTION
There are two relatively common use cases where Latin-based sentence punctuation won't be used:

- Informal writing, particularly text messaging, where punctuation and capitalisation are read as being overly formal.
- Non-Latin languages, which only sometimes use Latin punctuation.

In both of these cases, we can treat line breaks as being the equivalent of sentence breaks. When we need to split up a chunk of content into multiple tweets, line breaks are a good indicator that it's a reasonable place in the content to split.

### Screenshots

Chrome and Firefox render the line break split indicator slightly differently, I was unable to determine why.

<img width="400" alt="line break split indicator rendered in Chrome" src="https://user-images.githubusercontent.com/352291/96524153-34482c80-12c3-11eb-9940-75f43ed4bdfc.png"> <img width="400" alt="line break split indicator rendered in Firefox" src="https://user-images.githubusercontent.com/352291/96524163-37431d00-12c3-11eb-941d-6fb14e597509.png">


#### Changes proposed in this Pull Request:
* The Twitter thread generator can now choose to split content at line breaks, when it needs to.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Create a new post, and change to Twitter thread mode.
* Add content that has a varying number of line breaks, and check that those line breaks are used appropriately when splitting content into Tweets.
* Check that the Tweet split indicator appears in the correct place.

#### Proposed changelog entry for your changes:
* Publicize: When generating Twitter threads, allow text to be split at line breaks, where appropriate.
