### PR TITLE
Make the story block available in production

### DIFF
--- a/extensions/blocks/story/index.js
+++ b/extensions/blocks/story/index.js
@@ -57,7 +57,7 @@ export const settings = {
 	attributes,
 	supports: {
 		html: false,
-		inserter: true, // toggle to false before merging to BETA blocks
+		inserter: false,
 	},
 	icon: {
 		src: icon,

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -32,12 +32,13 @@
 		"simple-payments",
 		"slideshow",
 		"social-previews",
+		"story",
 		"subscriptions",
 		"tiled-gallery",
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "story" ],
+	"beta": [ "amazon" ],
 	"experimental": [ "seo" ],
 	"no-post-editor": [
 		"business-hours",


### PR DESCRIPTION
This PR makes the Story block available to everyone in production, it keeps the block hidden in the block picker though.

#### Changes proposed in this Pull Request:
Currently a beta block, this PR simply moves the definition of "jetpack/story" from the "beta" section to the "production" section,

#### Jetpack product discussion
pbD5rk-m7-p2

#### Testing instructions:
- Apply this patch
- Disable beta and experimental blocks on your jetpack config
- Ensure the Story block is not available in the picker when you search for it
- Ensure you can edit story blocks created from the mobile app or when pasting a template

#### Proposed changelog entry for your changes:
* Add support for the Story block