### PR TITLE
Podcast Player: Show error from API

### DIFF
--- a/extensions/blocks/podcast-player/api.js
+++ b/extensions/blocks/podcast-player/api.js
@@ -30,9 +30,14 @@ export const fetchPodcastFeed = async url => {
 	}
 
 	// Try if we have another block that can embed this URL.
-	const externalEmbed = await apiFetch( {
-		path: addQueryArgs( '/oembed/1.0/proxy', { url } ),
-	} );
+	let externalEmbed;
+	try {
+		externalEmbed = await apiFetch( {
+			path: addQueryArgs( '/oembed/1.0/proxy', { url } ),
+		} );
+	} catch ( err ) {
+		// We don't care about this error.
+	}
 
 	// We can use an embed block for this URL, unless API returned the fallback code.
 	const oEmbedLinkCheck = '<a href="' + url + '">' + url + '</a>';

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -124,7 +124,10 @@ const PodcastPlayerEdit = ( {
 					// Show error and allow to edit URL.
 					debug( 'feed error', error );
 					createErrorNotice(
-						__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
+						// Error messages already come localized.
+						error.message ||
+							// Fallback to a generic message.
+							__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
 					);
 					setIsEditing( true );
 				}


### PR DESCRIPTION
Fixes #17496

#### Changes proposed in this Pull Request:
* Surface errors from the Podcast Player API - they contain useful context of the exact error.
* Only use the generic error as a fallback

#### Jetpack product discussion
—

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Test for example with an empty feed
* or force the API error like I did:
  * at the top of the method `get_player_data` in `_inc/lib/class-jetpack-podcast-helper.php`,
  * `return new WP_Error( 'err_code', __( 'Custom error message', 'jetpack' ) );`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* More helpful error messages in the Podcast Player block
