### PR TITLE
reCaptcha: add filter to verify against multiple hostnames

### DIFF
--- a/modules/sharedaddy/recaptcha.php
+++ b/modules/sharedaddy/recaptcha.php
@@ -144,7 +144,7 @@ class Jetpack_ReCaptcha {
 			 *
 			 * @param array [ $url['host'] ] List of the valid hostnames to check against.
 			 */
-			$valid_hostnames = apply_filters( 'jetpack_recaptcha_valid_hostnames', [ $url['host'] ] );
+			$valid_hostnames = apply_filters( 'jetpack_recaptcha_valid_hostnames', array( $url['host'] ) );
 
 			if ( ! in_array( $resp_decoded['hostname'], $valid_hostnames, true ) ) {
 				return new WP_Error( 'unexpected-host', $this->error_codes['unexpected-hostname'] );

--- a/modules/sharedaddy/recaptcha.php
+++ b/modules/sharedaddy/recaptcha.php
@@ -144,7 +144,7 @@ class Jetpack_ReCaptcha {
 			 */
 			$valid_hostnames = apply_filters( 'jetpack_recaptcha_valid_hostnames', [ $url['host'] ] );
 
-			if ( ! in_array( $resp_decoded['hostname'], $valid_hostnames ) ) {
+			if ( ! in_array( $resp_decoded['hostname'], $valid_hostnames, true ) ) {
 				return new WP_Error( 'unexpected-host', $this->error_codes['unexpected-hostname'] );
 			}
 		}

--- a/modules/sharedaddy/recaptcha.php
+++ b/modules/sharedaddy/recaptcha.php
@@ -138,6 +138,8 @@ class Jetpack_ReCaptcha {
 			 * This can be useful in cases where the token hostname is expected to be
 			 * different from the get_home_url (ex. AMP recaptcha token contains a different hostname)
 			 *
+			 * @module sharedaddy
+			 *
 			 * @since 9.1.0
 			 *
 			 * @param array [ $url['host'] ] List of the valid hostnames to check against.

--- a/modules/sharedaddy/recaptcha.php
+++ b/modules/sharedaddy/recaptcha.php
@@ -128,11 +128,23 @@ class Jetpack_ReCaptcha {
 		if ( true !== $resp_decoded['success'] ) {
 			return new WP_Error( $error_code, $error_message );
 		}
-
 		// Validate the hostname matches expected source
 		if ( isset( $resp_decoded['hostname'] ) ) {
 			$url = wp_parse_url( get_home_url() );
-			if ( $url['host'] !== $resp_decoded['hostname'] ) {
+
+			/**
+			 * Allow other valid hostnames.
+			 *
+			 * This can be useful in cases where the token hostname is expected to be
+			 * different from the get_home_url (ex. AMP recaptcha token contains a different hostname)
+			 *
+			 * @since 9.1.0
+			 *
+			 * @param array [ $url['host'] ] List of the valid hostnames to check against.
+			 */
+			$valid_hostnames = apply_filters( 'jetpack_recaptcha_valid_hostnames', [ $url['host'] ] );
+
+			if ( ! in_array( $resp_decoded['hostname'], $valid_hostnames ) ) {
 				return new WP_Error( 'unexpected-host', $this->error_codes['unexpected-hostname'] );
 			}
 		}


### PR DESCRIPTION

This commit was generated from D50774-code.
The original wpcom diff (D50774-code) attempts to provide AMP compatibility to the VIP Contact Form.

#### Changes proposed in this Pull Request:
This adds a filter to allows us to add extra valid hostnames with which to compare the hostname from the recaptcha token. This is needed because the [amp-recaptcha-input](https://amp.dev/documentation/components/amp-recaptcha-input/) component returns a different hostname than `get_home_url()`

#### Jetpack product discussion
More info: pau2Xa-23c-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Instructions can be found in the original diff D50774-code.
Alternatively, a simpler set of instructions would to check if the VIP Contact Form still works.

* Go to https://wordpress.com/pricing/
* Scroll down to the VIP CTA section and click on `Learn more`
<img src="https://user-images.githubusercontent.com/2749938/96597904-ffee6380-12f6-11eb-9573-249b2ca8e537.png" width="640" />

* Fill in the VIP Contact Form and Submit
* The submit should be successful and the recaptcha should have properly validated
<img src="https://user-images.githubusercontent.com/2749938/96598776-e568ba00-12f7-11eb-8c58-a5699f292070.png" width="480" />

#### Proposed changelog entry for your changes:
None