### PR TITLE
: Patch site creation to fix all requests coming from WPAndroid

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -760,7 +760,6 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 			case 'visibility':
 				// This is needed to fix a bug in WPAndroid where `public: "PUBLIC"` is sent in place of `public: 1`
-				// https://mobileguildp2.wordpress.com/2020/10/20/site-creation-problem-in-wordpress-for-android
 				if ( 'public' === strtolower( $value ) ) {
 					$return[ $key ] = 1;
 				} else if ( 'private' === strtolower( $value ) ) {

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -758,6 +758,18 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$return[ $key ] = (array) $this->cast_and_filter( $value, $docs, false, $for_output );
 				break;
 
+			case 'visibility':
+				// This is needed to fix a bug in WPAndroid where `public: "PUBLIC"` is sent in place of `public: 1`
+				// https://mobileguildp2.wordpress.com/2020/10/20/site-creation-problem-in-wordpress-for-android
+				if ( 'public' === strtolower( $value ) ) {
+					$return[ $key ] = 1;
+				} else if ( 'private' === strtolower( $value ) ) {
+					$return[ $key ] = -1;
+				} else {
+					$return[ $key ] = (int) $value;
+				}
+				break;
+
 			default:
 				$method_name = $type['type'] . '_docs';
 				if ( method_exists( 'WPCOM_JSON_API_Jetpack_Overrides', $method_name ) ) {


### PR DESCRIPTION

Summary: This patch switches the site visibility to public for all sites created from WPAndroid. It does so by updating the type expected by the sites/new endpoint to also accept a string and it that case checks if it's equal to the parameter name itsef. So `public: "PUBLIC"` gets transformed to `public: 1` while `public: "PRIVATE"` gets transformed to `public: 0` (because (int) "PRIVATE" is 0)

Test Plan: Try creating a site from WPAndroid while sandboxing [private link], the new site should be public

Differential Revision: D51492-code

This commit syncs r215520-wpcom.

This PR add a new API type definition that is currently used in the /sites/new endpoint. 

#### Changes proposed in this Pull Request:
* Add a new API type definition that is currently used in the /sites/new endpoint. 

#### Jetpack product discussion
This PR doesn't currently effect Jetpack. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
- Do the tests pass? 

#### Proposed changelog entry for your changes:
* No need for chancelog changes.
