### PR TITLE
Connection Package: Ensure a text/xml header is set

### DIFF
--- a/packages/connection/legacy/class-jetpack-ixr-client.php
+++ b/packages/connection/legacy/class-jetpack-ixr-client.php
@@ -37,9 +37,11 @@ class Jetpack_IXR_Client extends IXR_Client {
 		$defaults = array(
 			'url'     => $connection->xmlrpc_api_url(),
 			'user_id' => 0,
+			'headers' => array(),
 		);
 
-		$args = wp_parse_args( $args, $defaults );
+		$args            = wp_parse_args( $args, $defaults );
+		$args['headers'] = array_merge( array( 'Content-Type' => 'text/xml' ), (array) $args['headers'] );
 
 		$this->jetpack_args = $args;
 


### PR DESCRIPTION
Brings over a change made in r215538-wpcom . We aren't setting the Content-Type on these requests.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Tests pass.
* Connect a new site to Jetpack. Interact with it via WordPress.com (Calypso or the developer.wordpress.com/console).
* Any obvious errors in the browser dev console/networking tab? Specifically wanting to ensure setting the Content-Type doesn't break normal interactions with a Jetpack site.

#### Proposed changelog entry for your changes:
* Connection Package: Declare Content-Type.
