### PR TITLE
Block Styles Selector: fix toolbar buttons

### DIFF
--- a/extensions/shared/components/block-styles-selector/index.js
+++ b/extensions/shared/components/block-styles-selector/index.js
@@ -10,7 +10,7 @@ import { isEqual } from 'lodash';
 import { memo } from '@wordpress/element';
 import { getBlockType, getBlockFromExample, createBlock } from '@wordpress/blocks';
 import { BlockControls, BlockPreview, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, Toolbar } from '@wordpress/components';
+import { PanelBody, ToolbarGroup } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
@@ -72,7 +72,7 @@ export default function BlockStylesSelector( {
 	return (
 		<>
 			<BlockControls>
-				<Toolbar
+				<ToolbarGroup
 					isCollapsed={ true }
 					icon="admin-appearance"
 					label={ __( 'Style', 'jetpack' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR fixes an issue adding the block-styles buttons to the toolbar. We are using the wrong component. Instead of [Toolbar](https://developer.wordpress.org/block-editor/components/toolbar/), we should use [ToolbarGroup](https://developer.wordpress.org/block-editor/components/toolbar-group/).

before | after
-------|-----
<img width="500" src="https://user-images.githubusercontent.com/77539/96643530-121fd000-12fe-11eb-8f76-1e94da17996a.png" /> | <img width="500" src="https://user-images.githubusercontent.com/77539/96643602-2d8adb00-12fe-11eb-9ac7-db19f22a0a18.png">


Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Restore block styles buttons in the block toolbar

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes (use D51527-code for Simple sites)
* Go to create/edit a post
* Add, for instance, en Eventbrite embed block
* I picked up https://www.eventbrite.com.ar/e/a-feminists-guide-to-botany-online-botanical-painting-session-tickets-121982903147

**before**
* Confirm you don't see the block style buttons in the toolbar

**after**
* Confirm you see the block style buttons right there

![image](https://user-images.githubusercontent.com/77539/96643924-a8ec8c80-12fe-11eb-8511-6a6753f5de5b.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Restore block styles buttons in the block toolbar
