### PR TITLE
Instant Search: Show unicode in URL path

### DIFF
--- a/modules/search/instant-search/components/path-breadcrumbs.jsx
+++ b/modules/search/instant-search/components/path-breadcrumbs.jsx
@@ -5,7 +5,7 @@
  */
 import { h } from 'preact';
 
-import './path-breadcrumbs';
+import './path-breadcrumbs.scss';
 
 function splitDomainPath( path ) {
 	const splits = path.split( '/' ).filter( piece => piece.length > 0 );

--- a/modules/search/instant-search/components/path-breadcrumbs.jsx
+++ b/modules/search/instant-search/components/path-breadcrumbs.jsx
@@ -1,0 +1,36 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+import './path-breadcrumbs';
+
+function splitDomainPath( path ) {
+	const splits = path.split( '/' ).filter( piece => piece.length > 0 );
+	splits.shift(); // Removes domain name from splits; e.g. 'jetpack.com'
+	return splits.length === 0 ? [ '/' ] : splits;
+}
+
+const PathBreadcrumbs = ( { className, onClick, url } ) => {
+	return (
+		<div className={ `jetpack-instant-search__path-breadcrumb ${ className ? className : '' }` }>
+			<a
+				className="jetpack-instant-search__path-breadcrumb-link"
+				href={ `//${ url }` }
+				onClick={ onClick }
+				rel="noopener noreferrer"
+				target="_blank"
+			>
+				{ splitDomainPath( url ).map( ( piece, index, pieces ) => (
+					<span className="jetpack-instant-search__path-breadcrumb-piece">
+						{ decodeURIComponent( piece ) }
+						{ index !== pieces.length - 1 ? ' › ' : '' }
+					</span>
+				) ) }
+			</a>
+		</div>
+	);
+};
+export default PathBreadcrumbs;

--- a/modules/search/instant-search/components/path-breadcrumbs.scss
+++ b/modules/search/instant-search/components/path-breadcrumbs.scss
@@ -1,0 +1,22 @@
+.jetpack-instant-search__path-breadcrumb {
+	font-size: 0.9em;
+	margin: 0;
+	overflow-x: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	max-width: calc( 100vw - 2em );
+}
+
+.jetpack-instant-search__path-breadcrumb-link {
+	text-decoration: none;
+}
+
+.jetpack-instant-search__path-breadcrumb,
+.jetpack-instant-search__path-breadcrumb-link {
+	.jetpack-instant-search__overlay--light & {
+		color: $studio-gray-70;
+	}
+	.jetpack-instant-search__overlay--dark & {
+		color: $studio-gray-30;
+	}
+}

--- a/modules/search/instant-search/components/path-breadcrumbs.scss
+++ b/modules/search/instant-search/components/path-breadcrumbs.scss
@@ -1,3 +1,5 @@
+@import '../lib/style-helpers';
+
 .jetpack-instant-search__path-breadcrumb {
 	font-size: 0.9em;
 	margin: 0;

--- a/modules/search/instant-search/components/search-result-expanded.jsx
+++ b/modules/search/instant-search/components/search-result-expanded.jsx
@@ -8,22 +8,10 @@ import { h } from 'preact';
 /**
  * Internal dependencies
  */
-import Gridicon from './gridicon';
 import PathBreadcrumbs from './path-breadcrumbs';
 import PhotonImage from './photon-image';
 import SearchResultComments from './search-result-comments';
 import './search-result-expanded.scss';
-
-function getGridiconName( postType ) {
-	if ( postType === 'post' || postType === 'page' ) {
-		return `${ postType }s`;
-	}
-	return 'image';
-}
-
-function getPostTypeIcon( postType ) {
-	return <Gridicon icon={ getGridiconName( postType ) } size={ 32 } />;
-}
 
 export default function SearchResultExpanded( props ) {
 	const { result_type, fields, highlight } = props.result;

--- a/modules/search/instant-search/components/search-result-expanded.jsx
+++ b/modules/search/instant-search/components/search-result-expanded.jsx
@@ -8,9 +8,10 @@ import { h } from 'preact';
 /**
  * Internal dependencies
  */
-import SearchResultComments from './search-result-comments';
-import PhotonImage from './photon-image';
 import Gridicon from './gridicon';
+import PathBreadcrumbs from './path-breadcrumbs';
+import PhotonImage from './photon-image';
+import SearchResultComments from './search-result-comments';
 import './search-result-expanded.scss';
 
 function getGridiconName( postType ) {
@@ -22,12 +23,6 @@ function getGridiconName( postType ) {
 
 function getPostTypeIcon( postType ) {
 	return <Gridicon icon={ getGridiconName( postType ) } size={ 32 } />;
-}
-
-function splitDomainPath( path ) {
-	const splits = path.split( '/' ).filter( piece => piece.length > 0 );
-	splits.shift(); // Removes domain name from splits; e.g. 'jetpack.com'
-	return splits;
 }
 
 export default function SearchResultExpanded( props ) {
@@ -58,23 +53,11 @@ export default function SearchResultExpanded( props ) {
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>
 				</h3>
-				<div className="jetpack-instant-search__result-expanded__path">
-					<a
-						className="jetpack-instant-search__result-expanded__path-link"
-						href={ `//${ fields[ 'permalink.url.raw' ] }` }
-						onClick={ props.onClick }
-						rel="noopener noreferrer"
-						target="_blank"
-					>
-						{ splitDomainPath( fields[ 'permalink.url.raw' ] ).map( ( piece, index, pieces ) => (
-							<span className="jetpack-instant-search__result-expanded__path-piece">
-								{ decodeURIComponent( piece ) }
-								{ index !== pieces.length - 1 ? ' › ' : '' }
-							</span>
-						) ) }
-					</a>
-				</div>
-
+				<PathBreadcrumbs
+					className="jetpack-instant-search__result-expanded__path"
+					onClick={ props.onClick }
+					url={ `//${ fields[ 'permalink.url.raw' ] }` }
+				/>
 				<div
 					className="jetpack-instant-search__result-expanded__content"
 					//eslint-disable-next-line react/no-danger

--- a/modules/search/instant-search/components/search-result-expanded.jsx
+++ b/modules/search/instant-search/components/search-result-expanded.jsx
@@ -68,7 +68,7 @@ export default function SearchResultExpanded( props ) {
 					>
 						{ splitDomainPath( fields[ 'permalink.url.raw' ] ).map( ( piece, index, pieces ) => (
 							<span className="jetpack-instant-search__result-expanded__path-piece">
-								{ piece }
+								{ decodeURIComponent( piece ) }
 								{ index !== pieces.length - 1 ? ' › ' : '' }
 							</span>
 						) ) }

--- a/modules/search/instant-search/components/search-result-expanded.scss
+++ b/modules/search/instant-search/components/search-result-expanded.scss
@@ -27,26 +27,7 @@ $min-height: 190px;
 	}
 }
 .jetpack-instant-search__result-expanded__path {
-	font-size: 0.9em;
 	margin: 0.5em 0;
-	overflow-x: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	max-width: calc( 100vw - 2em );
-}
-
-.jetpack-instant-search__result-expanded__path-link {
-	text-decoration: none;
-}
-
-.jetpack-instant-search__result-expanded__path,
-.jetpack-instant-search__result-expanded__path-link {
-	.jetpack-instant-search__overlay--light & {
-		color: $studio-gray-70;
-	}
-	.jetpack-instant-search__overlay--dark & {
-		color: $studio-gray-30;
-	}
 }
 
 .jetpack-instant-search__result-expanded__copy-container {

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -9,6 +9,7 @@ import { h, Component } from 'preact';
  * Internal dependencies
  */
 import Gridicon from './gridicon';
+import PathBreadcrumbs from './path-breadcrumbs';
 import PostTypeIcon from './post-type-icon';
 import SearchResultComments from './search-result-comments';
 import './search-result-minimal.scss';
@@ -41,15 +42,12 @@ class SearchResultMinimal extends Component {
 	}
 
 	renderNoMatchingContent() {
-		const path = new URL( 'http://' + this.props.result.fields[ 'permalink.url.raw' ] ).pathname;
 		const tags = this.getTags();
 		const cats = this.getCategories();
 		const noTags = tags.length === 0 && cats.length === 0;
 		return (
 			<div className="jetpack-instant-search__search-result-minimal-content">
-				{ noTags && (
-					<div className="jetpack-instant-search__search-result-minimal-path">{ path }</div>
-				) }
+				{ noTags && <PathBreadcrumbs url={ this.props.result.fields[ 'permalink.url.raw' ] } /> }
 				{ tags.length !== 0 && (
 					<div className="jetpack-instant-search__search-result-minimal-tags">
 						{ tags.map( tag => (
@@ -101,6 +99,8 @@ class SearchResultMinimal extends Component {
 						className="jetpack-instant-search__search-result-minimal-title"
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						onClick={ this.props.onClick }
+						rel="noopener noreferrer"
+						target="_blank"
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>


### PR DESCRIPTION
Fixes #16738.

#### Changes proposed in this Pull Request:
* Decodes encoded path pieces to show intelligible URLs.

> Before
> <img width="1403" alt="Screen Shot 2020-10-20 at 3 08 32 PM" src="https://user-images.githubusercontent.com/4044428/96644381-3a033980-12e6-11eb-8090-9ed2d5f53c63.png">


> After
> <img width="570" alt="Screen Shot 2020-10-20 at 3 08 03 PM" src="https://user-images.githubusercontent.com/4044428/96644356-32dc2b80-12e6-11eb-8ebc-b5ce88c4d218.png">

#### Does this pull request change what data or activity we track or use?
None.

#### Testing instructions:
1. Apply this patch to your site with Jetpack Search enabled.
2. Set your search result style to "Expanded".
3. Create a page with a non-ASCII path.
4. Search for the page in step 2. Ensure that the URL appears intelligible.

#### Proposed changelog entry for your changes:
* Improved URL formatting for the expanded search layout.
