### PR TITLE
Resolve PHP Warning with array_filter usage in sync of action_links.

### DIFF
--- a/packages/sync/src/modules/class-callables.php
+++ b/packages/sync/src/modules/class-callables.php
@@ -370,8 +370,13 @@ class Callables extends Module {
 			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
 			$action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, null, 'all' );
 			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-			$action_links           = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, null, 'all' );
-			$action_links           = array_filter( $action_links );
+			$action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, null, 'all' );
+			// Verify $action_links is still an array to resolve warnings from filters not returning an array.
+			if ( is_array( $action_links ) ) {
+				$action_links = array_filter( $action_links );
+			} else {
+				$action_links = array();
+			}
 			$formatted_action_links = null;
 			if ( ! empty( $action_links ) && count( $action_links ) > 0 ) {
 				$dom_doc = new \DOMDocument();


### PR DESCRIPTION
Verify that $action_links is still an array after filters before calling array_filter on it.

Fixes #17550

#### Changes proposed in this Pull Request:
* Resolve PHP Warning when $action_links has been filtered to not be an array.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

1. Add a filter to plugin_action_links that returns null
`add_filter( 'plugin_action_links', '__return_true' );`
2. delete_option( 'jetpack_callables_sync_checksum' );
3. delete_transient( 'jetpack_sync_callables_await' );
4. modify a post -> triggers sync

**Before PR**
Warning will be visible in error logs.

**After PR**
No Warning is generated.

#### Proposed changelog entry for your changes:
* Jetpack Sync - Resolve array_filter warning that can be triggered by filters returning unexpected data.
