### PR TITLE
Instant Search: add inputmode to overlay search input

### DIFF
--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -50,6 +50,7 @@ const SearchBox = props => {
 						autocomplete="off"
 						id={ inputId }
 						className="search-field jetpack-instant-search__box-input"
+						inputmode="search"
 						onInput={ props.onChangeQuery }
 						ref={ inputRef }
 						placeholder={ __( 'Search…', 'jetpack' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/16948.

In our overlay, the search keyboard should be triggered by `type="search"` on the input, but it appears that an action on the form is also required:

https://stackoverflow.com/a/26287843

We don't have one of those. Rather than adding a dummy `action`, this PR uses the `inputmode` attribute to encourage mobile browsers to show the search keyboard rather than the standard one.

https://caniuse.com/?search=inputmode

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the `inputmode` attribute to the search input in the instant search overlay. This triggers the search keyboard in iOS.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Part of the Jetpack Search Product Quality project: p9xfpQ-12j-p2.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply this patch to your site with Jetpack Search enabled.
2. Visit your site on your iOS device, open the search overlay and tap on the main search input.
3. Ensure that the search keyboard is displayed (with a blue "go" button).

![image](https://user-images.githubusercontent.com/17325/96671611-b49f8800-13be-11eb-9763-0b2546e85ee7.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Instant Search: make sure the search keyboard is shown on mobile devices.
