### PR TITLE
Sharing: remove get_blog_lang_code() call

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -997,7 +997,7 @@ function get_base_recaptcha_lang_code() {
 		'tr'    => 'tr',
 	);
 
-	$blog_lang_code = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_bloginfo( 'language' );
+	$blog_lang_code = get_bloginfo( 'language' );
 	if ( isset( $base_recaptcha_lang_code_mapping[ $blog_lang_code ] ) ) {
 		return $base_recaptcha_lang_code_mapping[ $blog_lang_code ];
 	}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Opening this to replace #9767, since Travis does not report test results in that PR and since I do not have the permissions to push to that forked repo to rebase the branch and trigger Travis again.

In some hosting environments (VIP Go), the use of `get_blog_lang_code` (a function defined on WordPress.com and VIP Go) can trigger a deprecation warning:
`get_blog_lang_code is deprecated since version 2.0.0 with no alternative available.`
-- https://github.com/Automattic/vip-go-mu-plugins-built/blob/ed65a52b9b27554efa92b301e31124df1e1e244a/vip-helpers/vip-deprecated.php#L786

This solves this issue.

See discussion in #9767 for more background on this.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:

* Not much to test here, `get_bloginfo( 'language' )` is supported in all environments.
* On VIP Go, the deprecation warning should be gone.

#### Proposed changelog entry for your changes:
* N/A
