### PR TITLE
Build: Remove lazy-images ES5 validation

### DIFF
--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -80,6 +80,11 @@ if [ ! -f /tmp/wordpress-develop/wp-tests-config.php ]; then
 	cp /tmp/wp-tests-config.php /tmp/wordpress-develop/wp-tests-config.php
 fi
 
+# Symlink jetpack into wordpress-develop for WP >= 5.6-beta1
+if [ ! -e /tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack ]; then
+	ln -s /var/www/html/wp-content/plugins/jetpack /tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack
+fi
+
 # Add a PsySH dependency to wp-cli
 echo 'require: /usr/local/bin/psysh' >> /var/www/html/wp-cli.yml
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"build-production-php": "COMPOSER_MIRROR_PATH_REPOS=1 composer install -o --no-dev --classmap-authoritative --prefer-dist",
 		"build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client && yarn validate-es5 -- ./_inc/build/",
 		"build-production-extensions": "NODE_ENV=production BABEL_ENV=production yarn build-extensions",
-		"build-production-packages": "NODE_ENV=production BABEL_ENV=production yarn build-packages && yarn validate-es5 -- ./packages/lazy-images/",
+		"build-production-packages": "NODE_ENV=production BABEL_ENV=production yarn build-packages",
 		"build-production-search": "NODE_ENV=production BABEL_ENV=production yarn build-search && yarn validate-es5 -- ./_inc/build/instant-search/",
 		"build-production": "yarn distclean && yarn install --production=false && yarn build-production-client && yarn build-production-php && yarn build-production-extensions && yarn build-production-search && yarn build-production-packages",
 		"build-production-concurrently": "yarn distclean && yarn install --production=false && yarn concurrently 'yarn build-production-client' 'yarn build-production-php' 'NODE_ENV=production yarn build-extensions' 'NODE_ENV=production yarn build-search' 'NODE_ENV=production yarn build-packages'",

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -850,10 +850,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		// Nothing should have changed since we cache the results.
 		$this->assertEquals( $this->extract_plugins_we_are_testing( $plugins_action_links ), $expected_array );
 
-		if ( file_exists( WP_CONTENT_DIR . '/plugins/hello.php' )  ) {
+		if ( file_exists( WP_PLUGIN_DIR . '/hello.php' ) ) {
 			activate_plugin('hello.php', '', false, true );
 		}
-		if ( file_exists( WP_CONTENT_DIR . '/plugins/hello-dolly/hello.php' ) ) {
+		if ( file_exists( WP_PLUGIN_DIR . '/hello-dolly/hello.php' ) ) {
 			activate_plugin('hello-dolly/hello.php', '', false, true );
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
@@ -138,7 +138,7 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 		return (object) array(
 			'response' => array(
 				'the/the.php' => (object) array(
-					'package' => ABSPATH . WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP
+					'package' => WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP,
 				)
 			)
 		);
@@ -155,7 +155,7 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 		return (object) array(
 			'response' => array(
 				'the/the.php' => (object) array(
-					'package' => ABSPATH . WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP . '-doesnotexitst.zip'
+					'package' => WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP . '-doesnotexitst.zip',
 				)
 			)
 		);

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -4,7 +4,7 @@
  */
 class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 	protected $theme;
-	const PLUGIN_ZIP = 'wp-content/plugins/jetpack/tests/php/files/the.1.1.zip';
+	const PLUGIN_ZIP = __DIR__ . '/../files/the.1.1.zip';
 
 	public function setUp() {
 		parent::setUp();
@@ -202,21 +202,21 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 			new Automatic_Upgrader_Skin( $plugin_defaults )
 		);
 		// 'https://downloads.wordpress.org/plugin/the.1.1.zip' Install it from local disk
-		$upgrader->install( ABSPATH . self::PLUGIN_ZIP );
+		$upgrader->install( self::PLUGIN_ZIP );
 	}
 
 	function set_update_plugin_transient( $transient ) {
 		return (object) array(
 			'response' => array(
 				'the/the.php' => (object) array(
-					'package' => ABSPATH . self::PLUGIN_ZIP
+					'package' => self::PLUGIN_ZIP,
 				)
 			)
 		);
 	}
 
 	static function remove_plugin() {
-		if ( file_exists( ABSPATH .  'wp-content/plugins/the/the.php' ) ) {
+		if ( file_exists( WP_PLUGIN_DIR . '/the/the.php' ) ) {
 			delete_plugins( array( 'the/the.php' ) );
 			wp_cache_delete( 'plugins', 'plugins' );
 		}

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -50,6 +50,8 @@ fi
 
 cd ..
 cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$PLUGIN_SLUG"
+# Plugin dir for tests in WP >= 5.6-beta1
+ln -s "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$PLUGIN_SLUG" "/tmp/wordpress-$WP_BRANCH/tests/phpunit/data/plugins/$PLUGIN_SLUG"
 cd /tmp/wordpress-$WP_BRANCH
 
 cp wp-tests-config-sample.php wp-tests-config.php


### PR DESCRIPTION
`yarn build-production-packages` currently fails due to the recently introduced ES5 validation (#17127). (That PR probably went green in CI since it was last rebased before #17489 was merged.) This PR removes the latter, until the issues reported [here](https://github.com/Automattic/jetpack/pull/17489#issuecomment-713520423) are fixed.

#### Changes proposed in this Pull Request:

Remove ES5 validation from `build-production-packages` command.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No
#### Testing instructions:
Verify that CI goes green. Locally, verify that the following passes without errors:

```
`yarn build-production-packages
```
