### PR TITLE
REST API: postpone the call to `wp_templating_constants();` until we are on a correct blog

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1587,6 +1587,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 	// Load the functions.php file for the current theme to get its post formats, CPTs, etc.
 	function load_theme_functions() {
+		if ( false === defined( 'STYLESHEETPATH' ) ) {
+			wp_templating_constants();
+		}
+
 		// bail if we've done this already (can happen when calling /batch endpoint)
 		if ( defined( 'REST_API_THEME_FUNCTIONS_LOADED' ) ) {
 			return;

--- a/json-endpoints/class.wpcom-json-api-render-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-render-endpoint.php
@@ -15,6 +15,10 @@ abstract class WPCOM_JSON_API_Render_Endpoint extends WPCOM_JSON_API_Endpoint {
 	function process_render( $callback, $callback_arg ) {
 		global $wp_scripts, $wp_styles;
 
+		if ( false === defined( 'STYLESHEETPATH' ) ) {
+			wp_templating_constants();
+		}
+
 		// initial scripts & styles (to subtract)
 		ob_start();
 		wp_head();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Based on the D50016, but now with a hotfix for embed rendering endpoint to prevent all the PHP warnings :)

See p7H4VZ-2F7-p2#comment-8953

Test Plan: manual

Reviewers: scruffian

Tags: #touches_jetpack_files

Differential Revision: D51494-code

This commit syncs r215583-wpcom

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:

See p7H4VZ-2F7-p2#comment-8953
#### Proposed changelog entry for your changes:
* N/A