### PR TITLE
Calendly: set link preview explicitly

### DIFF
--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -8,7 +8,7 @@ import queryString from 'query-string';
 /**
  * WordPress dependencies
  */
-import { BlockControls, BlockIcon, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
+import { BlockControls, BlockIcon, InnerBlocks, InspectorControls, BlockPreview } from '@wordpress/block-editor';
 import {
 	Button,
 	ExternalLink,
@@ -22,7 +22,7 @@ import {
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { getBlockDefaultClassName } from '@wordpress/blocks';
+import { getBlockDefaultClassName, createBlock } from '@wordpress/blocks';
 import { select, dispatch } from '@wordpress/data';
 
 /**
@@ -235,7 +235,17 @@ function CalendlyEdit( props ) {
 
 	const styleOptions = [
 		{ value: 'inline', label: __( 'Inline', 'jetpack' ) },
-		{ value: 'link', label: __( 'Link', 'jetpack' ) },
+		{
+			value: 'link',
+			label: __( 'Link', 'jetpack' ),
+			preview: <BlockPreview
+				blocks = { createBlock( innerButtonBlock.name, {
+					...innerButtonBlock.attributes,
+					...embedButtonAttributes,
+					passthroughAttributes: { url: 'url' },
+				} ) }
+			/>
+		},
 	];
 
 	const inspectorControls = (

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -243,7 +243,9 @@ function CalendlyEdit( props ) {
 					...innerButtonBlock.attributes,
 					...embedButtonAttributes,
 					passthroughAttributes: { url: 'url' },
+					align: 'center',
 				} ) }
+				viewportWidth={ 300 }
 			/>
 		},
 	];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR fixes an issue in Calendly block:

![96621676-eccb9b80-12d6-11eb-80bf-2c4da349bf33](https://user-images.githubusercontent.com/77539/96733721-27453f00-1390-11eb-86e0-09f2baa98246.gif)

When the block is inserted in the editor canvas, the preview breaks the block settings (sidebar) and block toolbar. Setting the preview for the `link` style explicitly fixes the issue.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix Calendly block styles bug

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes to your dev end. Use D51573-code for Simple sites.
* Go to create/edit a post
* Add a Calendly Block. You can use this link https://calendly.com/wordpresscom/jetpack-block-example for testing purposes.

**before**
* Confirm the block toolbar and settings are broken

**after**

* Confirm either block toolbar as well block settings (sidebar) work as expected
* Confirm you can switch between `inline` and `link` styles.
* Confirm styles are applied in the front-end

<img width="1044" alt="Screen Shot 2020-10-21 at 11 59 53 AM" src="https://user-images.githubusercontent.com/77539/96738368-03d0c300-1395-11eb-815a-c604f7c7f422.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix Calendly block styles bug
