### PR TITLE
Fix tests for upstream test environment change

### DIFF
--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -80,6 +80,11 @@ if [ ! -f /tmp/wordpress-develop/wp-tests-config.php ]; then
 	cp /tmp/wp-tests-config.php /tmp/wordpress-develop/wp-tests-config.php
 fi
 
+# Symlink jetpack into wordpress-develop for WP >= 5.6-beta1
+if [ ! -e /tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack ]; then
+	ln -s /var/www/html/wp-content/plugins/jetpack /tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack
+fi
+
 # Add a PsySH dependency to wp-cli
 echo 'require: /usr/local/bin/psysh' >> /var/www/html/wp-cli.yml
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -850,10 +850,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		// Nothing should have changed since we cache the results.
 		$this->assertEquals( $this->extract_plugins_we_are_testing( $plugins_action_links ), $expected_array );
 
-		if ( file_exists( WP_CONTENT_DIR . '/plugins/hello.php' )  ) {
+		if ( file_exists( WP_PLUGIN_DIR . '/hello.php' ) ) {
 			activate_plugin('hello.php', '', false, true );
 		}
-		if ( file_exists( WP_CONTENT_DIR . '/plugins/hello-dolly/hello.php' ) ) {
+		if ( file_exists( WP_PLUGIN_DIR . '/hello-dolly/hello.php' ) ) {
 			activate_plugin('hello-dolly/hello.php', '', false, true );
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
@@ -138,7 +138,7 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 		return (object) array(
 			'response' => array(
 				'the/the.php' => (object) array(
-					'package' => ABSPATH . WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP
+					'package' => WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP,
 				)
 			)
 		);
@@ -155,7 +155,7 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 		return (object) array(
 			'response' => array(
 				'the/the.php' => (object) array(
-					'package' => ABSPATH . WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP . '-doesnotexitst.zip'
+					'package' => WP_Test_Jetpack_Sync_Plugins::PLUGIN_ZIP . '-doesnotexitst.zip',
 				)
 			)
 		);

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -4,7 +4,7 @@
  */
 class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 	protected $theme;
-	const PLUGIN_ZIP = 'wp-content/plugins/jetpack/tests/php/files/the.1.1.zip';
+	const PLUGIN_ZIP = __DIR__ . '/../files/the.1.1.zip';
 
 	public function setUp() {
 		parent::setUp();
@@ -202,21 +202,21 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 			new Automatic_Upgrader_Skin( $plugin_defaults )
 		);
 		// 'https://downloads.wordpress.org/plugin/the.1.1.zip' Install it from local disk
-		$upgrader->install( ABSPATH . self::PLUGIN_ZIP );
+		$upgrader->install( self::PLUGIN_ZIP );
 	}
 
 	function set_update_plugin_transient( $transient ) {
 		return (object) array(
 			'response' => array(
 				'the/the.php' => (object) array(
-					'package' => ABSPATH . self::PLUGIN_ZIP
+					'package' => self::PLUGIN_ZIP,
 				)
 			)
 		);
 	}
 
 	static function remove_plugin() {
-		if ( file_exists( ABSPATH .  'wp-content/plugins/the/the.php' ) ) {
+		if ( file_exists( WP_PLUGIN_DIR . '/the/the.php' ) ) {
 			delete_plugins( array( 'the/the.php' ) );
 			wp_cache_delete( 'plugins', 'plugins' );
 		}

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -50,7 +50,7 @@ fi
 
 cd ..
 cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$PLUGIN_SLUG"
-# Plugin dir for tests in WP > 5.5.1
+# Plugin dir for tests in WP >= 5.6-beta1
 ln -s "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$PLUGIN_SLUG" "/tmp/wordpress-$WP_BRANCH/tests/phpunit/data/plugins/$PLUGIN_SLUG"
 cd /tmp/wordpress-$WP_BRANCH
 

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -49,7 +49,10 @@ if [ $clone_exit_code -ne 0 ]; then
 fi
 
 cd ..
+# Plugin dir for WP <= 5.5.1
 cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$PLUGIN_SLUG"
+# Plugin dir for WP > 5.5.1
+cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_BRANCH/tests/phpunit/data/plugins/$PLUGIN_SLUG"
 cd /tmp/wordpress-$WP_BRANCH
 
 cp wp-tests-config-sample.php wp-tests-config.php

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -49,10 +49,9 @@ if [ $clone_exit_code -ne 0 ]; then
 fi
 
 cd ..
-# Plugin dir for WP <= 5.5.1
 cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$PLUGIN_SLUG"
-# Plugin dir for WP > 5.5.1
-cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_BRANCH/tests/phpunit/data/plugins/$PLUGIN_SLUG"
+# Plugin dir for tests in WP > 5.5.1
+ln -s "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$PLUGIN_SLUG" "/tmp/wordpress-$WP_BRANCH/tests/phpunit/data/plugins/$PLUGIN_SLUG"
 cd /tmp/wordpress-$WP_BRANCH
 
 cp wp-tests-config-sample.php wp-tests-config.php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
WordPress upstream has changed the test environment to define
WP_PLUGIN_DIR (see WordPress/wordpress-develop@9e83d04). Which made our
Travis tests fail when they were expecting that Jetpack would be listed
by `get_plugins()`.

For the time being, at least, let's copy Jetpack into both the old
and new locations so `get_plugins()` will find it.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None, but several threads in Slack.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See if tests are green.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
