### PR TITLE
Docker: Add symlink for WordPress test environment change

### DIFF
--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -80,6 +80,11 @@ if [ ! -f /tmp/wordpress-develop/wp-tests-config.php ]; then
 	cp /tmp/wp-tests-config.php /tmp/wordpress-develop/wp-tests-config.php
 fi
 
+# Symlink jetpack into wordpress-develop for WP > 5.5.1
+if [ ! -e /tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack ]; then
+	ln -s /var/www/html/wp-content/plugins/jetpack /tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack
+fi
+
 # Add a PsySH dependency to wp-cli
 echo 'require: /usr/local/bin/psysh' >> /var/www/html/wp-cli.yml
 

--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -80,7 +80,7 @@ if [ ! -f /tmp/wordpress-develop/wp-tests-config.php ]; then
 	cp /tmp/wp-tests-config.php /tmp/wordpress-develop/wp-tests-config.php
 fi
 
-# Symlink jetpack into wordpress-develop for WP > 5.5.1
+# Symlink jetpack into wordpress-develop for WP >= 5.6-beta1
 if [ ! -e /tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack ]; then
 	ln -s /var/www/html/wp-content/plugins/jetpack /tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This adds a symlink into the Docker environment like #17570 did for
Travis.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To see the failure this is fixing,
* Run `yarn docker:update-core-unit-tests`
* Run `yarn docker:phpunit --filter=test_plugin_action_links_get_synced`, the test should fail.

To test the fix,
* Run `yarn docker:build-image`
* Stop (`yarn docker:stop`) and restart (`yarn docker:up`) the Docker dev environment.
* Run `yarn docker:update-core-unit-tests`, if necessary.
* Run `yarn docker:phpunit --filter=test_plugin_action_links_get_synced`, the test should pass now.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Probably none.