### PR TITLE
Instant Search: Scroll to top after filter selection

### DIFF
--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -9,6 +9,8 @@ import { __ } from '@wordpress/i18n';
 //       Do not import the entire lodash library!
 // eslint-disable-next-line lodash/import-scope
 import get from 'lodash/get';
+// eslint-disable-next-line lodash/import-scope
+import debounce from 'lodash/debounce';
 
 /**
  * Internal dependencies
@@ -22,8 +24,13 @@ export default class SearchFilters extends Component {
 		showClearFiltersButton: true,
 	};
 
+	scrollToTop = debounce( () => {
+		document.querySelector( '.jetpack-instant-search__overlay' ).scroll( 0, 0 );
+	}, 150 );
+
 	onChangeFilter = ( filterName, filterValue ) => {
 		setFilterQuery( filterName, filterValue );
+		this.scrollToTop();
 		this.props.onChange && this.props.onChange();
 	};
 


### PR DESCRIPTION
Fixes #14614.

#### Changes proposed in this Pull Request:
* Scrolls to the top of the search overlay after search filter selection.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this to your Jetpack site with Instant Search enabled.
* Ensure that you have filters configured for your search widgets inside the overlay.
* Perform a search. Ensure that the results are as expected.
* Select a filter in the overlay. Ensure that the overlay has been scrolled to the top after filter selection.

#### Proposed changelog entry for your changes:
* None.
