### PR TITLE
Instant Search: add role and label to dialog

### DIFF
--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { h } from 'preact';
 import { useEffect } from 'preact/hooks';
 
@@ -27,14 +28,19 @@ const Overlay = props => {
 
 	return (
 		<div
+			aria-labelledby="jetpack-instant-search__overlay-title"
 			className={ [
 				'jetpack-instant-search__overlay',
 				`jetpack-instant-search__overlay--${ colorTheme }`,
 				hasOverlayWidgets ? '' : 'jetpack-instant-search__overlay--no-sidebar',
 				isVisible ? '' : 'is-hidden',
 			].join( ' ' ) }
+			role="dialog"
 			style={ { opacity: isVisible ? opacity / 100 : 0 } }
 		>
+			<h1 id="jetpack-instant-search__overlay-title" className="screen-reader-text">
+				{ __( 'Search results' ) }
+			</h1>
 			{ children }
 		</div>
 	);

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -39,7 +39,7 @@ const Overlay = props => {
 			style={ { opacity: isVisible ? opacity / 100 : 0 } }
 		>
 			<h1 id="jetpack-instant-search__overlay-title" className="screen-reader-text">
-				{ __( 'Search results' ) }
+				{ __( 'Search results', 'jetpack' ) }
 			</h1>
 			{ children }
 		</div>

--- a/modules/search/instant-search/components/search-app.scss
+++ b/modules/search/instant-search/components/search-app.scss
@@ -6,3 +6,18 @@
 .theme-twentytwenty .cover-modal.show-modal.search-modal {
 	display: none;
 }
+
+// Text meant only for screen readers
+// https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal !important;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of https://github.com/Automattic/jetpack/issues/17554.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add the role `dialog` to the Instant Search overlay and include a title that is only visible to screen readers.

A good reference: https://bitsofco.de/accessible-modal-dialog/.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Part of the Jetpack Search Product Quality project: p9xfpQ-12j-p2.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your site with Jetpack Search enabled.
* Verify that the overlay has the correct `role` and `aria-labelledby` attributes applied.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Instant Search: accessibility improvements for the search overlay.
