### PR TITLE
Test Embed API: Update resolve-redirect route

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
@@ -29,7 +29,7 @@ class WPCOM_REST_API_V2_Endpoint_Resolve_Redirect extends WP_REST_Controller {
 		// GET /sites/<blog_id>/resolve-redirect/<url> - Follow 301/302 redirects on a URL, and return the final destination.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<url>.+)',
+			'/' . $this->rest_base . '/?(?P<url>.+)?',
 			array(
 				'args'   => array(
 					'url' => array(

--- a/extensions/shared/test-embed-url.js
+++ b/extensions/shared/test-embed-url.js
@@ -25,7 +25,7 @@ export default function testEmbedUrl( url, setIsResolvingUrl = noop ) {
 	setIsResolvingUrl( true );
 
 	return new Promise( ( resolve, reject ) => {
-		apiFetch( { path: `/wpcom/v2/resolve-redirect/${ url }` } ).then(
+		apiFetch( { path: `/wpcom/v2/resolve-redirect/?url=${ encodeURIComponent( url ) }` } ).then(
 			response => {
 				setIsResolvingUrl( false );
 				const responseStatusCode = response.status ? parseInt( response.status, 10 ) : null;


### PR DESCRIPTION
While testing on a local dev site I noticed that the resolve-redirect
API call was being 301 redirected and would then fail as the `//` in the
URL parameter was being switched to a single `/`.

After a lot of debugging, I discovered that it was Cloudflare that was
seeing a URL like
`https://test.com/wp-json/wpcom/v2/resolve-redirect/https://calendly.com`
as invalid, and redirecting to a sanitised version.

#### Changes proposed in this Pull Request:

The solution was to make the URL parameter in the path optional, so that
it could be passed as a query parameter.

This change implements that so the old style of calling the endpoint will still work, but also we can swap to using a more
conventional URL format.

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* If testing on WPCOM, sandbox the API
* Insert a calendly block
* Add a URL like https://calendly.com/paul-bunkham
* Click on the embed, and check that you don't get an error, and that the block can be previewed.

#### Proposed changelog entry for your changes:
Not sure one is required but maybe:
* Updated the `resolve-redirect` API endpoint so the `url` value can be passed as a query parameter.
