### PR TITLE
RegisterJetpackBlock: improve settings block example

### DIFF
--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -86,11 +86,16 @@ export default function registerJetpackBlock( name, settings, childBlocks = [] )
 		return false;
 	}
 
-	const result = registerBlockType( `jetpack/${ name }`, {
+	const jetpackBlockSettings = {
 		...settings,
 		title: buildBlockTitle( settings.title, buildBlockTags( name, requiredPlan ) ),
-		example: requiredPlan ? undefined : settings.example,
-	} );
+	};
+
+	if ( ! requiredPlan && settings.example ) {
+		jetpackBlockSettings.example = settings.example;
+	}
+
+	const result = registerBlockType( `jetpack/${ name }`, jetpackBlockSettings );
 
 	if ( requiredPlan ) {
 		addFilter(

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -57,7 +57,7 @@ function buildBlockTags( name ) {
  * @returns {string} Block title
  */
 function buildBlockTitle( blockTitle, blockTags = [] ) {
-	if ( ! blockTags?.length ) {
+	if ( ! blockTags.length ) {
 		return blockTitle;
 	}
 	return `${ blockTitle } (${ blockTags.join( ', ' ) })`;

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -57,11 +57,10 @@ function buildBlockTags( name ) {
  * @returns {string} Block title
  */
 function buildBlockTitle( blockTitle, blockTags = [] ) {
-	if ( blockTags.length ) {
-		blockTitle = `${ blockTitle } (${ blockTags.join( ', ' ) })`;
+	if ( ! blockTags?.length ) {
+		return blockTitle;
 	}
-
-	return blockTitle;
+	return `${ blockTitle } (${ blockTags.join( ', ' ) })`;
 }
 
 /**

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -86,16 +86,10 @@ export default function registerJetpackBlock( name, settings, childBlocks = [] )
 		return false;
 	}
 
-	const jetpackBlockSettings = {
+	const result = registerBlockType( `jetpack/${ name }`, {
 		...settings,
 		title: buildBlockTitle( settings.title, buildBlockTags( name, requiredPlan ) ),
-	};
-
-	if ( ! requiredPlan && settings.example ) {
-		jetpackBlockSettings.example = settings.example;
-	}
-
-	const result = registerBlockType( `jetpack/${ name }`, jetpackBlockSettings );
+	} );
 
 	if ( requiredPlan ) {
 		addFilter(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

~This PR improves the way to define the block example when registering the jetpack block. In short, it won't add the `example` key to the block settings, instead of adding it with an `undefined` value.~

This PR enables showing the block examples for all blocks, removing the conditional about if it requires a paid plan or not. For instance, `pay with paypal`:

<img src="https://user-images.githubusercontent.com/77539/96927115-f72f9600-148c-11eb-93ea-46425a83ea14.png" width="500px" />

Indirectly, it fixes the following issue in Calendly block:

![96621676-eccb9b80-12d6-11eb-80bf-2c4da349bf33](https://user-images.githubusercontent.com/77539/96733721-27453f00-1390-11eb-86e0-09f2baa98246.gif)

When the block is inserted in the editor canvas, the preview breaks the block settings (sidebar) and block toolbar. Setting the preview for the `link` style explicitly fixes the issue.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Improve setting block example process

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes to your dev end. Use D51652-code for Simple sites.
* Go to create/edit a post
* Add a Calendly Block. You can use this link https://calendly.com/wordpresscom/jetpack-block-example for testing purposes.

**before**
* Confirm the block toolbar and settings are broken

**after**

* Confirm either block toolbar as well block settings (sidebar) work as expected
* Confirm you can switch between `inline` and `link` styles.
* Confirm styles are applied in the front-end

<img width="1044" alt="Screen Shot 2020-10-21 at 11 59 53 AM" src="https://user-images.githubusercontent.com/77539/96738368-03d0c300-1395-11eb-815a-c604f7c7f422.png">


* Confirm the block examples works for all blocks.

<img src="https://user-images.githubusercontent.com/77539/96927315-437ad600-148d-11eb-9c4f-192041fe40bd.png" width="500px" />




#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve setting block example process`
