### PR TITLE
JITM: use is_active from the connection package

### DIFF
--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\JITMS;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\JITMS\Post_Connection_JITM;
 use Automattic\Jetpack\JITMS\Pre_Connection_JITM;
@@ -37,7 +38,7 @@ class JITM {
 	 * @return Post_Connection_JITM|Pre_Connection_JITM JITM instance.
 	 */
 	public static function get_instance() {
-		if ( \Jetpack::is_active() ) {
+		if ( ( new Connection_Manager() )->is_active() ) {
 			$jitm = new Post_Connection_JITM();
 		} else {
 			$jitm = new Pre_Connection_JITM();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The JITM package shouldn't depend on methods from the Jetpack plugin, so let's use the `Manager::is_active` method instead of `Jetpack::is_active`.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install and activate Jetpack.

2. Set up the `jetpack_pre_connection_prompt_helpers` filter, which allows the pre-connection JITMs to be displayed:  
    `add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );`

3. Verify that the pre-connection JITMs are displayed. For example, navigate to wp-admin -> Appearance -> Widgets. The "Looking for event more widgets?" JITM should be displayed.

4. Connect Jetpack.

5. Verify that the post-connection JITMs are displayed. For example, naviage to wp-admin -> Jetpack -> Dashboard -> At a Glance. The "Give your site a speed boost" JITM should be displayed, assuming that you haven't previously dismissed it.

#### Proposed changelog entry for your changes:
* n/a
