### PR TITLE
use wordbless to test the assets package

### DIFF
--- a/packages/assets/.gitignore
+++ b/packages/assets/.gitignore
@@ -1,0 +1,1 @@
+wordpress

--- a/packages/assets/composer.json
+++ b/packages/assets/composer.json
@@ -8,8 +8,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
-		"php-mock/php-mock": "^2.1",
-		"brain/monkey": "2.4.0"
+		"automattic/wordbless": "@dev"
 	},
 	"autoload": {
 		"classmap": [
@@ -20,7 +19,8 @@
 		"phpunit": [
 			"@composer install",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
-		]
+		],
+		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
 	},
 	"repositories": [
 		{

--- a/packages/assets/tests/php/bootstrap.php
+++ b/packages/assets/tests/php/bootstrap.php
@@ -9,3 +9,5 @@
  * Load the composer packages.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+\WorDBless\Load::load();

--- a/packages/assets/tests/php/test-assets.php
+++ b/packages/assets/tests/php/test-assets.php
@@ -7,81 +7,10 @@
 
 namespace Automattic\Jetpack;
 
-use PHPUnit\Framework\TestCase;
-use Automattic\Jetpack\Constants as Jetpack_Constants;
-use Brain\Monkey;
-use Brain\Monkey\Filters;
-
-/**
- * Retrieves a URL within the plugins or mu-plugins directory.
- *
- * @param string $path        Extra path appended to the end of the URL, including the relative directory if $plugin is supplied.
- * @param string $plugin_path A full path to a file inside a plugin or mu-plugin.
- *                            The URL will be relative to its directory.
- *                            Typically this is done by passing __FILE__ as the argument.
- */
-function plugins_url( $path, $plugin_path ) {
-	if ( strpos( $plugin_path, 'test-package.php' ) ) {
-		return 'http://www.example.com/wp-content/plugins/jetpack/packages/test-package/' . $path;
-	}
-
-	return 'http://www.example.com//wp-content/plugins/jetpack/' . $path;
-}
-
-/**
- * Enqueue a script.
- *
- * Registers the script if $src provided (does NOT overwrite), and enqueues it.
- *
- * @param string           $handle    Name of the script. Should be unique.
- * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
- *                                    Default empty.
- * @param string[]         $deps      Optional. An array of registered script handles this script depends on. Default empty array.
- * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
- *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
- *                                    If set to null, no version is added.
- * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
- *                                    Default 'false'.
- */
-function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $in_footer = false ) {
-	$GLOBALS['_was_called_wp_enqueue_script'][] = array( $handle, $src, $deps, $ver, $in_footer );
-}
-
-/**
- * A wrapper for PHP's parse_url()
- *
- * @param string $url       The URL to parse.
- * @param int    $component The specific component to retrieve. Use one of the PHP
- *                          predefined constants to specify which one.
- *                          Defaults to -1 (= return all parts as an array).
- */
-function wp_parse_url( $url, $component = -1 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	return parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
-}
-
 /**
  * Assets test suite.
  */
-class AssetsTest extends TestCase {
-
-	/**
-	 * Test setup.
-	 */
-	public function setUp() {
-		Monkey\setUp();
-		$plugin_file = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/jetpack.php';
-		Jetpack_Constants::set_constant( 'JETPACK__PLUGIN_FILE', $plugin_file );
-
-	}
-
-	/**
-	 * Run after every test.
-	 */
-	public function tearDown() {
-		Monkey\tearDown();
-		$GLOBALS['_was_called_wp_enqueue_script'] = array();
-	}
+class AssetsTest extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Test get_file_url_for_environment
@@ -146,7 +75,12 @@ class AssetsTest extends TestCase {
 	 * @see p58i-8nS-p2
 	 */
 	public function test_get_file_url_for_environment_with_filter() {
-		Filters\expectApplied( 'jetpack_get_file_for_environment' )->once()->andReturn( 'special-test.js' );
+		add_filter(
+			'jetpack_get_file_for_environment',
+			function() {
+				return 'special-test.js';
+			}
+		);
 
 		$file_url = Assets::get_file_url_for_environment( 'test.min.js', 'test.js' );
 
@@ -220,17 +154,21 @@ class AssetsTest extends TestCase {
 	public function test_enqueue_async_script_adds_script_loader_tag_filter() {
 		Assets::enqueue_async_script( 'handle', 'minpath.js', 'path.js', array(), '123', true );
 		$asset_instance = Assets::instance();
-		self::assertTrue( has_filter( 'script_loader_tag', array( $asset_instance, 'script_add_async' ) ) );
+		self::assertEquals( 10, has_filter( 'script_loader_tag', array( $asset_instance, 'script_add_async' ) ) );
 	}
 
 	/**
 	 * Test that enqueue_async_script calls wp_enqueue_script
 	 */
 	public function test_enqueue_async_script_calls_wp_enqueue_script() {
-		Assets::enqueue_async_script( 'handle', '/minpath.js', '/path.js', array(), '123', true );
-		$this->assertEquals(
-			$GLOBALS['_was_called_wp_enqueue_script'],
-			array( array( 'handle', Assets::get_file_url_for_environment( '/minpath.js', '/path.js' ), array(), '123', true ) )
-		);
+		Assets::enqueue_async_script( 'test-handle', '/minpath.js', '/path.js', array(), '123', true );
+
+		$this->assertTrue( wp_script_is( 'test-handle', 'enqueued' ) );
+
+		$enqueued_script = wp_scripts()->query( 'test-handle', 'registered' );
+
+		$this->assertEquals( Assets::get_file_url_for_environment( '/minpath.js', '/path.js' ), $enqueued_script->src );
+		$this->assertEquals( '123', $enqueued_script->ver );
+
 	}
 }


### PR DESCRIPTION

This PR replaces other dependencies in the Assets package with WroDBless for testing purposes. It simplifies what's needed to test the package and also improves the testability.


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the tests for the package
* Look at the changes and see if we are still testing everything we want

