### PR TITLE
JITM: add a Pre_Connection_JITM::generate_admin_url method

### DIFF
--- a/packages/jitm/src/class-pre-connection-jitm.php
+++ b/packages/jitm/src/class-pre-connection-jitm.php
@@ -18,13 +18,20 @@ class Pre_Connection_JITM extends JITM {
 	 * Returns all the pre-connection messages.
 	 */
 	private function get_raw_messages() {
+		$jetpack_setup_url = $this->generate_admin_url(
+			array(
+				'page'    => 'jetpack',
+				'#/setup' => '',
+			)
+		);
+
 		return array(
 			array(
 				'id'             => 'jpsetup-posts',
 				'message_path'   => '/wp:edit-post:admin_notices/',
 				'message'        => __( 'Do you know which of these posts gets the most traffic?', 'jetpack' ),
 				'description'    => __( 'Set up Jetpack to get in-depth stats about your content and visitors.', 'jetpack' ),
-				'button_link'    => \Jetpack::admin_url( '#/setup' ),
+				'button_link'    => $jetpack_setup_url,
 				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
 			),
 			array(
@@ -32,7 +39,7 @@ class Pre_Connection_JITM extends JITM {
 				'message_path'   => '/wp:upload:admin_notices/',
 				'message'        => __( 'Do you want lightning-fast images?', 'jetpack' ),
 				'description'    => __( 'Set up Jetpack, enable Site Accelerator, and start serving your images lightning fast, for free.', 'jetpack' ),
-				'button_link'    => \Jetpack::admin_url( '#/setup' ),
+				'button_link'    => $jetpack_setup_url,
 				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
 			),
 			array(
@@ -40,10 +47,23 @@ class Pre_Connection_JITM extends JITM {
 				'message_path'   => '/wp:widgets:admin_notices/',
 				'message'        => __( 'Looking for even more widgets?', 'jetpack' ),
 				'description'    => __( 'Set up Jetpack for great additional widgets that display business contact info and maps, blog stats, and top posts.', 'jetpack' ),
-				'button_link'    => \Jetpack::admin_url( '#/setup' ),
+				'button_link'    => $jetpack_setup_url,
 				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
 			),
 		);
+	}
+
+	/**
+	 * Adds the input query arguments to the admin url.
+	 *
+	 * @param array $args The query arguments.
+	 *
+	 * @return string The admin url.
+	 */
+	private function generate_admin_url( $args ) {
+		$args = wp_parse_args( $args );
+		$url  = add_query_arg( $args, admin_url( 'admin.php' ) );
+		return $url;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Currently, the `Pre_Connection_JITM` class uses `Jetpack::admin_url()` to generate the Jetpack admin url. The JITM package shouldn't depend on the Jetpack plugin, so let's add a new method that generates an admin url in the `Pre_Connection_JITM` class.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install and activate Jetpack (don't connect).

2. Set up the `jetpack_pre_connection_prompt_helpers` filter, which allows the pre-connection JITMs to be displayed:
    `add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );`

3. Navigate to wp-admin -> Posts. A pre-connection JITM should be displayed. Verify that the `SET UP JETPACK` button link contains `?page=jetpack&#/setup`.

4. Navigate to wp-admin -> Media. A pre-connection JITM should be displayed. Verify that the button link contains `?page=jetpack&#/setup`.

5. Navigate to wp-admin -> Appearance -> Widgets. A pre-connection JITM should be displayed. Verify that the button link contains `?page=jetpack&#/setup`.

6. Click the `SET UP JETPACK` button in at least one of the pre-connection JITMs and verify that you're taken to the connection setup page.

#### Proposed changelog entry for your changes:
* n/a
