### PR TITLE
Core_API_Site_Endpoint: check whether a WP_Error was returned in get_benefits

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -155,8 +155,10 @@ class Jetpack_Core_API_Site_Endpoint {
 			$stats = stats_get_from_restapi( array( 'fields' => 'stats' ) );
 		}
 
+		$has_stats = null !== $stats && ! is_wp_error( $stats );
+
 		// Yearly visitors.
-		if ( null !== $stats && ! is_wp_error( $stats ) && $stats->stats->visitors > 0 ) {
+		if ( $has_stats && $stats->stats->visitors > 0 ) {
 			$benefits[] = array(
 				'name'        => 'jetpack-stats',
 				'title'       => esc_html__( 'Site Stats', 'jetpack' ),
@@ -179,7 +181,7 @@ class Jetpack_Core_API_Site_Endpoint {
 		}
 
 		// Number of followers.
-		if ( null !== $stats && ! is_wp_error( $stats ) && $stats->stats->followers_blog > 0 && Jetpack::is_module_active( 'subscriptions' ) ) {
+		if ( $has_stats && $stats->stats->followers_blog > 0 && Jetpack::is_module_active( 'subscriptions' ) ) {
 			$benefits[] = array(
 				'name'        => 'subscribers',
 				'title'       => esc_html__( 'Subscribers', 'jetpack' ),
@@ -270,7 +272,7 @@ class Jetpack_Core_API_Site_Endpoint {
 		}
 
 		// Total number of shares.
-		if ( null !== $stats && ! is_wp_error( $stats ) && $stats->stats->shares > 0 ) {
+		if ( $has_stats && $stats->stats->shares > 0 ) {
 			$benefits[] = array(
 				'name'        => 'sharing',
 				'title'       => esc_html__( 'Sharing', 'jetpack' ),

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -156,7 +156,7 @@ class Jetpack_Core_API_Site_Endpoint {
 		}
 
 		// Yearly visitors.
-		if ( null !== $stats && $stats->stats->visitors > 0 ) {
+		if ( null !== $stats && ! is_wp_error( $stats ) && $stats->stats->visitors > 0 ) {
 			$benefits[] = array(
 				'name'        => 'jetpack-stats',
 				'title'       => esc_html__( 'Site Stats', 'jetpack' ),
@@ -179,7 +179,7 @@ class Jetpack_Core_API_Site_Endpoint {
 		}
 
 		// Number of followers.
-		if ( null !== $stats && $stats->stats->followers_blog > 0 && Jetpack::is_module_active( 'subscriptions' ) ) {
+		if ( null !== $stats && ! is_wp_error( $stats ) && $stats->stats->followers_blog > 0 && Jetpack::is_module_active( 'subscriptions' ) ) {
 			$benefits[] = array(
 				'name'        => 'subscribers',
 				'title'       => esc_html__( 'Subscribers', 'jetpack' ),
@@ -270,7 +270,7 @@ class Jetpack_Core_API_Site_Endpoint {
 		}
 
 		// Total number of shares.
-		if ( null !== $stats && $stats->stats->shares > 0 ) {
+		if ( null !== $stats && ! is_wp_error( $stats ) && $stats->stats->shares > 0 ) {
 			$benefits[] = array(
 				'name'        => 'sharing',
 				'title'       => esc_html__( 'Sharing', 'jetpack' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The `stats_get_from_restapi()` function [can return](https://github.com/Automattic/jetpack/blob/master/modules/stats.php#L1632) a `WP_Error` object. When that happens, a PHP notice will be generated when we try to access the stats property of the `$stats` variable in `Jetpack_Core_API_Site_Endpoint::get_benefits`. So, let's check whether the `$stats` variable is a `WP_Error` object before trying to access its properties.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Verify that the benefits endpoint still works correctly.
1. Install, activate, and connect Jetpack.
2. Visit your site in an incognito window to generate visitor stats.
3. Navigate to wp-admin -> Jetpack -> Dashboard. Scroll down to the `Site connection` card and click the `Manage site connection` link. You should see the disconnection modal, which includes stats for the connection benefits. 

##### Force the stats API to return an error.
4. Edit the `Jetpack_Core_API_Site_Endpoint::get_benefits` [method ](https://github.com/Automattic/jetpack/blob/master/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php#L155)so that the `$stats` variable is a `WP_Error` object.
5. Navigate to wp-admin -> Jetpack -> Dashboard. Scroll down to the `Site connection` card and click the `Manage site connection` link. You should see the disconnection modal. The visitor stats should be missing from the modal.
6. Check the `debug.log` file and verify that no PHP notices were generated. 

#### Proposed changelog entry for your changes:
* n/a
