### PR TITLE
Instant Search: Remove accidentally restored Webpack settings

### DIFF
--- a/webpack.config.search.js
+++ b/webpack.config.search.js
@@ -32,14 +32,6 @@ const sharedWebpackConfig = {
 
 module.exports = {
 	...sharedWebpackConfig,
-
-	performance: isDevelopment
-		? false
-		: {
-				maxAssetSize: 153600,
-				maxEntrypointSize: 153600,
-				hints: 'error',
-		  },
 	plugins: [
 		...sharedWebpackConfig.plugins,
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* We moved from using Webpack performance settings to `size-limit` for checking bundle sizes in #17507. Unfortunately, #17495 restored the Webpack performance settings due to git shenanigans.
* This PR removes the Webpack performance settings.

#### Testing instructions:
* Run `yarn build-search`. Ensure it works as expected.
* Run `yarn test-search`. Ensure it works as expected.

#### Proposed changelog entry for your changes:
* None.
