### PR TITLE
Autoloader: Reuse an existing autoloader suffix if available

### DIFF
--- a/packages/autoloader/src/CustomAutoloaderPlugin.php
+++ b/packages/autoloader/src/CustomAutoloaderPlugin.php
@@ -113,14 +113,51 @@ class CustomAutoloaderPlugin implements PluginInterface, EventSubscriberInterfac
 		$localRepo           = $repoManager->getLocalRepository();
 		$package             = $this->composer->getPackage();
 		$optimize            = $event->getFlags()['optimize'];
-		$suffix              = $config->get( 'autoloader-suffix' )
-			? $config->get( 'autoloader-suffix' )
-			: md5( uniqid( '', true ) );
+		$suffix              = $this->determineSuffix();
 
 		$generator = new AutoloadGenerator( $this->io );
 
 		$generator->dump( $config, $localRepo, $package, $installationManager, 'composer', $optimize, $suffix );
 		$this->generated = true;
+	}
+
+	/**
+	 * Determine the suffix for the autoloader class.
+	 *
+	 * Reuses an existing suffix from vendor/autoload_packages.php or vendor/autoload.php if possible.
+	 *
+	 * @return string Suffix.
+	 */
+	private function determineSuffix() {
+		$config     = $this->composer->getConfig();
+		$vendorPath = $config->get( 'vendor-dir' );
+
+		// Command line.
+		$suffix = $config->get( 'autoloader-suffix' );
+		if ( $suffix ) {
+			return $suffix;
+		}
+
+		// Reuse our own suffix, if any.
+		if ( is_readable( $vendorPath . '/autoload_packages.php' ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$content = file_get_contents( $vendorPath . '/autoload_packages.php' );
+			if ( preg_match( '/^namespace Automattic\\\\Jetpack\\\\Autoloader\\\\jp([^;\s]+);/m', $content, $match ) ) {
+				return $match[1];
+			}
+		}
+
+		// Reuse Composer's suffix, if any.
+		if ( is_readable( $vendorPath . '/autoload.php' ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$content = file_get_contents( $vendorPath . '/autoload.php' );
+			if ( preg_match( '{ComposerAutoloaderInit([^:\s]+)::}', $content, $match ) ) {
+				return $match[1];
+			}
+		}
+
+		// Generate a random suffix.
+		return md5( uniqid( '', true ) );
 	}
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The autoloader will now try to reuse the random suffix, instead of trying to generate a new one each time. This may help avoid issues when deploying new code.
* In order, it will prefer an autoloader suffix configured in composer.json, an existing Jetpack Autoloader suffix, or an existing Composer autoloader suffix. See commit message on 49c8fce for additional context.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1601923798428600-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test 1:
1. You probably have an existing vendor directory with `vendor/autoload_packages.php` already existing (if not, `composer install` should create one; ideally do this on master before checking out this patch). Make note of the suffix on the namespace line.
2. Run `composer install`.
3. Check that `vendor/autoload_packages.php` has not changed.

Test 2:
1. Remove `vendor/autoload_packages.php`.
2. Run `composer install`.
3. Check that `vendor/autoload_packages.php` uses the same suffix as `vendor/autoload.php`.

Test 3:
1. Run `composer config autoloader-suffix foobar`.
2. Run `composer install`.
3. Check that `vendor/autoload_packages.php` (and `vendor/autoload.php`) both now use "foobar" as the suffix.
4. Run `composer config --unset autoloader-suffix` or `git restore composer.json` to clean up from step 1.

Test 4:
1. Remove your vendor directory.
2. Run `composer install`.
3. Check that `vendor/autoload_packages.php` and `vendor/autoload.php` use the same suffix.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Developer only, none needed.