### PR TITLE
Remove jquery dependency from postmessage.js

### DIFF
--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -136,7 +136,7 @@ class Jetpack_Comment_Likes {
 		wp_enqueue_script(
 			'postmessage',
 			Assets::get_file_url_for_environment( '_inc/build/postmessage.min.js', '_inc/postmessage.js' ),
-			array( 'jquery' ),
+			array(),
 			JETPACK__VERSION,
 			true
 		);

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -283,7 +283,7 @@ class Jetpack_Likes {
 			add_filter( 'post_flair', array( &$this, 'post_likes' ), 30, 1 );
 			add_filter( 'post_flair_block_css', array( $this, 'post_flair_service_enabled_like' ) );
 
-			wp_enqueue_script( 'postmessage', '/wp-content/js/postmessage.js', array( 'jquery' ), JETPACK__VERSION, true );
+			wp_enqueue_script( 'postmessage', '/wp-content/js/postmessage.js', array(), JETPACK__VERSION, true );
 			wp_enqueue_script( 'jetpack_resize', '/wp-content/js/jquery/jquery.jetpack-resize.js', array( 'jquery' ), JETPACK__VERSION, true );
 			wp_enqueue_script( 'jetpack_likes_queuehandler', plugins_url( 'queuehandler.js' , __FILE__ ), array( 'jquery', 'postmessage', 'jetpack_resize' ), JETPACK__VERSION, true );
 			wp_enqueue_style( 'jetpack_likes', plugins_url( 'jetpack-likes.css', __FILE__ ), array(), JETPACK__VERSION );
@@ -297,7 +297,7 @@ class Jetpack_Likes {
 		wp_register_script(
 			'postmessage',
 			Assets::get_file_url_for_environment( '_inc/build/postmessage.min.js', '_inc/postmessage.js' ),
-			array( 'jquery' ),
+			array(),
 			JETPACK__VERSION,
 			true
 		);


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* The postmessage.js script register and enqueue indicate that jquery is a dependency.   However, postmessage.js itself - https://github.com/Automattic/jetpack/blob/master/_inc/postmessage.js - indicates that jquery is optional.  That being the case, it shouldn't be asking for jquery to be loaded.

#### Jetpack product discussion

* Primary issue: #16409 

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here. Try Liking posts and comments, and make sure that still works.


#### Proposed changelog entry for your changes:

* Likes: remove jQuery dependency where possible.
