### PR TITLE
Slideshow: dispatch the jetpack-lazy-images-load event in swiperInit

### DIFF
--- a/extensions/blocks/slideshow/swiper-callbacks.js
+++ b/extensions/blocks/slideshow/swiper-callbacks.js
@@ -12,6 +12,14 @@ const PAUSE_CLASS = 'wp-block-jetpack-slideshow_autoplay-paused';
 function swiperInit( swiper ) {
 	swiperResize( swiper );
 	swiperApplyAria( swiper );
+
+	/*
+	 * Dispatch the jetpack-lazy-images-load event to set up lazy loading for
+	 * the slideshow's duplicate first and last images.
+	 */
+	const bodyEl = document.querySelector( 'body' );
+	bodyEl.dispatchEvent( new Event( 'jetpack-lazy-images-load' ) );
+
 	swiper.el
 		.querySelector( '.wp-block-jetpack-slideshow_button-pause' )
 		.addEventListener( 'click', function () {


### PR DESCRIPTION
Fixes #16127

#### Changes proposed in this Pull Request:
* Lazy loading is set up before the slideshow's duplicate first and last images are generated. This leads to missing images when the slideshow loops when lazy image loading is enabled. To fix this, dispatch the `jetpack-lazy-images-load` event in `swiperInit`.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Reproduce the bug.
1. Install, activate, and connect Jetpack.
2. Navigate to wp-admin -> Jetpack -> Settings -> Performance and enable lazy loading for images.
3. Create a post that includes some content, including a slideshow block with multiple photos. The slideshow block should be at the bottom of the post so that lazy image loading will be used for the slideshow's images.
4. View the post while logged out or in an incognito window.
5. Click the slideshow arrow buttons to display the slide show images. When the slideshow images loop, the images are not displayed:
    * When the last image is displayed, click the forward arrow button and notice that the first image is not displayed.
    * When the first image is displayed, click the back arrow button and notice that the last image is not displayed.

<img src="https://user-images.githubusercontent.com/50059399/97056844-ed269980-1557-11eb-97ac-c413c2441c1b.gif" width="250" />

##### Test the fix.
6. Checkout this branch.
7. View the post from step 3 while logged out or in an incognito window.
8. Click the slideshow arrow buttons to display the slide show images. When the slideshow images loop, the images should be displayed.

#### Proposed changelog entry for your changes:
* Slideshow Block: fix a bug that prevented the first and last images from displaying when the slideshow loops.