### PR TITLE
Masterbar: Add Admin Menu endpoint

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -3,7 +3,7 @@
  * REST API endpoint for admin menus.
  *
  * @package Jetpack
- * @since 8.7.0
+ * @since 9.1.0
  */
 
 /**

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * REST API endpoint for admin menus.
+ *
+ * @package Jetpack
+ * @since 8.7.0
+ */
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Admin_Menu
+ */
+class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
+
+	/**
+	 * Namespace prefix.
+	 *
+	 * @var string
+	 */
+	public $namespace = 'wpcom/v2';
+
+	/**
+	 * Endpoint base route.
+	 *
+	 * @var string
+	 */
+	public $rest_base = 'admin-menu';
+
+	/**
+	 * WPCOM_REST_API_V2_Endpoint_Admin_Menu constructor.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to admin menus.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! current_user_can( 'read' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to view menus on this site.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the admin menu.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// All globals need to be declared for menu items to properly register.
+		global $menu, $submenu, $_wp_menu_nopriv, $_wp_submenu_nopriv; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+		require_once ABSPATH . 'wp-admin/menu.php';
+
+		return rest_ensure_response( $this->prepare_menu_for_response( $menu ) );
+	}
+
+	/**
+	 * Prepares the admin menu for the REST response.
+	 *
+	 * @param array $menu Admin menu.
+	 * @return array Admin menu
+	 */
+	public function prepare_menu_for_response( array $menu ) {
+		global $submenu;
+
+		$data = array();
+
+		/**
+		 * Note: if the shape of the API endpoint data changes it is important to also update
+		 * the corresponding schema.js file.
+		 * See: https://github.com/Automattic/wp-calypso/blob/ebde236ec9b21ea9621c0b0523bd5ea185523731/client/state/admin-menu/schema.js
+		 */
+		foreach ( $menu as $menu_item ) {
+			$item = $this->prepare_menu_item( $menu_item );
+
+			if ( ! empty( $submenu[ $menu_item[2] ] ) ) {
+				foreach ( $submenu[ $menu_item[2] ] as $submenu_item ) {
+					$item['children'][] = $this->prepare_submenu_item( $submenu_item, $menu_item );
+				}
+			}
+
+			$data[] = $item;
+		}
+
+		return array_filter( $data );
+	}
+
+	/**
+	 * Retrieves the admin menu's schema, conforming to JSON Schema.
+	 *
+	 * Note: if the shape of the API endpoint data changes it is important to also update
+	 * the corresponding schema.js file.
+	 *
+	 * @see https://github.com/Automattic/wp-calypso/blob/ebde236ec9b21ea9621c0b0523bd5ea185523731/client/state/admin-menu/schema.js
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'Admin Menu',
+			'type'       => 'object',
+			'properties' => array(
+				'count'    => array(
+					'description' => 'Plugin/Theme update count or unread comments count.',
+					'type'        => 'integer',
+				),
+				'icon'     => array(
+					'description' => 'Menu item icon. Dashicon slug or base64-encoded SVG.',
+					'type'        => 'string',
+				),
+				'slug'     => array(
+					'type' => 'string',
+				),
+				'children' => array(
+					'items' => array(
+						'parent' => array(
+							'type' => 'string',
+						),
+						'slug'   => array(
+							'type' => 'string',
+						),
+						'title'  => array(
+							'type' => 'string',
+						),
+						'type'   => array(
+							'enum' => array( 'submenu-item' ),
+							'type' => 'string',
+						),
+						'url'    => array(
+							'format' => 'uri',
+							'type'   => 'string',
+						),
+					),
+					'type'  => 'array',
+				),
+				'title'    => array(
+					'type' => 'string',
+				),
+				'type'     => array(
+					'enum' => array( 'separator', 'menu-item' ),
+					'type' => 'string',
+				),
+				'url'      => array(
+					'format' => 'uri',
+					'type'   => 'string',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Sets up a menu item for consumption by Calypso.
+	 *
+	 * @param array $menu_item Menu item.
+	 * @return array Prepared menu item.
+	 */
+	private function prepare_menu_item( array $menu_item ) {
+		if ( ! current_user_can( $menu_item[1] ) ) {
+			return array();
+		}
+
+		if ( false !== strpos( $menu_item[4], 'wp-menu-separator' ) ) {
+			return array(
+				'type' => 'separator',
+			);
+		}
+
+		$item = array(
+			'icon'  => $this->prepare_menu_item_icon( $menu_item[6] ),
+			'slug'  => sanitize_title_with_dashes( $menu_item[2] ),
+			'title' => wptexturize( $menu_item[0] ),
+			'type'  => 'menu-item',
+			'url'   => $this->prepare_menu_item_url( $menu_item[2] ),
+		);
+
+		if ( false !== strpos( $menu_item[0], 'count-' ) ) {
+			preg_match( '/class="(.+\s)?count-(\d*)/', $menu_item[0], $matches );
+
+			$count = absint( $matches[2] );
+			if ( $count > 0 ) {
+				$item['count'] = $count;
+			}
+
+			// Remove count badge HTML from title.
+			$item['title'] = wptexturize( trim( substr( $menu_item[0], 0, strpos( $menu_item[0], '<' ) ) ) );
+		}
+
+		return $item;
+	}
+
+	/**
+	 * Sets up a submenu item for consumption by Calypso.
+	 *
+	 * @param array $submenu_item Submenu item.
+	 * @param array $menu_item    Menu item.
+	 * @return array Prepared submenu item.
+	 */
+	private function prepare_submenu_item( array $submenu_item, array $menu_item ) {
+		$item = array();
+
+		if ( current_user_can( $submenu_item[1] ) ) {
+			$item = array(
+				'parent' => sanitize_title_with_dashes( $menu_item[2] ),
+				'slug'   => sanitize_title_with_dashes( $submenu_item[2] ),
+				'title'  => wptexturize( $submenu_item[0] ),
+				'type'   => 'submenu-item',
+				'url'    => $this->prepare_menu_item_url( $submenu_item[2], $menu_item[2] ),
+			);
+		}
+
+		return $item;
+	}
+
+	/**
+	 * Prepares a menu icon for consumption by Calypso.
+	 *
+	 * @param string $icon Menu icon.
+	 * @return string
+	 */
+	private function prepare_menu_item_icon( $icon ) {
+		$img = 'dashicons-admin-generic';
+
+		if ( ! empty( $icon ) ) {
+			$img = esc_url( $icon );
+
+			if ( 0 === strpos( $icon, 'data:image/svg+xml' ) ) {
+				$img = $icon;
+			} elseif ( 0 === strpos( $icon, 'dashicons-' ) ) {
+				$img = sanitize_html_class( $icon );
+			}
+		}
+
+		return $img;
+	}
+
+	/**
+	 * Prepares a menu icon for consumption by Calypso.
+	 *
+	 * @param string $url         Menu slug.
+	 * @param string $parent_slug Optional. Parent menu item slug. Default empty string.
+	 * @return string
+	 */
+	private function prepare_menu_item_url( $url, $parent_slug = '' ) {
+		// Calypso URLs need the base removed so they're not interpreted as external links.
+		if ( 0 === strpos( $url, 'https://wordpress.com' ) ) {
+			$url = str_replace( 'https://wordpress.com', '', $url );
+		} else {
+			$menu_hook = get_plugin_page_hook( $url, 'admin.php' );
+			$menu_file = wp_parse_url( $url, PHP_URL_PATH ); // Removes query args to get a file name.
+
+			if (
+				! empty( $menu_hook ) ||
+				(
+					'index.php' !== $url &&
+					file_exists( WP_PLUGIN_DIR . "/$menu_file" ) &&
+					! file_exists( ABSPATH . "/wp-admin/$menu_file" )
+				)
+			) {
+				if ( ( 'admin.php' !== $parent_slug && file_exists( WP_PLUGIN_DIR . "/$parent_slug" ) && ! is_dir( WP_PLUGIN_DIR . "/$parent_slug" ) ) || file_exists( ABSPATH . "/wp-admin/$parent_slug" ) ) {
+					$url = add_query_arg( array( 'page' => $url ), admin_url( $parent_slug ) );
+				} else {
+					$url = add_query_arg( array( 'page' => $url ), admin_url( 'admin.php' ) );
+				}
+			} else {
+				$url = admin_url( $url );
+			}
+		}
+
+		return esc_url( $url );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -86,6 +86,7 @@ module.exports = [
 	'packages',
 	'tests/e2e/plugins',
 	'tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php',
+	'tests/php/core-api/wpcom-endpoints/test_class-wpcom-rest-api-v2-endpoint-admin-menu',
 	'tests/php/general/test-class.jetpack-network.php',
 	'tests/php/test_class.jetpack_photon.php',
 	'views/admin/deactivation-dialog.php',

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -31,6 +31,7 @@ module.exports = [
 	'_inc/lib/class-jetpack-wizard.php',
 	'_inc/lib/components.php',
 	'_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php',
+	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php',

--- a/packages/redirect/tests/php/bootstrap.php
+++ b/packages/redirect/tests/php/bootstrap.php
@@ -10,8 +10,8 @@ function get_home_url() {
 	return 'http://example.org';
 }
 
-function wp_parse_url( $url ) {
-	return parse_url( $url );
+function wp_parse_url( $url, $component = -1 ) {
+	return parse_url( $url, $component );
 }
 
 function apply_filters( $hook, $string ) {

--- a/tests/php/core-api/wpcom-endpoints/test_class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/tests/php/core-api/wpcom-endpoints/test_class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -1,0 +1,297 @@
+<?php // phpcs:ignore
+/**
+ * Tests for /wpcom/v2/admin-menu endpoint.
+ */
+
+require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+
+/**
+ * Class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu
+ *
+ * @coversDefaultClass WPCOM_REST_API_V2_Endpoint_Admin_Menu
+ */
+class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST_Testcase {
+
+	/**
+	 * Mock user ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id = 0;
+
+	/**
+	 * Create shared database fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$user_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * Setup the environment for a test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( static::$user_id );
+	}
+
+	/**
+	 * Tests the permission check.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_get_item_permissions_check() {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/admin-menu' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+	}
+
+	/**
+	 * Tests get item.
+	 *
+	 * @covers ::get_item
+	 * @covers ::prepare_menu_for_response
+	 */
+	public function test_get_item() {
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/admin-menu' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertTrue( rest_validate_value_from_schema( $response->get_data(), ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->get_public_item_schema() ) );
+	}
+
+	/**
+	 * Tests preparing a menu item.
+	 *
+	 * @param array $menu_item Menu item as generated in wp-admin/menu.php.
+	 * @param array $expected  Menu item object ready for API response.
+	 *
+	 * @throws \ReflectionException Noop.
+	 * @dataProvider menu_item_data
+	 * @covers ::prepare_menu_item
+	 */
+	public function test_prepare_menu_item( array $menu_item, array $expected ) {
+		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
+
+		$prepare_menu_item = $class->getMethod( 'prepare_menu_item' );
+		$prepare_menu_item->setAccessible( true );
+
+		$this->assertEquals(
+			$expected,
+			$prepare_menu_item->invokeArgs( new WPCOM_REST_API_V2_Endpoint_Admin_Menu(), array( $menu_item ) )
+		);
+	}
+
+	/**
+	 * Data provider for test_prepare_menu_item.
+	 *
+	 * @return \string[][][]
+	 */
+	public function menu_item_data() {
+		return array(
+			// User doesn't have necessary permissions.
+			array(
+				array( '', 'manage_options', 'separator1', '', 'wp-menu-separator' ),
+				array(),
+			),
+			// Separator item.
+			array(
+				array( '', 'read', 'separator1', '', 'wp-menu-separator' ),
+				array(
+					'type' => 'separator',
+				),
+			),
+			// Regular menu item.
+			array(
+				array( 'Media', 'upload_files', 'upload.php', '', 'menu-top menu-icon-media', 'menu-media', 'dashicons-admin-media' ),
+				array(
+					'type'  => 'menu-item',
+					'icon'  => 'dashicons-admin-media',
+					'slug'  => 'upload-php',
+					'title' => 'Media',
+					'url'   => 'http://example.org/wp-admin/upload.php',
+				),
+			),
+			// Menu item with update count.
+			array(
+				array( 'Plugins <span class="update-plugins count-5"><span class="plugin-count">5</span></span>', 'moderate_comments', 'plugins.php', '', 'menu-top menu-icon-plugins', 'menu-plugins', 'dashicons-admin-plugins' ),
+				array(
+					'type'  => 'menu-item',
+					'icon'  => 'dashicons-admin-plugins',
+					'slug'  => 'plugins-php',
+					'title' => 'Plugins',
+					'url'   => 'http://example.org/wp-admin/plugins.php',
+					'count' => 5,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests preparing a submenu item.
+	 *
+	 * @param array $submenu_item Submenu item as generated in wp-admin/menu.php.
+	 * @param array $menu_item    Menu item as generated in wp-admin/menu.php.
+	 * @param array $expected     Menu item object ready for API response.
+	 *
+	 * @throws \ReflectionException Noop.
+	 * @dataProvider submenu_item_data
+	 * @covers ::prepare_submenu_item
+	 */
+	public function test_prepare_submenu_item( array $submenu_item, array $menu_item, array $expected ) {
+		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
+
+		$prepare_submenu_item = $class->getMethod( 'prepare_submenu_item' );
+		$prepare_submenu_item->setAccessible( true );
+
+		$this->assertEquals(
+			$expected,
+			$prepare_submenu_item->invokeArgs( new WPCOM_REST_API_V2_Endpoint_Admin_Menu(), array( $submenu_item, $menu_item ) )
+		);
+	}
+
+	/**
+	 * Data provider for test_prepare_submenu_item.
+	 *
+	 * @return \string[][][]
+	 */
+	public function submenu_item_data() {
+		return array(
+			// User doesn't have necessary permissions.
+			array(
+				array( 'Library', 'manage_options', 'upload.php' ),
+				array( 'Media', 'upload_files', 'upload.php', '', 'menu-top menu-icon-media', 'menu-media', 'dashicons-admin-media' ),
+
+				array(),
+			),
+			// Regular submenu item.
+			array(
+				array( 'Library', 'upload_files', 'upload.php' ),
+				array( 'Media', 'upload_files', 'upload.php', '', 'menu-top menu-icon-media', 'menu-media', 'dashicons-admin-media' ),
+				array(
+					'parent' => 'upload-php',
+					'type'   => 'submenu-item',
+					'slug'   => 'upload-php',
+					'title'  => 'Library',
+					'url'    => 'http://example.org/wp-admin/upload.php',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests preparing a menu item icon.
+	 *
+	 * @param string $icon     Menu item icon as generated in wp-admin/menu.php.
+	 * @param string $expected Menu item icon ready for API response.
+	 *
+	 * @throws \ReflectionException Noop.
+	 * @dataProvider menu_item_icon_data
+	 * @covers ::prepare_menu_item_icon
+	 */
+	public function test_prepare_menu_item_icon( $icon, $expected ) {
+		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
+
+		$prepare_menu_item_icon = $class->getMethod( 'prepare_menu_item_icon' );
+		$prepare_menu_item_icon->setAccessible( true );
+
+		$this->assertEquals(
+			$expected,
+			$prepare_menu_item_icon->invokeArgs( new WPCOM_REST_API_V2_Endpoint_Admin_Menu(), array( $icon ) )
+		);
+	}
+
+	/**
+	 * Data provider for test_prepare_submenu_item.
+	 *
+	 * @return \string[][]
+	 */
+	public function menu_item_icon_data() {
+		return array(
+			// Empty icon.
+			array(
+				'',
+				'dashicons-admin-generic',
+			),
+			// Icon URL.
+			array(
+				'http://example.org/files/jetpack.jpg',
+				'http://example.org/files/jetpack.jpg',
+			),
+			// Dashicon.
+			array(
+				'dashicons-admin-media',
+				'dashicons-admin-media',
+			),
+			// SVG.
+			array(
+				'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJub25lIiBkPSJNMTMgNy41aDV2MmgtNXptMCA3aDV2MmgtNXpNMTkgM0g1Yy0xLjEgMC0yIC45LTIgMnYxNGMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjVjMC0xLjEtLjktMi0yLTJ6bTAgMTZINVY1aDE0djE0ek0xMSA2SDZ2NWg1VjZ6bS0xIDRIN1Y3aDN2M3ptMSAzSDZ2NWg1di01em0tMSA0SDd2LTNoM3YzeiIvPjwvc3ZnPg==',
+				'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJub25lIiBkPSJNMTMgNy41aDV2MmgtNXptMCA3aDV2MmgtNXpNMTkgM0g1Yy0xLjEgMC0yIC45LTIgMnYxNGMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjVjMC0xLjEtLjktMi0yLTJ6bTAgMTZINVY1aDE0djE0ek0xMSA2SDZ2NWg1VjZ6bS0xIDRIN1Y3aDN2M3ptMSAzSDZ2NWg1di01em0tMSA0SDd2LTNoM3YzeiIvPjwvc3ZnPg==',
+			),
+		);
+	}
+
+	/**
+	 * Tests preparing a menu item url.
+	 *
+	 * @param string $url         Menu item url as generated in wp-admin/menu.php.
+	 * @param string $parent_slug Menu parent slug as generated in wp-admin/menu.php.
+	 * @param string $expected    Menu item url ready for API response.
+	 *
+	 * @throws \ReflectionException Noop.
+	 * @dataProvider menu_item_url_data
+	 * @covers ::prepare_menu_item_url
+	 */
+	public function test_prepare_menu_item_url( $url, $parent_slug, $expected ) {
+		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
+
+		$prepare_menu_item_url = $class->getMethod( 'prepare_menu_item_url' );
+		$prepare_menu_item_url->setAccessible( true );
+
+		// Fake plugin page.
+		add_action( 'admin_page_' . $url, '__return_false' );
+
+		$this->assertEquals(
+			$expected,
+			$prepare_menu_item_url->invokeArgs( new WPCOM_REST_API_V2_Endpoint_Admin_Menu(), array( $url, $parent_slug ) )
+		);
+	}
+
+	/**
+	 * Data provider for test_prepare_menu_item_url.
+	 *
+	 * @return \string[][]
+	 */
+	public function menu_item_url_data() {
+		return array(
+			// Calypso URL.
+			array(
+				'https://wordpress.com/me',
+				'',
+				'/me',
+			),
+			// Core menu item URL.
+			array(
+				'uploads.php',
+				'',
+				'http://example.org/wp-admin/uploads.php',
+			),
+			// Submenu item URL.
+			array(
+				'custom_settings',
+				'upload.php',
+				'http://example.org/wp-admin/upload.php?page=custom_settings',
+			),
+			// Plugin menu item URL.
+			array(
+				'custom_settings',
+				'admin.php',
+				'http://example.org/wp-admin/admin.php?page=custom_settings',
+			),
+		);
+	}
+}

--- a/tests/php/core-api/wpcom-endpoints/test_class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/tests/php/core-api/wpcom-endpoints/test_class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -38,6 +38,23 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	}
 
 	/**
+	 * Tests the schema response for OPTIONS requests.
+	 */
+	public function test_schema_request() {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( Requests::OPTIONS, '/wpcom/v2/admin-menu' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$schema = ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->get_public_item_schema();
+
+		$this->assertEquals( $schema, $data['schema'] );
+		$this->assertEquals( 'wpcom/v2', $data['namespace'] );
+		$this->assertEquals( array( Requests::GET ), $data['methods'] );
+	}
+
+	/**
 	 * Tests the permission check.
 	 *
 	 * @covers ::get_item_permissions_check

--- a/tests/php/core-api/wpcom-endpoints/test_class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/tests/php/core-api/wpcom-endpoints/test_class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -71,6 +71,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	/**
 	 * Tests get item.
 	 *
+	 * @covers ::get_item_permissions_check
 	 * @covers ::get_item
 	 * @covers ::prepare_menu_for_response
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

First step towards enhancing the Masterbar module with nav-unification for Calypso.

This change has no dependencies and doesn't change the way Masterbar works. It introduces the admin menu API endpoint that Calypso will use to import a site's menu. The PR includes unit tests for all endpoint methods as well.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add Admin Menu API endpoint.
* Add unit tests for API endpoint
* Update phpcs require list to include the two new files.
* Update `wp_parse_url()` function signature that caused an error in my editor.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbAPfg-VL-p2#comment-1904

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To run unit tests:
* Follow [setup guidelines](https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md#unit-testing) if you don't have unit tests set up yet.
* Run `phpunit --filter WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed at this time.

#### Code Coverage
![Screen Shot 2020-10-23 at 2 49 57 PM](https://user-images.githubusercontent.com/1398304/97057083-58b03d00-153f-11eb-94e9-16171fbb27b7.png)
