### PR TITLE
WPCOM Block Editor: Update meta key name

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -41,11 +41,8 @@ class Jetpack_WPCOM_Block_Editor {
 		}
 
 		require_once dirname( __FILE__ ) . '/functions.classic-editor.php';
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		if ( ! is_plugin_active( 'classic-editor/classic-editor.php' ) || false === has_filter( 'block_editor_settings', array( 'Classic_Editor', 'remember_block_editor' ) ) ) {
-			add_action( 'edit_form_top', 'Jetpack\ClassicEditor\remember_classic_editor' );
-			add_filter( 'block_editor_settings', 'Jetpack\ClassicEditor\remember_block_editor', 10, 2 );
-		}
+		add_action( 'edit_form_top', 'Jetpack\ClassicEditor\remember_classic_editor' );
+		add_filter( 'block_editor_settings', 'Jetpack\ClassicEditor\remember_block_editor', 10, 2 );
 
 		add_action( 'login_init', array( $this, 'allow_block_editor_login' ), 1 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ), 9 );

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -40,9 +40,9 @@ class Jetpack_WPCOM_Block_Editor {
 			add_filter( 'admin_body_class', array( $this, 'add_iframed_body_class' ) );
 		}
 
-		require_once dirname( __FILE__ ) . '/functions.classic-editor.php';
-		add_action( 'edit_form_top', 'Jetpack\ClassicEditor\remember_classic_editor' );
-		add_filter( 'block_editor_settings', 'Jetpack\ClassicEditor\remember_block_editor', 10, 2 );
+		require_once dirname( __FILE__ ) . '/functions.editor-type.php';
+		add_action( 'edit_form_top', 'Jetpack\EditorType\remember_classic_editor' );
+		add_filter( 'block_editor_settings', 'Jetpack\EditorType\remember_block_editor', 10, 2 );
 
 		add_action( 'login_init', array( $this, 'allow_block_editor_login' ), 1 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ), 9 );

--- a/modules/wpcom-block-editor/functions.classic-editor.php
+++ b/modules/wpcom-block-editor/functions.classic-editor.php
@@ -45,8 +45,8 @@ function remember_block_editor( $editor_settings, $post ) {
  * @param string $editor  String name of the editor, 'classic-editor' or 'block-editor'.
  */
 function remember_editor( $post_id, $editor ) {
-	if ( get_post_meta( $post_id, 'classic-editor-remember', true ) !== $editor ) {
-		update_post_meta( $post_id, 'classic-editor-remember', $editor );
+	if ( get_post_meta( $post_id, '_last_editor_used', true ) !== $editor ) {
+		update_post_meta( $post_id, '_last_editor_used', $editor );
 	}
 }
 

--- a/modules/wpcom-block-editor/functions.editor-type.php
+++ b/modules/wpcom-block-editor/functions.editor-type.php
@@ -45,8 +45,8 @@ function remember_block_editor( $editor_settings, $post ) {
  * @param string $editor  String name of the editor, 'classic-editor' or 'block-editor'.
  */
 function remember_editor( $post_id, $editor ) {
-	if ( get_post_meta( $post_id, '_jetpack_last_editor_used', true ) !== $editor ) {
-		update_post_meta( $post_id, '_jetpack_last_editor_used', $editor );
+	if ( get_post_meta( $post_id, '_last_editor_used_jetpack', true ) !== $editor ) {
+		update_post_meta( $post_id, '_last_editor_used_jetpack', $editor );
 	}
 }
 

--- a/modules/wpcom-block-editor/functions.editor-type.php
+++ b/modules/wpcom-block-editor/functions.editor-type.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * This file contains some 'remember' functions taken from the core Classic Editor Plugin
+ * This file contains some 'remember' functions inspired by the core Classic Editor Plugin
  * Used to align the 'last editor' metadata so that it is set on all Jetpack and WPCOM sites
  *
  * @package Jetpack
  */
 
-namespace Jetpack\ClassicEditor;
+namespace Jetpack\EditorType;
 
 /**
  * Remember when the classic editor was used to edit a post.
@@ -31,7 +31,7 @@ function remember_classic_editor( $post ) {
 function remember_block_editor( $editor_settings, $post ) {
 	$post_type = get_post_type( $post );
 
-	if ( $post_type && classic_editor_can_edit_post_type( $post_type ) ) {
+	if ( $post_type && can_edit_post_type( $post_type ) ) {
 		remember_editor( $post->ID, 'block-editor' );
 	}
 
@@ -45,8 +45,8 @@ function remember_block_editor( $editor_settings, $post ) {
  * @param string $editor  String name of the editor, 'classic-editor' or 'block-editor'.
  */
 function remember_editor( $post_id, $editor ) {
-	if ( get_post_meta( $post_id, '_last_editor_used', true ) !== $editor ) {
-		update_post_meta( $post_id, '_last_editor_used', $editor );
+	if ( get_post_meta( $post_id, '_jetpack_last_editor_used', true ) !== $editor ) {
+		update_post_meta( $post_id, '_jetpack_last_editor_used', $editor );
 	}
 }
 
@@ -56,7 +56,7 @@ function remember_editor( $post_id, $editor ) {
  * @param  string $post_type The post type to check.
  * @return bool              Whether the block editor can be used to edit the supplied post type.
  */
-function classic_editor_can_edit_post_type( $post_type ) {
+function can_edit_post_type( $post_type ) {
 	$can_edit = false;
 
 	if ( function_exists( 'gutenberg_can_edit_post_type' ) ) {

--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -706,6 +706,7 @@ class Defaults {
 		'_feedback_extra_fields',
 		'_g_feedback_shortcode',
 		'_jetpack_post_thumbnail',
+		'_last_editor_used_jetpack',
 		'_menu_item_classes',
 		'_menu_item_menu_item_parent',
 		'_menu_item_object',


### PR DESCRIPTION
After some discussion, we decided that it was probably beneficial to not
tie the meta key for the last editor used to the one used by the Classic
Editor Plugin. This simplifies the code because we don't need to check
for the plugin being present, and means we can make the meta key hidden
by prepending an underscore, as @jeherve suggested [in the original PR](https://github.com/Automattic/jetpack/pull/17407).

#### Changes proposed in this Pull Request:

This PR changes the meta key to `_last_editor_used_jetpack` and removes the logic to check the Classic Editor Plugin settings if the plugin is active.

There is an associated WPCOM change in D50744-code

#### Testing instructions:

Create and save a post. Check that it has `_last_editer_used_jetpack` set as post meta, and that the value is correct - either `classic-editor` or `block-editor`

To see the value sync'd, apply D50744-code to your sandbox and set `JETPACK__SANDBOX_DOMAIN` to an appropriate value.

#### Proposed changelog entry for your changes:
N/A - this is a tweak to a new feature. The changelog is the same as #17407
