### PR TITLE
Use the first good image for the open graph tag

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -316,23 +316,21 @@ function jetpack_og_get_image( $width = 200, $height = 200, $deprecated = null )
 
 		// Attempt to find something good for this post using our generalized PostImages code.
 		if ( empty( $image ) && class_exists( 'Jetpack_PostImages' ) ) {
-			$post_images = Jetpack_PostImages::get_images(
+			$post_image = Jetpack_PostImages::get_image(
 				get_the_ID(),
 				array(
 					'width'  => $width,
 					'height' => $height,
 				)
 			);
-			if ( $post_images && ! is_wp_error( $post_images ) ) {
-				foreach ( (array) $post_images as $post_image ) {
-					$image['src'] = $post_image['src'];
-					if ( isset( $post_image['src_width'], $post_image['src_height'] ) ) {
-						$image['width']  = $post_image['src_width'];
-						$image['height'] = $post_image['src_height'];
-					}
-					if ( ! empty( $post_image['alt_text'] ) ) {
-						$image['alt_text'] = $post_image['alt_text'];
-					}
+			if ( ! empty( $post_image ) && is_array( $post_image ) ) {
+				$image['src'] = $post_image['src'];
+				if ( isset( $post_image['src_width'], $post_image['src_height'] ) ) {
+					$image['width']  = $post_image['src_width'];
+					$image['height'] = $post_image['src_height'];
+				}
+				if ( ! empty( $post_image['alt_text'] ) ) {
+					$image['alt_text'] = $post_image['alt_text'];
 				}
 			}
 		}

--- a/tests/php/test_class.functions.opengraph.php
+++ b/tests/php/test_class.functions.opengraph.php
@@ -22,6 +22,10 @@ class WP_Test_Functions_OpenGraph extends Jetpack_Attachment_Test_Case {
 	 * Include Open Graph functions after each test.
 	 */
 	public function tearDown() {
+		// Restoring global variables.
+		global $wp_the_query;
+		$wp_the_query = new WP_Query(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
 		parent::tearDown();
 
 		wp_delete_attachment( $this->icon_id );

--- a/tests/php/test_class.functions.opengraph.php
+++ b/tests/php/test_class.functions.opengraph.php
@@ -206,7 +206,7 @@ class WP_Test_Functions_OpenGraph extends Jetpack_Attachment_Test_Case {
 	 *
 	 * @author automattic
 	 * @covers ::jetpack_og_get_image
-	 * @since  9.1.0
+	 * @since  9.2.0
 	 */
 	public function test_jetpack_og_get_image_from_post_order() {
 		// Create a post containing two image blocks.

--- a/tests/php/test_class.functions.opengraph.php
+++ b/tests/php/test_class.functions.opengraph.php
@@ -22,11 +22,11 @@ class WP_Test_Functions_OpenGraph extends Jetpack_Attachment_Test_Case {
 	 * Include Open Graph functions after each test.
 	 */
 	public function tearDown() {
+		parent::tearDown();
+
 		// Restoring global variables.
 		global $wp_the_query;
 		$wp_the_query = new WP_Query(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		parent::tearDown();
 
 		wp_delete_attachment( $this->icon_id );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This is a tweak to the open graph image selection logic, making it select the first 'good' image in a post instead of the last (the Twitter card tag logic already does this).

The image tags can be inspected by viewing the source of a post page, they look like this:

```html
<!-- Jetpack Open Graph Tags -->
<meta property="og:type" content="article" />
<meta property="og:title" content="A story post" />
<meta property="og:url" content="https://example.com/2020/10/20/a-story-post/" />
<meta property="og:description" content="Visit the post for more." />
<meta property="article:published_time" content="2020-10-20T06:39:37+00:00" />
<meta property="article:modified_time" content="2020-10-20T06:39:37+00:00" />
<meta property="og:site_name" content="alexforcier" />
<meta property="og:image" content="https://i2.wp.com/example.com/wp-content/uploads/2020/10/cropped-WP-Icon.png?fit=512%2C512&amp;ssl=1" />
<meta property="og:image:width" content="512" />
<meta property="og:image:height" content="512" />
<meta property="og:locale" content="en_US" />
<meta name="twitter:text:title" content="A story post" />
<meta name="twitter:image" content="https://i2.wp.com/example.com/wp-content/uploads/2020/10/cropped-WP-Icon.png?fit=240%2C240&amp;ssl=1" />
<meta name="twitter:card" content="summary" />
<meta name="twitter:description" content="Visit the post for more." />
```

This was originally done in https://github.com/Automattic/jetpack/pull/17198 and has been extracted here to its own PR.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Run the new unit test.

For any post with multiple images, inspect the image tags. The `og:image` tag should contain the first image in the post, or if the post contains a story block, the first slide in the story.

(The `twitter:image` tag behavior is unaffected by this PR, but you can observe it now has the same image as the `og:image` tag, where before they differed for posts with multiple images.)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Open Graph Tags: Use the first suitable image found in the post.
