### PR TITLE
Email &Notifications & Reader: Pinterest Fallback

### DIFF
--- a/extensions/blocks/pinterest/deprecated/v1/index.js
+++ b/extensions/blocks/pinterest/deprecated/v1/index.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { pinType } from '../../utils';
+
+export default {
+	attributes: {
+		url: {
+			type: 'string',
+		},
+	},
+	supports: {
+		align: false,
+		html: false,
+	},
+	save: ( { attributes, className } ) => {
+		const { url } = attributes;
+
+		const type = pinType( url );
+
+		if ( ! type ) {
+			return null;
+		}
+
+		return (
+			<div className={ className }>
+				<a data-pin-do={ pinType( url ) } href={ url } />
+			</div>
+		);
+	},
+};

--- a/extensions/blocks/pinterest/index.js
+++ b/extensions/blocks/pinterest/index.js
@@ -11,6 +11,7 @@ import { createBlock } from '@wordpress/blocks';
 import edit from './edit';
 import save from './save';
 import { getIconColor } from '../../shared/block-icons';
+import deprecatedV1 from './deprecated/v1';
 
 export const URL_REGEX = /^\s*https?:\/\/(?:www\.)?(?:[a-z]{2}\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^/]+)(\/[^/]+)?/i;
 
@@ -80,4 +81,6 @@ export const settings = {
 			url: PINTEREST_EXAMPLE_URL,
 		},
 	},
+
+	deprecated: [ deprecatedV1 ],
 };

--- a/extensions/blocks/pinterest/index.js
+++ b/extensions/blocks/pinterest/index.js
@@ -9,7 +9,7 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import edit from './edit';
-import { pinType } from './utils';
+import save from './save';
 import { getIconColor } from '../../shared/block-icons';
 
 export const URL_REGEX = /^\s*https?:\/\/(?:www\.)?(?:[a-z]{2}\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^/]+)(\/[^/]+)?/i;
@@ -59,21 +59,7 @@ export const settings = {
 
 	edit,
 
-	save: ( { attributes, className } ) => {
-		const { url } = attributes;
-
-		const type = pinType( url );
-
-		if ( ! type ) {
-			return null;
-		}
-
-		return (
-			<div className={ className }>
-				<a data-pin-do={ pinType( url ) } href={ url } />
-			</div>
-		);
-	},
+	save,
 
 	transforms: {
 		from: [

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -228,7 +228,7 @@ function load_assets( $attr, $content ) {
 		$type = pin_type( $url );
 
 		if ( ! $type ) {
-			return null;
+			return '';
 		}
 
 		wp_enqueue_script( 'pinterest-pinit', 'https://assets.pinterest.com/js/pinit.js', array(), JETPACK__VERSION, true );

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -180,6 +180,11 @@ function render_amp_pin( $attr ) {
  * @return string
  */
 function load_assets( $attr, $content ) {
+	if ( ! jetpack_is_frontend() ) {
+		$url           = esc_url( $attr['url'] );
+		$block_content = '<a href="' . $url . '">' . $url . '</a>';
+		return $block_content;
+	}
 	if ( Blocks::is_amp_request() ) {
 		return render_amp_pin( $attr );
 	} else {

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -234,10 +234,11 @@ function load_assets( $attr, $content ) {
 		wp_enqueue_script( 'pinterest-pinit', 'https://assets.pinterest.com/js/pinit.js', array(), JETPACK__VERSION, true );
 		return sprintf(
 			'
-			<div class="wp-block-jetpack-pinterest">
-				<a data-pin-do="%1$s" href="%2$s"></a>
+			<div class="%1$s">
+				<a data-pin-do="%2$s" href="%3$s"></a>
 			</div>
 		',
+			esc_attr( Blocks::classes( FEATURE_NAME, $attr ) ),
 			esc_attr( $type ),
 			esc_url( $url )
 		);

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -15,6 +15,44 @@ use WP_Error;
 const FEATURE_NAME = 'pinterest';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 const URL_PATTERN  = '#^https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.[a-z.]+/pin/(?P<pin_id>[^/]+)/?#i'; // Taken from AMP plugin, originally from Jetpack.
+// This is the validate Pinterest URLs, converted from URL_REGEX in wp-content/mu-plugins/jetpack/extensions/blocks/pinterest/index.js.
+const PINTEREST_URL_REGEX = '/^https?:\/\/(?:www\.)?(?:[a-z]{2\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^\/]+)(\/[^\/]+)?/i';
+// This looks for matches in /foo/ of https://www.pinterest.ca/foo/.
+const REMAINING_URL_PATH_REGEX = '/^\/([^\/]+)\/?$/';
+// This looks for matches with /foo/bar/ of https://www.pinterest.ca/foo/bar/.
+const REMAINING_URL_PATH_WITH_SUBPATH_REGEX = '/^\/([^\/]+)\/([^\/]+)\/?$/';
+
+/**
+ * Determines the Pinterest embed type from the URL.
+ *
+ * @param string $url the URL to check.
+ * @returns {string} The pin type. Empty string if it isn't a valid Pinterest URL.
+ */
+function pin_type( $url ) {
+	if ( ! preg_match( PINTEREST_URL_REGEX, $url ) ) {
+		return '';
+	}
+
+	$path = wp_parse_url( $url, PHP_URL_PATH );
+
+	if ( ! $path ) {
+		return '';
+	}
+
+	if ( substr( $path, 0, 5 ) === '/pin/' ) {
+		return 'embedPin';
+	}
+
+	if ( preg_match( REMAINING_URL_PATH_REGEX, $path ) ) {
+		return 'embedUser';
+	}
+
+	if ( preg_match( REMAINING_URL_PATH_WITH_SUBPATH_REGEX, $path ) ) {
+		return 'embedBoard';
+	}
+
+	return '';
+}
 
 /**
  * Registers the block for use in Gutenberg
@@ -181,14 +219,27 @@ function render_amp_pin( $attr ) {
  */
 function load_assets( $attr, $content ) {
 	if ( ! jetpack_is_frontend() ) {
-		$url           = esc_url( $attr['url'] );
-		$block_content = '<a href="' . $url . '">' . $url . '</a>';
-		return $block_content;
+		return $content;
 	}
 	if ( Blocks::is_amp_request() ) {
 		return render_amp_pin( $attr );
 	} else {
+		$url  = $attr['url'];
+		$type = pin_type( $url );
+
+		if ( ! $type ) {
+			return null;
+		}
+
 		wp_enqueue_script( 'pinterest-pinit', 'https://assets.pinterest.com/js/pinit.js', array(), JETPACK__VERSION, true );
-		return $content;
+		return sprintf(
+			'
+			<div class="wp-block-jetpack-pinterest">
+				<a data-pin-do="%1$s" href="%2$s"></a>
+			</div>
+		',
+			$type,
+			$url
+		);
 	}
 }

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -239,7 +239,7 @@ function load_assets( $attr, $content ) {
 			</div>
 		',
 			esc_attr( $type ),
-			$url
+			esc_url( $url )
 		);
 	}
 }

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -15,7 +15,7 @@ use WP_Error;
 const FEATURE_NAME = 'pinterest';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 const URL_PATTERN  = '#^https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.[a-z.]+/pin/(?P<pin_id>[^/]+)/?#i'; // Taken from AMP plugin, originally from Jetpack.
-// This is the validate Pinterest URLs, converted from URL_REGEX in wp-content/mu-plugins/jetpack/extensions/blocks/pinterest/index.js.
+// This is the validate Pinterest URLs, converted from URL_REGEX in extensions/blocks/pinterest/index.js.
 const PINTEREST_URL_REGEX = '/^https?:\/\/(?:www\.)?(?:[a-z]{2\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^\/]+)(\/[^\/]+)?/i';
 // This looks for matches in /foo/ of https://www.pinterest.ca/foo/.
 const REMAINING_URL_PATH_REGEX = '/^\/([^\/]+)\/?$/';

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -238,7 +238,7 @@ function load_assets( $attr, $content ) {
 				<a data-pin-do="%1$s" href="%2$s"></a>
 			</div>
 		',
-			$type,
+			esc_attr( $type ),
 			$url
 		);
 	}

--- a/extensions/blocks/pinterest/save.js
+++ b/extensions/blocks/pinterest/save.js
@@ -1,0 +1,4 @@
+export default function Save( { attributes } ) {
+	const { url } = attributes;
+	return <a href={ url }>{ url }</a>;
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/46539

#### Changes proposed in this Pull Request:
The Pinterest block does not render any content in the Notifications view, Reader view, or on an email.

These changes assign a fallback, in the event that this block appears in a notification, email,  or reader, so that the user sees a link to the content.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Apply this patch to your sandbox `arc patch D52023` and sandbox the API.
- Disable the block fallbacks cache by adding `define( 'BLOCK_FALLBACKS_DEBUG', true );` to your `/wp-content/mu-plugins/0-sandbox.php` file.
- You can either do this on your own sandboxed site or [Spin up a JN site running `master`](https://jurassic.ninja/create/?jetpack-beta).
- Set up Jetpack and purchase any paid plan.
- Go to WP Admin > Posts > Add new.
- Insert a Pinterest block and embed a URL.
- Publish the post.
- Go to WP Admin > Jetpack > Jetpack Beta.
- Switch to the branch of this PR (`fix/pinterest-block-fallback`).
- Visit the frontend of the post you published before.
- Make sure there are no regressions in the Pinterest block.
- Go to WP Admin > Posts.
- Edit the post you published before.
- Make sure there are no regressions in the Pinterest block.
- Open the "More" menu and activate the "Code editor" view.
- Make sure the HTML markup is the fallback output (just the URL).
- Switch back to the "Visual editor" view.
- Click on the "Update" button.
- Visit the frontend of the post.
- Make sure the UI is displayed with the embedded Pinterest blocks.

Only testable via Wordpress.com

Notifications
* See the"Creating post notification" section in the README at https://github.com/Automattic/wp-calypso/blob/master/apps/notifications/src/doc/note-rendering.md
Use the "Follow" button that appears in the bottom right corner of the blog to add it to your Reader subscriptions:
* Then navigate to https://wordpress.com/following/manage and enable "Notify me of new posts" for the blog. With this enabled, future posts on that blog will appear as notifications in your masterbar.
* Create a post for the blog you're following with a Pinterest block. Embed a URL.
* Go to your masterbar and select the notification that contains the Pinterest block. Confirm the Pinterest block appears as a URL.

Email
* Run this script to send yourself an email of the post:
`php ./bin/subscriptions/send.php blog_id post post_id your.email@automattic.com`
* Replace blog_id and post_id and your.email@automattic.com with the site ID, the post ID, and your email address.
* You should get an email with the Pinterest block converted to a link.

Reader
- Go to https://wordpress.com/read and click on the post.
- The Pinterest block should appear as a link.

**Email**
<img width="612" alt="Screen Shot 2020-10-29 at 11 46 31 PM" src="https://user-images.githubusercontent.com/66652282/97657814-2754d700-1a41-11eb-98f1-8e2147fdd099.png">


**Notifications**
<img width="403" alt="Screen Shot 2020-10-29 at 11 46 52 PM" src="https://user-images.githubusercontent.com/66652282/97657827-3176d580-1a41-11eb-9859-2244d669a76f.png">

**Reader**
<img width="746" alt="Screen Shot 2020-10-29 at 11 47 04 PM" src="https://user-images.githubusercontent.com/66652282/97657830-35a2f300-1a41-11eb-87fa-0698d1240d20.png">


**Post**
<img width="874" alt="Screen Shot 2020-10-29 at 11 46 42 PM" src="https://user-images.githubusercontent.com/66652282/97657823-2d4ab800-1a41-11eb-9f37-c3a0d1848871.png">


#### Proposed changelog entry for your changes:
Emails and Notifications: Pinterest Block Fallback
