### PR TITLE
Unit Tests: look for global PHPUnit installation in 2  places

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ git:
 
 before_script:
   - export PLUGIN_SLUG=$(basename $(pwd))
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - export PATH="$HOME/.config/composer/vendor/bin:$HOME/.composer/vendor/bin:$PATH"
   - ./tests/setup-travis.sh
 
 script: ./tests/run-travis.sh


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In some scenarios, composer is set in `$HOME/.config/composer/` instead of `$HOME/.composer/

Internal discussion: p1603706416114500-slack-CBG1CP4EN

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Do all the tests pass?

#### Proposed changelog entry for your changes:

* N/A
