### PR TITLE
Alignment of comment_status_to_approval_value function. 

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -328,19 +328,21 @@ class Replicastore implements Replicastore_Interface {
 	 * @return string|bool New comment_approved value, false if the status doesn't affect it.
 	 */
 	private function comment_status_to_approval_value( $status ) {
-		switch ( $status ) {
+		switch ( (string) $status ) {
 			case 'approve':
+			case '1':
 				return '1';
 			case 'hold':
+			case '0':
 				return '0';
 			case 'spam':
 				return 'spam';
 			case 'trash':
 				return 'trash';
+			case 'post-trashed':
+				return 'post-trashed';
 			case 'any':
-				return false;
 			case 'all':
-				return false;
 			default:
 				return false;
 		}


### PR DESCRIPTION
Addition of post-trashed status and cleanup of cases.

#### Changes proposed in this Pull Request:
* N/A - Cleanup of technical debt.

#### Does this pull request change what data or activity we track or use?
- NO

#### Testing instructions:

* On Master run the following commands in shell
* `$store = new \Automattic\Jetpack\Sync\Replicastore();`
* `$store->comment_count( 'approve' );
* record this return value.
* Apply this PR / checkout branch
* Run the same commands in shell
* Verify the return is consistent.

* Add a new Post
* Add several comments to the new Post
* Trash the new Post
* Execute $store->comment_count( 'post-trashed' );
* Verify it returns count of posts with 'post-trashed' status

#### Proposed changelog entry for your changes:
* Jetpack Sync : Update of Replicastore functions with enhancements from WordPress.com implementation.
