### PR TITLE
Alignment of delete_batch_metadata function

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -706,8 +706,6 @@ class Replicastore implements Replicastore_Interface {
 	 *
 	 * @access public
 	 *
-	 * @todo Test this out to make sure it works as expected..
-	 *
 	 * @param string $type       Meta type.
 	 * @param array  $object_ids IDs of the objects.
 	 * @param string $meta_key   Meta key.
@@ -740,7 +738,7 @@ class Replicastore implements Replicastore_Interface {
 	 * @param int    $object_id ID of the object.
 	 * @return void
 	 */
-	private function reset_deleted_metadata_mapping( $type, $object_id ) {
+	protected function reset_deleted_metadata_mapping( $type, $object_id ) {
 		wp_cache_delete( $object_id, $type . '_meta' );
 	}
 


### PR DESCRIPTION
Addition of post-trashed status and cleanup of cases. Introduces a new reset_deleted_metadata_mapping that can be used by extending classes to have custom cache deletion logic.

#### Changes proposed in this Pull Request:
* N/A - Cleanup of technical debt.

#### Does this pull request change what data or activity we track or use?
- NO

#### Testing instructions:

* On Master perform the following:
* Create several new posts that have a meta entry for new key "my-key".
* Open wp shell and execute
* `$store = new \Automattic\Jetpack\Sync\Replicastore();`
* `$store->delete_batch_metadata('post', [ Post IDs ], "my-key");
* Verify the meta was removed.
* Apply this PR / checkout branch
* Repeat the same steps

#### Proposed changelog entry for your changes:
* Jetpack Sync : Update of Replicastore functions with enhancements from WordPress.com implementation.
