### PR TITLE
Upgrade URL: Set default to add current user to the redirect URL in the state selector.

### DIFF
--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -165,7 +165,7 @@ export function getUsername( state ) {
  * @returns {int} The user id in wp-admin
  */
 export function getUserId( state ) {
-	return get( state.jetpack.initialState.userData.currentUser, 'id' );
+	return get( state.jetpack.initialState.userData.currentUser, 'id', '' );
 }
 
 export function userCanViewStats( state ) {
@@ -339,7 +339,7 @@ export const getUpgradeUrl = ( state, source, userId = '', planDuration = false 
 	return (
 		`https://jetpack.com/redirect/?source=${ source }&site=${ getSiteRawUrl( state ) }` +
 		( affiliateCode ? `&aff=${ affiliateCode }` : '' ) +
-		( userId ? `&u=${ userId }` : '' ) +
+		( userId ? `&u=${ userId }` : getUserId( state ) ) +
 		( subsidiaryId ? `&subsidiaryId=${ subsidiaryId }` : '' )
 	);
 };

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -333,13 +333,15 @@ export function getPartnerSubsidiaryId( state ) {
 export const getUpgradeUrl = ( state, source, userId = '', planDuration = false ) => {
 	const affiliateCode = getAffiliateCode( state );
 	const subsidiaryId = getPartnerSubsidiaryId( state );
+	const uid = userId || getUserId( state );
 	if ( planDuration && 'monthly' === getPlanDuration( state ) ) {
 		source += '-monthly';
 	}
+
 	return (
 		`https://jetpack.com/redirect/?source=${ source }&site=${ getSiteRawUrl( state ) }` +
 		( affiliateCode ? `&aff=${ affiliateCode }` : '' ) +
-		( userId ? `&u=${ userId }` : getUserId( state ) ) +
+		( uid ? `&u=${ uid }` : '' ) +
 		( subsidiaryId ? `&subsidiaryId=${ subsidiaryId }` : '' )
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

It's not clear that a user_id needs to be added to the redirect parameter in order for it to be tracked. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Adds a default for the selector `getUpgradeUrl` that will fall back to whatever is set in the getUserId() state. Also updated the `getUserId` to default to an empty string, to match the pattern of what it's replacing. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Yes, see panfyZ-48-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, it will ensure that any usage of `getUpgradeUrl` within the react dashboard will carry a user_id along, and will get tracked on wpcom side unless they've opted out. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Connect
- Hover over this button:
![image](https://user-images.githubusercontent.com/7129409/97241763-76dc9e00-17c8-11eb-8ab6-d73f280493ba.png)

- You should see the redirect URL with the `u=` parameter defined. 
- If you click it, you should also see your tracks even get logged in the live feed. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A