### PR TITLE
Alignment of delete_term with implementations.

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -985,6 +985,7 @@ class Replicastore implements Replicastore_Interface {
 	 * @return bool|int|\WP_Error True on success, false if term doesn't exist. Zero if trying with default category. \WP_Error on invalid taxonomy.
 	 */
 	public function delete_term( $term_id, $taxonomy ) {
+		$this->ensure_taxonomy( $taxonomy );
 		return wp_delete_term( $term_id, $taxonomy );
 	}
 


### PR DESCRIPTION
Call ensure_taxonomy before delete to make sure Taxonomy has been initialized.

#### Changes proposed in this Pull Request:
* N/A - Cleanup of technical debt.

#### Does this pull request change what data or activity we track or use?
- NO

#### Testing instructions:

* Create a new Term
* On Master run the following commands in shell
* `$store = new \Automattic\Jetpack\Sync\Replicastore();`
* `$store->delete_term( $term_id, $taxonomy );
* Verify the term has been removed
* Apply this PR / checkout branch
* Repeat the above steps

#### Proposed changelog entry for your changes:
* Jetpack Sync : Update of Replicastore functions with enhancements from WordPress.com implementation.
