### PR TITLE
Additional documentation on get_constant return value

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -733,6 +733,8 @@ class Replicastore implements Replicastore_Interface {
 	/**
 	 * Retrieve value of a constant based on the constant name.
 	 *
+	 * We explicitly return null instead of false if the constant doesn't exist.
+	 *
 	 * @access public
 	 *
 	 * @param string $constant Name of constant to retrieve.


### PR DESCRIPTION
Addition dev note on the explicit return of null instead of false when constant not found.

#### Changes proposed in this Pull Request:
* Documentation


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
N/A


#### Proposed changelog entry for your changes:
* Jetpack Sync : Update of Replicastore functions with enhancements from WordPress.com implementation.
