### PR TITLE
Update get_term Replicastore function to handle term_taxonomy_id option

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -880,13 +880,13 @@ class Replicastore implements Replicastore_Interface {
 	 *
 	 * @param string $taxonomy   Taxonomy slug.
 	 * @param int    $term_id    ID of the term.
-	 * @param string $id_field   ID Field `term_id` or `term_taxonomy_id`.
+	 * @param string $term_key   ID Field `term_id` or `term_taxonomy_id`.
 	 * @return \WP_Term|\WP_Error Term object on success, \WP_Error object on failure.
 	 */
-	public function get_term( $taxonomy, $term_id, $id_field = 'term_id' ) {
+	public function get_term( $taxonomy, $term_id, $term_key = 'term_id' ) {
 
 		// Full Sync will pass false for the $taxonomy so a check for term_taxonomy_id is needed before ensure_taxonomy.
-		if ( 'term_taxonomy_id' === $id_field ) {
+		if ( 'term_taxonomy_id' === $term_key ) {
 			return get_term_by( 'term_taxonomy_id', $term_id );
 		}
 

--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -878,12 +878,12 @@ class Replicastore implements Replicastore_Interface {
 	 *
 	 * @access public
 	 *
-	 * @param string $taxonomy   Taxonomy slug.
-	 * @param int    $term_id    ID of the term.
-	 * @param bool   $is_term_id Whether this is a `term_id` or a `term_taxonomy_id`.
+	 * @param string      $taxonomy   Taxonomy slug.
+	 * @param int         $term_id    ID of the term.
+	 * @param bool|string $is_term_id Whether this is a `term_id`, otherwise pass 'term_taxonomy_id'.
 	 * @return \WP_Term|\WP_Error Term object on success, \WP_Error object on failure.
 	 */
-	public function get_term( $taxonomy, $term_id, $is_term_id = true ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function get_term( $taxonomy, $term_id, $is_term_id = true ) {
 
 		// Full Sync will pass false for the $taxonomy so a check for term_taxonomy_id is needed before ensure_taxonomy.
 		if ( 'term_taxonomy_id' === $is_term_id ) {

--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -884,6 +884,12 @@ class Replicastore implements Replicastore_Interface {
 	 * @return \WP_Term|\WP_Error Term object on success, \WP_Error object on failure.
 	 */
 	public function get_term( $taxonomy, $term_id, $is_term_id = true ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+		// Full Sync will pass false for the $taxonomy so a check for term_taxonomy_id is needed before ensure_taxonomy.
+		if ( 'term_taxonomy_id' === $is_term_id ) {
+			return get_term_by( 'term_taxonomy_id', $term_id );
+		}
+
 		$t = $this->ensure_taxonomy( $taxonomy );
 		if ( ! $t || is_wp_error( $t ) ) {
 			return $t;

--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -878,15 +878,15 @@ class Replicastore implements Replicastore_Interface {
 	 *
 	 * @access public
 	 *
-	 * @param string      $taxonomy   Taxonomy slug.
-	 * @param int         $term_id    ID of the term.
-	 * @param bool|string $is_term_id Whether this is a `term_id`, otherwise pass 'term_taxonomy_id'.
+	 * @param string $taxonomy   Taxonomy slug.
+	 * @param int    $term_id    ID of the term.
+	 * @param string $id_field   ID Field `term_id` or `term_taxonomy_id`.
 	 * @return \WP_Term|\WP_Error Term object on success, \WP_Error object on failure.
 	 */
-	public function get_term( $taxonomy, $term_id, $is_term_id = true ) {
+	public function get_term( $taxonomy, $term_id, $id_field = 'term_id' ) {
 
 		// Full Sync will pass false for the $taxonomy so a check for term_taxonomy_id is needed before ensure_taxonomy.
-		if ( 'term_taxonomy_id' === $is_term_id ) {
+		if ( 'term_taxonomy_id' === $id_field ) {
 			return get_term_by( 'term_taxonomy_id', $term_id );
 		}
 

--- a/packages/sync/src/interface-replicastore.php
+++ b/packages/sync/src/interface-replicastore.php
@@ -416,9 +416,9 @@ interface Replicastore_Interface {
 	 *
 	 * @param string $taxonomy   Taxonomy slug.
 	 * @param int    $term_id    ID of the term.
-	 * @param string $id_field   ID Field `term_id` or `term_taxonomy_id`.
+	 * @param string $term_key   ID Field `term_id` or `term_taxonomy_id`.
 	 */
-	public function get_term( $taxonomy, $term_id, $id_field = 'term_id' );
+	public function get_term( $taxonomy, $term_id, $term_key = 'term_id' );
 
 	/**
 	 * Insert or update a term.

--- a/packages/sync/src/interface-replicastore.php
+++ b/packages/sync/src/interface-replicastore.php
@@ -416,9 +416,9 @@ interface Replicastore_Interface {
 	 *
 	 * @param string $taxonomy   Taxonomy slug.
 	 * @param int    $term_id    ID of the term.
-	 * @param bool   $is_term_id Whether this is a `term_id` or a `term_taxonomy_id`.
+	 * @param string $id_field   ID Field `term_id` or `term_taxonomy_id`.
 	 */
-	public function get_term( $taxonomy, $term_id, $is_term_id = true );
+	public function get_term( $taxonomy, $term_id, $id_field = 'term_id' );
 
 	/**
 	 * Insert or update a term.


### PR DESCRIPTION
During a Full Sync the taxonomy is not available and causes ensure_taxonomy to fail. This update makes a call to get_term_by when term_taxonomy_id is provided during Full Syncs.

#### Changes proposed in this Pull Request:
* N/A - Cleanup of technical debt.

#### Does this pull request change what data or activity we track or use?
* NO

#### Testing instructions:

* Obtain the term_taxonomy_id for a term on your site
* $store = new \Automattic\Jetpack\Sync\Replicastore();
* `$store->get_term( null, $term_taxonomy_id, "term_taxonomy_id" );
* Verify term is returned.

#### Proposed changelog entry for your changes:
* Jetpack Sync : Update of Replicastore functions with enhancements from WordPress.com implementation.
