### PR TITLE
Pay with PayPal: Fix currencies lib loading

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -290,7 +290,7 @@ class Jetpack_Simple_Payments {
 	 * @return string           Formatted price.
 	 */
 	private function format_price( $price, $currency ) {
-		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-currencies.php';
+		jetpack_require_lib( 'class-jetpack-currencies' );
 		return Jetpack_Currencies::format_price( $price, $currency );
 	}
 
@@ -553,7 +553,7 @@ class Jetpack_Simple_Payments {
 	 * @return ?array               Currency object or null if not found.
 	 */
 	private static function get_currency( $the_currency ) {
-		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-currencies.php';
+		jetpack_require_lib( 'class-jetpack-currencies' );
 		$currencies = Jetpack_Currencies::CURRENCIES;
 
 		if ( isset( $currencies[ $the_currency ] ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
In https://github.com/Automattic/jetpack/pull/17381 I moved the new `Jetpack_Currencies` class from the root of Jetpack to `_inc/lib` but forgot to load it correctly using `jetpack_require_lib` when rendering a `simple-payment` shortcode. This PR ensures the lib is loaded as expected.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* [Spin a JN site running this branch](https://jurassic.ninja/create/?jetpack-beta&branch=fix/pay-with-paypal-require-lib).
* Set up Jetpack and purchase any paid plan.
* Go to WP Admin > Posts > Add new.
* Insert a Pay with PayPal block and fill it with data.
* Switch to the code editor in order to grab the ID of the internal `simple-payment` object created.
<img width="990" alt="Screen Shot 2020-10-27 at 12 55 32" src="https://user-images.githubusercontent.com/1233880/97299517-5870b400-1855-11eb-93f0-08d040606e6c.png">

* Switch back to the visual editor and insert a Shortcode block.
* Enter `[simple-payment id=<ID>]`.
<img width="649" alt="Screen Shot 2020-10-27 at 13 07 32" src="https://user-images.githubusercontent.com/1233880/97299554-64f50c80-1855-11eb-973f-c597a1ba18c6.png">

* Publish the post.
* Make sure the post is published successfully.
* Visit the published post.
* Make sure the shortcode is rendered successfully.


#### Proposed changelog entry for your changes:
N/A.
