### PR TITLE
Edit Post API: Restores the post comments when untrashing a post.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -301,6 +301,16 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			if ( 'publish' === $new_status && 'draft' === $last_status && ! isset( $input['date_gmt'] ) && $date_in_past ) {
 				$input['date_gmt'] = gmdate( 'Y-m-d H:i:s' );
 			}
+
+			// Untrash a post so that the proper hooks get called as well as the comments get untrashed.
+			if ( 'trash' === $last_status && 'trash' !== $new_status && isset( $post->ID ) ) {
+				wp_untrash_post( $post->ID );
+				$untashed_post = get_post( $post->ID );
+				// Lets make sure that we use the revert the slug.
+				if ( isset( $untashed_post->post_name ) && $untashed_post->post_name . '__trashed' === $input['slug'] ) {
+					unset( $input['slug'] );
+				}
+			}
 		}
 
 		if ( function_exists( 'wpcom_switch_to_locale' ) ) {

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -329,6 +329,11 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 			if ( $reset_draft_date || $reset_scheduled_date ) {
 				$input['date_gmt'] = gmdate( 'Y-m-d H:i:s' );
 			}
+
+			// Untrash a post so that the proper hooks get called as well as the comments get untrashed.
+			if ( $this->should_untrash_post( $last_status, $new_status, $post ) ) {
+				$input = $this->untrash_post( $post, $input );
+			}
 		}
 
 		if ( function_exists( 'wpcom_switch_to_blog_locale' ) ) {
@@ -990,6 +995,20 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 			return new WP_Error( 'invalid_author', 'Invalid author provided' );
 
 		return $_user->ID;
+	}
+
+	protected function should_untrash_post( $last_status, $new_status, $post ) {
+		return 'trash' === $last_status && 'trash' !== $new_status && isset( $post->ID );
+	}
+
+	protected function untrash_post( $post, $input ) {
+		wp_untrash_post( $post->ID );
+		$untrashed_post = get_post( $post->ID );
+		// Lets make sure that we use the reverted the slug.
+		if ( isset( $untrashed_post->post_name ) && $untrashed_post->post_name . '__trashed' === $input['slug'] ) {
+			unset( $input['slug'] );
+		}
+		return $input;
 	}
 
 	protected function should_load_theme_functions( $post_id = null ) {

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -273,6 +273,11 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			if ( $reset_draft_date || $reset_scheduled_date ) {
 				$input['date_gmt'] = gmdate( 'Y-m-d H:i:s' );
 			}
+
+			// Untrash a post so that the proper hooks get called as well as the comments get untrashed.
+			if ( $this->should_untrash_post( $last_status, $new_status, $post ) ) {
+				$input = $this->untrash_post( $post, $input );
+			}
 		}
 
 		if ( function_exists( 'wpcom_switch_to_blog_locale' ) ) {

--- a/tests/php/json-api/test-class.json-api-update-post-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-update-post-endpoints.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Jetpack `sites/%s/posts/%d` endpoint unit tests.
+ *
+ * @package Jetpack
+ */
+
+require_jetpack_file( 'class.json-api-endpoints.php' );
+
+/**
+ * Jetpack `sites/%s/posts/%d` endpoint unit tests.
+ */
+class WP_Test_Json_Api_Update_Post_Endpoints extends WP_UnitTestCase {
+
+	/**
+	 * Inserts globals needed to initialize the endpoint.
+	 */
+	private function set_globals() {
+		$_SERVER['REQUEST_METHOD'] = 'Post';
+		$_SERVER['HTTP_HOST']      = '127.0.0.1';
+		$_SERVER['REQUEST_URI']    = '/';
+	}
+
+	/**
+	 * Prepare the environment for the test.
+	 */
+	public function setUp() {
+		global $blog_id;
+
+		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
+			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
+		}
+
+		parent::setUp();
+
+		$this->set_globals();
+
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
+	}
+
+	/**
+	 * Unit tests the should untrash post protected method.
+	 */
+	public function test_update_post_api_v1_1() {
+
+		$post_id  = $this->get_post();
+		$endpoint = $this->get_endpoint();
+
+		$post = get_post( $post_id );
+
+		$this->assertTrue( $this->invoke_method( $endpoint, 'should_untrash_post', array( 'trash', 'draft', $post ) ) );
+		$this->assertFalse( $this->invoke_method( $endpoint, 'should_untrash_post', array( 'publish', 'trash', $post ) ) );
+		$this->assertFalse( $this->invoke_method( $endpoint, 'should_untrash_post', array( 'publish', 'draft', $post ) ) );
+	}
+
+	/**
+	 * Unit tests the untrash post protected method.
+	 */
+	public function test_update_post_api_v1_1_untrash_post() {
+		$post_id  = $this->get_post();
+		$endpoint = $this->get_endpoint();
+
+		wp_trash_post( $post_id );
+		$post  = get_post( $post_id );
+		$input = array( 'slug' => 'hello__trashed' );
+
+		$updated_input = $this->invoke_method( $endpoint, 'untrash_post', array( $post, $input ) );
+		// Tests that we remove the slug id it contains the '__trashed' suffix.
+		$this->assertTrue( empty( $updated_input ) );
+	}
+
+	/**
+	 * Helper function that inserts a post.
+	 *
+	 * @return int|WP_Error
+	 */
+	private function get_post() {
+		return wp_insert_post(
+			array(
+				'post_title'   => 'hello',
+				'post_content' => 'world',
+				'post_status'  => 'publish',
+			)
+		);
+
+	}
+
+	/**
+	 * Helper function that returns the post endpoint object.
+	 *
+	 * @return WPCOM_JSON_API_Update_Post_v1_1_Endpoint
+	 */
+	private function get_endpoint() {
+		return new WPCOM_JSON_API_Update_Post_v1_1_Endpoint(
+			array(
+				'description'    => 'Edit a post.',
+				'group'          => 'posts',
+				'stat'           => 'posts:1:POST',
+				'new_version'    => '1.2',
+				'min_version'    => '1.1',
+				'max_version'    => '1.1',
+				'method'         => 'POST',
+				'path'           => '/sites/%s/posts/%d',
+				'path_labels'    => array(
+					'$site'    => '(int|string) Site ID or domain',
+					'$post_ID' => '(int) The post ID',
+				),
+
+				'request_format' => array(
+					'date'              => "(ISO 8601 datetime) The post's creation time.",
+					'title'             => '(HTML) The post title.',
+					'content'           => '(HTML) The post content.',
+					'excerpt'           => '(HTML) An optional post excerpt.',
+					'slug'              => '(string) The name (slug) for the post, used in URLs.',
+					'author'            => '(string) The username or ID for the user to assign the post to.',
+					'publicize'         => '(array|bool) True or false if the post be publicized to external services. An array of services if we only want to publicize to a select few. Defaults to true.',
+					'publicize_message' => '(string) Custom message to be publicized to external services.',
+					'status'            => array(
+						'publish' => 'Publish the post.',
+						'private' => 'Privately publish the post.',
+						'draft'   => 'Save the post as a draft.',
+						'future'  => 'Schedule the post (alias for publish; you must also set a future date).',
+						'pending' => 'Mark the post as pending editorial approval.',
+						'trash'   => 'Set the post as trashed.',
+					),
+					'sticky'            => array(
+						'false' => 'Post is not marked as sticky.',
+						'true'  => 'Stick the post to the front page.',
+					),
+					'password'          => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
+					'parent'            => "(int) The post ID of the new post's parent.",
+					'terms'             => '(object) Mapping of taxonomy to comma-separated list or array of terms (name or id)',
+					'categories'        => '(array|string) Comma-separated list or array of categories (name or id)',
+					'tags'              => '(array|string) Comma-separated list or array of tags (name or id)',
+					'format'            => array_merge( array( 'default' => 'Use default post format' ), get_post_format_strings() ),
+					'discussion'        => '(object) A hash containing one or more of the following boolean values, which default to the blog\'s discussion preferences: `comments_open`, `pings_open`',
+					'likes_enabled'     => '(bool) Should the post be open to likes?',
+					'menu_order'        => '(int) (Pages only) the order pages should appear in. Use 0 to maintain alphabetical order.',
+					'page_template'     => '(string) (Pages Only) The page template this page should use.',
+					'sharing_enabled'   => '(bool) Should sharing buttons show on this post?',
+					'featured_image'    => '(string) The post ID of an existing attachment to set as the featured image. Pass an empty string to delete the existing image.',
+					'media'             => '(media) An array of files to attach to the post. To upload media, the entire request should be multipart/form-data encoded. Multiple media items will be displayed in a gallery. Accepts  jpg, jpeg, png, gif, pdf, doc, ppt, odt, pptx, docx, pps, ppsx, xls, xlsx, key. Audio and Video may also be available. See <code>allowed_file_types</code> in the options resposne of the site endpoint. <br /><br /><strong>Example</strong>:<br />' .
+									"<code>curl \<br />--form 'title=Image' \<br />--form 'media[]=@/path/to/file.jpg' \<br />-H 'Authorization: BEARER your-token' \<br />'https://public-api.wordpress.com/rest/v1/sites/123/posts/new'</code>",
+					'media_urls'        => '(array) An array of URLs for images to attach to a post. Sideloads the media in for a post.',
+					'metadata'          => '(array) Array of metadata objects containing the following properties: `key` (metadata key), `id` (meta ID), `previous_value` (if set, the action will only occur for the provided previous value), `value` (the new value to set the meta to), `operation` (the operation to perform: `update` or `add`; defaults to `update`). All unprotected meta keys are available by default for read requests. Both unprotected and protected meta keys are available for authenticated requests with proper capabilities. Protected meta keys can be made available with the <code>rest_api_allowed_public_metadata</code> filter.',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Call protected/private method of a class.
+	 *
+	 * @param object $object    Instantiated object that we will run method on.
+	 * @param string $method_name Method name to call.
+	 * @param array  $parameters Array of parameters to pass into method.
+	 *
+	 * @return mixed Method return.
+	 */
+	public function invoke_method( &$object, $method_name, array $parameters = array() ) {
+		$reflection = new \ReflectionClass( get_class( $object ) );
+		$method     = $reflection->getMethod( $method_name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $object, $parameters );
+	}
+}

--- a/tests/php/json-api/test-class.json-api-update-post-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-update-post-endpoints.php
@@ -41,7 +41,7 @@ class WP_Test_Json_Api_Update_Post_Endpoints extends WP_UnitTestCase {
 	/**
 	 * Unit tests the should untrash post protected method.
 	 */
-	public function test_update_post_api_v1_1() {
+	public function test_should_untrash_post_method() {
 
 		$post_id  = $this->get_post();
 		$endpoint = $this->get_endpoint();
@@ -62,6 +62,7 @@ class WP_Test_Json_Api_Update_Post_Endpoints extends WP_UnitTestCase {
 
 		wp_trash_post( $post_id );
 		$post  = get_post( $post_id );
+		// hello is coming from the post title.
 		$input = array( 'slug' => 'hello__trashed' );
 
 		$updated_input = $this->invoke_method( $endpoint, 'untrash_post', array( $post, $input ) );


### PR DESCRIPTION
Summary:
Currently when you untrash a post (Set to Draft from the trash) using mobile apps. The posts comments get lots.

The apps uses the update post endpoint in order for that to happen. This process doesn't take the post though the 'untrash flow'. So we end up with missing comments.

See https://github.com/wordpress-mobile/WordPress-Android/issues/11026.

This PR tries to address this issue by update the post endpoint and setting running the wp_untrash_post() function if the post status goes from trashed to something else.

Test Plan:
- Sandbox and proxy the api. Use the iOS simulator to create a post. leave a comment on that post
- Trash the post. Restore the post using the UI in the simulator on iOS and Android.
- Notice that the comments appear as expected again.
- Notice that the post slug is set to what we expect it to be.

Do the tests pass as expected?
Run the test locally.
```
$ cd bin/tests/isolated/
$ phpunit --testsuite=post-2 --filter=test_restore_post_updates_status_to_publish_restores_comments
```

Reviewers: mattchowning, dekervit

Reviewed By: mattchowning, dekervit

Tags: #touches_jetpack_files

Differential Revision: D51446-code

This commit syncs r215923-wpcom.

We should make sure that it works as expected for jetpack sites by connecting a jetpack site to the mobile app. (Andorid) and making sure that when you trash a post that has comments and then untrash the post. The comments come back as expected. 

