### PR TITLE
Build: Prevent dev packages from being versioned / Composer 2 compat

### DIFF
--- a/bin/version-packages.sh
+++ b/bin/version-packages.sh
@@ -51,12 +51,12 @@ fi
 # Bail if no composer.json to check for.
 if [[ ! -f "$CURRENT_DIR/composer.json" ]]; then
     echo "EXITING: This script must be run from a directory with composer.json at it's root."
-    exit;
+    exit 1;
 fi
 
 if [[ $COMPOSER_VER == "1."* ]]; then
 	echo "EXITING: This script requires Composer 2.0.0+"
-	exit;
+	exit 1;
 fi
 
 # Get the list of package names to update.

--- a/bin/version-packages.sh
+++ b/bin/version-packages.sh
@@ -56,7 +56,8 @@ fi
 # Get the list of package names to update.
 # Works in accordance of `composer show`, and will only act on packages prefixed with `automattic/jetpack-`.
 # Using --self because it is agnostic to whether /vendor is populated.
-composer show --self |
+# Using --no-dev since we don't care about ensuring version of development packages.
+composer show --self --no-dev |
     while read -r LINE
     do
         # Only looks for packages labeled @dev

--- a/bin/version-packages.sh
+++ b/bin/version-packages.sh
@@ -57,7 +57,7 @@ fi
 # Works in accordance of `composer show`, and will only act on packages prefixed with `automattic/jetpack-`.
 # Using --self because it is agnostic to whether /vendor is populated.
 # --self displays all of the production requires, then "requires (dev)" followed by the dev requirements.
-# If we get to the `requires (dev)` line, we can flag to install with `--no dev`.
+# If we get to the `requires (dev)` line, we can flag to install with `--dev`.
 DEV='';
 composer show --self |
     while read -r LINE

--- a/bin/version-packages.sh
+++ b/bin/version-packages.sh
@@ -40,6 +40,7 @@ done
 CURRENT_DIR=$( pwd )
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 JETPACK_ROOT="$(dirname "$SCRIPT_DIR")"
+COMPOSER_VER="$( composer --version | cut -d" " -f3 )"
 
 # If we're only modifying a sub-package.
 if [[ ! -z $PACKAGE ]]; then
@@ -51,6 +52,11 @@ fi
 if [[ ! -f "$CURRENT_DIR/composer.json" ]]; then
     echo "EXITING: This script must be run from a directory with composer.json at it's root."
     exit;
+fi
+
+if [[ $COMPOSER_VER == "1."* ]]; then
+	echo "EXITING: This script requires Composer 2.0.0+"
+	exit;
 fi
 
 # Get the list of package names to update.

--- a/bin/version-packages.sh
+++ b/bin/version-packages.sh
@@ -56,17 +56,19 @@ fi
 # Get the list of package names to update.
 # Works in accordance of `composer show`, and will only act on packages prefixed with `automattic/jetpack-`.
 # Using --self because it is agnostic to whether /vendor is populated.
-# --self displays all of the production requires, then "requires (dev)" followed by the dev requirements. If we reach this point, we can finish.
+# --self displays all of the production requires, then "requires (dev)" followed by the dev requirements.
+# If we get to the `requires (dev)` line, we can flag to install with `--no dev`.
+DEV='';
 composer show --self |
     while read -r LINE
     do
+        if [[ $LINE == "requires (dev)" ]]; then
+            DEV='--dev'
+        fi
         # Only looks for packages labeled @dev
         if [[ $LINE == "automattic/jetpack-"*"@dev" ]]; then
             PACKAGE=$( echo $LINE | cut -d " " -f1 )
             echo "Updating $PACKAGE in $CURRENT_DIR/composer.json..."
-            composer require $PACKAGE $UPDATE
-        fi
-        if [[ $LINE == "requires (dev)" ]]; then
-            exit;
+            composer require $DEV $PACKAGE $UPDATE
         fi
     done

--- a/bin/version-packages.sh
+++ b/bin/version-packages.sh
@@ -40,7 +40,6 @@ done
 CURRENT_DIR=$( pwd )
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 JETPACK_ROOT="$(dirname "$SCRIPT_DIR")"
-COMPOSER_VER="$( composer --version | cut -d" " -f3 )"
 
 # If we're only modifying a sub-package.
 if [[ ! -z $PACKAGE ]]; then
@@ -54,7 +53,9 @@ if [[ ! -f "$CURRENT_DIR/composer.json" ]]; then
     exit 1;
 fi
 
-if [[ $COMPOSER_VER == "1."* ]]; then
+# composer show --no-dev is required for general usage, only in Composer 2+.
+composer show --no-dev > /dev/null 2>&1
+if [[ $? == 1 ]]; then
 	echo "EXITING: This script requires Composer 2.0.0+"
 	exit 1;
 fi

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
 	"repositories": [
 		{
 			"type": "path",
-			"url": "./packages/*"
+			"url": "./packages/*",
+			"canonical": false
 		}
 	],
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -54,8 +54,7 @@
 	"repositories": [
 		{
 			"type": "path",
-			"url": "./packages/*",
-			"canonical": false
+			"url": "./packages/*"
 		}
 	],
 	"autoload": {


### PR DESCRIPTION
The jetpack-codesniffer package is our first that is `require-dev` in Composer and our script to version packages for release branches assumed that all pacakges were going to be `require`.

This PR fixes by using Composer 2's new `composer show --no-dev` flag to only display `require` packages. Since this flag is not available in <2.0, this also adds a check for that.

Additionally, this PR sets our repo in composer.json as "non-canonical". In Composer 2.0, all repos are now consider canonical by default. Previously, it was reversed.

A "canonical repo" is one where, once a package is found in that repo, no other repos after that are checked. In our case, that meant our local file path was the *only* place Composer would look for versions of any our monorepo packages. Only if we didn't have the files locally would it use the packagist default. By setting canonical as false, since we prefer stable builds, it'll check our filepath, see no stable versions, then check Packagist for one.

#### Changes proposed in this Pull Request:
* Build command

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* `composer self-update 1.10.16`
* `bin/version-packages.sh --no-update` This should error.
* `composer self-update 2.0.2`
* `bin/version-packages.sh --no-update` This should work without including the jetpack-codesniffer package. (To confirm bug, try the same command on `master`.

#### Proposed changelog entry for your changes:
* n/a
