### PR TITLE
REST API: Add endpoint property for allowing fallback to blog token

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -132,37 +132,45 @@ abstract class WPCOM_JSON_API_Endpoint {
 	 */
 	public $require_rewind_auth = false;
 
+	/**
+	 * Whether this endpoint allows falling back to a blog token for making requests to remote Jetpack sites.
+	 *
+	 * @var bool
+	 */
+	public $allow_fallback_to_jetpack_blog_token = false;
+
 	function __construct( $args ) {
 		$defaults = array(
-			'in_testing'                 => false,
-			'allowed_if_flagged'         => false,
-			'allowed_if_red_flagged'     => false,
-			'allowed_if_deleted'         => false,
-			'description'                => '',
-			'group'                      => '',
-			'method'                     => 'GET',
-			'path'                       => '/',
-			'min_version'                => '0',
-			'max_version'                => WPCOM_JSON_API__CURRENT_VERSION,
-			'force'                      => '',
-			'deprecated'                 => false,
-			'new_version'                => WPCOM_JSON_API__CURRENT_VERSION,
-			'jp_disabled'                => false,
-			'path_labels'                => array(),
-			'request_format'             => array(),
-			'response_format'            => array(),
-			'query_parameters'           => array(),
-			'version'                    => 'v1',
-			'example_request'            => '',
-			'example_request_data'       => '',
-			'example_response'           => '',
-			'required_scope'             => '',
-			'pass_wpcom_user_details'    => false,
-			'custom_fields_filtering'    => false,
-			'allow_cross_origin_request' => false,
-			'allow_unauthorized_request' => false,
-			'allow_jetpack_site_auth'    => false,
-			'allow_upload_token_auth'    => false,
+			'in_testing'                           => false,
+			'allowed_if_flagged'                   => false,
+			'allowed_if_red_flagged'               => false,
+			'allowed_if_deleted'                   => false,
+			'description'                          => '',
+			'group'                                => '',
+			'method'                               => 'GET',
+			'path'                                 => '/',
+			'min_version'                          => '0',
+			'max_version'                          => WPCOM_JSON_API__CURRENT_VERSION,
+			'force'                                => '',
+			'deprecated'                           => false,
+			'new_version'                          => WPCOM_JSON_API__CURRENT_VERSION,
+			'jp_disabled'                          => false,
+			'path_labels'                          => array(),
+			'request_format'                       => array(),
+			'response_format'                      => array(),
+			'query_parameters'                     => array(),
+			'version'                              => 'v1',
+			'example_request'                      => '',
+			'example_request_data'                 => '',
+			'example_response'                     => '',
+			'required_scope'                       => '',
+			'pass_wpcom_user_details'              => false,
+			'custom_fields_filtering'              => false,
+			'allow_cross_origin_request'           => false,
+			'allow_unauthorized_request'           => false,
+			'allow_jetpack_site_auth'              => false,
+			'allow_upload_token_auth'              => false,
+			'allow_fallback_to_jetpack_blog_token' => false,
 		);
 
 		$args = wp_parse_args( $args, $defaults );
@@ -195,11 +203,12 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$this->pass_wpcom_user_details = $args['pass_wpcom_user_details'];
 		$this->custom_fields_filtering = (bool) $args['custom_fields_filtering'];
 
-		$this->allow_cross_origin_request = (bool) $args['allow_cross_origin_request'];
-		$this->allow_unauthorized_request = (bool) $args['allow_unauthorized_request'];
-		$this->allow_jetpack_site_auth    = (bool) $args['allow_jetpack_site_auth'];
-		$this->allow_upload_token_auth    = (bool) $args['allow_upload_token_auth'];
-		$this->require_rewind_auth        = isset( $args['require_rewind_auth'] ) ? (bool) $args['require_rewind_auth'] : false;
+		$this->allow_cross_origin_request           = (bool) $args['allow_cross_origin_request'];
+		$this->allow_unauthorized_request           = (bool) $args['allow_unauthorized_request'];
+		$this->allow_jetpack_site_auth              = (bool) $args['allow_jetpack_site_auth'];
+		$this->allow_upload_token_auth              = (bool) $args['allow_upload_token_auth'];
+		$this->allow_fallback_to_jetpack_blog_token = (bool) $args['allow_fallback_to_jetpack_blog_token'];
+		$this->require_rewind_auth                  = isset( $args['require_rewind_auth'] ) ? (bool) $args['require_rewind_auth'] : false;
 
 		$this->version = $args['version'];
 

--- a/json-endpoints/class.wpcom-json-api-get-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comment-endpoint.php
@@ -12,6 +12,8 @@ new WPCOM_JSON_API_Get_Comment_Endpoint( array(
 		'$comment_ID' => '(int) The comment ID'
 	),
 
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comments/147564'
 ) );
 

--- a/json-endpoints/class.wpcom-json-api-get-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-post-endpoint.php
@@ -13,6 +13,8 @@ new WPCOM_JSON_API_Get_Post_Endpoint( array(
 		'$post_ID' => '(int) The post ID',
 	),
 
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/posts/7'
 ) );
 
@@ -42,6 +44,8 @@ new WPCOM_JSON_API_Get_Post_Endpoint( array(
 		'$site'      => '(int|string) Site ID or domain',
 		'$post_slug' => '(string) The post slug (a.k.a. sanitized name)',
 	),
+
+	'allow_fallback_to_jetpack_blog_token' => true,
 
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/posts/slug:blogging-and-stuff',
 ) );

--- a/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
@@ -12,6 +12,9 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint( array(
 		'$site'    => '(int|string) Site ID or domain',
 		'$post_ID' => '(int) The post ID',
 	),
+
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'example_request'  => 'https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/posts/7'
 ) );
 
@@ -27,6 +30,9 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint( array(
 		'$site'      => '(int|string) Site ID or domain',
 		'$post_slug' => '(string) The post slug (a.k.a. sanitized name)',
 	),
+
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/posts/slug:blogging-and-stuff',
 ) );
 

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -13,6 +13,9 @@ new WPCOM_JSON_API_GET_Site_Endpoint( array(
 		'$site' => '(int|string) Site ID or domain',
 	),
 	'allow_jetpack_site_auth' => true,
+
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'query_parameters' => array(
 		'context' => false,
 		'options' => '(string) Optional. Returns specified options only. Comma-separated list. Example: options=login_url,timezone',
@@ -728,6 +731,8 @@ new WPCOM_JSON_API_List_Post_Formats_Endpoint( array(
 	'query_parameters' => array(
 		'context' => false,
 	),
+
+	'allow_fallback_to_jetpack_blog_token' => true,
 
 	'response_format' => array(
 		'formats' => '(object) An object of supported post formats, each key a supported format slug mapped to its display string.',

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -12,6 +12,8 @@ new WPCOM_JSON_API_GET_Site_V1_2_Endpoint( array(
 		'$site' => '(int|string) Site ID or domain',
 	),
 
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'query_parameters' => array(
 		'context' => false,
 	),

--- a/json-endpoints/class.wpcom-json-api-get-taxonomies-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-taxonomies-endpoint.php
@@ -27,6 +27,9 @@ new WPCOM_JSON_API_Get_Taxonomies_Endpoint( array(
 		'found'      => '(int) The number of categories returned.',
 		'categories' => '(array) Array of category objects.',
 	),
+
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/categories/?number=5'
 ) );
 
@@ -53,6 +56,9 @@ new WPCOM_JSON_API_Get_Taxonomies_Endpoint( array(
 			'count' => 'Order by the number of posts in each tag.',
 		),
 	),
+
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'response_format' => array(
 		'found'    => '(int) The number of tags returned.',
 		'tags'     => '(array) Array of tag objects.',

--- a/json-endpoints/class.wpcom-json-api-get-taxonomy-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-taxonomy-endpoint.php
@@ -12,6 +12,8 @@ new WPCOM_JSON_API_Get_Taxonomy_Endpoint( array(
 		'$category' => '(string) The category slug'
 	),
 
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/categories/slug:community'
 ) );
 
@@ -26,6 +28,8 @@ new WPCOM_JSON_API_Get_Taxonomy_Endpoint( array(
 		'$site' => '(int|string) Site ID or domain',
 		'$tag'  => '(string) The tag slug'
 	),
+
+	'allow_fallback_to_jetpack_blog_token' => true,
 
 	'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/tags/slug:wordpresscom'
 ) );

--- a/json-endpoints/class.wpcom-json-api-get-term-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-term-endpoint.php
@@ -19,7 +19,10 @@ new WPCOM_JSON_API_Get_Term_Endpoint( array(
 		'post_count'  => '(int) The number of posts using this term.',
 		'parent'      => '(int) The parent ID for the term, if hierarchical.',
 	),
-	'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/taxonomies/post_tag/terms/slug:wordpresscom'
+
+	'allow_fallback_to_jetpack_blog_token' => true,
+
+	'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/taxonomies/post_tag/terms/slug:wordpresscom',
 ) );
 
 class WPCOM_JSON_API_Get_Term_Endpoint extends WPCOM_JSON_API_Endpoint {
@@ -35,7 +38,7 @@ class WPCOM_JSON_API_Get_Term_Endpoint extends WPCOM_JSON_API_Endpoint {
 		}
 
 		$taxonomy_meta = get_taxonomy( $taxonomy );
-		if ( false === $taxonomy_meta || ( ! $taxonomy_meta->public && 
+		if ( false === $taxonomy_meta || ( ! $taxonomy_meta->public &&
 				! current_user_can( $taxonomy_meta->cap->assign_terms ) ) ) {
 			return new WP_Error( 'invalid_taxonomy', 'The taxonomy does not exist', 400 );
 		}

--- a/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -72,7 +72,9 @@ new WPCOM_JSON_API_List_Comments_Endpoint( array(
 		'$site' => '(int|string) Site ID or domain',
 	),
 
-	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comments/?number=2'
+	'allow_fallback_to_jetpack_blog_token' => true,
+
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comments/?number=2',
 ) );
 
 new WPCOM_JSON_API_List_Comments_Endpoint( array(
@@ -87,7 +89,9 @@ new WPCOM_JSON_API_List_Comments_Endpoint( array(
 		'$post_ID' => '(int) The post ID',
 	),
 
-	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/posts/7/replies/?number=2'
+	'allow_fallback_to_jetpack_blog_token' => true,
+
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/posts/7/replies/?number=2',
 ) );
 
 // @todo permissions

--- a/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
@@ -11,6 +11,8 @@ new WPCOM_JSON_API_List_Post_Types_Endpoint( array (
 		'$site' => '(int|string) Site ID or domain',
 	),
 
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'query_parameters' => array(
 		'api_queryable' => '(bool) If true, only queryable post types are returned',
 	),

--- a/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
@@ -13,6 +13,8 @@ new WPCOM_JSON_API_List_Posts_Endpoint( array(
 		'$site' => '(int|string) Site ID or domain',
 	),
 
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'query_parameters' => array(
 		'number'   => '(int=20) The number of posts to return. Limit: 100.',
 		'offset'   => '(int=0) 0-indexed offset.',
@@ -235,7 +237,7 @@ class WPCOM_JSON_API_List_Posts_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			$query['tax_query'] = array();
 			foreach ( $args['term'] as $taxonomy => $slug ) {
 				$taxonomy_object = get_taxonomy( $taxonomy );
-				if ( false === $taxonomy_object || ( ! $taxonomy_object->public && 
+				if ( false === $taxonomy_object || ( ! $taxonomy_object->public &&
 						! current_user_can( $taxonomy_object->cap->assign_terms ) ) ) {
 					continue;
 				}
@@ -244,7 +246,7 @@ class WPCOM_JSON_API_List_Posts_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 					'taxonomy' => $taxonomy,
 					'field' => 'slug',
 					'terms' => explode( ',', $slug )
-				);				
+				);
 			}
 		}
 

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -15,6 +15,8 @@ new WPCOM_JSON_API_List_Posts_v1_1_Endpoint(
 			'$site' => '(int|string) Site ID or domain',
 		),
 
+		'allow_fallback_to_jetpack_blog_token' => true,
+
 		'query_parameters' => array(
 			'number'          => '(int=20) The number of posts to return. Limit: 100.',
 			'offset'          => '(int=0) 0-indexed offset.',

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -15,6 +15,8 @@ new WPCOM_JSON_API_List_Posts_v1_2_Endpoint(
 			'$site' => '(int|string) Site ID or domain',
 		),
 
+		'allow_fallback_to_jetpack_blog_token' => true,
+
 		'query_parameters' => array(
 			'number'                => '(int=20) The number of posts to return. Limit: 100.',
 			'offset'                => '(int=0) 0-indexed offset.',

--- a/json-endpoints/class.wpcom-json-api-list-terms-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-terms-endpoint.php
@@ -24,6 +24,9 @@ new WPCOM_JSON_API_List_Terms_Endpoint( array(
 			'count' => 'Order by the number of posts in each tag.',
 		),
 	),
+
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'response_format' => array(
 		'found' => '(int) The number of terms returned.',
 		'terms' => '(array) Array of tag objects.',
@@ -44,7 +47,7 @@ class WPCOM_JSON_API_List_Terms_Endpoint extends WPCOM_JSON_API_Endpoint {
 		}
 
 		$taxonomy_meta = get_taxonomy( $taxonomy );
-		if ( false === $taxonomy_meta || ( ! $taxonomy_meta->public && 
+		if ( false === $taxonomy_meta || ( ! $taxonomy_meta->public &&
 				! current_user_can( $taxonomy_meta->cap->assign_terms ) ) ) {
 			return new WP_Error( 'invalid_taxonomy', 'The taxonomy does not exist', 400 );
 		}

--- a/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -21,6 +21,8 @@ new WPCOM_JSON_API_Update_Comment_Endpoint( array(
 
 	'pass_wpcom_user_details' => true,
 
+	'allow_fallback_to_jetpack_blog_token' => true,
+
 	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/posts/843/replies/new/',
 	'example_request_data' =>  array(
 		'headers' => array(
@@ -51,6 +53,8 @@ new WPCOM_JSON_API_Update_Comment_Endpoint( array(
 	),
 
 	'pass_wpcom_user_details' => true,
+
+	'allow_fallback_to_jetpack_blog_token' => true,
 
 	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/comments/29/replies/new',
 	'example_request_data' => array(


### PR DESCRIPTION
This commit syncs r215949-wpcom.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a new endpoint property, `allow_fallback_to_jetpack_blog_token`, whether this endpoint allows falling back to a blog token for making requests to remote Jetpack sites.
* Update existing endpoints that should allow falling back to Jetpack blog token

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Yq-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
n/a

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a :: Hardening WPCOM REST API v1