### PR TITLE
Update get_terms to utilize ensure_taxonomy so that the Taxonomy is registered.

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -870,6 +870,10 @@ class Replicastore implements Replicastore_Interface {
 	 * @return array Array of terms.
 	 */
 	public function get_terms( $taxonomy ) {
+		$t = $this->ensure_taxonomy( $taxonomy );
+		if ( ! $t || is_wp_error( $t ) ) {
+			return $t;
+		}
 		return get_terms( $taxonomy );
 	}
 
@@ -951,7 +955,7 @@ class Replicastore implements Replicastore_Interface {
 			)
 		);
 		if ( ! $exists ) {
-			$term_object   = sanitize_term( clone( $term_object ), $taxonomy, 'db' );
+			$term_object   = sanitize_term( clone $term_object, $taxonomy, 'db' );
 			$term          = array(
 				'term_id'    => $term_object->term_id,
 				'name'       => $term_object->name,

--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -867,7 +867,7 @@ class Replicastore implements Replicastore_Interface {
 	 * @access public
 	 *
 	 * @param string $taxonomy Taxonomy slug.
-	 * @return array Array of terms.
+	 * @return array|\WP_Error Array of terms or WP_Error object on failure.
 	 */
 	public function get_terms( $taxonomy ) {
 		$t = $this->ensure_taxonomy( $taxonomy );


### PR DESCRIPTION
Alignment of ReplicaStore with WP.com implementation. A Replica Store can be hosted on another server that does not have access to the same themes/plugins. Therefore it is needed to call ensure_taxonomies so that the Taxonomy is registered before attempting to retrieve terms.

#### Changes proposed in this Pull Request:
N/A - Cleanup of technical debt.

#### Does this pull request change what data or activity we track or use?
NO

#### Testing instructions:
* $store = new \Automattic\Jetpack\Sync\Replicastore();
* $store->get_terms( $taxonomy_slug );
* Verify terms are returned.

#### Proposed changelog entry for your changes: 
* Jetpack Sync : Update of Replicastore functions with enhancements from WordPress.com implementation.
