### PR TITLE
Update update_object_terms to utilize ensure_taxonomy so that the Taxonomy is registered.

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -951,7 +951,7 @@ class Replicastore implements Replicastore_Interface {
 			)
 		);
 		if ( ! $exists ) {
-			$term_object   = sanitize_term( clone( $term_object ), $taxonomy, 'db' );
+			$term_object   = sanitize_term( clone $term_object, $taxonomy, 'db' );
 			$term          = array(
 				'term_id'    => $term_object->term_id,
 				'name'       => $term_object->name,
@@ -999,6 +999,7 @@ class Replicastore implements Replicastore_Interface {
 	 * @param bool             $append    Optional. If false will delete difference of terms. Default false.
 	 */
 	public function update_object_terms( $object_id, $taxonomy, $terms, $append ) {
+		$this->ensure_taxonomy( $taxonomy );
 		wp_set_object_terms( $object_id, $terms, $taxonomy, $append );
 	}
 


### PR DESCRIPTION
Alignment of ReplicaStore with WP.com implementation. A Replica Store can be hosted on another server that does not have access to the same themes/plugins. Therefore it is needed to call ensure_taxonomies so that the Taxonomy is registered before attempting to update object terms.

#### Changes proposed in this Pull Request:
* N/A - Cleanup of technical debt.

#### Does this pull request change what data or activity we track or use?
* NO

#### Testing instructions:
* N/A - local testing will always early return with ensure_taxonomy 

#### Proposed changelog entry for your changes:
* Jetpack Sync : Update of Replicastore functions with enhancements from WordPress.com implementation.
