### PR TITLE
Connection: Plugin Tracking

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -8,13 +8,13 @@
 namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Heartbeat;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
 use WP_Error;
 use WP_User;
-use Automattic\Jetpack\Heartbeat;
 
 /**
  * The Jetpack Connection Manager class that is used as a single gateway between WordPress.com
@@ -877,6 +877,7 @@ class Manager {
 				'jetpack_version'    => Constants::get_constant( 'JETPACK__VERSION' ),
 				'ABSPATH'            => Constants::get_constant( 'ABSPATH' ),
 				'current_user_email' => wp_get_current_user()->user_email,
+				'connect_plugin'     => $this->get_plugin() ? $this->get_plugin()->get_slug() : null,
 			)
 		);
 
@@ -1624,7 +1625,7 @@ class Manager {
 		 */
 		do_action( 'jetpack_verify_secrets_begin', $action, $user );
 
-		$return_error = function( \WP_Error $error ) use ( $action, $user ) {
+		$return_error = function ( \WP_Error $error ) use ( $action, $user ) {
 			/**
 			 * Verifying of the previously generated secret has failed.
 			 *

--- a/packages/connection/src/class-plugin.php
+++ b/packages/connection/src/class-plugin.php
@@ -41,6 +41,15 @@ class Plugin {
 	}
 
 	/**
+	 * Get the plugin slug.
+	 *
+	 * @return string
+	 */
+	public function get_slug() {
+		return $this->slug;
+	}
+
+	/**
 	 * Add the plugin connection info into Jetpack.
 	 *
 	 * @param string $name Plugin name, required.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When a plugin (e.g. Jetpack or WCPay) initiates a connection, we don't know the name of the plugin.
The slug of the plugin is now passed to WP.com during site registration.

#### Does this pull request change what data or activity we track or use?
We pass additional parameter into the registration API request - name of the plugin initiating the connection.

#### Testing instructions:
1. Disconnect your site, make sure that `blog_id` is clean.
2. Apply D51955-code and switch your site to the sandbox.
3. Connect Jetpack.
4. Check the Tracks Live to confirm that events `wpcom_jpc_register_begin` and `wpcom_jpc_register_success` have the `connect_plugin: jetpack` property.
5. Disconnect Jetpack, install WCPay.
6. Connect WCPay.
7. Confirm that the same events contain the property `connect_plugin: woocommerce-payments`.

#### Proposed changelog entry for your changes:
n/a