### PR TITLE
Slideshow Block: Fix Wide/Full Alignment

### DIFF
--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -8,6 +8,7 @@ import './shared/stripe-connection-notification';
 import './shared/external-media';
 import './extended-blocks/core-embed';
 import './extended-blocks/paid-blocks';
+import './shared/styles/slideshow-fix.scss';
 
 import analytics from '../_inc/client/lib/analytics';
 

--- a/extensions/shared/styles/slideshow-fix.scss
+++ b/extensions/shared/styles/slideshow-fix.scss
@@ -1,0 +1,9 @@
+// See https://github.com/WordPress/gutenberg/pull/26552
+// and https://github.com/Automattic/jetpack/issues/17616
+// for context.
+// Can be removed once Jetpack requires a WordPress version that
+// includes https://github.com/WordPress/gutenberg/pull/26552.
+
+.interface-interface-skeleton__editor {
+	max-width: 100%;
+}


### PR DESCRIPTION
Fixes #17616. Carried over from https://github.com/WordPress/gutenberg/pull/26552 so we have a short-term fix while waiting for that PR to land.

#### Changes proposed in this Pull Request:

Set `max-width` of `.interface-interface-skeleton__editor` to 100%, so that blocks cannot 

> exceed the editor boundaries and, when set to full width, gain a width of literally millions of pixels, making the editor unusable.

For more details, see https://github.com/WordPress/gutenberg/pull/26552.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Verify that #17616 is fixed.

#### Proposed changelog entry for your changes:
Set `max-width` of `.interface-interface-skeleton__editor` to 100% to fix wide/full alignment of Slideshow Block.