### PR TITLE
Danger Bot: use code freeze date provided in milestone description

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -117,12 +117,12 @@ function setReleaseDates() {
 			jetpackReleaseDate = moment( nextMilestone.due_on ).format( 'LL' );
 
 			// Look for a code freeze date in the milestone description.
-			const dateRegex = /\d{4}[/-]?(0?[1-9]|1[012])[/-]?(0?[1-9]|[12][0-9]|3[01])$/;
+			const dateRegex = /^Code Freeze: (\d{4}-\d{2}-\d{2})\s*$/m;
 			const freezeDateDescription = nextMilestone.description.match( dateRegex );
 
-			// If we have a date, use it, otherwise set code freeze to a week before the release.
-			if ( freezeDateDescription ) {
-				codeFreezeDate = moment( freezeDateDescription[ 0 ] ).format( 'LL' );
+			// If we have a date and it is valid, use it, otherwise set code freeze to a week before the release.
+			if ( freezeDateDescription && moment( freezeDateDescription[ 1 ] ).isValid() ) {
+				codeFreezeDate = moment( freezeDateDescription[ 1 ] ).format( 'LL' );
 			} else {
 				codeFreezeDate = moment( nextMilestone.due_on ).subtract( 7, 'd' ).format( 'LL' );
 			}

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -117,7 +117,7 @@ function setReleaseDates() {
 			jetpackReleaseDate = moment( nextMilestone.due_on ).format( 'LL' );
 
 			// Look for a code freeze date in the milestone description.
-			const dateRegex = /\d{4}[/-](0?[1-9]|1[012])[/-](0?[1-9]|[12][0-9]|3[01])$/;
+			const dateRegex = /\d{4}[/-]?(0?[1-9]|1[012])[/-]?(0?[1-9]|[12][0-9]|3[01])$/;
 			const freezeDateDescription = nextMilestone.description.match( dateRegex );
 
 			// If we have a date, use it, otherwise set code freeze to a week before the release.

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -115,7 +115,17 @@ function setReleaseDates() {
 
 		if ( nextMilestone ) {
 			jetpackReleaseDate = moment( nextMilestone.due_on ).format( 'LL' );
-			codeFreezeDate = moment( nextMilestone.due_on ).subtract( 7, 'd' ).format( 'LL' );
+
+			// Look for a code freeze date in the milestone description.
+			const dateRegex = /\d{4}[/-](0?[1-9]|1[012])[/-](0?[1-9]|[12][0-9]|3[01])$/;
+			const freezeDateDescription = nextMilestone.description.match( dateRegex );
+
+			// If we have a date, use it, otherwise set code freeze to a week before the release.
+			if ( freezeDateDescription ) {
+				codeFreezeDate = moment( freezeDateDescription[ 0 ] ).format( 'LL' );
+			} else {
+				codeFreezeDate = moment( nextMilestone.due_on ).subtract( 7, 'd' ).format( 'LL' );
+			}
 		} else {
 			// Fallback to raw math calculation
 			// Calculate next release date


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

We currently automatically set the code freeze date displayed in Danger Bot messages, 7 days prior to the milestone's due date.

This holds true for most of the year, but in some scenarios we deviate from this one-week beta period standard.

When that's the case, we can define a code freeze date in the milestone description (using ISO 8601), and we'll now try to pick this up with Danger.
If no date has been provided there, we'll fallback to the previous behaviour.

#### Jetpack product discussion

* p1603982867285900-slack-CBG1CP4EN?thread_ts=1603977448.274600&cid=CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* I've added the 9.1 milestone to this PR, so when Danger comes around, the code freeze should be set to October 26 instead of the default November 3.

#### Proposed changelog entry for your changes:

* N/A