### PR TITLE
Jetpack Menu: Use WP APIs to register menu items

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -16,16 +16,12 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 	function get_page_hook() {
 		// Add the main admin Jetpack menu
-		return add_menu_page( 'Jetpack', 'Jetpack', 'jetpack_admin_page', 'jetpack', array( $this, 'render' ), 'div' );
+		return add_menu_page( 'Jetpack', 'Jetpack', 'jetpack_admin_page', 'jetpack', array( $this, 'render' ), 'div', 3 );
 	}
 
 	function add_page_actions( $hook ) {
 		/** This action is documented in class.jetpack.php */
 		do_action( 'jetpack_admin_menu', $hook );
-
-		// Place the Jetpack menu item on top and others in the order they appear
-		add_filter( 'custom_menu_order',         '__return_true' );
-		add_filter( 'menu_order',                array( $this, 'jetpack_menu_order' ) );
 
 		if ( ! isset( $_GET['page'] ) || 'jetpack' !== $_GET['page'] ) {
 			return; // No need to handle the fallback redirection if we are not on the Jetpack page
@@ -54,8 +50,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 */
 	function jetpack_add_set_up_sub_nav_item() {
 		if ( $this->show_setup_wizard() ) {
-			global $submenu;
-			$submenu['jetpack'][] = array( __( 'Set up', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/setup' );
+			add_submenu_page( 'jetpack', __( 'Set up', 'jetpack' ), __( 'Set up', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/setup', '__return_null' );
 		}
 	}
 
@@ -68,10 +63,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 */
 	function jetpack_add_dashboard_sub_nav_item() {
 		if ( ( new Status() )->is_offline_mode() || Jetpack::is_active() ) {
-			global $submenu;
-			if ( current_user_can( 'jetpack_admin_page' ) ) {
-				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/dashboard' );
-			}
+			add_submenu_page( 'jetpack', __( 'Dashboard', 'jetpack' ), __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/dashboard', '__return_null' );
+			remove_submenu_page( 'jetpack', 'jetpack' );
 		}
 	}
 
@@ -81,9 +74,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	function jetpack_add_settings_sub_nav_item() {
-		if ( ( ( new Status() )->is_offline_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) && current_user_can( 'edit_posts' ) ) {
-			global $submenu;
-			$submenu['jetpack'][] = array( __( 'Settings', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/settings' );
+		if ( ( ( new Status() )->is_offline_mode() || Jetpack::is_active() ) && current_user_can( 'edit_posts' ) ) {
+			add_submenu_page( 'jetpack', __( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/settings', '__return_null' );
 		}
 	}
 
@@ -97,7 +89,16 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		echo '</noscript>';
 	}
 
+	/**
+	 * Custom menu order.
+	 *
+	 * @deprecated since 9.1.0
+	 * @param array $menu_order Menu order.
+	 * @return array
+	 */
 	function jetpack_menu_order( $menu_order ) {
+		_deprecated_function( __METHOD__, 'jetpack-9.1' );
+
 		$jp_menu_order = array();
 
 		foreach ( $menu_order as $index => $item ) {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -92,12 +92,12 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	/**
 	 * Custom menu order.
 	 *
-	 * @deprecated since 9.1.0
+	 * @deprecated since 9.2.0
 	 * @param array $menu_order Menu order.
 	 * @return array
 	 */
 	function jetpack_menu_order( $menu_order ) {
-		_deprecated_function( __METHOD__, 'jetpack-9.1' );
+		_deprecated_function( __METHOD__, 'jetpack-9.2' );
 
 		return $menu_order;
 	}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -99,17 +99,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	function jetpack_menu_order( $menu_order ) {
 		_deprecated_function( __METHOD__, 'jetpack-9.1' );
 
-		$jp_menu_order = array();
-
-		foreach ( $menu_order as $index => $item ) {
-			if ( $item != 'jetpack' )
-				$jp_menu_order[] = $item;
-
-			if ( $index == 0 )
-				$jp_menu_order[] = 'jetpack';
-		}
-
-		return $jp_menu_order;
+		return $menu_order;
 	}
 
 	function page_render() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

By appending a position number in the initial menu registration we should be able to avoid having to change the menu order. For the submenu items it turns out that defining a callback function will make WP add the action that the menu renderer relies on to build the correct admin URL.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a position value to top menu item registration.
* Remove menu order manipulation hooks.
* Deprecated menu order callback.
* Moves submenu registrations to using the menus API.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin and make sure menu items still show up and work as they're supposed to.
* Particularly with the Set Up menu item, I'm not sure how best to test this. Any hints?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Uses menus API to register menu items and removed custom menu ordering.
