### PR TITLE
Instant Search: change messaging for results loaded without a query

### DIFF
--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -17,6 +17,10 @@ import SearchForm from './search-form';
 import SearchResult from './search-result';
 import SearchSidebar from './search-sidebar';
 import { getConstrastingColor } from '../lib/colors';
+
+/**
+ * Style dependencies
+ */
 import './search-results.scss';
 
 class SearchResults extends Component {
@@ -27,11 +31,17 @@ class SearchResults extends Component {
 		const num = new Intl.NumberFormat().format( total );
 
 		if ( this.props.isLoading ) {
+			if ( ! hasQuery ) {
+				return __( 'Loading popular results…', 'jetpack' );
+			}
+
 			return sprintf( __( 'Searching…', 'jetpack' ), this.props.query );
 		}
+
 		if ( total === 0 || this.props.hasError ) {
 			return sprintf( __( 'No results found', 'jetpack' ), this.props.query );
 		}
+
 		if ( hasQuery && hasCorrectedQuery ) {
 			return sprintf(
 				_n( 'Found %s result for "%s"', 'Found %s results for "%s"', total, 'jetpack' ),
@@ -45,7 +55,8 @@ class SearchResults extends Component {
 				this.props.query
 			);
 		}
-		return sprintf( _n( 'Found %s result', 'Found %s results', total, 'jetpack' ), num );
+
+		return __( 'Showing popular results', 'jetpack' );
 	}
 
 	renderPrimarySection() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16868.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
If a user doesn't specify a search query in Instant Search, we load and display popular results instead. This has caused a bit of confusion, so this PR aims to improve the messaging to make it clear what we're displaying.

The original issue called for the 'Relevance' sort option to be renamed 'Popularity' when there's no query, but to me it feels odd to alter the label of the form control, so I tried to address it in the title instead. One other option would be to hide the sort selector altogether when there's no query. I'd welcome feedback on the choice I've made here.

<img width="789" alt="Screen Shot 2020-10-30 at 14 06 00" src="https://user-images.githubusercontent.com/17325/97648473-b7366780-1ab9-11eb-9e67-7e47321d2457.png">

<img width="515" alt="Screen Shot 2020-10-30 at 14 06 08" src="https://user-images.githubusercontent.com/17325/97648478-bbfb1b80-1ab9-11eb-84e1-3c9ef27703ec.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See #16868.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with Instant Search enabled, open the search overlay. It's easiest to use a theme with a search button like Twenty Twenty.
* Check that the loading message and 'showing' title describe the default results as "popular" as per the screenshots above.
* Make sure that you get the correct title and loading message when you enter a search query into the input.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Not required.
