### PR TITLE
Pinterest: Fix typo in Pinterest URL regex

### DIFF
--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -16,7 +16,7 @@ const FEATURE_NAME = 'pinterest';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 const URL_PATTERN  = '#^https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.[a-z.]+/pin/(?P<pin_id>[^/]+)/?#i'; // Taken from AMP plugin, originally from Jetpack.
 // This is the validate Pinterest URLs, converted from URL_REGEX in extensions/blocks/pinterest/index.js.
-const PINTEREST_URL_REGEX = '/^https?:\/\/(?:www\.)?(?:[a-z]{2\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^\/]+)(\/[^\/]+)?/i';
+const PINTEREST_URL_REGEX = '/^https?:\/\/(?:www\.)?(?:[a-z]{2}\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^\/]+)(\/[^\/]+)?/i';
 // This looks for matches in /foo/ of https://www.pinterest.ca/foo/.
 const REMAINING_URL_PATH_REGEX = '/^\/([^\/]+)\/?$/';
 // This looks for matches with /foo/bar/ of https://www.pinterest.ca/foo/bar/.

--- a/tests/php/extensions/blocks/test-class.pinterest.php
+++ b/tests/php/extensions/blocks/test-class.pinterest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Pinterest Block tests.
+ *
+ * @package Jetpack
+ */
+
+use Automattic\Jetpack\Extensions\Pinterest;
+require_once JETPACK__PLUGIN_DIR . '/extensions/blocks/pinterest/pinterest.php';
+
+/**
+ * Pinterest block tests.
+ */
+class WP_Test_Pinterest extends \WP_UnitTestCase {
+	/**
+	 * `pin_type` with null URL
+	 */
+	public function test_pin_type_with_null_url() {
+		$pin_type = Pinterest\pin_type( null );
+		$this->assertSame( '', $pin_type );
+	}
+
+	/**
+	 * `pin_type` with empty string URL
+	 */
+	public function test_pin_type_with_empty_url() {
+		$pin_type = Pinterest\pin_type( '' );
+		$this->assertSame( '', $pin_type );
+	}
+
+	/**
+	 * `pin_type` with invalid URL
+	 */
+	public function test_pin_type_with_invalid_url() {
+		$pin_type = Pinterest\pin_type( 'abcdefghijk' );
+		$this->assertSame( '', $pin_type );
+
+		$pin_type = Pinterest\pin_type( 'file://www.pinterest.com/pin/12345' );
+		$this->assertSame( '', $pin_type );
+	}
+
+	/**
+	 * `pin_type` with invalid subdomain to Pinterest URL
+	 */
+	public function test_pin_type_with_invalid_subdomain_url() {
+		$pin_type = Pinterest\pin_type( 'https://abc.pinterest.com/pin/12345' );
+		$this->assertSame( '', $pin_type );
+	}
+
+	/**
+	 * `pin_type` with invalid path in Pinterest URL
+	 */
+	public function test_pin_type_with_invalid_path() {
+		$pin_type = Pinterest\pin_type( 'https://www.pinterest.com/' );
+		$this->assertSame( '', $pin_type );
+	}
+
+	/**
+	 * `pin_type` with www subdomain to valid Pinterest URL
+	 */
+	public function test_pin_type_with_www_subdomain() {
+		$pin_type = Pinterest\pin_type( 'https://www.pinterest.com/pin/12345' );
+		$this->assertSame( 'embedPin', $pin_type );
+	}
+
+	/**
+	 * `pin_type` with locale subdomain to valid Pinterest URL
+	 */
+	public function test_pin_type_with_locale_subdomain() {
+		$pin_type = Pinterest\pin_type( 'https://in.pinterest.com/pin/12345' );
+		$this->assertSame( 'embedPin', $pin_type );
+	}
+
+	/**
+	 * `pin_type` with username in Pinterest URL
+	 */
+	public function test_pin_type_with_username_url() {
+		$pin_type = Pinterest\pin_type( 'https://www.pinterest.ca/foo/' );
+		$this->assertSame( 'embedUser', $pin_type );
+	}
+
+	/**
+	 * `pin_type` with username and board in Pinterest URL
+	 */
+	public function test_pin_type_with_username_and_board_url() {
+		$pin_type = Pinterest\pin_type( 'https://www.pinterest.ca/foo/bar/' );
+		$this->assertSame( 'embedBoard', $pin_type );
+	}
+}

--- a/tests/php/extensions/blocks/test-class.pinterest.php
+++ b/tests/php/extensions/blocks/test-class.pinterest.php
@@ -13,77 +13,69 @@ require_once JETPACK__PLUGIN_DIR . '/extensions/blocks/pinterest/pinterest.php';
  */
 class WP_Test_Pinterest extends \WP_UnitTestCase {
 	/**
-	 * `pin_type` with null URL
+	 * Test the Pin type detected for a given Pinterest URL.
+	 *
+	 * @covers Automattic\Jetpack\Extensions\Pinterest::pin_type
+	 * @dataProvider get_pinterest_urls
+	 *
+	 * @since 9.2.0
+	 *
+	 * @param null|string $url      Pinterest URL.
+	 * @param string      $expected Pinterest pin type.
 	 */
-	public function test_pin_type_with_null_url() {
-		$pin_type = Pinterest\pin_type( null );
-		$this->assertSame( '', $pin_type );
+	public function test_pin_type( $url, $expected ) {
+		$pin_type = Pinterest\pin_type( $url );
+
+		$this->assertSame( $expected, $pin_type );
 	}
 
 	/**
-	 * `pin_type` with empty string URL
+	 * URL variations to be used by the Pinterest block.
+	 *
+	 * @covers Automattic\Jetpack\Extensions\Pinterest::pin_type
 	 */
-	public function test_pin_type_with_empty_url() {
-		$pin_type = Pinterest\pin_type( '' );
-		$this->assertSame( '', $pin_type );
-	}
-
-	/**
-	 * `pin_type` with invalid URL
-	 */
-	public function test_pin_type_with_invalid_url() {
-		$pin_type = Pinterest\pin_type( 'abcdefghijk' );
-		$this->assertSame( '', $pin_type );
-
-		$pin_type = Pinterest\pin_type( 'file://www.pinterest.com/pin/12345' );
-		$this->assertSame( '', $pin_type );
-	}
-
-	/**
-	 * `pin_type` with invalid subdomain to Pinterest URL
-	 */
-	public function test_pin_type_with_invalid_subdomain_url() {
-		$pin_type = Pinterest\pin_type( 'https://abc.pinterest.com/pin/12345' );
-		$this->assertSame( '', $pin_type );
-	}
-
-	/**
-	 * `pin_type` with invalid path in Pinterest URL
-	 */
-	public function test_pin_type_with_invalid_path() {
-		$pin_type = Pinterest\pin_type( 'https://www.pinterest.com/' );
-		$this->assertSame( '', $pin_type );
-	}
-
-	/**
-	 * `pin_type` with www subdomain to valid Pinterest URL
-	 */
-	public function test_pin_type_with_www_subdomain() {
-		$pin_type = Pinterest\pin_type( 'https://www.pinterest.com/pin/12345' );
-		$this->assertSame( 'embedPin', $pin_type );
-	}
-
-	/**
-	 * `pin_type` with locale subdomain to valid Pinterest URL
-	 */
-	public function test_pin_type_with_locale_subdomain() {
-		$pin_type = Pinterest\pin_type( 'https://in.pinterest.com/pin/12345' );
-		$this->assertSame( 'embedPin', $pin_type );
-	}
-
-	/**
-	 * `pin_type` with username in Pinterest URL
-	 */
-	public function test_pin_type_with_username_url() {
-		$pin_type = Pinterest\pin_type( 'https://www.pinterest.ca/foo/' );
-		$this->assertSame( 'embedUser', $pin_type );
-	}
-
-	/**
-	 * `pin_type` with username and board in Pinterest URL
-	 */
-	public function test_pin_type_with_username_and_board_url() {
-		$pin_type = Pinterest\pin_type( 'https://www.pinterest.ca/foo/bar/' );
-		$this->assertSame( 'embedBoard', $pin_type );
+	public function get_pinterest_urls() {
+		return array(
+			'null_url'               => array(
+				null,
+				'',
+			),
+			'empty_url'              => array(
+				'',
+				'',
+			),
+			'invalid_url'            => array(
+				'abcdefghijk',
+				'',
+			),
+			'invalid_protocol'       => array(
+				'file://www.pinterest.com/pin/12345',
+				'',
+			),
+			'invalid_subdomain_url'  => array(
+				'https://abc.pinterest.com/pin/12345',
+				'',
+			),
+			'invalid_path'           => array(
+				'https://www.pinterest.com/',
+				'',
+			),
+			'www_subdomain'          => array(
+				'https://www.pinterest.com/pin/12345',
+				'embedPin',
+			),
+			'locale_subdomain'       => array(
+				'https://in.pinterest.com/pin/12345',
+				'embedPin',
+			),
+			'username_url'           => array(
+				'https://www.pinterest.ca/foo/',
+				'embedUser',
+			),
+			'username_and_board_url' => array(
+				'https://www.pinterest.ca/foo/bar/',
+				'embedBoard',
+			),
+		);
 	}
 }


### PR DESCRIPTION
Fixes: #17684
Fixes https://github.com/Automattic/wp-calypso/issues/46539

#### Changes proposed in this Pull Request:
* Fix typo in URL validation regex preventing rendering Pinterest block on frontend.

#### Does this pull request change what data or activity we track or use?
No changes.

#### Screenshots

| Before | After |
|--------|------|
| <img width="981" alt="Screen Shot 2020-11-02 at 3 17 34 pm" src="https://user-images.githubusercontent.com/60436221/97832507-b5211280-1d1e-11eb-9ca7-d4c431141319.png"> | <img width="982" alt="Screen Shot 2020-11-02 at 3 18 00 pm" src="https://user-images.githubusercontent.com/60436221/97832517-bb16f380-1d1e-11eb-9d15-8b9629309305.png"> |

#### Testing instructions:
1. Create a new post
2. Add Pinterest block with following URL: https://in.pinterest.com/pin/412220172147844842/
3. Save post
4. View post on frontend and confirm no Pinterest block is rendered
5. Apply this PR
6. Reload the post on the frontend and confirm the Pinterest block now displays
7. For bonus points, add additional Pinterest blocks using `www` or alternative locale subdomain based URLs and ensure correct display

#### Proposed changelog entry for your changes:
* Fix Pinterest URL validation bug preventing rendering on frontend
