### PR TITLE
Podcast Player: Render fallback link outside the frontend

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -74,10 +74,15 @@ function render_error( $message ) {
 /**
  * Podcast Player block registration/dependency declaration.
  *
- * @param array $attributes Array containing the Podcast Player block attributes.
+ * @param array  $attributes Array containing the Podcast Player block attributes.
+ * @param string $content    Fallback content - a direct link to RSS, as rendered by save.js.
  * @return string
  */
-function render_block( $attributes ) {
+function render_block( $attributes, $content ) {
+	// Don't render an interactive version of the block outside the frontend context.
+	if ( ! jetpack_is_frontend() ) {
+		return $content;
+	}
 
 	// Test for empty URLS.
 	if ( empty( $attributes['url'] ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When the block detects it runs outside the frontend, it renders the fallback content. The best example of the context outside frontend is the RSS feed - our player will never work there but we still rendered the full HTML of the player. This PR makes it just a hypertext link to the RSS, which was previously chosen and implemented as a fallback experience.

#### Jetpack product discussion
p9dueE-22u-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* publish a post with a configured podcast player
* load the `/feed/` of your site and you should see a full markup for the player
* apply this PR and reload the `/feed/`
* confirm the player markup is gone and all that's left is a link — `<a class="wp-block-jetpack-podcast-player jetpack-podcast-player__direct-link" href="…RSS…">…RSS…</a>`

#### Proposed changelog entry for your changes:
Not sure about an phrasing here, maybe we can also position it as a speed improvement as it prevents remote fetch of the RSS and rendering the markup in RSS? 

* Simplify the Podcast Player block output outside frontend (for example in RSS feeds)