### PR TITLE
Story block set inserter support to false for web, but keep it for native

### DIFF
--- a/extensions/blocks/story/index.js
+++ b/extensions/blocks/story/index.js
@@ -1,7 +1,8 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -57,7 +58,7 @@ export const settings = {
 	attributes,
 	supports: {
 		html: false,
-		inserter: false,
+		inserter: Platform.OS !== 'web', // false for web, true for mobile
 	},
 	icon: {
 		src: icon,


### PR DESCRIPTION
With this PR https://github.com/Automattic/jetpack/pull/17536/files the story block was hidden from the inserter altogether but we want it to be available on mobile behind a feature flag as per https://github.com/wordpress-mobile/gutenberg-mobile/pull/2762

This PR fixes that (which otherwise would make the Story block not available in the inserter for _all_  platforms), by making the `supports.inserter` flag `false` for the web, and `true` for native platforms.
