### PR TITLE
Update access of comment_status_to_approval_value to allow extension.

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -322,12 +322,12 @@ class Replicastore implements Replicastore_Interface {
 	/**
 	 * Translate a comment status to a value of the comment_approved field.
 	 *
-	 * @access private
+	 * @access protected
 	 *
 	 * @param string $status Comment status.
 	 * @return string|bool New comment_approved value, false if the status doesn't affect it.
 	 */
-	private function comment_status_to_approval_value( $status ) {
+	protected function comment_status_to_approval_value( $status ) {
 		switch ( (string) $status ) {
 			case 'approve':
 			case '1':


### PR DESCRIPTION
comment_status_to_approval_value is currently marked as private, it should be protected to allow overwriting if needed.

#### Changes proposed in this Pull Request:
* Update private to protected 


#### Does this pull request change what data or activity we track or use?
NO

#### Testing instructions:

* N/A

#### Proposed changelog entry for your changes:
* Jetpack Sync : Update of Replicastore functions with enhancements from WordPress.com implementation.
