### PR TITLE
Contact Form: Use the same default email and subject as the form block

### DIFF
--- a/extensions/blocks/contact-form/attributes.js
+++ b/extensions/blocks/contact-form/attributes.js
@@ -6,7 +6,6 @@ import { __ } from '@wordpress/i18n';
 export default {
 	subject: {
 		type: 'string',
-		default: __( 'A new message from your website', 'jetpack' ),
 	},
 	to: {
 		type: 'string',


### PR DESCRIPTION
Fixes #17534

#### Changes proposed in this Pull Request:
The form block currently displays the following default values:
* The site's admin email address as the default form submission email address.
* The phrase "A new message from your website" as the default form submission email subject.

The backend uses a different set of defaults:
* The post author's email address.
* "[_site title_] _post title_". as the email subject.

This results in confusing behavior for users. The form submissions are not sent to the expected email address, and the email's subject is not the expected subject. 

To fix this, change the email address and subject default values on the front end. The default email address should be the post author's email address, and the default subject should be "[_site title_] _post title_".

**NOTE:** The default subject is set when the form block it added, and it includes the current post title. The subject is not updated if the user changes the post title after the form block is added. I think this provides the most consistent behavior for the user.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Confirm that the changes do not change the behavior of existing contact forms.

1. Install the master branch of Jetpack.
2. Activate, and connect Jetpack.
3. Create a secondary admin user with an email address that is different than the site's admin email address.
4. While logged in as the secondary admin, create a post.
5. Add a title to the post.
6. Add a contact form to the post.
7. Do not change the form’s email address or subject.
8. Publish the post.
9. Navigate to the contact form post and submit a contact form message.
10. Note the destination address and subject line of the form submission email. They don't match the form block settings. We want to maintain the current behavior for existing forms, so note the actual address and subject of the form submission email.
11. Switch to this branch.
12. Navigate to the contact form post and submit a contact form message.
13. Verify that the destination address and subject line match those in step 10.
14. Navigate to the post editor for the contact form post. Select a form field in the editor, and then select the `Form` breadcrumb in the breadcrumb navigation bar at the bottom of the page to open the form block settings. The email address and subject should now match the actual destination address and subject of the form submission email.

##### Test the behavior of a newly created contact form.

1. While logged in as the secondary admin, create a post.
2. Add a title to the post.
3. Add a contact form to the post.
4. Confirm that the contact form submission email address is the post author's email address. Do not change it.
5. Confirm that the contact form submission subject is "[_site title_] _post title_". Do not change it.
6. Publish the post.
7. Navigate to the contact form post and submit a contact form message.
8. Confirm that the contact form submission email was sent to the post author's email address and that the subject is "[_site title_] _post title_".
9. Edit the post created in step 3. Change the submission email address and the subject.
10. Navigate to the contact form post and submit a message.
11. Confirm that the message was sent to the email address and with the subject used in Step 9.

#### Proposed changelog entry for your changes:
* Contact Form: displays the correct default email address and subject in the form block settings.
