### PR TITLE
Pinterest Block - Fix Regex for URL Embeds

### DIFF
--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -16,7 +16,7 @@ const FEATURE_NAME = 'pinterest';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 const URL_PATTERN  = '#^https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.[a-z.]+/pin/(?P<pin_id>[^/]+)/?#i'; // Taken from AMP plugin, originally from Jetpack.
 // This is the validate Pinterest URLs, converted from URL_REGEX in extensions/blocks/pinterest/index.js.
-const PINTEREST_URL_REGEX = '/^https?:\/\/(?:www\.)?(?:[a-z]{2\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^\/]+)(\/[^\/]+)?/i';
+const PINTEREST_URL_REGEX = '/^https?:\/\/(?:www\.)?(?:[a-z]{2}\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^\/]+)(\/[^\/]+)?/i';
 // This looks for matches in /foo/ of https://www.pinterest.ca/foo/.
 const REMAINING_URL_PATH_REGEX = '/^\/([^\/]+)\/?$/';
 // This looks for matches with /foo/bar/ of https://www.pinterest.ca/foo/bar/.


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/46539

#### Changes proposed in this Pull Request:
The Pinterest block does not render any content in the Notifications view, Reader view, or on an email for Pinterest URLs with a subdomain. For example: https://in.pinterest.com/pin/412220172147844842/. These changes fix the regex to allow for subdomains in the Pinterest URL.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Apply this patch to your sandbox `arc patch D52207` and sandbox the API.
- Disable the block fallbacks cache by adding `define( 'BLOCK_FALLBACKS_DEBUG', true );` to your `/wp-content/mu-plugins/0-sandbox.php` file.
- You can either do this on your own sandboxed site or [Spin up a JN site running `master`](https://jurassic.ninja/create/?jetpack-beta).
- Set up Jetpack and purchase any paid plan.
- Go to WP Admin > Posts > Add new.
- Insert a Pinterest block and embed a URL.
- Publish the post.
- Go to WP Admin > Jetpack > Jetpack Beta.
- Switch to the branch of this PR (`fix/pinterest-block-fallback`).
- Visit the frontend of the post you published before.
- Make sure there are no regressions in the Pinterest block.
- Go to WP Admin > Posts.
- Edit the post you published before.
- Make sure there are no regressions in the Pinterest block.
- Open the "More" menu and activate the "Code editor" view.
- Make sure the HTML markup is the fallback output (just the URL).
- Switch back to the "Visual editor" view.
- Click on the "Update" button.
- Visit the frontend of the post.
- Make sure the UI is displayed with the embedded Pinterest blocks.

Only testable via Wordpress.com

Notifications
* See the"Creating post notification" section in the README at https://github.com/Automattic/wp-calypso/blob/master/apps/notifications/src/doc/note-rendering.md
Use the "Follow" button that appears in the bottom right corner of the blog to add it to your Reader subscriptions:
* Then navigate to https://wordpress.com/following/manage and enable "Notify me of new posts" for the blog. With this enabled, future posts on that blog will appear as notifications in your masterbar.
* Create a post for the blog you're following with a Pinterest block. Embed a URL with a subdomain, like https://in.pinterest.com/pin/412220172147844842/
* Go to your masterbar and select the notification that contains the Pinterest block. Confirm the Pinterest block appears as a URL.

Email
* Run this script to send yourself an email of the post:
`php ./bin/subscriptions/send.php blog_id post post_id your.email@automattic.com`
* Replace blog_id and post_id and your.email@automattic.com with the site ID, the post ID, and your email address.
* You should get an email with the Pinterest block converted to a link.

Reader
- Go to https://wordpress.com/read and click on the post.
- The Pinterest block should appear as a link.

Screenshot of Regex Working
<img width="2279" alt="Screen Shot 2020-11-03 at 12 08 28 AM" src="https://user-images.githubusercontent.com/66652282/97951609-bbd47780-1d68-11eb-94d9-06b67dc1ef33.png">



#### Proposed changelog entry for your changes:
Emails and Notifications: Pinterest Block Regex Fix for URL Embeds