### PR TITLE
E2E Tests: Fix calypso plans page locators

### DIFF
--- a/tests/e2e/lib/pages/wpcom/pick-a-plan.js
+++ b/tests/e2e/lib/pages/wpcom/pick-a-plan.js
@@ -6,16 +6,14 @@ import { waitAndClick } from '../../page-helper';
 
 export default class PickAPlanPage extends Page {
 	constructor( page ) {
-		const expectedSelector = '.jetpack-product-card-alt .jetpack-product-card-alt__raw-price';
+		const expectedSelector = 'div[data-e2e-product-slug="jetpack_complete"]';
 		super( page, { expectedSelector, explicitWaitMS: 40000 } );
 	}
 
-	async select( product = 'free', type = 'daily' ) {
+	async select( product = 'free' ) {
 		switch ( product ) {
 			case 'complete':
 				return await this.selectComplete();
-			case 'security':
-				return await this.selectSecurity( type );
 			case 'free':
 			default:
 				return await this.selectFreePlan();
@@ -28,17 +26,8 @@ export default class PickAPlanPage extends Page {
 	}
 
 	async selectComplete() {
-		const buttonSelector = 'div[data-icon="jetpack_complete_v2"] .jetpack-product-card-alt__button';
+		const buttonSelector =
+			'div[data-e2e-product-slug="jetpack_complete"] [class*="summary"] button';
 		return await waitAndClick( this.page, buttonSelector );
-	}
-
-	async selectSecurity( type ) {
-		const buttonSelector = 'div[data-icon="jetpack_security_v2"] .jetpack-product-card-alt__button';
-		await waitAndClick( this.page, buttonSelector );
-
-		// We actually redirecting to new view, so lets wait for a expected selector here.
-		await this.waitForPage();
-		const securityTypeSelector = `[data-icon="jetpack_security_${ type }_v2"] .jetpack-product-card-alt__button`;
-		return await waitAndClick( this.page, securityTypeSelector );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/pull/47015
cc @monsieur-z 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* update locators for a Calypso pricing page

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the E2E tests in GH actions are green now
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a