### PR TITLE
Instagram: introduce new function to clean up URL and params

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -207,16 +207,16 @@ function jetpack_instagram_get_allowed_parameters( $url, $atts = array() ) {
 	return $params;
 }
 
-	/**
-	 * Add auth token required by Instagram's oEmbed REST API, or proxy through WP.com.
-	 *
-	 * @since 9.1.0
-	 *
-	 * @param string $provider URL of the oEmbed provider.
-	 * @param string $url      URL of the content to be embedded.
-	 *
-	 * @return string
-	 */
+/**
+ * Add auth token required by Instagram's oEmbed REST API, or proxy through WP.com.
+ *
+ * @since 9.1.0
+ *
+ * @param string $provider URL of the oEmbed provider.
+ * @param string $url      URL of the content to be embedded.
+ *
+ * @return string
+ */
 function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
 	if ( ! wp_startswith( $provider, 'https://graph.facebook.com/v5.0/instagram_oembed/' ) ) {
 		return $provider;
@@ -259,12 +259,12 @@ function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
 	return str_replace( 'https://graph.facebook.com/v5.0/instagram_oembed/', $wpcom_oembed_proxy, $provider );
 }
 
-	/**
-	 * Add JP auth headers if we're proxying through WP.com.
-	 *
-	 * @param array  $args oEmbed remote get arguments.
-	 * @param string $url  URL to be inspected.
-	 */
+/**
+ * Add JP auth headers if we're proxying through WP.com.
+ *
+ * @param array  $args oEmbed remote get arguments.
+ * @param string $url  URL to be inspected.
+ */
 function jetpack_instagram_oembed_remote_get_args( $args, $url ) {
 	if ( ! wp_startswith( $url, Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ) . '/wpcom/v2/oembed-proxy/instagram/' ) ) {
 		return $args;
@@ -278,11 +278,11 @@ function jetpack_instagram_oembed_remote_get_args( $args, $url ) {
 	return $signed_request['request'];
 }
 
-	/**
-	 * Fetches a Facebook API access token used for query for Instagram embed information, if one is set.
-	 *
-	 * @return string The access token or ''
-	 */
+/**
+ * Fetches a Facebook API access token used for query for Instagram embed information, if one is set.
+ *
+ * @return string The access token or ''
+ */
 function jetpack_instagram_get_access_token() {
 	/**
 	 * Filters the Instagram embed token that is used for querying the Facebook API.
@@ -299,11 +299,11 @@ function jetpack_instagram_get_access_token() {
 	return (string) apply_filters( 'jetpack_instagram_embed_token', (string) Constants::get_constant( 'JETPACK_INSTAGRAM_EMBED_TOKEN' ) );
 }
 
-	/**
-	 * Display the Instagram shortcode.
-	 *
-	 * @param array $atts Shortcode attributes.
-	 */
+/**
+ * Display the Instagram shortcode.
+ *
+ * @param array $atts Shortcode attributes.
+ */
 function jetpack_shortcode_instagram( $atts ) {
 	global $wp_embed;
 

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -163,7 +163,7 @@ function jetpack_instagram_get_allowed_parameters( $url, $atts = array() ) {
 	 * embeds does not like query parameters. See p7H4VZ-2DU-p2.
 	 */
 	$parsed_url = wp_parse_url( $url );
-	if ( $parsed_url ) {
+	if ( $parsed_url && isset( $parsed_url['host'] ) && isset( $parsed_url['path'] ) ) {
 		// Bail early if this is not an Instagram URL.
 		if ( ! preg_match( '/instagr(\.am|am\.com)/', $parsed_url['host'] ) ) {
 			return array();

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -214,24 +214,22 @@ function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
 		return $provider;
 	}
 
-	// Attempt to clean query params from the URL.
-	$parsed_url = wp_parse_url( $url );
-	if ( $parsed_url ) {
-		// Get a set of URL and parameters supported by Facebook.
-		$clean_parameters = jetpack_instagram_get_whitelisted_parameters( $url );
+	// Get a set of URL and parameters supported by Facebook.
+	$clean_parameters = jetpack_instagram_get_whitelisted_parameters( $url );
 
-		$base_url = $clean_parameters['url'];
-		unset( $clean_parameters['url'] );
-
-		// Create a clean URL with only supported parameters.
-		$clean_url = add_query_arg(
-			$clean_parameters,
-			$base_url
-		);
-
+	if ( ! empty( $clean_parameters['url'] ) ) {
 		// Replace existing URL by our clean version.
 		$provider_without_url = remove_query_arg( 'url', $provider );
-		$provider             = add_query_arg( 'url', rawurlencode( $clean_url ), $provider_without_url );
+		$provider             = add_query_arg( 'url', rawurlencode( $clean_parameters['url'] ), $provider_without_url );
+	}
+
+	// Our shortcode supports the width param, but the API expects maxwidth.
+	if ( ! empty( $clean_parameters['width'] ) ) {
+		$provider = add_query_arg( 'maxwidth', $clean_parameters['width'], $provider );
+	}
+
+	if ( ! empty( $clean_parameters['hidecaption'] ) ) {
+		$provider = add_query_arg( 'hidecaption', true, $provider );
 	}
 
 	$access_token = jetpack_instagram_get_access_token();

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -147,7 +147,7 @@ function jetpack_instagram_embed_reversal( $content ) {
  *
  * @return array $params Array of parameters to be used in Instagram query.
  */
-function jetpack_instagram_get_whitelisted_parameters( $url, $atts = array() ) {
+function jetpack_instagram_get_allowed_parameters( $url, $atts = array() ) {
 	global $content_width;
 
 	// Any URL passed via a shortcode attribute takes precedence.
@@ -221,7 +221,7 @@ function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
 	}
 
 	// Get a set of URL and parameters supported by Facebook.
-	$clean_parameters = jetpack_instagram_get_whitelisted_parameters( $url );
+	$clean_parameters = jetpack_instagram_get_allowed_parameters( $url );
 
 	if ( ! empty( $clean_parameters['url'] ) ) {
 		// Replace existing URL by our clean version.
@@ -309,7 +309,7 @@ function jetpack_shortcode_instagram( $atts ) {
 		return '';
 	}
 
-	$atts = jetpack_instagram_get_whitelisted_parameters( $atts['url'], $atts );
+	$atts = jetpack_instagram_get_allowed_parameters( $atts['url'], $atts );
 
 	if ( empty( $atts['url'] ) ) {
 		return '';

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -178,6 +178,8 @@ function jetpack_instagram_get_allowed_parameters( $url, $atts = array() ) {
 
 			$atts = array_merge( $atts, $query_args );
 		}
+	} else {
+		return array();
 	}
 
 	$max_width = 698;

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -165,7 +165,7 @@ function jetpack_instagram_get_allowed_parameters( $url, $atts = array() ) {
 	$parsed_url = wp_parse_url( $url );
 	if ( $parsed_url && isset( $parsed_url['host'] ) && isset( $parsed_url['path'] ) ) {
 		// Bail early if this is not an Instagram URL.
-		if ( ! preg_match( '/instagr(\.am|am\.com)/', $parsed_url['host'] ) ) {
+		if ( ! preg_match( '/(?:^|\.)instagr(?:\.am|am\.com)$/', $parsed_url['host'] ) ) {
 			return array();
 		}
 
@@ -205,16 +205,16 @@ function jetpack_instagram_get_allowed_parameters( $url, $atts = array() ) {
 	return $params;
 }
 
-/**
- * Add auth token required by Instagram's oEmbed REST API, or proxy through WP.com.
- *
- * @since 9.1.0
- *
- * @param string $provider URL of the oEmbed provider.
- * @param string $url      URL of the content to be embedded.
- *
- * @return string
- */
+	/**
+	 * Add auth token required by Instagram's oEmbed REST API, or proxy through WP.com.
+	 *
+	 * @since 9.1.0
+	 *
+	 * @param string $provider URL of the oEmbed provider.
+	 * @param string $url      URL of the content to be embedded.
+	 *
+	 * @return string
+	 */
 function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
 	if ( ! wp_startswith( $provider, 'https://graph.facebook.com/v5.0/instagram_oembed/' ) ) {
 		return $provider;
@@ -257,12 +257,12 @@ function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
 	return str_replace( 'https://graph.facebook.com/v5.0/instagram_oembed/', $wpcom_oembed_proxy, $provider );
 }
 
-/**
- * Add JP auth headers if we're proxying through WP.com.
- *
- * @param array  $args oEmbed remote get arguments.
- * @param string $url  URL to be inspected.
- */
+	/**
+	 * Add JP auth headers if we're proxying through WP.com.
+	 *
+	 * @param array  $args oEmbed remote get arguments.
+	 * @param string $url  URL to be inspected.
+	 */
 function jetpack_instagram_oembed_remote_get_args( $args, $url ) {
 	if ( ! wp_startswith( $url, Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ) . '/wpcom/v2/oembed-proxy/instagram/' ) ) {
 		return $args;
@@ -276,11 +276,11 @@ function jetpack_instagram_oembed_remote_get_args( $args, $url ) {
 	return $signed_request['request'];
 }
 
-/**
- * Fetches a Facebook API access token used for query for Instagram embed information, if one is set.
- *
- * @return string The access token or ''
- */
+	/**
+	 * Fetches a Facebook API access token used for query for Instagram embed information, if one is set.
+	 *
+	 * @return string The access token or ''
+	 */
 function jetpack_instagram_get_access_token() {
 	/**
 	 * Filters the Instagram embed token that is used for querying the Facebook API.
@@ -297,11 +297,11 @@ function jetpack_instagram_get_access_token() {
 	return (string) apply_filters( 'jetpack_instagram_embed_token', (string) Constants::get_constant( 'JETPACK_INSTAGRAM_EMBED_TOKEN' ) );
 }
 
-/**
- * Display the Instagram shortcode.
- *
- * @param array $atts Shortcode attributes.
- */
+	/**
+	 * Display the Instagram shortcode.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 */
 function jetpack_shortcode_instagram( $atts ) {
 	global $wp_embed;
 

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -133,7 +133,7 @@ function jetpack_instagram_embed_reversal( $content ) {
 }
 
 /**
- * List of whitelisted and sanitized parameters
+ * List of allowed and sanitized parameters
  * that can be used with the Instagram oEmbed endpoint.
  *
  * Those parameters can be provided via the Instagram URL, or via shortcode parameters.

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -319,6 +319,13 @@ function jetpack_shortcode_instagram( $atts ) {
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		$url_pattern = '#http(s?)://(www\.)?instagr(\.am|am\.com)/p/([^/?]+)#i';
 		preg_match( $url_pattern, $atts['url'], $matches );
+		if ( ! $matches ) {
+			return sprintf(
+				'<a href="%1$s" class="amp-wp-embed-fallback">%1$s</a>',
+				esc_url( $atts['url'] )
+			);
+		}
+
 		$shortcode_id = end( $matches );
 		$width        = ! empty( $atts['width'] ) ? $atts['width'] : 600;
 		$height       = ! empty( $atts['height'] ) ? $atts['height'] : 600;

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -225,10 +225,9 @@ function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
 	// Get a set of URL and parameters supported by Facebook.
 	$clean_parameters = jetpack_instagram_get_allowed_parameters( $url );
 
+	// Replace existing URL by our clean version.
 	if ( ! empty( $clean_parameters['url'] ) ) {
-		// Replace existing URL by our clean version.
-		$provider_without_url = remove_query_arg( 'url', $provider );
-		$provider             = add_query_arg( 'url', rawurlencode( $clean_parameters['url'] ), $provider_without_url );
+		$provider = add_query_arg( 'url', rawurlencode( $clean_parameters['url'] ), $provider );
 	}
 
 	// Our shortcode supports the width param, but the API expects maxwidth.

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -392,7 +392,7 @@ BODY;
 	}
 
 	/**
-	 * Test the build of a set of whitelisted parameters from a variety of inputs.
+	 * Test the build of a set of allowed parameters from a variety of inputs.
 	 *
 	 * @dataProvider get_instagram_parameters
 	 * @covers ::jetpack_instagram_get_allowed_parameters

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -4,6 +4,13 @@ use Automattic\Jetpack\Constants;
 
 class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 
+	/**
+	 * Mock global $content_width value.
+	 *
+	 * @var int
+	 */
+	const CONTENT_WIDTH = 640;
+
 	public function setUp() {
 		parent::setUp();
 
@@ -38,6 +45,16 @@ class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 			 */
 			add_filter( 'pre_http_request', array( $this, 'pre_http_request' ), 10, 3 );
 		}
+	}
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function tearDown() {
+		unset( $GLOBALS['content_width'] );
+		parent::tearDown();
 	}
 
 	public function pre_http_request( $response, $args, $url ) {
@@ -303,7 +320,7 @@ BODY;
 		$url_with_id       = 'https://www.instagram.com/p/' . $shortcode_id;
 		$short_url_with_id = 'https://instagr.am/p/' . $shortcode_id;
 		$wrong_url_with_id = 'https://www.twitter.com/p/' . $shortcode_id;
-		$default_dimension = 600;
+		$default_height    = 600;
 
 		return array(
 			'no_attribute'                   => array(
@@ -316,27 +333,27 @@ BODY;
 			),
 			'non_instagram_url'              => array(
 				'[instagram url=' . $wrong_url_with_id . ']',
-				'<a href="' . $wrong_url_with_id . '" class="amp-wp-embed-fallback">' . $wrong_url_with_id . '</a>',
+				'',
 			),
 			'url_value_as_attribute'         => array(
 				'[instagram url=' . $url_with_id . ']',
-				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="' . $default_dimension . '" height="' . $default_dimension . '" data-captioned></amp-instagram>',
+				'<amp-instagram data-shortcode="' . $shortcode_id . '" layout="responsive" width="' . self::CONTENT_WIDTH . '" height="' . $default_height . '" data-captioned></amp-instagram>',
 			),
 			'short_url_value_as_attribute'   => array(
 				'[instagram url=' . $short_url_with_id . ']',
-				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="' . $default_dimension . '" height="' . $default_dimension . '" data-captioned></amp-instagram>',
+				'<amp-instagram data-shortcode="' . $shortcode_id . '" layout="responsive" width="' . self::CONTENT_WIDTH . '" height="' . $default_height . '" data-captioned></amp-instagram>',
 			),
 			'width_in_attributes'            => array(
-				'[instagram url=' . $url_with_id . ' width=300]',
-				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="300" height="' . $default_dimension . '" data-captioned></amp-instagram>',
+				'[instagram url=' . $url_with_id . ' width=320]',
+				'<amp-instagram data-shortcode="' . $shortcode_id . '" layout="responsive" width="320" height="' . $default_height . '" data-captioned></amp-instagram>',
 			),
 			'width_and_height_in_attributes' => array(
-				'[instagram url=' . $url_with_id . ' width=300 height="200"]',
-				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="300" height="200" data-captioned></amp-instagram>',
+				'[instagram url=' . $url_with_id . ' width=320 height="200"]',
+				'<amp-instagram data-shortcode="' . $shortcode_id . '" layout="responsive" width="320" height="200" data-captioned></amp-instagram>',
 			),
 			'0_width_in_attributes'          => array(
 				'[instagram url=' . $url_with_id . ' width=0]',
-				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="' . $default_dimension . '" height="' . $default_dimension . '" data-captioned></amp-instagram>',
+				'<amp-instagram data-shortcode="' . $shortcode_id . '" layout="responsive" width="320" height="' . $default_height . '" data-captioned></amp-instagram>',
 			),
 		);
 	}
@@ -356,6 +373,7 @@ BODY;
 			return;
 		}
 
+		$GLOBALS['content_width'] = self::CONTENT_WIDTH;
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 		$this->assertEquals( $expected, do_shortcode( $shortcode_content ) );
 	}
@@ -386,6 +404,8 @@ BODY;
 	 * @param array  $expected Array of expected parameters.
 	 */
 	public function test_shortcodes_instagram_whitelisted_parameters( $url, $atts, $expected ) {
+		$GLOBALS['content_width'] = self::CONTENT_WIDTH;
+
 		$actual = jetpack_instagram_get_whitelisted_parameters( $url, $atts );
 		$this->assertEquals( $expected, $actual );
 	}
@@ -406,7 +426,8 @@ BODY;
 				array(),
 				array(
 					'url'         => $base_instagram_url,
-					'width'       => 640,
+					'width'       => self::CONTENT_WIDTH,
+					'height'      => '',
 					'hidecaption' => false,
 				),
 			),
@@ -415,7 +436,8 @@ BODY;
 				array(),
 				array(
 					'url'         => $base_instagram_url,
-					'width'       => 640,
+					'width'       => self::CONTENT_WIDTH,
+					'height'      => '',
 					'hidecaption' => false,
 				),
 			),
@@ -424,7 +446,8 @@ BODY;
 				array(),
 				array(
 					'url'         => $base_instagram_url,
-					'width'       => 640,
+					'width'       => self::CONTENT_WIDTH,
+					'height'      => '',
 					'hidecaption' => 'true',
 				),
 			),
@@ -433,7 +456,8 @@ BODY;
 				array(),
 				array(
 					'url'         => $base_instagram_url,
-					'width'       => 640,
+					'width'       => self::CONTENT_WIDTH,
+					'height'      => '',
 					'hidecaption' => 'true',
 				),
 			),
@@ -444,7 +468,8 @@ BODY;
 				),
 				array(
 					'url'         => $base_instagram_url,
-					'width'       => 640,
+					'width'       => self::CONTENT_WIDTH,
+					'height'      => '',
 					'hidecaption' => 'true',
 				),
 			),
@@ -455,7 +480,8 @@ BODY;
 				),
 				array(
 					'url'         => $base_instagram_url,
-					'width'       => 640,
+					'width'       => self::CONTENT_WIDTH,
+					'height'      => '',
 					'hidecaption' => false,
 				),
 			),
@@ -467,6 +493,7 @@ BODY;
 				array(
 					'url'         => $base_instagram_url,
 					'width'       => 420,
+					'height'      => '',
 					'hidecaption' => false,
 				),
 			),
@@ -478,6 +505,7 @@ BODY;
 				array(
 					'url'         => $base_instagram_url,
 					'width'       => 698,
+					'height'      => '',
 					'hidecaption' => false,
 				),
 			),

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -511,12 +511,12 @@ BODY;
 			),
 			// Tests some bad URLs to confirm we don't parse them.
 			'bad_url_1'                    => array(
-				'https://instagram.com.evil.example.com',
+				'https://instagram.com.evil.example.com/p/BnMOk_FFsxg',
 				array(),
 				array(),
 			),
 			'bad_url_2'                    => array(
-				'https://not-really-instagr.am',
+				'https://not-really-instagr.am/p/BnMOk_FFsxg',
 				array(),
 				array(),
 			),

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -395,25 +395,25 @@ BODY;
 	 * Test the build of a set of whitelisted parameters from a variety of inputs.
 	 *
 	 * @dataProvider get_instagram_parameters
-	 * @covers ::jetpack_instagram_get_whitelisted_parameters
-	 *
-	 * @since 9.1.0
+	 * @covers ::jetpack_instagram_get_allowed_parameters
 	 *
 	 * @param string $url      URL of the content to be embedded.
 	 * @param array  $atts     Shortcode attributes.
 	 * @param array  $expected Array of expected parameters.
+	 *
+	 * @since 9.1.0
 	 */
 	public function test_shortcodes_instagram_whitelisted_parameters( $url, $atts, $expected ) {
 		$GLOBALS['content_width'] = self::CONTENT_WIDTH;
 
-		$actual = jetpack_instagram_get_whitelisted_parameters( $url, $atts );
+		$actual = jetpack_instagram_get_allowed_parameters( $url, $atts );
 		$this->assertEquals( $expected, $actual );
 	}
 
 	/**
 	 * Variety of parameters available from an embed.
 	 *
-	 * @covers ::jetpack_instagram_get_whitelisted_parameters
+	 * @covers ::jetpack_instagram_get_allowed_parameters
 	 *
 	 * @since 9.1.0
 	 */

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -473,6 +473,18 @@ BODY;
 					'hidecaption' => 'true',
 				),
 			),
+			'url_in_att_takes_precedence' => array(
+				'https://www.instagram.com/p/BnMO9vRleEx',
+				array(
+					'url' => $base_instagram_url,
+				),
+				array(
+					'url'         => $base_instagram_url,
+					'width'       => self::CONTENT_WIDTH,
+					'height'      => '',
+					'hidecaption' => false,
+				),
+			),
 			'invalid_atts_in_url_att'      => array(
 				$base_instagram_url,
 				array(

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -403,7 +403,7 @@ BODY;
 	 *
 	 * @since 9.1.0
 	 */
-	public function test_shortcodes_instagram_whitelisted_parameters( $url, $atts, $expected ) {
+	public function test_shortcodes_instagram_allowed_parameters( $url, $atts, $expected ) {
 		$GLOBALS['content_width'] = self::CONTENT_WIDTH;
 
 		$actual = jetpack_instagram_get_allowed_parameters( $url, $atts );

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -372,4 +372,115 @@ BODY;
 		add_filter( 'jetpack_is_amp_request', '__return_false' );
 		$this->assertNotContains( 'amp-instagram', do_shortcode( $shortcode_content ) );
 	}
+
+	/**
+	 * Test the build of a set of whitelisted parameters from a variety of inputs.
+	 *
+	 * @dataProvider get_instagram_parameters
+	 * @covers ::jetpack_instagram_get_whitelisted_parameters
+	 *
+	 * @since 9.1.0
+	 *
+	 * @param string $url      URL of the content to be embedded.
+	 * @param array  $atts     Shortcode attributes.
+	 * @param array  $expected Array of expected parameters.
+	 */
+	public function test_shortcodes_instagram_whitelisted_parameters( $url, $atts, $expected ) {
+		$actual = jetpack_instagram_get_whitelisted_parameters( $url, $atts );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Variety of parameters available from an embed.
+	 *
+	 * @covers ::jetpack_instagram_get_whitelisted_parameters
+	 *
+	 * @since 9.1.0
+	 */
+	public function get_instagram_parameters() {
+		$base_instagram_url = 'https://www.instagram.com/p/BnMOk_FFsxg';
+
+		return array(
+			'no_query_strings_no_atts'     => array(
+				$base_instagram_url,
+				array(),
+				array(
+					'url'         => $base_instagram_url,
+					'width'       => 640,
+					'hidecaption' => false,
+				),
+			),
+			'invalid_query_string_no_atts' => array(
+				$base_instagram_url . '?utm_source=ig_web_copy_link',
+				array(),
+				array(
+					'url'         => $base_instagram_url,
+					'width'       => 640,
+					'hidecaption' => false,
+				),
+			),
+			'invalid_query_string_hidecaption_string_no_atts' => array(
+				$base_instagram_url . '?utm_source=ig_web_copy_link&hidecaption=true',
+				array(),
+				array(
+					'url'         => $base_instagram_url,
+					'width'       => 640,
+					'hidecaption' => 'true',
+				),
+			),
+			'hidecaption_string_no_atts'   => array(
+				$base_instagram_url . '?hidecaption=true',
+				array(),
+				array(
+					'url'         => $base_instagram_url,
+					'width'       => 640,
+					'hidecaption' => 'true',
+				),
+			),
+			'hidecaption_att'              => array(
+				$base_instagram_url,
+				array(
+					'hidecaption' => 'true',
+				),
+				array(
+					'url'         => $base_instagram_url,
+					'width'       => 640,
+					'hidecaption' => 'true',
+				),
+			),
+			'invalid_atts_in_url_att'      => array(
+				$base_instagram_url,
+				array(
+					'url' => $base_instagram_url . '?utm_source=ig_web_copy_link',
+				),
+				array(
+					'url'         => $base_instagram_url,
+					'width'       => 640,
+					'hidecaption' => false,
+				),
+			),
+			'custom_width_att'             => array(
+				$base_instagram_url,
+				array(
+					'width' => '420',
+				),
+				array(
+					'url'         => $base_instagram_url,
+					'width'       => 420,
+					'hidecaption' => false,
+				),
+			),
+			'width_att_out_of_bounds'      => array(
+				$base_instagram_url,
+				array(
+					'width' => '999',
+				),
+				array(
+					'url'         => $base_instagram_url,
+					'width'       => 698,
+					'hidecaption' => false,
+				),
+			),
+		);
+	}
 }

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -509,6 +509,17 @@ BODY;
 					'hidecaption' => false,
 				),
 			),
+			// Tests some bad URLs to confirm we don't parse them.
+			'bad_url_1'                    => array(
+				'https://instagram.com.evil.example.com',
+				array(),
+				array(),
+			),
+			'bad_url_2'                    => array(
+				'https://not-really-instagr.am',
+				array(),
+				array(),
+			),
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This will allow us to provide a set of parameters that are supported by Facebook's Graph API, while everything else will get stripped away.
It also cleans up the URL that we pass to Facebook's API so only supported parameters are sent.

#### Jetpack product discussion

* Internal discussion: p1604395525052300-slack-C03AP0WBV
* Internal reference: p7H4VZ-2DU-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

Worth noting that tests will be impacted by [this Facebook bug](https://developers.facebook.com/support/bugs/730016047927322/); the `hidecaption` parameter does not result into the caption getting hidden at the moment.

* On a site connected to WordPress.com, try to embed different types of Instagram posts. I tried with those:
    - `https://www.instagram.com/p/BnMOk_FFsxg/`
    - `https://www.instagram.com/p/BnMOk_FFsxg/?utm_source=ig_web_copy_link`
    - `https://www.instagram.com/p/BnMOk_FFsxg/?utm_source=ig_web_copy_link&hidecaption=true`
    - `[instagram url="https://www.instagram.com/p/BnMOk_FFsxg/" hidecaption="true"]`
    - `[instagram url="https://www.instagram.com/p/BnMOk_FFsxg/?utm_source=ig_web_copy_link&hidecaption=true"]`
    - `[instagram url="https://www.instagram.com/p/BnMOk_FFsxg/?utm_source=ig_web_copy_link" width="340"]`
* Do the tests pass?

#### Proposed changelog entry for your changes:

* Instagram Embeds: add support for embed parameters supported by Instagram