### PR TITLE
Payments Block: Remove upgrade nudges when used in Premium Content block

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -79,6 +79,8 @@ class MembershipsButtonEdit extends Component {
 		this.hasUpgradeNudge =
 			! recurringPaymentsAvailability.available &&
 			recurringPaymentsAvailability.unavailableReason === 'missing_plan';
+
+		this.isPremiumContentChild = this.props.context.isPremiumContentChild || false;
 	}
 
 	componentDidMount = () => {
@@ -511,7 +513,7 @@ class MembershipsButtonEdit extends Component {
 		return (
 			<Fragment>
 				{ this.props.noticeUI }
-				{ ! this.props.isInPremiumContentBlock() && this.renderUpgradeNudges() }
+				{ ! this.isPremiumContentChild && this.renderUpgradeNudges() }
 				{ showControls && inspectorControls }
 
 				<InnerBlocks
@@ -532,20 +534,8 @@ class MembershipsButtonEdit extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { clientId } ) => ( {
+	withSelect( ( select ) => ( {
 		postId: select( 'core/editor' ).getCurrentPostId(),
-		innerButtons: select( 'core/editor' ).getBlocksByClientId( clientId ),
-		isInPremiumContentBlock: () => {
-			const parentClientIds = select( 'core/block-editor' ).getBlockParents( clientId );
-			for ( let i = 0; i < parentClientIds.length; i++ ) {
-				const parentBlock = select( 'core/block-editor' ).getBlock( parentClientIds[ i ] );
-
-				if ( parentBlock.name.includes( 'premium-content' ) ) {
-					return true;
-				}
-			}
-			return false;
-		}
 	} ) ),
 	withDispatch( dispatch => {
 		const { updateBlockAttributes } = dispatch( 'core/editor' );

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -385,7 +385,7 @@ class MembershipsButtonEdit extends Component {
 
 	renderUpgradeNudges = () => {
 		const { notices, postId } = this.props;
-		const { connected, connectURL, products } = this.state;
+		const { connected, connectURL } = this.state;
 
 		return (
 			<>
@@ -416,6 +416,16 @@ class MembershipsButtonEdit extends Component {
 					</Placeholder>
 				</div>
 			) }
+			</>
+		);
+	}
+
+	renderPlanNotices = () => {
+		const { notices } = this.props;
+		const { connected, products } = this.state;
+
+		return (
+			<>
 			{ ( connected === API_STATE_LOADING ||
 				this.state.addingMembershipAmount === PRODUCT_FORM_SUBMITTED ) &&
 				! this.props.attributes.planId && (
@@ -471,7 +481,7 @@ class MembershipsButtonEdit extends Component {
 				) }
 			</>
 		);
-	}
+	};
 
 	render = () => {
 		const { products } = this.state;
@@ -513,7 +523,8 @@ class MembershipsButtonEdit extends Component {
 		return (
 			<Fragment>
 				{ this.props.noticeUI }
-				{ ! this.isPremiumContentChild && this.renderUpgradeNudges() }
+				{ ! this.isPremiumContentChild && this.renderUpgradeNudges() && this.renderPlanNotices() }
+
 				{ showControls && inspectorControls }
 
 				<InnerBlocks

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -523,7 +523,8 @@ class MembershipsButtonEdit extends Component {
 		return (
 			<Fragment>
 				{ this.props.noticeUI }
-				{ ! this.isPremiumContentChild && this.renderUpgradeNudges() && this.renderPlanNotices() }
+				{ ! this.isPremiumContentChild && this.renderUpgradeNudges() }
+				{ ! this.isPremiumContentChild && this.renderPlanNotices() }
 
 				{ showControls && inspectorControls }
 

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -77,6 +77,7 @@ class MembershipsButtonEdit extends Component {
 
 		const recurringPaymentsAvailability = getJetpackExtensionAvailability( 'recurring-payments' );
 		this.hasUpgradeNudge =
+			! this.props.isInPremiumContentBlock() &&
 			! recurringPaymentsAvailability.available &&
 			recurringPaymentsAvailability.unavailableReason === 'missing_plan';
 	}
@@ -522,6 +523,17 @@ export default compose( [
 	withSelect( ( select, { clientId } ) => ( {
 		postId: select( 'core/editor' ).getCurrentPostId(),
 		innerButtons: select( 'core/editor' ).getBlocksByClientId( clientId ),
+		isInPremiumContentBlock: () => {
+			const parentClientIds = select( 'core/block-editor' ).getBlockParents( clientId );
+			for ( let i = 0; i < parentClientIds.length; i++ ) {
+				const parentBlock = select( 'core/block-editor' ).getBlock( parentClientIds[ i ] );
+
+				if ( parentBlock.name.includes( 'premium-content' ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
 	} ) ),
 	withDispatch( dispatch => {
 		const { updateBlockAttributes } = dispatch( 'core/editor' );

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -345,7 +345,8 @@ class MembershipsButtonEdit extends Component {
 		const defaultTextForCurrentPlan = currentPlanId
 			? this.getFormattedPriceByProductId( currentPlanId ) + __( ' Contribution', 'jetpack' )
 			: undefined;
-		if ( innerButtons.length ) {
+
+		if ( innerButtons && innerButtons.length ) {
 			innerButtons[ 0 ].innerBlocks.forEach( block => {
 				const currentText = block.attributes.text;
 				const text =

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -46,6 +46,7 @@ export const settings = {
 		'stripe',
 		_x( 'memberships', 'block search term', 'jetpack' ),
 	],
+	usesContext: [ 'isPremiumContentChild' ],
 	attributes: {
 		planId: {
 			type: 'integer',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Remove all native upgrade nudges inside the Payments block when used within the Premium Content block. This stops the duplication of nudges when used together. This also helps us when using these blocks in patterns so the canvas is cleaner.

Partially fixes https://github.com/Automattic/wp-calypso/issues/46923

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* First apply this PR and sync to your sandbox to provide context: https://github.com/Automattic/wp-calypso/pull/47245
* Apply this Jetpack PR
* Sync to your dotcom sandbox
* Sandbox a free WordPress.com site
* Insert a premium content block
* Confirm that you can edit the block on a free plan, and the "Subscribe" button is visible (not a placeholder or nudge instead).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
