### PR TITLE
Tiled Gallery Block: Update styles for WP.com emails.

### DIFF
--- a/extensions/blocks/tiled-gallery/view.scss
+++ b/extensions/blocks/tiled-gallery/view.scss
@@ -121,3 +121,9 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 		width: 100%;
 	}
 }
+
+@media only email {
+	.tiled-gallery__gallery {
+		display: block;
+	}
+}


### PR DESCRIPTION
Adding these styles will improve rendering of the Tiled Gallery block in WordPress.com subscriber emails.

Fixes 196-gh-Automattic/dotcom-manage

Before | After
--- | ---
<img width="500" alt="Screen Shot 2020-11-03 at 1 55 50 PM" src="https://user-images.githubusercontent.com/349751/98044944-92edca00-1ddc-11eb-8d63-42d16664231d.png"> | <img width="500" alt="Screen Shot 2020-11-03 at 1 55 33 PM" src="https://user-images.githubusercontent.com/349751/98044951-95e8ba80-1ddc-11eb-90ce-e40853056e96.png">


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Apply this patch to your WP.com sandbox using the Fusion-generated diff.
* On a WordPress.com test site, publish a post with a Jetpack Tiled Gallery block.
* Send a test email for this post (see PCYsg-tvN-p2).
* Verify the results look good. It doesn't have to be an exact layout match, the images should just make some visual sense and not be crowded.

#### Proposed changelog entry for your changes:
No changelog needed.