### PR TITLE
Story block improvements

### DIFF
--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -129,6 +129,7 @@ export default withNotices( function StoryEdit( {
 				<StoryPlayer
 					slides={ mediaFiles }
 					disabled={ ! isSelected }
+					showSlideCount={ isSelected }
 					shadowDOM={ {
 						enabled: false,
 					} }

--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -98,7 +98,7 @@ export default withNotices( function StoryEdit( {
 				instructions:
 					! hasImages &&
 					__(
-						'Drag images and videos, upload new ones or select files from your library.',
+						'Drag images and videos, upload new ones, or select files from your library.',
 						'jetpack'
 					),
 			} }

--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -27,6 +27,7 @@ const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 export const pickRelevantMediaFiles = ( media, sizeSlug = 'large' ) => {
 	const mediaProps = pick( media, [
 		'alt',
+		'title',
 		'id',
 		'link',
 		'type',
@@ -43,8 +44,9 @@ export const pickRelevantMediaFiles = ( media, sizeSlug = 'large' ) => {
 		media.url;
 	mediaProps.type = media.media_type || media.type;
 	mediaProps.mime = media.mime_type || media.mime;
-	mediaProps.width = mediaProps.width || get( media, [ 'media_details', 'width' ] );
-	mediaProps.height = mediaProps.height || get( media, [ 'media_details', 'height' ] );
+	mediaProps.title = mediaProps.title?.rendered || mediaProps.title;
+	mediaProps.width = mediaProps.width || media.media_details?.width;
+	mediaProps.height = mediaProps.height || media.media_details?.height;
 	return mediaProps;
 };
 

--- a/extensions/blocks/story/icon.js
+++ b/extensions/blocks/story/icon.js
@@ -1,15 +1,30 @@
 /**
  * WordPress dependencies
  */
-import { Path, SVG } from '@wordpress/components';
+import { Path, Rect, SVG } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { getIconColor } from '../../shared/block-icons';
 
 export default (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path d="M0 0h24v24H0z" fill="none" />
 		<Path
-			fillRule="evenodd"
-			clipRule="evenodd"
-			d="M6 3H14V17H6L6 3ZM4 3C4 1.89543 4.89543 1 6 1H14C15.1046 1 16 1.89543 16 3V17C16 18.1046 15.1046 19 14 19H6C4.89543 19 4 18.1046 4 17V3ZM18 5C19.1046 5 20 5.89543 20 7V21C20 22.1046 19.1046 23 18 23H10C8.89543 23 8 22.1046 8 21H18V5Z"
+			fill="none"
+			stroke={ getIconColor() }
+			stroke-width="1.5"
+			d="M19 7V19C19 20.1046 18.1061 21 17.0015 21C14.8931 21 11.4097 21 8 21"
+		/>
+		<Rect
+			fill="none"
+			stroke={ getIconColor() }
+			stroke-width="1.5"
+			x="5.75"
+			y="2.75"
+			width="9.5"
+			height="14.5"
+			rx="0.875"
 		/>
 	</SVG>
 );

--- a/extensions/blocks/story/icon.js
+++ b/extensions/blocks/story/icon.js
@@ -3,22 +3,17 @@
  */
 import { Path, Rect, SVG } from '@wordpress/components';
 
-/**
- * Internal dependencies
- */
-import { getIconColor } from '../../shared/block-icons';
-
 export default (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path
 			fill="none"
-			stroke={ getIconColor() }
+			stroke="currentColor"
 			stroke-width="1.5"
 			d="M19 7V19C19 20.1046 18.1061 21 17.0015 21C14.8931 21 11.4097 21 8 21"
 		/>
 		<Rect
 			fill="none"
-			stroke={ getIconColor() }
+			stroke="currentColor"
 			stroke-width="1.5"
 			x="5.75"
 			y="2.75"

--- a/extensions/blocks/story/icon.js
+++ b/extensions/blocks/story/icon.js
@@ -8,13 +8,13 @@ export default (
 		<Path
 			fill="none"
 			stroke="currentColor"
-			stroke-width="1.5"
+			strokeWidth="1.5"
 			d="M19 7V19C19 20.1046 18.1061 21 17.0015 21C14.8931 21 11.4097 21 8 21"
 		/>
 		<Rect
 			fill="none"
 			stroke="currentColor"
-			stroke-width="1.5"
+			strokeWidth="1.5"
 			x="5.75"
 			y="2.75"
 			width="9.5"

--- a/extensions/blocks/story/player/components/bullet.js
+++ b/extensions/blocks/story/player/components/bullet.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -13,19 +14,25 @@ import { Button } from '@wordpress/components';
  * Internal dependencies
  */
 
-export default function Bullet( { disabled, index, isSelected, progress, onClick } ) {
-	const label = isSelected
-		? sprintf( __( 'Slide %d, currently selected.', 'jetpack' ), index + 1 )
-		: sprintf( __( 'Slide %d', 'jetpack' ), index + 1 );
+export default function Bullet( { isEllipsis, disabled, index, isSelected, progress, onClick } ) {
+	const bulletDisabled = disabled || isEllipsis;
+	let label = null;
+	if ( ! isEllipsis ) {
+		label = isSelected
+			? sprintf( __( 'Slide %d, currently selected.', 'jetpack' ), index + 1 )
+			: sprintf( __( 'Slide %d', 'jetpack' ), index + 1 );
+	}
 	return (
 		<Button
-			role={ disabled ? 'presentation' : 'tab' }
+			role={ bulletDisabled ? 'presentation' : 'tab' }
 			key={ index }
-			className="wp-story-pagination-bullet"
+			className={ classNames( 'wp-story-pagination-bullet', {
+				'wp-story-pagination-ellipsis': isEllipsis,
+			} ) }
 			aria-label={ label }
-			aria-disabled={ disabled || isSelected }
-			onClick={ ! disabled && ! isSelected ? onClick : undefined }
-			disabled={ disabled }
+			aria-disabled={ bulletDisabled || isSelected }
+			onClick={ ! bulletDisabled && ! isSelected ? onClick : undefined }
+			disabled={ bulletDisabled }
 		>
 			<div className="wp-story-pagination-bullet-bar">
 				<div

--- a/extensions/blocks/story/player/components/button.js
+++ b/extensions/blocks/story/player/components/button.js
@@ -9,9 +9,10 @@ import classNames from 'classnames';
 import { createElement } from '@wordpress/element';
 import './button.scss';
 
-export const DecoratedButton = ( { className, size, ...extraProps } ) => (
+export const DecoratedButton = ( { className, size, isPressed, ...extraProps } ) => (
 	<button
 		type="button"
+		aria-pressed={ isPressed }
 		className={ classNames(
 			'jetpack-mdc-icon-button',
 			'circle-icon',
@@ -27,9 +28,10 @@ export const DecoratedButton = ( { className, size, ...extraProps } ) => (
 	/>
 );
 
-export const SimpleButton = ( { className, size = 24, ...extraProps } ) => (
+export const SimpleButton = ( { className, size = 24, isPressed, ...extraProps } ) => (
 	<button
 		type="button"
+		aria-pressed={ isPressed }
 		className={ classNames( 'jetpack-mdc-icon-button', className ) }
 		style={ {
 			width: `${ size }px`,

--- a/extensions/blocks/story/player/components/button.js
+++ b/extensions/blocks/story/player/components/button.js
@@ -7,12 +7,11 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { createElement } from '@wordpress/element';
-import { Button } from '@wordpress/components';
-
 import './button.scss';
 
 export const DecoratedButton = ( { className, size, ...extraProps } ) => (
-	<Button
+	<button
+		type="button"
 		className={ classNames(
 			'jetpack-mdc-icon-button',
 			'circle-icon',
@@ -29,7 +28,8 @@ export const DecoratedButton = ( { className, size, ...extraProps } ) => (
 );
 
 export const SimpleButton = ( { className, size = 24, ...extraProps } ) => (
-	<Button
+	<button
+		type="button"
 		className={ classNames( 'jetpack-mdc-icon-button', className ) }
 		style={ {
 			width: `${ size }px`,

--- a/extensions/blocks/story/player/components/media.js
+++ b/extensions/blocks/story/player/components/media.js
@@ -12,12 +12,13 @@ import { createElement } from '@wordpress/element';
  * Internal dependencies
  */
 
-export const Image = ( { alt, className, id, mediaRef, mime, sizes, srcset, url } ) => (
+export const Image = ( { title, alt, className, id, mediaRef, mime, sizes, srcset, url } ) => (
 	// eslint-disable-next-line jsx-a11y/media-has-caption
 	<img
 		ref={ mediaRef }
 		data-id={ id }
 		data-mime={ mime }
+		title={ title }
 		alt={ alt }
 		src={ url }
 		className={ classNames( 'wp-story-image', `wp-image-${ id }`, className ) }
@@ -26,13 +27,13 @@ export const Image = ( { alt, className, id, mediaRef, mime, sizes, srcset, url 
 	/>
 );
 
-export const Video = ( { alt, className, id, mediaRef, mime, url } ) => (
+export const Video = ( { title, className, id, mediaRef, mime, url } ) => (
 	// eslint-disable-next-line jsx-a11y/media-has-caption
 	<video
 		className={ classNames( 'wp-story-video', 'intrinsic-ignore', `wp-video-${ id }`, className ) }
 		ref={ mediaRef }
 		data-id={ id }
-		title={ alt }
+		title={ title }
 		type={ mime }
 		src={ url }
 		playsInline

--- a/extensions/blocks/story/player/components/overlay.js
+++ b/extensions/blocks/story/player/components/overlay.js
@@ -26,6 +26,7 @@ export default function Overlay( {
 	onPreviousSlide,
 	icon,
 	slideCount,
+	showSlideCount,
 } ) {
 	const onPreviousSlideHandler = useCallback(
 		event => {
@@ -51,13 +52,13 @@ export default function Overlay( {
 
 	return (
 		<div className="wp-story-overlay">
-			{ icon && (
+			{ showSlideCount && (
 				<div className="wp-story-embed-icon">
 					{ icon }
 					<span>{ slideCount }</span>
 				</div>
 			) }
-			{ ! icon && (
+			{ ! showSlideCount && (
 				<div className="wp-story-embed-icon-expand">
 					<GridiconFullscreen role="img" />
 				</div>

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -25,6 +25,7 @@ const defaultSettings = {
 	loadInFullscreen: false,
 	blurredBackground: true,
 	showSlideCount: false,
+	showProgressBar: true,
 	shadowDOM: {
 		enabled: true,
 		mode: 'open', // closed not supported right now

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -36,6 +36,8 @@ const defaultSettings = {
 	cropUpTo: 0.2, // crop percentage allowed, after which media is displayed in letterbox
 	volume: 0.5,
 	renderInterval: 50, // in ms
+	maxBullets: 7,
+	maxBulletsFullscreen: 14,
 };
 
 export default function StoryPlayer( { slides, metadata, disabled, ...settings } ) {

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -50,7 +50,6 @@ export const Player = ( { slides, disabled, ref, ...settings } ) => {
 	const [ lastScrollPosition, setLastScrollPosition ] = useState( null );
 
 	const uploading = some( slides, media => isBlobURL( media.url ) );
-	const showProgressBar = fullscreen || ! settings.showSlideCount;
 	const isVideo = slideIndex => {
 		const media = slideIndex < slides.length ? slides[ slideIndex ] : null;
 		if ( ! media ) {
@@ -233,16 +232,16 @@ export const Player = ( { slides, disabled, ref, ...settings } ) => {
 					) ) }
 				</div>
 				<Overlay
-					icon={ settings.showSlideCount && icon }
+					icon={ icon }
 					slideCount={ slides.length }
+					showSlideCount={ settings.showSlideCount }
 					ended={ ended }
 					hasPrevious={ currentSlideIndex > 0 }
 					hasNext={ currentSlideIndex < slides.length - 1 }
-					disabled={ disabled }
 					onPreviousSlide={ tryPreviousSlide }
 					onNextSlide={ tryNextSlide }
 				/>
-				{ showProgressBar && (
+				{ settings.showProgressBar && (
 					<ProgressBar
 						slides={ slides }
 						fullscreen={ fullscreen }

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -244,10 +244,11 @@ export const Player = ( { slides, disabled, ref, ...settings } ) => {
 				{ settings.showProgressBar && (
 					<ProgressBar
 						slides={ slides }
-						fullscreen={ fullscreen }
+						disabled={ ! fullscreen }
 						currentSlideIndex={ currentSlideIndex }
 						currentSlideProgress={ currentSlideProgress }
 						onSlideSeek={ showSlide }
+						maxBullets={ fullscreen ? settings.maxBulletsFullscreen : settings.maxBullets }
 					/>
 				) }
 				<Controls

--- a/extensions/blocks/story/player/progress-bar.js
+++ b/extensions/blocks/story/player/progress-bar.js
@@ -7,36 +7,68 @@ import { createElement } from '@wordpress/element';
  * Internal dependencies
  */
 import { Bullet } from './components';
+import { range } from 'lodash';
 
 export const ProgressBar = ( {
 	slides,
-	fullscreen,
+	disabled,
 	currentSlideIndex,
 	currentSlideProgress,
 	onSlideSeek,
+	maxBullets,
 } ) => {
+	const bulletCount = Math.min( slides.length, maxBullets );
+	const middleBullet = Math.floor( bulletCount / 2 );
+
+	let currentBulletIndex;
+	let firstReachableSlideIndex = 0;
+	let lastReachableSlideIndex = slides.length - 1;
+
+	if ( currentSlideIndex < middleBullet ) {
+		currentBulletIndex = currentSlideIndex;
+		lastReachableSlideIndex = bulletCount - 1;
+	} else if ( currentSlideIndex > slides.length - middleBullet ) {
+		currentBulletIndex = currentSlideIndex - slides.length + bulletCount;
+		firstReachableSlideIndex = slides.length - bulletCount;
+	} else {
+		currentBulletIndex = middleBullet;
+		firstReachableSlideIndex = currentSlideIndex - middleBullet;
+		lastReachableSlideIndex = currentSlideIndex + middleBullet;
+	}
 	return (
 		<div className="wp-story-pagination wp-story-pagination-bullets" role="tablist">
-			{ slides.map( ( slide, index ) => {
+			{ firstReachableSlideIndex > 0 && (
+				<Bullet key="bullet-0" index={ firstReachableSlideIndex - 1 } progress={ 100 } isEllipsis />
+			) }
+			{ range( 1, bulletCount + 1 ).map( ( slide, bulletIndex ) => {
+				const slideIndex = bulletIndex + firstReachableSlideIndex;
 				let progress;
-				if ( index < currentSlideIndex ) {
+				if ( slideIndex < currentSlideIndex ) {
 					progress = 100;
-				} else if ( index > currentSlideIndex ) {
+				} else if ( slideIndex > currentSlideIndex ) {
 					progress = 0;
 				} else {
 					progress = currentSlideProgress;
 				}
 				return (
 					<Bullet
-						key={ index }
-						index={ index }
+						key={ `bullet-${ bulletIndex }` }
+						index={ slideIndex }
 						progress={ progress }
-						disabled={ ! fullscreen }
-						isSelected={ currentSlideIndex === index }
-						onClick={ () => onSlideSeek( index ) }
+						disabled={ disabled }
+						isSelected={ currentBulletIndex === bulletIndex }
+						onClick={ () => onSlideSeek( slideIndex ) }
 					/>
 				);
 			} ) }
+			{ lastReachableSlideIndex < slides.length - 1 && (
+				<Bullet
+					key={ `bullet-${ bulletCount + 1 }` }
+					index={ lastReachableSlideIndex + 1 }
+					progress={ 0 }
+					isEllipsis
+				/>
+			) }
 		</div>
 	);
 };

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -265,6 +265,7 @@
 		left: 0;
 		bottom: 0;
 		overflow: hidden;
+		transition: flex-basis 1000ms ease-in-out;
 
 		.wp-story-pagination-bullet {
 			flex: 1;
@@ -292,6 +293,14 @@
 				height: 4px;
 				background-color: $wp-story-pagination-bullet-progress-color;
 				transition: width 50ms;
+			}
+		}
+
+		.wp-story-pagination-ellipsis {
+			flex: 0 0 4px;
+
+			.wp-story-pagination-bullet-bar {
+				min-width: 6px;
 			}
 		}
 	}

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -190,6 +190,7 @@
 			align-items: center;
 			background-color: rgba(0, 0, 0, 0.5);
 			border-radius: 5px;
+			color: #fff;
 
 			* {
 				margin: 0 2px;

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -17,6 +17,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 
 const EMBED_SIZE        = array( 180, 320 );
 const CROP_UP_TO        = 0.2;
+const MAX_BULLETS       = 7;
 const IMAGE_BREAKPOINTS = '(max-width: 460px) 576w, (max-width: 614px) 768w, 120vw'; // 120vw to match the 20% CROP_UP_TO ratio
 
 /**
@@ -272,14 +273,16 @@ function render_top_right_icon( $settings ) {
  * Render a pagination bullet
  *
  * @param array $slide_index The slide index it corresponds to.
+ * @param array $class_name Optional css class name(s) to customize the bullet element.
  *
  * @return string
  */
-function render_pagination_bullet( $slide_index ) {
+function render_pagination_bullet( $slide_index, $class_name = '' ) {
 	return sprintf(
-		'<a href="#" class="wp-story-pagination-bullet" aria-label="%s">
+		'<a href="#" class="wp-story-pagination-bullet %s" aria-label="%s">
 			<div class="wp-story-pagination-bullet-bar"></div>
 		</a>',
+		$class_name,
 		/* translators: %d is the slide number (1, 2, 3...) */
 		sprintf( __( 'Go to slide %d', 'jetpack' ), $slide_index )
 	);
@@ -297,12 +300,16 @@ function render_pagination( $settings ) {
 	if ( $show_slide_count ) {
 		return '';
 	}
-	$slide_count = isset( $settings['slides'] ) ? count( $settings['slides'] ) : 0;
+	$slide_count     = isset( $settings['slides'] ) ? count( $settings['slides'] ) : 0;
+	$bullet_count    = min( $slide_count, MAX_BULLETS );
+	$bullet_ellipsis = $slide_count > $bullet_count
+		? render_pagination_bullet( $bullet_count + 1, 'wp-story-pagination-ellipsis' )
+		: '';
 	return sprintf(
 		'<div class="wp-story-pagination wp-story-pagination-bullets">
 			%s
 		</div>',
-		join( "\n", array_map( __NAMESPACE__ . '\render_pagination_bullet', range( 1, $slide_count ) ) )
+		join( "\n", array_map( __NAMESPACE__ . '\render_pagination_bullet', range( 1, $bullet_count ) ) ) . $bullet_ellipsis
 	);
 }
 

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -282,7 +282,7 @@ function render_pagination_bullet( $slide_index, $class_name = '' ) {
 		'<a href="#" class="wp-story-pagination-bullet %s" aria-label="%s">
 			<div class="wp-story-pagination-bullet-bar"></div>
 		</a>',
-		$class_name,
+		esc_attr( $class_name ),
 		/* translators: %d is the slide number (1, 2, 3...) */
 		sprintf( __( 'Go to slide %d', 'jetpack' ), $slide_index )
 	);

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -41,7 +41,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  */
 function with_width_height_srcset_and_sizes( $media_files ) {
 	return array_map(
-		function( $media_file ) {
+		function ( $media_file ) {
 			if ( ! isset( $media_file['id'] ) || ! empty( $media_file['srcset'] ) ) {
 				return $media_file;
 			}
@@ -60,10 +60,13 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 				return array_merge(
 					$media_file,
 					array(
-						'width'  => absint( $width ),
-						'height' => absint( $height ),
-						'srcset' => wp_calculate_image_srcset( $size_array, $src, $image_meta, $attachment_id ),
-						'sizes'  => IMAGE_BREAKPOINTS,
+						'width'   => absint( $width ),
+						'height'  => absint( $height ),
+						'srcset'  => wp_calculate_image_srcset( $size_array, $src, $image_meta, $attachment_id ),
+						'sizes'   => IMAGE_BREAKPOINTS,
+						'title'   => get_the_title( $attachment_id ),
+						'alt'     => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+						'caption' => wp_get_attachment_caption( $attachment_id ),
 					)
 				);
 			} else {
@@ -76,10 +79,12 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 				return array_merge(
 					$media_file,
 					array(
-						'width'  => absint( $video_meta['width'] ),
-						'height' => absint( $video_meta['height'] ),
-						'alt'    => $description,
-						'url'    => $url,
+						'width'   => absint( $video_meta['width'] ),
+						'height'  => absint( $video_meta['height'] ),
+						'alt'     => $description,
+						'url'     => $url,
+						'title'   => get_the_title( $attachment_id ),
+						'caption' => wp_get_attachment_caption( $attachment_id ),
 					)
 				);
 			}
@@ -116,6 +121,7 @@ function render_image( $media ) {
 		array(
 			'class' => sprintf( 'wp-story-image wp-image-%d %s', $media['id'], $crop_class ),
 			'sizes' => IMAGE_BREAKPOINTS,
+			'title' => get_the_title( $media['id'] ),
 		)
 	);
 }
@@ -166,9 +172,11 @@ function render_video( $media ) {
 		$description = ! empty( $metadata['videopress']['description'] ) ? $metadata['videopress']['description'] : '';
 		return sprintf(
 			'<img
+				title="%s"
 				alt="%s"
 				class="wp-block-jetpack-story_image wp-story-image %s"
 				src="%s">',
+			esc_attr( get_the_title( $media['id'] ) ),
 			esc_attr( $description ),
 			get_image_crop_class( $metadata['videopress']['width'], $metadata['videopress']['height'] ),
 			esc_attr( $poster_url )
@@ -183,7 +191,7 @@ function render_video( $media ) {
 			data-id="%3$s"
 			src="%4$s">
 		</video>',
-		esc_attr( $media['alt'] ),
+		esc_attr( get_the_title( $media['id'] ) ),
 		esc_attr( $media['mime'] ),
 		$media['id'],
 		esc_attr( $media['url'] )
@@ -209,6 +217,7 @@ function render_slide( $media, $index = 0 ) {
 			$media_template = render_image( $media, $index );
 			break;
 		case 'video':
+		case 'file':
 			$media_template = render_video( $media, $index );
 			break;
 	}


### PR DESCRIPTION
Improvements to the Story block

- Improve progress indicator in story preview when there are many frames.
- Add title attribute to image and videos
- Block editor: Minor copy fix: added a comma after “upload new ones”
- Block editor: Remove the fullscreen icon from the story block preview. Replaced with a slide count
- Block editor: Fix CSS regressions on new versions of wordpress: left and right arrow too small, stopped using the Button component from `@wordpress/components`
- Minor update to the story icon, updated to match the other G2 style icons in the web block picker

#### Testing instructions:
Make sure there is no regression after this patch is applied and all the items in the list are addressed.

#### Proposed changelog entry for your changes:
* Minor visual improvements to the Story block
