### PR TITLE
Set WPAdmin color scheme based on Calypso account color scheme setting

### DIFF
--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -55,6 +55,7 @@ $connected_tools = array(
 	// Starting from 2020-10-24, they need an authentication token, and that token is stored on WordPress.com.
 	// More information: https://developers.facebook.com/docs/instagram/oembed/.
 	'shortcodes/instagram.php',
+	'unified-color-schemes.php',
 );
 
 // Add connected features to our existing list if the site is currently connected.

--- a/modules/unified-color-schemes.php
+++ b/modules/unified-color-schemes.php
@@ -2,25 +2,22 @@
 
 use Automattic\Jetpack\Connection\Client;
 
-function ucs_admin_color_override( $color ) {
+function ucs_admin_color_override() {
 
 	$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
 		'me/preferences', // path
-		'1.1', // REST API version
+		'2', // REST API version
 		array(
 			'method' => 'GET',
 		),
 		null, // body
-		'rest' // REST API root. Default is `wpcom`.
+		'wpcom' // REST API root. Default is `wpcom`.
 	);
 
-	$response_body = wp_remote_retrieve_body( $response );
+	$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
 
-	echo '<pre>';
-	var_dump( $response_body );
-	echo '</pre>';
 
-	return 'blue';
+	return $response_body['colorScheme'];
 }
 
 function ucs_setup_admin() {

--- a/modules/unified-color-schemes.php
+++ b/modules/unified-color-schemes.php
@@ -4,20 +4,25 @@ use Automattic\Jetpack\Connection\Client;
 
 function ucs_admin_color_override() {
 
+	$default_color_scheme = 'default';
+
 	$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
-		'me/preferences', // path
-		'2', // REST API version
+		'me/preferences',
+		'2',
 		array(
 			'method' => 'GET',
 		),
-		null, // body
-		'wpcom' // REST API root. Default is `wpcom`.
+		null,
+		'wpcom'
 	);
+
+	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		return $default_color_scheme;
+	}
 
 	$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
 
-
-	return $response_body['colorScheme'];
+	return ! empty( $response_body['colorScheme'] ) ? $response_body['colorScheme'] : $default_color_scheme;
 }
 
 function ucs_setup_admin() {

--- a/modules/unified-color-schemes.php
+++ b/modules/unified-color-schemes.php
@@ -1,0 +1,33 @@
+<?php
+
+use Automattic\Jetpack\Connection\Client;
+
+function ucs_admin_color_override( $color ) {
+
+	$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+		'me/preferences', // path
+		'1.1', // REST API version
+		array(
+			'method' => 'GET',
+		),
+		null, // body
+		'rest' // REST API root. Default is `wpcom`.
+	);
+
+	$response_body = wp_remote_retrieve_body( $response );
+
+	echo '<pre>';
+	var_dump( $response_body );
+	echo '</pre>';
+
+	return 'blue';
+}
+
+function ucs_setup_admin() {
+	add_filter( 'get_user_option_admin_color', 'ucs_admin_color_override' );
+}
+
+add_action( 'admin_init', 'ucs_setup_admin', 6 );
+
+
+


### PR DESCRIPTION
The aim of this PR is to automatically set the color scheme for WPAdmin based on what is set in the Calypso color scheme setting. This will happen on WPCom envs only.

This forms part of the Nav Unification project for WPCom.

Unfortunately there is no easy way to an access the Calypso preferences from WPAdmin. Therefore we are trying to make a REST API call  to the WPCom API endpoint `/me/preferences` which will provide the color setting value we require.

One we have this then we can use the appropriate filter to overide the WPAdmin setting based on the Calypso setting.

Fixes https://github.com/Automattic/wp-calypso/issues/47039

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
