### PR TITLE
Handle empty SERVER_PORT information on signature checks

### DIFF
--- a/packages/connection/legacy/class-jetpack-signature.php
+++ b/packages/connection/legacy/class-jetpack-signature.php
@@ -74,34 +74,7 @@ class Jetpack_Signature {
 			}
 		}
 
-		$host_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : '';
-		$host_port = '' === $host_port && isset( $_SERVER['SERVER_PORT'] ) ? $_SERVER['SERVER_PORT'] : $host_port;
-
-		/**
-		 * Note: This port logic is tested in the Jetpack_Cxn_Tests->test__server_port_value() test.
-		 * Please update the test if any changes are made in this logic.
-		 */
-		if ( is_ssl() ) {
-			// 443: Standard Port
-			// 80: Assume we're behind a proxy without X-Forwarded-Port. Hardcoding "80" here means most sites
-			// with SSL termination proxies (self-served, Cloudflare, etc.) don't need to fiddle with
-			// the JETPACK_SIGNATURE__HTTPS_PORT constant. The code also implies we can't talk to a
-			// site at https://example.com:80/ (which would be a strange configuration).
-			// JETPACK_SIGNATURE__HTTPS_PORT: Set this constant in wp-config.php to the back end webserver's port
-			// if the site is behind a proxy running on port 443 without
-			// X-Forwarded-Port and the back end's port is *not* 80. It's better,
-			// though, to configure the proxy to send X-Forwarded-Port.
-			$https_port = defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) ? JETPACK_SIGNATURE__HTTPS_PORT : 443;
-			$port       = in_array( $host_port, array( 443, 80, $https_port ), false ) ? '' : $host_port; // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
-		} else {
-			// 80: Standard Port
-			// JETPACK_SIGNATURE__HTTPS_PORT: Set this constant in wp-config.php to the back end webserver's port
-			// if the site is behind a proxy running on port 80 without
-			// X-Forwarded-Port. It's better, though, to configure the proxy to
-			// send X-Forwarded-Port.
-			$http_port = defined( 'JETPACK_SIGNATURE__HTTP_PORT' ) ? JETPACK_SIGNATURE__HTTP_PORT : 80;
-			$port      = in_array( $host_port, array( 80, $http_port ), false ) ? '' : $host_port; // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
-		}
+		$port = $this->get_current_request_port();
 
 		$this->current_request_url = "{$scheme}://{$_SERVER['HTTP_HOST']}:{$port}" . stripslashes( $_SERVER['REQUEST_URI'] );
 
@@ -360,5 +333,45 @@ class Jetpack_Signature {
 
 		sort( $result );
 		return $result;
+	}
+
+	/**
+	 * Gets the port that should be considered to sign the current request.
+	 *
+	 * It will analyze the current request, as well as some Jetpack constants, to return the string
+	 * to be concatenated in the URL representing the port of the current request.
+	 *
+	 * @return string The port to be used in the signature
+	 */
+	public function get_current_request_port() {
+		$host_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : '';
+		$host_port = '' === $host_port && isset( $_SERVER['SERVER_PORT'] ) ? $_SERVER['SERVER_PORT'] : $host_port;
+
+		/**
+		 * Note: This port logic is tested in the Jetpack_Cxn_Tests->test__server_port_value() test.
+		 * Please update the test if any changes are made in this logic.
+		 */
+		if ( is_ssl() ) {
+			// 443: Standard Port
+			// 80: Assume we're behind a proxy without X-Forwarded-Port. Hardcoding "80" here means most sites
+			// with SSL termination proxies (self-served, Cloudflare, etc.) don't need to fiddle with
+			// the JETPACK_SIGNATURE__HTTPS_PORT constant. The code also implies we can't talk to a
+			// site at https://example.com:80/ (which would be a strange configuration).
+			// JETPACK_SIGNATURE__HTTPS_PORT: Set this constant in wp-config.php to the back end webserver's port
+			// if the site is behind a proxy running on port 443 without
+			// X-Forwarded-Port and the back end's port is *not* 80. It's better,
+			// though, to configure the proxy to send X-Forwarded-Port.
+			$https_port = defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) ? JETPACK_SIGNATURE__HTTPS_PORT : 443;
+			$port       = in_array( $host_port, array( 443, 80, $https_port ), false ) ? '' : $host_port; // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
+		} else {
+			// 80: Standard Port
+			// JETPACK_SIGNATURE__HTTPS_PORT: Set this constant in wp-config.php to the back end webserver's port
+			// if the site is behind a proxy running on port 80 without
+			// X-Forwarded-Port. It's better, though, to configure the proxy to
+			// send X-Forwarded-Port.
+			$http_port = defined( 'JETPACK_SIGNATURE__HTTP_PORT' ) ? JETPACK_SIGNATURE__HTTP_PORT : 80;
+			$port      = in_array( $host_port, array( 80, $http_port ), false ) ? '' : $host_port; // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
+		}
+		return (string) $port;
 	}
 }

--- a/packages/connection/legacy/class-jetpack-signature.php
+++ b/packages/connection/legacy/class-jetpack-signature.php
@@ -74,8 +74,8 @@ class Jetpack_Signature {
 			}
 		}
 
-		$host_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : $_SERVER['SERVER_PORT'];
-		$host_port = (int) $host_port;
+		$host_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : '';
+		$host_port = '' === $host_port && isset( $_SERVER['SERVER_PORT'] ) ? $_SERVER['SERVER_PORT'] : $host_port;
 
 		/**
 		 * Note: This port logic is tested in the Jetpack_Cxn_Tests->test__server_port_value() test.

--- a/packages/connection/legacy/class-jetpack-signature.php
+++ b/packages/connection/legacy/class-jetpack-signature.php
@@ -341,11 +341,15 @@ class Jetpack_Signature {
 	 * It will analyze the current request, as well as some Jetpack constants, to return the string
 	 * to be concatenated in the URL representing the port of the current request.
 	 *
+	 * @since 9.2.0
+	 *
 	 * @return string The port to be used in the signature
 	 */
 	public function get_current_request_port() {
-		$host_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : '';
-		$host_port = '' === $host_port && isset( $_SERVER['SERVER_PORT'] ) ? $_SERVER['SERVER_PORT'] : $host_port;
+		$host_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? $this->sanitize_host_post( $_SERVER['HTTP_X_FORWARDED_PORT'] ) : '';
+		if ( '' === $host_port && isset( $_SERVER['SERVER_PORT'] ) ) {
+			$host_port = $this->sanitize_host_post( $_SERVER['SERVER_PORT'] );
+		}
 
 		/**
 		 * Note: This port logic is tested in the Jetpack_Cxn_Tests->test__server_port_value() test.
@@ -361,17 +365,40 @@ class Jetpack_Signature {
 			// if the site is behind a proxy running on port 443 without
 			// X-Forwarded-Port and the back end's port is *not* 80. It's better,
 			// though, to configure the proxy to send X-Forwarded-Port.
-			$https_port = defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) ? JETPACK_SIGNATURE__HTTPS_PORT : 443;
-			$port       = in_array( $host_port, array( 443, 80, $https_port ), false ) ? '' : $host_port; // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
+			$https_port = defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) ? $this->sanitize_host_post( JETPACK_SIGNATURE__HTTPS_PORT ) : '443';
+			$port       = in_array( $host_port, array( '443', '80', $https_port ), true ) ? '' : $host_port;
 		} else {
 			// 80: Standard Port
 			// JETPACK_SIGNATURE__HTTPS_PORT: Set this constant in wp-config.php to the back end webserver's port
 			// if the site is behind a proxy running on port 80 without
 			// X-Forwarded-Port. It's better, though, to configure the proxy to
 			// send X-Forwarded-Port.
-			$http_port = defined( 'JETPACK_SIGNATURE__HTTP_PORT' ) ? JETPACK_SIGNATURE__HTTP_PORT : 80;
-			$port      = in_array( $host_port, array( 80, $http_port ), false ) ? '' : $host_port; // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
+			$http_port = defined( 'JETPACK_SIGNATURE__HTTP_PORT' ) ? $this->sanitize_host_post( JETPACK_SIGNATURE__HTTP_PORT ) : '80';
+			$port      = in_array( $host_port, array( '80', $http_port ), true ) ? '' : $host_port;
 		}
 		return (string) $port;
+	}
+
+	/**
+	 * Sanitizes a variable checking if it's a valid port number, which can be an integer or a numeric string
+	 *
+	 * @since 9.2.0
+	 *
+	 * @param mixed $port_number Variable representing a port number.
+	 * @return string Always a string with a valid port number, or an empty string if input is invalid
+	 */
+	public function sanitize_host_post( $port_number ) {
+
+		if ( ! is_int( $port_number ) && ! is_string( $port_number ) ) {
+			return '';
+		}
+		if ( is_string( $port_number ) && ! ctype_digit( $port_number ) ) {
+			return '';
+		}
+
+		if ( 0 >= (int) $port_number ) {
+			return '';
+		}
+		return (string) $port_number;
 	}
 }

--- a/packages/connection/legacy/class-jetpack-signature.php
+++ b/packages/connection/legacy/class-jetpack-signature.php
@@ -396,7 +396,7 @@ class Jetpack_Signature {
 			return '';
 		}
 
-		if ( 0 >= (int) $port_number ) {
+		if ( 0 >= (int) $port_number || 65535 < $port_number ) {
 			return '';
 		}
 		return (string) $port_number;

--- a/packages/connection/tests/php/bootstrap.php
+++ b/packages/connection/tests/php/bootstrap.php
@@ -10,4 +10,9 @@
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+// Work around WordPress bug when `@runInSeparateProcess` is used.
+if ( empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
+	$_SERVER['SCRIPT_FILENAME'] = __DIR__ . '/vendor/phpunit/phpunit/phpunit';
+}
+
 \WorDBless\Load::load();

--- a/packages/connection/tests/php/test_Signature.php
+++ b/packages/connection/tests/php/test_Signature.php
@@ -395,61 +395,19 @@ class SignatureTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_request_port_constants() {
-		define( 'JETPACK_SIGNATURE__HTTP_PORT', 81 );
+		define( 'JETPACK_SIGNATURE__HTTP_PORT', 81 ); // http as integer.
 		$this->test_get_request_port( 81, '', '' );
 		$this->test_get_request_port( '81', '', '' );
 		$this->test_get_request_port( 81, '82', '' );
 		$this->test_get_request_port( 82, '81', '82' );
 		$this->test_get_request_port( '82', '81', '82' );
 
-		define( 'JETPACK_SIGNATURE__HTTPS_PORT', 444 );
+		define( 'JETPACK_SIGNATURE__HTTPS_PORT', '444' ); // https as string.
 		$this->test_get_request_port( 444, '', '', true );
 		$this->test_get_request_port( '444', '', '', true );
 		$this->test_get_request_port( 444, '445', '', true );
 		$this->test_get_request_port( 445, '444', '445', true );
 		$this->test_get_request_port( '445', '444', '445', true );
-	}
-
-	/**
-	 * Runs isolated tests to check the behavior of constants when declared as strings
-	 *
-	 * Uses @see self::test_get_request_port
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_request_port_constants_as_strings() {
-		define( 'JETPACK_SIGNATURE__HTTP_PORT', '81' );
-		$this->test_get_request_port( 81, '', '' );
-		$this->test_get_request_port( '81', '', '' );
-		$this->test_get_request_port( 81, '82', '' );
-		$this->test_get_request_port( 82, '81', '82' );
-		$this->test_get_request_port( '82', '81', '82' );
-
-		define( 'JETPACK_SIGNATURE__HTTPS_PORT', '444' );
-		$this->test_get_request_port( 444, '', '', true );
-		$this->test_get_request_port( '444', '', '', true );
-		$this->test_get_request_port( 444, '445', '', true );
-		$this->test_get_request_port( 445, '444', '445', true );
-		$this->test_get_request_port( '445', '444', '445', true );
-	}
-
-	/**
-	 * Runs isolated tests to check the behavior of constants with invalid values
-	 *
-	 * Uses @see self::test_get_request_port
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_request_port_constants_invalid_valies() {
-		define( 'JETPACK_SIGNATURE__HTTP_PORT', 'string' );
-		$this->test_get_request_port( 81, '', '81' );
-		$this->test_get_request_port( '80', '', '' );
-
-		define( 'JETPACK_SIGNATURE__HTTPS_PORT', false );
-		$this->test_get_request_port( 444, '', '444', true );
-		$this->test_get_request_port( '443', '', '', true );
 	}
 
 }

--- a/packages/connection/tests/php/test_Signature.php
+++ b/packages/connection/tests/php/test_Signature.php
@@ -211,6 +211,10 @@ class SignatureTest extends TestCase {
 				'13',
 				'13',
 			),
+			array(
+				'65536',
+				'',
+			),
 		);
 	}
 

--- a/packages/connection/tests/php/test_Signature.php
+++ b/packages/connection/tests/php/test_Signature.php
@@ -155,4 +155,153 @@ class SignatureTest extends TestCase {
 				),
 		);
 	}
+
+	/**
+	 * Tests the get_current_request_port method
+	 *
+	 * @param mixed   $http_x_forwarded_port value of $_SERVER[ 'HTTP_X_FORWARDED_PORT' ].
+	 * @param mixed   $server_port value of $_SERVER[ 'SERVER_PORT' ]. Null will unset the value.
+	 * @param string  $expeceted The expected output. Null will unset the value.
+	 * @param boolean $ssl Whether to consider current request using SSL or not.
+	 *
+	 * @dataProvider get_request_port_data_provider
+	 */
+	public function test_get_request_port( $http_x_forwarded_port, $server_port, $expeceted, $ssl = false ) {
+
+		$original_server = $_SERVER;
+
+		$_SERVER['HTTP_X_FORWARDED_PORT'] = $http_x_forwarded_port;
+		$_SERVER['SERVER_PORT']           = $server_port;
+
+		if ( $ssl ) {
+			$_SERVER['HTTPS'] = 'on'; // is_ssl will return true.
+		}
+
+		if ( is_null( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ) {
+			unset( $_SERVER['HTTP_X_FORWARDED_PORT'] );
+		}
+
+		if ( is_null( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ) {
+			unset( $_SERVER['HTTP_X_FORWARDED_PORT'] );
+		}
+
+		$signature = new \Jetpack_Signature( 'some-secret', 0 );
+		$port      = $signature->get_current_request_port();
+
+		$_SERVER = $original_server;
+
+		$this->assertSame( $expeceted, $port );
+	}
+
+	/**
+	 * Data provider for test_get_request_port
+	 *
+	 * @return array
+	 */
+	public function get_request_port_data_provider() {
+		return array(
+			array(
+				'',
+				80,
+				'',
+			),
+			array(
+				'',
+				'80',
+				'',
+			),
+			array(
+				'',
+				null,
+				'',
+			),
+			array(
+				null,
+				null,
+				'',
+			),
+			array(
+				'',
+				81,
+				'81',
+			),
+			array(
+				'',
+				'81',
+				'81',
+			),
+			array(
+				82,
+				'81',
+				'82',
+			),
+			array(
+				'82',
+				'81',
+				'82',
+			),
+			array(
+				82,
+				'',
+				'82',
+			),
+
+			// SSL.
+			array(
+				'',
+				443,
+				'',
+				true,
+			),
+			array(
+				'',
+				'443',
+				'',
+				true,
+			),
+			array(
+				null,
+				'443',
+				'',
+				true,
+			),
+			array(
+				null,
+				null,
+				'',
+				true,
+			),
+			array(
+				'',
+				444,
+				'444',
+				true,
+			),
+			array(
+				'',
+				'444',
+				'444',
+				true,
+			),
+			array(
+				445,
+				'444',
+				'445',
+				true,
+			),
+			array(
+				'445',
+				'444',
+				'445',
+				true,
+			),
+			array(
+				445,
+				'',
+				'445',
+				true,
+			),
+		);
+	}
+
 }


### PR DESCRIPTION
Related to this JPOP issue 6089-gh-jpop-issues

### The bug

We are not handling situations where PHP variable `$_SERVER['SERVER_PORT']` is not set. We assume it is always there, but according to the PHP documentation](https://www.php.net/manual/en/reserved.variables.server.php):

```
Note: Under the Apache 2, you must set UseCanonicalName = On, as well as UseCanonicalPhysicalPort = On in order to get the physical (real) port, otherwise, this value can be spoofed and it may or may not return the physical port value. It is not safe to rely on this value in security-dependent contexts. 
```

When this value is not set, we cast it to integer and it ends up as `0` -> https://github.com/Automattic/jetpack/blob/master/packages/connection/legacy/class-jetpack-signature.php#L78

Then, when we check it further, `0` is not in the list of the default ports and it ends up in the URL, making it invalid. -> https://github.com/Automattic/jetpack/blob/master/packages/connection/legacy/class-jetpack-signature.php#L95

### Why

[16 Sep 2019](https://github.com/Automattic/jetpack/pull/13489) - We made the `in_array` check strict, to match our PHPCS rules

[24 Sep 2019](https://github.com/Automattic/jetpack/pull/13523) - This broke the check for the PORT number, because it is often a string, so the typecast was introduced

[22 Nov 2019](https://github.com/Automattic/jetpack/pull/14111) - The loose comparison was reintroduced, because it was breaking other situations

So the typecast was introduced to fix something that was removed later on and could safely be removed.

### The Fix

We could simply remove the line that does the typecast, but that would keep throwing an Error Notice when `$_SERVER['SERVER_PORT']` is not set, so we fixed that as well.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a connected site on the master branch
* Edit your `wp-config.php` and add `unset($_SERVER['SERVER_PORT']);`.
* Access the Jetpack debugger and debug your site
* Check that the debugger returns an error
* Check your local error logs and confirm it's throwing a PHP Error notice for the undefined variable

* Check out this branch
* Visit the debugger again
* Confirm Everything Looks Great
* Confirm there are no errors in your local logs

* Edit your `wp-config.php` and add `$_SERVER['HTTP_X_FORWARDED_PORT'] = 80`
* run the tests and check that everything works

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Handle XMLRPC requests when SERVER_PORT is not defined