### PR TITLE
Pass HTTP POST when making a wp.com api request

### DIFF
--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -424,7 +424,7 @@ class Client {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_filter( 'is_jetpack_authorized_for_site', '__return_true' );
 			require_lib( 'wpcom-api-direct' );
-			return \WPCOM_API_Direct::do_request( $validated_args );
+			return \WPCOM_API_Direct::do_request( $validated_args, $body );
 		}
 
 		return self::remote_request( $validated_args, $body );


### PR DESCRIPTION
To support the new VideoPress endpoint in D52124-code we need to pass the body through to the connection client when making a request to wp.com via `wpcom_json_api_request_as_blog()`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Passes through the `$body` object `WPCOM_API_Direct::do_request`. The body is safely checked if it exists in that function.

#### Jetpack product discussion
pxWta-Tk-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Apply PR and verify existing calls to wp.com are still functioning as expected. I tested the latest Instagram posts block.
* See D52124-code for testing instructions that utilize a POST request.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changes.
