### PR TITLE
Publicize: avoid Fatal errors in post editor in PHP 8

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -1004,10 +1004,11 @@ abstract class Publicize_Base {
 		foreach ( (array) $this->get_services( 'connected' ) as $service_name => $connections ) {
 			foreach ( $connections as $connection ) {
 				$connection_data = '';
-				if ( method_exists( $connection, 'get_meta' ) )
+				if ( is_object( $connection ) && method_exists( $connection, 'get_meta' ) ) {
 					$connection_data = $connection->get_meta( 'connection_data' );
-				elseif ( ! empty( $connection['connection_data'] ) )
+				} elseif ( ! empty( $connection['connection_data'] ) ) {
 					$connection_data = $connection['connection_data'];
+				}
 
 				/** This action is documented in modules/publicize/ui.php */
 				if ( false == apply_filters( 'wpas_submit_post?', $submit_post, $post_id, $service_name, $connection_data ) ) {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Avoid Fatal errors when opening the post editor in PHP 8.

**Note** There may be other instances of that problem in other parts of the codebase; I took note of it in the primary issue. This fixes the immediate fatal in the post editor.

#### Jetpack product discussion

* Primary issue: #17166 

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a site on a PHP 8 environment, connect the site to WordPress.com and enable Publicize
* Go to Posts > Add New
* Your site should stay up.

#### Proposed changelog entry for your changes:

* Publicize: improve compatibility with PHP 8
