### PR TITLE
Git hooks: Improve "not verified" flagging

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -96,11 +96,11 @@ function checkFileAgainstDirtyList( file, filesList ) {
 }
 
 /**
- * Captures a pre-commit date to be used later in prepare-commit-msg.js hook to figure out whether pre-commit was executed
+ * Captures the tree hash being committed to be used later in prepare-commit-msg.js hook to figure out whether pre-commit was executed
  */
-function capturePreCommitDate() {
+function capturePreCommitTreeHash() {
 	if ( exitCode === 0 ) {
-		fs.writeFileSync( '.git/last-commit-date', Date.now() );
+		fs.writeFileSync( '.git/last-commit-tree', execSync( 'git write-tree' ) );
 	}
 }
 
@@ -201,7 +201,7 @@ function checkComposerLock() {
  * @param {Number} exitCodePassed Shell exit code.
  */
 function exit( exitCodePassed ) {
-	capturePreCommitDate();
+	capturePreCommitTreeHash();
 	process.exit( exitCodePassed );
 }
 

--- a/bin/prepare-commit-msg.js
+++ b/bin/prepare-commit-msg.js
@@ -1,18 +1,30 @@
 /* eslint-disable no-console */
+const execSync = require( 'child_process' ).execSync;
 const fs = require( 'fs' );
 
-fs.readFile( '.git/last-commit-date', ( err, data ) => {
+const notVerifiedPrefix = '[not verified] ';
+
+fs.readFile( '.git/last-commit-tree', ( err, data ) => {
 	if ( err ) {
 		console.log( 'skipping prepare-commit-msg hook' );
 		return;
 	}
-	const commitDate = data.toString();
+	const commitTree = data.toString();
+	const curTree = execSync( 'git write-tree' ).toString();
 
-	if ( Date.now() - commitDate > 2000 /* 2sec*/ ) {
+	const commitMsg = fs.readFileSync( '.git/COMMIT_EDITMSG' ).toString();
+	let newCommitMsg = null;
+	if ( commitTree !== curTree ) {
 		console.log( 'WARNING: git pre-commit hook was skipped!' );
-		const commitMsg = fs.readFileSync( '.git/COMMIT_EDITMSG' );
-		const newCommitMsg = '[not verified] ' + commitMsg.toString();
-
+		if ( ! commitMsg.startsWith( notVerifiedPrefix ) ) {
+			newCommitMsg = notVerifiedPrefix + commitMsg;
+		}
+	} else {
+		if ( commitMsg.startsWith( notVerifiedPrefix ) ) {
+			newCommitMsg = commitMsg.substring( notVerifiedPrefix.length );
+		}
+	}
+	if ( null !== newCommitMsg ) {
 		fs.writeFileSync( '.git/COMMIT_EDITMSG', newCommitMsg );
 	}
 } );

--- a/bin/prepare-commit-msg.js
+++ b/bin/prepare-commit-msg.js
@@ -19,10 +19,8 @@ fs.readFile( '.git/last-commit-tree', ( err, data ) => {
 		if ( ! commitMsg.startsWith( notVerifiedPrefix ) ) {
 			newCommitMsg = notVerifiedPrefix + commitMsg;
 		}
-	} else {
-		if ( commitMsg.startsWith( notVerifiedPrefix ) ) {
-			newCommitMsg = commitMsg.substring( notVerifiedPrefix.length );
-		}
+	} else if ( commitMsg.startsWith( notVerifiedPrefix ) ) {
+		newCommitMsg = commitMsg.substring( notVerifiedPrefix.length );
 	}
 	if ( null !== newCommitMsg ) {
 		fs.writeFileSync( '.git/COMMIT_EDITMSG', newCommitMsg );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Improvements:

* We can more reliably detect whether the hook was run by storing the
  tree hash that's going to be committed rather than a timestamp.
* If the commit is already flagged as not verified, there's no point in
  adding the flag again ("[not verified] [not verified]").
* If the commit is flagged as not verified but it was just verified, we
  can remove the flag.

There seems to be no way to do the right thing (i.e. verify) on a cherry
pick or rebase. But this does still improve the situation for those too.
For a cherry pick you can `git commit --amend` immediately after, which
will verify and will now remove the flag. For a rebase, you can do it
with --interactive and change "pick" to "reword" on all lines, which
will for some reason also verify each one.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None, although #16985 is somewhat relevant.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a commit with `--no-verify`. See that it gets flagged with `[not verified]`.
* Amend the commit with `--no-verify`. See that the `[not verified]` remains, but is not doubled.
* Amend the commit without `--no-verify`. See that checks are run and the `[not verified]` is removed.
* Amend the commit with `--no-verify`. See that the `[not verified]` is added back.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Developer only, none needed.
