### PR TITLE
Codesniffer: Fix code coverage generation hang due to Generic.PHP.Syntax sniff

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -23,6 +23,11 @@
 		</properties>
 	</rule>
 
+	<!-- WordPress-Extra pulls this in. But PHP linting can be run more efficiently via bin/parallel-lint.sh than by having phpcs shell out to `php -l`. -->
+	<rule ref="Generic.PHP.Syntax">
+		<exclude name="Generic.PHP.Syntax" />
+	</rule>
+
 	<!-- Check all PHP files in directory tree by default. -->
 	<arg name="extensions" value="php"/>
 	<file>.</file>

--- a/packages/codesniffer/Jetpack/ruleset.xml
+++ b/packages/codesniffer/Jetpack/ruleset.xml
@@ -44,12 +44,6 @@
 		<type>error</type>
 	</rule>
 
-	<!-- WordPress-Extra pulls this in. But PHP linting can be run more efficiently than having phpcs shell out to `php -l`. -->
-	<!-- Plus including it breaks code coverage generation with phpdbg. -->
-	<rule ref="Generic.PHP.Syntax">
-		<exclude name="Generic.PHP.Syntax" />
-	</rule>
-
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
 		<properties>
 			<property name="allowWordPressPassByRefFunctions" value="true" />

--- a/packages/codesniffer/Jetpack/ruleset.xml
+++ b/packages/codesniffer/Jetpack/ruleset.xml
@@ -44,6 +44,12 @@
 		<type>error</type>
 	</rule>
 
+	<!-- WordPress-Extra pulls this in. But PHP linting can be run more efficiently than having phpcs shell out to `php -l`. -->
+	<!-- Plus including it breaks code coverage generation with phpdbg. -->
+	<rule ref="Generic.PHP.Syntax">
+		<exclude name="Generic.PHP.Syntax" />
+	</rule>
+
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
 		<properties>
 			<property name="allowWordPressPassByRefFunctions" value="true" />

--- a/packages/codesniffer/tests/php/tests/test-jetpackstandard.php
+++ b/packages/codesniffer/tests/php/tests/test-jetpackstandard.php
@@ -44,6 +44,9 @@ class JetpackStandardTest extends TestCase {
 		$config->reportWidth = PHP_INT_MAX; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$config->showSources = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$config->tabWidth    = 4; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$config->exclude     = array(
+			'Generic.PHP.Syntax', // Tries to use `PHP_BINARY` to shell out to `php -l`, which breaks if tests are being run under phpdbg for coverage.
+		);
 
 		$ruleset = new Ruleset( $config );
 		$dummy   = new DummyFile( $contents, $ruleset, $config );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We generate code coverage using phpdbg. If you pass it `-qrr` it works to execute command-line scripts, but it's not really command-line compatible with the standard PHP executable.

None the less, it still sets `PHP_BINARY` to point to itself, and without the `-qrr`. This will break anything that tries to use `PHP_BINARY` to shell out to PHP, and in particular breaks the Generic.PHP.Syntax sniff's attempt to shell out to `php -l`.

So when we try to generate code coverage for the codesniffer package, and it executes the sniffs to test them, the Generic.PHP.Syntax sniff hangs.

There are a few ways we might work around this:

1. Exclude Generic.PHP.Syntax from the Jetpack standard. Linting can be done more efficiently with php-parallel-lint.
2. Exclude Generic.PHP.Syntax when running tests, as if phpcs had been invoked by `--exclude=Generic.PHP.Syntax`.
3. Have the tests override phpcs's use of `PHP_BINARY`. But,
   a. We'd have to determine what replacement to use.
   b. Phpcs does this in static methods with global state.

This PR does #<span/>2. #<span/>1 got pushback in code review. #<span/>3 isn't _hard_, but might be fragile so let's avoid it unless we have to.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1604598844016200-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See if the code coverage generation works now.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Developer only, none needed.
