### PR TITLE
Tests: Clean up registered post types

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -630,6 +630,9 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
 		$sync_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$this->assertFalse( $sync_event );
+
+		// Clean up.
+		unregister_post_type( 'snitch' );
 	}
 
 	/**
@@ -650,6 +653,9 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
 		$sync_event = $this->server_event_storage->get_most_recent_event( 'jetpack_published_post' );
 		$this->assertFalse( $sync_event );
+
+		// Clean up.
+		unregister_post_type( 'snitch' );
 	}
 
 	/**
@@ -672,6 +678,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertFalse( $deleted_event );
 
+		// Clean up.
+		unregister_post_type( 'snitch' );
 	}
 
 	function test_filters_out_blacklisted_post_types_and_their_post_meta() {
@@ -690,6 +698,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'hello', true ) );
 
+		// Clean up.
+		unregister_post_type( 'snitch' );
 	}
 
 	function test_post_types_blacklist_can_be_appended_in_settings() {
@@ -718,6 +728,9 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		foreach( Defaults::$blacklisted_post_types as $hardcoded_blacklist_post_type ) {
 			$this->assertTrue( in_array( $hardcoded_blacklist_post_type, $setting ) );
 		}
+
+		// Clean up.
+		unregister_post_type( 'filter_me' );
 	}
 
 	function test_does_not_publicize_blacklisted_post_types() {
@@ -733,6 +746,9 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$good_post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
 
 		$this->assertTrue( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $good_post_id ) ) );
+
+		// Clean up.
+		unregister_post_type( 'dont_publicize_me' );
 	}
 
 	function test_returns_post_object_by_id() {
@@ -996,6 +1012,8 @@ POST_CONTENT;
 		$this->assertEquals( '', $synced_post->post_content_filtered );
 		$this->assertEquals( '', $synced_post->post_excerpt_filtered );
 
+		// Clean up.
+		unregister_post_type( 'non_public' );
 	}
 
 	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -627,12 +627,12 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
+		// Clean up.
+		unregister_post_type( 'snitch' );
+
 		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
 		$sync_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_post' );
 		$this->assertFalse( $sync_event );
-
-		// Clean up.
-		unregister_post_type( 'snitch' );
 	}
 
 	/**
@@ -650,19 +650,18 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
+		// Clean up.
+		unregister_post_type( 'snitch' );
+
 		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
 		$sync_event = $this->server_event_storage->get_most_recent_event( 'jetpack_published_post' );
 		$this->assertFalse( $sync_event );
-
-		// Clean up.
-		unregister_post_type( 'snitch' );
 	}
 
 	/**
 	 * Tests that deleted_post events are not sent for blacklisted post_types.
 	 */
 	public function test_filters_out_blacklisted_post_types_deleted_posts() {
-
 		$args = array(
 			'public' => true,
 			'label'  => 'Snitch',
@@ -676,10 +675,10 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$deleted_event = $this->server_event_storage->get_most_recent_event( 'deleted_post' );
 
-		$this->assertFalse( $deleted_event );
-
 		// Clean up.
 		unregister_post_type( 'snitch' );
+
+		$this->assertFalse( $deleted_event );
 	}
 
 	function test_filters_out_blacklisted_post_types_and_their_post_meta() {
@@ -694,29 +693,35 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
+		// Clean up.
+		unregister_post_type( 'snitch' );
+
 		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
 
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'hello', true ) );
-
-		// Clean up.
-		unregister_post_type( 'snitch' );
 	}
 
 	function test_post_types_blacklist_can_be_appended_in_settings() {
 		register_post_type( 'filter_me', array( 'public' => true, 'label' => 'Filter Me' ) );
-
 		$post_id = $this->factory->post->create( array( 'post_type' => 'filter_me' ) );
-
 		$this->sender->do_sync();
+		unregister_post_type( 'filter_me' );
 
 		// first, show that post is being synced
 		$this->assertTrue( !! $this->server_replica_storage->get_post( $post_id ) );
 
 		Settings::update_settings( array( 'post_types_blacklist' => array( 'filter_me' ) ) );
 
+		register_post_type(
+			'filter_me',
+			array(
+				'public' => true,
+				'label'  => 'Filter Me',
+			)
+		);
 		$post_id = $this->factory->post->create( array( 'post_type' => 'filter_me' ) );
-
 		$this->sender->do_sync();
+		unregister_post_type( 'filter_me' );
 
 		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
 
@@ -728,14 +733,14 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		foreach( Defaults::$blacklisted_post_types as $hardcoded_blacklist_post_type ) {
 			$this->assertTrue( in_array( $hardcoded_blacklist_post_type, $setting ) );
 		}
-
-		// Clean up.
-		unregister_post_type( 'filter_me' );
 	}
 
 	function test_does_not_publicize_blacklisted_post_types() {
 		register_post_type( 'dont_publicize_me', array( 'public' => true, 'label' => 'Filter Me' ) );
 		$post_id = $this->factory->post->create( array( 'post_type' => 'dont_publicize_me' ) );
+
+		// Clean up.
+		unregister_post_type( 'dont_publicize_me' );
 
 		$this->assertTrue( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $post_id ) ) );
 
@@ -746,9 +751,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$good_post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
 
 		$this->assertTrue( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $good_post_id ) ) );
-
-		// Clean up.
-		unregister_post_type( 'dont_publicize_me' );
 	}
 
 	function test_returns_post_object_by_id() {
@@ -1009,11 +1011,11 @@ POST_CONTENT;
 		$this->sender->do_sync();
 		$synced_post = $this->server_replica_storage->get_post( $post_id );
 
-		$this->assertEquals( '', $synced_post->post_content_filtered );
-		$this->assertEquals( '', $synced_post->post_excerpt_filtered );
-
 		// Clean up.
 		unregister_post_type( 'non_public' );
+
+		$this->assertSame( '', $synced_post->post_content_filtered );
+		$this->assertSame( '', $synced_post->post_excerpt_filtered );
 	}
 
 	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -407,6 +407,9 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
 
 		$this->assertFalse( $event );
+
+		// Clean up.
+		unregister_post_type( 'http_listener' );
 	}
 
 	function test_do_not_send_empty_queue_clear_skipped_items() {

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -406,10 +406,10 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
 
-		$this->assertFalse( $event );
-
 		// Clean up.
 		unregister_post_type( 'http_listener' );
+
+		$this->assertFalse( $event );
 	}
 
 	function test_do_not_send_empty_queue_clear_skipped_items() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
There are tests that register custom post types but don't clean them up after. This results in an unexpected menu structure for the admin menu tests that I'm currently working on in #17629.

Before change: https://travis-ci.com/github/Automattic/jetpack/jobs/430331383
After change: https://travis-ci.com/github/Automattic/jetpack/jobs/430390368

See #17629.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `unregister_post_type` calls to every test that registers a post type.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To run unit tests:
* Follow [setup guidelines](https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md#unit-testing) if you don't have unit tests set up yet.
* Run `phpunit`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
