### PR TITLE
Coming soon: synching roll back changes on WPCOM 

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -129,7 +129,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'jetpack_frame_nonce',
 		'page_on_front',
 		'page_for_posts',
-		'wpcom_public_coming_soon_page_id',
 		'headstart',
 		'headstart_is_fresh',
 		'ak_vp_bundle_enabled',
@@ -556,9 +555,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					if ( $custom_front_page ) {
 						$options[ $key ] = $site->get_page_for_posts();
 					}
-					break;
-				case 'wpcom_public_coming_soon_page_id':
-					$options[ $key ] = $site->get_wpcom_public_coming_soon_page_id();
 					break;
 				case 'headstart' :
 					$options[ $key ] = $site->is_headstart();

--- a/json-endpoints/class.wpcom-json-api-update-site-homepage-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-site-homepage-endpoint.php
@@ -14,13 +14,11 @@ new WPCOM_JSON_API_Update_Site_Homepage_Endpoint( array (
 		'is_page_on_front' => '(bool) True if we will use a page as the homepage; false to use a blog page as the homepage.',
 		'page_on_front_id' => '(int) Optional. The ID of the page to use as the homepage if is_page_on_front is true.',
 		'page_for_posts_id' => '(int) Optional. The ID of the page to use as the blog page if is_page_on_front is true.',
-		'wpcom_public_coming_soon_page_id' => '(int) Optional. The ID of the page to use as the coming soon page page.',
 	),
 	'response_format'  => array(
 		'is_page_on_front' => '(bool) True if we will use a page as the homepage; false to use a blog page as the homepage.',
 		'page_on_front_id' => '(int) The ID of the page to use as the homepage if is_page_on_front is true.',
 		'page_for_posts_id' => '(int) The ID of the page to use as the blog page if is_page_on_front is true.',
-		'wpcom_public_coming_soon_page_id' => '(int) The ID of the page to use as the coming soon page.',
 	),
 	'example_request'  => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/homepage',
 	'example_request_data' => array(
@@ -29,10 +27,9 @@ new WPCOM_JSON_API_Update_Site_Homepage_Endpoint( array (
 			'is_page_on_front' => true,
 			'page_on_front_id' => 1,
 			'page_for_posts_id' => 0,
-			'wpcom_public_coming_soon_page_id' => 0,
 		),
 	),
-	'example_response' => '{"is_page_on_front":true,"page_on_front_id":1,"page_for_posts_id":0,"wpcom_public_coming_soon_page_id":0}',
+	'example_response' => '{"is_page_on_front":true,"page_on_front_id":1,"page_for_posts_id":0}',
 ) );
 
 class WPCOM_JSON_API_Update_Site_Homepage_Endpoint extends WPCOM_JSON_API_Endpoint {
@@ -62,9 +59,6 @@ class WPCOM_JSON_API_Update_Site_Homepage_Endpoint extends WPCOM_JSON_API_Endpoi
 		if ( isset( $args['page_for_posts_id'] ) ) {
 			update_option( 'page_for_posts', $args['page_for_posts_id'] );
 		}
-		if ( isset( $args['wpcom_public_coming_soon_page_id'] ) ) {
-			update_option( 'wpcom_public_coming_soon_page_id', $args['wpcom_public_coming_soon_page_id'] );
-		}
 
 		return $this->get_current_settings();
 	}
@@ -73,13 +67,11 @@ class WPCOM_JSON_API_Update_Site_Homepage_Endpoint extends WPCOM_JSON_API_Endpoi
 		$is_page_on_front = ( get_option( 'show_on_front' ) === 'page' );
 		$page_on_front_id = get_option( 'page_on_front' );
 		$page_for_posts_id = get_option( 'page_for_posts' );
-		$wpcom_public_coming_soon_page_id = get_option( 'wpcom_public_coming_soon_page_id' );
 
 		return array(
 			'is_page_on_front' => $is_page_on_front,
 			'page_on_front_id' => $page_on_front_id,
 			'page_for_posts_id' => $page_for_posts_id,
-			'wpcom_public_coming_soon_page_id' => $wpcom_public_coming_soon_page_id,
 		);
 	}
 }

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -616,10 +616,6 @@ abstract class SAL_Site {
 		return (int) get_option( 'page_for_posts' );
 	}
 
-	public function get_wpcom_public_coming_soon_page_id() {
-		return (int) get_option( 'wpcom_public_coming_soon_page_id' );
-	}
-
 	function is_headstart() {
 		return get_option( 'headstart' );
 	}


### PR DESCRIPTION
####  Summary

This commit:
- syncs changes from D52434-code (r216472-wpcom) and D52433-code (r216472-wpcom)  (which rolled back the corresponding code in WPCOM)
- effectively rolls back https://github.com/Automattic/jetpack/pull/17105 

### Privacy
This PR makes no changes to data or privacy.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Remove support for public coming soon page redesign, which we've decided not to release at all
