### PR TITLE
Add Unified Admin Color Schemes module skeleton

### DIFF
--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -55,6 +55,7 @@ $connected_tools = array(
 	// Starting from 2020-10-24, they need an authentication token, and that token is stored on WordPress.com.
 	// More information: https://developers.facebook.com/docs/instagram/oembed/.
 	'shortcodes/instagram.php',
+	'unified-admin-color-schemes.php',
 );
 
 // Add connected features to our existing list if the site is currently connected.

--- a/modules/unified-admin-color-schemes.php
+++ b/modules/unified-admin-color-schemes.php
@@ -1,0 +1,10 @@
+<?php
+
+function uacs_setup_admin() {
+
+}
+
+add_action( 'admin_init', 'uacs_setup_admin', 6 );
+
+
+


### PR DESCRIPTION
Adds a new module skeleton to provide a starting point for all code required for the admin color scheme unification on Dotcom.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds new module `unified-admin-color-schemes`.

#### Jetpack product discussion

https://github.com/Automattic/wp-calypso/issues/45675

#### Does this pull request change what data or activity we track or use?
Nope

#### Testing instructions:

* Checkout PR.
* Add some debugging to the `uacs_setup_admin` function.
* Check the debugging is run.

#### Proposed changelog entry for your changes:

* Adds `unified-admin-color-schemes` module.
