### PR TITLE
Git hooks: Revert code removing the "not verified" tag

### DIFF
--- a/bin/prepare-commit-msg.js
+++ b/bin/prepare-commit-msg.js
@@ -20,7 +20,11 @@ fs.readFile( '.git/last-commit-tree', ( err, data ) => {
 			newCommitMsg = notVerifiedPrefix + commitMsg;
 		}
 	} else if ( commitMsg.startsWith( notVerifiedPrefix ) ) {
-		newCommitMsg = commitMsg.substring( notVerifiedPrefix.length );
+		// Ideally we'd remove the tag here, but to reliably do that we'd have to have
+		// pre-commit-hook.js check all files in --amend instead of only the ones being
+		// changed in the amendment. So for now, don't do it.
+		//
+		// newCommitMsg = commitMsg.substring( notVerifiedPrefix.length );
 	}
 	if ( null !== newCommitMsg ) {
 		fs.writeFileSync( '.git/COMMIT_EDITMSG', newCommitMsg );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In #17728 we added some code to remove the "not verified" tag when
verification passed, on the assumption that the pre-commit hook was
verifying the whole commit on an --amend.

It turns out that it only verifies the changes being made, rather than
the commit as a whole. So removing the tag is not the correct thing to
do unless we can figure out a way to detect --amend and reverify the
whole commit.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a commit with --no-verify. See that it gets flagged with [not verified].
* Amend the commit with --no-verify. See that the [not verified] remains, but is not doubled.
* Amend the commit without --no-verify. See that the [not verified] remains, but is not doubled.
* Amend the commit with --no-verify. See that the [not verified] remains, but is not doubled.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Developer only, none needed.
