### PR TITLE
Scan: Use admin menu API to register menu item

### DIFF
--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -65,19 +65,6 @@ class Admin_Sidebar_Link {
 			return;
 		}
 
-		$new_link = $this->get_new_link();
-
-		// Splice the nav menu item into the Jetpack nav.
-		global $submenu;
-		array_splice( $submenu['jetpack'], $this->get_link_offset(), 0, array( $new_link ) );
-	}
-
-	/**
-	 * Retuns the new link.
-	 *
-	 *  @return array Link array to be added to the sidebar.
-	 */
-	private function get_new_link() {
 		$has_scan   = $this->has_scan();
 		$has_backup = $this->has_backup();
 
@@ -92,16 +79,11 @@ class Admin_Sidebar_Link {
 			$menu_label = __( 'Backup & Scan', 'jetpack' );
 		}
 
-		return array(
-			esc_html( $menu_label ) . ' <span class="dashicons dashicons-external"></span>',
-			'manage_options', // Check permissions here.
-			esc_url( $url ),
-		);
-
+		add_submenu_page( 'jetpack', $menu_label, esc_html( $menu_label ) . ' <span class="dashicons dashicons-external"></span>', 'manage_options', esc_url( $url ), null, $this->get_link_offset() );
 	}
 
 	/**
-	 * We create a menu offset by counting all the pages that have a jetpack_admin_page set as the link.
+	 * We create a menu offset by counting all the pages that have a jetpack_admin_page set as the capability.
 	 *
 	 * This makes it so that the highlight of the pages works as expected. When you click on the Setting or Dashboard.
 	 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Using the admin menu API when registering menu items ensures that they only get registered for users with the right capabilities and get associated with the right parent menu item.

Heads Up: `maybe_add_admin_link()` gets registered as a callback to `jetpack_admin_menu` for all requests, even front-end requests.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the private function `get_new_link()` and brings its content into `maybe_add_admin_link()`.
* Uses the admin menu api to add the menu item rather than splicing it into the `$submenu` global.
* Maintains escaping and permissions for back compat.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a test install, make sure VaultPress is active for the link to show up.
* Load wp-admin and make sure the link still shows up and works as intended.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
