### PR TITLE
Story block: Fix static preview for VideoPress videos on WP.com

### DIFF
--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -229,8 +229,13 @@ function render_slide( $media, $index = 0 ) {
 			$media_template = render_image( $media, $index );
 			break;
 		case 'video':
-		case 'file':
 			$media_template = render_video( $media, $index );
+			break;
+		case 'file':
+			// VideoPress videos on WordPress.com can have type 'file'.
+			if ( 'video' === substr( $media['mime'], 0, 5 ) ) {
+				$media_template = render_video( $media, $index );
+			}
 			break;
 	}
 	return sprintf(

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -168,9 +168,20 @@ function render_video( $media ) {
 	}
 
 	$metadata = wp_get_attachment_metadata( $media['id'] );
+
 	if ( ! empty( $metadata ) && ! empty( $metadata['videopress'] ) ) {
+		// Use poster image for VideoPress videos.
 		$poster_url  = $metadata['videopress']['poster'];
 		$description = ! empty( $metadata['videopress']['description'] ) ? $metadata['videopress']['description'] : '';
+	} elseif ( ! empty( $metadata['thumb'] ) ) {
+		// On WordPress.com, VideoPress videos have a 'thumb' property with the
+		// poster image filename instead.
+		$video_url   = wp_get_attachment_url( $media['id'] );
+		$poster_url  = str_replace( wp_basename( $video_url ), $metadata['thumb'], $video_url );
+		$description = ! empty( $media['alt'] ) ? $media['alt'] : '';
+	}
+
+	if ( ! empty( $poster_url ) ) {
 		return sprintf(
 			'<img
 				title="%s"

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -173,24 +173,25 @@ function render_video( $media ) {
 		// Use poster image for VideoPress videos.
 		$poster_url  = $metadata['videopress']['poster'];
 		$description = ! empty( $metadata['videopress']['description'] ) ? $metadata['videopress']['description'] : '';
+		$meta_width  = $metadata['videopress']['width'];
+		$meta_height = $metadata['videopress']['height'];
 	} elseif ( ! empty( $metadata['thumb'] ) ) {
 		// On WordPress.com, VideoPress videos have a 'thumb' property with the
 		// poster image filename instead.
 		$video_url   = wp_get_attachment_url( $media['id'] );
 		$poster_url  = str_replace( wp_basename( $video_url ), $metadata['thumb'], $video_url );
 		$description = ! empty( $media['alt'] ) ? $media['alt'] : '';
+		$meta_width  = $metadata['width'];
+		$meta_height = $metadata['height'];
 	}
 
 	if ( ! empty( $poster_url ) ) {
 		return sprintf(
-			'<img
-				title="%s"
-				alt="%s"
-				class="wp-block-jetpack-story_image wp-story-image %s"
-				src="%s">',
+			'<img title="%1$s" alt="%2$s" class="%3$s" src="%4$s">',
 			esc_attr( get_the_title( $media['id'] ) ),
 			esc_attr( $description ),
-			get_image_crop_class( $metadata['videopress']['width'], $metadata['videopress']['height'] ),
+			'wp-block-jetpack-story_image wp-story-image ' .
+			get_image_crop_class( $meta_width, $meta_height ),
 			esc_attr( $poster_url )
 		);
 	}

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -187,12 +187,14 @@ function render_video( $media ) {
 
 	if ( ! empty( $poster_url ) ) {
 		return sprintf(
-			'<img title="%1$s" alt="%2$s" class="%3$s" src="%4$s">',
+			'<img title="%1$s" alt="%2$s" class="%3$s" src="%4$s" width="%5$s" height="%6$s">',
 			esc_attr( get_the_title( $media['id'] ) ),
 			esc_attr( $description ),
 			'wp-block-jetpack-story_image wp-story-image ' .
 			get_image_crop_class( $meta_width, $meta_height ),
-			esc_attr( $poster_url )
+			esc_attr( $poster_url ),
+			$meta_width,
+			$meta_height
 		);
 	}
 

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -187,14 +187,14 @@ function render_video( $media ) {
 
 	if ( ! empty( $poster_url ) ) {
 		return sprintf(
-			'<img title="%1$s" alt="%2$s" class="%3$s" src="%4$s" width="%5$s" height="%6$s">',
+			'<img title="%1$s" alt="%2$s" class="%3$s" src="%4$s"%5$s%6$s>',
 			esc_attr( get_the_title( $media['id'] ) ),
 			esc_attr( $description ),
 			'wp-block-jetpack-story_image wp-story-image ' .
 			get_image_crop_class( $meta_width, $meta_height ),
 			esc_attr( $poster_url ),
-			$meta_width,
-			$meta_height
+			! empty( $meta_width ) ? " width=\"$meta_width\"" : '',
+			! empty( $meta_height ) ? " height=\"$meta_height\"" : ''
 		);
 	}
 

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -193,8 +193,8 @@ function render_video( $media ) {
 			'wp-block-jetpack-story_image wp-story-image ' .
 			get_image_crop_class( $meta_width, $meta_height ),
 			esc_attr( $poster_url ),
-			! empty( $meta_width ) ? " width=\"$meta_width\"" : '',
-			! empty( $meta_height ) ? " height=\"$meta_height\"" : ''
+			! empty( $meta_width ) ? ' width="' . esc_attr( $meta_width ) . '"' : '',
+			! empty( $meta_height ) ? ' height="' . esc_attr( $meta_height ) . '"' : ''
 		);
 	}
 

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -235,7 +235,7 @@ function render_slide( $media, $index = 0 ) {
 			$media_template = render_video( $media, $index );
 			break;
 		case 'file':
-			// VideoPress videos on WordPress.com can have type 'file'.
+			// VideoPress videos can sometimes have type 'file', and mime 'video/videopress' or 'video/mp4'.
 			if ( 'video' === substr( $media['mime'], 0, 5 ) ) {
 				$media_template = render_video( $media, $index );
 			}

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -173,16 +173,16 @@ function render_video( $media ) {
 		// Use poster image for VideoPress videos.
 		$poster_url  = $metadata['videopress']['poster'];
 		$description = ! empty( $metadata['videopress']['description'] ) ? $metadata['videopress']['description'] : '';
-		$meta_width  = $metadata['videopress']['width'];
-		$meta_height = $metadata['videopress']['height'];
+		$meta_width  = ! empty( $metadata['videopress']['width'] ) ? $metadata['videopress']['width'] : '';
+		$meta_height = ! empty( $metadata['videopress']['height'] ) ? $metadata['videopress']['height'] : '';
 	} elseif ( ! empty( $metadata['thumb'] ) ) {
 		// On WordPress.com, VideoPress videos have a 'thumb' property with the
 		// poster image filename instead.
 		$video_url   = wp_get_attachment_url( $media['id'] );
 		$poster_url  = str_replace( wp_basename( $video_url ), $metadata['thumb'], $video_url );
 		$description = ! empty( $media['alt'] ) ? $media['alt'] : '';
-		$meta_width  = $metadata['width'];
-		$meta_height = $metadata['height'];
+		$meta_width  = ! empty( $metadata['width'] ) ? $metadata['width'] : '';
+		$meta_height = ! empty( $metadata['height'] ) ? $metadata['height'] : '';
 	}
 
 	if ( ! empty( $poster_url ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates the static fallback for video slides when the slide is a VideoPress video on WordPress.com, so that the poster image for the video is located and used instead of a `<video>` tag.

This already worked for Jetpack, but VideoPress data is stored differently on WP.com and requires a different method than Jetpack (I did the same treatment for post images in a preview PR, see #17198).

This change mostly affects the Reader, which relies on the static fallback for image previews in the feed list.

I also added width and height attributes to the image tag for VideoPress poster images in Stories, since the mobile Readers look for that to determine whether an image is large enough to display in the Reader list.

~Note: Targeting #17708 since there are some related changes there I want to make sure are correctly accounted for/don't conflict.~

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Mostly needs to be tested on WP.com with D52989-code, but also confirm that previews for Jetpack sites with VideoPress work as before.

**1. Inspect static fallback directly**

1. On a WordPress.com site with VideoPress enabled, create a story with a VideoPress video as its first slide
2. Open the post with the story and disable JS for the page
3. Inspect the story HTML, and verify that the preview is a VideoPress poster image and not a `<video>` tag

**2. Check Reader**

The reader won't render a video tag (which is what , so the fix is more obvious here:
1. Follow a WordPress.com + VideoPress site in the Reader
2. Create a story post with a VideoPress video as its first slide
3. Without this patch, find that story in the Reader list
4. Confirm that no preview image is shown
5. Apply this patch and reload the Reader list (might need to create a new post due to caching)
6. Confirm that this time there's a preview image (the poster URL for the VideoPress video)

#### Proposed changelog entry for your changes:
No changelog entry needed.
