### PR TITLE
Prevent Twitter URLs from being incorrectly parsed as markdown

### DIFF
--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -15,10 +15,23 @@
  * More parameters and another tweet syntax admitted:
  * [tweet tweet="https://twitter.com/jack/statuses/20" align="left" width="350" align="center" lang="es"]
  *
+ * Tweets can also be referenced without a shortcode:
+ * https://twitter.com/jack/statuses/20
+ *
  * @package Jetpack
  */
 
 add_shortcode( 'tweet', array( 'Jetpack_Tweet', 'jetpack_tweet_shortcode' ) );
+
+/**
+ * Prevent single line Tweets from being incorrectly parsed as markdown
+ */
+function twitter_custom_md_pattern( $patterns ) {
+    $patterns[] = '/^http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})\/status(es)*\/(\d+)$/';
+
+    return $patterns;
+}
+add_filter( 'jetpack_markdown_preserve_pattern', 'twitter_custom_md_pattern' );
 
 /**
  * Tweet Shortcode class.


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/10595

Ensures that:
https://github.com/Automattic/jetpack/blob/236a2d89ba825409c0070215a9af857d0ca4094c/_inc/lib/markdown/gfm.php#L106
does not parse a plain URL as markdown.

As per https://github.com/Automattic/jetpack/pull/3415

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #10595


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Stops Tweets like `https://twitter.com/_sagesharp_/status/1323662905716273152` being parsed as markdown. Previously the above would not oembed, but become `https://twitter.com/<em>sagesharp</em>/status/1323662905716273152`

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post with the following line: `https://twitter.com/_sagesharp_/status/1323662905716273152`
* Preview the post
* See that the tweet is not oembeded
* Apply the patch
* Preview the post
* Tweet is properly embedded

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix bug causing some tweets not to be embeded correctly.
