### PR TITLE
Clarified error message for non-writable options table.

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -830,7 +830,7 @@ class Manager {
 		$secrets = $this->generate_secrets( 'register', get_current_user_id(), 600 );
 
 		if ( false === $secrets ) {
-			return new WP_Error( 'cannot_save_secrets', __( 'Could not save secrets. Please confirm that the options table is writable.', 'jetpack' ) );
+			return new WP_Error( 'cannot_save_secrets', __( 'Jetpack experienced an issue trying to save options (cannot_save_secrets). We suggest that you contact your hosting provider, and ask them for help checking that the options table is writable on your site.', 'jetpack' ) );
 		}
 
 		if (

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -829,6 +829,10 @@ class Manager {
 		add_action( 'pre_update_jetpack_option_register', array( '\\Jetpack_Options', 'delete_option' ) );
 		$secrets = $this->generate_secrets( 'register', get_current_user_id(), 600 );
 
+		if ( false === $secrets ) {
+			return new WP_Error( 'cannot_save_secrets', __( 'Could not save secrets. Please confirm that the options table is writable.', 'jetpack' ) );
+		}
+
 		if (
 			empty( $secrets['secret_1'] ) ||
 			empty( $secrets['secret_2'] ) ||
@@ -1330,8 +1334,8 @@ class Manager {
 
 		$secrets[ $secret_name ] = $secret_value;
 
-		\Jetpack_Options::update_raw_option( self::SECRETS_OPTION_NAME, $secrets );
-		return $secrets[ $secret_name ];
+		$res = Jetpack_Options::update_raw_option( self::SECRETS_OPTION_NAME, $secrets );
+		return $res ? $secrets[ $secret_name ] : false;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When the `wp_options` table is not writeable, connecting Jetpack will result in the error `Verification secrets not found`.
This PR clarifies the error, informing the user that they need to confirm the options table is writable.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Disconnect Jetpack (if connected).
2. Remove `AUTO_INCREMENT` from the `wp_options` table:
```sql
ALTER TABLE wp_options CHANGE option_id option_id bigint(20) unsigned NOT NULL;
```
3. Try to connect Jetpack.
4. The "Set up Jetpack" page should be reloaded, the error message "Could not save secrets. Please confirm that the options table is writable." should show up.

**Before:**
<img width="720" alt="Screen Shot 2020-11-10 at 3 21 55 PM" src="https://user-images.githubusercontent.com/1341249/98735110-816e6a00-2368-11eb-957f-3b7f2722c3a5.png">

**After:**
<img width="1050" alt="Screen Shot 2020-11-11 at 1 35 30 PM" src="https://user-images.githubusercontent.com/1341249/98860557-7f201480-2429-11eb-849c-983265326fa5.png">

#### Proposed changelog entry for your changes:
* Displaying a clarified error message when the options table is not writable.