### PR TITLE
Add user options REST endpoint

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-user-options.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-user-options.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * REST API endpoint for user options
+ *
+ * @package Jetpack
+ * @since TODO
+ */
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_User_Option
+ */
+class WPCOM_REST_API_V2_Endpoint_User_Option extends WP_REST_Controller {
+
+	/**
+	 * Namespace prefix.
+	 *
+	 * @var string
+	 */
+	public $namespace = 'wpcom/v2';
+
+	/**
+	 * Endpoint base route.
+	 *
+	 * @var string
+	 */
+	public $rest_base = 'user-option';
+
+	/**
+	 * WPCOM_REST_API_V2_Endpoint_User_Option constructor.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/',
+			array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'get_option' ),
+					// 'permission_callback' => array( $this, 'get_option_permissions_check' ),
+				),
+			)
+		);
+	}
+
+
+
+	/**
+	 * Retrieves the admin menu.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_option( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$option = get_user_option( 'admin_color' );
+		return rest_ensure_response( $option );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_User_Option' );

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-user-options.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-user-options.php
@@ -41,12 +41,33 @@ class WPCOM_REST_API_V2_Endpoint_User_Option extends WP_REST_Controller {
 			$this->rest_base . '/',
 			array(
 				array(
-					'methods'  => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'get_option' ),
-					// 'permission_callback' => array( $this, 'get_option_permissions_check' ),
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_option' ),
+					'permission_callback' => array( $this, 'get_option_permissions_check' ),
 				),
 			)
 		);
+	}
+
+
+	/**
+	 * Checks if a given request has access to admin menus.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_option_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+		// https://wordpress.org/support/article/roles-and-capabilities/#read
+		if ( ! current_user_can( 'read' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to read user options on this site.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
 	}
 
 
@@ -57,8 +78,28 @@ class WPCOM_REST_API_V2_Endpoint_User_Option extends WP_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
-	public function get_option( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$option = get_user_option( 'admin_color' );
+	public function get_option( $request ) {
+
+		if ( empty( $request['option'] ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You must provide a valid option.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		$option_key = $request['option'];
+
+		$option = get_user_option( $option_key );
+
+		if ( false === $option ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( "No option found with key '$option_key'.", 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
 		return rest_ensure_response( $option );
 	}
 }

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-user-options.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-user-options.php
@@ -44,6 +44,16 @@ class WPCOM_REST_API_V2_Endpoint_User_Option extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_option' ),
 					'permission_callback' => array( $this, 'get_option_permissions_check' ),
+					'args'                => array(
+						'option' => array(
+							'description'       => __( 'User option name.', 'jetpack' ),
+							'type'              => 'string',
+							'required'          => 'true',
+							'validate_callback' => function ( $param ) {
+								return is_string( $param ) && ! is_numeric( $param );
+							},
+						),
+					),
 				),
 			)
 		);


### PR DESCRIPTION
Adds a new endpoint to read/write user options on the Jetpack site.

Fixes https://github.com/Automattic/jetpack/issues/17763

#### Changes proposed in this Pull Request:
* Add new REST API endpoint for managing user options.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

paYJgx-17t-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

TBC

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add new REST API endpoint for managing user options.