### PR TITLE
Github Actions: Always run (but sometimes skip) phpcompatibility-dev

### DIFF
--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -5,24 +5,38 @@
 
 name: PHP Compatibility
 
-on:
-  pull_request:
-    paths:
-      # If any PHP file changed, they need checking.
-      - '**.php'
-      # If composer or phpcs config changed, there may be a new standard.
-      - 'composer.json'
-      - 'composer.lock'
-      - '.phpcs.xml.dist'
-      # If other files used by this workflow changed, run it to test those changes.
-      - '.github/files/phpcompatibility-dev-phpcs.xml'
-      - '.github/matchers/phpcs-problem-matcher.json'
-      - '.github/workflows/phpcompatibility-dev.yml'
+on: pull_request
 
 jobs:
+  changed_files:
+    runs-on: ubuntu-latest
+    outputs:
+      php: ${{ steps.filter.outputs.php }}
+      misc: ${{ steps.filter.outputs.misc }}
+
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            php:
+              # If any PHP file changed, they need checking.
+              - '**.php'
+            misc:
+              # If composer or phpcs config changed, there may be a new standard.
+              - 'composer.json'
+              - 'composer.lock'
+              - '.phpcs.xml.dist'
+              # If other files used by this workflow changed, run it to test those changes.
+              - '.github/files/phpcompatibility-dev-phpcs.xml'
+              - '.github/matchers/phpcs-problem-matcher.json'
+              - '.github/workflows/phpcompatibility-dev.yml'
+
   phpcompatibility:
     name: dev branch for PHP 8.0
     runs-on: ubuntu-latest
+    needs: changed_files
+    if: needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc == 'true'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -9,6 +9,7 @@ on: pull_request
 
 jobs:
   changed_files:
+    name: detect changed files
     runs-on: ubuntu-latest
     outputs:
       php: ${{ steps.filter.outputs.php }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Github Actions [does not work well](https://github.community/t/feature-request-conditional-required-checks/16761/) when a required action uses `paths` to
skip workflow execution. But it's fine if you skip job execution with
`if`.

So switch phpcompatibility-dev to have the job check for modified files
manually rather than using Github's `paths`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1605116547182500-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See that this PR has the "dev branch for PHP 8.0" job running.

* See that #17786 shows the job skipped, and still shows as being mergeable despite that job being required.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Developer only, none needed.