### PR TITLE
Markdown: avoid processing URLs that may include Markdown syntax

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/markdown/gfm.php
+++ b/projects/plugins/jetpack/_inc/lib/markdown/gfm.php
@@ -99,6 +99,9 @@ class WPCom_GHF_Markdown_Parser extends MarkdownExtra_Parser {
 			$text = $this->latex_preserve( $text );
 		}
 
+		// Do not process characters inside URLs.
+		$text = $this->urls_preserve( $text );
+
 		// escape line-beginning # chars that do not have a space after them.
 		$text = preg_replace_callback( '|^#{1,6}( )?|um', array( $this, '_doEscapeForHashWithoutSpacing' ), $text );
 
@@ -225,6 +228,22 @@ class WPCom_GHF_Markdown_Parser extends MarkdownExtra_Parser {
 	 */
 	protected function shortcode_preserve( $text ) {
 		$text = preg_replace_callback( $this->get_shortcode_regex(), array( $this, '_doRemoveText' ), $text );
+		return $text;
+	}
+
+	/**
+	 * Avoid characters inside URLs from being formatted by Markdown in any way.
+	 *
+	 * @param  string $text Text in which to preserve URLs.
+	 *
+	 * @return string Text with URLs replaced by a hash that will be restored later.
+	 */
+	protected function urls_preserve( $text ) {
+		$text = preg_replace_callback(
+			'#(https?|ftp)://[^*\)\s]+#i',
+			array( $this, '_doRemoveText' ),
+			$text
+		);
 		return $text;
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/markdown/gfm.php
+++ b/projects/plugins/jetpack/_inc/lib/markdown/gfm.php
@@ -240,7 +240,7 @@ class WPCom_GHF_Markdown_Parser extends MarkdownExtra_Parser {
 	 */
 	protected function urls_preserve( $text ) {
 		$text = preg_replace_callback(
-			'#(https?|ftp)://[^*\)\s]+#i',
+			'#(?<!<)(?:https?|ftp)://([^\s<>"\[\]()]+|\[(?1)*+\]|\((?1)*+\))+(?<![_*.?])#i',
 			array( $this, '_doRemoveText' ),
 			$text
 		);

--- a/projects/plugins/jetpack/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
@@ -6,7 +6,7 @@
  */
 
 // Require the whole lib to process text.
-require_once JETPACK__PLUGIN_DIR . '_inc/lib/markdown/0-load.php';
+require_once JETPACK__PLUGIN_DIR . '_inc/lib/markdown.php';
 
 /**
  * Class for testing the WPCom_GHF_Markdown_Parser class.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
@@ -91,6 +91,11 @@ class WP_Test_WPCom_GHF_Markdown_Parser extends WP_UnitTestCase {
 				'https://example.com/_form?type=*&q=a+(b+or+c)&arr[]=1&arr[]=2&value=_foo_bar',
 				'https://example.com/_form?type=*&q=a+(b+or+c)&arr[]=1&arr[]=2&value=_foo_bar',
 			),
+			// Let's ensure we are not breaking regular HTML. This should not change.
+			'image tag'                         => array(
+				'<img src="whatever.png" alt="Text" width="1024" height="470" class="alignleft size-full wp-image-37190" />',
+				'<img src="whatever.png" alt="Text" width="1024" height="470" class="alignleft size-full wp-image-37190" />',
+			),
 		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
@@ -44,29 +44,52 @@ class WP_Test_WPCom_GHF_Markdown_Parser extends WP_UnitTestCase {
 	 */
 	public function get_text_urls() {
 		return array(
-			'no_link_bold'          => array(
+			'no_link_bold'                      => array(
 				'Some **bold** text',
 				'Some <strong>bold</strong> text',
 			),
-			'link_bold'             => array(
+			'link_bold'                         => array(
 				'**[A bold link](https://jetpack.com/)**',
 				'<strong><a href="https://jetpack.com/">A bold link</a></strong>',
 			),
-			'link_undercore'        => array(
+			'link_undercore'                    => array(
 				'[A link with underscore in URL](https://jetpack.com/_features_/)',
 				'<a href="https://jetpack.com/_features_/">A link with underscore in URL</a>',
 			),
-			'link_alone'            => array(
+			'link_alone'                        => array(
 				'https://jetpack.com/',
 				'https://jetpack.com/',
 			),
-			'link_underscore_alone' => array(
+			'link_underscore_alone'             => array(
 				'https://jetpack.com/_features_/',
 				'https://jetpack.com/_features_/',
 			),
-			'ftp_link_underscore'   => array(
+			'ftp_link_underscore'               => array(
 				'ftp://_best_pack@jetpack.com:123',
 				'ftp://_best_pack@jetpack.com:123',
+			),
+			// This is current behavior before this patch.
+			'explicit URL'                      => array(
+				'url: <https://jetpack.com/_features_/>',
+				'url: <a href="https://jetpack.com/_features_/">https://jetpack.com/_features_/</a>',
+			),
+			// This too.
+			'URL in link text'                  => array(
+				'url: [https://jetpack.com/](https://jetpack.com/#xyz)',
+				'url: <a href="https://jetpack.com/#xyz">https://jetpack.com/</a>',
+			),
+
+			'bolded URL'                        => array(
+				'**https://jetpack.com/_features_/**',
+				'<strong>https://jetpack.com/_features_/</strong>',
+			),
+			'emphasized URL'                    => array(
+				'_https://jetpack.com/_features_/_',
+				'<em>https://jetpack.com/_features_/</em>',
+			),
+			'URL with odd but legal characters' => array(
+				'https://example.com/_form?type=*&q=a+(b+or+c)&arr[]=1&arr[]=2&value=_foo_bar',
+				'https://example.com/_form?type=*&q=a+(b+or+c)&arr[]=1&arr[]=2&value=_foo_bar',
 			),
 		);
 	}

--- a/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
+++ b/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * GitHub-Flavoured Markdown unit tests.
+ *
+ * @package Jetpack
+ */
+
+// Require the whole lib to process text.
+require_once JETPACK__PLUGIN_DIR . '_inc/lib/markdown/0-load.php';
+
+/**
+ * Class for testing the WPCom_GHF_Markdown_Parser class.
+ *
+ * @covers WPCom_GHF_Markdown_Parser
+ */
+class WP_Test_WPCom_GHF_Markdown_Parser extends WP_UnitTestCase {
+	/**
+	 * Test that links are preserved when going through the Markdown parser.
+	 *
+	 * @covers WPCom_GHF_Markdown_Parser->transform
+	 * @dataProvider get_text_urls
+	 *
+	 * @since 9.2.0
+	 *
+	 * @param string $text     The Markdown text we want to transform.
+	 * @param string $expected Expected HTML content.
+	 */
+	public function test_urls_preserve( $text, $expected ) {
+		/*
+		 * Text always ends with a newline.
+		 * Let's add it here (and not in the data provider)
+		 * to make things clearer there.
+		 */
+		$expected .= "\n";
+
+		$transformed_text = ( new WPCom_GHF_Markdown_Parser() )->transform( $text );
+		$this->assertEquals( $expected, $transformed_text );
+	}
+
+	/**
+	 * Get link examples to test how Markdown avoids transforming elements in links.
+	 *
+	 * @return array The test data.
+	 */
+	public function get_text_urls() {
+		return array(
+			'no_link_bold'          => array(
+				'Some **bold** text',
+				'Some <strong>bold</strong> text',
+			),
+			'link_bold'             => array(
+				'**[A bold link](https://jetpack.com/)**',
+				'<strong><a href="https://jetpack.com/">A bold link</a></strong>',
+			),
+			'link_undercore'        => array(
+				'[A link with underscore in URL](https://jetpack.com/_features_/)',
+				'<a href="https://jetpack.com/_features_/">A link with underscore in URL</a>',
+			),
+			'link_alone'            => array(
+				'https://jetpack.com/',
+				'https://jetpack.com/',
+			),
+			'link_underscore_alone' => array(
+				'https://jetpack.com/_features_/',
+				'https://jetpack.com/_features_/',
+			),
+			'ftp_link_underscore'   => array(
+				'ftp://_best_pack@jetpack.com:123',
+				'ftp://_best_pack@jetpack.com:123',
+			),
+		);
+	}
+}


### PR DESCRIPTION
Fixes #10595
Closes #17761

#### Changes proposed in this Pull Request:

* This is an alternative approach to #17761, trying to solve the issue for all types of links that may include underscores, whether we use the Shortcodes feature or not.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No 

#### Testing instructions:

* Go to Jetpack > Settings > Writing, and enable the Markdown feature.
* Go to Plugins > Add New, install and activate the Classic editor plugin.
* Go to Posts > Add New, and start writing a new post. 
* Try testing with different types of Markdown content; you can find some examples [here](https://daringfireball.net/projects/markdown/syntax).
* You can also focus on links in Markdown, in different formats, with or without underscores:
    - `https://twitter.com/_sagesharp_/status/1323662905716273152` on its own line.
    - `[A link with underscore in URL](https://jetpack.com/_features_/)`
    - `_[An italic link with underscore in URL](https://jetpack.com/_features_/)_`

#### Proposed changelog entry for your changes:

* Markdown: avoid processing URLs that may include Markdown syntax
