### PR TITLE
Show Recurring Payments preview on frontend for site admins/editors

### DIFF
--- a/_inc/lib/components.php
+++ b/_inc/lib/components.php
@@ -104,26 +104,4 @@ class Jetpack_Components {
 			)
 		);
 	}
-
-	/**
-	 * Load and display a pre-rendered component
-	 *
-	 * @since 7.7.0
-	 *
-	 * @param array $props Component properties.
-	 *
-	 * @return string The component markup
-	 */
-	public static function render_stripe_nudge( $block_name ) {
-		$post_id = get_the_ID();
-
-		return self::render_component(
-			'stripe-nudge',
-			array(
-				'blockName'        => $block_name,
-				'postId'           => $post_id,
-				'stripeConnectUrl' => Jetpack::init()->build_connect_url( true, false, false ),
-			)
-		);
-	}
 }

--- a/_inc/lib/components.php
+++ b/_inc/lib/components.php
@@ -19,7 +19,6 @@ class Jetpack_Components {
 	 * @return string The component markup
 	 */
 	public static function render_component( $name, $props ) {
-
 		$rtl = is_rtl() ? '.rtl' : '';
 		wp_enqueue_style( 'jetpack-components', plugins_url( "_inc/blocks/components{$rtl}.css", JETPACK__PLUGIN_FILE ), array( 'wp-components' ), JETPACK__VERSION );
 
@@ -102,6 +101,28 @@ class Jetpack_Components {
 			array(
 				'planName'   => $plan->product_name,
 				'upgradeUrl' => $upgrade_url,
+			)
+		);
+	}
+
+	/**
+	 * Load and display a pre-rendered component
+	 *
+	 * @since 7.7.0
+	 *
+	 * @param array $props Component properties.
+	 *
+	 * @return string The component markup
+	 */
+	public static function render_stripe_nudge( $block_name ) {
+		$post_id = get_the_ID();
+
+		return self::render_component(
+			'stripe-nudge',
+			array(
+				'blockName'        => $block_name,
+				'postId'           => $post_id,
+				'stripeConnectUrl' => Jetpack::init()->build_connect_url( true, false, false ),
 			)
 		);
 	}

--- a/_inc/lib/components.php
+++ b/_inc/lib/components.php
@@ -19,6 +19,7 @@ class Jetpack_Components {
 	 * @return string The component markup
 	 */
 	public static function render_component( $name, $props ) {
+
 		$rtl = is_rtl() ? '.rtl' : '';
 		wp_enqueue_style( 'jetpack-components', plugins_url( "_inc/blocks/components{$rtl}.css", JETPACK__PLUGIN_FILE ), array( 'wp-components' ), JETPACK__VERSION );
 

--- a/extensions/shared/components/index.jsx
+++ b/extensions/shared/components/index.jsx
@@ -7,7 +7,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
  * Internal dependencies
  */
 import { UpgradeNudge } from './upgrade-nudge';
-import  { StripeNudge } from './stripe-nudge';
+import { StripeNudge } from './stripe-nudge';
 
 import './style.scss';
 

--- a/extensions/shared/components/index.jsx
+++ b/extensions/shared/components/index.jsx
@@ -7,14 +7,15 @@ import { renderToStaticMarkup } from 'react-dom/server';
  * Internal dependencies
  */
 import { UpgradeNudge } from './upgrade-nudge';
-import StripeNudge from './stripe-nudge';
+import  { StripeNudge } from './stripe-nudge';
 
 import './style.scss';
 
 // Use dummy props that can be overwritten by a str_replace() on the server.
 //
-// Note that we're using the 'dumb' component exported from `upgrade-nudge.jsx` here,
-// rather than the 'smart' one (which is wrapped in `withSelect` and `withDispatch` calls).
+// Note that we're using the 'dumb' component exported from `upgrade-nudge.jsx` and
+// 'stripe-nudge.jsx' here, rather than the 'smart' one (which is wrapped in `withSelect`
+// and `withDispatch` calls).
 // This means putting the burden of props computation on PHP (`components.php`).
 // If we wanted to use the 'smart' component instead, we'd need to provide sufficiently
 // initialised Redux state when rendering ir (probably through globals set as arguments
@@ -24,7 +25,7 @@ const upgradeNudge = renderToStaticMarkup(
 );
 
 const stripeNudge = renderToStaticMarkup(
-	<StripeNudge blockName="#blockName#" postId="#postId#" stripeConnectUrl="#stripeConnectUrl#" />
+	<StripeNudge blockName="#blockName#" url="#url#" />
 );
 
 // StaticSiteGeneratorPlugin only supports `.html` extensions, even though

--- a/extensions/shared/components/index.jsx
+++ b/extensions/shared/components/index.jsx
@@ -7,6 +7,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
  * Internal dependencies
  */
 import { UpgradeNudge } from './upgrade-nudge';
+import StripeNudge from './stripe-nudge';
 
 import './style.scss';
 
@@ -22,8 +23,13 @@ const upgradeNudge = renderToStaticMarkup(
 	<UpgradeNudge planName="#planName#" upgradeUrl="#upgradeUrl#" />
 );
 
+const stripeNudge = renderToStaticMarkup(
+	<StripeNudge blockName="#blockName#" postId="#postId#" stripeConnectUrl="#stripeConnectUrl#" />
+);
+
 // StaticSiteGeneratorPlugin only supports `.html` extensions, even though
 // our rendered components contain some PHP.
 export default () => ( {
 	'upgrade-nudge.html': upgradeNudge,
+	'stripe-nudge.html': stripeNudge,
 } );

--- a/extensions/shared/components/index.jsx
+++ b/extensions/shared/components/index.jsx
@@ -25,7 +25,7 @@ const upgradeNudge = renderToStaticMarkup(
 );
 
 const stripeNudge = renderToStaticMarkup(
-	<StripeNudge blockName="#blockName#" url="#url#" />
+	<StripeNudge blockName="#blockName#" />
 );
 
 // StaticSiteGeneratorPlugin only supports `.html` extensions, even though

--- a/extensions/shared/components/stripe-nudge/index.jsx
+++ b/extensions/shared/components/stripe-nudge/index.jsx
@@ -17,6 +17,36 @@ import BlockNudge from '../block-nudge';
 
 import './style.scss';
 
+export const StripeNudge = ( {
+	blockName,
+	url
+} ) => (
+	<BlockNudge
+		className="jetpack-stripe-nudge__banner"
+		buttonLabel={ __( 'Connect', 'jetpack' ) }
+		icon={
+			<GridiconStar
+				className="jetpack-stripe-nudge__icon"
+				size={ 18 }
+				aria-hidden="true"
+				role="img"
+				focusable="false"
+			/>
+		}
+		href={ url }
+		onClick={ () =>
+			void analytics.tracks.recordEvent( 'jetpack_editor_block_stripe_connect_click', {
+				block: blockName,
+			} )
+		}
+		title={ __( 'Connect to Stripe to use this block on your site', 'jetpack' ) }
+		subtitle={ __(
+			'This block will be hidden from your visitors until you connect to Stripe.',
+			'jetpack'
+		) }
+	/>
+);
+
 export default ( { blockName, postId, stripeConnectUrl } ) => {
 	if ( ! isURL( stripeConnectUrl ) ) {
 		return null;
@@ -38,29 +68,6 @@ export default ( { blockName, postId, stripeConnectUrl } ) => {
 	}
 
 	return (
-		<BlockNudge
-			className="jetpack-stripe-nudge__banner"
-			buttonLabel={ __( 'Connect', 'jetpack' ) }
-			icon={
-				<GridiconStar
-					className="jetpack-stripe-nudge__icon"
-					size={ 18 }
-					aria-hidden="true"
-					role="img"
-					focusable="false"
-				/>
-			}
-			href={ url }
-			onClick={ () =>
-				void analytics.tracks.recordEvent( 'jetpack_editor_block_stripe_connect_click', {
-					block: blockName,
-				} )
-			}
-			title={ __( 'Connect to Stripe to use this block on your site', 'jetpack' ) }
-			subtitle={ __(
-				'This block will be hidden from your visitors until you connect to Stripe.',
-				'jetpack'
-			) }
-		/>
+		<StripeNudge blockName={ blockName } url={ url } />
 	);
 };

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -231,7 +231,7 @@ class Jetpack_Memberships {
 	/**
 	 * Renders a preview of the Recurring Payment button, which is not hooked
 	 * up to the subscription url. Used to preview the block on the frontend
-	 * for admin users when Stripe has not been connected.
+	 * for site editors when Stripe has not been connected.
 	 *
 	 * @param array  $attrs - attributes in the shortcode.
 	 * @param string $content - Recurring Payment block content.
@@ -249,7 +249,7 @@ class Jetpack_Memberships {
 
 	/**
 	 * Determines whether the button preview should be rendered. Returns true
-	 * if the user is an admin, the button is not configured correctly
+	 * if the user has editing permissions, the button is not configured correctly
 	 * (because it requires a plan upgrade or Stripe connection), and the
 	 * button is a child of a Premium Content block.
 	 *
@@ -258,7 +258,7 @@ class Jetpack_Memberships {
 	 * @return boolean
 	 */
 	public function should_render_button_preview( $block ) {
-		$is_admin                   = $this->user_can_edit();
+		$user_can_edit              = $this->user_can_edit();
 		$requires_stripe_connection = ! $this->get_connected_account_id();
 
 		$requires_upgrade = false;
@@ -276,7 +276,7 @@ class Jetpack_Memberships {
 
 		return (
 			$is_premium_content_child &&
-			$is_admin &&
+			$user_can_edit &&
 			( $requires_upgrade || $requires_stripe_connection )
 		);
 	}

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -422,17 +422,18 @@ class Jetpack_Memberships {
 		// This gate was introduced to prevent duplicate registration. A race condition exists where
 		// the registration that happens via extensions/blocks/recurring-payments/recurring-payments.php
 		// was adding the registration action after the action had been run in some contexts.
-
 		if ( self::$has_registered_block ) {
 			return;
 		}
 
 		if ( self::is_enabled_jetpack_recurring_payments() ) {
+			$deprecated = function_exists( 'gutenberg_get_post_from_context' );
+			$uses       = $deprecated ? 'context' : 'uses_context';
 			Blocks::jetpack_register_block(
 				'jetpack/recurring-payments',
 				array(
 					'render_callback' =>  array( $this, 'render_button' ),
-					'uses_context' => array( 'isPremiumContentChild' ),
+					$uses => array( 'isPremiumContentChild' ),
 				)
 			);
 		} else {

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -255,7 +255,7 @@ class Jetpack_Memberships {
 	 *
 	 * @return string|void
 	 */
-	public function render_button( $attributes, $content = null ) {
+	public function render_button( $attributes, $content, $block ) {
 		Jetpack_Gutenberg::load_assets_as_required( self::$button_block_name, array( 'thickbox', 'wp-polyfill' ) );
 		// If the user is a site admin, and the block needs to have a Stripe account connected,
 		// render a preview disconnected button in the frontend as a preview.
@@ -432,6 +432,7 @@ class Jetpack_Memberships {
 				'jetpack/recurring-payments',
 				array(
 					'render_callback' =>  array( $this, 'render_button' ),
+					'uses_context' => array( 'isPremiumContentChild' ),
 				)
 			);
 		} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
If there is no Stripe account connected, but the current user is ~~an admin~~ able to edit the post, the Recurring Payments block will be displayed on the frontend anyway with the button disconnected, so that the author can preview what the block looks like on the frontend.

This is done to enable displaying a preview of the Premium Content block on the frontend for site admins/editors when the block would otherwise be hidden (due to missing plan upgrade or Stripe connection).

The plan upgrade and Stripe connection nudges should also display in the frontend _for the Premium Content block_ when relevant; the Stripe nudge will display without the `Connect` button since the url cannot be fully built in the SSR-rendered component. The user must return to the editor to connect to Stripe. The nudges do not display for the Payments block itself.

<!-- #### Jetpack product discussion -->
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### WPCOM site
Sync the changes to your sandbox and create a post with a Premium Content block.

For a site with a free plan:
- [ ]  Verify that you see the upgrade banner in the editor
- [ ]  Publish the post and verify that you see the block on the frontend, and that the button is disconnected (when logged in as the site administrator). The upgrade nudge should also display.
- [ ] View the post as a logged-out user and verify that you cannot see the button

For a site with a premium plan upgrade:
- [ ]  Verify that you do not see the upgrade banner in the editor, but you do see the Stripe connection banner
- [ ]  Publish the post and verify that you see the block on the frontend, and that the button is disconnected (when logged in as the site administrator). The stripe nudge should display, with no Connect button.
- [ ] View the post as a logged-out user and verify that you cannot see the button

For a site with a premium plan upgrade and Stripe connected:
- [ ]  Verify that you do not see and upgrade/Stripe warnings or nudges in the editor
- [ ]  Configure a plan for the block and publish the post. Verify that you see the block on the frontend, and that the button is connected (when logged in as the site administrator). No nudges should display.
- [ ] View the post as a logged-out user and verify that you can see the button

Repeat tests with a Jetpack site.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
