### PR TITLE
Status: Improve the staging site detection

### DIFF
--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -209,7 +209,7 @@ class Status {
 
 		if ( isset( $known_staging['urls'] ) ) {
 			foreach ( $known_staging['urls'] as $url ) {
-				if ( preg_match( $url, site_url() ) ) {
+				if ( preg_match( $url, wp_parse_url( site_url(), PHP_URL_HOST ) ) ) {
 					$is_staging = true;
 					break;
 				}

--- a/packages/status/tests/php/test-status.php
+++ b/packages/status/tests/php/test-status.php
@@ -39,6 +39,12 @@ class Test_Status extends TestCase {
 	 */
 	public function setUp() {
 		Monkey\setUp();
+
+		// Set defaults for Core functionality.
+		Functions\when( 'site_url' )->justReturn( $this->site_url );
+		Functions\when( 'wp_get_environment_type' )->justReturn( 'production' );
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+
 		$this->status = new Status();
 	}
 
@@ -56,7 +62,6 @@ class Test_Status extends TestCase {
 	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_default() {
-		Functions\when( 'site_url' )->justReturn( $this->site_url );
 		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( false );
 
 		$this->assertFalse( $this->status->is_offline_mode() );
@@ -68,7 +73,6 @@ class Test_Status extends TestCase {
 	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_filter_true() {
-		Functions\when( 'site_url' )->justReturn( $this->site_url );
 		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( true );
 
 		$this->assertTrue( $this->status->is_offline_mode() );
@@ -80,7 +84,6 @@ class Test_Status extends TestCase {
 	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_filter_bool() {
-		Functions\when( 'site_url' )->justReturn( $this->site_url );
 		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( 0 );
 
 		$this->assertFalse( $this->status->is_offline_mode() );
@@ -172,7 +175,6 @@ class Test_Status extends TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_is_offline_mode_constant() {
-		Functions\when( 'site_url' )->justReturn( $this->site_url );
 		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( false );
 
 		$constants_mocks = $this->mock_constants(
@@ -355,13 +357,19 @@ class Test_Status extends TestCase {
 	 * @covers Automattic\Jetpack\Status::is_staging_site
 	 *
 	 * @param string $site_url Site URL.
+	 * @param bool   $expected Expected return.
 	 */
-	public function test_is_staging_site_for_known_hosting_providers( $site_url ) {
+	public function test_is_staging_site_for_known_hosting_providers( $site_url, $expected ) {
 		Functions\when( 'site_url' )->justReturn( $site_url );
 		$result = $this->status->is_staging_site();
-		$this->assertTrue(
+		$this->assertEquals(
+			$expected,
 			$result,
-			sprintf( 'Expected %s to return true for `is_staging_site()', $site_url )
+			sprintf(
+				'Expected %1$s to return %2$s for is_staging_site()',
+				$site_url,
+				$expected
+			)
 		);
 	}
 
@@ -376,21 +384,31 @@ class Test_Status extends TestCase {
 		return array(
 			'wpengine'              => array(
 				'http://bjk.staging.wpengine.com',
+				true,
 			),
 			'kinsta'                => array(
 				'http://test.staging.kinsta.com',
+				true,
 			),
 			'dreampress'            => array(
 				'http://ebinnion.stage.site',
+				true,
 			),
 			'newspack'              => array(
 				'http://test.newspackstaging.com',
+				true,
 			),
 			'wpengine_subdirectory' => array(
 				'http://bjk.staging.wpengine.com/staging',
+				true,
 			),
 			'wpengine_endslash'     => array(
 				'http://bjk.staging.wpengine.com/',
+				true,
+			),
+			'not_a_staging_site'    => array(
+				'http://staging.wpengine.com.example.com/',
+				false,
 			),
 		);
 	}


### PR DESCRIPTION
@georgestephanis asked me about if the existing regex for `is_staging_site` would pick up an URL that included a directory or an ending slash.

In #17758, I added a couple of tests to make sure that those cases were covered. But, I felt unsettled about it all.

In running the Status suite PHPUnit tests in a random order, I realized that the additions I made were actually failing because the testing environment was polluted by other tests not cleaning up after itself.

#### Changes proposed in this Pull Request:
* Use `wp_parse_url` to pull out just the host to use for detection.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* `yarn docker:phpunit:package status` for automated testing.
*  Manual testing would be to setup an URL on a staging server with a directory.

#### Proposed changelog entry for your changes:
* Status: improve detection of staging servers.
