### PR TITLE
Google Analytics: Add Support for GA4 Tags with GA4 JS

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -137,6 +137,8 @@ Will stop all of the containers created by this docker-compose configuration and
 
 ### Running unit tests
 
+These commands require the WordPress container to be running.
+
 ```sh
 yarn docker:phpunit
 ```
@@ -230,7 +232,7 @@ You can also access it via phpMyAdmin at [http://localhost:8181](http://localhos
 Another way to accessing the database is MySQL client using the following command:
 ```sh
 yarn docker:db
-```  
+```
 This command utilizes credentials from the config file (`~/.my.cnf`) to log you into MySQL without entering any connection information.
 
 ## SFTP access
@@ -378,7 +380,7 @@ That will let you omit those parameters while initiating the connection:
 yarn docker:jt-up
 ```
 
-More information: PCYsg-snO-p2. 
+More information: PCYsg-snO-p2.
 
 ## Custom plugins & themes in the container
 

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -156,7 +156,10 @@ class Jetpack_Google_Analytics_Legacy {
 		 * @param array $universal_commands Array of gtag function calls.
 		 */
 		$universal_commands = array( apply_filters( 'jetpack_gtag_universal_commands', array() ) );
-		l( 'blahblahblah', $universal_commands );
+		$custom_vars        = array();
+		if ( is_404() ) {
+			$custom_vars[] = "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";
+		}
 
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
@@ -171,6 +174,7 @@ class Jetpack_Google_Analytics_Legacy {
 			foreach ( $universal_commands as $command ) {
 				echo 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $command ) ) . " );\n";
 			}
+			implode( "\r\n", $custom_vars )
 			?>
 		</script>
 		<!-- End Jetpack Google Analytics -->

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -172,7 +172,7 @@ class Jetpack_Google_Analytics_Legacy {
 			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
 			<?php
 			echo esc_js( implode( "\r\n", $universal_commands ) );
-			echo esc_js( ( implode( "\r\n", $custom_vars ) ) );
+			echo esc_js( implode( "\r\n", $custom_vars ) );
 			?>
 		</script>
 		<!-- End Jetpack Google Analytics -->

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -160,7 +160,7 @@ class Jetpack_Google_Analytics_Legacy {
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
 		<!-- Jetpack Google Analytics -->
-		<script async src='https://www.googletagmanager.com/gtag/js?id=<?php echo esc_url( $tracking_id ); ?>'></script>
+		<script async src='https://www.googletagmanager.com/gtag/js?id=<?php echo esc_attr( $tracking_id ); ?>'></script>
 		<script>
 			window.dataLayer = window.dataLayer || [];
 			function gtag() { dataLayer.push( arguments ); }

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -155,7 +155,7 @@ class Jetpack_Google_Analytics_Legacy {
 		 *
 		 * @param array $universal_commands Array of gtag function calls.
 		 */
-		$universal_commands = array( apply_filters( 'jetpack_gtag_universal_commands', array() ) );
+		$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
 		$custom_vars        = '';
 		if ( is_404() ) {
 			$custom_vars = "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -155,7 +155,8 @@ class Jetpack_Google_Analytics_Legacy {
 		 *
 		 * @param array $universal_commands Array of gtag function calls.
 		 */
-		$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
+		$universal_commands = array( apply_filters( 'jetpack_gtag_universal_commands', array() ) );
+		l( 'blahblahblah', $universal_commands );
 
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
@@ -165,8 +166,12 @@ class Jetpack_Google_Analytics_Legacy {
 			window.dataLayer = window.dataLayer || [];
 			function gtag() { dataLayer.push( arguments ); }
 			gtag( 'js', new Date() );
-			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
-			<?php echo esc_js( implode( "\r\n", $universal_commands ) ); ?>
+			gtag( 'config', '<?php echo wp_json_encode( $tracking_id ); ?>' );
+			<?php
+			foreach ( $universal_commands as $command ) {
+				echo 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $command ) ) . " );\n";
+			}
+			?>
 		</script>
 		<!-- End Jetpack Google Analytics -->
 		<?php

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -174,7 +174,7 @@ class Jetpack_Google_Analytics_Legacy {
 			foreach ( $universal_commands as $command ) {
 				echo '//' . implode($command) . '//' . implode($universal_commands) . '\n' . 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $command ) ) . " );\n";
 			}
-			echo implode( "\r\n", $custom_vars )
+			echo esc_js(implode( "\r\n", $custom_vars ));
 			?>
 		</script>
 		<!-- End Jetpack Google Analytics -->

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -169,10 +169,10 @@ class Jetpack_Google_Analytics_Legacy {
 			window.dataLayer = window.dataLayer || [];
 			function gtag() { dataLayer.push( arguments ); }
 			gtag( 'js', new Date() );
-			gtag( 'config', '<?php echo wp_json_encode( $tracking_id ); ?>' );
+			gtag( 'config', '<?php echo json_encode( $tracking_id ); ?>' );
 			<?php
 			foreach ( $universal_commands as $command ) {
-				echo '//' . implode($command) . '//' . implode($universal_commands) . '\n' . 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $command ) ) . " );\n";
+				echo 'gtag( ' . implode( ', ', array_map( 'json_encode', $command ) ) . " );\n";
 			}
 			echo esc_js(implode( "\r\n", $custom_vars ));
 			?>

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -1,16 +1,16 @@
 <?php
 
 /**
-* Jetpack_Google_Analytics_Legacy hooks and enqueues support for ga.js
-* https://developers.google.com/analytics/devguides/collection/gajs/
-*
-* @author Aaron D. Campbell (original)
-* @author allendav
-*/
+ * Jetpack_Google_Analytics_Legacy hooks and enqueues support for ga.js
+ * https://developers.google.com/analytics/devguides/collection/gajs/
+ *
+ * @author Aaron D. Campbell (original)
+ * @author allendav
+ */
 
 /**
-* Bail if accessed directly
-*/
+ * Bail if accessed directly
+ */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -31,7 +31,7 @@ class Jetpack_Google_Analytics_Legacy {
 	 * @return string - Tracking URL
 	 */
 	private function _get_url( $track ) {
-		$site_url = ( is_ssl() ? 'https://':'http://' ) . sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ); // Input var okay.
+		$site_url = ( is_ssl() ? 'https://' : 'http://' ) . sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ); // Input var okay.
 		foreach ( $track as $k => $value ) {
 			if ( strpos( strtolower( $value ), strtolower( $site_url ) ) === 0 ) {
 				$track[ $k ] = substr( $track[ $k ], strlen( $site_url ) );
@@ -110,7 +110,7 @@ class Jetpack_Google_Analytics_Legacy {
 		if ( ! empty( $track ) ) {
 			$track['url'] = $this->_get_url( $track );
 			// adjust the code that we output, account for both types of tracking.
-			$track['url'] = esc_js( str_replace( '&', '&amp;', $track['url'] ) );
+			$track['url']  = esc_js( str_replace( '&', '&amp;', $track['url'] ) );
 			$custom_vars[] = "_gaq.push(['_trackPageview','{$track['url']}']);";
 		} else {
 			$custom_vars[] = "_gaq.push(['_trackPageview']);";
@@ -184,6 +184,7 @@ class Jetpack_Google_Analytics_Legacy {
 	/**
 	 * Used to filter in the anonymize IP snippet to the custom vars array for classic analytics
 	 * Ref https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat#_gat._anonymizelp
+	 *
 	 * @param array custom vars to be filtered
 	 * @return array possibly updated custom vars
 	 */
@@ -197,6 +198,7 @@ class Jetpack_Google_Analytics_Legacy {
 
 	/**
 	 * Used to filter in the order details to the custom vars array for classic analytics
+	 *
 	 * @param array custom vars to be filtered
 	 * @return array possibly updated custom vars
 	 */
@@ -226,7 +228,8 @@ class Jetpack_Google_Analytics_Legacy {
 				array_push(
 					$custom_vars,
 					sprintf(
-						'_gaq.push( %s );', json_encode(
+						'_gaq.push( %s );',
+						json_encode(
 							array(
 								'_addTrans',
 								(string) $order->get_order_number(),
@@ -236,7 +239,7 @@ class Jetpack_Google_Analytics_Legacy {
 								(string) $order->get_total_shipping(),
 								(string) $order->get_billing_city(),
 								(string) $order->get_billing_state(),
-								(string) $order->get_billing_country()
+								(string) $order->get_billing_country(),
 							)
 						)
 					)
@@ -245,13 +248,14 @@ class Jetpack_Google_Analytics_Legacy {
 				// Order items
 				if ( $order->get_items() ) {
 					foreach ( $order->get_items() as $item ) {
-						$product = $order->get_product_from_item( $item );
+						$product           = $order->get_product_from_item( $item );
 						$product_sku_or_id = $product->get_sku() ? $product->get_sku() : $product->get_id();
 
 						array_push(
 							$custom_vars,
 							sprintf(
-								'_gaq.push( %s );', json_encode(
+								'_gaq.push( %s );',
+								json_encode(
 									array(
 										'_addItem',
 										(string) $order->get_order_number(),
@@ -259,7 +263,7 @@ class Jetpack_Google_Analytics_Legacy {
 										$item['name'],
 										Jetpack_Google_Analytics_Utils::get_product_categories_concatenated( $product ),
 										(string) $order->get_item_total( $item ),
-										(string) $item['qty']
+										(string) $item['qty'],
 									)
 								)
 							)
@@ -295,13 +299,13 @@ class Jetpack_Google_Analytics_Legacy {
 
 		if ( is_product() ) { // product page
 			global $product;
-			$product_sku_or_id = $product->get_sku() ? $product->get_sku() : "#" + $product->get_id();
+			$product_sku_or_id = $product->get_sku() ? $product->get_sku() : '#' + $product->get_id();
 			wc_enqueue_js(
 				"$( '.single_add_to_cart_button' ).click( function() {
 					_gaq.push(['_trackEvent', 'Products', 'Add to Cart', '#" . esc_js( $product_sku_or_id ) . "']);
 				} );"
 			);
-		} else if ( is_woocommerce() ) { // any other page that uses templates (like product lists, archives, etc)
+		} elseif ( is_woocommerce() ) { // any other page that uses templates (like product lists, archives, etc)
 			wc_enqueue_js(
 				"$( '.add_to_cart_button:not(.product_type_variable, .product_type_grouped)' ).click( function() {
 					var label = $( this ).data( 'product_sku' ) ? $( this ).data( 'product_sku' ) : '#' + $( this ).data( 'product_id' );

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -163,7 +163,7 @@ class Jetpack_Google_Analytics_Legacy {
 				'exception',
 				array(
 					'description' => '404',
-					'fatal'       => 'false',
+					'fatal'       => false,
 				),
 			);
 			// "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -176,7 +176,7 @@ class Jetpack_Google_Analytics_Legacy {
 			window.dataLayer = window.dataLayer || [];
 			function gtag() { dataLayer.push( arguments ); }
 			gtag( 'js', new Date() );
-			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
+			gtag( 'config', <?php echo wp_json_encode( $tracking_id ); ?> );
 			<?php
 			foreach ( $universal_commands as $command ) {
 				echo 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $command ) ) . " );\n";

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -171,8 +171,8 @@ class Jetpack_Google_Analytics_Legacy {
 			gtag( 'js', new Date() );
 			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
 			<?php
-      echo esc_js( implode( "\r\n", $universal_commands ));
-			echo json_encode((implode( "\r\n", $custom_vars )));
+			echo esc_js( implode( "\r\n", $universal_commands ) );
+			echo esc_js( ( implode( "\r\n", $custom_vars ) ) );
 			?>
 		</script>
 		<!-- End Jetpack Google Analytics -->

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -171,7 +171,7 @@ class Jetpack_Google_Analytics_Legacy {
 			gtag( 'js', new Date() );
 			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
 			<?php
-      echo esc_js( implode( "\r\n", $universal_commands );
+      echo esc_js( implode( "\r\n", $universal_commands ));
 			echo json_encode((implode( "\r\n", $custom_vars )));
 			?>
 		</script>

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -155,33 +155,30 @@ class Jetpack_Google_Analytics_Legacy {
 		 *
 		 * @param array $universal_commands Array of gtag function calls.
 		 */
-		$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
-		$custom_vars        = array();
-		// if ( is_404() ) {
-			$custom_vars[] = "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";
-		// }
-
+		$universal_commands = array( apply_filters( 'jetpack_gtag_universal_commands', array() ) );
+		$custom_vars        = '';
+		if ( is_404() ) {
+			$custom_vars = "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";
+		}
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		$async_code = "
-			<!-- Jetpack Google Analytics -->
-			<script async src='https://www.googletagmanager.com/gtag/js?id=%tracking_id%'></script>
-			<script>
-				window.dataLayer = window.dataLayer || [];
-				function gtag() { dataLayer.push( arguments ); }
-				gtag( 'js', new Date() );
-				gtag( 'config', %tracking_id% );
-				%universal_commands%
-				%custom_vars%
-			</script>
-			<!-- End Jetpack Google Analytics -->
-		";
+		?>
+		<!-- Jetpack Google Analytics -->
+		<script async src='https://www.googletagmanager.com/gtag/js?id=<?php echo esc_attr( $tracking_id ); ?>'></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag() { dataLayer.push( arguments ); }
+			gtag( 'js', new Date() );
+			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
+			<?php
+			foreach ( $universal_commands as $command ) {
+				echo 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $command ) ) . " );\n";
+			}
+			echo esc_js( $custom_vars );
+			?>
+		</script>
+		<!-- End Jetpack Google Analytics -->
+		<?php
 		// phpcs:enable
-		$async_code                = str_replace( '%tracking_id%', $tracking_id, $async_code );
-		$universal_commands_string = implode( "\r\n", $universal_commands );
-		$async_code                = str_replace( '%universal_commands%', $universal_commands_string, $async_code );
-		$custom_vars_string        = implode( "\r\n", $custom_vars );
-		$async_code                = str_replace( '%custom_vars%', $custom_vars_string, $async_code );
-		echo esc_js( "$async_code\r\n" );
 	}
 
 	/**

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -157,9 +157,9 @@ class Jetpack_Google_Analytics_Legacy {
 		 */
 		$universal_commands = array( apply_filters( 'jetpack_gtag_universal_commands', array() ) );
 		$custom_vars        = array();
-		if ( is_404() ) {
+		// if ( is_404() ) {
 			$custom_vars[] = "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";
-		}
+		// }
 
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
@@ -172,9 +172,9 @@ class Jetpack_Google_Analytics_Legacy {
 			gtag( 'config', '<?php echo wp_json_encode( $tracking_id ); ?>' );
 			<?php
 			foreach ( $universal_commands as $command ) {
-				echo 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $command ) ) . " );\n";
+				echo '//' . implode($command) . '//' . implode($universal_commands) . '\n' . 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $command ) ) . " );\n";
 			}
-			implode( "\r\n", $custom_vars )
+			echo implode( "\r\n", $custom_vars )
 			?>
 		</script>
 		<!-- End Jetpack Google Analytics -->

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -110,7 +110,7 @@ class Jetpack_Google_Analytics_Legacy {
 		if ( ! empty( $track ) ) {
 			$track['url'] = $this->_get_url( $track );
 			// adjust the code that we output, account for both types of tracking.
-			$track['url']  = esc_js( str_replace( '&', '&amp;', $track['url'] ) );
+			$track['url'] = esc_js( str_replace( '&', '&amp;', $track['url'] ) );
 			$custom_vars[] = "_gaq.push(['_trackPageview','{$track['url']}']);";
 		} else {
 			$custom_vars[] = "_gaq.push(['_trackPageview']);";
@@ -155,7 +155,7 @@ class Jetpack_Google_Analytics_Legacy {
 		 *
 		 * @param array $universal_commands Array of gtag function calls.
 		 */
-		$universal_commands = array( apply_filters( 'jetpack_gtag_universal_commands', array() ) );
+		$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
 		$custom_vars        = array();
 		// if ( is_404() ) {
 			$custom_vars[] = "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";
@@ -169,12 +169,10 @@ class Jetpack_Google_Analytics_Legacy {
 			window.dataLayer = window.dataLayer || [];
 			function gtag() { dataLayer.push( arguments ); }
 			gtag( 'js', new Date() );
-			gtag( 'config', '<?php echo json_encode( $tracking_id ); ?>' );
+			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
 			<?php
-			foreach ( $universal_commands as $command ) {
-				echo 'gtag( ' . implode( ', ', array_map( 'json_encode', $command ) ) . " );\n";
-			}
-			echo esc_js(implode( "\r\n", $custom_vars ));
+      echo esc_js( implode( "\r\n", $universal_commands );
+			echo json_encode((implode( "\r\n", $custom_vars )));
 			?>
 		</script>
 		<!-- End Jetpack Google Analytics -->

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -148,6 +148,15 @@ class Jetpack_Google_Analytics_Legacy {
 	 * @param string $tracking_id Google Analytics measurement ID.
 	 */
 	private function render_gtag_code( $tracking_id ) {
+		/**
+		 * Allow for additional elements to be added to the Global Site Tags array.
+		 *
+		 * @since 9.2.0
+		 *
+		 * @param array $universal_commands Array of gtag function calls.
+		 */
+		$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
+
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
 		<!-- Jetpack Google Analytics -->
@@ -157,6 +166,7 @@ class Jetpack_Google_Analytics_Legacy {
 			function gtag() { dataLayer.push( arguments ); }
 			gtag( 'js', new Date() );
 			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
+			<?php echo esc_js( implode( "\r\n", $universal_commands ) ); ?>
 		</script>
 		<!-- End Jetpack Google Analytics -->
 		<?php

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -162,22 +162,26 @@ class Jetpack_Google_Analytics_Legacy {
 		// }
 
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		?>
-		<!-- Jetpack Google Analytics -->
-		<script async src='https://www.googletagmanager.com/gtag/js?id=<?php echo esc_attr( $tracking_id ); ?>'></script>
-		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag() { dataLayer.push( arguments ); }
-			gtag( 'js', new Date() );
-			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
-			<?php
-			echo esc_js( implode( "\r\n", $universal_commands ) );
-			echo esc_js( implode( "\r\n", $custom_vars ) );
-			?>
-		</script>
-		<!-- End Jetpack Google Analytics -->
-		<?php
+		$async_code = "
+			<!-- Jetpack Google Analytics -->
+			<script async src='https://www.googletagmanager.com/gtag/js?id=%tracking_id%'></script>
+			<script>
+				window.dataLayer = window.dataLayer || [];
+				function gtag() { dataLayer.push( arguments ); }
+				gtag( 'js', new Date() );
+				gtag( 'config', %tracking_id% );
+				%universal_commands%
+				%custom_vars%
+			</script>
+			<!-- End Jetpack Google Analytics -->
+		";
 		// phpcs:enable
+		$async_code                = str_replace( '%tracking_id%', $tracking_id, $async_code );
+		$universal_commands_string = implode( "\r\n", $universal_commands );
+		$async_code                = str_replace( '%universal_commands%', $universal_commands_string, $async_code );
+		$custom_vars_string        = implode( "\r\n", $custom_vars );
+		$async_code                = str_replace( '%custom_vars%', $custom_vars_string, $async_code );
+		echo esc_js( "$async_code\r\n" );
 	}
 
 	/**

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -77,6 +77,19 @@ class Jetpack_Google_Analytics_Legacy {
 			return;
 		}
 
+		if ( 'G-' === substr( $tracking_id, 0, 2 ) ) {
+			$this->render_gtag_code( $tracking_id );
+		} else {
+			$this->render_ga_code( $tracking_id );
+		}
+	}
+
+	/**
+	 * Renders legacy ga.js code.
+	 *
+	 * @param string $tracking_id Google Analytics measurement ID.
+	 */
+	private function render_ga_code( $tracking_id ) {
 		$custom_vars = array(
 			"_gaq.push(['_setAccount', '{$tracking_id}']);",
 		);
@@ -97,7 +110,7 @@ class Jetpack_Google_Analytics_Legacy {
 		if ( ! empty( $track ) ) {
 			$track['url'] = $this->_get_url( $track );
 			// adjust the code that we output, account for both types of tracking.
-			$track['url'] = esc_js( str_replace( '&', '&amp;', $track['url'] ) );
+			$track['url']  = esc_js( str_replace( '&', '&amp;', $track['url'] ) );
 			$custom_vars[] = "_gaq.push(['_trackPageview','{$track['url']}']);";
 		} else {
 			$custom_vars[] = "_gaq.push(['_trackPageview']);";
@@ -123,9 +136,31 @@ class Jetpack_Google_Analytics_Legacy {
 					ga.src = ('https:' === document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
 					var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 				})();
-			</script>\r\n",
+			</script>
+			<!-- End Jetpack Google Analytics -->\r\n",
 			implode( "\r\n", $custom_vars )
 		);
+	}
+
+	/**
+	 * Renders new gtag code.
+	 *
+	 * @param string $tracking_id Google Analytics measurement ID.
+	 */
+	private function render_gtag_code( $tracking_id ) {
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		?>
+		<!-- Jetpack Google Analytics -->
+		<script async src='https://www.googletagmanager.com/gtag/js?id=<?php echo esc_url( $tracking_id ); ?>'></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag() { dataLayer.push( arguments ); }
+			gtag( 'js', new Date() );
+			gtag( 'config', '<?php echo esc_js( $tracking_id ); ?>' );
+		</script>
+		<!-- End Jetpack Google Analytics -->
+		<?php
+		// phpcs:enable
 	}
 
 	/**

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -157,7 +157,7 @@ class Jetpack_Google_Analytics_Legacy {
 		 */
 		$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
 		$custom_vars        = array();
-		// if ( is_404() ) {
+		if ( is_404() ) {
 			$custom_vars[] = array(
 				'event',
 				'exception',
@@ -166,8 +166,7 @@ class Jetpack_Google_Analytics_Legacy {
 					'fatal'       => false,
 				),
 			);
-			// "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";
-		// }
+		}
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
 		<!-- Jetpack Google Analytics -->

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -156,9 +156,17 @@ class Jetpack_Google_Analytics_Legacy {
 		 * @param array $universal_commands Array of gtag function calls.
 		 */
 		$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
-		$custom_vars        = '';
+		$custom_vars        = array();
 		// if ( is_404() ) {
-			$custom_vars = "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";
+			$custom_vars[] = array(
+				'event',
+				'exception',
+				array(
+					'description' => '404',
+					'fatal'       => 'false',
+				),
+			);
+			// "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";
 		// }
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
@@ -173,7 +181,9 @@ class Jetpack_Google_Analytics_Legacy {
 			foreach ( $universal_commands as $command ) {
 				echo 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $command ) ) . " );\n";
 			}
-			echo esc_js( $custom_vars );
+			foreach ( $custom_vars as $var ) {
+				echo 'gtag( ' . implode( ', ', array_map( 'wp_json_encode', $var ) ) . " );\n";
+			}
 			?>
 		</script>
 		<!-- End Jetpack Google Analytics -->

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -157,9 +157,9 @@ class Jetpack_Google_Analytics_Legacy {
 		 */
 		$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
 		$custom_vars        = '';
-		if ( is_404() ) {
+		// if ( is_404() ) {
 			$custom_vars = "gtag('event', 'exception', { 'description': '404', 'fatal': 'false'});";
-		}
+		// }
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
 		<!-- Jetpack Google Analytics -->

--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -65,23 +65,20 @@ class Jetpack_Google_Analytics_Universal {
 		 * @param array $custom_vars Array of universal Google Analytics queue elements
 		 */
 		$universal_commands = apply_filters( 'jetpack_wga_universal_commands', array() );
-		if ( substr( $tracking_code, 0, 2 ) === 'G-' ) {
+		if ( 'G-' === substr( $tracking_code, 0, 2 ) ) {
 			// Upgrade script from UA to GA4 -- https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs.
 			// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 			$async_code = "
 				<script async src='https://www.googletagmanager.com/gtag/js?id=%tracking_code%'></script>
 				<script>
 					window.dataLayer = window.dataLayer || [];
-					function gtag(){dataLayer.push(arguments);}
-					gtag('js', new Date());
-					gtag('config', '%tracking_code%');
-
+					function gtag() { dataLayer.push( arguments ); }
+					gtag( 'js', new Date() );
+					gtag( 'config', '%tracking_code%' );
 				</script>
+				<!-- End Jetpack Google Analytics -->
 			";
-			// phpcs:enable
-			$async_code = str_replace( '%tracking_code%', $tracking_code, $async_code );
 		} else {
-			// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 			$async_code = "
 				<!-- Jetpack Google Analytics -->
 				<script>
@@ -94,10 +91,12 @@ class Jetpack_Google_Analytics_Universal {
 				<!-- End Jetpack Google Analytics -->
 			";
 			// phpcs:enable
-			$async_code                = str_replace( '%tracking_id%', $tracking_code, $async_code );
-			$universal_commands_string = implode( "\r\n", $universal_commands );
-			$async_code                = str_replace( '%universal_commands%', $universal_commands_string, $async_code );
 		}
+
+		$universal_commands_string = implode( "\r\n", $universal_commands );
+		$async_code                = str_replace( '%universal_commands%', $universal_commands_string, $async_code );
+		$async_code                = str_replace( '%tracking_code%', $tracking_code, $async_code );
+
 		echo "$async_code\r\n";
 	}
 

--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -57,55 +57,30 @@ class Jetpack_Google_Analytics_Universal {
 			return;
 		}
 
-		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		/**
+		 * Allow for additional elements to be added to the universal Google Analytics queue (ga) array
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param array $custom_vars Array of universal Google Analytics queue elements
+		 */
+		$universal_commands = apply_filters( 'jetpack_wga_universal_commands', array() );
 
-		if ( 'G-' === substr( $tracking_code, 0, 2 ) ) {
-			// Upgrade script from UA to GA4 -- https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs.
-			/**
-			 * Allow for additional elements to be added to the Global Site Tags array.
-			 *
-			 * @since 9.2.0
-			 *
-			 * @param array $universal_commands Array of gtag function calls.
-			 */
-			$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
-			$async_code         = "
-				<script async src='https://www.googletagmanager.com/gtag/js?id=%tracking_code%'></script>
-				<script>
-					window.dataLayer = window.dataLayer || [];
-					function gtag() { dataLayer.push( arguments ); }
-					gtag( 'js', new Date() );
-					gtag( 'config', '%tracking_code%' );
-					%universal_commands%
-				</script>
-				<!-- End Jetpack Google Analytics -->
-			";
-		} else {
-			/**
-			 * Allow for additional elements to be added to the universal Google Analytics queue (ga) array
-			 *
-			 * @since 5.6.0
-			 *
-			 * @param array $custom_vars Array of universal Google Analytics queue elements
-			 */
-			$universal_commands = apply_filters( 'jetpack_wga_universal_commands', array() );
-			$async_code         = "
-				<!-- Jetpack Google Analytics -->
-				<script>
-					window.ga = window.ga || function(){ ( ga.q = ga.q || [] ).push( arguments ) }; ga.l=+new Date;
-					ga( 'create', '%tracking_id%', 'auto' );
-					ga( 'require', 'ec' );
-					%universal_commands%
-				</script>
-				<script async src='https://www.google-analytics.com/analytics.js'></script>
-				<!-- End Jetpack Google Analytics -->
-			";
-			// phpcs:enable
-		}
+		$async_code = "
+			<!-- Jetpack Google Analytics -->
+			<script>
+				window.ga = window.ga || function(){ ( ga.q = ga.q || [] ).push( arguments ) }; ga.l=+new Date;
+				ga( 'create', '%tracking_id%', 'auto' );
+				ga( 'require', 'ec' );
+				%universal_commands%
+			</script>
+			<script async src='https://www.google-analytics.com/analytics.js'></script>
+			<!-- End Jetpack Google Analytics -->
+		";
+		$async_code = str_replace( '%tracking_id%', $tracking_code, $async_code );
 
 		$universal_commands_string = implode( "\r\n", $universal_commands );
-		$async_code                = str_replace( '%universal_commands%', $universal_commands_string, $async_code );
-		$async_code                = str_replace( '%tracking_code%', $tracking_code, $async_code );
+		$async_code = str_replace( '%universal_commands%', $universal_commands_string, $async_code );
 
 		echo "$async_code\r\n";
 	}

--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -57,29 +57,39 @@ class Jetpack_Google_Analytics_Universal {
 			return;
 		}
 
-		/**
-		 * Allow for additional elements to be added to the universal Google Analytics queue (ga) array
-		 *
-		 * @since 5.6.0
-		 *
-		 * @param array $custom_vars Array of universal Google Analytics queue elements
-		 */
-		$universal_commands = apply_filters( 'jetpack_wga_universal_commands', array() );
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+
 		if ( 'G-' === substr( $tracking_code, 0, 2 ) ) {
 			// Upgrade script from UA to GA4 -- https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs.
-			// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
-			$async_code = "
+			/**
+			 * Allow for additional elements to be added to the Global Site Tags array.
+			 *
+			 * @since 9.2.0
+			 *
+			 * @param array $universal_commands Array of gtag function calls.
+			 */
+			$universal_commands = apply_filters( 'jetpack_gtag_universal_commands', array() );
+			$async_code         = "
 				<script async src='https://www.googletagmanager.com/gtag/js?id=%tracking_code%'></script>
 				<script>
 					window.dataLayer = window.dataLayer || [];
 					function gtag() { dataLayer.push( arguments ); }
 					gtag( 'js', new Date() );
 					gtag( 'config', '%tracking_code%' );
+					%universal_commands%
 				</script>
 				<!-- End Jetpack Google Analytics -->
 			";
 		} else {
-			$async_code = "
+			/**
+			 * Allow for additional elements to be added to the universal Google Analytics queue (ga) array
+			 *
+			 * @since 5.6.0
+			 *
+			 * @param array $custom_vars Array of universal Google Analytics queue elements
+			 */
+			$universal_commands = apply_filters( 'jetpack_wga_universal_commands', array() );
+			$async_code         = "
 				<!-- Jetpack Google Analytics -->
 				<script>
 					window.ga = window.ga || function(){ ( ga.q = ga.q || [] ).push( arguments ) }; ga.l=+new Date;

--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -65,23 +65,39 @@ class Jetpack_Google_Analytics_Universal {
 		 * @param array $custom_vars Array of universal Google Analytics queue elements
 		 */
 		$universal_commands = apply_filters( 'jetpack_wga_universal_commands', array() );
+		if ( substr( $tracking_code, 0, 2 ) === 'G-' ) {
+			// Upgrade script from UA to GA4 -- https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs.
+			// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+			$async_code = "
+				<script async src='https://www.googletagmanager.com/gtag/js?id=%tracking_code%'></script>
+				<script>
+					window.dataLayer = window.dataLayer || [];
+					function gtag(){dataLayer.push(arguments);}
+					gtag('js', new Date());
+					gtag('config', '%tracking_code%');
 
-		$async_code = "
-			<!-- Jetpack Google Analytics -->
-			<script>
-				window.ga = window.ga || function(){ ( ga.q = ga.q || [] ).push( arguments ) }; ga.l=+new Date;
-				ga( 'create', '%tracking_id%', 'auto' );
-				ga( 'require', 'ec' );
-				%universal_commands%
-			</script>
-			<script async src='https://www.google-analytics.com/analytics.js'></script>
-			<!-- End Jetpack Google Analytics -->
-		";
-		$async_code = str_replace( '%tracking_id%', $tracking_code, $async_code );
-
-		$universal_commands_string = implode( "\r\n", $universal_commands );
-		$async_code = str_replace( '%universal_commands%', $universal_commands_string, $async_code );
-
+				</script>
+			";
+			// phpcs:enable
+			$async_code = str_replace( '%tracking_code%', $tracking_code, $async_code );
+		} else {
+			// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+			$async_code = "
+				<!-- Jetpack Google Analytics -->
+				<script>
+					window.ga = window.ga || function(){ ( ga.q = ga.q || [] ).push( arguments ) }; ga.l=+new Date;
+					ga( 'create', '%tracking_id%', 'auto' );
+					ga( 'require', 'ec' );
+					%universal_commands%
+				</script>
+				<script async src='https://www.google-analytics.com/analytics.js'></script>
+				<!-- End Jetpack Google Analytics -->
+			";
+			// phpcs:enable
+			$async_code                = str_replace( '%tracking_id%', $tracking_code, $async_code );
+			$universal_commands_string = implode( "\r\n", $universal_commands );
+			$async_code                = str_replace( '%universal_commands%', $universal_commands_string, $async_code );
+		}
 		echo "$async_code\r\n";
 	}
 

--- a/tests/php/modules/google-analytics/test-class.google-analytics.php
+++ b/tests/php/modules/google-analytics/test-class.google-analytics.php
@@ -13,11 +13,18 @@ require_jetpack_file( 'modules/google-analytics/wp-google-analytics.php' );
 class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 
 	/**
-	 * Testing Google Analytics account.
+	 * Testing Google Analytics account (UA).
 	 *
 	 * @var string
 	 */
-	const GA_ID = 'UA-000000000-1';
+	const UA_ID = 'UA-000000000-1';
+
+	/**
+	 * Testing Google Analytics account (GA4).
+	 *
+	 * @var string
+	 */
+	const GA4_ID = 'G-XXXXXXX';
 
 	/**
 	 * Runs the routine before each test is executed.
@@ -31,7 +38,7 @@ class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 		add_filter(
 			'pre_option_jetpack_wga',
 			function( $option ) {
-				$option['code'] = self::GA_ID;
+				$option['code'] = self::UA_ID;
 				return $option;
 			}
 		);
@@ -48,7 +55,7 @@ class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 		$config_data = wp_json_encode(
 			array(
 				'vars'     => array(
-					'account' => self::GA_ID,
+					'account' => self::UA_ID,
 				),
 				'triggers' => array(
 					'trackPageview' => array(
@@ -98,7 +105,7 @@ class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 		add_filter(
 			'pre_option_jetpack_wga',
 			function ( $option ) {
-				$option['code'] = 'G-XXXXXXX';
+				$option['code'] = self::GA4_ID;
 				return $option;
 			}
 		);
@@ -120,7 +127,11 @@ class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 					array(
 						'event',
 						'another_jetpack_testing_event',
-						'bar',
+						array(
+							'event_category' => 'foo',
+							'event_label'    => 'bar',
+							'value'          => 'baz',
+						),
 					),
 				);
 			}
@@ -136,7 +147,7 @@ class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 		);
 
 		$this->assertContains(
-			'gtag( "event", "another_jetpack_testing_event", "bar" );',
+			'gtag( "event", "another_jetpack_testing_event", {"event_category":"foo","event_label":"bar","value":"baz"} );',
 			$actual
 		);
 	}

--- a/tests/php/modules/google-analytics/test-class.google-analytics.php
+++ b/tests/php/modules/google-analytics/test-class.google-analytics.php
@@ -137,8 +137,17 @@ class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 			}
 		);
 
+		// GA code is only inserted in non-admin screens.
+		set_current_screen( 'front' );
+
+		// Mock `Jetpack_Google_Analytics_Legacy` instance to disable the constructor class.
+		$instance = $this->getMockBuilder( Jetpack_Google_Analytics_Legacy::class )
+			->setMethods( null )
+			->disableOriginalConstructor()
+			->getMock();
+
 		ob_start();
-		( new Jetpack_Google_Analytics_Legacy() )->insert_code();
+		$instance->insert_code();
 		$actual = ob_get_clean();
 
 		$this->assertContains(


### PR DESCRIPTION
Helps with 305-gh-dotcom-manage

## Changes proposed in this Pull Request:
Currently, adding a GA4 from the Google Analytics Plugin, does not result in tracking being sent through to the Google Analytics page.

This is because the incorrect Google Analytics script is being used. GA4 uses a new script, documented here, which is backwards compatible https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs

These changes identify whether the tag is a GA4 tag, and if so, uses the GA4 JS script. Otherwise, we'll continue to use the UA JS script.

That way, tracking that was used by previous users continues to work, and tracking used my new users will work as well.

GA4 Script in source index
<img width="702" alt="Screen Shot 2020-11-12 at 7 05 14 PM" src="https://user-images.githubusercontent.com/66652282/99012158-b8d14800-251b-11eb-9198-d8ed69c8f9a9.png">

Google Analytics Metrics
<img width="779" alt="Screen Shot 2020-11-12 at 7 05 06 PM" src="https://user-images.githubusercontent.com/66652282/99012189-ca1a5480-251b-11eb-9d6c-1287bbc72766.png">

## Jetpack product discussion
N/A.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
For WooCommerce sites:
1. Spin up a JN website
2. Set up Jetpack
3. Choose a Jetpack plan (Daily Security)
4. Set up a new Google Analytics property with a GA4 tag for your Jetpack site
5. In `https://wordpress.com/marketing/traffic/{site_id}`,  enter your GA4 tag in the Google Analytics Tracking ID
6. Go to your Jetpack site, if you inspect the source index, you should be able to find your GA4 tag, and the GA4 script documented here: https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs
7. Go to your Google Analytics page, you should see at least one user viewing your site in realtime.
8. All functionality with the UA tags should be preserved

### Testing adding custom gtag events via filter

This implementation [enables addition of custom `gtag` events](https://developers.google.com/analytics/devguides/collection/gtagjs/events) via the filter `jetpack_gtag_universal_commands`. To test this.

* Create an `mu-plugin` on your test site - call it whatever you want. Keep it simple.
* Add the following code to your `mu-plugin` - this hooks into the filter and returns an assoc array of events for inclusion in the `<script>` tag output as custom `gtag()` events:

```php
function add_jetpack_gtag_universal_commands() {

	return array(
		array(
			'event',
			'jetpack_testing_event',
			array(
				'event_category' => 'somecat',
				'event_label'    => 'somelabel',
				'value'          => 'someval',
			),
		),
		array(
			'event',
			'another_jetpack_testing_event',
			array(
				'event_category' => 'foo',
				'event_label'    => 'bar',
				'value'          => 'baz',
			),
		),
	);
}

add_filter( 'jetpack_gtag_universal_commands', 'add_jetpack_gtag_universal_commands' );
```

* Ensure your `mu-plugin` is definitely working on your site - add some debugging output and then load the front page of your site and `View Source` (remember it only loads GA code on the front of your site not in WPAdmin).
* `View Source` and search for `dataLayer` using your browser's "Search" utility.
* You should see something akin to:

```html
<!-- Jetpack Google Analytics -->
<script async src='https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX'></script>
<script>
    window.dataLayer = window.dataLayer || [];
    function gtag() { dataLayer.push( arguments ); }
    gtag( 'js', new Date() );
    gtag( 'config', 'G-XXXXXXX' );
    gtag( "event", "jetpack_testing_event", {"event_category":"somecat","event_label":"somelabel","value":"someval"} );
    gtag( "event", "another_jetpack_testing_event", {"event_category":"foo","event_label":"bar","value":"baz"} );
</script>
<!-- End Jetpack Google Analytics -->
```

* Go to your Google Analytics Dashboard for the property that corresponds with the `G-XXXXX` Measurement ID (aka "Tracking ID") that you used above.
* Go to `All Events` and then create x2 events by clicking on the `Create Event` button twice.
* Name your events as per the config above - namely: `jetpack_testing_event` and `another_jetpack_testing_event`.
* Make sure you save both events.
* Back on your site, go around clicking on a few pages. Do this for about 1 minute. Do it also in Incognito mode if possible.
* Back in GA Dashboard go to `Real-time` and look for the box that reads `Event count by Event name`. 
* Wait for a bit and you should see your events show up.
* One day they will probably also show up in the `All Events` section as well but that takes longer!
* For bonus points also create some more custom events as per https://developers.google.com/analytics/devguides/collection/gtagjs/events so that we can be sure we've covered all the formats required by Google.

## Proposed changelog entry for your changes:
- Support Google Analytics 4 tags with GA4 JS script