### PR TITLE
Add the no_user_testing mode

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -522,6 +522,9 @@ class Manager {
 	 * @return Boolean is the site connected?
 	 */
 	public function is_active() {
+		if ( ( new Status() )->is_no_user_testing_mode() ) {
+			return $this->is_registered();
+		}
 		return (bool) $this->get_access_token( self::CONNECTION_OWNER );
 	}
 
@@ -2263,6 +2266,10 @@ class Manager {
 		$possible_special_tokens = array();
 		$possible_normal_tokens  = array();
 		$user_tokens             = \Jetpack_Options::get_option( 'user_tokens' );
+
+		if ( ( new Status() )->is_no_user_testing_mode() ) {
+			$user_tokens = false;
+		}
 
 		if ( $user_id ) {
 			if ( ! $user_tokens ) {

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -74,6 +74,34 @@ class Status {
 	}
 
 	/**
+	 * Is Jetpack in "No User test mode"?
+	 *
+	 * This will make jetpack act as if there were no connected users, but only a site connectino (aka blog token)
+	 *
+	 * @since 9.2.0
+	 *
+	 * @return bool Whether Jetpack's No User Testing Mode is active.
+	 */
+	public function is_no_user_testing_mode() {
+		$test_mode = false;
+		if ( defined( 'JETPACK_NO_USER_TEST_MODE' ) ) {
+			$test_mode = JETPACK_NO_USER_TEST_MODE;
+		}
+
+		/**
+		 * Filters Jetpack's No User test mode.
+		 *
+		 * @since 9.2.0
+		 *
+		 * @param bool $offline_mode Is Jetpack's offline mode active.
+		 */
+		$test_mode = (bool) apply_filters( 'jetpack_offline_mode', $test_mode );
+
+		return $test_mode;
+
+	}
+
+	/**
 	 * Whether this is a system with a multiple networks.
 	 * Implemented since there is no core is_multi_network function.
 	 * Right now there is no way to tell which network is the dominant network on the system.

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -89,13 +89,13 @@ class Status {
 		}
 
 		/**
-		 * Filters Jetpack's No User test mode.
+		 * Filters Jetpack's No User testing mode.
 		 *
 		 * @since 9.2.0
 		 *
-		 * @param bool $offline_mode Is Jetpack's offline mode active.
+		 * @param bool $test_mode Is Jetpack's No User testing mode active.
 		 */
-		$test_mode = (bool) apply_filters( 'jetpack_offline_mode', $test_mode );
+		$test_mode = (bool) apply_filters( 'jetpack_no_user_testing_mode', $test_mode );
 
 		return $test_mode;
 

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -76,7 +76,7 @@ class Status {
 	/**
 	 * Is Jetpack in "No User test mode"?
 	 *
-	 * This will make jetpack act as if there were no connected users, but only a site connectino (aka blog token)
+	 * This will make Jetpack act as if there were no connected users, but only a site connection (aka blog token)
 	 *
 	 * @since 9.2.0
 	 *


### PR DESCRIPTION
Adds the possibility for developers to run Jetpack in a "No user" mode

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* adds a check for the `no_user_test_mode`
* If this mode is active, Jetpack will be considered `active` if it has the blog token and will disconsider the user tokens. Those will be ignored and never returned from the database.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-a4a-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* New site
* Add `define( 'JETPACK_NO_USER_TEST_MODE', true );` to your `wp-config.php`
* Connect Jetpack
* You will be asked to connect a user, as usual. Connect
* The screen will freeze in the last step "Finalizing". Refresh the window
* Check that you see the Jetpack Dashboard
* Check you see dialogs suggesting you to connect your user to WPCOM (as if you were not connected)
* remove the defined constant and add: `add_filter( 'jetpack_no_user_testing_mode', '__return_true' );`
* Check if the test mode is still working

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Adds no_user_test_mode