### PR TITLE
Widgets: PHPCS + Fusion Milestone widget

### DIFF
--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -77,6 +77,8 @@ module.exports = [
 	'modules/widgets/contact-info.php',
 	'modules/widgets/class-jetpack-instagram-widget.php',
 	'modules/widgets/eu-cookie-law/widget-amp.php',
+	'modules/widgets/milestone.php',
+	'modules/widgets/milestone/',
 	'modules/widgets/social-icons.php',
 	'modules/woocommerce-analytics/',
 	'modules/woocommerce-analytics.php',

--- a/modules/widgets/milestone.php
+++ b/modules/widgets/milestone.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Milestone widget loader.
+ *
+ * Everything happens within the folder, but Jetpack loads widgets via a widgets/*.php scheme.
+ *
+ * @package Jetpack.
+ */
+
+/**
  * Register the milestone widget.  This makes it easier to keep the /milestone/ dir content in sync with wpcom.
  */
-include dirname( __FILE__ ) . '/milestone/milestone.php';
+require __DIR__ . '/milestone/class-milestone-widget.php';

--- a/modules/widgets/milestone/class-milestone-widget.php
+++ b/modules/widgets/milestone/class-milestone-widget.php
@@ -313,7 +313,7 @@ class Milestone_Widget extends WP_Widget {
 				switch ( $data['unit'] ) {
 					case 'years':
 						$data['message'] = sprintf(
-								/* translators: %s is the number of year(s). */
+							/* translators: %s is the number of year(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">year ago.</span>',
 								'<span class="difference">%s</span> <span class="label">years ago.</span>',
@@ -325,7 +325,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'months':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of month(s). */
+							/* translators: %s is the number of month(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">month ago.</span>',
 								'<span class="difference">%s</span> <span class="label">months ago.</span>',
@@ -337,7 +337,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'days':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of days(s). */
+							/* translators: %s is the number of days(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">day ago.</span>',
 								'<span class="difference">%s</span> <span class="label">days ago.</span>',
@@ -349,7 +349,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'hours':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of hours(s). */
+							/* translators: %s is the number of hours(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">hour ago.</span>',
 								'<span class="difference">%s</span> <span class="label">hours ago.</span>',
@@ -361,7 +361,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'minutes':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of minutes(s). */
+							/* translators: %s is the number of minutes(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">minute ago.</span>',
 								'<span class="difference">%s</span> <span class="label">minutes ago.</span>',
@@ -373,7 +373,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'seconds':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of second(s). */
+							/* translators: %s is the number of second(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">second ago.</span>',
 								'<span class="difference">%s</span> <span class="label">seconds ago.</span>',
@@ -388,7 +388,7 @@ class Milestone_Widget extends WP_Widget {
 				switch ( $this->get_unit( $diff, $instance['unit'] ) ) {
 					case 'years':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of year(s). */
+							/* translators: %s is the number of year(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">year to go.</span>',
 								'<span class="difference">%s</span> <span class="label">years to go.</span>',
@@ -400,7 +400,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'months':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of month(s). */
+							/* translators: %s is the number of month(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">month to go.</span>',
 								'<span class="difference">%s</span> <span class="label">months to go.</span>',
@@ -412,7 +412,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'days':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of days(s). */
+							/* translators: %s is the number of days(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">day to go.</span>',
 								'<span class="difference">%s</span> <span class="label">days to go.</span>',
@@ -424,7 +424,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'hours':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of hour(s). */
+							/* translators: %s is the number of hour(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">hour to go.</span>',
 								'<span class="difference">%s</span> <span class="label">hours to go.</span>',
@@ -436,7 +436,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'minutes':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of minute(s). */
+							/* translators: %s is the number of minute(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">minute to go.</span>',
 								'<span class="difference">%s</span> <span class="label">minutes to go.</span>',
@@ -448,7 +448,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'seconds':
 						$data['message'] = sprintf(
-						/* translators: %s is the number of second(s). */
+							/* translators: %s is the number of second(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">second to go.</span>',
 								'<span class="difference">%s</span> <span class="label">seconds to go.</span>',

--- a/modules/widgets/milestone/class-milestone-widget.php
+++ b/modules/widgets/milestone/class-milestone-widget.php
@@ -1,26 +1,30 @@
 <?php
-/*
-Plugin Name: Milestone
-Description: Countdown to a specific date.
-Version: 1.0
-Author: Automattic Inc.
-Author URI: https://automattic.com/
-License: GPLv2 or later
-Text Domain: jetpack
-*/
+/**
+ * Milestone Countdown Widget
+ *
+ * @package Jetpack.
+ */
 
 use Automattic\Jetpack\Assets;
 
+/**
+ * Registers the widget for use!
+ */
 function jetpack_register_widget_milestone() {
 	register_widget( 'Milestone_Widget' );
 }
 add_action( 'widgets_init', 'jetpack_register_widget_milestone' );
 
+/**
+ * Class Milestone_Widget
+ */
 class Milestone_Widget extends WP_Widget {
-	private static $dir       = null;
-	private static $url       = null;
-	private static $defaults  = null;
-	private static $config_js = null;
+	/**
+	 * Holding array for widget configuration and localization.
+	 *
+	 * @var array
+	 */
+	private static $config_js = array();
 
 	/**
 	 * Available time units sorted in descending order.
@@ -36,7 +40,10 @@ class Milestone_Widget extends WP_Widget {
 		'seconds',
 	);
 
-	function __construct() {
+	/**
+	 * Milestone_Widget constructor.
+	 */
+	public function __construct() {
 		$widget = array(
 			'classname'   => 'milestone-widget',
 			'description' => __( 'Display a countdown to a certain date.', 'jetpack' ),
@@ -49,9 +56,6 @@ class Milestone_Widget extends WP_Widget {
 			$widget
 		);
 
-		self::$dir = trailingslashit( __DIR__ );
-		self::$url = plugin_dir_url( __FILE__ );
-
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
 		add_action( 'wp_footer', array( $this, 'localize_script' ) );
@@ -61,9 +65,14 @@ class Milestone_Widget extends WP_Widget {
 		}
 	}
 
+	/**
+	 * Enqueue admin assets.
+	 *
+	 * @param string $hook_suffix Hook suffix provided by WordPress.
+	 */
 	public static function enqueue_admin( $hook_suffix ) {
-		if ( 'widgets.php' == $hook_suffix ) {
-			wp_enqueue_style( 'milestone-admin', self::$url . 'style-admin.css', array(), '20161215' );
+		if ( 'widgets.php' === $hook_suffix ) {
+			wp_enqueue_style( 'milestone-admin', plugin_dir_url( __FILE__ ) . 'style-admin.css', array(), '20161215' );
 			wp_enqueue_script(
 				'milestone-admin-js',
 				Assets::get_file_url_for_environment(
@@ -77,6 +86,9 @@ class Milestone_Widget extends WP_Widget {
 		}
 	}
 
+	/**
+	 * Enqueue the frontend JS.
+	 */
 	public static function enqueue_template() {
 		if ( Jetpack_AMP_Support::is_amp_request() ) {
 			return;
@@ -94,6 +106,9 @@ class Milestone_Widget extends WP_Widget {
 		);
 	}
 
+	/**
+	 * Output the frontend styling.
+	 */
 	public static function styles_template() {
 		global $themecolors;
 		$colors = wp_parse_args(
@@ -117,8 +132,8 @@ class Milestone_Widget extends WP_Widget {
 	text-align: center;
 }
 .milestone-header {
-	background-color: <?php echo self::sanitize_color_hex( $colors['text'] ); ?>;
-	color: <?php echo self::sanitize_color_hex( $colors['bg'] ); ?>;
+	background-color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	line-height: 1.3;
 	margin: 0;
 	padding: .8em;
@@ -138,10 +153,10 @@ class Milestone_Widget extends WP_Widget {
 }
 .milestone-countdown,
 .milestone-message {
-	background-color: <?php echo self::sanitize_color_hex( $colors['bg'] ); ?>;
-	border: 1px solid <?php echo self::sanitize_color_hex( $colors['border'] ); ?>;
+	background-color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	border: 1px solid <?php echo self::sanitize_color_hex( $colors['border'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	border-top: 0;
-	color: <?php echo self::sanitize_color_hex( $colors['text'] ); ?>;
+	color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	padding-bottom: 1em;
 }
 .milestone-message {
@@ -155,7 +170,9 @@ class Milestone_Widget extends WP_Widget {
 	 * Ensure that a string representing a color in hexadecimal
 	 * notation is safe for use in css and database saves.
 	 *
-	 * @param string Color in hexadecimal notation. "#" may or may not be prepended to the string.
+	 * @param string $hex Hexademical code to sanitize.
+	 * @param string $prefix Prefix for the hex code.
+	 *
 	 * @return string Color in hexadecimal notation on success - the string "transparent" otherwise.
 	 */
 	public static function sanitize_color_hex( $hex, $prefix = '#' ) {
@@ -185,7 +202,7 @@ class Milestone_Widget extends WP_Widget {
 	 *
 	 * Hooks into the "wp_footer" action.
 	 */
-	function localize_script() {
+	public function localize_script() {
 		if ( Jetpack_AMP_Support::is_amp_request() ) {
 			return;
 		}
@@ -200,14 +217,17 @@ class Milestone_Widget extends WP_Widget {
 
 	/**
 	 * Widget
+	 *
+	 * @param array $args Widget args.
+	 * @param array $instance Widget instance.
 	 */
-	function widget( $args, $instance ) {
-		echo $args['before_widget'];
+	public function widget( $args, $instance ) {
+		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $instance['title'] );
 		if ( ! empty( $title ) ) {
-			echo $args['before_title'] . $title . $args['after_title'];
+			echo $args['before_title'] . esc_html( $title ) . $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 		$data   = $this->get_widget_data( $instance );
@@ -233,17 +253,24 @@ class Milestone_Widget extends WP_Widget {
 		echo '<span class="date">' . esc_html( date_i18n( get_option( 'date_format' ), $data['milestone'] ) ) . '</span>';
 		echo '</div>';
 
-		echo $data['message'];
+		echo wp_kses_post( $data['message'] );
 
 		echo '</div><!--milestone-content-->';
 
-		echo $args['after_widget'];
+		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This action is documented in modules/widgets/gravatar-profile.php */
 		do_action( 'jetpack_stats_extra', 'widget_view', 'milestone' );
 	}
 
-	function get_widget_data( $instance ) {
+	/**
+	 * Getter for the widget data.
+	 *
+	 * @param array $instance Widget instance.
+	 *
+	 * @return array
+	 */
+	public function get_widget_data( $instance ) {
 		$data = array();
 
 		$instance = $this->sanitize_instance( $instance );
@@ -261,22 +288,22 @@ class Milestone_Widget extends WP_Widget {
 		$data['diff'] = $diff;
 		$data['unit'] = $this->get_unit( $diff, $instance['unit'] );
 
-		// Setting the refresh counter to equal the number of seconds it takes to flip a unit
+		// Setting the refresh counter to equal the number of seconds it takes to flip a unit.
 		$refresh_intervals = array(
-			0, // should be YEAR_IN_SECONDS, but doing setTimeout for a year doesn't seem to be logical
-			0, // same goes for MONTH_IN_SECONDS,
+			0, // should be YEAR_IN_SECONDS, but doing setTimeout for a year doesn't seem to be logical.
+			0, // same goes for MONTH_IN_SECONDS.
 			DAY_IN_SECONDS,
 			HOUR_IN_SECONDS,
 			MINUTE_IN_SECONDS,
 			1,
 		);
 
-		$data['refresh']   = $refresh_intervals[ array_search( $data['unit'], $this->available_units ) ];
+		$data['refresh']   = $refresh_intervals[ array_search( $data['unit'], $this->available_units, true ) ];
 		$data['milestone'] = $milestone;
 
 		if ( ( 1 > $diff ) && ( 'until' === $type ) ) {
 			$data['message'] = '<div class="milestone-message">' . $instance['message'] . '</div>';
-			$data['refresh'] = 0; // No need to refresh, the milestone has been reached
+			$data['refresh'] = 0; // No need to refresh, the milestone has been reached.
 		} else {
 			$interval_text = $this->get_interval_in_units( $diff, $data['unit'] );
 			$interval      = (int) $interval_text;
@@ -286,6 +313,7 @@ class Milestone_Widget extends WP_Widget {
 				switch ( $data['unit'] ) {
 					case 'years':
 						$data['message'] = sprintf(
+								/* translators: %s is the number of year(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">year ago.</span>',
 								'<span class="difference">%s</span> <span class="label">years ago.</span>',
@@ -297,6 +325,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'months':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of month(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">month ago.</span>',
 								'<span class="difference">%s</span> <span class="label">months ago.</span>',
@@ -308,6 +337,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'days':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of days(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">day ago.</span>',
 								'<span class="difference">%s</span> <span class="label">days ago.</span>',
@@ -319,6 +349,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'hours':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of hours(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">hour ago.</span>',
 								'<span class="difference">%s</span> <span class="label">hours ago.</span>',
@@ -330,6 +361,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'minutes':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of minutes(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">minute ago.</span>',
 								'<span class="difference">%s</span> <span class="label">minutes ago.</span>',
@@ -341,6 +373,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'seconds':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of second(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">second ago.</span>',
 								'<span class="difference">%s</span> <span class="label">seconds ago.</span>',
@@ -355,6 +388,7 @@ class Milestone_Widget extends WP_Widget {
 				switch ( $this->get_unit( $diff, $instance['unit'] ) ) {
 					case 'years':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of year(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">year to go.</span>',
 								'<span class="difference">%s</span> <span class="label">years to go.</span>',
@@ -366,6 +400,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'months':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of month(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">month to go.</span>',
 								'<span class="difference">%s</span> <span class="label">months to go.</span>',
@@ -377,6 +412,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'days':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of days(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">day to go.</span>',
 								'<span class="difference">%s</span> <span class="label">days to go.</span>',
@@ -388,6 +424,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'hours':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of hour(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">hour to go.</span>',
 								'<span class="difference">%s</span> <span class="label">hours to go.</span>',
@@ -399,6 +436,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'minutes':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of minute(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">minute to go.</span>',
 								'<span class="difference">%s</span> <span class="label">minutes to go.</span>',
@@ -410,6 +448,7 @@ class Milestone_Widget extends WP_Widget {
 						break;
 					case 'seconds':
 						$data['message'] = sprintf(
+						/* translators: %s is the number of second(s). */
 							_n(
 								'<span class="difference">%s</span> <span class="label">second to go.</span>',
 								'<span class="difference">%s</span> <span class="label">seconds to go.</span>',
@@ -430,7 +469,7 @@ class Milestone_Widget extends WP_Widget {
 	/**
 	 * Return the largest possible time unit that the difference will be displayed in.
 	 *
-	 * @param Integer $seconds the interval in seconds
+	 * @param Integer $seconds the interval in seconds.
 	 * @param String  $maximum_unit the maximum unit that will be used. Optional.
 	 * @return String $calculated_unit
 	 */
@@ -438,50 +477,50 @@ class Milestone_Widget extends WP_Widget {
 		$unit = '';
 
 		if ( $seconds >= YEAR_IN_SECONDS * 2 ) {
-			// more than 2 years - show in years, one decimal point
+			// more than 2 years - show in years, one decimal point.
 			$unit = 'years';
 
 		} elseif ( $seconds >= YEAR_IN_SECONDS ) {
 			if ( 'years' === $maximum_unit ) {
 				$unit = 'years';
 			} else {
-				// automatic mode - showing months even if it's between one and two years
+				// automatic mode - showing months even if it's between one and two years.
 				$unit = 'months';
 			}
 		} elseif ( $seconds >= MONTH_IN_SECONDS * 3 ) {
-			// fewer than 2 years - show in months
+			// fewer than 2 years - show in months.
 			$unit = 'months';
 
 		} elseif ( $seconds >= MONTH_IN_SECONDS ) {
 			if ( 'months' === $maximum_unit ) {
 				$unit = 'months';
 			} else {
-				// automatic mode - showing days even if it's between one and three months
+				// automatic mode - showing days even if it's between one and three months.
 				$unit = 'days';
 			}
 		} elseif ( $seconds >= DAY_IN_SECONDS - 1 ) {
-			// fewer than a month - show in days
+			// fewer than a month - show in days.
 			$unit = 'days';
 
 		} elseif ( $seconds >= HOUR_IN_SECONDS - 1 ) {
-			// less than 1 day - show in hours
+			// less than 1 day - show in hours.
 			$unit = 'hours';
 
 		} elseif ( $seconds >= MINUTE_IN_SECONDS - 1 ) {
-			// less than 1 hour - show in minutes
+			// less than 1 hour - show in minutes.
 			$unit = 'minutes';
 
 		} else {
-			// less than 1 minute - show in seconds
+			// less than 1 minute - show in seconds.
 			$unit = 'seconds';
 		}
 
-		$maximum_unit_index = array_search( $maximum_unit, $this->available_units );
-		$unit_index         = array_search( $unit, $this->available_units );
+		$maximum_unit_index = array_search( $maximum_unit, $this->available_units, true );
+		$unit_index         = array_search( $unit, $this->available_units, true );
 
 		if (
-			false === $maximum_unit_index // the maximum unit parameter is automatic
-			|| $unit_index > $maximum_unit_index // there is not enough seconds for even one maximum time unit
+			false === $maximum_unit_index // the maximum unit parameter is automatic.
+			|| $unit_index > $maximum_unit_index // there is not enough seconds for even one maximum time unit.
 		) {
 			return $unit;
 		}
@@ -491,9 +530,9 @@ class Milestone_Widget extends WP_Widget {
 	/**
 	 * Returns a time difference value in specified units.
 	 *
-	 * @param Integer $seconds
-	 * @param String  $units
-	 * @return Integer|String $time_in_units
+	 * @param int    $seconds Number of seconds.
+	 * @param string $units Unit.
+	 * @return int $time_in_units.
 	 */
 	protected function get_interval_in_units( $seconds, $units ) {
 		switch ( $units ) {
@@ -515,13 +554,18 @@ class Milestone_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Update
+	 * Update widget.
+	 *
+	 * @param array $new_instance New instance of the widget being saved.
+	 * @param array $old_instance Previous instance being saved over.
+	 *
+	 * @return array
 	 */
-	function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->sanitize_instance( $new_instance );
 	}
 
-	/*
+	/**
 	 * Make sure that a number is within a certain range.
 	 * If the number is too small it will become the possible lowest value.
 	 * If the number is too large it will become the possible highest value.
@@ -530,7 +574,7 @@ class Milestone_Widget extends WP_Widget {
 	 * @param int $floor The lowest possible value.
 	 * @param int $ceil The highest possible value.
 	 */
-	function sanitize_range( $n, $floor, $ceil ) {
+	public function sanitize_range( $n, $floor, $ceil ) {
 		$n = (int) $n;
 		if ( $n < $floor ) {
 			$n = $floor;
@@ -540,15 +584,20 @@ class Milestone_Widget extends WP_Widget {
 		return $n;
 	}
 
-	/*
+	/**
 	 * Sanitize an instance of this widget.
 	 *
 	 * Date ranges match the documentation for mktime in the php manual.
+	 *
 	 * @see https://php.net/manual/en/function.mktime.php#refsect1-function.mktime-parameters
 	 *
 	 * @uses Milestone_Widget::sanitize_range().
+	 *
+	 * @param array $dirty Unsantized data for the widget.
+	 *
+	 * @return array Santized data.
 	 */
-	function sanitize_instance( $dirty ) {
+	public function sanitize_instance( $dirty ) {
 		$now = (int) current_time( 'timestamp' );
 
 		$dirty = wp_parse_args(
@@ -559,9 +608,9 @@ class Milestone_Widget extends WP_Widget {
 				'unit'    => 'automatic',
 				'type'    => 'until',
 				'message' => __( 'The big day is here.', 'jetpack' ),
-				'day'     => date( 'd', $now ),
-				'month'   => date( 'm', $now ),
-				'year'    => date( 'Y', $now ),
+				'day'     => gmdate( 'd', $now ),
+				'month'   => gmdate( 'm', $now ),
+				'year'    => gmdate( 'Y', $now ),
 				'hour'    => 0,
 				'min'     => 0,
 			)
@@ -578,8 +627,8 @@ class Milestone_Widget extends WP_Widget {
 		);
 
 		$clean = array(
-			'title'   => trim( strip_tags( stripslashes( $dirty['title'] ) ) ),
-			'event'   => trim( strip_tags( stripslashes( $dirty['event'] ) ) ),
+			'title'   => trim( wp_strip_all_tags( stripslashes( $dirty['title'] ) ) ),
+			'event'   => trim( wp_strip_all_tags( stripslashes( $dirty['event'] ) ) ),
 			'unit'    => $dirty['unit'],
 			'type'    => $dirty['type'],
 			'message' => wp_kses( $dirty['message'], $allowed_tags ),
@@ -589,15 +638,17 @@ class Milestone_Widget extends WP_Widget {
 			'min'     => zeroise( $this->sanitize_range( $dirty['min'], 0, 59 ), 2 ),
 		);
 
-		$clean['day'] = $this->sanitize_range( $dirty['day'], 1, date( 't', mktime( 0, 0, 0, $clean['month'], 1, $clean['year'] ) ) );
+		$clean['day'] = $this->sanitize_range( $dirty['day'], 1, gmdate( 't', mktime( 0, 0, 0, $clean['month'], 1, $clean['year'] ) ) );
 
 		return $clean;
 	}
 
 	/**
 	 * Form
+	 *
+	 * @param array $instance Widget instance.
 	 */
-	function form( $instance ) {
+	public function form( $instance ) {
 		$instance = $this->sanitize_instance( $instance );
 
 		$units = array(
@@ -608,98 +659,109 @@ class Milestone_Widget extends WP_Widget {
 			'hours'     => _x( 'Hours', 'Milestone widget: mode in which the date unit is set to hours', 'jetpack' ),
 		);
 		?>
+		<div class="milestone-widget">
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title', 'jetpack' ); ?></label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+			</p>
 
-	<div class="milestone-widget">
-		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
-		</p>
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'event' ) ); ?>"><?php esc_html_e( 'Description', 'jetpack' ); ?></label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'event' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'event' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['event'] ); ?>" />
+			</p>
 
-		<p>
-			<label for="<?php echo $this->get_field_id( 'event' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'event' ); ?>" name="<?php echo $this->get_field_name( 'event' ); ?>" type="text" value="<?php echo esc_attr( $instance['event'] ); ?>" />
-		</p>
+			<fieldset class="jp-ms-data-time">
+				<legend><?php esc_html_e( 'Date', 'jetpack' ); ?></legend>
 
-		<fieldset class="jp-ms-data-time">
-			<legend><?php esc_html_e( 'Date', 'jetpack' ); ?></legend>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'month' ) ); ?>" class="assistive-text"><?php esc_html_e( 'Month', 'jetpack' ); ?></label>
+				<select id="<?php echo esc_attr( $this->get_field_id( 'month' ) ); ?>" class="month" name="<?php echo esc_attr( $this->get_field_name( 'month' ) ); ?>">
+					<?php
+								global $wp_locale;
+					for ( $i = 1; $i < 13; $i++ ) {
+						$monthnum = zeroise( $i, 2 );
+						printf(
+							'<option value="%s" %s>%s-%s</option>',
+							esc_attr( $monthnum ),
+							selected( $i, $instance['month'], false ),
+							esc_attr( $monthnum ),
+							esc_attr( $wp_locale->get_month_abbrev( $wp_locale->get_month( $i ) ) )
+						);
+					}
+					?>
+				</select>
 
-			<label for="<?php echo $this->get_field_id( 'month' ); ?>" class="assistive-text"><?php _e( 'Month', 'jetpack' ); ?></label>
-			<select id="<?php echo $this->get_field_id( 'month' ); ?>" class="month" name="<?php echo $this->get_field_name( 'month' ); ?>">
-								   <?php
-									global $wp_locale;
-									for ( $i = 1; $i < 13; $i++ ) {
-										$monthnum = zeroise( $i, 2 );
-										echo '<option value="' . esc_attr( $monthnum ) . '"' . selected( $i, $instance['month'], false ) . '>' . $monthnum . '-' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $i ) ) . '</option>';
-									}
-									?>
-			</select>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'day' ) ); ?>" class="assistive-text"><?php esc_html_e( 'Day', 'jetpack' ); ?></label>
+				<input id="<?php echo esc_attr( $this->get_field_id( 'day' ) ); ?>" class="day" name="<?php echo esc_attr( $this->get_field_name( 'day' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['day'] ); ?>">,
 
-			<label for="<?php echo $this->get_field_id( 'day' ); ?>" class="assistive-text"><?php _e( 'Day', 'jetpack' ); ?></label>
-			<input id="<?php echo $this->get_field_id( 'day' ); ?>" class="day" name="<?php echo $this->get_field_name( 'day' ); ?>" type="text" value="<?php echo esc_attr( $instance['day'] ); ?>">,
+				<label for="<?php echo esc_attr( $this->get_field_id( 'year' ) ); ?>" class="assistive-text"><?php esc_html_e( 'Year', 'jetpack' ); ?></label>
+				<input id="<?php echo esc_attr( $this->get_field_id( 'year' ) ); ?>" class="year" name="<?php echo esc_attr( $this->get_field_name( 'year' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['year'] ); ?>">
+			</fieldset>
 
-			<label for="<?php echo $this->get_field_id( 'year' ); ?>" class="assistive-text"><?php _e( 'Year', 'jetpack' ); ?></label>
-			<input id="<?php echo $this->get_field_id( 'year' ); ?>" class="year" name="<?php echo $this->get_field_name( 'year' ); ?>" type="text" value="<?php echo esc_attr( $instance['year'] ); ?>">
-		</fieldset>
+			<fieldset class="jp-ms-data-time">
+				<legend><?php esc_html_e( 'Time', 'jetpack' ); ?></legend>
 
-		<fieldset class="jp-ms-data-time">
-			<legend><?php esc_html_e( 'Time', 'jetpack' ); ?></legend>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'hour' ) ); ?>" class="assistive-text"><?php esc_html_e( 'Hour', 'jetpack' ); ?></label>
+				<input id="<?php echo esc_attr( $this->get_field_id( 'hour' ) ); ?>" class="hour" name="<?php echo esc_attr( $this->get_field_name( 'hour' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['hour'] ); ?>">
 
-			<label for="<?php echo $this->get_field_id( 'hour' ); ?>" class="assistive-text"><?php _e( 'Hour', 'jetpack' ); ?></label>
-			<input id="<?php echo $this->get_field_id( 'hour' ); ?>" class="hour" name="<?php echo $this->get_field_name( 'hour' ); ?>" type="text" value="<?php echo esc_attr( $instance['hour'] ); ?>">
+				<label for="<?php echo esc_attr( $this->get_field_id( 'min' ) ); ?>" class="assistive-text"><?php esc_html_e( 'Minutes', 'jetpack' ); ?></label>
 
-			<label for="<?php echo $this->get_field_id( 'min' ); ?>" class="assistive-text"><?php _e( 'Minutes', 'jetpack' ); ?></label>
+				<span class="time-separator">:</span>
 
-			<span class="time-separator">:</span>
+				<input id="<?php echo esc_attr( $this->get_field_id( 'min' ) ); ?>" class="minutes" name="<?php echo esc_attr( $this->get_field_name( 'min' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['min'] ); ?>">
+			</fieldset>
 
-			<input id="<?php echo $this->get_field_id( 'min' ); ?>" class="minutes" name="<?php echo $this->get_field_name( 'min' ); ?>" type="text" value="<?php echo esc_attr( $instance['min'] ); ?>">
-		</fieldset>
+			<fieldset class="jp-ms-data-unit">
+				<legend><?php esc_html_e( 'Time Unit', 'jetpack' ); ?></legend>
 
-		<fieldset class="jp-ms-data-unit">
-			<legend><?php esc_html_e( 'Time Unit', 'jetpack' ); ?></legend>
-
-			<label for="<?php echo $this->get_field_id( 'unit' ); ?>" class="assistive-text">
-				<?php _e( 'Time Unit', 'jetpack' ); ?>
-			</label>
-			<select id="<?php echo $this->get_field_id( 'unit' ); ?>" class="unit" name="<?php echo $this->get_field_name( 'unit' ); ?>">
-			<?php
-			foreach ( $units as $key => $unit ) {
-				echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $instance['unit'], false ) . '>' . $unit . '</option>';
-			}
-			?>
-			</select>
-		</fieldset>
-
-		<ul class="milestone-type">
-			<li>
-				<label>
-					<input
-						<?php checked( $instance['type'], 'until' ); ?>
-						name="<?php echo esc_attr( $this->get_field_name( 'type' ) ); ?>"
-						type="radio"
-						value="until"
-					/>
-					<?php esc_html_e( 'Until your milestone', 'jetpack' ); ?>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'unit' ) ); ?>" class="assistive-text">
+					<?php esc_html_e( 'Time Unit', 'jetpack' ); ?>
 				</label>
-			</li>
 
-			<li>
-				<label>
-					<input
-						<?php checked( $instance['type'], 'since' ); ?>
-						name="<?php echo esc_attr( $this->get_field_name( 'type' ) ); ?>"
-						type="radio"
-						value="since"
-					/>
-					<?php esc_html_e( 'Since your milestone', 'jetpack' ); ?>
-				</label>
-			</li>
-		</ul>
+				<select id="<?php echo esc_attr( $this->get_field_id( 'unit' ) ); ?>" class="unit" name="<?php echo esc_attr( $this->get_field_name( 'unit' ) ); ?>">
+					<?php
+					foreach ( $units as $key => $unit ) {
+						printf(
+							'<option value="%s" %s>%s</option>',
+							esc_attr( $key ),
+							selected( $key, $instance['unit'], false ),
+							esc_html( $unit )
+						);
+					}
+					?>
+				</select>
+			</fieldset>
 
-		<p class="milestone-message-wrapper">
-			<label for="<?php echo $this->get_field_id( 'message' ); ?>"><?php _e( 'Milestone Reached Message', 'jetpack' ); ?></label>
-			<textarea id="<?php echo $this->get_field_id( 'message' ); ?>" name="<?php echo $this->get_field_name( 'message' ); ?>" class="widefat" rows="3"><?php echo esc_textarea( $instance['message'] ); ?></textarea>
-		</p>
-	</div>
+			<ul class="milestone-type">
+				<li>
+					<label>
+						<input
+								<?php checked( $instance['type'], 'until' ); ?>
+								name="<?php echo esc_attr( $this->get_field_name( 'type' ) ); ?>"
+								type="radio"
+								value="until"
+						/>
+						<?php esc_html_e( 'Until your milestone', 'jetpack' ); ?>
+					</label>
+				</li>
+
+				<li>
+					<label>
+						<input
+								<?php checked( $instance['type'], 'since' ); ?>
+								name="<?php echo esc_attr( $this->get_field_name( 'type' ) ); ?>"
+								type="radio"
+								value="since"
+						/>
+						<?php esc_html_e( 'Since your milestone', 'jetpack' ); ?>
+					</label>
+				</li>
+			</ul>
+
+			<p class="milestone-message-wrapper">
+				<label for="<?php echo esc_attr( $this->get_field_id( 'message' ) ); ?>"><?php esc_html_e( 'Milestone Reached Message', 'jetpack' ); ?></label>
+				<textarea id="<?php echo esc_attr( $this->get_field_id( 'message' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'message' ) ); ?>" class="widefat" rows="3"><?php echo esc_textarea( $instance['message'] ); ?></textarea>
+			</p>
+		</div>
 
 		<?php
 	}

--- a/modules/widgets/milestone/class-milestone-widget.php
+++ b/modules/widgets/milestone/class-milestone-widget.php
@@ -72,7 +72,7 @@ class Milestone_Widget extends WP_Widget {
 	 */
 	public static function enqueue_admin( $hook_suffix ) {
 		if ( 'widgets.php' === $hook_suffix ) {
-			wp_enqueue_style( 'milestone-admin', plugin_dir_url( __FILE__ ) . 'style-admin.css', array(), '20161215' );
+			wp_enqueue_style( 'milestone-admin', plugin_dir_url( __FILE__ ) . 'style-admin.css', array(), '20201113' );
 			wp_enqueue_script(
 				'milestone-admin-js',
 				Assets::get_file_url_for_environment(
@@ -80,7 +80,7 @@ class Milestone_Widget extends WP_Widget {
 					'modules/widgets/milestone/admin.js'
 				),
 				array( 'jquery' ),
-				'20170915',
+				'20201113',
 				true
 			);
 		}
@@ -90,7 +90,7 @@ class Milestone_Widget extends WP_Widget {
 	 * Enqueue the frontend JS.
 	 */
 	public static function enqueue_template() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 			return;
 		}
 
@@ -101,7 +101,7 @@ class Milestone_Widget extends WP_Widget {
 				'modules/widgets/milestone/milestone.js'
 			),
 			array(),
-			'20160520',
+			'20201113',
 			true
 		);
 	}
@@ -203,7 +203,7 @@ class Milestone_Widget extends WP_Widget {
 	 * Hooks into the "wp_footer" action.
 	 */
 	public function localize_script() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 			return;
 		}
 

--- a/modules/widgets/milestone/class-milestone-widget.php
+++ b/modules/widgets/milestone/class-milestone-widget.php
@@ -276,7 +276,7 @@ class Milestone_Widget extends WP_Widget {
 		$instance = $this->sanitize_instance( $instance );
 
 		$milestone = mktime( $instance['hour'], $instance['min'], 0, $instance['month'], $instance['day'], $instance['year'] );
-		$now       = (int) current_time( 'timestamp' );
+		$now       = (int) current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 		$type      = $instance['type'];
 
 		if ( 'since' === $type ) {
@@ -598,7 +598,7 @@ class Milestone_Widget extends WP_Widget {
 	 * @return array Santized data.
 	 */
 	public function sanitize_instance( $dirty ) {
-		$now = (int) current_time( 'timestamp' );
+		$now = (int) current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 
 		$dirty = wp_parse_args(
 			$dirty,

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -6,6 +6,7 @@ Version: 1.0
 Author: Automattic Inc.
 Author URI: https://automattic.com/
 License: GPLv2 or later
+Text Domain: jetpack
 */
 
 use Automattic\Jetpack\Assets;
@@ -23,6 +24,7 @@ class Milestone_Widget extends WP_Widget {
 
 	/**
 	 * Available time units sorted in descending order.
+	 *
 	 * @var Array
 	 */
 	protected $available_units = array(
@@ -31,7 +33,7 @@ class Milestone_Widget extends WP_Widget {
 		'days',
 		'hours',
 		'minutes',
-		'seconds'
+		'seconds',
 	);
 
 	function __construct() {
@@ -47,7 +49,7 @@ class Milestone_Widget extends WP_Widget {
 			$widget
 		);
 
-		self::$dir = trailingslashit( dirname( __FILE__ ) );
+		self::$dir = trailingslashit( __DIR__ );
 		self::$url = plugin_dir_url( __FILE__ );
 
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
@@ -94,12 +96,15 @@ class Milestone_Widget extends WP_Widget {
 
 	public static function styles_template() {
 		global $themecolors;
-		$colors = wp_parse_args( $themecolors, array(
-			'bg'     => 'ffffff',
-			'border' => 'cccccc',
-			'text'   => '333333',
-		) );
-?>
+		$colors = wp_parse_args(
+			$themecolors,
+			array(
+				'bg'     => 'ffffff',
+				'border' => 'cccccc',
+				'text'   => '333333',
+			)
+		);
+		?>
 <style>
 .milestone-widget {
 	margin-bottom: 1em;
@@ -143,7 +148,7 @@ class Milestone_Widget extends WP_Widget {
 	padding-top: 1em
 }
 </style>
-<?php
+		<?php
 	}
 
 	/**
@@ -244,8 +249,8 @@ class Milestone_Widget extends WP_Widget {
 		$instance = $this->sanitize_instance( $instance );
 
 		$milestone = mktime( $instance['hour'], $instance['min'], 0, $instance['month'], $instance['day'], $instance['year'] );
-		$now  = (int) current_time( 'timestamp' );
-		$type = $instance['type'];
+		$now       = (int) current_time( 'timestamp' );
+		$type      = $instance['type'];
 
 		if ( 'since' === $type ) {
 			$diff = (int) floor( $now - $milestone );
@@ -263,10 +268,10 @@ class Milestone_Widget extends WP_Widget {
 			DAY_IN_SECONDS,
 			HOUR_IN_SECONDS,
 			MINUTE_IN_SECONDS,
-			1
+			1,
 		);
 
-		$data['refresh'] = $refresh_intervals[ array_search( $data['unit'], $this->available_units ) ];
+		$data['refresh']   = $refresh_intervals[ array_search( $data['unit'], $this->available_units ) ];
 		$data['milestone'] = $milestone;
 
 		if ( ( 1 > $diff ) && ( 'until' === $type ) ) {
@@ -274,7 +279,7 @@ class Milestone_Widget extends WP_Widget {
 			$data['refresh'] = 0; // No need to refresh, the milestone has been reached
 		} else {
 			$interval_text = $this->get_interval_in_units( $diff, $data['unit'] );
-			$interval = (int) $interval_text;
+			$interval      = (int) $interval_text;
 
 			if ( 'since' === $type ) {
 
@@ -289,7 +294,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'months':
 						$data['message'] = sprintf(
 							_n(
@@ -300,7 +305,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'days':
 						$data['message'] = sprintf(
 							_n(
@@ -311,7 +316,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'hours':
 						$data['message'] = sprintf(
 							_n(
@@ -322,7 +327,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'minutes':
 						$data['message'] = sprintf(
 							_n(
@@ -333,7 +338,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'seconds':
 						$data['message'] = sprintf(
 							_n(
@@ -344,7 +349,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 				}
 			} else {
 				switch ( $this->get_unit( $diff, $instance['unit'] ) ) {
@@ -358,7 +363,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'months':
 						$data['message'] = sprintf(
 							_n(
@@ -369,7 +374,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'days':
 						$data['message'] = sprintf(
 							_n(
@@ -380,7 +385,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'hours':
 						$data['message'] = sprintf(
 							_n(
@@ -391,7 +396,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'minutes':
 						$data['message'] = sprintf(
 							_n(
@@ -402,7 +407,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 					case 'seconds':
 						$data['message'] = sprintf(
 							_n(
@@ -413,7 +418,7 @@ class Milestone_Widget extends WP_Widget {
 							),
 							$interval_text
 						);
-					break;
+						break;
 				}
 			}
 			$data['message'] = '<div class="milestone-countdown">' . $data['message'] . '</div>';
@@ -426,7 +431,7 @@ class Milestone_Widget extends WP_Widget {
 	 * Return the largest possible time unit that the difference will be displayed in.
 	 *
 	 * @param Integer $seconds the interval in seconds
-	 * @param String $maximum_unit the maximum unit that will be used. Optional.
+	 * @param String  $maximum_unit the maximum unit that will be used. Optional.
 	 * @return String $calculated_unit
 	 */
 	protected function get_unit( $seconds, $maximum_unit = 'automatic' ) {
@@ -436,35 +441,33 @@ class Milestone_Widget extends WP_Widget {
 			// more than 2 years - show in years, one decimal point
 			$unit = 'years';
 
-		} else if ( $seconds >= YEAR_IN_SECONDS ) {
+		} elseif ( $seconds >= YEAR_IN_SECONDS ) {
 			if ( 'years' === $maximum_unit ) {
 				$unit = 'years';
 			} else {
 				// automatic mode - showing months even if it's between one and two years
 				$unit = 'months';
 			}
-
-		} else if ( $seconds >= MONTH_IN_SECONDS * 3 ) {
+		} elseif ( $seconds >= MONTH_IN_SECONDS * 3 ) {
 			// fewer than 2 years - show in months
 			$unit = 'months';
 
-		} else if ( $seconds >= MONTH_IN_SECONDS ) {
+		} elseif ( $seconds >= MONTH_IN_SECONDS ) {
 			if ( 'months' === $maximum_unit ) {
 				$unit = 'months';
 			} else {
 				// automatic mode - showing days even if it's between one and three months
 				$unit = 'days';
 			}
-
-		} else if ( $seconds >= DAY_IN_SECONDS - 1 ) {
+		} elseif ( $seconds >= DAY_IN_SECONDS - 1 ) {
 			// fewer than a month - show in days
 			$unit = 'days';
 
-		} else if ( $seconds >= HOUR_IN_SECONDS - 1 ) {
+		} elseif ( $seconds >= HOUR_IN_SECONDS - 1 ) {
 			// less than 1 day - show in hours
 			$unit = 'hours';
 
-		} else if ( $seconds >= MINUTE_IN_SECONDS - 1 ) {
+		} elseif ( $seconds >= MINUTE_IN_SECONDS - 1 ) {
 			// less than 1 hour - show in minutes
 			$unit = 'minutes';
 
@@ -474,7 +477,7 @@ class Milestone_Widget extends WP_Widget {
 		}
 
 		$maximum_unit_index = array_search( $maximum_unit, $this->available_units );
-		$unit_index = array_search( $unit, $this->available_units );
+		$unit_index         = array_search( $unit, $this->available_units );
 
 		if (
 			false === $maximum_unit_index // the maximum unit parameter is automatic
@@ -489,13 +492,13 @@ class Milestone_Widget extends WP_Widget {
 	 * Returns a time difference value in specified units.
 	 *
 	 * @param Integer $seconds
-	 * @param String $units
+	 * @param String  $units
 	 * @return Integer|String $time_in_units
 	 */
 	protected function get_interval_in_units( $seconds, $units ) {
 		switch ( $units ) {
 			case 'years':
-				$years = $seconds / YEAR_IN_SECONDS;
+				$years    = $seconds / YEAR_IN_SECONDS;
 				$decimals = abs( round( $years, 1 ) - round( $years ) ) > 0 ? 1 : 0;
 				return number_format_i18n( $years, $decimals );
 			case 'months':
@@ -548,21 +551,28 @@ class Milestone_Widget extends WP_Widget {
 	function sanitize_instance( $dirty ) {
 		$now = (int) current_time( 'timestamp' );
 
-		$dirty = wp_parse_args( $dirty, array(
-			'title'   => '',
-			'event'   => __( 'The Big Day', 'jetpack' ),
-			'unit'    => 'automatic',
-			'type'    => 'until',
-			'message' => __( 'The big day is here.', 'jetpack' ),
-			'day'     => date( 'd', $now ),
-			'month'   => date( 'm', $now ),
-			'year'    => date( 'Y', $now ),
-			'hour'    => 0,
-			'min'     => 0,
-		) );
+		$dirty = wp_parse_args(
+			$dirty,
+			array(
+				'title'   => '',
+				'event'   => __( 'The Big Day', 'jetpack' ),
+				'unit'    => 'automatic',
+				'type'    => 'until',
+				'message' => __( 'The big day is here.', 'jetpack' ),
+				'day'     => date( 'd', $now ),
+				'month'   => date( 'm', $now ),
+				'year'    => date( 'Y', $now ),
+				'hour'    => 0,
+				'min'     => 0,
+			)
+		);
 
 		$allowed_tags = array(
-			'a'      => array( 'title' => array(), 'href' => array(), 'target' => array() ),
+			'a'      => array(
+				'title'  => array(),
+				'href'   => array(),
+				'target' => array(),
+			),
 			'em'     => array( 'title' => array() ),
 			'strong' => array( 'title' => array() ),
 		);
@@ -573,9 +583,9 @@ class Milestone_Widget extends WP_Widget {
 			'unit'    => $dirty['unit'],
 			'type'    => $dirty['type'],
 			'message' => wp_kses( $dirty['message'], $allowed_tags ),
-			'year'    => $this->sanitize_range( $dirty['year'],  1901, 2037 ),
+			'year'    => $this->sanitize_range( $dirty['year'], 1901, 2037 ),
 			'month'   => $this->sanitize_range( $dirty['month'], 1, 12 ),
-			'hour'    => $this->sanitize_range( $dirty['hour'],  0, 23 ),
+			'hour'    => $this->sanitize_range( $dirty['hour'], 0, 23 ),
 			'min'     => zeroise( $this->sanitize_range( $dirty['min'], 0, 59 ), 2 ),
 		);
 
@@ -592,35 +602,37 @@ class Milestone_Widget extends WP_Widget {
 
 		$units = array(
 			'automatic' => _x( 'Automatic', 'Milestone widget: mode in which the date unit is determined automatically', 'jetpack' ),
-			'years' => _x( 'Years', 'Milestone widget: mode in which the date unit is set to years', 'jetpack' ),
-			'months' => _x( 'Months', 'Milestone widget: mode in which the date unit is set to months', 'jetpack' ),
-			'days' => _x( 'Days', 'Milestone widget: mode in which the date unit is set to days', 'jetpack' ),
-			'hours' => _x( 'Hours', 'Milestone widget: mode in which the date unit is set to hours', 'jetpack' ),
+			'years'     => _x( 'Years', 'Milestone widget: mode in which the date unit is set to years', 'jetpack' ),
+			'months'    => _x( 'Months', 'Milestone widget: mode in which the date unit is set to months', 'jetpack' ),
+			'days'      => _x( 'Days', 'Milestone widget: mode in which the date unit is set to days', 'jetpack' ),
+			'hours'     => _x( 'Hours', 'Milestone widget: mode in which the date unit is set to hours', 'jetpack' ),
 		);
 		?>
 
 	<div class="milestone-widget">
-        <p>
-        	<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title', 'jetpack' ); ?></label>
-        	<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
-        </p>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+		</p>
 
-        <p>
-        	<label for="<?php echo $this->get_field_id( 'event' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>
-        	<input class="widefat" id="<?php echo $this->get_field_id( 'event' ); ?>" name="<?php echo $this->get_field_name( 'event' ); ?>" type="text" value="<?php echo esc_attr( $instance['event'] ); ?>" />
-        </p>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'event' ); ?>"><?php _e( 'Description', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'event' ); ?>" name="<?php echo $this->get_field_name( 'event' ); ?>" type="text" value="<?php echo esc_attr( $instance['event'] ); ?>" />
+		</p>
 
 		<fieldset class="jp-ms-data-time">
 			<legend><?php esc_html_e( 'Date', 'jetpack' ); ?></legend>
 
 			<label for="<?php echo $this->get_field_id( 'month' ); ?>" class="assistive-text"><?php _e( 'Month', 'jetpack' ); ?></label>
-			<select id="<?php echo $this->get_field_id( 'month' ); ?>" class="month" name="<?php echo $this->get_field_name( 'month' ); ?>"><?php
-				global $wp_locale;
-				for ( $i = 1; $i < 13; $i++ ) {
-					$monthnum = zeroise( $i, 2 );
-					echo '<option value="' . esc_attr( $monthnum ) . '"' . selected( $i, $instance['month'], false ) . '>' . $monthnum . '-' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $i ) ) . '</option>';
-				}
-			?></select>
+			<select id="<?php echo $this->get_field_id( 'month' ); ?>" class="month" name="<?php echo $this->get_field_name( 'month' ); ?>">
+								   <?php
+									global $wp_locale;
+									for ( $i = 1; $i < 13; $i++ ) {
+										$monthnum = zeroise( $i, 2 );
+										echo '<option value="' . esc_attr( $monthnum ) . '"' . selected( $i, $instance['month'], false ) . '>' . $monthnum . '-' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $i ) ) . '</option>';
+									}
+									?>
+			</select>
 
 			<label for="<?php echo $this->get_field_id( 'day' ); ?>" class="assistive-text"><?php _e( 'Day', 'jetpack' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'day' ); ?>" class="day" name="<?php echo $this->get_field_name( 'day' ); ?>" type="text" value="<?php echo esc_attr( $instance['day'] ); ?>">,
@@ -650,10 +662,11 @@ class Milestone_Widget extends WP_Widget {
 			</label>
 			<select id="<?php echo $this->get_field_id( 'unit' ); ?>" class="unit" name="<?php echo $this->get_field_name( 'unit' ); ?>">
 			<?php
-				foreach ( $units as $key => $unit ) {
-					echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $instance['unit'], false ) . '>' . $unit . '</option>';
-				}
-			?></select>
+			foreach ( $units as $key => $unit ) {
+				echo '<option value="' . esc_attr( $key ) . '"' . selected( $key, $instance['unit'], false ) . '>' . $unit . '</option>';
+			}
+			?>
+			</select>
 		</fieldset>
 
 		<ul class="milestone-type">
@@ -689,5 +702,5 @@ class Milestone_Widget extends WP_Widget {
 	</div>
 
 		<?php
-    }
+	}
 }


### PR DESCRIPTION
As part of WordPress.com's work to remove/reduce jQuery deps, we discovered that the Milestone widget was not being actively fusioned with WP.com and did not get the update to remove jQuery that Jetpack committed a few months back.

#### Changes proposed in this Pull Request:
* PHPCS Compliance in order to pass current WP.com linting.
* Update the version number of assets to be common to today on both platforms.
* Adds a class_exists before using the `Jetpack_AMP_Support` class since it is not presently available on WP.com.

#### Jetpack product discussion
None, but supports webperf's jQuery work.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Ensure Widgets are enabled on the Jetpack test site.
* Visit the Appearance->Widgets wp-admin page to ensure no errors. Use/edit the widget.
* View the front end of a site with a milestone widget. No errors in the console or PHP?

#### Proposed changelog entry for your changes:
* Can be included as part of a generic PHPCS/code improvement changelog entry.
