### PR TITLE
Autoloader: AutoloadGenerator no longer extends Composer's AutoloadGenerator class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ php:
 - "7.3"
 - "7.4snapshot"
 
-before_install:
- - composer self-update 2.0.6
-
 env:
   global:
   # Global variable is re-defined in matrix-include -list
@@ -50,6 +47,8 @@ matrix:
     name: "Build dashboard & extensions"
     language: node_js
     env: WP_TRAVISCI="yarn build-concurrently"
+    before_install:
+      - composer self-update
 
   # Disable for now until we fix all the spelling issues
   # - name: "Spell check Markdown files"

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -115,7 +115,7 @@ AUTOLOADER_COMMENT;
 	 * @param  array            $packageMap  Array of array(package, installDir-relative-to-composer.json).
 	 * @param  PackageInterface $mainPackage Main package instance.
 	 *
-	 * @return array The list of path mappsings.
+	 * @return array The list of path mappings.
 	 */
 	public function parseAutoloads( array $packageMap, PackageInterface $mainPackage ) {
 		$rootPackageMap = array_shift( $packageMap );

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -15,15 +15,14 @@
 // phpcs:disable WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 // phpcs:disable WordPress.WP.AlternativeFunctions.file_system_read_fopen
 // phpcs:disable WordPress.WP.AlternativeFunctions.file_system_read_fwrite
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
 
-
 namespace Automattic\Jetpack\Autoloader;
 
-use Composer\Autoload\AutoloadGenerator as BaseGenerator;
 use Composer\Autoload\ClassMapGenerator;
 use Composer\Config;
 use Composer\Installer\InstallationManager;
@@ -31,11 +30,12 @@ use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Util\Filesystem;
+use Composer\Util\PackageSorter;
 
 /**
  * Class AutoloadGenerator.
  */
-class AutoloadGenerator extends BaseGenerator {
+class AutoloadGenerator {
 
 	const COMMENT = <<<AUTOLOADER_COMMENT
 /**
@@ -73,6 +73,7 @@ AUTOLOADER_COMMENT;
 	 * @param string                       $targetDir Path to the current target directory.
 	 * @param bool                         $scanPsrPackages Whether or not PSR packages should be converted to a classmap.
 	 * @param string                       $suffix The autoloader suffix.
+	 * @param Composer                     $composer The Composer instance.
 	 */
 	public function dump(
 		Config $config,
@@ -81,11 +82,13 @@ AUTOLOADER_COMMENT;
 		InstallationManager $installationManager,
 		$targetDir,
 		$scanPsrPackages = false,
-		$suffix = null
+		$suffix = null,
+		$composer = null
 	) {
+
 		$this->filesystem->ensureDirectoryExists( $config->get( 'vendor-dir' ) );
 
-		$packageMap = $this->buildPackageMap( $installationManager, $mainPackage, $localRepo->getCanonicalPackages() );
+		$packageMap = $composer->getAutoloadGenerator()->buildPackageMap( $installationManager, $mainPackage, $localRepo->getCanonicalPackages() );
 		$autoloads  = $this->parseAutoloads( $packageMap, $mainPackage );
 
 		// Convert the autoloads into a format that the manifest generator can consume more easily.
@@ -107,6 +110,117 @@ AUTOLOADER_COMMENT;
 	}
 
 	/**
+	 * Compiles an ordered list of namespace => path mappings
+	 *
+	 * @param  array            $packageMap  Array of array(package, installDir-relative-to-composer.json).
+	 * @param  PackageInterface $mainPackage Main package instance.
+	 *
+	 * @return array The list of path mappsings.
+	 */
+	public function parseAutoloads( array $packageMap, PackageInterface $mainPackage ) {
+		$rootPackageMap = array_shift( $packageMap );
+
+		$sortedPackageMap   = $this->sortPackageMap( $packageMap );
+		$sortedPackageMap[] = $rootPackageMap;
+		array_unshift( $packageMap, $rootPackageMap );
+
+		$psr0     = $this->parseAutoloadsType( $packageMap, 'psr-0', $mainPackage );
+		$psr4     = $this->parseAutoloadsType( $packageMap, 'psr-4', $mainPackage );
+		$classmap = $this->parseAutoloadsType( array_reverse( $sortedPackageMap ), 'classmap', $mainPackage );
+		$files    = $this->parseAutoloadsType( $sortedPackageMap, 'files', $mainPackage );
+
+		krsort( $psr0 );
+		krsort( $psr4 );
+
+		return array(
+			'psr-0'    => $psr0,
+			'psr-4'    => $psr4,
+			'classmap' => $classmap,
+			'files'    => $files,
+		);
+	}
+
+	/**
+	 * Sorts packages by dependency weight
+	 *
+	 * Packages of equal weight retain the original order
+	 *
+	 * @param  array $packageMap The package map.
+	 * @return array
+	 */
+	protected function sortPackageMap( array $packageMap ) {
+		$packages = array();
+		$paths    = array();
+
+		foreach ( $packageMap as $item ) {
+			list($package, $path) = $item;
+			$name                 = $package->getName();
+			$packages[ $name ]    = $package;
+			$paths[ $name ]       = $path;
+		}
+
+		$sortedPackages = PackageSorter::sortPackages( $packages );
+
+		$sortedPackageMap = array();
+
+		foreach ( $sortedPackages as $package ) {
+			$name               = $package->getName();
+			$sortedPackageMap[] = array( $packages[ $name ], $paths[ $name ] );
+		}
+
+		return $sortedPackageMap;
+	}
+
+	/**
+	 * Returns the file identifier.
+	 *
+	 * @param PackageInterface $package The package instance.
+	 * @param string           $path The path.
+	 */
+	protected function getFileIdentifier( PackageInterface $package, $path ) {
+		return md5( $package->getName() . ':' . $path );
+	}
+
+	/**
+	 * Returns the path code for the given path.
+	 *
+	 * @param Filesystem $filesystem The filesystem instance.
+	 * @param string     $basePath The base path.
+	 * @param string     $vendorPath The vendor path.
+	 * @param string     $path The path.
+	 *
+	 * @return string The path code.
+	 */
+	protected function getPathCode( Filesystem $filesystem, $basePath, $vendorPath, $path ) {
+		if ( ! $filesystem->isAbsolutePath( $path ) ) {
+			$path = $basePath . '/' . $path;
+		}
+		$path = $filesystem->normalizePath( $path );
+
+		$baseDir = '';
+		if ( 0 === strpos( $path . '/', $vendorPath . '/' ) ) {
+			$path    = substr( $path, strlen( $vendorPath ) );
+			$baseDir = '$vendorDir';
+
+			if ( false !== $path ) {
+				$baseDir .= ' . ';
+			}
+		} else {
+			$path = $filesystem->normalizePath( $filesystem->findShortestPath( $basePath, $path, true ) );
+			if ( ! $filesystem->isAbsolutePath( $path ) ) {
+				$baseDir = '$baseDir . ';
+				$path    = '/' . $path;
+			}
+		}
+
+		if ( strpos( $path, '.phar' ) !== false ) {
+			$baseDir = "'phar://' . " . $baseDir;
+		}
+
+		return $baseDir . ( ( false !== $path ) ? var_export( $path, true ) : '' );
+	}
+
+	/**
 	 * This function differs from the composer parseAutoloadsType in that beside returning the path.
 	 * It also return the path and the version of a package.
 	 *
@@ -120,10 +234,6 @@ AUTOLOADER_COMMENT;
 	 */
 	protected function parseAutoloadsType( array $packageMap, $type, PackageInterface $mainPackage ) {
 		$autoloads = array();
-
-		if ( 'psr-4' !== $type && 'classmap' !== $type && 'files' !== $type && 'psr-0' !== $type ) {
-			return parent::parseAutoloadsType( $packageMap, $type, $mainPackage );
-		}
 
 		foreach ( $packageMap as $item ) {
 			list($package, $installPath) = $item;

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -153,10 +153,10 @@ AUTOLOADER_COMMENT;
 		$paths    = array();
 
 		foreach ( $packageMap as $item ) {
-			list($package, $path) = $item;
-			$name                 = $package->getName();
-			$packages[ $name ]    = $package;
-			$paths[ $name ]       = $path;
+			list( $package, $path ) = $item;
+			$name                   = $package->getName();
+			$packages[ $name ]      = $package;
+			$paths[ $name ]         = $path;
 		}
 
 		$sortedPackages = PackageSorter::sortPackages( $packages );

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -24,6 +24,7 @@
 namespace Automattic\Jetpack\Autoloader;
 
 use Composer\Autoload\ClassMapGenerator;
+use Composer\Composer;
 use Composer\Config;
 use Composer\Installer\InstallationManager;
 use Composer\IO\IOInterface;
@@ -66,26 +67,25 @@ AUTOLOADER_COMMENT;
 	/**
 	 * Dump the Jetpack autoloader files.
 	 *
+	 * @param Composer                     $composer The Composer object.
 	 * @param Config                       $config Config object.
-	 * @param InstalledRepositoryInterface $localRepo Installed Reposetories object.
+	 * @param InstalledRepositoryInterface $localRepo Installed Repository object.
 	 * @param PackageInterface             $mainPackage Main Package object.
 	 * @param InstallationManager          $installationManager Manager for installing packages.
 	 * @param string                       $targetDir Path to the current target directory.
 	 * @param bool                         $scanPsrPackages Whether or not PSR packages should be converted to a classmap.
 	 * @param string                       $suffix The autoloader suffix.
-	 * @param Composer                     $composer The Composer instance.
 	 */
 	public function dump(
+		Composer $composer,
 		Config $config,
 		InstalledRepositoryInterface $localRepo,
 		PackageInterface $mainPackage,
 		InstallationManager $installationManager,
 		$targetDir,
 		$scanPsrPackages = false,
-		$suffix = null,
-		$composer = null
+		$suffix = null
 	) {
-
 		$this->filesystem->ensureDirectoryExists( $config->get( 'vendor-dir' ) );
 
 		$packageMap = $composer->getAutoloadGenerator()->buildPackageMap( $installationManager, $mainPackage, $localRepo->getCanonicalPackages() );

--- a/packages/autoloader/src/CustomAutoloaderPlugin.php
+++ b/packages/autoloader/src/CustomAutoloaderPlugin.php
@@ -115,7 +115,7 @@ class CustomAutoloaderPlugin implements PluginInterface, EventSubscriberInterfac
 		$suffix              = $this->determineSuffix();
 
 		$generator = new AutoloadGenerator( $this->io );
-		$generator->dump( $config, $localRepo, $package, $installationManager, 'composer', $optimize, $suffix, $this->composer );
+		$generator->dump( $this->composer, $config, $localRepo, $package, $installationManager, 'composer', $optimize, $suffix );
 		$this->generated = true;
 	}
 

--- a/packages/autoloader/src/CustomAutoloaderPlugin.php
+++ b/packages/autoloader/src/CustomAutoloaderPlugin.php
@@ -115,8 +115,7 @@ class CustomAutoloaderPlugin implements PluginInterface, EventSubscriberInterfac
 		$suffix              = $this->determineSuffix();
 
 		$generator = new AutoloadGenerator( $this->io );
-
-		$generator->dump( $config, $localRepo, $package, $installationManager, 'composer', $optimize, $suffix );
+		$generator->dump( $config, $localRepo, $package, $installationManager, 'composer', $optimize, $suffix, $this->composer );
 		$this->generated = true;
 	}
 


### PR DESCRIPTION
A few method signatures in Composer's `AutoloadGenerator` class were changed in Composer 2.0.7, making the Jetpack autoloader's `AutoloadGenerator` class incompatible with 2.0.7.

To fix this incompatibility, refactor the `Automattic\Jetpack\Autoloader\AutoloadGenerator` class so that it is no longer a subclass of `Composer\Autoload\AutoloadGenerator`.

#### Changes proposed in this Pull Request:
* Remove the `composer self-update 2.0.6` command from the .travis.yml file. The changes in this PR allow the latest version of composer to be used.

* Add a `composer self-update` commend to the "Build dashboard & extensions" Travis test. The build currently uses Composer 1.5.2, which is not compatible with the changes in this PR. Since 1.5.2 was released in 2017, I don't think it's necessary to support it.

* The `Automattic\Jetpack\Autoloader\AutoloadGenerator` class no longer extends `Composer\Autoload|AutoloadGenerator`. 

* Add a new `$composer` parameter to the `Automattic\Jetpack\Autoloader\AutoloadGenerator::dump` method. This is used to obtain the `Composer` instance's `Composer\Autoload\AutoloadGenerator` property, which is needed to build the package map.

* Add the following utility methods, which are mostly copied from the `Composer\Autoload\AutoloadGenerator` class:
    * `Automattic\Jetpack\Autoloader\AutoloadGenerator::parseAutoloads`
    * `Automattic\Jetpack\Autoloader\AutoloadGenerator::sortPackageMap`
    * `Automattic\Jetpack\Autoloader\AutoloadGenerator::getFileIdentifier`
    * `Automattic\Jetpack\Autoloader\AutoloadGenerator::getPathCode`

* Remove the call to `parent::parseAutoloadsType()` in `Automattic\Jetpack\Autoloader\AutoloadGenerator::parseAutoloadsType`. 

#### Jetpack product discussion
* p1605297018253700-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Run `composer install` and verify that the autoloader files have been generated correctly.

#### Proposed changelog entry for your changes:
* tbd