### PR TITLE
Disable web stories open graph tags.

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -27,6 +27,7 @@ function load_3rd_party() {
 		'polldaddy.php',
 		'qtranslate-x.php',
 		'vaultpress.php',
+		'web-stories.php',
 		'wpml.php',
 		'woocommerce.php',
 		'woocommerce-services.php',

--- a/3rd-party/web-stories.php
+++ b/3rd-party/web-stories.php
@@ -9,7 +9,7 @@
 function web_stories_disable_open_graph( $enabled ) {
 	$active_modules = Jetpack::get_active_modules();
 	if ( in_array( 'publicize', $active_modules ) || in_array( 'sharedaddy', $active_modules ) ) {
-		$enabled = false;
+		$enabled = apply_filters( 'jetpack_enable_open_graph', false );
 	}
 
 	return $enabled;

--- a/3rd-party/web-stories.php
+++ b/3rd-party/web-stories.php
@@ -7,12 +7,14 @@
  * @return bool
  */
 function web_stories_disable_open_graph( $enabled ) {
-	$active_modules = Jetpack::get_active_modules();
-	if ( in_array( 'publicize', $active_modules ) || in_array( 'sharedaddy', $active_modules ) ) {
-		$enabled = apply_filters( 'jetpack_enable_open_graph', false );
+	$jetpack_enabled = apply_filters( 'jetpack_enable_open_graph', false );
+	$active_modules  = Jetpack::get_active_modules();
+	if ( $jetpack_enabled || in_array( 'publicize', $active_modules ) || in_array( 'sharedaddy', $active_modules ) ) {
+		$enabled = false;
 	}
 
 	return $enabled;
 }
 
-add_filter( 'web_stories_enable_open_graph', 'web_stories_disable_open_graph' );
+add_filter( 'web_stories_enable_open_graph_metadata', 'web_stories_disable_open_graph' );
+add_filter( 'web_stories_enable_twitter_metadata', 'web_stories_disable_open_graph' );

--- a/3rd-party/web-stories.php
+++ b/3rd-party/web-stories.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Filter to enable web stories built in open graph data from being output.
+ *
+ * @param bool $enabled If web stories open graph data is enabled.
+ *
+ * @return bool
+ */
+function web_stories_disable_open_graph( $enabled ) {
+	$active_modules = Jetpack::get_active_modules();
+	if ( in_array( 'publicize', $active_modules ) || in_array( 'sharedaddy', $active_modules ) ) {
+		$enabled = false;
+	}
+
+	return $enabled;
+}
+
+add_filter( 'web_stories_enable_open_graph', 'web_stories_disable_open_graph' );

--- a/3rd-party/web-stories.php
+++ b/3rd-party/web-stories.php
@@ -6,7 +6,7 @@
  *
  * @return bool
  */
-function web_stories_disable_open_graph( $enabled ) {
+function jetpack_web_stories_disable_open_graph( $enabled ) {
 	$jetpack_enabled = apply_filters( 'jetpack_enable_open_graph', false );
 	$active_modules  = Jetpack::get_active_modules();
 	if ( $jetpack_enabled || in_array( 'publicize', $active_modules ) || in_array( 'sharedaddy', $active_modules ) ) {
@@ -16,5 +16,5 @@ function web_stories_disable_open_graph( $enabled ) {
 	return $enabled;
 }
 
-add_filter( 'web_stories_enable_open_graph_metadata', 'web_stories_disable_open_graph' );
-add_filter( 'web_stories_enable_twitter_metadata', 'web_stories_disable_open_graph' );
+add_filter( 'web_stories_enable_open_graph_metadata', 'jetpack_web_stories_disable_open_graph' );
+add_filter( 'web_stories_enable_twitter_metadata', 'jetpack_web_stories_disable_open_graph' );

--- a/3rd-party/web-stories.php
+++ b/3rd-party/web-stories.php
@@ -1,20 +1,36 @@
 <?php
 /**
+ * Compatibility functions for the Web Stories plugin.
+ * https://wordpress.org/plugins/web-stories/
+ *
+ * @since 9.2.0
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Web_Stories;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
  * Filter to enable web stories built in open graph data from being output.
+ * If Jetpack is already handling Open Graph Meta Tags, the Web Stories plugin will not output any.
  *
  * @param bool $enabled If web stories open graph data is enabled.
  *
  * @return bool
  */
-function jetpack_web_stories_disable_open_graph( $enabled ) {
+function maybe_disable_open_graph( $enabled ) {
+	/** This filter is documented in class.jetpack.php */
 	$jetpack_enabled = apply_filters( 'jetpack_enable_open_graph', false );
-	$active_modules  = Jetpack::get_active_modules();
-	if ( $jetpack_enabled || in_array( 'publicize', $active_modules ) || in_array( 'sharedaddy', $active_modules ) ) {
+
+	if ( $jetpack_enabled ) {
 		$enabled = false;
 	}
 
 	return $enabled;
 }
-
-add_filter( 'web_stories_enable_open_graph_metadata', 'jetpack_web_stories_disable_open_graph' );
-add_filter( 'web_stories_enable_twitter_metadata', 'jetpack_web_stories_disable_open_graph' );
+add_filter( 'web_stories_enable_open_graph_metadata', __NAMESPACE__ . '\maybe_disable_open_graph' );
+add_filter( 'web_stories_enable_twitter_metadata', __NAMESPACE__ . '\maybe_disable_open_graph' );

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -8,6 +8,7 @@ module.exports = [
 	'3rd-party/class-jetpack-bbpress-rest-api.php',
 	'3rd-party/class-jetpack-crm-data.php',
 	'3rd-party/creative-mail.php',
+	'3rd-party/web-stories.php',
 	'3rd-party/woocommerce-services.php',
 	'class.jetpack-bbpress-json-api.compat.php',
 	'class.jetpack-gutenberg.php',


### PR DESCRIPTION
The web stories plugin, outputs it's own open graph tags. In this PR, with a filter, we disable them if jetpack's open graph tags are enabled. This PR relays on [this](https://github.com/google/web-stories-wp/pull/5312 ) to merged first.

Related:  https://github.com/google/web-stories-wp/pull/5312 

Fixes https://github.com/google/web-stories-wp/issues/4913

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
