### PR TITLE
Tests: Use Composer 2.0.6 in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ php:
 - "7.3"
 - "7.4snapshot"
 
+before_install:
+ - composer self-update 2.0.6
+
 env:
   global:
   # Global variable is re-defined in matrix-include -list


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Composer 2.0.7 is incompatible with the Jetpack autoloader, which causes the Travis tests to fail. To fix the failing tests, use Composer 2.0.6 in the the Travis tests.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Verify that the Travis tests pass.

#### Proposed changelog entry for your changes:
* n/a