### PR TITLE
social-icons: only return a single icon per link

### DIFF
--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -168,7 +168,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 											)
 										);
 										$found_icon = true;
-										break;
+										break 2;
 									}
 								}
 							}
@@ -498,34 +498,6 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => 'Facebook',
 			),
 			array(
-				'url'   => array(
-					'/feed/',         // WordPress default feed url.
-					'/feeds/',        // Blogspot and others.
-					'/blog/feed',     // No trailing slash WordPress feed, could use /feed but may match unexpectedly.
-					'format=RSS',     // Squarespace and others.
-					'/rss',           // Tumblr.
-					'/.rss',          // Reddit.
-					'/rss.xml',       // Moveable Type, Typepad.
-					'http://rss.',    // Old custom format.
-					'https://rss.',   // Old custom format.
-					'rss=1',
-					'/feed=rss',      // Catches feed=rss / feed=rss2.
-					'?feed=rss',      // WordPress non-permalink - Catches feed=rss / feed=rss2.
-					'?feed=rdf',      // WordPress non-permalink.
-					'?feed=atom',     // WordPress non-permalink.
-					'http://feeds.',  // FeedBurner.
-					'https://feeds.', // FeedBurner.
-					'/feed.xml',      // Feedburner Alias, and others.
-					'/index.xml',     // Moveable Type, and others.
-					'/atom.xml',      // Typepad, Squarespace.
-					'.atom',          // Shopify blog.
-					'/atom',          // Some non-WordPress feeds.
-					'index.rdf',      // Typepad.
-				),
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
 				'url'   => array( 'flickr.com' ),
 				'icon'  => 'flickr',
 				'label' => 'Flickr',
@@ -679,6 +651,36 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'url'   => array( 'youtube.com' ),
 				'icon'  => 'youtube',
 				'label' => 'YouTube',
+			),
+
+			// keep feed at the end so that more specific icons can take precedence
+			array(
+				'url'   => array(
+					'/feed/',         // WordPress default feed url.
+					'/feeds/',        // Blogspot and others.
+					'/blog/feed',     // No trailing slash WordPress feed, could use /feed but may match unexpectedly.
+					'format=RSS',     // Squarespace and others.
+					'/rss',           // Tumblr.
+					'/.rss',          // Reddit.
+					'/rss.xml',       // Moveable Type, Typepad.
+					'http://rss.',    // Old custom format.
+					'https://rss.',   // Old custom format.
+					'rss=1',
+					'/feed=rss',      // Catches feed=rss / feed=rss2.
+					'?feed=rss',      // WordPress non-permalink - Catches feed=rss / feed=rss2.
+					'?feed=rdf',      // WordPress non-permalink.
+					'?feed=atom',     // WordPress non-permalink.
+					'http://feeds.',  // FeedBurner.
+					'https://feeds.', // FeedBurner.
+					'/feed.xml',      // Feedburner Alias, and others.
+					'/index.xml',     // Moveable Type, and others.
+					'/atom.xml',      // Typepad, Squarespace.
+					'.atom',          // Shopify blog.
+					'/atom',          // Some non-WordPress feeds.
+					'index.rdf',      // Typepad.
+				),
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 		);
 


### PR DESCRIPTION
[Status] Needs Review

Fixes #15162

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix a bug where multiple icons were shown in the Social Icons widget when the URL matched both a service domain (like wordpress.com) and the Feed URL match (like /feed/)

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add Social Icons widget to widget area
* Enter URL "https://twitter.com/feed/"
* Observe that both Twitter and Feed icons are displayed

(reproduction steps also documented in #15162)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed bug causing multiple icons to display for some links in Social Icons widget
