### PR TITLE
Testing Tools: Add Jetpack Debug Helper to live branches script

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.16
+// @version      1.17
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*
@@ -129,6 +129,10 @@
 							label: 'Jetpack CRM',
 							name: 'zero-bs-crm',
 						},
+						{
+							label: 'Jetpack Debug Helper',
+							name: 'jetpack-debug-helper',
+						}
 					],
 					33
 				) }


### PR DESCRIPTION
JN now supports the Debug Helper plugin, so let's add it as an option to our userscript.

#### Changes proposed in this Pull Request:
* Adds a "Jetpack Debug Helper" checkbox to the userscript.

#### Jetpack product discussion
p9dueE-277-p2


#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Install the userscript in tools/jetpack-live-branches/jetpack-live-branches.user.js (click Raw on the GH editor view for that page).
* Go to a PR, see the live branch info following the PR description. Check the Debug Helper box and spin up a JN. Confirm the Debug Helper menu appears on the JN site that is provisioned.

#### Proposed changelog entry for your changes:
* n/a, does not ship.