### PR TITLE
Milestone Widget: Remove non-class code from class definition file. 

### DIFF
--- a/modules/widgets/milestone.php
+++ b/modules/widgets/milestone.php
@@ -8,6 +8,6 @@
  */
 
 /**
- * Register the milestone widget.  This makes it easier to keep the /milestone/ dir content in sync with wpcom.
+ * Includes the milestone widget.  This makes it easier to keep the /milestone/ dir content in sync with wpcom.
  */
-require __DIR__ . '/milestone/class-milestone-widget.php';
+require_once __DIR__ . '/milestone/milestone.php';

--- a/modules/widgets/milestone/class-milestone-widget.php
+++ b/modules/widgets/milestone/class-milestone-widget.php
@@ -8,14 +8,6 @@
 use Automattic\Jetpack\Assets;
 
 /**
- * Registers the widget for use!
- */
-function jetpack_register_widget_milestone() {
-	register_widget( 'Milestone_Widget' );
-}
-add_action( 'widgets_init', 'jetpack_register_widget_milestone' );
-
-/**
  * Class Milestone_Widget
  */
 class Milestone_Widget extends WP_Widget {

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Milestone Widget Loader.
+ *
+ * @package Jetpack.
+ */
+
+/**
+ * The widget class.
+ */
+require_once __DIR__ . '/class-milestone-widget.php';
+
+/**
+ * Registers the widget for use!
+ */
+function jetpack_register_widget_milestone() {
+	register_widget( 'Milestone_Widget' );
+}
+add_action( 'widgets_init', 'jetpack_register_widget_milestone' );


### PR DESCRIPTION
See #17802

In 17802, to comply with PHP, the file was renamed to match the role as a class definition file. Widgets are, generally, all old before PHPCS cared about such things, so most widgets follow the convention of inclusion code with the class definition in the same file.

As we progress forward with the code base, we should update the structure to match modern standards.

#### Changes proposed in this Pull Request:
* Moves code around a bit to maintain separation of class definition from executing code.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Enable Widgets for Jetpack.
* Ensure the milestone widget is available under Appearance->Widgets once done without PHP error/notice.

#### Proposed changelog entry for your changes:
* n/a
