### PR TITLE
Pre-commit: Run phpcs-changed even if no required files are changed

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -306,6 +306,8 @@ if ( phpLintResult && phpLintResult.status ) {
 if ( phpcsFiles.length > 0 ) {
 	runPHPCbf();
 	runPHPCS();
+}
+if ( phpFiles.length > 0 ) {
 	runPHPCSChanged( phpFiles );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
PR #17726 accidentally changed the behavior of the hook to only run
phpcs-changed when at least one file in phpcs-required was changed. It
should be run if any PHP file is changed.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make changes to a non-required file that will fail the linter.
* Run `node bin/pre-commit-hook.js` and see whether they're reported.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Developer only, none needed.
