### PR TITLE
Build: use symlinked dev versions of packages in dev environment

### DIFF
--- a/bin/version-packages.sh
+++ b/bin/version-packages.sh
@@ -53,6 +53,9 @@ if [[ ! -f "$CURRENT_DIR/composer.json" ]]; then
     exit 1;
 fi
 
+# Remove the local repo from composer.json.
+composer config --unset repositories.0
+
 # Get the list of package names to update.
 # Works in accordance of `composer show`, and will only act on packages prefixed with `automattic/jetpack-`.
 # Using --self because it is agnostic to whether /vendor is populated.

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,7 @@
 	"repositories": [
 		{
 			"type": "path",
-			"url": "./packages/*",
-			"canonical": false
+			"url": "./packages/*"
 		}
 	],
 	"autoload": {


### PR DESCRIPTION
Composer 2.x sets all repositories as canonical by default. We added the `"canonical": false` setting to our local path repo in `composer.json` so that stable versions would be used when the release version of Jetpack is built. However, this causes stable versions to also be used in the development environment, which is undesirable. During development, the development versions of the packages from the current branch should be symlinked to the vendor directory.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove the `"canonical": false` setting from the local path repo in `composer.json`.
*  In `version-packages.sh`, remove the local repo from `composer.json`. This will prevent development versions from being used when the release version of Jetpack is built.

(If there's a better way to do this, let me know. I'm not very familiar with the composer repository settings.)

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Install the composer packages in the development environment.
1. `rm -rf vendor`
2. `rm composer.lock`
3. `composer update`
4. Verify that the development branch versions of Jetpack's packages were symlinked from the current git branch.

##### Prepare the composer.json file for the release build.
1. `bin/version-packages.sh --no-update`
2. Verify that the Jetpack package versions in the `composer.json` file were changed to the latest stable versions.


#### Proposed changelog entry for your changes:
* tbd