### PR TITLE
Migrate jetpack_published_post to wp_after_insert_post hook

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1226,6 +1226,37 @@ That was a cool video.';
 	}
 
 	/**
+	 * Data Provider for test_sync_jetpack_published_post_no_action test.
+	 *
+	 * @return array[] Test parameters.
+	 */
+	public function provider_jetpack_published_post_no_action() {
+		return array(
+			array( null, $this->post ),
+			array( 'alpha', $this->post ),
+			array( $this->post_id, null ),
+			array( -1111, $this->post ),
+		);
+	}
+
+	/**
+	 * Verify no `jetpack_published_post` action is triggerd with invalid $post_ID or $post provided.
+	 *
+	 * @dataProvider provider_jetpack_published_post_no_action
+	 * @param int      $post_ID Post ID.
+	 * @param \WP_Post $post    Post object.
+	 */
+	public function test_sync_jetpack_published_post_no_action( $post_ID, $post ) {
+		$this->server_event_storage->reset();
+		do_action( 'wp_after_insert_post', $post_ID, $post, false );
+
+		$this->sender->do_sync();
+
+		$events = $this->server_event_storage->get_all_events( 'jetpack_published_post' );
+		$this->assertSame( 0, count( $events ) );
+	}
+
+	/**
 	 * Test if `Modules\Posts\daily_akismet_meta_cleanup_before` will properly chunk it's parameters in chunks of 100
 	 *
 	 * @throws ReflectionException Throw if Reflection fails to initialize.


### PR DESCRIPTION
WP 5.6 introduces the new `wp_after_insert_post` function and action that is triggered after a post and its terms, meta have been saved. We are migrating the `jetpack_published_post` sync event to this new hook to ensure that Publicize, Subscriptions and Elastic based functionality has the complete data available to it when they are triggered.

Fixes #14629
See: https://core.trac.wordpress.org/changeset/49172
See: https://make.wordpress.org/core/2020/11/20/new-action-wp_after_insert_post-in-wordpress-5-6/

#### Changes proposed in this Pull Request:
* Migrate `jetpack_published_post` sync event to trigger on `wp_after_insert_post` instead of `wp_insert_post`.

#### Jetpack product discussion
Historically WP.com dependent Jetpack functionality has run into issues with race conditions or chunked sync event processing that has lead to Publicize, Subscription Emails, Related Posts, Search being triggered that does not contain the full terms and meta data. This missing data would in several cases have caused different flows in processing. 

This migration to wp_after_insert_post allows us to ensure that publish actions have the full context of the post and its term/meta data so we are confidently triggering the proper action across all functionality. 

#### Does this pull request change what data or activity we track or use?
No, the same content is being synced.

#### Testing instructions:
This change requires a full regression of functionality tied to `jetpack_published_post`
* Publicize. -- Are social posts being created
* Subscription Emails -- see #14629 for test instructions
* Related Posts  - post is in global index
* Likes - post in global index (otherwise likes don't render)
* Instant Search - jetpack-search index has correct terms,meta when publishing a post
* Activity Log - 3 activities reference this action 
* Backups - latest post info is captured

Specific Instructions
Confirm jetpack_published_post is being sent in 5.6
* Update your site to use latest 5.6 release candidate
* Add a post to your site
* Verify jetpack_published_post action is queued and sent via Sync

Confirm jetpack_published_post is being sent still for versions less than 5.6
* Update your site to use WP 5.5.*
* Add a post to your site
* Verify jetpack_published_post action is queued and sent via Sync

Note there are several methods to testing sync events. They are outlined at : https://wp.me/PCYsg-svc

#### Proposed changelog entry for your changes:
* Jetpack Sync :: Migration of `jetpack_published_post` action to new 5.6 hook `wp_after_insert_post`
