### PR TITLE
Proof of concept: Anchor.FM link in post-publish

### DIFF
--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -9,6 +9,7 @@ import './shared/external-media';
 import './extended-blocks/core-embed';
 import './extended-blocks/paid-blocks';
 import './shared/styles/slideshow-fix.scss';
+import './shared/anchor-post-publish';
 
 import analytics from '../_inc/client/lib/analytics';
 

--- a/extensions/shared/anchor-post-publish.js
+++ b/extensions/shared/anchor-post-publish.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
+
+registerPlugin( 'anchor-post-publish', {
+	render: () => (
+		<PluginPostPublishPanel
+			className="my-plugin-post-publish-panel"
+			title={ __( 'Convert to audio', 'jetpack' ) }
+			initialOpen
+		>
+			<p>
+				{ __(
+					'Turn your post into a podcast episode and let your readers listen to your post.',
+					'jetpack'
+				) }
+			</p>
+			<p>
+				<a href="https://anchor.fm" target="_blank" rel="noreferrer">
+					{ __( 'Create a podcast episode', 'jetpack' ) }
+				</a>
+			</p>
+		</PluginPostPublishPanel>
+	),
+} );


### PR DESCRIPTION
#### Issues

- Unsure we will be doing this
- Do we need to restrict what sites it shows up on, for example, only
  wpcom?
- Plugin icon shows next to "Convert to Audio"
- "Convert to Audio" isn't bold
- Icon indicating the link goes to a new tab is missing
- Need actual URL to Anchor.fm

#### Screenshot

![2020-11-18_16-25](https://user-images.githubusercontent.com/937354/99595603-a42cfe00-29ba-11eb-91f8-10aaae352800.png)


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
