### PR TITLE
Instant Search: Stop passing search string as query string object

### DIFF
--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -188,9 +188,9 @@ function generateApiQueryString( {
 	);
 }
 
-function promiseifedProxyRequest( proxyRequest, path, query ) {
+function promiseifedProxyRequest( proxyRequest, path ) {
 	return new Promise( function ( resolve, reject ) {
-		proxyRequest( { path, query, apiVersion: '1.3' }, function ( err, body, headers ) {
+		proxyRequest( { path, apiVersion: '1.3' }, function ( err, body, headers ) {
 			if ( err ) {
 				reject( err );
 			}
@@ -259,7 +259,7 @@ export function search( options ) {
 	const { apiNonce, apiRoot, isPrivateSite, isWpcom } = window[ SERVER_OBJECT_NAME ];
 	if ( isPrivateSite && isWpcom ) {
 		return import( '../external/wpcom-proxy-request' ).then( ( { default: proxyRequest } ) => {
-			return promiseifedProxyRequest( proxyRequest, pathForPublicApi, options.query )
+			return promiseifedProxyRequest( proxyRequest, pathForPublicApi )
 				.catch( errorHandler )
 				.then( responseHandler );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Stops erroneously passing search string input as a query string object for `wpcom-proxy-request`.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Apply this change to a sandboxed and private WordPress.com site.
- Perform a search (e.g. "hello").
- Ensure that your search string hasn't been added to the search API request as its own key-value pair (e.g. "?hello") in the network panel.

#### Proposed changelog entry for your changes:
* None.