### PR TITLE
Remove spacing inside figure tag for Story block

### DIFF
--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -224,9 +224,7 @@ function render_slide( $media, $index = 0 ) {
 	}
 	return sprintf(
 		'<div class="wp-story-slide" style="display: %s;">
-			<figure>
-				%s
-			</figure>
+			<figure>%s</figure>
 		</div>',
 		0 === $index ? 'block' : 'none',
 		$media_template


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fixes blank previews for the Story block in Calypso/the notifications panel.

![calypso-notifications-before-after](https://user-images.githubusercontent.com/9613966/99868741-7b9a4380-2c08-11eb-9c6c-0c851665df5b.png)

It seems that at some point the notifications code is converting the line break between `<img>` and `</figure>` in the slide output into a `<br>`. This made it into the `note` structure sent by the notifications API, which for some reason made the front-end ignore the image tag and only include the `<br>` tag as a child of `<figure>` in the displayed notification, causing it to look blank as in the screenshot.

I'm not familiar enough with the notifications code to understand why this would be the case - but since merely removing the line break solves the issue and I don't see a good reason not to inline the `figure` wrapping the `img` tag, I haven't dug in any further.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this patch to a Jetpack site and to WP.com
* Subscribe to post notifications for a site with Stories (from https://wordpress.com/following/manage)
* Load Calypso and open the notifications panel
* Open a notification for a post containing a Story
* Notice that the preview image shows correctly

#### Proposed changelog entry for your changes:
No changelog needed.