### PR TITLE
Status: Fix test failure

### DIFF
--- a/packages/status/tests/php/test-status.php
+++ b/packages/status/tests/php/test-status.php
@@ -47,9 +47,6 @@ class Test_Status extends TestCase {
 		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
 
 		$this->status = new Status();
-
-		// Default to a non-set environment type, unless decided otherwise in each test.
-		Functions\when( 'wp_get_environment_type' )->justReturn( '' );
 	}
 
 	/**
@@ -367,13 +364,13 @@ class Test_Status extends TestCase {
 	public function test_is_staging_site_for_known_hosting_providers( $site_url, $expected ) {
 		Functions\when( 'site_url' )->justReturn( $site_url );
 		$result = $this->status->is_staging_site();
-		$this->assertEquals(
+		$this->assertSame(
 			$expected,
 			$result,
 			sprintf(
 				'Expected %1$s to return %2$s for is_staging_site()',
 				$site_url,
-				$expected
+				var_export( $expected, 1 ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			)
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
PRs #17794 and #17820 both added mocking of WP core's
wp_get_environment_type to setUp(), but did so in slightly different
ways in different places within the method.

17794 also changed tests to depend on its specific way, but since
17820's came later it took precedence once both were merged and caused
tests to fail. Resolve the problem by removing 17820's attempt.

Also, while I'm poking at it, swap assertEquals for assertSame and have
the custom message actually print "true"/"false" rather than "1"/"".

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See if tests pass now.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
