### PR TITLE
Fix Date constructor RangeError exception on Firefox when running alongside Gutenberg 9.4.1

### DIFF
--- a/extensions/shared/external-media/constants.js
+++ b/extensions/shared/external-media/constants.js
@@ -176,7 +176,7 @@ export const MONTH_SELECT_OPTIONS = [
 	{ label: __( 'Any Month', 'jetpack' ), value: -1 },
 	...map( range( 0, 12 ), value => ( {
 		// Following call generates a new date object for the particular month and gets its name.
-		label: dateI18n( 'F', new Date( [ 0, value + 1 ] ) ),
+		label: dateI18n( 'F', new Date( 0, value + 1 ) ),
 		value,
 	} ) ),
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #17850

### Changes proposed in this Pull Request:

The 'year' and 'month' args were passed wrapped in a single array argument to the `Date` constructor. This overload fails on Firefox. 

This started happening after Gutenberg 9.4 migrated to `dateFns` from `moment`. We still don't know why it worked before, but I have a hunch that `moment` (or other package in its dependency tree) monkeypatched/polyfilled the Data object in order to allow it to accept an array (?).

### Does this pull request change what data or activity we track or use?

No

### Testing instructions:

#### Reproducing the issue

Run a WP instance (com or org) with Jetpack and Gutenberg 9.4.1, start a new post and watch the console for the exception. You'll also noticed JP blocks haven't loaded.

#### Testing the fix works

1. Apply this patch to your Jetpack instance;
1. Start a new post, be sure to have the JS console open and look for errors. A "RangeError" should not happen;
1. JP blocks should be present, test by searching for them in the inserter.


#### Proposed changelog entry for your changes:

* Fix Date constructor RangeError exception on Firefox when running alongside Gutenberg 9.4.1.
