### PR TITLE
oEmbeds: Change Instagram WP.com proxy endpoint to Core's

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -251,10 +251,9 @@ function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
 		return $provider;
 	}
 
-	// @TODO Use Core's /oembed/1.0/proxy endpoint on WP.com
-	// (Currently not global but per-site, i.e. /oembed/1.0/sites/1234567/proxy)
-	// and deprecate /oembed-proxy/instagram endpoint.
-	$wpcom_oembed_proxy = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ) . '/wpcom/v2/oembed-proxy/instagram/';
+	$site_id            = \Jetpack_Options::get_option( 'id' );
+	$wpcom_oembed_proxy = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ) . "/oembed/1.0/sites/$site_id/proxy";
+
 	return str_replace( 'https://graph.facebook.com/v5.0/instagram_oembed/', $wpcom_oembed_proxy, $provider );
 }
 
@@ -265,7 +264,7 @@ function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
  * @param string $url  URL to be inspected.
  */
 function jetpack_instagram_oembed_remote_get_args( $args, $url ) {
-	if ( ! wp_startswith( $url, Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ) . '/wpcom/v2/oembed-proxy/instagram/' ) ) {
+	if ( ! wp_startswith( $url, Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ) . '/oembed/1.0/sites/' ) ) {
 		return $args;
 	}
 

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -15,7 +15,7 @@ class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 		parent::setUp();
 
 		// Note: This forces the tests below to use the flow that's used when an auth token
-		// for the Instagram oEmbed REST API is set. This means that the call to the /oembed-proxy
+		// for the Instagram oEmbed REST API is set. This means that the call to the /oembed proxy
 		// endpoint isn't covered with tests. We should create at least one test below that
 		// specifically covers that.
 		Constants::set_constant( 'JETPACK_INSTAGRAM_EMBED_TOKEN', 'test' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Use Core's `/oembed/1.0/` proxy endpoint rather than JP/WP.com's `/oembed-proxy` when falling back to WP.com for Instagram oEmbeds.

_This is unfortunately currently not working, even though I've seen the `/oembed/1.0` proxy endpoint work for embeds in GB on WP.com. I have yet to figure out why._

#### Jetpack product discussion
pc9Uba-6d-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Start writing a new post, and insert the URL of an Instagram post.

#### Proposed changelog entry for your changes:
oEmbeds: Use Core's `/oembed/1.0/proxy` endpoint rather than JP/WP.com's `/oembed-proxy` when falling back to WP.com for Instagram oEmbeds.