### PR TITLE
Docs: Add minimum composer version to dev env doc

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -69,6 +69,7 @@ To get a local WordPress site up and running you need a web server (Apache, Ngin
  * Node.js - LTS (Currently 10, see engines section of package.json)
  * Yarn - 1.3 (See engines section of package.json)
  * PHP - 7.4 (in case you're running WordPress locally)
+ * Composer - 1.9.0
 
 ---
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add the minimum supported version of composer to the development environment doc. The minimum version is 1.9.0.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
This is just a documentation update. If you'd like, you can verify that Composer 1.9.0 works:
1. Install Composer 1.9.0: `composer self-update 1.9.0`
2. Remove the vendor folder and lock file: `rm -rf vendor && rm composer.lock`
3. Run `composer update` and verify that no errors are generated.
5. Update to the latest version of composer: `composer self-update`

#### Proposed changelog entry for your changes:
* n/a
