### PR TITLE
Admin: add a filter for disabling the update modal

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3252,7 +3252,17 @@ p {
 	 * Sets the display_update_modal state.
 	 */
 	public static function set_update_modal_display() {
-		self::state( 'display_update_modal', true );
+		/**
+		 * Displays or disables the Jetpack update modal.
+		 *
+		 * @since 9.3.0
+		 *
+		 * @param bool If true, the update modal will be displayed.
+		 */
+		$display_update_modal = apply_filters( 'jetpack_display_update_modal', '__return_true' );
+		if ( $display_update_modal ) {
+			self::state( 'display_update_modal', true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add a filter, `jetpack_display_update_modal`, which can be used to disable the update modal. The default value is true.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* tbd

#### Proposed changelog entry for your changes:
* tbd
