### PR TITLE
Podcast Helpers: Add method to find specific track

### DIFF
--- a/_inc/lib/class-jetpack-podcast-helper.php
+++ b/_inc/lib/class-jetpack-podcast-helper.php
@@ -92,6 +92,7 @@ class Jetpack_Podcast_Helper {
 			foreach ( $rss->get_items() as $track ) {
 				if ( $guid === $track->get_id() ) {
 					$track_data = self::setup_tracks_callback( $track );
+					break;
 				}
 			}
 

--- a/_inc/lib/class-jetpack-podcast-helper.php
+++ b/_inc/lib/class-jetpack-podcast-helper.php
@@ -76,13 +76,13 @@ class Jetpack_Podcast_Helper {
 		$feed = esc_url_raw( $feed );
 
 		// Try loading track data from the cache.
-		$transient_key = 'jetpack_podcast_' . md5( $feed ) . '_' . md5( $guid );
+		$transient_key = 'jetpack_podcast_' . md5( "$feed::$guid" );
 		$track_data    = get_transient( $transient_key );
 
 		// Fetch data if we don't have any cached.
 		if ( false === $track_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
 			// Load feed.
-			$rss = self::load_feed( $feed );
+			$rss = static::load_feed( $feed );
 
 			if ( is_wp_error( $rss ) ) {
 				return $rss;
@@ -91,7 +91,7 @@ class Jetpack_Podcast_Helper {
 			// Loop over all tracks to find the one.
 			foreach ( $rss->get_items() as $track ) {
 				if ( $guid === $track->get_id() ) {
-					$track_data = self::setup_tracks_callback( $track );
+					$track_data = static::setup_tracks_callback( $track );
 					break;
 				}
 			}

--- a/tests/php/_inc/lib/mocks/class-mock-jetpack-podcast-helper.php
+++ b/tests/php/_inc/lib/mocks/class-mock-jetpack-podcast-helper.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Mock class to help make Jetpack_Podcast_Helper more testable.
+ *
+ * @package jetpack
+ */
+
+/**
+ * Class Mock_Jetpack_Podcast_Helper
+ */
+class Mock_Jetpack_Podcast_Helper extends Jetpack_Podcast_Helper {
+	/**
+	 * Mock of load_feed().
+	 *
+	 * @param string $feed Feed.
+	 * @return \Mock_SimplePie|\WP_Error
+	 */
+	public static function load_feed( $feed ) {
+		if ( 'http://error' === $feed ) {
+			return new WP_Error( 'feed_error', 'Feed error.' );
+		}
+
+		return new Mock_SimplePie();
+	}
+
+	/**
+	 * Mock of setup_tracks_callback().
+	 *
+	 * @param \SimplePie_Item $episode Episode.
+	 * @return array
+	 */
+	public static function setup_tracks_callback( $episode ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return array(
+			'id'          => wp_unique_id( 'podcast-track-' ),
+			'link'        => 'https://example.org',
+			'src'         => 'https://example.org',
+			'type'        => 'episode',
+			'description' => '',
+			'title'       => '',
+		);
+	}
+}

--- a/tests/php/_inc/lib/mocks/class-mock-simplepie-item.php
+++ b/tests/php/_inc/lib/mocks/class-mock-simplepie-item.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Mock class to help make Jetpack_Podcast_Helper more testable.
+ *
+ * @package jetpack
+ */
+
+/**
+ * Class Mock_SimplePie_Item.
+ */
+class Mock_SimplePie_Item {
+	/**
+	 * Holds ID.
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * Mock_SimplePie_Item constructor.
+	 *
+	 * @param int $id ID.
+	 */
+	public function __construct( $id ) {
+		$this->id = $id;
+	}
+
+	/**
+	 * Returns ID.
+	 *
+	 * @return int
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+}

--- a/tests/php/_inc/lib/mocks/class-mock-simplepie.php
+++ b/tests/php/_inc/lib/mocks/class-mock-simplepie.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Mock class to help make Jetpack_Podcast_Helper more testable.
+ *
+ * @package jetpack
+ */
+
+/**
+ * Class Mock_SimplePie
+ */
+class Mock_SimplePie {
+	/**
+	 * Mock of get_items().
+	 *
+	 * @return \Mock_SimplePie_Item[]
+	 */
+	public function get_items() {
+		return array(
+			new Mock_SimplePie_Item( 0 ),
+			new Mock_SimplePie_Item( 1 ),
+		);
+	}
+}

--- a/tests/php/_inc/lib/test-class-jetpack-podcast-helper.php
+++ b/tests/php/_inc/lib/test-class-jetpack-podcast-helper.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Podcast Helper unit tests.
+ *
+ * @package Jetpack
+ */
+
+jetpack_require_lib( 'class-jetpack-podcast-helper' );
+require_once __DIR__ . '/mocks/class-mock-jetpack-podcast-helper.php';
+require_once __DIR__ . '/mocks/class-mock-simplepie.php';
+require_once __DIR__ . '/mocks/class-mock-simplepie-item.php';
+
+/**
+ * Class for testing the Jetpack_Podcast_Helper class.
+ *
+ * @coversDefaultClass Jetpack_Podcast_Helper
+ */
+class WP_Test_Jetpack_Podcast_Helper extends WP_UnitTestCase {
+	/**
+	 * Tests get_track_data().
+	 *
+	 * @covers ::get_track_data
+	 */
+	public function test_get_track_data() {
+		// `load_feed()` returns error.
+		$error = Mock_Jetpack_Podcast_Helper::get_track_data( 'error', '' );
+		$this->assertWPError( $error );
+		$this->assertSame( $error->get_error_code(), 'feed_error' );
+		$this->assertSame( $error->get_error_message(), 'Feed error.' );
+
+		// Can't find an episode.
+		$error = Mock_Jetpack_Podcast_Helper::get_track_data( '', '' );
+		$this->assertWPError( $error );
+		$this->assertSame( $error->get_error_code(), 'no_track' );
+		$this->assertSame( $error->get_error_message(), 'The track was not found.' );
+
+		// Success.
+		$episode = Mock_Jetpack_Podcast_Helper::get_track_data( '', 1 );
+		$this->assertSame(
+			$episode,
+			array(
+				'id'          => 'podcast-track-1',
+				'link'        => 'https://example.org',
+				'src'         => 'https://example.org',
+				'type'        => 'episode',
+				'description' => '',
+				'title'       => '',
+			)
+		);
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* this adds a new method to the helper class which allows us to find the track info for a specific podcast episode (by guid)

#### Jetpack product discussion
—

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* `Jetpack_Podcast_Helper::get_track_data( $feed, $guid )` — this method accepts the feed URL and episode GUID
* the result is cached for an hour, per episode

#### Proposed changelog entry for your changes:
* none, this is an internal helper class