### PR TITLE
changelog: first approach

### DIFF
--- a/extensions/blocks/changelog/attributes.js
+++ b/extensions/blocks/changelog/attributes.js
@@ -1,0 +1,23 @@
+export default {
+	label: {
+		type: "string",
+		default: "new",
+	},
+	labelSlug: {
+		type: "string",
+		default: "new",
+	},
+	timeStamp: {
+		type: "string",
+		default: "00:00",
+	},
+	showTimeStamp: {
+		type: "boolen",
+		default: false,
+	},
+	content: {
+		type: 'array',
+		source: 'children',
+		selector: 'p',
+	},
+};

--- a/extensions/blocks/changelog/attributes.js
+++ b/extensions/blocks/changelog/attributes.js
@@ -12,7 +12,7 @@ export default {
 		default: "00:00",
 	},
 	showTimeStamp: {
-		type: "boolen",
+		type: "boolean",
 		default: false,
 	},
 	content: {

--- a/extensions/blocks/changelog/changelog.php
+++ b/extensions/blocks/changelog/changelog.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Changelog Block.
+ *
+ * @since 9.x
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Changelog;
+
+use Automattic\Jetpack\Blocks;
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'changelog';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	Blocks::jetpack_register_block(
+		BLOCK_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_block',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Changelog block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Changelog block attributes.
+ * @param string $content String containing the Changelog block content.
+ *
+ * @return string
+ */
+function render_block( $attr, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
+	return $content;
+}

--- a/extensions/blocks/changelog/components/labels-dropdown.js
+++ b/extensions/blocks/changelog/components/labels-dropdown.js
@@ -52,7 +52,7 @@ export default function LabelsDropdown ( {
 		>
 			{ () => (
 				<Fragment>
-					<MenuGroup>
+					<MenuGroup className={ `${ className }__labels-selector` }>
 						{ map( labels, ( { value: newLabel, slug: newLabelSlug } ) => (
 							<MenuItem
 								key={ newLabelSlug }

--- a/extensions/blocks/changelog/components/labels-dropdown.js
+++ b/extensions/blocks/changelog/components/labels-dropdown.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { map, find } from 'lodash';
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	TextControl,
+	BaseControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+
+export default function LabelsDropdown ( {
+	id,
+	className,
+	labels,
+	value,
+	slug,
+	onSelect,
+	onChange,
+	position = { position: 'bottom' },
+} ) {
+	const labelBySlug = find( labels, ( label ) => label.slug === slug );
+	const defaultLabelObject = slug && labelBySlug ? labelBySlug : labels[ 0 ];
+
+	const isCustomLabel = ! slug && value;
+	const currentValue = isCustomLabel ? value : defaultLabelObject.value;
+	const currentSlug = ! isCustomLabel ? ( slug || defaultLabelObject.slug ) : null;
+
+	return (
+		<DropdownMenu
+			popoverProps={ position }
+			className={ `${ className }__label-container` }
+			toggleProps={ {
+				className: classNames(
+					`${ className }__label`,
+					{
+						[ `is-${ currentSlug }-label` ]: !! currentSlug,
+						[ 'is-custom-label' ]: isCustomLabel,
+					}
+				),
+				children: <span>{ currentValue }</span>,
+			} }
+			icon={ null }
+		>
+			{ () => (
+				<Fragment>
+					<MenuGroup>
+						{ map( labels, ( { value: newLabel, slug: newLabelSlug } ) => (
+							<MenuItem
+								key={ newLabelSlug }
+								onClick={ () => onSelect( { newLabel, newLabelSlug } ) }
+								isSelected={ true }
+							>
+								{ newLabel }
+							</MenuItem>
+						) ) }
+					</MenuGroup>
+
+					<BaseControl
+						id={ id }
+						className={ `${ className }__custom-label` }
+						label={ __( 'Custom', 'jetpack' ) }
+					>
+						<div className={ `${ className }__text-button-container` }>
+							<TextControl
+								id={ id }
+								value={ value }
+								onChange={ ( newLabel ) => onChange( { newLabel, newLabelSlug: null } ) }
+							/>
+						</div>
+					</BaseControl>
+				</Fragment>
+			) }
+		</DropdownMenu>
+	);
+}

--- a/extensions/blocks/changelog/components/time-stamp-control.js
+++ b/extensions/blocks/changelog/components/time-stamp-control.js
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	BaseControl,
+	__experimentalNumberControl as NumberControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+function checkValidValue( val, max ) {
+	if ( val > max ) {
+		return val = max;
+	} else if ( val < 0 ) {
+		return val = 0;
+	}
+
+	return val;
+}
+
+const timeStampMap = [ 'hour', 'min', 'sec' ];
+
+/**
+ * Helper function to parse and stringify the time stamp,
+ * in the HH:MM:SS format.
+ * `HH` is optional, meaning when it's empty,
+ * the string won't contain it, returning MM:SS.
+ *
+ * @param {object} typeValue - { type: value } pair value of the time stamp.
+ * @param {Array} smh - current [ second, menute, hour ] array values.
+ * @returns {string} HH:MM:SS format.
+ */
+function setTimeStampValue( typeValue, smh ) {
+	if ( smh.length <= 2 ) {
+		smh.unshift( '00' );
+	}
+
+	const type = Object.keys( typeValue )?.[ 0 ];
+	if ( ! type ) {
+		return smh.join( ':' );
+	}
+
+	let newValue = String( checkValidValue( typeValue[ type ], type === 'hour' ? 23 : 59 ) );
+
+	// Mask HH:MM:SS values.
+	if ( newValue?.length === 1 ) {
+		newValue = `0${ newValue }`;
+	} else if ( newValue?.length === 0 ) {
+		newValue = '00';
+	}
+
+	smh[ timeStampMap.indexOf( type ) ] = newValue;
+
+	// Remove HH when zero.
+	if ( smh.length === 3 && smh[ 0 ] === '00' ) {
+		smh.shift();
+	}
+
+	return smh.join( ':' );
+}
+
+function TimeStamp ( { value, className, onChange } ) {
+	const smh = value.split( ':' );
+	if ( smh.length <= 2 ) {
+		smh.unshift( '00' );
+	}
+
+	return (
+		<div className={ className }>
+			<NumberControl
+				className={ `${ className }__hour` }
+				label={ __( 'Hour', 'jetpack' ) }
+				value={ smh[ 0 ] }
+				min={ 0 }
+				max={ 23 }
+				onChange={ ( hour ) => {
+					onChange( setTimeStampValue( { hour }, smh ) );
+				} }
+			/>
+
+			<NumberControl
+				className={ `${ className }__minute` }
+				label={ __( 'Minute', 'jetpack' ) }
+				value={ smh[ 1 ] }
+				min={ 0 }
+				max={ 59 }
+				onChange={ ( min ) => {
+					onChange( setTimeStampValue( { min }, smh ) );
+				} }
+			/>
+
+			<NumberControl
+				className={ `${ className }__second` }
+				label={ __( 'Second', 'jetpack' ) }
+				value={ smh[ 2 ] }
+				min={ 0 }
+				max={ 59 }
+				onChange={ ( sec ) => {
+					onChange( setTimeStampValue( { sec }, smh ) );
+				} }
+			/>
+		</div>
+	);
+}
+
+export default function TimeStampControl( {
+	className,
+	value,
+	onChange,
+} ) {
+	return (
+		<BaseControl>
+			<TimeStamp
+				className={ className }
+				value={ value }
+				onChange={ onChange }
+			/>
+		</BaseControl>
+	);
+}

--- a/extensions/blocks/changelog/components/time-stamp-control.js
+++ b/extensions/blocks/changelog/components/time-stamp-control.js
@@ -11,7 +11,7 @@ function checkValidValue( val, max ) {
 	if ( val > max ) {
 		return val = max;
 	} else if ( val < 0 ) {
-		return val = 0;
+		return 0;
 	}
 
 	return val;

--- a/extensions/blocks/changelog/edit.js
+++ b/extensions/blocks/changelog/edit.js
@@ -1,0 +1,138 @@
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, RichText } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import {
+	Panel,
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import LabelsDropdown from './components/labels-dropdown';
+import TimeStampControl from './components/time-stamp-control';
+
+const blockName = 'jetpack/changelog';
+const fallbackBlockName = 'core/paragraph';
+
+const defaultLabels = [
+	{
+		value: __( 'new', 'jetpack' ),
+		slug: 'new',
+	},
+	{
+		value: __( 'improved', 'jetpack' ),
+		slug: 'improved',
+	},
+	{
+		value: __( 'fixed', 'jetpack' ),
+		slug: 'fixed',
+	},
+];
+
+export default function ChangelogEdit ( {
+	className,
+	attributes,
+	setAttributes,
+	mergeBlocks,
+	onReplace,
+	instanceId,
+} ) {
+	const {
+		label,
+		labelSlug,
+		showTimeStamp,
+		timeStamp,
+		content,
+		placeholder,
+	} = attributes;
+
+	return (
+		<div class={ className }>
+			<InspectorControls>
+				<Panel>
+					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+						<ToggleControl
+							label={ __( 'Show time stamp', 'jetpack' ) }
+							checked={ showTimeStamp }
+							onChange={
+								( show ) => setAttributes( { showTimeStamp: show } )
+							}
+						/>
+
+						{ showTimeStamp && (
+							<TimeStampControl
+								className={ `${ className }__timestamp-control` }
+								value={ timeStamp }
+								onChange={ ( newTimeStampValue ) => {
+									setAttributes( { timeStamp: newTimeStampValue } );
+								} }
+							/>
+						) }
+					</PanelBody>
+				</Panel>
+			</InspectorControls>
+
+			<div class={ `${ className }__meta` }>
+				<LabelsDropdown
+					id={ `changelog-${ instanceId }-labels-selector` }
+					className={ className }
+					labels={ defaultLabels }
+					value={ label }
+					slug={ labelSlug }
+					onSelect={ ( { newLabel, newLabelSlug } ) => {
+						setAttributes( {
+							labelSlug: newLabelSlug,
+							label: newLabel,
+						} );
+					 } }
+					onChange={ ( { newLabel, newLabelSlug } ) => setAttributes( {
+						labelSlug: newLabelSlug,
+						label: newLabel,
+					} ) }
+				/>
+
+				{ showTimeStamp && (
+					<div className={ `${ className }__timestamp` }>
+						{ timeStamp }
+					</div>
+				) }
+			</div>
+
+			<RichText
+				identifier="content"
+				wrapperClassName="wp-block-p2-changelog__content"
+				value={ content }
+				onChange={ ( value ) =>
+					setAttributes( { content: value } )
+				}
+				onMerge={ mergeBlocks }
+				onSplit={ ( value ) => {
+					if ( ! content.length ) {
+						return createBlock( fallbackBlockName );
+					}
+
+					if ( ! value ) {
+						return createBlock( blockName );
+					}
+
+					return createBlock( blockName, {
+						...attributes,
+						content: value,
+					} );
+				} }
+				onReplace={ onReplace }
+				onRemove={
+					onReplace ? () => onReplace( [] ) : undefined
+				}
+				placeholder={ placeholder || __( 'Add entry' ) }
+			/>
+		</div>
+	);
+}

--- a/extensions/blocks/changelog/editor.js
+++ b/extensions/blocks/changelog/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from '../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/extensions/blocks/changelog/editor.scss
+++ b/extensions/blocks/changelog/editor.scss
@@ -2,6 +2,12 @@
  * Editor Canvas context.
  */
 
+ .wp-block-jetpack-changelog__labels-selector .components-menu-item__button,
+ .wp-block-jetpack-changelog__text-button-container .components-text-control__input {
+	font-size: 12px;
+	text-transform: uppercase;
+ }
+ 
 /*
  * Block settings sidebar.
  */

--- a/extensions/blocks/changelog/editor.scss
+++ b/extensions/blocks/changelog/editor.scss
@@ -1,0 +1,15 @@
+/*
+ * Editor Canvas context.
+ */
+
+/*
+ * Block settings sidebar.
+ */
+ .wp-block-jetpack-changelog__timestamp-control {
+	display: flex;
+}
+
+.wp-block-jetpack-changelog__timestamp-control__hour,
+.wp-block-jetpack-changelog__timestamp-control__minute {
+	margin-right: 5px;
+} 

--- a/extensions/blocks/changelog/index.js
+++ b/extensions/blocks/changelog/index.js
@@ -22,7 +22,7 @@ export const settings = {
 	title,
 	description: __( 'Changelog', 'jetpack' ),
 	icon: {
-		src: 'yes',
+		src: 'list-view',
 		foreground: getIconColor(),
 	},
 	category: 'layout',

--- a/extensions/blocks/changelog/index.js
+++ b/extensions/blocks/changelog/index.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getIconColor } from '../../shared/block-icons';
+import attributes from './attributes';
+import edit from './edit';
+import save from './save';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export const name = 'changelog';
+export const title = __( 'Changelog block', 'jetpack' );
+export const settings = {
+	title,
+	description: __( 'Changelog', 'jetpack' ),
+	icon: {
+		src: 'yes',
+		foreground: getIconColor(),
+	},
+	category: 'layout',
+	supports: {
+		'align': true,
+	},
+	edit,
+	save,
+	attributes,
+	usesContext: [
+		'changelog/labels',
+		'changelog/showTimeStamp',
+	],
+};

--- a/extensions/blocks/changelog/index.js
+++ b/extensions/blocks/changelog/index.js
@@ -32,8 +32,4 @@ export const settings = {
 	edit,
 	save,
 	attributes,
-	usesContext: [
-		'changelog/labels',
-		'changelog/showTimeStamp',
-	],
 };

--- a/extensions/blocks/changelog/save.js
+++ b/extensions/blocks/changelog/save.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+export default function save( { attributes } ) {
+	const { label, labelSlug, content, showTimeStamp, timeStamp } = attributes;
+
+	const className = 'wp-block-jetpack-changelog';
+
+	const labelClasses = classNames(
+		`${ className }__label`,
+		{
+			[ `is-${ labelSlug }-label` ]: !! labelSlug,
+			[ 'is-custom-label' ]: ! labelSlug,
+		}
+	);
+
+	return (
+		<div>
+			<div class={ `${ className }__meta` }>
+				<div class={ `${ className }__label-container` }>
+					<div className={ labelClasses }>{ label }</div>
+					{ showTimeStamp && (
+						<div className={ `${ className }__timestamp` }>
+							{ timeStamp }
+						</div>
+					) }
+				</div>
+			</div>
+
+			<p>{ content }</p>
+		</div>
+	);
+}

--- a/extensions/blocks/changelog/style.scss
+++ b/extensions/blocks/changelog/style.scss
@@ -1,0 +1,67 @@
+
+
+.wp-block-jetpack-changelog {
+	display: flex;
+}
+
+.wp-block-jetpack-changelog__meta {
+	min-width: 90px;
+	margin-right: 10px;
+}
+
+
+.wp-block-jetpack-changelog__label-container {
+	text-align: right;
+	width: 100%;;
+}
+
+.wp-block-jetpack-changelog__timestamp {
+	font-size: 12px;
+	text-align: right;
+}
+
+.components-dropdown-menu__toggle.wp-block-jetpack-changelog__label,
+.wp-block-jetpack-changelog__label {
+	cursor: pointer;
+	border-radius: 2px;
+	white-space: nowrap;
+
+	&.is-new-label,
+	&.is-improved-label,
+	&.is-fixed-label,
+	&.is-custom-label {
+		cursor: pointer;
+		color: white;
+		text-transform: uppercase;
+		padding: 3px 6px;
+		height: auto;
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 1.5;
+		letter-spacing: 0.02em;
+		display: inline-flex;
+		position: relative;
+		top: -4px;
+		span {
+			max-width: 78px;
+			text-overflow: ellipsis;
+			overflow: hidden;
+		}
+	}
+
+	&.is-new-label {
+		background-color: #13d66a;		
+	}
+
+	&.is-improved-label {
+		background-color: #0092f9;
+	}
+
+	&.is-fixed-label {
+		background-color: #ff832b;
+	}
+
+	&.is-custom-label {
+		background-color: #845fef;
+	}
+}

--- a/extensions/blocks/changelog/view.js
+++ b/extensions/blocks/changelog/view.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './style.scss';

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -3,6 +3,7 @@
 		"business-hours",
 		"button",
 		"calendly",
+		"changelog",
 		"contact-form",
 		"contact-info",
 		"donations",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR adds a new block to the Jetpack extension blocks: `changelog`.

<img src="https://user-images.githubusercontent.com/77539/100103142-43cb1000-2e43-11eb-94f4-733501306590.png" width="500px" />

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add changelog block

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start to create/edit a post
* Add the `changelog` block

You can change the label using the dropdown.

<img width="400" alt="Screen Shot 2020-11-24 at 10 53 49 AM" src="https://user-images.githubusercontent.com/77539/100103273-6d843700-2e43-11eb-9871-bed925d43970.png">

There are three default values, and also it's possible to set a custom one.

It's possible to add an optional timestamp.

<img src="https://user-images.githubusercontent.com/77539/100103563-d075ce00-2e43-11eb-8287-a972e26b2515.png" width="600px" />

* save the post
* check that the content is properly rendered in the front-end.

<img src="https://user-images.githubusercontent.com/77539/100103697-ff8c3f80-2e43-11eb-8f8e-ba5380a7225d.png" width="500px" />


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
