### PR TITLE
External Media: Fix month order in Google Photos

### DIFF
--- a/extensions/shared/external-media/constants.js
+++ b/extensions/shared/external-media/constants.js
@@ -176,7 +176,7 @@ export const MONTH_SELECT_OPTIONS = [
 	{ label: __( 'Any Month', 'jetpack' ), value: -1 },
 	...map( range( 0, 12 ), value => ( {
 		// Following call generates a new date object for the particular month and gets its name.
-		label: dateI18n( 'F', new Date( 0, value + 1 ) ),
+		label: dateI18n( 'F', new Date( 0, value ) ),
 		value,
 	} ) ),
 ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

See https://github.com/Automattic/jetpack/pull/17876#issuecomment-733005068 and the below screenshots:
Prior to this PR, the month selector would start at February, go thru December, and append January at the end.
This PR fixes the order to start with January and end with December.

##### Before

![image](https://user-images.githubusercontent.com/96308/100013859-cfa65300-2dd5-11eb-97a9-b857ac446719.png)

##### After

![image](https://user-images.githubusercontent.com/96308/100108014-9cfa6a00-2e6a-11eb-9cdb-f8873c5122ab.png)

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Add an Image block
* Click "Select Image", then "Google Photos" in the popup menu.
* Change the "Filter by time period" to "Specific Month/Year". The dropdown generated here is then used for selecting the specific month.

#### Proposed changelog entry for your changes:
External Media: Fix month order in Google Photos