### PR TITLE
Theme Tools: add Twenty Twenty One compatibility files

### DIFF
--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -71,6 +71,7 @@ module.exports = [
 	'modules/shortcodes/',
 	'modules/sitemaps/sitemaps.php',
 	'modules/theme-tools/compat/twentytwenty.php',
+	'modules/theme-tools/compat/twentytwentyone.php',
 	'modules/theme-tools/site-breadcrumbs.php',
 	'modules/theme-tools/social-menu/',
 	'modules/theme-tools/devicepx.php',

--- a/modules/theme-tools.php
+++ b/modules/theme-tools.php
@@ -43,6 +43,7 @@ function jetpack_load_theme_compat() {
 			'twentyseventeen' => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyseventeen.php',
 			'twentynineteen'  => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentynineteen.php',
 			'twentytwenty'    => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentytwenty.php',
+			'twentytwentyone' => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentytwentyone.php',
 		)
 	);
 

--- a/modules/theme-tools/compat/twentytwentyone.css
+++ b/modules/theme-tools/compat/twentytwentyone.css
@@ -2,7 +2,7 @@
  * Related Posts
  */
 
-#jp-relatedposts {
+.entry-content #jp-relatedposts {
 	max-width: var(--responsive--aligndefault-width);
 	margin-left: auto;
 	margin-right: auto;

--- a/modules/theme-tools/compat/twentytwentyone.css
+++ b/modules/theme-tools/compat/twentytwentyone.css
@@ -1,0 +1,9 @@
+/**
+ * Related Posts
+ */
+
+#jp-relatedposts {
+	max-width: var(--responsive--aligndefault-width);
+	margin-left: auto;
+	margin-right: auto;
+}

--- a/modules/theme-tools/compat/twentytwentyone.php
+++ b/modules/theme-tools/compat/twentytwentyone.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Jetpack Compatibility File
+ * See: https://jetpack.com/
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Add Jetpack extra functionality to Twenty Twenty One.
+ */
+function twentytwentyone_jetpack_setup() {
+	/**
+	 * Add theme support for geo-location.
+	 */
+	add_theme_support( 'jetpack-geo-location' );
+}
+add_action( 'after_setup_theme', 'twentytwentyone_jetpack_setup' );
+
+/**
+ * Add our compat CSS file for custom styles.
+ * Set the version equal to filemtime for development builds, and the JETPACK__VERSION for production
+ * or skip it entirely for wpcom.
+ */
+function twentytwentyone_enqueue_jetpack_style() {
+	$version = Jetpack::is_development_version()
+		? filemtime( JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentytwentyone.css' )
+		: JETPACK__VERSION;
+
+	wp_enqueue_style( 'twentytwentyone-jetpack', plugins_url( 'twentytwentyone.css', __FILE__ ), array(), $version );
+	wp_style_add_data( 'twentytwentyone-jetpack', 'rtl', 'replace' );
+}
+add_action( 'wp_enqueue_scripts', 'twentytwentyone_enqueue_jetpack_style' );

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -66,6 +66,7 @@ const separate_list = [
 	'modules/tiled-gallery/tiled-gallery/tiled-gallery.css',
 	'modules/theme-tools/compat/twentynineteen.css',
 	'modules/theme-tools/compat/twentytwenty.css',
+	'modules/theme-tools/compat/twentytwentyone.css',
 ];
 
 const cwd = process.cwd() + '/';


### PR DESCRIPTION
See #17248 

#### Changes proposed in this Pull Request:

* Ensure that no features look too out of place in the new default theme. 

**It doesn't do much, I consider this the strict minimum. We can iterate in future PRs and future releases to add support for more Jetpack features such as Content Options or Infinite Scroll**. Jetpack widgets and features don't actually look too bad out of the box imo. Only Related Posts were not aligned properly.

#### Jetpack product discussion

* pNEWy-did-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a site running WP 5.6 Beta, either via the WordPress Beta plugin, or via `yarn docker:wp core update --version=trunk` locally.
* Go to Appearance > Themes and activate the theme.
* Go to Jetpack > Settings and activate Jetpack features that are displayed on the frontend: sharing, likes, ads, related posts
* Ensure that those features look good in all browsers.
    * We're especially interested in the look of Related Posts, since that's what's changing here.

#### Proposed changelog entry for your changes:

* Twenty Twenty-One: ensure that Jetpack's features are compatible with the upcoming new default theme 
