### PR TITLE
Connection: Auto-disconnect on plugin deactivation

### DIFF
--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -78,26 +78,26 @@ class Config {
 	 *
 	 * Usage example:
 	 * <code>
-	 * $config->ensure_bunch(
-	 *     array(
-	 *         'slug'        => 'an-example-plugin',
-	 *         'name'        => 'An Example Plugin,
-	 *         'url_info'    => 'https://example.org',
-	 *         'plugin_file' => __FILE__,
-	 *     ),
+	 * $config->setup(
 	 *     array(
 	 *         'connection' => array(
 	 *             'deactivate_disconnect' => true,
 	 *             'tos_link'              => true,
 	 *         )
+	 *     ),
+	 *     array(
+	 *         'slug'        => 'an-example-plugin',
+	 *         'name'        => 'An Example Plugin,
+	 *         'url_info'    => 'https://example.org',
+	 *         'plugin_file' => __FILE__,
 	 *     )
 	 * );
 	 * </code>
 	 *
-	 * @param array $common_options The common options to be passed into each feature's initialization method.
 	 * @param array $features       Features to be enabled and their options.
+	 * @param array $common_options The common options to be passed into each feature's initialization method.
 	 */
-	public function ensure_bunch( array $common_options, array $features ) {
+	public function setup( array $features, array $common_options ) {
 		foreach ( $features as $feature => $feature_options ) {
 			$this->ensure( $feature, array_merge( $common_options, is_array( $feature_options ) ? $feature_options : array() ) );
 		}

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -245,14 +245,14 @@ class Config {
 
 			if ( ! empty( $options['deactivate_disconnect'] ) ) {
 				if ( empty( $options['plugin_file'] ) ) {
-					$plugin_path = file_exists( WP_PLUGIN_DIR . "/{$slug}/{$slug}.php" )
-						? WP_PLUGIN_DIR . "/{$slug}/{$slug}.php"
+					$plugin_file = file_exists( WP_PLUGIN_DIR . "/{$slug}/{$slug}.php" )
+						? "{$slug}/{$slug}.php"
 						: null;
 				} else {
-					$plugin_path = $options['plugin_file'];
+					$plugin_file = basename( dirname( $options['plugin_file'] ) ) . '/' . basename( $options['plugin_file'] );
 				}
 
-				$connection->initialize_deactivate_disconnect( $plugin_path );
+				$connection->initialize_deactivate_disconnect( $plugin_file );
 			}
 		}
 

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -226,7 +226,9 @@ class Manager {
 	 * @param string $plugin_path Path to the plugin file.
 	 */
 	public function initialize_deactivate_disconnect( $plugin_path ) {
-		if ( is_plugin_active_for_network( 'jetpack/jetpack.php' ) ) {
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+
+		if ( is_plugin_active_for_network( $plugin_path ) ) {
 			register_deactivation_hook( $plugin_path, array( $this, 'deactivate_disconnect_network' ) );
 		} else {
 			register_deactivation_hook( $plugin_path, array( $this, 'deactivate_disconnect' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This commit allows plugins using `jetpack-connection` to configure the package so it would automatically disconnect from WP.com when the plugin gets deactivated.

Whether soft or hard disconnect is used is also decided automatically, depending on other plugins utilizing the connection.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Testing of this PR may not be easy, please ping me if you run into something unexpected.

*Single Site*
1. Install Jetpack and Jetpack Beta (checkout this branch), connect Jetpack.
2. Install Client-Example and checkout its branch `add/config-setup`.
3. Go to the `wp-content/plugins/client-example` directory, and create a symlink for the `vendor` dir:
```bash
ln -s /path/to/plugins/jetpack-dev/vendor
```
4. Connect Jetpack.
5. Deactivate Client Example, make sure Jetpack is still connected.
6. Activate Client Example, deactivate Jetpack. This will break the connection, so please connect back using Client Example.
7. Deactivate Client Example, activate it back.
8. Go to Client Example, confirm that it has been disconnected.

*Multisite Network*
1. Setup a multisite network with Jetpack and Jetpack Beta (checkout this branch).
2. Install Client Example and checkout its branch `add/config-setup`.
3. Go to the "Network -> Plugins" and make sure neither Jetpack nor Client Example are network-wide active.
4. Go to the `wp-content/plugins/client-example` directory, and create a symlink for the `vendor` dir:
```bash
ln -s /path/to/plugins/jetpack-dev/vendor
```
5. Create three additional sub-sites to get 4 subsites ready for testing.
6. Setup the sites in the following fashion:
**_When you activate Jetpack on sub-sites, make sure it's the `jetpack-dev` you're activating._**
_Site 1:_ Activate Jetpack and Client Example, connect Jetpack.
_Site 2:_ Activate Client-Example, connect it.
_Site 3:_ Activate Jetpack, connect it.
_Site 4:_ Don't activate anything, keep both Jetpack and Client Example disabled.
7. Go to Network Plugins and activate Client Example network-wide.
8. Go to Site 4 and connect it to WP.com (keep Jetpack disabled there).
9. Go to Network Plugins and deactivate Client Example.
10. Visit the sites:
_Site 1:_ Make sure Jetpack and Client Example are active and connected.
_Site 2:_ Confirm that Client Example is active and connected.
_Site 3:_ Confirm that Jetpack is active and connected.
_Site 4:_ Client Example should be disabled. Activate it and make sure it's not connected.

#### Proposed changelog entry for your changes:
TBD