### PR TITLE
Remove dangerous early call to is_active

### DIFF
--- a/_inc/lib/functions.wp-notify.php
+++ b/_inc/lib/functions.wp-notify.php
@@ -7,7 +7,7 @@ use Automattic\Jetpack\Redirect;
 
 // phpcs:disable WordPress.WP.I18n.MissingArgDomain --reason: WP Core string.
 
-if ( ! function_exists( 'wp_notify_postauthor' ) && Jetpack::is_active() ) :
+if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 	/**
 	 * Notify an author (and/or others) of a comment/trackback/pingback on a post.
 	 *
@@ -224,7 +224,7 @@ if ( ! function_exists( 'wp_notify_postauthor' ) && Jetpack::is_active() ) :
 	}
 endif;
 
-if ( ! function_exists( 'wp_notify_moderator' ) && Jetpack::is_active() ) :
+if ( ! function_exists( 'wp_notify_moderator' ) ) :
 	/**
 	 * Notifies the moderator of the site about a new comment that is awaiting approval.
 	 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR removes an unnecessary check to `Jetpack::is_active()` done too early that can lead to Fatal errors.

`functions.wp-notify.php` is [included](https://github.com/Automattic/jetpack/blob/update%2Fremove_early_call/class.jetpack.php#L731) if the `edit_links_calypso_redirect` is present.

This file will override two WP core pluggable functions that send email notifications. Since it has to declare the function before Core does, it has to be included super early in the load.

The problem is that `functions.wp-notify.php` has a call to `Jetpack::is_active()`, which calls `Connection\Manager::is_active()` before the whole environment is loaded. For example, when this file is loaded, functions such as `get_userdata()` do not exist yet.

My suggestion here is to remove this check, considering:

* It's super dangerous because we don't usually have this option in our environments and if we change how `is_active` works we could depend on something that is not yet loaded and lead to Fatal errors on Atomic sites
* It's not easy to emulate this situation on automated tests, so it could very well go unnoticed
* even if we could test it, this limits our possibilities of changing when a site `is_active`

And also:
* There's no UI for the user to set this option. It's only used by atomic sites so we are safe to assume that if the option is present, we should override those functions. This will not affect self-hosted sites.

As a side note, we should consider changing the approach there to use the provided filters instead of overriding the whole function, if possible.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove a check to `is_active` when an option that's only used by Atomic sites is present

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1606239364347400-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing to test really, just discuss if the argumentation is solid
