### PR TITLE
E2E Tests: In CI, also run in Firefox

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,6 +48,7 @@ jobs:
       run: yarn build-production-concurrently
 
     - name: "Install Puppeteer with ${{ matrix.browser }}"
+      if: matrix.browser != 'chrome'
       run: PUPPETEER_PRODUCT=${{ matrix.browser }} yarn add puppeteer
 
     - name: Set up environment

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,11 +11,12 @@ on:
 
 jobs:
   e2e-tests:
-    name: "E2E tests: with ${{ matrix.gutenberg }} plugin"
+    name: "E2E tests in ${{ matrix.browser }} with ${{ matrix.gutenberg }} plugin"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        browser: [ 'chrome', 'firefox' ]
         gutenberg: [ 'no', 'latest' ]
     env:
       GUTENBERG: ${{ matrix.gutenberg }}
@@ -46,6 +47,9 @@ jobs:
     - name: Build Production Jetpack
       run: yarn build-production-concurrently
 
+    - name: "Install Puppeteer with ${{ matrix.browser }}"
+      run: PUPPETEER_PRODUCT=${{ matrix.browser }} yarn add puppeteer
+
     - name: Set up environment
       env:
         NGROK_KEY: ${{ secrets.NGROK_KEY }}
@@ -56,11 +60,11 @@ jobs:
 
     - name: Run tests
       if: matrix.gutenberg == 'no'
-      run: yarn test-e2e
+      run: PUPPETEER_PRODUCT=${{ matrix.browser }} yarn test-e2e
 
     - name: Run tests (excluding updater)
       if: matrix.gutenberg == 'latest'
-      run: yarn test-e2e --testPathIgnorePatterns=updater
+      run: PUPPETEER_PRODUCT=${{ matrix.browser }} yarn test-e2e --testPathIgnorePatterns=updater
 
     - name: Upload Allure artifacts
       if: matrix.gutenberg == 'no' && always()

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -28,7 +28,7 @@ Jetpack E2E tests relies on encrypted configuration file, which is included in t
 To decrypt the config file (a8c only):
 
 - Find a decryption key. Search secret store for "E2E Jetpack CONFIG_KEY"
-- Run `CONFIG_KEY=YOUR_KEY yarn test-decrypt-config`. This command should create a new file  [`local-test.js`](./config/local-test.js)
+- Run `CONFIG_KEY=YOUR_KEY yarn test-decrypt-config`. This command should create a new file [`local-test.js`](./config/local-test.js)
 
 #### WP Site Configuration
 
@@ -56,19 +56,19 @@ yarn test-e2e
 Puppeteer runs headless by default (i.e. browser is not visible). However, sometimes it's useful to observe the browser while running tests. To see the browser window and the running tests you can pass `PUPPETEER_HEADLESS=false` as follows:
 
 ```bash
-PUPPETEER_HEADLESS=false npm run test-e2e
+PUPPETEER_HEADLESS=false yarn test-e2e
 ```
 
 To run an individual test, use the direct path to the spec. For example:
 
 ```bash
-npm run test-e2e ./tests/e2e/specs/dummy.test.js
+yarn test-e2e ./tests/e2e/specs/dummy.test.js
 ```
 
 For the best experience while debugging and/or writing new tests `E2E_DEBUG` constant is recommended to use. Also Jest's `-t` argument could be used to run single test from the test suite(file)
 
 ```bash
-E2E_DEBUG=true PUPPETEER_HEADLESS=false npm run test-e2e ./tests/e2e/specs/some.test.js -t 'Test name'
+E2E_DEBUG=true PUPPETEER_HEADLESS=false yarn test-e2e ./tests/e2e/specs/some.test.js -t 'Test name'
 ```
 
 ## Writing tests


### PR DESCRIPTION
Fixes #17874

#### Changes proposed in this Pull Request:
WIP. First stab at running e2e tests in Firefox, when run in CI.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
See if the e2e tests GH Action passes :crossed_fingers: 

To run locally (with tests visible):

```
PUPPETEER_HEADLESS=false PUPPETEER_PRODUCT=firefox yarn test-e2e
```

#### Proposed changelog entry for your changes:
E2E Tests: Also run in Firefox, when invoked from CI.

#### TODO

- [ ] Do the same for the gutenberg plugin e2e tests (further down in that file).
- [ ] Once that's done: Revert 2260dfc81bcf9398ed3ca118950be98fc5bd66a1 and 417ed45bc3b73cfa728184a71a538f78793293ea and (temporarily) push to this PR to verify that without those fixes, e2e tests fail on Firefox for Gutenberg 9.4.1.
- [x] Can we share setup parts across jobs in that file? Or make it a proper matrix (`[ 'chrome', 'firefox' ]`)? See e.g. [here](https://github.com/WordPress/wordpress-develop/blob/0d53804ea3e8a9dc40f8b6c9c481aa7a8fecb77c/.github/workflows/phpunit-tests.yml#L123-L144) for inspiration.
- [ ] Add instructions to README on how to run this locally.

cc/ @brbrr @bsessions85 