### PR TITLE
Check for VIP constant before deprecated function

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1607,7 +1607,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		// VIP context loading is handled elsewhere, so bail to prevent
 		// duplicate loading. See `switch_to_blog_and_validate_user()`
-		if ( ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) || ( function_exists( 'wpcom_is_vip' ) && wpcom_is_vip() ) ) {
+		if ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) {
 			return;
 		}
 

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1607,7 +1607,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		// VIP context loading is handled elsewhere, so bail to prevent
 		// duplicate loading. See `switch_to_blog_and_validate_user()`
-		if ( function_exists( 'wpcom_is_vip' ) && wpcom_is_vip() ) {
+		if ( ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) || ( function_exists( 'wpcom_is_vip' ) && wpcom_is_vip() ) ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The [`wpcom_is_vip()` function](https://github.com/Automattic/vip-go-mu-plugins/blob/dfc36174ce2274def920a9ed4bf88e7d50303b35/vip-helpers/vip-deprecated.php#L1096-L1110) is marked a deprecated for VIP Go sites, and the `WPCOM_IS_VIP_ENV` constant should be used instead.

Since all of the VIP sites should be off of WPCOM by the end of the this month, it may be that the `wpcom_is_vip()` function could be removed completely.