### PR TITLE
Change URL attribute type to string

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -30,7 +30,7 @@ function register_block() {
 		array(
 			'attributes'      => array(
 				'url'                    => array(
-					'type' => 'url',
+					'type' => 'string',
 				),
 				'itemsToShow'            => array(
 					'type'    => 'integer',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Our code started generating notices like this in WP 5.5.0:

> Notice: rest_validate_value_from_schema was called incorrectly. The “type” schema keyword for can only be one of the built-in types: array, object, string, number, integer, boolean, and null. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /srv/users/…/apps/…/public/wp-includes/functions.php on line 5229

The fix is to change the type to string. `url` type probably wasn't ever a thing and we had it wrong.

#### Jetpack product discussion
p8oabR-Av-p2#comment-4805

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* In WP 5.5.0, try this branch and observe the block rendered on the frontend. Compared to the default branch, the notice should be gone.

#### Proposed changelog entry for your changes:
—