### PR TITLE
API: Expose `anchor_podcast` option in the site endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -151,6 +151,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_creation_flow',
 		'is_cloud_eligible',
 		'selected_features',
+		'anchor_podcast',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -641,6 +642,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					if ( $selected_features ) {
 						$options[ $key ] = $selected_features;
 					}
+					break;
+				case 'anchor_podcast':
+					$options[ $key ] = $site->get_anchor_podcast();
 					break;
 			}
 		}

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -695,7 +695,7 @@ abstract class SAL_Site {
 	 *
 	 * @return string
 	 */
-	protected function get_anchor_podcast() {
+	public function get_anchor_podcast() {
 		return get_option( 'anchor_podcast' );
 	}
 }

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -689,4 +689,13 @@ abstract class SAL_Site {
 	public function get_selected_features() {
 		return get_option( 'selected_features' );
 	}
+
+	/**
+	 * Get the option storing the Anchor podcast ID that identifies a site as a podcasting site.
+	 *
+	 * @return string
+	 */
+	protected function get_anchor_podcast() {
+		return get_option( 'anchor_podcast' );
+	}
 }

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -321,7 +321,7 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	 *
 	 * @return string
 	 */
-	protected function get_anchor_podcast() {
+	public function get_anchor_podcast() {
 		return $this->get_atomic_cloud_site_option( 'anchor_podcast' );
 	}
 

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -316,4 +316,13 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return new Jetpack_Post( $this, $post, $context );
 	}
 
+	/**
+	 * Get the option storing the Anchor podcast ID that identifies a site as a podcasting site.
+	 *
+	 * @return string
+	 */
+	protected function get_anchor_podcast() {
+		return $this->get_atomic_cloud_site_option( 'anchor_podcast' );
+	}
+
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR exposes the new `anchor_podcast` blog option introduced in D53245-code in the response of the site endpoints. This option identifies the Anchor podcast ID used in podcasting sites set up as part of the partnership between WP.com and Anchor.

By exposing this option, we allow API consumers like Calypso to perform actions based on its value (e.g. https://github.com/Automattic/wp-calypso/pull/47747).

#### Jetpack product discussion
pbAPfg-PF-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Apply D53313-code to your WP.com sandbox.
- Modify your `/etc/hosts` file and point `public-api.wordpress.com` to the IP of your WP.com sandbox.
- Go to the [WP.com API console](https://developer.wordpress.com/docs/api/console/).
- Make a `GET` request to `/rest/v1.1/site/:site?fields=options&options=anchor_podcast` for a site where the `anchor_podcast` option is still unset.
- Make sure `options.anchor_podcast` has a `false` value.
<img width="946" alt="Screen Shot 2020-11-25 at 15 56 47" src="https://user-images.githubusercontent.com/1233880/100244719-8f5ee600-2f37-11eb-816d-304c6df69a2e.png">

- Set a `anchor_podcast` option value for your site:
  - Open a WP shell in your WP.com sandbox: `wp shell --user=<YOUR_WPCOM_USERNAME> --url=<YOUR_SITE_ADDRESS>`.
  - Update the blog option: `update_blog_option( <SITE_ID>, 'anchor_podcast', '3e51070' );`
- Repeat the `GET` request to `/rest/v1.1/site/:site?fields=options&options=anchor_podcast`.
- Make sure `options.anchor_podcast` has the value you entered above.
<img width="926" alt="Screen Shot 2020-11-25 at 15 56 25" src="https://user-images.githubusercontent.com/1233880/100245138-0300f300-2f38-11eb-9d2a-aaca9d3cd71f.png">

- Clean up the `anchor_podcast` option value from your site:
  - Open a WP shell in your WP.com sandbox: `wp shell --user=<YOUR_WPCOM_USERNAME> --url=<YOUR_SITE_ADDRESS>`.
  - Remove the blog option: `delete_blog_option( <SITE_ID>, 'anchor_podcast' );`

#### Proposed changelog entry for your changes:
N/A.