### PR TITLE
Ensure that masterbar.js is not loaded when nav-unification is enabled.

### DIFF
--- a/modules/masterbar/admin-menu/admin-menu.js
+++ b/modules/masterbar/admin-menu/admin-menu.js
@@ -27,7 +27,7 @@
 				wpwrap.classList.toggle( 'wp-responsive-open' );
 				if ( wpwrap.classList.contains( 'wp-responsive-open' ) ) {
 					setAriaExpanded( 'true' );
-					var first = document.querySelector( '#adminmenu a:first' );
+					var first = document.querySelector( '#adminmenu a' );
 					if ( first ) {
 						first.focus();
 					}

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -45,7 +45,7 @@ class Admin_Menu {
 
 		add_action( 'admin_menu', array( $this, 'reregister_menu_items' ), 99999 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts', 20 ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 	}
 

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -45,6 +45,7 @@ class Admin_Menu {
 
 		add_action( 'admin_menu', array( $this, 'reregister_menu_items' ), 99999 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts', 20 ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 	}
 

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -45,6 +45,7 @@ class Admin_Menu {
 
 		add_action( 'admin_menu', array( $this, 'reregister_menu_items' ), 99999 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 	}
 
 	/**
@@ -641,6 +642,13 @@ class Admin_Menu {
 			'1',
 			true
 		);
+	}
+
+	/**
+	 * Dequeues unnecessary scripts.
+	 */
+	public function dequeue_scripts() {
+		wp_dequeue_script( 'a8c_wpcom_masterbar_overrides' ); // Initially loaded in modules/masterbar/masterbar/class-masterbar.php.
 	}
 
 	/**

--- a/modules/masterbar/masterbar/class-masterbar.php
+++ b/modules/masterbar/masterbar/class-masterbar.php
@@ -296,13 +296,16 @@ class Masterbar {
 			false
 		);
 
-		wp_enqueue_script(
-			'a8c_wpcom_masterbar_overrides',
-			$this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ),
-			array( 'jquery' ),
-			JETPACK__VERSION,
-			false
-		);
+		if ( ! apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
+			// This ensures that masterbar.js is only loaded for sites that don't have nav-unification enabled.
+			wp_enqueue_script(
+				'a8c_wpcom_masterbar_overrides',
+				$this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ),
+				array( 'jquery' ),
+				JETPACK__VERSION,
+				false
+			);
+		}
 	}
 
 	/**

--- a/modules/masterbar/masterbar/class-masterbar.php
+++ b/modules/masterbar/masterbar/class-masterbar.php
@@ -296,6 +296,7 @@ class Masterbar {
 			false
 		);
 
+		/** This filter is already documented in modules/masterbar.php */
 		if ( ! apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
 			// This ensures that masterbar.js is only loaded for sites that don't have nav-unification enabled.
 			wp_enqueue_script(

--- a/modules/masterbar/masterbar/class-masterbar.php
+++ b/modules/masterbar/masterbar/class-masterbar.php
@@ -296,17 +296,13 @@ class Masterbar {
 			false
 		);
 
-		/** This filter is already documented in modules/masterbar.php */
-		if ( ! apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
-			// This ensures that masterbar.js is only loaded for sites that don't have nav-unification enabled.
-			wp_enqueue_script(
-				'a8c_wpcom_masterbar_overrides',
-				$this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ),
-				array( 'jquery' ),
-				JETPACK__VERSION,
-				false
-			);
-		}
+		wp_enqueue_script(
+			'a8c_wpcom_masterbar_overrides',
+			$this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ),
+			array( 'jquery' ),
+			JETPACK__VERSION,
+			false
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Builds on https://github.com/Automattic/jetpack/pull/17629

Fixes https://github.com/Automattic/jetpack/pull/17629#issuecomment-725510025

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Do not load masterbar.js for sites that have nav-unification enabled. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the same steps as in https://github.com/Automattic/jetpack/pull/17629
* Make sure that clicking on My Sites for desktop breakpoints does nothing
* Switch to a mobile breakpoint, clicking My Sites should open / close the mobile menu

Before | After
-------|------
![](https://cln.sh/FfdzLZ+) | ![](https://cln.sh/ZAhQzG+)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Displays a unified mobile menu
