### PR TITLE
Connection: Refreshing connected plugin on multisite networks

### DIFF
--- a/packages/connection/src/class-plugin-storage.php
+++ b/packages/connection/src/class-plugin-storage.php
@@ -40,6 +40,15 @@ class Plugin_Storage {
 	private static $plugins = array();
 
 	/**
+	 * The blog ID the storage is setup for.
+	 * The data will be refreshed if the blog ID changes.
+	 * Used for the multisite networks.
+	 *
+	 * @var int
+	 */
+	private static $current_blog_id = null;
+
+	/**
 	 * Add or update the plugin information in the storage.
 	 *
 	 * @param string $slug Plugin slug.
@@ -132,6 +141,11 @@ class Plugin_Storage {
 			return new WP_Error( 'too_early', __( 'You cannot call this method until Jetpack Config is configured', 'jetpack' ) );
 		}
 
+		if ( is_multisite() && get_current_blog_id() !== self::$current_blog_id ) {
+			self::$plugins         = (array) get_option( self::ACTIVE_PLUGINS_OPTION_NAME, array() );
+			self::$current_blog_id = get_current_blog_id();
+		}
+
 		return true;
 	}
 
@@ -141,9 +155,12 @@ class Plugin_Storage {
 	 * @return void
 	 */
 	public static function configure() {
-
 		if ( self::$configured ) {
 			return;
+		}
+
+		if ( is_multisite() ) {
+			self::$current_blog_id = get_current_blog_id();
 		}
 
 		// If a plugin was activated or deactivated.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
While working in a multisite network, calling `switch_to_blog()` will not refresh the list of plugins, so it will still contain the data from the original blog.
Furthermore, the new blog's data will get overwritten with the data from the original site.

This PR fixes the issue by checking if the blog ID has changed every time somebody tries to pull the list of connected plugins from the `Plugin_Storage`. If the blog ID did change, the list of plugins will be pulled from the options, thus refreshing the data stored in the `Plugin_Storage`.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
The issue is a bit hard to reproduce, so please ping me if you run into any issues along the way.

1. Create a multisite, install Jetpack and Jetpack Beta, activate both network-wide.
2. Switch Jetpack Beta to this branch (`fix/connected-plugins-multisite`).
3. Create one more sub-site so you had at least two.
4. Install `client-example`, and create a symlink to the Jetpack's `vendor` directory to get this branch's version of the packages:
```bash
ln -s /path/to/plugins/jetpack-dev/vendor
```
5. Activate `client-example` for Site 1, **do not** activate it for Site 2.
6. Add following code into the theme's `functions.php` (assuming your sub-sites have IDs `1` and `2`):
```php
add_action( 'init', function() {
        if ( ! empty( $_GET['debugme'] ) ) {
                switch_to_blog( 1 );
                var_dump( \Automattic\Jetpack\Connection\Plugin_Storage::get_all() );
                switch_to_blog( 2 );
                var_dump( \Automattic\Jetpack\Connection\Plugin_Storage::get_all() );
                die();
        }
} );
```
7. Load the debugging URL: `/wp-admin/index.php?debugme=1`.
8. Confirm that the correct plugins show up in the dump:
    - The first dump (site 1) contains both Jetpack and Client Example, because both are enabled.
    - Only Jetpack shows up in the second dump (site 2), because Client Example is not enabled there.

#### Proposed changelog entry for your changes:
n/a