### PR TITLE
Slideshow block: Force captions to have opacity

### DIFF
--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -167,6 +167,7 @@
 		left: 0;
 		margin: 0 !important;
 		max-height: 100%;
+		opacity: 1;
 		padding: 0.75em;
 		position: absolute;
 		right: 0;


### PR DESCRIPTION
This adds extra CSS to the Slideshow block captions to ensure they are visible in all themes.

Fixes #17911
Fixes https://github.com/Automattic/themes/issues/2835

#### Changes proposed in this Pull Request:

This extra CSS will make the block larger, but it's important for the block to prevent themes overriding its styles. Another solution could be to use a different class name.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
See https://github.com/Automattic/themes/issues/2835

#### Proposed changelog entry for your changes:

* Slideshow Block: show captions in all themes.
