### PR TITLE
Closes 16836 - Added NPE check for post when updating image metadata

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -176,7 +176,7 @@ class Jetpack_AMP_Support {
 			$metadata = self::add_site_icon_to_metadata( $metadata );
 		}
 
-		if ( ! isset( $metadata['image'] ) && isset($post) ) {
+		if ( ! isset( $metadata['image'] ) && ! empty($post) ) {
 			$metadata = self::add_image_to_metadata( $metadata, $post );
 		}
 

--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -176,7 +176,7 @@ class Jetpack_AMP_Support {
 			$metadata = self::add_site_icon_to_metadata( $metadata );
 		}
 
-		if ( ! isset( $metadata['image'] ) && ! empty($post) ) {
+		if ( ! isset( $metadata['image'] ) && ! empty( $post ) ) {
 			$metadata = self::add_image_to_metadata( $metadata, $post );
 		}
 

--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -176,7 +176,7 @@ class Jetpack_AMP_Support {
 			$metadata = self::add_site_icon_to_metadata( $metadata );
 		}
 
-		if ( ! isset( $metadata['image'] ) ) {
+		if ( ! isset( $metadata['image'] ) && isset($post) ) {
 			$metadata = self::add_image_to_metadata( $metadata, $post );
 		}
 


### PR DESCRIPTION
Fixes #16836.

#### Changes proposed in this Pull Request:

* Added NPE check prior to updating metadata for post, in case the post data was unavailable.

## Diagnosis and changes

At the top level, the associated filter that triggers this error is found at `3rd-party/class.jetpack-amp-support.php`:

```php
		// Add post template metadata for legacy AMP.
		add_filter( 'amp_post_template_metadata', array( 'Jetpack_AMP_Support', 'amp_post_template_metadata' ), 10, 2 );
```

which references the static method `amp_post_template_metadata` from file `3rd-party/class.jetpack-amp-support.php`, which is a deprecated method:

```php
/**
	 * Add publisher and image metadata to legacy AMP post.
	 *
	 * @since 6.2.0
	 *
	 * @param array   $metadata Metadata array.
	 * @param WP_Post $post     Post.
	 * @return array Modified metadata array.
	 */
	public static function amp_post_template_metadata( $metadata, $post ) {
		if ( isset( $metadata['publisher'] ) && ! isset( $metadata['publisher']['logo'] ) ) {
			$metadata = self::add_site_icon_to_metadata( $metadata );
		}

		if ( ! isset( $metadata['image'] )) {
			$metadata = self::add_image_to_metadata( $metadata, $post );
		}

		return $metadata;
	}
```

The above method calls function `add_image_to_metadata`, which [is legacy code](https://amp-wp.org/reference/hook/amp_post_template_metadata/). Future devs should no longer use it. Based on AMP docs recommendation:

> In general the amp_schemaorg_metadata filter should be used instead.

:warning: :bug: The above issue is [caused by a NPE](https://wiki.php.net/rfc/catchable-call-to-member-of-non-object) upon accessing `$post->ID` wherein `$post = null`, thus causing the original error:

```
[12-Aug-2020 18:31:56 UTC] PHP Notice: Trying to get property 'ID' of non-object in wp-content/plugins/jetpack/3rd-party/class.jetpack-amp-support.php on line 229
```

```php
/**
	 * Add image to legacy AMP post metadata.
	 *
	 * @since 6.2.0
	 *
	 * @param array   $metadata Metadata.
	 * @param WP_Post $post     Post.
	 * @return array Metadata.
	 */
	private static function add_image_to_metadata( $metadata, $post ) {
		$image = Jetpack_PostImages::get_image(
			$post->ID,
			array(
				'fallback_to_avatars' => true,
				'avatar_size'         => 200,
				// AMP already attempts these.
				'from_thumbnail'      => false,
				'from_attachment'     => false,
			)
		);

		if ( empty( $image ) ) {
			return self::add_fallback_image_to_metadata( $metadata );
		}

		if ( ! isset( $image['src_width'] ) ) {
			$dimensions = self::extract_image_dimensions_from_getimagesize(
				array(
					$image['src'] => false,
				)
			);

			if ( false !== $dimensions[ $image['src'] ] ) {
				$image['src_width']  = $dimensions['width'];
				$image['src_height'] = $dimensions['height'];
			}
		}

		$metadata['image'] = array(
			'@type' => 'ImageObject',
			'url'   => $image['src'],
		);
		if ( isset( $image['src_width'] ) ) {
			$metadata['image']['width'] = $image['src_width'];
		}
		if ( isset( $image['src_width'] ) ) {
			$metadata['image']['height'] = $image['src_height'];
		}

		return $metadata;
	}
```

**Recommendation:**

because the method `add_image_to_metadata` depends on the `$post` object to retrieve the image, the whole operation should not proceed if it doesn't have the necessary dependency `$post` (for whatever reason that prevents it from retrieving the post- e.g. limitations for backwards compatibility).

**Notes:**

This error occurs on lower versions of PHP, but on newer versions of PHP, this is a silent error. Having an explicit NPE check increases resilience of the plugin.

#### Does this pull request change what data or activity we track or use?

No it doesn't. It prevents error logs from occurring, because of missing checks.

#### Testing instructions:

Before 

<img width="552" alt="image" src="https://user-images.githubusercontent.com/2420577/100551995-443e2d80-32bf-11eb-9df1-18a70841725d.png">

After

<img width="549" alt="image" src="https://user-images.githubusercontent.com/2420577/100552012-5a4bee00-32bf-11eb-8961-17aa8f6e5a3d.png">


#### Proposed changelog entry for your changes:

* Added null pointer checks before performing metadata updates for AMP on legacy method.