### PR TITLE
Serialize Videopress Block Anchor as <figure /> Id

### DIFF
--- a/extensions/blocks/videopress/edit.js
+++ b/extensions/blocks/videopress/edit.js
@@ -310,7 +310,7 @@ const VideoPressEdit = CoreVideoEdit =>
 			return (
 				<Fragment>
 					{ blockSettings }
-					<BlockFigureWrapper id={anchor} className={ sandboxClassnames }>
+					<BlockFigureWrapper id={ anchor } className={ sandboxClassnames }>
 						<div className="wp-block-embed__wrapper">
 							<SandBox html={ html } scripts={ scripts } type={ sandboxClassnames } />
 						</div>

--- a/extensions/blocks/videopress/edit.js
+++ b/extensions/blocks/videopress/edit.js
@@ -182,7 +182,7 @@ const VideoPressEdit = CoreVideoEdit =>
 				setAttributes,
 			} = this.props;
 			const { fallback, isFetchingMedia, interactive } = this.state;
-			const { autoplay, caption, controls, loop, muted, poster, preload } = attributes;
+			const { autoplay, caption, controls, loop, muted, poster, preload, anchor } = attributes;
 
 			const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
 
@@ -310,7 +310,7 @@ const VideoPressEdit = CoreVideoEdit =>
 			return (
 				<Fragment>
 					{ blockSettings }
-					<BlockFigureWrapper className={ sandboxClassnames }>
+					<BlockFigureWrapper id={anchor} className={ sandboxClassnames }>
 						<div className="wp-block-embed__wrapper">
 							<SandBox html={ html } scripts={ scripts } type={ sandboxClassnames } />
 						</div>


### PR DESCRIPTION
This PR forwards the anchor attribute of the core/video block to the rendered `figure` element. This fixes the issue of the anchor being lost on save. 

Fixes https://github.com/Automattic/wp-calypso/issues/47254

#### Testing instructions:
TBD

#### Proposed changelog entry for your changes:
This is a bug fix, please let me know if a changelog entry is needed.

Thanks!