### PR TITLE
Jetpack Search: fix PHP notice raised when generate_widget_filter_name is called without a widget filter type

### DIFF
--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -227,6 +227,10 @@ class Jetpack_Search_Helpers {
 	static function generate_widget_filter_name( $widget_filter ) {
 		$name = '';
 
+		if ( ! is_array( $widget_filter ) || ! array_key_exists( 'type', $widget_filter ) ) {
+			return $name;
+		}
+
 		switch ( $widget_filter['type'] ) {
 			case 'post_type':
 				$name = _x( 'Post Types', 'label for filtering posts', 'jetpack' );

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -227,7 +227,7 @@ class Jetpack_Search_Helpers {
 	static function generate_widget_filter_name( $widget_filter ) {
 		$name = '';
 
-		if ( ! is_array( $widget_filter ) || ! array_key_exists( 'type', $widget_filter ) ) {
+		if ( ! isset( $widget_filter['type'] ) ) {
 			return $name;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15716.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Fixes a PHP notice spotted by @kraftbj in #15716.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Borrowed from the original issue:

* Run Site Health with Query Monitor installed with PHP notices enabled.
* Make sure there are no PHP notices related to `generate_widget_filter_name` in the console.
* Make sure your search filters still have a reasonable default name, if you haven't specified one.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
Not required.
