### PR TITLE
React Dashboard: Fix focusTrap import

### DIFF
--- a/_inc/client/components/modal/index.jsx
+++ b/_inc/client/components/modal/index.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import { assign, omit } from 'lodash';
-import focusTrap from 'focus-trap';
+import { createFocusTrap } from 'focus-trap';
 
 // this flag will prevent ANY modals from closing.
 // use with caution!
@@ -51,7 +51,8 @@ class Modal extends React.Component {
 		jQuery( 'body' ).addClass( 'dops-modal-showing' ).on( 'touchmove.dopsmodal', false );
 		jQuery( document ).keyup( this.handleEscapeKey );
 		try {
-			focusTrap.activate( ReactDOM.findDOMNode( this ), {
+			this.focusTrap = createFocusTrap( ReactDOM.findDOMNode( this ) );
+			this.focusTrap.activate( {
 				// onDeactivate: this.maybeClose,
 				initialFocus: this.props.initialFocus,
 			} );
@@ -64,7 +65,7 @@ class Modal extends React.Component {
 		jQuery( 'body' ).removeClass( 'dops-modal-showing' ).off( 'touchmove.dopsmodal', false );
 		jQuery( document ).unbind( 'keyup', this.handleEscapeKey );
 		try {
-			focusTrap.deactivate();
+			this.focusTrap.deactivate();
 		} catch ( e ) {
 			//noop
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
One of the build errors when attempting to upgrade the `@automattic/calypso-build` dependency to `v6.3.0` (#16845) is that the `focus-trap` npm module doesn't have a default export symbol. (This is confirmed by [its docs](https://github.com/focus-trap/focus-trap#usage).)

I assume that we're relying on a Babel plugin to add those default exports (mostly for CommonJS backwards compatibility), and the new calypso-build version would drop it. However, it even seems like `focus-trap`'s API has long changed, so the current approach probably doesn't really work anyway (and just fails silently, since it's wrapped in `try...catch` calls).

Some more context:
- `focusTrap` was first introduced by Osk in #8208 (as part of the big PR that brought dops-components into JP). At the time, the `focus-trap` version used per `package.json` was [`^2.3.1`](https://github.com/Automattic/jetpack/pull/8208/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R61).
- CommonJS `require`s were updated to ESM `import`s by yours truly in #11677.
- The breaking `focus-trap` API change [apparently happened in `v6.0.0`](https://github.com/focus-trap/focus-trap/blob/27e39e08161d4279ac41017c2fc80e8da5d728fa/CHANGELOG.md#600).
- JP was updated to use that version in #17516 (about a month ago).

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
Nah.

#### Testing instructions:
I don't really know what this does :grimacing: 

#### Proposed changelog entry for your changes:
React Dashboard: Fix focusTrap import.