### PR TITLE
Calypsoify: fix Masterbar reference after its refactor

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -4,6 +4,7 @@
  * Ported from an internal Automattic plugin.
  */
 
+use Automattic\Jetpack\Dashboard_Customizations\Masterbar;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
@@ -76,8 +77,8 @@ class Jetpack_Calypsoify {
 	}
 
 	public function mock_masterbar_activation() {
-		include_once JETPACK__PLUGIN_DIR . 'modules/masterbar/masterbar.php';
-		new A8C_WPCOM_Masterbar;
+		include_once JETPACK__PLUGIN_DIR . 'modules/masterbar/masterbar/class-masterbar.php';
+		new Masterbar();
 	}
 
 	public function remove_core_menus() {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,9 @@
 		<testsuite name="comment-likes">
 			<directory prefix="test" suffix=".php">tests/php/modules/comment-likes</directory>
 		</testsuite>
+		<testsuite name="calypsoify">
+			<directory prefix="test" suffix=".php">tests/php/modules/calypsoify</directory>
+		</testsuite>
 		<testsuite name="likes">
 			<directory prefix="test_" suffix=".php">tests/php/modules/likes</directory>
 		</testsuite>

--- a/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
+++ b/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Class Calypsoify.
+ *
+ * @package Jetpack
+ */
+
+require_jetpack_file( 'modules/calypsoify/class.jetpack-calypsoify.php' );
+
+/**
+ * Class WP_Test_Jetpack_Calypsoify
+ */
+class WP_Test_Jetpack_Calypsoify extends WP_UnitTestCase {
+
+	/**
+	 * Sets up each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = Jetpack_Calypsoify::getInstance();
+	}
+
+	/**
+	 * Sets up the Masterbar mock.
+	 *
+	 * For sites when Masterbar is not active, we mock it. This test confirms that functions.
+	 *
+	 * @covers Jetpack_Calypsoify::mock_masterbar_activation
+	 * @see https://github.com/Automattic/jetpack/pull/17939
+	 */
+	public function test_mock_masterbar_activation() {
+		$this->instance->mock_masterbar_activation();
+		$this->assertTrue( class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Masterbar' ) );
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* In #17762 and #17783 we've refactored the Masterbar, but forgot to update references to it in the Calypsoify feature, thus causing Fatal errors.


#### Jetpack product discussion

* p1606836053244800-slack-C02C4GXMY

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a fresh Jetpack site running this branch.
* Go to Jetpack > Settings and enable SSO.
* Go to `https://wordpress.com/posts/yoursite.com`
* Click on the button to start writing a new post.
* You should not see any Fatal errors

#### Proposed changelog entry for your changes:

* WordPress.com Toolbar: avoid Fatal errors when the feature is not active.