### PR TITLE
Calypsoify: Add test to fail under 9.2

### DIFF
--- a/_inc/client/components/modal/index.jsx
+++ b/_inc/client/components/modal/index.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import { assign, omit } from 'lodash';
-import focusTrap from 'focus-trap';
+import { createFocusTrap } from 'focus-trap';
 
 // this flag will prevent ANY modals from closing.
 // use with caution!
@@ -51,7 +51,8 @@ class Modal extends React.Component {
 		jQuery( 'body' ).addClass( 'dops-modal-showing' ).on( 'touchmove.dopsmodal', false );
 		jQuery( document ).keyup( this.handleEscapeKey );
 		try {
-			focusTrap.activate( ReactDOM.findDOMNode( this ), {
+			this.focusTrap = createFocusTrap( ReactDOM.findDOMNode( this ) );
+			this.focusTrap.activate( {
 				// onDeactivate: this.maybeClose,
 				initialFocus: this.props.initialFocus,
 			} );
@@ -64,7 +65,7 @@ class Modal extends React.Component {
 		jQuery( 'body' ).removeClass( 'dops-modal-showing' ).off( 'touchmove.dopsmodal', false );
 		jQuery( document ).unbind( 'keyup', this.handleEscapeKey );
 		try {
-			focusTrap.deactivate();
+			this.focusTrap.deactivate();
 		} catch ( e ) {
 			//noop
 		}

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -13,6 +13,11 @@ Branches use the following naming conventions:
 
 For example, you can run: `git checkout master` and then `git checkout -b fix/whatsits` to create a new `fix/whatsits` branch off of `origin/master`.
 
+The Jetpack repo uses the following "reserved" branch name conventions:
+
+* `branch-{X.Y|something}[-built]` -- Used for release branches
+* `feature/{something}` -- Used for feature branches for larger feature projects when anticipated there will be multiple PRs into that feature branch. 
+
 ## Mind your commits
 
 * [Check In Early, Check In Often](http://blog.codinghorror.com/check-in-early-check-in-often/).

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,9 @@
 		<testsuite name="comment-likes">
 			<directory prefix="test" suffix=".php">tests/php/modules/comment-likes</directory>
 		</testsuite>
+		<testsuite name="calypsoify">
+			<directory prefix="test" suffix=".php">tests/php/modules/calypsoify</directory>
+		</testsuite>
 		<testsuite name="likes">
 			<directory prefix="test_" suffix=".php">tests/php/modules/likes</directory>
 		</testsuite>

--- a/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
+++ b/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Class Calypsoify.
+ *
+ * @package Jetpack
+ */
+
+require_jetpack_file( 'modules/calypsoify/class.jetpack-calypsoify.php' );
+
+/**
+ * Class WP_Test_Jetpack_Calypsoify
+ */
+class WP_Test_Jetpack_Calypsoify extends WP_UnitTestCase {
+
+	/**
+	 * Sets up each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = Jetpack_Calypsoify::getInstance();
+	}
+
+	/**
+	 * Sets up the Masterbar mock.
+	 *
+	 * For sites when Masterbar is not active, we mock it. This test confirms that functions.
+	 *
+	 * @covers Jetpack_Calypsoify::mock_masterbar_activation
+	 * @see https://github.com/Automattic/jetpack/pull/17939
+	 */
+	public function test_mock_masterbar_activation() {
+		$this->instance->mock_masterbar_activation();
+		$this->assertTrue( class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Masterbar' ) );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

See #17939

Adds an unit test to call the `mock_masterbar_activation` function to ensure it doesn't error.

As it stands, this PR will fail. Coupled with 17939, it should pass.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds unit test.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unit tests should fail. You can test directly under `yarn docker:phpunit --testsuite=calyposify`
* Merged into 17939 or into `master` after that's merged, it should pass.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
