### PR TITLE
Replace pluggable function with filter callbacks

### DIFF
--- a/_inc/lib/functions.wp-notify.php
+++ b/_inc/lib/functions.wp-notify.php
@@ -1,400 +1,400 @@
 <?php
 /** phpcs:disable Squiz.Commenting.FileComment.MissingPackageTag,Generic.Commenting.DocComment.MissingShort
- * Register two plugabble functions to handle notification emails to authors and moderators.
+ *
+ * Declare two functions to handle notification emails to authors and moderators.
+ *
+ * These functions are hooked into filters to short circuit the regular flow and send the emails.
+ * Code was copied from the original pluggable functions and slightly modified (modifications are commented).
+ *
+ * In the past, we used to overwrite the whole pluggable function, but we started using filters to avoid having
+ * to check for Jetpack::is_active() too early in the load flow.
  */
 
 use Automattic\Jetpack\Redirect;
 
 // phpcs:disable WordPress.WP.I18n.MissingArgDomain --reason: WP Core string.
 
-if ( ! function_exists( 'wp_notify_postauthor' ) && Jetpack::is_active() ) :
-	/**
-	 * Notify an author (and/or others) of a comment/trackback/pingback on a post.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int|WP_Comment $comment_id Comment ID or WP_Comment object.
-	 * @param string         $deprecated Not used.
-	 * @return bool True on completion. False if no email addresses were specified.
-	 */
-	function wp_notify_postauthor( $comment_id, $deprecated = null ) {
-		if ( null !== $deprecated ) {
-			_deprecated_argument( __FUNCTION__, '3.8.0' );
-		}
-
-		$comment = get_comment( $comment_id );
-
-		if ( empty( $comment ) || empty( $comment->comment_post_ID ) ) {
-			return false;
-		}
-
-		$post   = get_post( $comment->comment_post_ID );
-		$author = get_userdata( $post->post_author );
-
-		// Who to notify? By default, just the post author, but others can be added.
-		$emails = array();
-		if ( $author ) {
-			$emails[] = $author->user_email;
-		}
-
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$emails = apply_filters( 'comment_notification_recipients', $emails, $comment->comment_ID );
-		$emails = array_filter( $emails );
-
-		// If there are no addresses to send the comment to, bail.
-		if ( ! count( $emails ) ) {
-			return false;
-		}
-
-		// Facilitate unsetting below without knowing the keys.
-		$emails = array_flip( $emails );
-
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$notify_author = apply_filters( 'comment_notification_notify_author', false, $comment->comment_ID );
-
-		// The comment was left by the author.
-		if ( $author && ! $notify_author && $comment->user_id == $post->post_author ) {
-			unset( $emails[ $author->user_email ] );
-		}
-
-		// The author moderated a comment on their own post.
-		if ( $author && ! $notify_author && get_current_user_id() == $post->post_author ) {
-			unset( $emails[ $author->user_email ] );
-		}
-
-		// The post author is no longer a member of the blog.
-		if ( $author && ! $notify_author && ! user_can( $post->post_author, 'read_post', $post->ID ) ) {
-			unset( $emails[ $author->user_email ] );
-		}
-
-		// If there's no email to send the comment to, bail, otherwise flip array back around for use below.
-		if ( ! count( $emails ) ) {
-			return false;
-		} else {
-			$emails = array_flip( $emails );
-		}
-
-		$switched_locale = switch_to_locale( get_locale() );
-
-		$comment_author_domain = @gethostbyaddr( $comment->comment_author_IP );
-
-		// The blogname option is escaped with esc_html on the way into the database in sanitize_option
-		// we want to reverse this for the plain text arena of emails.
-		$blogname        = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-		$comment_content = wp_specialchars_decode( $comment->comment_content );
-
-		// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-		function is_user_connected( $email ) {
-			$user = get_user_by( 'email', $email );
-			return Jetpack::is_user_connected( $user->ID );
-		}
-
-		$moderate_on_wpcom = ! in_array( false, array_map( 'is_user_connected', $emails ) );
-
-		switch ( $comment->comment_type ) {
-			case 'trackback':
-				/* translators: 1: Post title */
-				$notify_message = sprintf( __( 'New trackback on your post "%s"' ), $post->post_title ) . "\r\n";
-				/* translators: 1: Trackback/pingback website name, 2: website IP address, 3: website hostname */
-				$notify_message .= sprintf( __( 'Website: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
-				/* translators: %s: Site URL */
-				$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
-				/* translators: %s: Comment Content */
-				$notify_message     .= sprintf( __( 'Comment: %s' ), "\r\n" . $comment_content ) . "\r\n\r\n";
-					$notify_message .= __( 'You can see all trackbacks on this post here:' ) . "\r\n";
-					/* translators: 1: blog name, 2: post title */
-					$subject = sprintf( __( '[%1$s] Trackback: "%2$s"' ), $blogname, $post->post_title );
-				break;
-			case 'pingback':
-				/* translators: 1: Post title */
-				$notify_message = sprintf( __( 'New pingback on your post "%s"' ), $post->post_title ) . "\r\n";
-				/* translators: 1: Trackback/pingback website name, 2: website IP address, 3: website hostname */
-				$notify_message .= sprintf( __( 'Website: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
-				/* translators: %s: Site URL */
-				$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
-				/* translators: %s: Comment Content */
-				$notify_message .= sprintf( __( 'Comment: %s' ), "\r\n" . $comment_content ) . "\r\n\r\n";
-				$notify_message .= __( 'You can see all pingbacks on this post here:' ) . "\r\n";
-				/* translators: 1: blog name, 2: post title */
-				$subject = sprintf( __( '[%1$s] Pingback: "%2$s"' ), $blogname, $post->post_title );
-				break;
-			default: // Comments.
-				/* translators: 1: Post title */
-				$notify_message = sprintf( __( 'New comment on your post "%s"' ), $post->post_title ) . "\r\n";
-				/* translators: 1: comment author, 2: comment author's IP address, 3: comment author's hostname */
-				$notify_message .= sprintf( __( 'Author: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
-				/* translators: %s: Email address */
-				$notify_message .= sprintf( __( 'Email: %s' ), $comment->comment_author_email ) . "\r\n";
-				/* translators: %s: Site URL */
-				$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
-				/* translators: %s: Comment Content */
-				$notify_message .= sprintf( __( 'Comment: %s' ), "\r\n" . $comment_content ) . "\r\n\r\n";
-				$notify_message .= __( 'You can see all comments on this post here:' ) . "\r\n";
-				/* translators: 1: blog name, 2: post title */
-				$subject = sprintf( __( '[%1$s] Comment: "%2$s"' ), $blogname, $post->post_title );
-				break;
-		}
-
-		$notify_message .= $moderate_on_wpcom
-			? Redirect::get_url(
-				'calypso-comments-all',
-				array(
-					'path' => $comment->comment_post_ID,
-				)
-			) . "/\r\n\r\n"
-			: get_permalink( $comment->comment_post_ID ) . "#comments\r\n\r\n";
-
-		/* translators: %s: URL */
-		$notify_message .= sprintf( __( 'Permalink: %s' ), get_comment_link( $comment ) ) . "\r\n";
-
-		$base_wpcom_edit_comment_url = Redirect::get_url(
-			'calypso-edit-comment',
-			array(
-				'path'  => $comment_id,
-				'query' => 'action=__action__', // __action__ will be replaced by the actual action.
-			)
-		);
-
-		if ( user_can( $post->post_author, 'edit_comment', $comment->comment_ID ) ) {
-			if ( EMPTY_TRASH_DAYS ) {
-				$notify_message .= sprintf(
-					/* translators: Placeholder is the edit URL */
-					__( 'Trash it: %s' ),
-					$moderate_on_wpcom
-					? str_replace( '__action__', 'trash', $base_wpcom_edit_comment_url )
-					: admin_url( "comment.php?action=trash&c={$comment->comment_ID}#wpbody-content" )
-				) . "\r\n";
-			} else {
-				$notify_message .= sprintf(
-					/* translators: Placeholder is the edit URL */
-					__( 'Delete it: %s' ),
-					$moderate_on_wpcom
-					? str_replace( '__action__', 'delete', $base_wpcom_edit_comment_url )
-					: admin_url( "comment.php?action=delete&c={$comment->comment_ID}#wpbody-content" )
-				) . "\r\n";
-			}
-			$notify_message .= sprintf(
-				/* translators: Placeholder is the edit URL */
-				__( 'Spam it: %s' ),
-				$moderate_on_wpcom
-				? str_replace( '__action__', 'spam', $base_wpcom_edit_comment_url )
-				: admin_url( "comment.php?action=spam&c={$comment->comment_ID}#wpbody-content" )
-			) . "\r\n";
-		}
-
-		$wp_email = 'wordpress@' . preg_replace( '#^www\.#', '', strtolower( $_SERVER['SERVER_NAME'] ) );
-
-		if ( '' == $comment->comment_author ) {
-			$from = "From: \"$blogname\" <$wp_email>";
-			if ( '' != $comment->comment_author_email ) {
-				$reply_to = "Reply-To: $comment->comment_author_email";
-			}
-		} else {
-			$from = "From: \"$comment->comment_author\" <$wp_email>";
-			if ( '' != $comment->comment_author_email ) {
-				$reply_to = "Reply-To: \"$comment->comment_author_email\" <$comment->comment_author_email>";
-			}
-		}
-
-		$message_headers = "$from\n"
-			. 'Content-Type: text/plain; charset="' . get_option( 'blog_charset' ) . "\"\n";
-
-		if ( isset( $reply_to ) ) {
-			$message_headers .= $reply_to . "\n";
-		}
-
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$notify_message = apply_filters( 'comment_notification_text', $notify_message, $comment->comment_ID );
-
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$subject = apply_filters( 'comment_notification_subject', $subject, $comment->comment_ID );
-
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$message_headers = apply_filters( 'comment_notification_headers', $message_headers, $comment->comment_ID );
-
-		foreach ( $emails as $email ) {
-			@wp_mail( $email, wp_specialchars_decode( $subject ), $notify_message, $message_headers );
-		}
-
-		if ( $switched_locale ) {
-			restore_previous_locale();
-		}
-
-		return true;
+/**
+ * Short circuits the {@see `wp_notify_postauthor`} function via the `comment_notification_recipients` filter.
+ *
+ * Notify an author (and/or others) of a comment/trackback/pingback on a post.
+ *
+ * @since 5.8.0
+ * @since 9.3.0 Switched from pluggable function to filter callback
+ *
+ * @param array          $emails List of recipients.
+ * @param int|WP_Comment $comment_id Comment ID or WP_Comment object.
+ * @return array Empty array to shortcircuit wp_notify_postauthor execution. $emails if we want to disable the filter.
+ */
+function jetpack_notify_postauthor( $emails, $comment_id ) {
+	// Don't do anything if Jetpack isn't active.
+	if ( ! Jetpack::is_active() || empty( $emails ) ) {
+		return $emails;
 	}
-endif;
 
-if ( ! function_exists( 'wp_notify_moderator' ) && Jetpack::is_active() ) :
-	/**
-	 * Notifies the moderator of the site about a new comment that is awaiting approval.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @global wpdb $wpdb WordPress database abstraction object.
-	 *
-	 * Uses the {@see 'notify_moderator'} filter to determine whether the site moderator
-	 * should be notified, overriding the site setting.
-	 *
-	 * @param int $comment_id Comment ID.
-	 * @return true Always returns true.
-	 */
-	function wp_notify_moderator( $comment_id ) {
-		global $wpdb;
+	// Original function modified: Code before the comment_notification_recipients filter removed.
 
-		$maybe_notify = get_option( 'moderation_notify' );
+	$comment = get_comment( $comment_id );
 
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$maybe_notify = apply_filters( 'notify_moderator', $maybe_notify, $comment_id );
+	$post   = get_post( $comment->comment_post_ID );
+	$author = get_userdata( $post->post_author );
 
-		if ( ! $maybe_notify ) {
-			return true;
-		}
+	// Facilitate unsetting below without knowing the keys.
+	$emails = array_flip( $emails );
 
-		$comment = get_comment( $comment_id );
-		$post    = get_post( $comment->comment_post_ID );
-		$user    = get_userdata( $post->post_author );
-		// Send to the administration and to the post author if the author can modify the comment.
-		$emails = array( get_option( 'admin_email' ) );
-		if ( $user && user_can( $user->ID, 'edit_comment', $comment_id ) && ! empty( $user->user_email ) ) {
-			if ( 0 !== strcasecmp( $user->user_email, get_option( 'admin_email' ) ) ) {
-				$emails[] = $user->user_email;
-			}
-		}
+	/** This filter is documented in core/src/wp-includes/pluggable.php */
+	$notify_author = apply_filters( 'comment_notification_notify_author', false, $comment->comment_ID );
 
-		$switched_locale = switch_to_locale( get_locale() );
+	// The comment was left by the author.
+	if ( $author && ! $notify_author && $comment->user_id == $post->post_author ) {
+		unset( $emails[ $author->user_email ] );
+	}
 
-		$comment_author_domain = @gethostbyaddr( $comment->comment_author_IP );
-		$comments_waiting      = $wpdb->get_var( "SELECT count(comment_ID) FROM $wpdb->comments WHERE comment_approved = '0'" );
+	// The author moderated a comment on their own post.
+	if ( $author && ! $notify_author && get_current_user_id() == $post->post_author ) {
+		unset( $emails[ $author->user_email ] );
+	}
 
-		// The blogname option is escaped with esc_html on the way into the database in sanitize_option
-		// we want to reverse this for the plain text arena of emails.
-		$blogname        = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-		$comment_content = wp_specialchars_decode( $comment->comment_content );
+	// The post author is no longer a member of the blog.
+	if ( $author && ! $notify_author && ! user_can( $post->post_author, 'read_post', $post->ID ) ) {
+		unset( $emails[ $author->user_email ] );
+	}
 
-		switch ( $comment->comment_type ) {
-			case 'trackback':
-				/* translators: 1: Post title */
-				$notify_message  = sprintf( __( 'A new trackback on the post "%s" is waiting for your approval' ), $post->post_title ) . "\r\n";
-				$notify_message .= get_permalink( $comment->comment_post_ID ) . "\r\n\r\n";
-				/* translators: 1: Trackback/pingback website name, 2: website IP address, 3: website hostname */
-				$notify_message .= sprintf( __( 'Website: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
-				/* translators: 1: Trackback/pingback/comment author URL */
-				$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
-				$notify_message .= __( 'Trackback excerpt: ' ) . "\r\n" . $comment_content . "\r\n\r\n";
-				break;
-			case 'pingback':
-				/* translators: 1: Post title */
-				$notify_message  = sprintf( __( 'A new pingback on the post "%s" is waiting for your approval' ), $post->post_title ) . "\r\n";
-				$notify_message .= get_permalink( $comment->comment_post_ID ) . "\r\n\r\n";
-				/* translators: 1: Trackback/pingback website name, 2: website IP address, 3: website hostname */
-				$notify_message .= sprintf( __( 'Website: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
-				/* translators: 1: Trackback/pingback/comment author URL */
-				$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
-				$notify_message .= __( 'Pingback excerpt: ' ) . "\r\n" . $comment_content . "\r\n\r\n";
-				break;
-			default: // Comments.
-				/* translators: 1: Post title */
-				$notify_message  = sprintf( __( 'A new comment on the post "%s" is waiting for your approval' ), $post->post_title ) . "\r\n";
-				$notify_message .= get_permalink( $comment->comment_post_ID ) . "\r\n\r\n";
-				/* translators: 1: Comment author name, 2: comment author's IP address, 3: comment author's hostname */
-				$notify_message .= sprintf( __( 'Author: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
-				/* translators: 1: Comment author URL */
-				$notify_message .= sprintf( __( 'Email: %s' ), $comment->comment_author_email ) . "\r\n";
-				/* translators: 1: Trackback/pingback/comment author URL */
-				$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
-				/* translators: 1: Comment text */
-				$notify_message .= sprintf( __( 'Comment: %s' ), "\r\n" . $comment_content ) . "\r\n\r\n";
-				break;
-		}
+	// If there's no email to send the comment to, bail, otherwise flip array back around for use below.
+	if ( ! count( $emails ) ) {
+		return array(); // Original function modified. Return empty array instead of false.
+	} else {
+		$emails = array_flip( $emails );
+	}
 
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$emails = apply_filters( 'comment_moderation_recipients', $emails, $comment_id );
+	$switched_locale = switch_to_locale( get_locale() );
 
-		// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-		function is_user_connected( $email ) {
-			$user = get_user_by( 'email', $email );
-			return Jetpack::is_user_connected( $user->ID );
-		}
+	$comment_author_domain = '';
+	if ( WP_Http::is_ip_address( $comment->comment_author_IP ) ) {
+		$comment_author_domain = gethostbyaddr( $comment->comment_author_IP );
+	}
 
-		$moderate_on_wpcom = ! in_array( false, array_map( 'is_user_connected', $emails ) );
+	// The blogname option is escaped with esc_html on the way into the database in sanitize_option
+	// we want to reverse this for the plain text arena of emails.
+	$blogname        = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+	$comment_content = wp_specialchars_decode( $comment->comment_content );
 
-		$base_wpcom_edit_comment_url = Redirect::get_url(
-			'calypso-edit-comment',
+	// Original function modified.
+	$moderate_on_wpcom = ! in_array( false, array_map( 'jetpack_notify_is_user_connected_by_email', $emails ) );
+
+	switch ( $comment->comment_type ) {
+		case 'trackback':
+			/* translators: 1: Post title */
+			$notify_message = sprintf( __( 'New trackback on your post "%s"' ), $post->post_title ) . "\r\n";
+			/* translators: 1: Trackback/pingback website name, 2: website IP address, 3: website hostname */
+			$notify_message .= sprintf( __( 'Website: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+			/* translators: %s: Site URL */
+			$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
+			/* translators: %s: Comment Content */
+			$notify_message     .= sprintf( __( 'Comment: %s' ), "\r\n" . $comment_content ) . "\r\n\r\n";
+				$notify_message .= __( 'You can see all trackbacks on this post here:' ) . "\r\n";
+				/* translators: 1: blog name, 2: post title */
+				$subject = sprintf( __( '[%1$s] Trackback: "%2$s"' ), $blogname, $post->post_title );
+			break;
+		case 'pingback':
+			/* translators: 1: Post title */
+			$notify_message = sprintf( __( 'New pingback on your post "%s"' ), $post->post_title ) . "\r\n";
+			/* translators: 1: Trackback/pingback website name, 2: website IP address, 3: website hostname */
+			$notify_message .= sprintf( __( 'Website: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+			/* translators: %s: Site URL */
+			$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
+			/* translators: %s: Comment Content */
+			$notify_message .= sprintf( __( 'Comment: %s' ), "\r\n" . $comment_content ) . "\r\n\r\n";
+			$notify_message .= __( 'You can see all pingbacks on this post here:' ) . "\r\n";
+			/* translators: 1: blog name, 2: post title */
+			$subject = sprintf( __( '[%1$s] Pingback: "%2$s"' ), $blogname, $post->post_title );
+			break;
+		default: // Comments.
+			/* translators: 1: Post title */
+			$notify_message = sprintf( __( 'New comment on your post "%s"' ), $post->post_title ) . "\r\n";
+			/* translators: 1: comment author, 2: comment author's IP address, 3: comment author's hostname */
+			$notify_message .= sprintf( __( 'Author: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+			/* translators: %s: Email address */
+			$notify_message .= sprintf( __( 'Email: %s' ), $comment->comment_author_email ) . "\r\n";
+			/* translators: %s: Site URL */
+			$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
+			/* translators: %s: Comment Content */
+			$notify_message .= sprintf( __( 'Comment: %s' ), "\r\n" . $comment_content ) . "\r\n\r\n";
+			$notify_message .= __( 'You can see all comments on this post here:' ) . "\r\n";
+			/* translators: 1: blog name, 2: post title */
+			$subject = sprintf( __( '[%1$s] Comment: "%2$s"' ), $blogname, $post->post_title );
+			break;
+	}
+
+	// Original function modified: Consider $moderate_on_wpcom when building $notify_message.
+	$notify_message .= $moderate_on_wpcom
+		? Redirect::get_url(
+			'calypso-comments-all',
 			array(
-				'path'  => $comment_id,
-				'query' => 'action=__action__', // __action__ will be replaced by the actual action.
+				'path' => $comment->comment_post_ID,
 			)
-		);
+		) . "/\r\n\r\n"
+		: get_permalink( $comment->comment_post_ID ) . "#comments\r\n\r\n";
 
-		$notify_message .= sprintf(
-			/* translators: Comment moderation. 1: Comment action URL */
-			__( 'Approve it: %s' ),
-			$moderate_on_wpcom
-			? str_replace( '__action__', 'approve', $base_wpcom_edit_comment_url )
-			: admin_url( "comment.php?action=approve&c={$comment_id}#wpbody-content" )
-		) . "\r\n";
+	/* translators: %s: URL */
+	$notify_message .= sprintf( __( 'Permalink: %s' ), get_comment_link( $comment ) ) . "\r\n";
 
+	$base_wpcom_edit_comment_url = Redirect::get_url(
+		'calypso-edit-comment',
+		array(
+			'path'  => $comment_id,
+			'query' => 'action=__action__', // __action__ will be replaced by the actual action.
+		)
+	);
+
+	// Original function modified: Consider $moderate_on_wpcom when building $notify_message.
+	if ( user_can( $post->post_author, 'edit_comment', $comment->comment_ID ) ) {
 		if ( EMPTY_TRASH_DAYS ) {
 			$notify_message .= sprintf(
-				/* translators: Comment moderation. 1: Comment action URL */
+				/* translators: Placeholder is the edit URL */
 				__( 'Trash it: %s' ),
 				$moderate_on_wpcom
 				? str_replace( '__action__', 'trash', $base_wpcom_edit_comment_url )
-				: admin_url( "comment.php?action=trash&c={$comment_id}#wpbody-content" )
+				: admin_url( "comment.php?action=trash&c={$comment->comment_ID}#wpbody-content" )
 			) . "\r\n";
 		} else {
 			$notify_message .= sprintf(
-				/* translators: Comment moderation. 1: Comment action URL */
+				/* translators: Placeholder is the edit URL */
 				__( 'Delete it: %s' ),
 				$moderate_on_wpcom
 				? str_replace( '__action__', 'delete', $base_wpcom_edit_comment_url )
-				: admin_url( "comment.php?action=delete&c={$comment_id}#wpbody-content" )
+				: admin_url( "comment.php?action=delete&c={$comment->comment_ID}#wpbody-content" )
 			) . "\r\n";
 		}
-
 		$notify_message .= sprintf(
-			/* translators: Comment moderation. 1: Comment action URL */
+			/* translators: Placeholder is the edit URL */
 			__( 'Spam it: %s' ),
 			$moderate_on_wpcom
 			? str_replace( '__action__', 'spam', $base_wpcom_edit_comment_url )
-			: admin_url( "comment.php?action=spam&c={$comment_id}#wpbody-content" )
+			: admin_url( "comment.php?action=spam&c={$comment->comment_ID}#wpbody-content" )
 		) . "\r\n";
-
-		$notify_message .= sprintf(
-			/* translators: Comment moderation. 1: Number of comments awaiting approval */
-			_n(
-				'Currently %s comment is waiting for approval. Please visit the moderation panel:',
-				'Currently %s comments are waiting for approval. Please visit the moderation panel:',
-				$comments_waiting
-			),
-			number_format_i18n( $comments_waiting )
-		) . "\r\n";
-
-		$notify_message .= $moderate_on_wpcom
-			? Redirect::get_url( 'calypso-comments-pending' )
-			: admin_url( 'edit-comments.php?comment_status=moderated#wpbody-content' ) . "\r\n";
-
-		/* translators: Comment moderation notification email subject. 1: Site name, 2: Post title */
-		$subject         = sprintf( __( '[%1$s] Please moderate: "%2$s"' ), $blogname, $post->post_title );
-		$message_headers = '';
-
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$notify_message = apply_filters( 'comment_moderation_text', $notify_message, $comment_id );
-
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$subject = apply_filters( 'comment_moderation_subject', $subject, $comment_id );
-
-		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		$message_headers = apply_filters( 'comment_moderation_headers', $message_headers, $comment_id );
-
-		foreach ( $emails as $email ) {
-			@wp_mail( $email, wp_specialchars_decode( $subject ), $notify_message, $message_headers );
-		}
-
-		if ( $switched_locale ) {
-			restore_previous_locale();
-		}
-
-		return true;
 	}
-endif;
+
+	$wp_email = 'wordpress@' . preg_replace( '#^www\.#', '', strtolower( $_SERVER['SERVER_NAME'] ) );
+
+	if ( '' == $comment->comment_author ) {
+		$from = "From: \"$blogname\" <$wp_email>";
+		if ( '' != $comment->comment_author_email ) {
+			$reply_to = "Reply-To: $comment->comment_author_email";
+		}
+	} else {
+		$from = "From: \"$comment->comment_author\" <$wp_email>";
+		if ( '' != $comment->comment_author_email ) {
+			$reply_to = "Reply-To: \"$comment->comment_author_email\" <$comment->comment_author_email>";
+		}
+	}
+
+	$message_headers = "$from\n"
+		. 'Content-Type: text/plain; charset="' . get_option( 'blog_charset' ) . "\"\n";
+
+	if ( isset( $reply_to ) ) {
+		$message_headers .= $reply_to . "\n";
+	}
+
+	/** This filter is documented in core/src/wp-includes/pluggable.php */
+	$notify_message = apply_filters( 'comment_notification_text', $notify_message, $comment->comment_ID );
+
+	/** This filter is documented in core/src/wp-includes/pluggable.php */
+	$subject = apply_filters( 'comment_notification_subject', $subject, $comment->comment_ID );
+
+	/** This filter is documented in core/src/wp-includes/pluggable.php */
+	$message_headers = apply_filters( 'comment_notification_headers', $message_headers, $comment->comment_ID );
+
+	foreach ( $emails as $email ) {
+		wp_mail( $email, wp_specialchars_decode( $subject ), $notify_message, $message_headers );
+	}
+
+	if ( $switched_locale ) {
+		restore_previous_locale();
+	}
+
+	return array();
+}
+
+/**
+ * Short circuits the {@see `wp_notify_moderator`} function via the `notify_moderator` filter.
+ *
+ * Notifies the moderator of the site about a new comment that is awaiting approval.
+ *
+ * @since 5.8.0
+ * @since 9.2.0 Switched from pluggable function to filter callback
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param string $notify_moderator The value of the moderation_notify option.
+ * @param int    $comment_id Comment ID.
+ * @return boolean Returns false to shortcircuit the execution of wp_notify_moderator
+ */
+function jetpack_notify_moderator( $notify_moderator, $comment_id ) {
+
+	// If Jetpack is not active, or if Notify moderators options is not set, let the default flow go on.
+	if ( ! (bool) $notify_moderator || ! Jetpack::is_active() ) {
+		return $notify_moderator;
+	}
+
+	// Original function modified: Removed code before the notify_moderator filter.
+
+	global $wpdb;
+
+	$comment = get_comment( $comment_id );
+	$post    = get_post( $comment->comment_post_ID );
+	$user    = get_userdata( $post->post_author );
+	// Send to the administration and to the post author if the author can modify the comment.
+	$emails = array( get_option( 'admin_email' ) );
+	if ( $user && user_can( $user->ID, 'edit_comment', $comment_id ) && ! empty( $user->user_email ) ) {
+		if ( 0 !== strcasecmp( $user->user_email, get_option( 'admin_email' ) ) ) {
+			$emails[] = $user->user_email;
+		}
+	}
+
+	$switched_locale = switch_to_locale( get_locale() );
+
+	$comment_author_domain = '';
+	if ( WP_Http::is_ip_address( $comment->comment_author_IP ) ) {
+		$comment_author_domain = gethostbyaddr( $comment->comment_author_IP );
+	}
+	$comments_waiting = $wpdb->get_var( "SELECT count(comment_ID) FROM $wpdb->comments WHERE comment_approved = '0'" );
+
+	// The blogname option is escaped with esc_html on the way into the database in sanitize_option
+	// we want to reverse this for the plain text arena of emails.
+	$blogname        = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+	$comment_content = wp_specialchars_decode( $comment->comment_content );
+
+	switch ( $comment->comment_type ) {
+		case 'trackback':
+			/* translators: 1: Post title */
+			$notify_message  = sprintf( __( 'A new trackback on the post "%s" is waiting for your approval' ), $post->post_title ) . "\r\n";
+			$notify_message .= get_permalink( $comment->comment_post_ID ) . "\r\n\r\n";
+			/* translators: 1: Trackback/pingback website name, 2: website IP address, 3: website hostname */
+			$notify_message .= sprintf( __( 'Website: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+			/* translators: 1: Trackback/pingback/comment author URL */
+			$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
+			$notify_message .= __( 'Trackback excerpt: ' ) . "\r\n" . $comment_content . "\r\n\r\n";
+			break;
+		case 'pingback':
+			/* translators: 1: Post title */
+			$notify_message  = sprintf( __( 'A new pingback on the post "%s" is waiting for your approval' ), $post->post_title ) . "\r\n";
+			$notify_message .= get_permalink( $comment->comment_post_ID ) . "\r\n\r\n";
+			/* translators: 1: Trackback/pingback website name, 2: website IP address, 3: website hostname */
+			$notify_message .= sprintf( __( 'Website: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+			/* translators: 1: Trackback/pingback/comment author URL */
+			$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
+			$notify_message .= __( 'Pingback excerpt: ' ) . "\r\n" . $comment_content . "\r\n\r\n";
+			break;
+		default: // Comments.
+			/* translators: 1: Post title */
+			$notify_message  = sprintf( __( 'A new comment on the post "%s" is waiting for your approval' ), $post->post_title ) . "\r\n";
+			$notify_message .= get_permalink( $comment->comment_post_ID ) . "\r\n\r\n";
+			/* translators: 1: Comment author name, 2: comment author's IP address, 3: comment author's hostname */
+			$notify_message .= sprintf( __( 'Author: %1$s (IP address: %2$s, %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+			/* translators: 1: Comment author URL */
+			$notify_message .= sprintf( __( 'Email: %s' ), $comment->comment_author_email ) . "\r\n";
+			/* translators: 1: Trackback/pingback/comment author URL */
+			$notify_message .= sprintf( __( 'URL: %s' ), $comment->comment_author_url ) . "\r\n";
+			/* translators: 1: Comment text */
+			$notify_message .= sprintf( __( 'Comment: %s' ), "\r\n" . $comment_content ) . "\r\n\r\n";
+			break;
+	}
+
+	/** This filter is documented in core/src/wp-includes/pluggable.php */
+	$emails = apply_filters( 'comment_moderation_recipients', $emails, $comment_id );
+
+	// Original function modified.
+	$moderate_on_wpcom = ! in_array( false, array_map( 'jetpack_notify_is_user_connected_by_email', $emails ) );
+
+	$base_wpcom_edit_comment_url = Redirect::get_url(
+		'calypso-edit-comment',
+		array(
+			'path'  => $comment_id,
+			'query' => 'action=__action__', // __action__ will be replaced by the actual action.
+		)
+	);
+
+	// Original function modified: Consider $moderate_on_wpcom when building $notify_message.
+	$notify_message .= sprintf(
+		/* translators: Comment moderation. 1: Comment action URL */
+		__( 'Approve it: %s' ),
+		$moderate_on_wpcom
+		? str_replace( '__action__', 'approve', $base_wpcom_edit_comment_url )
+		: admin_url( "comment.php?action=approve&c={$comment_id}#wpbody-content" )
+	) . "\r\n";
+
+	if ( EMPTY_TRASH_DAYS ) {
+		$notify_message .= sprintf(
+			/* translators: Comment moderation. 1: Comment action URL */
+			__( 'Trash it: %s' ),
+			$moderate_on_wpcom
+			? str_replace( '__action__', 'trash', $base_wpcom_edit_comment_url )
+			: admin_url( "comment.php?action=trash&c={$comment_id}#wpbody-content" )
+		) . "\r\n";
+	} else {
+		$notify_message .= sprintf(
+			/* translators: Comment moderation. 1: Comment action URL */
+			__( 'Delete it: %s' ),
+			$moderate_on_wpcom
+			? str_replace( '__action__', 'delete', $base_wpcom_edit_comment_url )
+			: admin_url( "comment.php?action=delete&c={$comment_id}#wpbody-content" )
+		) . "\r\n";
+	}
+
+	$notify_message .= sprintf(
+		/* translators: Comment moderation. 1: Comment action URL */
+		__( 'Spam it: %s' ),
+		$moderate_on_wpcom
+		? str_replace( '__action__', 'spam', $base_wpcom_edit_comment_url )
+		: admin_url( "comment.php?action=spam&c={$comment_id}#wpbody-content" )
+	) . "\r\n";
+
+	$notify_message .= sprintf(
+		/* translators: Comment moderation. 1: Number of comments awaiting approval */
+		_n(
+			'Currently %s comment is waiting for approval. Please visit the moderation panel:',
+			'Currently %s comments are waiting for approval. Please visit the moderation panel:',
+			$comments_waiting
+		),
+		number_format_i18n( $comments_waiting )
+	) . "\r\n";
+
+	$notify_message .= $moderate_on_wpcom
+		? Redirect::get_url( 'calypso-comments-pending' )
+		: admin_url( 'edit-comments.php?comment_status=moderated#wpbody-content' ) . "\r\n";
+
+	/* translators: Comment moderation notification email subject. 1: Site name, 2: Post title */
+	$subject         = sprintf( __( '[%1$s] Please moderate: "%2$s"' ), $blogname, $post->post_title );
+	$message_headers = '';
+
+	/** This filter is documented in core/src/wp-includes/pluggable.php */
+	$notify_message = apply_filters( 'comment_moderation_text', $notify_message, $comment_id );
+
+	/** This filter is documented in core/src/wp-includes/pluggable.php */
+	$subject = apply_filters( 'comment_moderation_subject', $subject, $comment_id );
+
+	/** This filter is documented in core/src/wp-includes/pluggable.php */
+	$message_headers = apply_filters( 'comment_moderation_headers', $message_headers, $comment_id );
+
+	foreach ( $emails as $email ) {
+		wp_mail( $email, wp_specialchars_decode( $subject ), $notify_message, $message_headers );
+	}
+
+	if ( $switched_locale ) {
+		restore_previous_locale();
+	}
+
+	return false;
+}
+
+/**
+ * Gets an user by email and verify if it's connected
+ *
+ * @param string $email The user email.
+ * @return boolean
+ */
+function jetpack_notify_is_user_connected_by_email( $email ) {
+	$user = get_user_by( 'email', $email );
+	return Jetpack::is_user_connected( $user->ID );
+}

--- a/_inc/lib/functions.wp-notify.php
+++ b/_inc/lib/functions.wp-notify.php
@@ -233,7 +233,7 @@ function jetpack_notify_postauthor( $emails, $comment_id ) {
 function jetpack_notify_moderator( $notify_moderator, $comment_id ) {
 
 	// If Jetpack is not active, or if Notify moderators options is not set, let the default flow go on.
-	if ( ! (bool) $notify_moderator || ! Jetpack::is_active() ) {
+	if ( ! $notify_moderator || ! Jetpack::is_active() ) {
 		return $notify_moderator;
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -733,10 +733,12 @@ class Jetpack {
 			add_filter( 'get_edit_comment_link', array( $this, 'point_edit_comment_links_to_calypso' ), 1 );
 
 			/*
-			 * We'll override wp_notify_postauthor and wp_notify_moderator pluggable functions
+			 * We'll shortcircuit wp_notify_postauthor and wp_notify_moderator pluggable functions
 			 * so they point moderation links on emails to Calypso.
 			 */
 			jetpack_require_lib( 'functions.wp-notify' );
+			add_filter( 'comment_notification_recipients', 'jetpack_notify_postauthor', 1, 2 );
+			add_filter( 'notify_moderator', 'jetpack_notify_moderator', 1, 2 );
 		}
 
 		add_action(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR removes the necessity to check `Jetpack::is_active()` too early which can lead to Fatal errors.

`functions.wp-notify.php` is [included](https://github.com/Automattic/jetpack/blob/update%2Fremove_early_call/class.jetpack.php#L731) if the `edit_links_calypso_redirect` is present.

This file will override two WP core pluggable functions that send email notifications. Since it has to declare the function before Core does, it has to be included super early in the load.

The problem is that `functions.wp-notify.php` has a call to `Jetpack::is_active()`, which calls `Connection\Manager::is_active()` before the whole environment is loaded. For example, when this file is loaded, functions such as `get_userdata()` do not exist yet.

There's no UI for the user to set the `edit_links_calypso_redirect` option. It's only used by atomic sites. This will not affect self-hosted sites.

Given the structure of the pluggable functions and the hooks available, it's not possible to do what is done here without duplicating a big part of the core's original functions.

What this PR does it slightly change those functions so we can use them as filter callbacks. This saves us from having to do the early check to `Jetpack::is_active` and check for it only when we are actually sending the emails.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Replace pluggable function with filter callbacks

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-2bt-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

DISCLAIMER: For some reason, the diff looks way more complicated than the actual changes actually are. I basically just changed the initial lines of each function. 

In the end, everything should stay the same.

##### Setting up:

Start with the `master` checked out.

* Create a new site and connect
* Make sure Akismet is not active
* Go to Settings > Discussion
* Under "Email me whenever", mark "Anyone posts a comment" and "A comment is held for moderation"
* Unmark everything under "Before a comment appears"
* Set the `edit_links_calypso_redirect` option: `wp jetpack options set edit_links_calypso_redirect 1`
* Open the MailDev debugger

##### Testing author notification

* Visit a post in an anonymous window
* post a comment
* Go to MailDev and verify there's an email about the new comment
* Make sure all links point to calypso

##### Test moderation notification

* Go to Settings > Discussion
* Under "Before a comment appears", mark "Comment must be manually approved "
* In the anonymous window, post a new comment
* Go to MailDev and verify there's an email about the new comment
* Make sure all links point to calypso

##### Check out this branch and run both tests again.

* Make sure the emails look exactly the same as they did on `master`.

##### Disconnected Jetpack

* Disconnect from Jetpack
* Run the tests again
* Make sure the emails look good and the links point directly to wp-admin dashboard this time.
