### PR TITLE
Calypsoify: update mock and PHPCS

### DIFF
--- a/bin/phpcs-excludelist.json
+++ b/bin/phpcs-excludelist.json
@@ -184,7 +184,6 @@
 	"json-endpoints.php",
 	"locales.php",
 	"modules/after-the-deadline.php",
-	"modules/calypsoify/class.jetpack-calypsoify.php",
 	"modules/carousel/jetpack-carousel.php",
 	"modules/carousel.php",
 	"modules/comment-likes.php",

--- a/modules/calypsoify/class-jetpack-calypsoify.php
+++ b/modules/calypsoify/class-jetpack-calypsoify.php
@@ -441,4 +441,4 @@ class Jetpack_Calypsoify {
 	}
 }
 
-$jetpack_calypsoify = Jetpack_Calypsoify::getInstance();
+$jetpack_calypsoify = Jetpack_Calypsoify::get_instance();

--- a/modules/calypsoify/class-jetpack-calypsoify.php
+++ b/modules/calypsoify/class-jetpack-calypsoify.php
@@ -441,4 +441,4 @@ class Jetpack_Calypsoify {
 	}
 }
 
-$jetpack_calypsoify = Jetpack_Calypsoify::get_instance();
+Jetpack_Calypsoify::get_instance();

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -76,9 +76,16 @@ class Jetpack_Calypsoify {
 		return 'fresh';
 	}
 
+	/**
+	 * Mocks the Masterbar module.
+	 *
+	 * Calypsoify uses the Masterbar, so for sites without the Masterbar module active, this will use it for the sake of a Calyposify request.
+	 *
+	 * @return Masterbar
+	 */
 	public function mock_masterbar_activation() {
 		include_once JETPACK__PLUGIN_DIR . 'modules/masterbar/masterbar/class-masterbar.php';
-		new Masterbar();
+		return new Masterbar();
 	}
 
 	public function remove_core_menus() {

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -45,7 +45,7 @@ $tools = array(
 
 // Some features are only available when connected to WordPress.com.
 $connected_tools = array(
-	'calypsoify/class.jetpack-calypsoify.php',
+	'calypsoify/class-jetpack-calypsoify.php',
 	'plugin-search.php',
 	'scan/scan.php', // Shows Jetpack Scan alerts in the admin bar if threats found.
 	'simple-payments/simple-payments.php',

--- a/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
+++ b/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
@@ -5,7 +5,7 @@
  * @package Jetpack
  */
 
-require_jetpack_file( 'modules/calypsoify/class.jetpack-calypsoify.php' );
+require_jetpack_file( 'modules/calypsoify/class-jetpack-calypsoify.php' );
 
 /**
  * Class WP_Test_Jetpack_Calypsoify

--- a/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
+++ b/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
@@ -31,7 +31,7 @@ class WP_Test_Jetpack_Calypsoify extends WP_UnitTestCase {
 	 * @see https://github.com/Automattic/jetpack/pull/17939
 	 */
 	public function test_mock_masterbar_activation() {
-		$this->instance->mock_masterbar_activation();
-		$this->assertTrue( class_exists( '\Automattic\Jetpack\Dashboard_Customizations\Masterbar' ) );
+		$result = $this->instance->mock_masterbar_activation();
+		$this->assertInstanceOf( 'Automattic\Jetpack\Dashboard_Customizations\Masterbar', $result, 'The Masterbar class was not initiated.' );
 	}
 }

--- a/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
+++ b/tests/php/modules/calypsoify/test-class.jetpack-calypsoify.php
@@ -11,6 +11,12 @@ require_jetpack_file( 'modules/calypsoify/class-jetpack-calypsoify.php' );
  * Class WP_Test_Jetpack_Calypsoify
  */
 class WP_Test_Jetpack_Calypsoify extends WP_UnitTestCase {
+	/**
+	 * Instance to test.
+	 *
+	 * @var Jetpack_Calypsoify
+	 */
+	private $instance;
 
 	/**
 	 * Sets up each test.
@@ -19,7 +25,7 @@ class WP_Test_Jetpack_Calypsoify extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		$this->instance = Jetpack_Calypsoify::getInstance();
+		$this->instance = Jetpack_Calypsoify::get_instance();
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #17939 and requires it before landing in `master`.

This PR slightly modifies the `mock_masterbar_activation` function to return the instance of the Masterbar. Functionally, this doesn't do anything, but for the sake of testing, we can confirm that the instance matches what we expect.

While in the file, PHPCS'd everything.

#### Changes proposed in this Pull Request:
* Return instance for testing.
* PHPCS.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Load up Calypsoify (see 17939 for instructions) and confirm it loads without notice/warning/error.

#### Proposed changelog entry for your changes:
* Calypsoify: improve code quality.
