### PR TITLE
Jetpack Search: auto-config a maximum of 3 taxonomies

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -530,11 +530,16 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			);
 		}
 
-		$taxonomies = get_taxonomies(
-			array(
-				'public'   => true,
-				'_builtin' => false,
-			)
+		// Grab a maximum of 3 taxonomies.
+		$taxonomies = array_slice(
+			get_taxonomies(
+				array(
+					'public'   => true,
+					'_builtin' => false,
+				)
+			),
+			0,
+			3
 		);
 
 		foreach ( $taxonomies as $t ) {
@@ -552,12 +557,14 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'taxonomy' => 'category',
 			'count'    => 5,
 		);
+
 		$settings['filters'][] = array(
 			'name'     => '',
 			'type'     => 'taxonomy',
 			'taxonomy' => 'post_tag',
 			'count'    => 5,
 		);
+
 		$settings['filters'][] = array(
 			'name'     => '',
 			'type'     => 'date_histogram',
@@ -565,6 +572,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'field'    => 'post_date',
 			'interval' => 'year',
 		);
+
 		return $settings;
 	}
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/17630.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When a user sets up Jetpack Search, we try and auto-configure their filters by adding all of their taxonomies. For a site with lots of taxonomies (perhaps 100s), this can lead to too many filters being created and searches failing.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a fresh test site on Jurassic Ninja - https://jurassic.ninja/create/.
2. Install the Jetpack Beta Tester plugin from https://jetpack.com/download-jetpack-beta/.
3. Look for this feature branch (`fix/instant-search-limit-auto-created-taxonomies`) at /wp-admin/admin.php?page=jetpack-beta and activate it.
4. Create lots of custom taxonomies.
5. Upgrade to Jetpack Search at https://jetpack.com/upgrade/search/.
6. Try Jetpack Search on your site, and make sure you have only got a maximum of three taxonomy filters.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Limit number of filters automatically set up for Jetpack Search.
