### PR TITLE
E2E Tests: Use matrix to run tests with and without GB plugin

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,6 +17,8 @@ jobs:
       fail-fast: true
       matrix:
         gutenberg: [ 'no', 'latest' ]
+    env:
+      GUTENBERG: ${{ matrix.gutenberg }}
 
     steps:
     - uses: actions/checkout@v2
@@ -48,7 +50,6 @@ jobs:
       env:
         NGROK_KEY: ${{ secrets.NGROK_KEY }}
         CONFIG_KEY: ${{ secrets.E2E_CONFIG_KEY }}
-        GUTENBERG: ${{ matrix.gutenberg }}
       run: |
         yarn test-decrypt-config
         ./tests/e2e/bin/env.sh start

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,8 +11,12 @@ on:
 
 jobs:
   e2e-tests:
-    name: All
+    name: "E2E tests: with ${{ matrix.gutenberg }} plugin"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        gutenberg: [ 'no', 'latest' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -44,15 +48,21 @@ jobs:
       env:
         NGROK_KEY: ${{ secrets.NGROK_KEY }}
         CONFIG_KEY: ${{ secrets.E2E_CONFIG_KEY }}
+        LATEST_GUTENBERG: ${{ matrix.gutenberg === 'latest' }}
       run: |
         yarn test-decrypt-config
         ./tests/e2e/bin/env.sh start
 
     - name: Run tests
+      if: ${{ matrix.gutenberg === 'no' }}
       run: yarn test-e2e
 
+    - name: Run tests (excluding updater)
+      if: ${{ matrix.gutenberg === 'latest' }}
+      run: yarn test-e2e --testPathIgnorePatterns=updater
+
     - name: Upload Allure artifacts
-      if: ${{ always() }}
+      if: ${{ matrix.gutenberg === 'no' }}
       continue-on-error: true
       env:
         ALLURE_VERSION: 2.13.5
@@ -64,46 +74,3 @@ jobs:
         sudo ln -s /opt/allure-$ALLURE_VERSION/bin/allure /usr/bin/allure
 
         ./tests/e2e/bin/push-allure-artifacts.sh
-
-  gutenberg-e2e-tests:
-    name: with latest Gutenberg
-    runs-on: ubuntu-latest
-    env:
-      LATEST_GUTENBERG: 1
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12'
-
-    - name: Use yarn cache
-      uses: actions/cache@v2
-      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-      with:
-        path: /home/runner/.cache/yarn/v6
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-
-    - name: Use composer cache
-      uses: actions/cache@v2
-      with:
-        path: /home/runner/.composer/cache/files
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Build Production Jetpack
-      run: yarn build-production-concurrently
-
-    - name: Set up environment
-      env:
-        NGROK_KEY: ${{ secrets.NGROK_KEY }}
-        CONFIG_KEY: ${{ secrets.E2E_CONFIG_KEY }}
-      run: |
-        yarn test-decrypt-config
-        ./tests/e2e/bin/env.sh start
-
-    - name: Run tests
-      run: yarn test-e2e --testPathIgnorePatterns=updater

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,21 +48,21 @@ jobs:
       env:
         NGROK_KEY: ${{ secrets.NGROK_KEY }}
         CONFIG_KEY: ${{ secrets.E2E_CONFIG_KEY }}
-        LATEST_GUTENBERG: ${{ matrix.gutenberg === 'latest' }}
+        LATEST_GUTENBERG: ${{ matrix.gutenberg == 'latest' }}
       run: |
         yarn test-decrypt-config
         ./tests/e2e/bin/env.sh start
 
     - name: Run tests
-      if: ${{ matrix.gutenberg === 'no' }}
+      if: ${{ matrix.gutenberg == 'no' }}
       run: yarn test-e2e
 
     - name: Run tests (excluding updater)
-      if: ${{ matrix.gutenberg === 'latest' }}
+      if: ${{ matrix.gutenberg == 'latest' }}
       run: yarn test-e2e --testPathIgnorePatterns=updater
 
     - name: Upload Allure artifacts
-      if: ${{ matrix.gutenberg === 'no' }}
+      if: ${{ matrix.gutenberg == 'no' }}
       continue-on-error: true
       env:
         ALLURE_VERSION: 2.13.5

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,7 +48,7 @@ jobs:
       env:
         NGROK_KEY: ${{ secrets.NGROK_KEY }}
         CONFIG_KEY: ${{ secrets.E2E_CONFIG_KEY }}
-        LATEST_GUTENBERG: ${{ matrix.gutenberg == 'latest' }}
+        GUTENBERG: ${{ matrix.gutenberg }}
       run: |
         yarn test-decrypt-config
         ./tests/e2e/bin/env.sh start

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: "E2E tests: with ${{ matrix.gutenberg }} plugin"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         gutenberg: [ 'no', 'latest' ]
     env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,7 +63,7 @@ jobs:
       run: yarn test-e2e --testPathIgnorePatterns=updater
 
     - name: Upload Allure artifacts
-      if: ${{ matrix.gutenberg == 'no' }}
+      if: ${{ matrix.gutenberg == 'no' && always() }}
       continue-on-error: true
       env:
         ALLURE_VERSION: 2.13.5

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -55,15 +55,15 @@ jobs:
         ./tests/e2e/bin/env.sh start
 
     - name: Run tests
-      if: ${{ matrix.gutenberg == 'no' }}
+      if: matrix.gutenberg == 'no'
       run: yarn test-e2e
 
     - name: Run tests (excluding updater)
-      if: ${{ matrix.gutenberg == 'latest' }}
+      if: matrix.gutenberg == 'latest'
       run: yarn test-e2e --testPathIgnorePatterns=updater
 
     - name: Upload Allure artifacts
-      if: ${{ matrix.gutenberg == 'no' && always() }}
+      if: matrix.gutenberg == 'no' && always()
       continue-on-error: true
       env:
         ALLURE_VERSION: 2.13.5

--- a/tests/e2e/bin/env.sh
+++ b/tests/e2e/bin/env.sh
@@ -23,7 +23,7 @@ reset_env() {
 }
 
 configure_wp_env() {
-	if [ -n "$LATEST_GUTENBERG" ]; then
+	if [ "$GUTENBERG" == "latest" ]; then
 		yarn wp-env run tests-cli wp plugin install gutenberg --activate
 	fi
 

--- a/tests/e2e/lib/reporters/slack.js
+++ b/tests/e2e/lib/reporters/slack.js
@@ -5,14 +5,14 @@ import { readFileSync, createReadStream } from 'fs';
 import { WebClient, ErrorCode } from '@slack/web-api';
 import config from 'config';
 
-const { GITHUB_EVENT_PATH, GITHUB_RUN_ID, LATEST_GUTENBERG } = process.env;
+const { GITHUB_EVENT_PATH, GITHUB_RUN_ID, GUTENBERG } = process.env;
 
 export default class SlackReporter {
 	constructor() {
 		const token = config.get( 'slackToken' );
 		this.webCli = new WebClient( token );
 		this.runURL = `https://github.com/Automattic/jetpack/actions/runs/${ GITHUB_RUN_ID }`;
-		this.runType = LATEST_GUTENBERG ? 'with latest :gutenberg:' : 'All';
+		this.runType = GUTENBERG === 'latest' ? 'with latest :gutenberg:' : 'All';
 
 		this.conversationId = config.get( 'slackChannel' );
 		this.ccBrbrr = 'cc <@U6NSPV1LY>';

--- a/tests/e2e/lib/reporters/slack.js
+++ b/tests/e2e/lib/reporters/slack.js
@@ -12,7 +12,8 @@ export default class SlackReporter {
 		const token = config.get( 'slackToken' );
 		this.webCli = new WebClient( token );
 		this.runURL = `https://github.com/Automattic/jetpack/actions/runs/${ GITHUB_RUN_ID }`;
-		this.runType = GUTENBERG === 'latest' ? 'with latest :gutenberg:' : 'All';
+		this.runType =
+			GUTENBERG === 'latest' ? 'with latest :gutenberg: plugin' : 'with no :gutenberg: plugin';
 
 		this.conversationId = config.get( 'slackChannel' );
 		this.ccBrbrr = 'cc <@U6NSPV1LY>';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

We currently run our e2e tests in two different ways:
- Once for a snapshot of the Jetpack plugin per the current PR.
- Once with the latest Gutenberg plugin installed.

The latter is supposed to help us uncover issues with our own GB blocks that depend on GB, in case the new GB plugin version makes changes that can cause breakage.

There might be opportunity to extend this further, such as also running them with the latest Gutenberg plugin _Release Candidate_ (rather than stable release) installed; or in different browsers (see #17893 for an ongoing experiment).

Anyway, the two ways we're currently running the e2e tests are implemented separately, even though they share most of the logic.

This PR thus attempts to merge them into one single flow, with a [build matrix](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix) to distinguish the different bits. This should make the GH action more maintainable and extensible.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Check out the relevant e2e tests GH action at the bottom end of this PR, and inspect to verify that e2e tests are still correctly run for both scenarios.

![image](https://user-images.githubusercontent.com/96308/100921313-ab84f900-34dc-11eb-96e8-3a1554a38548.png)

#### Proposed changelog entry for your changes:
E2E Tests: Use matrix to run tests with and without GB plugin