### PR TITLE
TwentyTwentyOne: Add Content Options

### DIFF
--- a/modules/theme-tools/compat/twentytwentyone.php
+++ b/modules/theme-tools/compat/twentytwentyone.php
@@ -18,7 +18,8 @@ function twentytwentyone_jetpack_setup() {
 	/**
 	 * Add theme support for Content Options.
 	 */
-	add_theme_support( 'jetpack-content-options',
+	add_theme_support(
+		'jetpack-content-options',
 		array(
 			'blog-display' => array( 'content', 'excerpt' ),
 			'post-details' => array(

--- a/modules/theme-tools/compat/twentytwentyone.php
+++ b/modules/theme-tools/compat/twentytwentyone.php
@@ -21,16 +21,16 @@ function twentytwentyone_jetpack_setup() {
 	add_theme_support(
 		'jetpack-content-options',
 		array(
-			'blog-display' => array( 'content', 'excerpt' ),
-			'post-details' => array(
+			'blog-display'    => array( 'content', 'excerpt' ),
+			'post-details'    => array(
 				'stylesheet' => 'twentytwentyone-style',
 				'date'       => '.posted-on',
 				'categories' => '.cat-links',
 			),
-			'featured-images'    => array(
-				'archive'  => true,
-				'post'     => true,
-				'page'     => true,
+			'featured-images' => array(
+				'archive' => true,
+				'post'    => true,
+				'page'    => true,
 			),
 		)
 	);

--- a/modules/theme-tools/compat/twentytwentyone.php
+++ b/modules/theme-tools/compat/twentytwentyone.php
@@ -14,6 +14,23 @@ function twentytwentyone_jetpack_setup() {
 	 * Add theme support for geo-location.
 	 */
 	add_theme_support( 'jetpack-geo-location' );
+
+	/**
+	 * Add theme support for Content Options.
+	 */
+	add_theme_support( 'jetpack-content-options', array(
+		'blog-display' => array( 'content', 'excerpt' ),
+    	'post-details' => array(
+			'stylesheet' => 'twentytwentyone-style',
+			'date'       => '.posted-on',
+			'categories' => '.cat-links',
+		),
+		'featured-images'    => array(
+			'archive'  => true,
+			'post'     => true,
+			'page'     => true,
+		),
+	) );
 }
 add_action( 'after_setup_theme', 'twentytwentyone_jetpack_setup' );
 

--- a/modules/theme-tools/compat/twentytwentyone.php
+++ b/modules/theme-tools/compat/twentytwentyone.php
@@ -18,19 +18,21 @@ function twentytwentyone_jetpack_setup() {
 	/**
 	 * Add theme support for Content Options.
 	 */
-	add_theme_support( 'jetpack-content-options', array(
-		'blog-display' => array( 'content', 'excerpt' ),
-    	'post-details' => array(
-			'stylesheet' => 'twentytwentyone-style',
-			'date'       => '.posted-on',
-			'categories' => '.cat-links',
-		),
-		'featured-images'    => array(
-			'archive'  => true,
-			'post'     => true,
-			'page'     => true,
-		),
-	) );
+	add_theme_support( 'jetpack-content-options',
+		array(
+			'blog-display' => array( 'content', 'excerpt' ),
+			'post-details' => array(
+				'stylesheet' => 'twentytwentyone-style',
+				'date'       => '.posted-on',
+				'categories' => '.cat-links',
+			),
+			'featured-images'    => array(
+				'archive'  => true,
+				'post'     => true,
+				'page'     => true,
+			),
+		)
+	);
 }
 add_action( 'after_setup_theme', 'twentytwentyone_jetpack_setup' );
 

--- a/modules/theme-tools/compat/twentytwentyone.php
+++ b/modules/theme-tools/compat/twentytwentyone.php
@@ -23,7 +23,7 @@ function twentytwentyone_jetpack_setup() {
 		array(
 			'blog-display'    => array( 'content', 'excerpt' ),
 			'post-details'    => array(
-				'stylesheet' => 'twentytwentyone-style',
+				'stylesheet' => 'twenty-twenty-one-style',
 				'date'       => '.posted-on',
 				'categories' => '.cat-links',
 			),


### PR DESCRIPTION
This adds Content Options to TwentyTwentyOne.

Part of https://github.com/Automattic/jetpack/issues/17248

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* I removed the lines for comment link, author bio and tags, as these don't appear in the excerpt.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Switch to TT1
* Open the Customizer
* Open the Content Options panel
* Try changing the settings and making sure that the post content updates accordingly

#### Proposed changelog entry for your changes:
* Add Content Options to TwentyTwentyOne