### PR TITLE
Admin Menu: Improve menu item url generator

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -268,7 +268,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	}
 
 	/**
-	 * Prepares a menu icon for consumption by Calypso.
+	 * Prepares a menu item url for consumption by Calypso.
 	 *
 	 * @param string $url         Menu slug.
 	 * @param string $parent_slug Optional. Parent menu item slug. Default empty string.
@@ -279,8 +279,9 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		if ( 0 === strpos( $url, 'https://wordpress.com' ) ) {
 			$url = str_replace( 'https://wordpress.com', '', $url );
 		} else {
-			$menu_hook = get_plugin_page_hook( $url, 'admin.php' );
-			$menu_file = wp_parse_url( $url, PHP_URL_PATH ); // Removes query args to get a file name.
+			$menu_hook   = get_plugin_page_hook( $url, $parent_slug );
+			$menu_file   = wp_parse_url( $url, PHP_URL_PATH ); // Removes query args to get a file name.
+			$parent_file = wp_parse_url( $parent_slug, PHP_URL_PATH );
 
 			if (
 				! empty( $menu_hook ) ||
@@ -291,19 +292,19 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				)
 			) {
 				if (
-					( 'admin.php' !== $parent_slug && file_exists( WP_PLUGIN_DIR . "/$parent_slug" ) && ! is_dir( WP_PLUGIN_DIR . "/$parent_slug" ) ) ||
-					( file_exists( ABSPATH . "/wp-admin/$parent_slug" ) && ! is_dir( ABSPATH . "/wp-admin/$parent_slug" ) )
+					( 'admin.php' !== $parent_file && file_exists( WP_PLUGIN_DIR . "/$parent_file" ) && ! is_dir( WP_PLUGIN_DIR . "/$parent_file" ) ) ||
+					( file_exists( ABSPATH . "/wp-admin/$parent_file" ) && ! is_dir( ABSPATH . "/wp-admin/$parent_file" ) )
 				) {
 					$url = add_query_arg( array( 'page' => $url ), admin_url( $parent_slug ) );
 				} else {
 					$url = add_query_arg( array( 'page' => $url ), admin_url( 'admin.php' ) );
 				}
-			} else {
+			} elseif ( file_exists( ABSPATH . "/wp-admin/$menu_file" ) ) {
 				$url = admin_url( $url );
 			}
 		}
 
-		return esc_url( $url );
+		return $url;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR emerged based on additional testing of admin menu endpoint on a site with WooCommerce enabled, after [this comment by Jeremy](https://github.com/Automattic/jetpack/pull/17629/#discussion_r532790440).

The way WP Admin generates these menu item URLs is quite intricate and replicating it for the endpoint has come with a steep learning curve. These updates get us closer to how `wp-admin/menu-header.php` generates those URLs and fixes a bunch of WooCommerce admin menu URLs as a result.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes passthrough of absolute URLs
* Generation of Core admin URLs works now like in `wp-admin/menu-header.php`.
* Fixes a bug where custom menu slugs didn't receive the correct filename prefix.
* Removes an abstraction layer in tests that led to false positives for Core admin URLs.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

No manual tests necessary. Unit tests have all changes covered.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
