### PR TITLE
Instant Search: Remove CSS to fix the display in TwentyTwentyOne

### DIFF
--- a/modules/search/instant-search/components/search-filters.scss
+++ b/modules/search/instant-search/components/search-filters.scss
@@ -6,7 +6,6 @@
 .jetpack-instant-search__filter-list-input,
 // Extra specific to override width in some themes, e.g. Zerif Lite
 .widget_search .jetpack-instant-search__filter-list-input {
-	width: inherit;
 	cursor: pointer;
 }
 


### PR DESCRIPTION
This line of CSS was introduced in https://github.com/Automattic/jetpack/pull/14493 for compatibility with the Zerif lite theme. This theme is no longer available on .org, but this line seems to cause a strange display issue in Twenty Twenty One:

Fixes https://github.com/Automattic/jetpack/issues/17552

If we remove this line everything still seems fine in all the other themes I have tested.

#### Changes proposed in this Pull Request:
* Remove unnecessary CSS

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Activate TT1 theme
* Activate the instant search Jetpack feature under performance (you'll need to purchase it)
* Do a search
* Check that the checkboxes look ok:

<img width="1029" alt="Screenshot 2020-12-03 at 11 42 54" src="https://user-images.githubusercontent.com/275961/101013763-b0898d00-355c-11eb-8ce6-a8f4773b2565.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fix display of checkboxes in Instant Search
