### PR TITLE
Story block: update icon

### DIFF
--- a/extensions/blocks/story/icon.js
+++ b/extensions/blocks/story/icon.js
@@ -1,25 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { Path, Rect, SVG } from '@wordpress/components';
+import { Path, Rect, G } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import renderMaterialIcon from '../../shared/render-material-icon';
 
-export default (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			d="M19 7V19C19 20.1046 18.1061 21 17.0015 21C14.8931 21 11.4097 21 8 21"
-		/>
-		<Rect
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			x="5.75"
-			y="2.75"
-			width="9.5"
-			height="14.5"
-			rx="0.875"
-		/>
-	</SVG>
+const icon = renderMaterialIcon(
+	<G>
+		<Path d="M17 5a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2h9z" />
+		<Path d="M13 4H5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2z" />
+		<Path d="M7 16h8a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2z" />
+	</G>
 );
+
+export default icon;


### PR DESCRIPTION
This PR updates the Story block icon as recently added to [gridicons](https://github.com/Automattic/gridicons/pull/309) repo.

Related Gutenberg-mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/2861
Related WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/13534

#### Testing instructions:
1. use WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/13534
2. create a new Post with the mobile Gutenberg editor
3. tap on + to display the block picker
4. observe the Story block shows as follows and is correctly displayed both in Android light and dark modes

**BEFORE:**
Observe the color is incorrectly set:
<img width="463" alt="Screen Shot 2020-12-03 at 13 58 51" src="https://user-images.githubusercontent.com/6597771/101061872-ba68bb80-356f-11eb-8ed2-55f12cb23ce3.png">
<img width="463" alt="Screen Shot 2020-12-03 at 13 58 20" src="https://user-images.githubusercontent.com/6597771/101061882-bd63ac00-356f-11eb-82b4-b147f0a9ed92.png">



**AFTER:**
Observe the icon shows itself uniformly as per the rest of the block icons:
<img width="463" alt="Screen Shot 2020-12-03 at 12 52 23" src="https://user-images.githubusercontent.com/6597771/101062011-e1bf8880-356f-11eb-9c5c-9a78a552040f.png">
<img width="463" alt="Screen Shot 2020-12-03 at 12 52 48" src="https://user-images.githubusercontent.com/6597771/101062003-dec49800-356f-11eb-9b7d-80293babd8dc.png">


#### Proposed changelog entry for your changes:
* no changelog entry needed
 