### PR TITLE
Improve is_missing_connection_owner heartbeat stats

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -1,6 +1,5 @@
 <?php
 
-use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Heartbeat;
 
 class Jetpack_Heartbeat {
@@ -96,10 +95,6 @@ class Jetpack_Heartbeat {
 			$return[ "{$prefix}xmlrpc-errors" ] = implode( ',', array_keys( $xmlrpc_errors ) );
 			Jetpack_Options::delete_option( 'xmlrpc_errors' );
 		}
-
-		// Missing the connection owner?
-		$connection_manager                 = new Manager();
-		$return[ "{$prefix}missing-owner" ] = $connection_manager->is_missing_connection_owner();
 
 		// is-multi-network can have three values, `single-site`, `single-network`, and `multi-network`.
 		$return[ "{$prefix}is-multi-network" ] = 'single-site';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR adds more detailed data about missing connection owners in the Connection package. It also adds tests to the method.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Write tests to Manager::is_missing_connection_owner()
* Refactor method after changes made in https://github.com/Automattic/jetpack/pull/17832
* Move the corresponding Heartbeat data from the Jetpack plugin into the Connection package
* Add more details of the error to the heartbeat

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-2bt-p2#comment-3783

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes. It anonymously tracks stats from sites that have a connection but don't have a blog owner properly connected

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a healthy connection
* use this command to check the heartbeat data: `wp jetpack-heartbeat`
* With a healthy connection, there should be a lot of data, but nothing related to missing owner
* Go to "Jetpack Debug" and click "Store these options"

1. delete the option
* In Jetpack Debug, click "Clear primary user"
* Check heartbeat and confirm you see `missing-owner | [true,"empty_master_user_option"]`
* This will be the only stat in the heartbeat data. That's because at this point Jetpack is not considered `active`

2. set invalid master_user id
* In Jetpack Debug, click"Randomize Primary user ID"
* Check heartbeat and confirm you see `missing-owner | [true,"no_token_for_user"]`
* This will be the only stat in the heartbeat data. That's because at this point Jetpack is not considered `active`

3. clear user tokens
* In Jetpack Debug, click "Restore from stored options"
* In Jetpack Debug, click "Clear user tokens"
* Check heartbeat and confirm you see `missing-owner | [true,"no_user_tokens"]`
* This will be the only stat in the heartbeat data. That's because at this point Jetpack is not considered `active`

4. Delete the user
* In Jetpack Debug, click "Restore from stored options"
* In a MySQL shell: `update wp_users SET ID = 9999 WHERE ID = 1;`
* Check heartbeat and confirm you see `missing-owner | [true,"missing_user"]`
* In this case, Jetpack is considered `active`, so this will be the last value of a big list of stats
* Don't forget to restore your user: `update wp_users SET ID = 1 WHERE ID = 9999;`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Add heartbeat data about missing connection owner