### PR TITLE
Instant Search: Improve filters popover UX in mobile

### DIFF
--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -9,6 +9,8 @@ import { __ } from '@wordpress/i18n';
 //       Do not import the entire lodash library!
 // eslint-disable-next-line lodash/import-scope
 import get from 'lodash/get';
+// eslint-disable-next-line lodash/import-scope
+import debounce from 'lodash/debounce';
 
 /**
  * Internal dependencies
@@ -23,8 +25,13 @@ export default class SearchFilters extends Component {
 		showClearFiltersButton: true,
 	};
 
+	scrollToTop = debounce( () => {
+		document.querySelector( '.jetpack-instant-search__overlay' ).scroll( 0, 0 );
+	}, 150 );
+
 	onChangeFilter = ( filterName, filterValue ) => {
 		setFilterQuery( filterName, filterValue );
+		this.scrollToTop();
 		this.props.onChange && this.props.onChange();
 	};
 

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -9,8 +9,6 @@ import { __ } from '@wordpress/i18n';
 //       Do not import the entire lodash library!
 // eslint-disable-next-line lodash/import-scope
 import get from 'lodash/get';
-// eslint-disable-next-line lodash/import-scope
-import debounce from 'lodash/debounce';
 
 /**
  * Internal dependencies
@@ -25,13 +23,8 @@ export default class SearchFilters extends Component {
 		showClearFiltersButton: true,
 	};
 
-	scrollToTop = debounce( () => {
-		document.querySelector( '.jetpack-instant-search__overlay' ).scroll( 0, 0 );
-	}, 150 );
-
 	onChangeFilter = ( filterName, filterValue ) => {
 		setFilterQuery( filterName, filterValue );
-		this.scrollToTop();
 		this.props.onChange && this.props.onChange();
 	};
 

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -25,16 +25,14 @@ const noop = event => event.preventDefault();
 
 class SearchForm extends Component {
 	state = {
-		showFilters: !! this.props.widget,
+		showFilters: false,
 	};
 
 	onChangeQuery = event => setSearchQuery( event.currentTarget.value );
 	onChangeSort = sort => {
 		this.props.onChangeSort( sort );
-		this.hideFilters();
 	};
 
-	hideFilters = () => this.setState( () => ( { showFilters: false } ) );
 	toggleFilters = event => {
 		if (
 			event.type === 'click' ||
@@ -88,7 +86,6 @@ class SearchForm extends Component {
 									filters={ getFilterQuery() }
 									loading={ this.props.isLoading }
 									locale={ this.props.locale }
-									onChange={ this.hideFilters }
 									postTypes={ this.props.postTypes }
 									results={ this.props.response }
 									showClearFiltersButton={ ! this.hasPreselectedFilters() && index === 0 }


### PR DESCRIPTION
Fixes #14614, take 2 of #17573.

#### Changes proposed in this Pull Request:
* Persists the mobile filter popover during filter and sort changes. Previously, the popover would close upon filter or sort changes.

<img width="375" alt="Screen Shot 2020-12-03 at 2 29 10 PM" src="https://user-images.githubusercontent.com/4044428/101090454-eab25900-3573-11eb-8d4e-0da5d22d4269.png">

#### Jetpack product discussion
See #14614.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Apply this to your Jetpack site with Instant Search enabled.
- Ensure that you have filters configured for your search widgets inside the overlay.
- Perform a search. Ensure that the results are as expected.
- Resize the window to emulate a mobile viewport (<768px). Ensure that you can see the Filters button to the left of the sort buttons.
- Click on the filters button and try applying various filters. Ensure that the popover remains open. Also, try modifying the sort options; ensure that the popover remains open.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None.
