### PR TITLE
Add a link to skip user auth when on "no user testing mode"

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -4,10 +4,15 @@ jQuery( document ).ready( function ( $ ) {
 	var connectButton = $( '.jp-connect-button, .jp-banner__alt-connect-button' ).eq( 0 );
 	var tosText = $( '.jp-connect-full__tos-blurb' );
 	var jetpackConnectIframe = $( '<iframe class="jp-jetpack-connect__iframe" />' );
+	// Sections that only show up in the first Set Up screen
 	var connectionHelpSections = $(
 		'#jetpack-connection-cards, .jp-connect-full__dismiss-paragraph, .jp-connect-full__testimonial'
 	);
+	// Sections that only show up in the "Authorize user" screen
+	var authenticationHelpSections = $( '#jp-authenticate-no_user_test_mode' );
 	var connectButtonFrom = '';
+
+	authenticationHelpSections.hide();
 
 	connectButton.on( 'click', function ( event ) {
 		event.preventDefault();
@@ -99,6 +104,7 @@ jQuery( document ).ready( function ( $ ) {
 			jetpackConnectIframe.on( 'load', function () {
 				jetpackConnectIframe.show();
 				$( '.jp-connect-full__button-container' ).hide();
+				authenticationHelpSections.show();
 			} );
 			jetpackConnectIframe.hide();
 			$( '.jp-connect-full__button-container' ).after( jetpackConnectIframe );

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -5,6 +5,7 @@ use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 
 class Jetpack_Connection_Banner {
 	/**
@@ -411,6 +412,12 @@ class Jetpack_Connection_Banner {
 				<div class="jp-connect-full__step-header">
 					<h2 class="jp-connect-full__step-header-title"><?php esc_html_e( 'Activate essential WordPress security and performance tools by setting up Jetpack', 'jetpack' ); ?></h2>
 				</div>
+
+				<?php if ( ( new Status() )->is_no_user_testing_mode() ) : ?>
+					<div id="jp-authenticate-no_user_test_mode">
+						<a href="<?php echo esc_url( Jetpack::admin_url() ); ?>">Skip user authentication</a>
+					</div>
+				<?php endif; ?>
 
 				<p class="jp-connect-full__tos-blurb">
 					<?php jetpack_render_tos_blurb(); ?>

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -485,3 +485,7 @@
 	top: rem(-3px);
 	fill: #eec74f;
 }
+
+#jp-authenticate-no_user_test_mode {
+	display: none;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Adds a link to skip user authentication to make it easier to test the user-less connection experience.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a link to skip user authentication when no_user_testing_mode is on

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-2bJ-p2#comment-3787

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a disconnected Jetpack
* add `define( 'JETPACK_NO_USER_TEST_MODE', true );` to your `wp-config.php`
* (option to Jurassica ninja coming soon -> https://github.com/Automattic/companion/pull/43)
* Make sure to `yarn build-client`
* Go to the Jetpack Dashboard
* Confirm the screen looks normal, with no "skip user authentication" link showing up
* Click "Set up"
* When you're prompted to authenticate the user, there should be a link to skip this step
* Click the "Skip user authentication" button
* Confirm you land in the Jetpack Dashboard

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* No user testing mode: Add link to skip user authentication