### PR TITLE
Videopress block: fix 16:9 aspect ratio

### DIFF
--- a/extensions/blocks/videopress/constants.js
+++ b/extensions/blocks/videopress/constants.js
@@ -2,7 +2,7 @@ export const ASPECT_RATIOS = [
 	// Common video resolutions.
 	{ ratio: '2.33', className: 'wp-embed-aspect-21-9' },
 	{ ratio: '2.00', className: 'wp-embed-aspect-18-9' },
-	{ ratio: '1.78', className: 'wp-embed-aspect-16-9' },
+	{ ratio: '1.77', className: 'wp-embed-aspect-16-9' },
 	{ ratio: '1.33', className: 'wp-embed-aspect-4-3' },
 	// Vertical video and instagram square video support.
 	{ ratio: '1.00', className: 'wp-embed-aspect-1-1' },


### PR DESCRIPTION
Some video sizes round to 1.78 and some to 1.77  - changing 16-9 setting to 1.77 catches both of these

Fixes # https://github.com/Automattic/wp-calypso/issues/46890

#### Changes proposed in this Pull Request:
* Changes 16:9 videopress aspect ratio check to 1.77 which picks up sizes that round to 1.78 and 1.77

#### Testing instructions:

- Check out this PR on a local install and enable Videopress support. Upload a 16:9 video and check that aspect ration is shown correctly
- Also test the PR against a sandboxed WPcom site and check that ratio is also set correctly to 16:9

Before on wpcom:
<img width="715" alt="Screen Shot 2020-12-04 at 2 02 11 PM" src="https://user-images.githubusercontent.com/3629020/101108922-7abad600-363a-11eb-89ab-1008c8ed1c20.png">

After on wpcom:
<img width="742" alt="Screen Shot 2020-12-04 at 2 01 17 PM" src="https://user-images.githubusercontent.com/3629020/101108933-83aba780-363a-11eb-94f6-06bccd9b8097.png">

#### Proposed changelog entry for your changes:
* Updated videopress aspect ratio check to make sure video sizes rounding to both 1.77 and 1.78 are classified as 16:9
