### PR TITLE
Related Posts: Add semantic dates

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -5,7 +5,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Sync\Settings;
 
 class Jetpack_RelatedPosts {
-	const VERSION   = '20191011';
+	const VERSION   = '20201207';
 	const SHORTCODE = 'jetpack-related-posts';
 
 	private static $instance     = null;

--- a/modules/related-posts/related-posts.css
+++ b/modules/related-posts/related-posts.css
@@ -181,7 +181,8 @@
 /* Related posts item content */
 
 #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title,
-#jp-relatedposts .jp-relatedposts-items p {
+#jp-relatedposts .jp-relatedposts-items p,
+#jp-relatedposts .jp-relatedposts-items time {
 	font-size: 14px;
 	line-height: 20px;
 	margin: 0;
@@ -199,7 +200,8 @@
 	border-bottom: 0;
 }
 
-#jp-relatedposts .jp-relatedposts-items p {
+#jp-relatedposts .jp-relatedposts-items p,
+#jp-relatedposts .jp-relatedposts-items time {
 	margin-bottom: 0;
 }
 

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -105,7 +105,12 @@
 					anchor[ 1 ] +
 					'</span>';
 				if ( options.showDate ) {
-					html += '<time class="jp-relatedposts-post-date" datetime="' + post.date + '">' + post.date + '</time>';
+					html +=
+						'<time class="jp-relatedposts-post-date" datetime="' +
+						post.date +
+						'">' +
+						post.date +
+						'</time>';
 				}
 				if ( options.showContext ) {
 					html += '<span class="jp-relatedposts-post-context">' + post.context + '</span>';
@@ -180,7 +185,12 @@
 					$( '<p>' ).text( post.excerpt ).html() +
 					'</p>';
 				if ( options.showDate ) {
-					html += '<time class="jp-relatedposts-post-date" datetime="' + post.date + '">' + post.date + '</time>';
+					html +=
+						'<time class="jp-relatedposts-post-date" datetime="' +
+						post.date +
+						'">' +
+						post.date +
+						'</time>';
 				}
 				if ( options.showContext ) {
 					html += '<p class="jp-relatedposts-post-context">' + post.context + '</p>';
@@ -303,8 +313,9 @@
 
 			$relatedPosts.append( html );
 			if ( options.showDate ) {
-				$relatedPosts.find( '.jp-relatedposts-post-date' ).show();
+				$relatedPosts.find( '.jp-relatedposts-post-date' ).css( 'display', 'block' );
 			}
+
 			$relatedPosts.show();
 			afterPostsHaveLoaded();
 		} );

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -105,7 +105,7 @@
 					anchor[ 1 ] +
 					'</span>';
 				if ( options.showDate ) {
-					html += '<span class="jp-relatedposts-post-date">' + post.date + '</span>';
+					html += '<time class="jp-relatedposts-post-date" datetime="' + post.date + '">' + post.date + '</time>';
 				}
 				if ( options.showContext ) {
 					html += '<span class="jp-relatedposts-post-context">' + post.context + '</span>';
@@ -180,7 +180,7 @@
 					$( '<p>' ).text( post.excerpt ).html() +
 					'</p>';
 				if ( options.showDate ) {
-					html += '<p class="jp-relatedposts-post-date">' + post.date + '</p>';
+					html += '<time class="jp-relatedposts-post-date" datetime="' + post.date + '">' + post.date + '</time>';
 				}
 				if ( options.showContext ) {
 					html += '<p class="jp-relatedposts-post-context">' + post.context + '</p>';


### PR DESCRIPTION


#### Changes proposed in this Pull Request:

* Uses `<time>` - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time - to ensure that the dates are semantic.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Start from a connected site with Related Posts enabled and displayed on a post.
* Add `define( 'SCRIPT_DEBUG', true );` to your site's `wp-config.php` file
* Apply this branch
* Refresh post
* Ensure that related posts look the same as they do on the stable version of Jetpack.

#### Proposed changelog entry for your changes:

* Related Posts: use the semantic time element when displaying dates.
