### PR TITLE
Stats: Use only defer for script tag

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -260,8 +260,8 @@ function stats_render_footer( $data ) {
 	$data_stats_array = stats_array( $data );
 
 	$stats_footer = <<<END
-<script type='text/javascript' src='{$script}' async='async' defer='defer'></script>
-<script type='text/javascript'>
+<script src='{$script}' defer></script>
+<script>
 	_stq = window._stq || [];
 	_stq.push([ 'view', {{$data_stats_array}} ]);
 	_stq.push([ 'clickTrackerInit', '{$data['blog']}', '{$data['post']}' ]);


### PR DESCRIPTION
Fixes https://twitter.com/rick_viscomi/status/1331735748060524551

#### Changes proposed in this Pull Request:
* Drop obsolete use of `type`.
* Use only `defer`.
* Skip PHPCS validation since the script should be enqueued, but that's going to be the beginning of a deep rabbit hole given how old a lot of this code is. :)

#### Jetpack product discussion
Discussed with perfops in p1607034688079500-slack-C4GAQ900P

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Logged out on a site connected to Jetpack, ensure no JS errors and that the stats were counted.
* Should not be via AMP.

#### Proposed changelog entry for your changes:
* Stats: Update JavaScript loading to meet modern best practices.