### PR TITLE
Debugger: Do not release key on 8.0+ No longer needed.

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -536,7 +536,10 @@ class Jetpack_Cxn_Test_Base {
 			);
 		}
 
-		openssl_free_key( $public_key );
+		// openssl_free_key was deprecated as no longer needed in PHP 8.0+. Can remove when PHP 8.0 is our minimum. (lol).
+		if ( PHP_VERSION_ID < 80000 ) {
+			openssl_free_key( $public_key );
+		}
 
 		return $return;
 	}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -538,7 +538,7 @@ class Jetpack_Cxn_Test_Base {
 
 		// openssl_free_key was deprecated as no longer needed in PHP 8.0+. Can remove when PHP 8.0 is our minimum. (lol).
 		if ( PHP_VERSION_ID < 80000 ) {
-			openssl_free_key( $public_key );
+			openssl_free_key( $public_key ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.openssl_free_keyDeprecated
 		}
 
 		return $return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes " Warning: /home/runner/work/jetpack/jetpack/_inc/lib/debugger/class-jetpack-cxn-test-base.php:539:3: warning - Function openssl_free_key() is deprecated since PHP 8.0 (PHPCompatibility.FunctionUse.RemovedFunctions.openssl_free_keyDeprecated)" as seen in https://github.com/Automattic/jetpack/pull/17974/checks?check_run_id=1501094595

#### Changes proposed in this Pull Request:
* Add conditional for PHP 8

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Confirm no warning on the PHP 8 compat check.
*

#### Proposed changelog entry for your changes:
* Various: PHP 8 compatibility improvements.
