### PR TITLE
Admin Menu: Account for top-level item capabilities

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -106,8 +106,19 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		foreach ( $menu as $menu_item ) {
 			$item = $this->prepare_menu_item( $menu_item );
 
+			// Are there submenu items to process?
 			if ( ! empty( $submenu[ $menu_item[2] ] ) ) {
-				foreach ( $submenu[ $menu_item[2] ] as $submenu_item ) {
+				$submenu_items = array_values( $submenu[ $menu_item[2] ] );
+
+				// If the user doesn't have the caps for the top level menu item, let's promote the first submenu item.
+				if ( empty( $item ) ) {
+					$menu_item[1] = $submenu_items[0][1]; // Capability.
+					$menu_item[2] = $submenu_items[0][2]; // Menu slug.
+					$item         = $this->prepare_menu_item( $menu_item );
+				}
+
+				// Add submenu items.
+				foreach ( $submenu_items as $submenu_item ) {
 					$item['children'][] = $this->prepare_submenu_item( $submenu_item, $menu_item );
 				}
 			}

--- a/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -35,6 +35,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 		parent::setUp();
 
 		wp_set_current_user( static::$user_id );
+		add_action( 'admin_menu', array( $this, 'add_orphan_submenu' ) );
 	}
 
 	/**
@@ -88,10 +89,8 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	 * @covers ::prepare_menu_for_response
 	 */
 	public function test_parent_menu_item_always_exists() {
-		add_action( 'admin_menu', array( $this, 'add_orphan_submenu' ) );
 		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/admin-menu' );
 		$response = $this->server->dispatch( $request );
-		remove_action( 'admin_menu', array( $this, 'add_orphan_submenu' ) );
 
 		$menu      = wp_list_filter( $response->get_data(), array( 'title' => 'Settings' ) );
 		$menu_item = array_pop( $menu );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #17977.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a second try for top-level menu items when they have submenu items available.
* Adds unit tests to make sure that a top-level item exists when there are submenu items that the user has caps for.
* Adds unit tests to make sure that top-level and the first submenu item have the same menu slug.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run unit tests and make sure there are no failures for the admin menu tests: `$phpunit --testsuite core-api`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed. Feature not in use yet.
