### PR TITLE
Masterbar: update path to tracks resource

### DIFF
--- a/modules/masterbar/masterbar/class-masterbar.php
+++ b/modules/masterbar/masterbar/class-masterbar.php
@@ -288,8 +288,8 @@ class Masterbar {
 		wp_enqueue_script(
 			'a8c_wpcom_masterbar_tracks_events',
 			Assets::get_file_url_for_environment(
-				'_inc/build/masterbar/tracks-events.min.js',
-				'modules/masterbar/tracks-events.js'
+				'_inc/build/masterbar/masterbar/tracks-events.min.js',
+				'modules/masterbar/masterbar/tracks-events.js'
 			),
 			array( 'jquery' ),
 			JETPACK__VERSION,


### PR DESCRIPTION
Fixes #17989 

#### Changes proposed in this Pull Request:

In #17762 and #17783 we've refactored the Masterbar, but forgot to update the reference to the script that got moved along with this.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Jetpack > Settings > Writing
* Enable the WordPress.com toolbar
* On page reload, check your browser network tools; you should see `_inc/build/masterbar/masterbar/tracks-events.min.js` load properly.

#### Proposed changelog entry for your changes:

* WordPress.com Toolbar: update resources' path.
