### PR TITLE
Anchor: Show outbound link after publishing a post

### DIFF
--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -114,6 +114,16 @@ function process_anchor_params() {
 		}
 	}
 
+	// Display an outbound link after publishing a post (only to English-speaking users since Anchor
+	// is English only).
+	if (
+		'post' === get_post_type() &&
+		! get_post_meta( $post->ID, 'jetpack_anchor_spotify_show', true ) &&
+		0 === strpos( get_user_locale(), 'en' )
+	) {
+		$data['action'] = 'show-post-publish-outbound-link';
+	}
+
 	wp_localize_script( 'jetpack-blocks-editor', 'Jetpack_AnchorFm', $data );
 }
 

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -1,9 +1,10 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
 import { dispatch, select } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { external, Icon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 
@@ -60,6 +61,7 @@ const ConvertToAudio = () => (
 		<p>
 			<a href="https://anchor.fm/wordpress" target="_top">
 				{ __( 'Create a podcast episode', 'jetpack' ) }
+				<Icon icon={ external } className="components-external-link__icon" />
 			</a>
 		</p>
 	</PluginPostPublishPanel>

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -3,6 +3,9 @@
  */
 import { createBlock } from '@wordpress/blocks';
 import { dispatch, select } from '@wordpress/data';
+import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
@@ -48,6 +51,26 @@ async function insertSpotifyBadge() {
 	}
 }
 
+const ConvertToAudio = () => (
+	<PluginPostPublishPanel>
+		<p className="post-publish-panel__postpublish-subheader">
+			<strong>{ __( 'Convert to audio', 'jetpack' ) }</strong>
+		</p>
+		<p>{ __( 'Let your readers listen to your post.', 'jetpack' ) }</p>
+		<p>
+			<a href="https://anchor.fm/wordpress" target="_top">
+				{ __( 'Create a podcast episode', 'jetpack' ) }
+			</a>
+		</p>
+	</PluginPostPublishPanel>
+);
+
+function showPostPublishOutboundLink() {
+	registerPlugin( 'post-publish-anchor-outbound-link', {
+		render: ConvertToAudio,
+	} );
+}
+
 function initAnchor() {
 	const isExtensionAvailable = getJetpackExtensionAvailability( name )?.available;
 	if ( ! isExtensionAvailable ) {
@@ -62,6 +85,9 @@ function initAnchor() {
 	switch ( data.action ) {
 		case 'insert-spotify-badge':
 			insertSpotifyBadge();
+			break;
+		case 'show-post-publish-outbound-link':
+			showPostPublishOutboundLink();
 			break;
 	}
 }


### PR DESCRIPTION
Fixes 313-gh-Automattic/dotcom-manage

#### Changes proposed in this Pull Request:
This PR displays an outbound link in the block editor's post-publish panel that sends users to the Anchor.fm <> WP.com entry page.

<img width="280" alt="Screen Shot 2020-12-14 at 11 40 05" src="https://user-images.githubusercontent.com/1233880/102071814-4c3eb700-3e01-11eb-926a-c89bbd909dcb.png">

#### Jetpack product discussion
pbAPfg-PF-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Activate the beta blocks:
  - If testing on a JN site, go to Settings > Jetpack Constants and turn on the `JETPACK_BETA_BLOCKS` option.
  - If testing locally, add a new plugin to docker/mu-plugins with `define( 'JETPACK_BETA_BLOCKS', true );`.
- Start writing a new post and publish it.
- Make sure the post-publish panel displays a link prompting users to convert the post into a podcast episode. The link should open `anchor.fm/wordpress` in the same tab (note that Anchor has still not implemented the landing page, so the URL currently links to a podcast, see p1606860188053400-slack-C017FUZGVAL?thread_ts=1606777886.050200&cid=C017FUZGVAL).
- Make sure the link is not displayed when publishing other post types (e.g. pages or custom post type such as portfolio).
- Make sure the link is not displayed when the interface language is not English.

#### Proposed changelog entry for your changes:
N/A.