### PR TITLE
Disallow amp_validated_url as it is not site content

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -386,6 +386,7 @@ class Defaults {
 	 */
 	public static $blacklisted_post_types = array(
 		'ai_log', // Logger - https://github.com/alleyinteractive/logger.
+		'amp_validated_url', // AMP Validation Errors.
 		'ai1ec_event',
 		'bwg_album',
 		'bwg_gallery',


### PR DESCRIPTION
The AMP plugin creates an amp_validated_url to store validation errors. This is not content and should not be Synced to the Cache Site.

#### Changes proposed in this Pull Request:
* Disallow amp_validated_url from Jetpack Sync.

#### Does this pull request change what data or activity we track or use?
Yes, it excludes amp_validated_url content from Jetpack Sync

#### Testing instructions:
N/A - The blacklist have unit tests. If desired you can create a post with the blacklisted post_type and then verify the post is not on the cache site.

#### Proposed changelog entry for your changes:
* Jetpack Sync - Exclude amp_validated_url content
