### PR TITLE
Autoloader: use the wp-textdomain npm package to update package textdomains

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,8 @@
 		"size-limit": "4.9.0",
 		"style-loader": "2.0.0",
 		"url-loader": "4.1.1",
-		"winston": "3.3.3"
+		"winston": "3.3.3",
+		"wp-textdomain": "^1.0.1"
 	},
 	"optionalDependencies": {
 		"react": "16.13.1",

--- a/packages/autoloader/js/update_textdomain.js
+++ b/packages/autoloader/js/update_textdomain.js
@@ -1,0 +1,9 @@
+const wpTextdomain = require( 'wp-textdomain' );
+
+const textDomain = process.argv[ 2 ];
+
+wpTextdomain( './vendor/automattic/**/*.php', {
+	domain: textDomain,
+	fix: true,
+	glob: { follow: true },
+} );


### PR DESCRIPTION
We need to provide a way for a consuming plugin to use its own textdomain in the package strings. This PR presents a possible solution which uses the [wp-textdomain NPM package](https://www.npmjs.com/package/wp-textdomain) to detect translatable strings and change them to a given textdomain.

#### How a Consumer Plugin Would Use This

1. Add the jetpack-autoloader package to the plugin's composer dependencies in `composer.json`. (All plugins that use Jetpack packages should use the autoloader package to load package files.)

2. Add a composer script to the plugins's `composer.json` file, with the plugin's textdomain as the first argument:
        `"post-autoload-dump": "node vendor/automattic/jetpack-autoloader/js/update_textdomain.js {textdomain}"`

3. Add `wp-textdomain` as a development dependency in the plugin's `package.json` file.

4. When the plugin is built with `composer install`, `composer update` or `composer dump-autoload`, the post autoload dump script will run. The script will update every textdomain in the .php files in the Automattic packages.

#### Changes proposed in this Pull Request:
* Add `wp-textdomain` to Jetpack's development dependencies in `package.json`.

* Add a new file to the autoloader package, `update_textdomain.js`, which uses `wp-textdomain` to detect and update the textdomain of package strings.

##### Why is this in the autoloader package?
I put this in the autoloader package because:
* Every plugin that consumes Jetpack packages should use Jetpack's autoloader.
* This code could (maybe should?) live in its own package, but then consumer plugins will need to include both the autoloader and new textdomain packages.
* The autoloader is already used to build the plugin's composer package manifest files when a consuming plugin is built. Since the textdomains are changed when the plugin is built, the autoloader package seemed like a natural place to include this code.



#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Add the composer script to `composer.json`. Enter a textdomain that's not `jetpack` so you can verify that the script worked.
        `"post-autoload-dump": "node vendor/automattic/jetpack-autoloader/js/update_textdomain.js {textdomain}"`

2.  Run `composer dump-autoload`. The textdomain for the translatable strings in the composer packages should be changed from `jetpack` to the string used in step 1.

#### Proposed changelog entry for your changes:
* n/a
