### PR TITLE
Instant Search: allow result format to be set via query string

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -18,6 +18,7 @@ import SearchResults from './search-results';
 import { search } from '../lib/api';
 import {
 	getFilterQuery,
+	getResultFormatQuery,
 	getSearchQuery,
 	getSortQuery,
 	hasFilter,
@@ -268,6 +269,9 @@ class SearchApp extends Component {
 	};
 
 	render() {
+		// Override the result format from the query string if result_format= is specified
+		const resultFormatQuery = getResultFormatQuery();
+
 		return createPortal(
 			<Overlay
 				closeColor={ this.state.overlayOptions.closeColor }
@@ -294,7 +298,7 @@ class SearchApp extends Component {
 					postTypes={ this.props.options.postTypes }
 					query={ getSearchQuery() }
 					response={ this.state.response }
-					resultFormat={ this.state.overlayOptions.resultFormat }
+					resultFormat={ resultFormatQuery || this.state.overlayOptions.resultFormat }
 					showPoweredBy={ this.state.overlayOptions.showPoweredBy }
 					sort={ this.getSort() }
 					widgets={ this.props.options.widgets }

--- a/modules/search/instant-search/lib/constants.js
+++ b/modules/search/instant-search/lib/constants.js
@@ -6,11 +6,16 @@ import { __ } from '@wordpress/i18n';
 export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';
 export const SORT_DIRECTION_ASC = 'ASC';
 export const SORT_DIRECTION_DESC = 'DESC';
+export const RESULT_FORMAT_EXPANDED = 'expanded';
 export const RESULT_FORMAT_MINIMAL = 'minimal';
 export const RESULT_FORMAT_PRODUCT = 'product';
-export const RESULT_FORMAT_EXPANDED = 'expanded';
 export const MINUTE_IN_MILLISECONDS = 60 * 1000;
 export const VALID_SORT_KEYS = [ 'newest', 'oldest', 'relevance' ];
+export const VALID_RESULT_FORMAT_KEYS = [
+	RESULT_FORMAT_MINIMAL,
+	RESULT_FORMAT_EXPANDED,
+	RESULT_FORMAT_PRODUCT,
+];
 export const SORT_OPTIONS = new Map( [
 	[ 'relevance', __( 'Relevance', 'jetpack' ) ],
 	[ 'newest', __( 'Newest', 'jetpack' ) ],

--- a/modules/search/instant-search/lib/constants.js
+++ b/modules/search/instant-search/lib/constants.js
@@ -12,8 +12,8 @@ export const RESULT_FORMAT_PRODUCT = 'product';
 export const MINUTE_IN_MILLISECONDS = 60 * 1000;
 export const VALID_SORT_KEYS = [ 'newest', 'oldest', 'relevance' ];
 export const VALID_RESULT_FORMAT_KEYS = [
-	RESULT_FORMAT_MINIMAL,
 	RESULT_FORMAT_EXPANDED,
+	RESULT_FORMAT_MINIMAL,
 	RESULT_FORMAT_PRODUCT,
 ];
 export const SORT_OPTIONS = new Map( [

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -10,8 +10,8 @@ import { encode } from 'qss';
 import {
 	SERVER_OBJECT_NAME,
 	SORT_DIRECTION_ASC,
-	VALID_SORT_KEYS,
 	VALID_RESULT_FORMAT_KEYS,
+	VALID_SORT_KEYS,
 } from './constants';
 import { getFilterKeys, getUnselectableFilterKeys, mapFilterToFilterKey } from './filters';
 import { decode } from '../external/query-string-decode';

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -7,7 +7,12 @@ import { encode } from 'qss';
 /**
  * Internal dependencies
  */
-import { SERVER_OBJECT_NAME, SORT_DIRECTION_ASC, VALID_SORT_KEYS } from './constants';
+import {
+	SERVER_OBJECT_NAME,
+	SORT_DIRECTION_ASC,
+	VALID_SORT_KEYS,
+	VALID_RESULT_FORMAT_KEYS,
+} from './constants';
 import { getFilterKeys, getUnselectableFilterKeys, mapFilterToFilterKey } from './filters';
 import { decode } from '../external/query-string-decode';
 
@@ -154,6 +159,16 @@ export function setFilterQuery( filterKey, filterValue ) {
 	const query = getQuery();
 	query[ filterKey ] = filterValue;
 	pushQueryString( encode( query ) );
+}
+
+export function getResultFormatQuery() {
+	const query = getQuery();
+
+	if ( ! VALID_RESULT_FORMAT_KEYS.includes( query.result_format ) ) {
+		return null;
+	}
+
+	return query.result_format;
 }
 
 export function restorePreviousHref( initialHref, callback ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Allow the Instant Search result format (minimal, expanded or product) to be set via the query string. 

Currently the only way to do this is via the Customizer. We're currently working on improving the 'product' results and don't want to ship that option to users in the Customizer just yet.

#### Jetpack product discussion
Project thread: p9xfpQ-18j-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Go to a test site with Instant Search enabled. Open search results without any query string specified, and ensure that you get the result format specified in the Customizer (under /wp-admin/customize.php?autofocus[section]=jetpack_search).
* Try reloading the page with `?result_format=minimal` and ensure you get the minimal result format:

<img width="737" alt="Screen Shot 2020-12-08 at 15 23 58" src="https://user-images.githubusercontent.com/17325/101430208-6d1e8c80-3969-11eb-9ae6-8e1ffb03db85.png">

* Try reloading the page with `?result_format=expanded` and ensure you get the expanded result format:

<img width="722" alt="Screen Shot 2020-12-08 at 15 20 20" src="https://user-images.githubusercontent.com/17325/101430216-727bd700-3969-11eb-9144-30171c11bf01.png">

* Try reloading the page with `?result_format=product` and ensure you get the (work in progress) product result format:

<img width="775" alt="Screen Shot 2020-12-08 at 15 23 32" src="https://user-images.githubusercontent.com/17325/101430240-7e679900-3969-11eb-99fc-3088532e9340.png">

* Try reloading the page with any other string as a result format, for example `?result_format=pandas` and ensure you get the result format you configured originally in the Customizer.

#### Proposed changelog entry for your changes:
Not required - this change is primarily for developer convenience.
