### PR TITLE
Assets: introduce new method to process static resources

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -1,5 +1,6 @@
 <?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Sync\Functions;
 
 /**
@@ -299,7 +300,7 @@ class Jetpack_AMP_Support {
 		if ( function_exists( 'staticize_subdomain' ) ) {
 			return staticize_subdomain( $domain );
 		} else {
-			return Jetpack::staticize_subdomain( $domain );
+			return Assets::staticize_subdomain( $domain );
 		}
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -789,6 +789,9 @@ class Jetpack {
 
 		// Actions for licensing.
 		Licensing::instance()->initialize();
+
+		// Make resources use static domain when possible.
+		add_filter( 'jetpack_static_url', array( 'Automattic\\Jetpack\\Assets', 'staticize_subdomain' ) );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5804,40 +5804,16 @@ endif;
 		}
 	}
 
+	/**
+	 * Serve a WordPress.com static resource via a randomized wp.com subdomain.
+	 *
+	 * @deprecated 9.3.0 Use Assets::staticize_subdomain.
+	 *
+	 * @param string $url WordPress.com static resource URL.
+	 */
 	public static function staticize_subdomain( $url ) {
-
-		// Extract hostname from URL
-		$host = wp_parse_url( $url, PHP_URL_HOST );
-
-		// Explode hostname on '.'
-		$exploded_host = explode( '.', $host );
-
-		// Retrieve the name and TLD
-		if ( count( $exploded_host ) > 1 ) {
-			$name = $exploded_host[ count( $exploded_host ) - 2 ];
-			$tld  = $exploded_host[ count( $exploded_host ) - 1 ];
-			// Rebuild domain excluding subdomains
-			$domain = $name . '.' . $tld;
-		} else {
-			$domain = $host;
-		}
-		// Array of Automattic domains.
-		$domains_allowed = array( 'wordpress.com', 'wp.com' );
-
-		// Return $url if not an Automattic domain.
-		if ( ! in_array( $domain, $domains_allowed, true ) ) {
-			return $url;
-		}
-
-		if ( is_ssl() ) {
-			return preg_replace( '|https?://[^/]++/|', 'https://s-ssl.wordpress.com/', $url );
-		}
-
-		srand( crc32( basename( $url ) ) );
-		$static_counter = rand( 0, 2 );
-		srand(); // this resets everything that relies on this, like array_rand() and shuffle()
-
-		return preg_replace( '|://[^/]+?/|', "://s$static_counter.wp.com/", $url );
+		_deprecated_function( __METHOD__, 'jetpack-9.3.0', 'Automattic\Jetpack\Assets::staticize_subdomain' );
+		return Assets::staticize_subdomain( $url );
 	}
 
 	/* JSON API Authorization */

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -77,7 +77,6 @@ require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.core-rest-api-endpoints.php';
 
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
 add_action( 'init', array( 'Jetpack', 'init' ) );
-add_filter( 'jetpack_static_url', array( 'Jetpack', 'staticize_subdomain' ) );
 add_filter( 'is_jetpack_site', '__return_true' );
 
 if ( JETPACK__SANDBOX_DOMAIN ) {

--- a/packages/assets/tests/php/test-assets.php
+++ b/packages/assets/tests/php/test-assets.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack;
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Brain\Monkey;
 use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -57,7 +58,7 @@ function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $
  *                          Defaults to -1 (= return all parts as an array).
  */
 function wp_parse_url( $url, $component = -1 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	return parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+	return parse_url( $url, $component ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 }
 
 /**
@@ -236,6 +237,69 @@ class AssetsTest extends TestCase {
 		$this->assertEquals(
 			$GLOBALS['_was_called_wp_enqueue_script'],
 			array( array( 'handle', Assets::get_file_url_for_environment( '/minpath.js', '/path.js' ), array(), '123', true ) )
+		);
+	}
+
+	/**
+	 * Test whether static resources are properly updated to use a WordPress.com static domain.
+	 *
+	 * @covers Automattic\Jetpack\Status::staticize_subdomain
+	 * @dataProvider get_resources_urls
+	 *
+	 * @param string $original       Source URL.
+	 * @param string $expected_http  Expected WordPress.com Static URL when we're mocking a site using HTTP.
+	 * @param string $expected_https Expected WordPress.com Static URL when we're mocking a site using HTTPS.
+	 */
+	public function test_staticize_subdomain( $original, $expected_http, $expected_https ) {
+		Functions\when( 'is_ssl' )->justReturn( false );
+		$static_resource = Assets::staticize_subdomain( $original );
+		$this->assertContains( $expected_http, $static_resource );
+
+		Functions\when( 'is_ssl' )->justReturn( true );
+		$static_resource = Assets::staticize_subdomain( $original );
+		$this->assertContains( $expected_https, $static_resource );
+	}
+
+	/**
+	 * Data provider to test staticize_subdomain
+	 */
+	public function get_resources_urls() {
+		return array(
+			'non_wpcom_domain'  => array(
+				'https://example.org/thing.jpg',
+				'https://example.org/thing.jpg',
+				'https://example.org/thing.jpg',
+			),
+			'wp_in_the_name'    => array(
+				'https://examplewp.com/thing.jpg',
+				'https://examplewp.com/thing.jpg',
+				'https://examplewp.com/thing.jpg',
+			),
+			'local_domain'      => array(
+				'https://localhost/dir/thing.jpg',
+				'https://localhost/dir/thing.jpg',
+				'https://localhost/dir/thing.jpg',
+			),
+			'wordpresscom'      => array(
+				'https://wordpress.com/i/blank.jpg',
+				'.wp.com/i/blank.jpg',
+				'https://s-ssl.wordpress.com/i/blank.jpg',
+			),
+			'wpcom'             => array(
+				'https://wp.com/i/blank.jpg',
+				'.wp.com/i/blank.jpg',
+				'https://s-ssl.wordpress.com/i/blank.jpg',
+			),
+			'www_wordpresscom'  => array(
+				'https://www.wordpress.com/i/blank.jpg',
+				'.wp.com/i/blank.jpg',
+				'https://s-ssl.wordpress.com/i/blank.jpg',
+			),
+			'http_wordpresscom' => array(
+				'http://wordpress.com/i/blank.jpg',
+				'.wp.com/i/blank.jpg',
+				'https://s-ssl.wordpress.com/i/blank.jpg',
+			),
 		);
 	}
 }

--- a/packages/assets/tests/php/test-assets.php
+++ b/packages/assets/tests/php/test-assets.php
@@ -253,11 +253,11 @@ class AssetsTest extends TestCase {
 	public function test_staticize_subdomain( $original, $expected_http, $expected_https ) {
 		Functions\when( 'is_ssl' )->justReturn( false );
 		$static_resource = Assets::staticize_subdomain( $original );
-		$this->assertContains( $expected_http, $static_resource );
+		$this->assertStringContainsString( $expected_http, $static_resource );
 
 		Functions\when( 'is_ssl' )->justReturn( true );
 		$static_resource = Assets::staticize_subdomain( $original );
-		$this->assertContains( $expected_https, $static_resource );
+		$this->assertEquals( $expected_https, $static_resource );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The `Jetpack` class already has a `staticize_subdomain` method one can use all across the Jetpack plugin. Let's move this to a package to keep moving things out of `class.jetpack.php`.

**Note**: I skipped the pre-commit check for my commit modifying `class.jetpack.php`, as it was triggering errors even for lines I hadn't touched.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Install the AMP plugin on your site.
* Publish a new post without any image.
* Visit the AMP view of that post and view source: you should see the OG Image meta tag using a `https://s*.wp.com/i/blank.jpg` image.
* Do the tests pass?

#### Proposed changelog entry for your changes:

* N/A
