### PR TITLE
Admin Color Schemes: Block Editor Support

### DIFF
--- a/modules/masterbar/admin-color-schemes/colors/_admin.scss
+++ b/modules/masterbar/admin-color-schemes/colors/_admin.scss
@@ -768,3 +768,6 @@ div#wp-responsive-toggle a:before {
 
 /* Overrides */
 @import 'overrides';
+
+/* Gutenberg Support */
+@import 'gutenberg';

--- a/modules/masterbar/admin-color-schemes/colors/_gutenberg.scss
+++ b/modules/masterbar/admin-color-schemes/colors/_gutenberg.scss
@@ -1,0 +1,14 @@
+/*
+ * This file ensures scheme colors propagating into the block editor. The editor expects colors
+ * as CSS variables. We generate them the same way it does for core color schemes.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/base-styles/_mixins.scss
+ */
+
+body {
+	--wp-admin-theme-color: #{$base-color};
+
+	// Darker shades.
+	--wp-admin-theme-color-darker-10: #{darken($base-color, 5%)};
+	--wp-admin-theme-color-darker-20: #{darken($base-color, 10%)};
+}

--- a/modules/masterbar/admin-color-schemes/colors/_gutenberg.scss
+++ b/modules/masterbar/admin-color-schemes/colors/_gutenberg.scss
@@ -6,9 +6,9 @@
  */
 
 body {
-	--wp-admin-theme-color: #{$base-color};
+	--wp-admin-theme-color: #{$highlight-color};
 
 	// Darker shades.
-	--wp-admin-theme-color-darker-10: #{darken($base-color, 5%)};
-	--wp-admin-theme-color-darker-20: #{darken($base-color, 10%)};
+	--wp-admin-theme-color-darker-10: #{darken($highlight-color, 5%)};
+	--wp-admin-theme-color-darker-20: #{darken($highlight-color, 10%)};
 }


### PR DESCRIPTION
The general support for admin color schemes is being added in #17828. This specific PR extends it so the color schemes also apply to the block editor, just as core color schemes. 

#### Changes proposed in this Pull Request:
* uses Sass variables to generate CSS vars the block editor uses to adjust its colors

#### Jetpack product discussion
—

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Follow instructions from #17828 and activate yourself some of the new color schemes
* Open the block editor and check if your color scheme has a desired effect on the editor UI. The editor doesn't change a lot but you can see those colors for example in the toolbar buttons (block inserter and publish) or form elements in the sidebar. 

A few examples of the green color propagating from the Sakura scheme:

<img width="193" alt="Screenshot 2020-12-08 at 15 21 16" src="https://user-images.githubusercontent.com/156676/101497848-b374eb00-396b-11eb-8436-e09c90f7d2ba.png"> <img width="129" alt="Screenshot 2020-12-08 at 15 21 25" src="https://user-images.githubusercontent.com/156676/101497867-b8399f00-396b-11eb-86f4-0b62ec4f18c4.png"> <img width="138" alt="Screenshot 2020-12-08 at 15 21 21" src="https://user-images.githubusercontent.com/156676/101497895-bff94380-396b-11eb-8097-51c5d76ee8a6.png">

Compared to the Sunset scheme:

<img width="230" alt="Screenshot 2020-12-08 at 15 43 10" src="https://user-images.githubusercontent.com/156676/101498258-2aaa7f00-396c-11eb-9b81-72492c3e7f74.png"> <img width="130" alt="Screenshot 2020-12-08 at 15 42 53" src="https://user-images.githubusercontent.com/156676/101498269-2e3e0600-396c-11eb-91dc-f6dd44e8885f.png"> <img width="135" alt="Screenshot 2020-12-08 at 15 43 43" src="https://user-images.githubusercontent.com/156676/101498277-31d18d00-396c-11eb-856f-19ac0834f69d.png">

#### Proposed changelog entry for your changes:
—

Fixes https://github.com/Automattic/jetpack/issues/18016