### PR TITLE
REST API: properly trap wp_die  when updating comments

### DIFF
--- a/class.json-api.php
+++ b/class.json-api.php
@@ -774,10 +774,21 @@ class WPCOM_JSON_API {
 	 * @param int         $http_status  HTTP status code, 400 by default.
 	 */
 	function trap_wp_die( $error_code = null, $http_status = 400 ) {
+		// Determine the filter name; based on the conditionals inside the wp_die function.
+		if ( wp_is_json_request() ) {
+			$die_handler = 'wp_die_json_handler';
+		} elseif ( wp_is_jsonp_request() ) {
+			$die_handler = 'wp_die_jsonp_handler';
+		} elseif ( wp_is_xml_request() ) {
+			$die_handler = 'wp_die_xml_handler';
+		} else {
+			$die_handler = 'wp_die_handler';
+		}
+
 		if ( is_null( $error_code ) ) {
 			$this->trapped_error = null;
 			// Stop trapping
-			remove_filter( 'wp_die_handler', array( $this, 'wp_die_handler_callback' ) );
+			remove_filter( $die_handler, array( $this, 'wp_die_handler_callback' ) );
 			return;
 		}
 
@@ -798,7 +809,7 @@ class WPCOM_JSON_API {
 			'message' => '',
 		);
 		// Start trapping
-		add_filter( 'wp_die_handler', array( $this, 'wp_die_handler_callback' ) );
+		add_filter( $die_handler, array( $this, 'wp_die_handler_callback' ) );
 	}
 
 	function wp_die_handler_callback() {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* REST API: properly trap wp_die in WPCOM_JSON_API_Update_Comment_Endpoint::new_comment

- Differential Revision: D53694-code
- This commit syncs r217961-wpcom.

After https://build.trac.wordpress.org/changeset/49090/ the `application/json; charset=utf-8` content-type is being recognized as json request, thus the `wp_die_json_handler` filter is being used instead of `wp_die`.

This patch covers all possible wp_die filters based on the conditional checks similar to those used inside the `wp_die` function. See https://github.com/WordPress/WordPress/blob/master/wp-includes/functions.php#L3351

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

manual

```
curl -k -H 'Host: [private link]' -H 'authorization: Bearer <Bearer>' -H 'content-type: application/json; charset=utf-8' --data-binary '{"content":"This is a unique comment"}' --compressed 'https://192.0.93.84/rest/v1.1/sites/xxx/posts/50913/replies/new/?locale=en_US'
```

should return something like: `{"error":"comment_duplicate","message":"Duplicate comment detected..."}`

before applying the patch, `error` contains `wp_die` instead of expected `comment_duplicate`.


#### Proposed changelog entry for your changes:

* N/A
