### PR TITLE
Docs: Add the path to Jetpack's ruleset in the development docs

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -333,7 +333,7 @@ To execute them in your local environment, you can use the following commands.
 
 We strongly recommend that you install tools to review your code in your IDE. It will make it easier for you to notice any missing documentation or coding standards you should respect. Most IDEs display warnings and notices inside the editor, making it even easier.
 
-- You can find [Code Sniffer rules for WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#installation) here. Once you've installed these rulesets, you can [follow the instructions here](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#how-to-use) to configure your IDE.
+- Jetpack's custom Code Sniffer ruleset is located at `./packages/codesniffer/Jetpack/ruleset.xml`. You can use this path to set up Jetpack's custom ruleset in your IDE.
 - For JavaScript, we recommend installing ESLint. Most IDEs come with an ESLint plugin that you can use. Jetpack includes a `.eslintrc.js` file that defines our coding standards.
 
 ## Linting


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
 * It shouldn't be necessary to install the WordPress Coding Standard, so remove the WPCS installation instructions.
 * Add information about the Jetpack custom ruleset path to the development docs.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
This is just a documentation change, so no testing is necessary. Just verify that the documentation changes are correct.

#### Proposed changelog entry for your changes:
* n/a
