### PR TITLE
Instant Search: Prevent 2020 theme from spawning its modal

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -27,6 +27,7 @@ import {
 	restorePreviousHref,
 } from '../lib/query-string';
 import { bindCustomizerChanges } from '../lib/customize';
+import './search-app.scss';
 
 class SearchApp extends Component {
 	static defaultProps = {

--- a/modules/search/instant-search/components/search-app.scss
+++ b/modules/search/instant-search/components/search-app.scss
@@ -3,7 +3,7 @@
 }
 
 // Hide the search modal in the TwentyTwenty theme
-.theme-twentytwenty .cover-modal.show-modal.search-modal {
+body.enable-search-modal .cover-modal.show-modal.search-modal.active {
 	display: none;
 }
 
@@ -11,8 +11,8 @@
 // https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/
 .screen-reader-text {
 	border: 0;
-	clip: rect(1px, 1px, 1px, 1px);
-	clip-path: inset(50%);
+	clip: rect( 1px, 1px, 1px, 1px );
+	clip-path: inset( 50% );
 	height: 1px;
 	margin: -1px;
 	overflow: hidden;


### PR DESCRIPTION
Follow-up on #17060.

#### Changes proposed in this Pull Request:
* Use a more specific HTML class to target TwentyTwenty's search modal (look for `enable-search-modal` from [this file](https://themes.svn.wordpress.org/twentytwenty/1.5/inc/template-tags.php)). `.theme-twentytwenty` is no longer valid.

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Activate the latest version of the 2020 theme on your site with Jetpack Instant Search enabled.
* Ensure that you've enabled the theme's header search function in the customizer.

---

* Click on the `.search-toggle` button in the header. Ensure that 2020's search modal appears; I was able to reliably summon the header by clicking on the padded part of the `.search-toggle` button.
* Apply this PR to your Jetpack installation. Repeat the above step; ensure that the modal is no longer being summoned. 

---

* Alternatively, manually find `div.search-modal` in the inspector and add ensure the following:
  1) It defaults to `display: none;`.
  2) When you manually add `show-modal active` to its class name, it does not appear on the screen.
  3) When you override the `body.enable-search-modal .cover-modal.show-modal.search-modal.active` styling rule introduced by this PR, the search modal appears again.

#### Proposed changelog entry for your changes:
* Improved Jetpack Search styling for the TwentyTwenty theme.