### PR TITLE
Terms of Service: Need to agree to register the site

### DIFF
--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -9,6 +9,7 @@
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-roles": "@dev",
 		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-terms-of-service": "@dev",
 		"automattic/jetpack-tracking": "@dev"
 	},
 	"require-dev": {

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -7,10 +7,12 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use Automattic\Jetpack\Back;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Heartbeat;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
 use WP_Error;
@@ -890,6 +892,12 @@ class Manager {
 	 * @return true|WP_Error The error object.
 	 */
 	public function register( $api_endpoint = 'register' ) {
+		if ( Back\Compatibility::can_use( Back\Features::SITE_REGISTRATION_TOS_REQUIRED ) ) {
+			if ( ! ( new Terms_Of_Service() )->has_agreed() ) {
+				return new WP_Error( 'tos_not_agreed', __( 'You need to agree to the Terms of Service to proceed.', 'jetpack' ) );
+			}
+		}
+
 		add_action( 'pre_update_jetpack_option_register', array( '\\Jetpack_Options', 'delete_option' ) );
 		$secrets = $this->generate_secrets( 'register', get_current_user_id(), 600 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR introduces a new requirement: site can't be registered until the user has agreed to the terms of service.
It also illustrates the usage of the Jetpack Backward Compatibility package.

#### Jetpack product discussion
`p9dueE-2cK#comment-3834`

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
tbd

#### Proposed changelog entry for your changes:
tbd