### PR TITLE
Admin Menu: Follow-up tasks from initial commit

### DIFF
--- a/modules/masterbar.php
+++ b/modules/masterbar.php
@@ -27,7 +27,7 @@ new Admin_Color_Schemes();
  * @use add_filter( 'jetpack_load_admin_menu_class', '__return_true' );
  * @module masterbar
  *
- * @since 9.2.0
+ * @since 9.3.0
  *
  * @param bool $load_admin_menu_class Load Jetpack's custom admin menu functionality. Default to false.
  */

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -478,11 +478,9 @@ class Admin_Menu {
 	 * @param string $domain  Site domain.
 	 */
 	public function add_plugins_menu( $domain ) {
-		$calypso = $this->is_wpcom_site();
-
 		remove_submenu_page( 'plugins.php', 'plugin-editor.php' );
 
-		if ( $calypso ) {
+		if ( $this->is_wpcom_site() ) {
 			remove_menu_page( 'plugins.php' );
 
 			if ( $this->is_api_request ) {
@@ -553,8 +551,10 @@ class Admin_Menu {
 		$admin_slug = 'tools.php';
 		$menu_slug  = $calypso ? 'https://wordpress.com/marketing/tools/' . $domain : $admin_slug;
 
-		add_submenu_page( $menu_slug, esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'manage_options', 'https://wordpress.com/marketing/tools/' . $domain, null, 5 );
-		add_submenu_page( $menu_slug, esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $domain, null, 10 );
+		if ( $this->is_wpcom_site() || jetpack_is_atomic_site() ) {
+			add_submenu_page( $menu_slug, esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'manage_options', 'https://wordpress.com/marketing/tools/' . $domain, null, 5 );
+			add_submenu_page( $menu_slug, esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $domain, null, 10 );
+		}
 
 		if ( $calypso ) {
 			remove_menu_page( $admin_slug );
@@ -583,8 +583,10 @@ class Admin_Menu {
 			remove_submenu_page( 'options-general.php', 'options-writing.php' );
 		}
 
-		add_options_page( esc_attr__( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $domain, null, 1 );
-		add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $domain, null, 6 );
+		if ( $this->is_wpcom_site() || jetpack_is_atomic_site() ) {
+			add_options_page( esc_attr__( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $domain, null, 1 );
+			add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $domain, null, 6 );
+		}
 	}
 
 	/**

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
 /**
@@ -391,13 +390,9 @@ class Admin_Menu {
 		$menu[ $position ][5] = 'toplevel_page_jetpack'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		remove_menu_page( 'jetpack' );
-		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
-
 		$this->migrate_submenus( 'jetpack', $jetpack_slug );
 
 		add_submenu_page( $jetpack_slug, esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $domain, null, 5 );
-		add_submenu_page( $jetpack_slug, esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $domain, null, 10 );
-		add_submenu_page( $jetpack_slug, esc_attr__( 'Scan', 'jetpack' ), __( 'Scan', 'jetpack' ), 'manage_options', 'https://wordpress.com/scan/' . $domain, null, 15 );
 
 		add_filter( 'parent_file', array( $this, 'jetpack_parent_file' ) );
 	}

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -519,8 +519,9 @@ class Admin_Menu {
 	public function add_users_menu( $domain, $calypso = true ) {
 		$users_slug   = $calypso ? 'https://wordpress.com/people/team/' . $domain : 'users.php';
 		$add_new_slug = 'https://wordpress.com/people/new/' . $domain;
-		$profile_slug = $calypso ? 'https://wordpress.com/me' : 'grofiles-editor';
-		$account_slug = $calypso ? 'https://wordpress.com/me/account' : 'grofiles-user-settings';
+		$profile_slug = $this->is_wpcom_site() ? 'grofiles-editor' : 'profile.php';
+		$profile_slug = $calypso ? 'https://wordpress.com/me' : $profile_slug;
+		$account_slug = $this->is_wpcom_site() && ! $calypso ? 'grofiles-user-settings' : 'https://wordpress.com/me/account';
 
 		if ( current_user_can( 'list_users' ) ) {
 			remove_menu_page( 'users.php' );
@@ -536,7 +537,7 @@ class Admin_Menu {
 			add_submenu_page( $users_slug, esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', $profile_slug, null, 15 );
 			add_submenu_page( $users_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', $account_slug, null, 20 );
 			$this->migrate_submenus( 'users.php', $users_slug );
-		} else {
+		} elseif ( $calypso && $this->is_wpcom_site() ) {
 			remove_menu_page( 'profile.php' );
 			remove_submenu_page( 'profile.php', 'grofiles-editor' );
 			remove_submenu_page( 'profile.php', 'grofiles-user-settings' );

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -664,6 +664,10 @@ class Admin_Menu {
 		 *
 		 * Filterable to make it easier to unit test other parts of this class.
 		 *
+		 * @module masterbar
+		 *
+		 * @since 9.3.0
+		 *
 		 * @param bool $is_wpcom Whether this is a WordPress.com request. Defaults to the value of IS_WPCOM,
 		 */
 		return apply_filters( 'jetpack_admin_menu_is_wpcom', defined( 'IS_WPCOM' ) && IS_WPCOM );

--- a/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -594,10 +594,13 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_users_menu() {
 		global $menu, $submenu;
 
-		// Only users that can edit posts get to see the comments menu.
+		// Current user can't list users.
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'editor' ) ) );
 		$menu = array();
-		static::$admin_menu->add_users_menu( static::$domain );
+
+		add_filter( 'jetpack_admin_menu_is_wpcom', '__return_true' );
+		static::$admin_menu->add_users_menu( static::$domain, true );
+		remove_filter( 'jetpack_admin_menu_is_wpcom', '__return_true' );
 
 		$profile_menu_item = array(
 			'My Profile',

--- a/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -684,8 +684,10 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_tools_menu() {
 		global $menu, $submenu;
 
+		add_filter( 'jetpack_admin_menu_is_wpcom', '__return_true' );
 		$slug = 'https://wordpress.com/marketing/tools/' . static::$domain;
 		static::$admin_menu->add_tools_menu( static::$domain );
+		remove_filter( 'jetpack_admin_menu_is_wpcom', '__return_true' );
 
 		$tools_menu_item = array(
 			'Tools',
@@ -766,7 +768,9 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_options_menu() {
 		global $submenu;
 
+		add_filter( 'jetpack_admin_menu_is_wpcom', '__return_true' );
 		static::$admin_menu->add_options_menu( static::$domain );
+		remove_filter( 'jetpack_admin_menu_is_wpcom', '__return_true' );
 
 		$this->assertNotContains( 'options-discussion.php', $submenu['options-general.php'] );
 		$this->assertNotContains( 'options-writing.php', $submenu['options-general.php'] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR tries to fix as many of the things @jeherve pointed out in the original PR as possible.
See https://github.com/Automattic/jetpack/pull/17629#pullrequestreview-544243248

Fixes #17973

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates version numbers to reflect the version this will ship in.
* Removes Scan & Backup submenu items to let Jetpack Scan handle them.
* Accounts for missing grofiles plugin on WoA sites. Falls back to `profile.php` again.
* Adds conditions for menu items that are wpcom-only.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/17629#pullrequestreview-544243248

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On your Jetpack test site, make sure you have the Masterbar module active
* Check that the Jetpack menu item doesn't contain "Scan" and "Backup" menu items anymore.
* Check that the Settings > Domains and Settings > Hosting Configuration menu items don't show up on Jetpack sites. They should still be visible for simple and atomic sites.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
