### PR TITLE
Admin Menu: Remove feature flag

### DIFF
--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -68,11 +68,6 @@ class Admin_Menu {
 
 		$domain = ( new Status() )->get_site_suffix();
 
-		// TODO: Remove once feature has shipped. See jetpack_parent_file().
-		if ( ! $this->is_api_request && ! defined( 'PHPUNIT_JETPACK_TESTSUITE' ) ) {
-			$domain = add_query_arg( 'flags', 'nav-unification', $domain );
-		}
-
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request && ( $this->is_wpcom_site() || jetpack_is_atomic_site() ) ) {
 			$this->add_browse_sites_link();
@@ -410,12 +405,7 @@ class Admin_Menu {
 	 */
 	public function jetpack_parent_file( $parent_file ) {
 		if ( 'jetpack' === $parent_file ) {
-			$parent_file = 'https://wordpress.com/activity-log/' . wp_parse_url( get_home_url(), PHP_URL_HOST );
-
-			// TODO: Remove once feature has shipped. See reregister_menu_items().
-			if ( ! $this->is_api_request && ! defined( 'PHPUNIT_JETPACK_TESTSUITE' ) ) {
-				$parent_file = add_query_arg( 'flags', 'nav-unification', $parent_file );
-			}
+			$parent_file = 'https://wordpress.com/activity-log/' . ( new Status() )->get_site_suffix();
 		}
 
 		return $parent_file;


### PR DESCRIPTION
No longer needed

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Removes unneeded feature flag.

We switched to the new experiments framework for internal testing and roll-out. It's user-based and doesn't require us to pass URL parameters back and forth anymore.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes addition of feature flag to Calypso URLs.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

No testing needed. URLs will still work as shown by passing integration tests.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
