### PR TITLE
Anchor.fm: implement a basic template for podcast blog post

### DIFF
--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -137,8 +137,7 @@ function process_anchor_params() {
 	// Add Spotify Badge template action.
 	if (
 		$insert_spotify_badge && (
-			'post-new.php' !== $GLOBALS['pagenow'] || // Delegate badge insertion to podcast template.
-			is_null( $episode_id ) // Add badge since basic template depends on episode.
+			'post-new.php' !== $GLOBALS['pagenow'] // Delegate badge insertion to podcast template.
 		)
 	) {
 		$data['actions'][] = array(

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -123,7 +123,7 @@ function process_anchor_params() {
 	}
 
 	// Insert Spotify Badge action.
-	if ( ! empty( $spotify_show_url ) ) {
+	if ( ! empty( $spotify_show_url ) && is_null( $episode_id ) ) {
 		$data['actions'][] = array(
 			'insert-spotify-badge',
 			array(

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -117,6 +117,7 @@ function process_anchor_params() {
 							),
 						);
 
+						// Add insert basic template action.
 						$data['actions'][] = array(
 							'insert-episode-template',
 							array(
@@ -131,7 +132,7 @@ function process_anchor_params() {
 		}
 	}
 
-	// Insert Spotify Badge action.
+	// Add Spotify Badge template action.
 	if ( ! empty( $spotify_show_url ) && is_null( $episode_id ) ) {
 		$data['actions'][] = array(
 			'insert-spotify-badge',

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -89,6 +89,14 @@ function process_anchor_params() {
 		'actions' => array(),
 	);
 
+	// add / update Spotify Badge URL.
+	if ( ! empty( $spotify_show_url ) ) {
+		$data['spotifyShowUrl'] = $spotify_show_url;
+		if ( get_post_meta( $post->ID, 'jetpack_anchor_spotify_show', true ) !== $spotify_show_url ) {
+			update_post_meta( $post->ID, 'jetpack_anchor_spotify_show', $spotify_show_url );
+		}
+	}
+
 	if ( ! empty( $podcast_id ) ) {
 		$feed           = 'https://anchor.fm/s/' . $podcast_id . '/podcast/rss';
 		$podcast_helper = new Jetpack_Podcast_Helper( $feed );
@@ -114,18 +122,15 @@ function process_anchor_params() {
 		}
 	}
 
-	if ( ! empty( $spotify_show_url ) && empty ( $epi)) {
-		$data['spotifyShowUrl'] = $spotify_show_url;
-		if ( get_post_meta( $post->ID, 'jetpack_anchor_spotify_show', true ) !== $spotify_show_url ) {
-			update_post_meta( $post->ID, 'jetpack_anchor_spotify_show', $spotify_show_url );
-			$data['actions'][] = array(
-				'insert-spotify-badge',
-				array(
-					'image' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
-					'url'   => $spotify_show_url,
-				),
-			);
-		}
+	// Insert Spotify Badge action.
+	if ( ! empty( $spotify_show_url ) ) {
+		$data['actions'][] = array(
+			'insert-spotify-badge',
+			array(
+				'image' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
+				'url'   => $spotify_show_url,
+			),
+		);
 	}
 
 	// Display an outbound link after publishing a post (only to English-speaking users since Anchor

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -120,13 +120,9 @@ function process_anchor_params() {
 						$data['actions'][] = array(
 							'insert-episode-template',
 							array(
-								'track' => $track,
-								'badge' => ! is_null( $spotify_show_url )
-									? array(
-										'image' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
-										'url'   => $spotify_show_url,
-									)
-									: false,
+								'episodeTrack'    => $track,
+								'spotifyImageUrl' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
+								'spotifyShowUrl'  => $spotify_show_url,
 							),
 						);
 					}
@@ -140,8 +136,8 @@ function process_anchor_params() {
 		$data['actions'][] = array(
 			'insert-spotify-badge',
 			array(
-				'image' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
-				'url'   => $spotify_show_url,
+				'spotifyImageUrl' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
+				'spotifyShowUrl'  => $spotify_show_url,
 			),
 		);
 	}

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -114,7 +114,7 @@ function process_anchor_params() {
 		}
 	}
 
-	if ( ! empty( $spotify_show_url ) ) {
+	if ( ! empty( $spotify_show_url ) && empty ( $epi)) {
 		$data['spotifyShowUrl'] = $spotify_show_url;
 		if ( get_post_meta( $post->ID, 'jetpack_anchor_spotify_show', true ) !== $spotify_show_url ) {
 			update_post_meta( $post->ID, 'jetpack_anchor_spotify_show', $spotify_show_url );

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -116,6 +116,19 @@ function process_anchor_params() {
 								'title' => $track['title'],
 							),
 						);
+
+						$data['actions'][] = array(
+							'insert-episode-template',
+							array(
+								'track' => $track,
+								'badge' => ! is_null( $spotify_show_url )
+									? array(
+										'image' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
+										'url'   => $spotify_show_url,
+									)
+									: false,
+							),
+						);
 					}
 				}
 			}

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -90,9 +90,11 @@ function process_anchor_params() {
 	);
 
 	// add / update Spotify Badge URL.
+	$insert_spotify_badge = false;
 	if ( ! empty( $spotify_show_url ) ) {
 		$data['spotifyShowUrl'] = $spotify_show_url;
 		if ( get_post_meta( $post->ID, 'jetpack_anchor_spotify_show', true ) !== $spotify_show_url ) {
+			$insert_spotify_badge = true;
 			update_post_meta( $post->ID, 'jetpack_anchor_spotify_show', $spotify_show_url );
 		}
 	}
@@ -133,7 +135,12 @@ function process_anchor_params() {
 	}
 
 	// Add Spotify Badge template action.
-	if ( ! empty( $spotify_show_url ) && is_null( $episode_id ) ) {
+	if (
+		$insert_spotify_badge && (
+			'post-new.php' !== $GLOBALS['pagenow'] || // Delegate badge insertion to podcast template.
+			is_null( $episode_id ) // Add badge since basic template depends on episode.
+		)
+	) {
 		$data['actions'][] = array(
 			'insert-spotify-badge',
 			array(

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -6,7 +6,6 @@ import { castArray } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { external, Icon } from '@wordpress/icons';
@@ -17,6 +16,7 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import { waitForEditor } from '../../shared/wait-for-editor';
+import { spotifyBadgeTemplate } from './templates';
 
 /**
  * Style dependencies
@@ -29,16 +29,11 @@ async function insertSpotifyBadge( { image, url } ) {
 	}
 
 	await waitForEditor();
-	dispatch( 'core/block-editor' ).insertBlock(
-		createBlock( 'core/image', {
-			url: image,
-			linkDestination: 'none',
-			href: url,
-			align: 'center',
-			width: 165,
-			height: 40,
-			className: 'is-spotify-podcast-badge',
-		} ),
+
+	const { insertBlocks } = dispatch( 'core/block-editor' );
+
+	insertBlocks(
+		spotifyBadgeTemplate( { spotifyShowUrl: url, spotifyImageUrl: image } ),
 		0,
 		undefined,
 		false

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -16,28 +16,48 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import { waitForEditor } from '../../shared/wait-for-editor';
-import { spotifyBadgeTemplate } from './templates';
+import { basicTemplate, spotifyBadgeTemplate } from './templates';
 
 /**
  * Style dependencies
  */
 import './editor.scss';
 
-async function insertSpotifyBadge( { image, url } ) {
-	if ( ! image || ! url ) {
-		return;
-	}
-
+async function insertTemplate( {
+	spotifyImageUrl,
+	spotifyShowUrl,
+	tpl,
+	episodeTrack
+} ) {
 	await waitForEditor();
 
 	const { insertBlocks } = dispatch( 'core/block-editor' );
 
-	insertBlocks(
-		spotifyBadgeTemplate( { spotifyShowUrl: url, spotifyImageUrl: image } ),
-		0,
-		undefined,
-		false
-	);
+	let templateBlocks = [];
+	switch ( tpl ) {
+		case 'sporifyBadge':
+			if ( spotifyImageUrl && spotifyShowUrl ) {
+				templateBlocks = spotifyBadgeTemplate( { spotifyShowUrl, spotifyImageUrl } );
+			}
+		break;
+
+		case 'basicEpisode':
+			templateBlocks = basicTemplate( {
+				spotifyShowUrl,
+				spotifyImageUrl,
+				episodeTrack,
+			} );
+		break;
+	}
+
+	if ( templateBlocks.length ) {
+		insertBlocks(
+			templateBlocks,
+			0,
+			undefined,
+			false
+		);
+	}
 }
 
 async function setEpisodeTitle( { title } ) {
@@ -79,7 +99,10 @@ function initAnchor() {
 		const [ actionName, actionParams ] = castArray( action );
 		switch ( actionName ) {
 			case 'insert-spotify-badge':
-				insertSpotifyBadge( actionParams );
+				insertTemplate( { ...actionParams, tpl: 'spotifyBadge' } );
+				break;
+			case 'insert-episode-template':
+				insertTemplate( { ...actionParams, tpl: 'basicEpisode' } );
 				break;
 			case 'show-post-publish-outbound-link':
 				showPostPublishOutboundLink();

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -29,8 +29,9 @@ async function insertTemplate( params ) {
 	const { insertBlocks } = dispatch( 'core/block-editor' );
 
 	let templateBlocks;
+
 	switch ( params.tpl ) {
-		case 'sporifyBadge':
+		case 'spotifyBadge':
 			templateBlocks = spotifyBadgeTemplate( params );
 		break;
 

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -9,7 +9,6 @@ import { castArray } from 'lodash';
 import { createBlock } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
-import { addFilter } from '@wordpress/hooks';
 import { external, Icon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -23,34 +23,23 @@ import { basicTemplate, spotifyBadgeTemplate } from './templates';
  */
 import './editor.scss';
 
-async function insertTemplate( {
-	spotifyImageUrl,
-	spotifyShowUrl,
-	tpl,
-	episodeTrack
-} ) {
+async function insertTemplate( params ) {
 	await waitForEditor();
 
 	const { insertBlocks } = dispatch( 'core/block-editor' );
 
-	let templateBlocks = [];
-	switch ( tpl ) {
+	let templateBlocks;
+	switch ( params.tpl ) {
 		case 'sporifyBadge':
-			if ( spotifyImageUrl && spotifyShowUrl ) {
-				templateBlocks = spotifyBadgeTemplate( { spotifyShowUrl, spotifyImageUrl } );
-			}
+			templateBlocks = spotifyBadgeTemplate( params );
 		break;
 
 		case 'basicEpisode':
-			templateBlocks = basicTemplate( {
-				spotifyShowUrl,
-				spotifyImageUrl,
-				episodeTrack,
-			} );
+			templateBlocks = basicTemplate( params );
 		break;
 	}
 
-	if ( templateBlocks.length ) {
+	if ( templateBlocks?.length ) {
 		insertBlocks(
 			templateBlocks,
 			0,

--- a/extensions/blocks/anchor-fm/templates/index.js
+++ b/extensions/blocks/anchor-fm/templates/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlocksFromInnerBlocksTemplate, } from '@wordpress/blocks';
+
+// Templates.
+function spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) {
+	return [ 'core/image', {
+		url: spotifyImageUrl,
+		linkDestination: 'none',
+		href: spotifyShowUrl,
+		align: 'center',
+		width: 165,
+		height: 40,
+		className: 'is-spotify-podcast-badge',
+	} ];
+}
+
+export function spotifyBadgeTemplate ( params ) {
+	return createBlocksFromInnerBlocksTemplate( [ spotifyTemplate( params ) ] );
+}

--- a/extensions/blocks/anchor-fm/templates/index.js
+++ b/extensions/blocks/anchor-fm/templates/index.js
@@ -23,6 +23,40 @@ function spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) {
 	} ];
 }
 
+function podcastSection( { episodeTrack } ) {
+	const { image, link } = episodeTrack;
+
+	return [ 'core/columns', {
+		align: 'wide',
+	}, [
+		[ 'core/column', { width: '30%' }, [
+			[ 'core/image', {
+				url: image ? image : null,
+			} ],
+		] ],
+		[ 'core/column', { width: '70%' }, [
+			[ 'jetpack/podcast-player', {
+				customPrimaryColor: getIconColor(),
+				hexPrimaryColor: getIconColor(),
+				url: link,
+			} ],
+		] ],
+	] ];
+}
+
+function podcastSummarySection( { episodeTrack } ) {
+	return [ 'core/group', {}, [
+		[ 'core/heading', {
+			content: 'Summary',
+			placeholder: __( 'Podcast episode title', 'jetpack' ),
+		} ],
+		[ 'core/paragraph', {
+			placeholder: __( 'Podcast episode summary', 'jetpack' ),
+			content: episodeTrack.description,
+		} ],
+	] ];
+}
+
 /*
  * Template parts
  */
@@ -31,39 +65,15 @@ function buildPlayerSection( {
 	spotifyImageUrl,
 	episodeTrack = {},
 } ) {
-	return [
-		// Podcast player section.
-		[ 'core/columns', {
-			align: 'wide',
-		}, [
-			[ 'core/column', { width: '30%' }, [
-				[ 'core/image', {
-					url: episodeTrack?.image ? episodeTrack.image : null,
-				} ],
-			] ],
-			[ 'core/column', { width: '70%' }, [
-				[ 'jetpack/podcast-player', {
-					customPrimaryColor: getIconColor(),
-					hexPrimaryColor: getIconColor(),
-					url: episodeTrack.link,
-				} ],
-			] ],
-		] ],
+	const tpl = [ podcastSection( { episodeTrack } ) ];
 
-		spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ),
+	if ( spotifyShowUrl && spotifyImageUrl ) {
+		tpl.push( spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) );
+	}
 
-		// Summary section.
-		[ 'core/group', {}, [
-			[ 'core/heading', {
-				content: 'Summary',
-				placeholder: __( 'Podcast episode title', 'jetpack' ),
-			} ],
-			[ 'core/paragraph', {
-				placeholder: __( 'Podcast episode summary', 'jetpack' ),
-				content: episodeTrack.description,
-			} ],
-		] ],
-	];
+	tpl.push( podcastSummarySection( { episodeTrack } ) );
+
+	return tpl;
 }
 
 export function basicTemplate( params ) {
@@ -71,5 +81,9 @@ export function basicTemplate( params ) {
 }
 
 export function spotifyBadgeTemplate( params ) {
+	if ( ! params.spotifyImageUrl || ! params.spotifyShowUrl ) {
+		return;
+	}
+
 	return createBlocksFromInnerBlocksTemplate( [ spotifyTemplate( params ) ] );
 }

--- a/extensions/blocks/anchor-fm/templates/index.js
+++ b/extensions/blocks/anchor-fm/templates/index.js
@@ -2,8 +2,15 @@
  * WordPress dependencies
  */
 import { createBlocksFromInnerBlocksTemplate, } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getIconColor } from '../../../shared/block-icons';
 
 // Templates.
+
 function spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) {
 	return [ 'core/image', {
 		url: spotifyImageUrl,
@@ -16,6 +23,53 @@ function spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) {
 	} ];
 }
 
-export function spotifyBadgeTemplate ( params ) {
+/*
+ * Template parts
+ */
+function buildPlayerSection( {
+	spotifyShowUrl,
+	spotifyImageUrl,
+	episodeTrack = {},
+} ) {
+	return [
+		// Podcast player section.
+		[ 'core/columns', {
+			align: 'wide',
+		}, [
+			[ 'core/column', { width: '30%' }, [
+				[ 'core/image', {
+					url: episodeTrack?.image ? episodeTrack.image : null,
+				} ],
+			] ],
+			[ 'core/column', { width: '70%' }, [
+				[ 'jetpack/podcast-player', {
+					customPrimaryColor: getIconColor(),
+					hexPrimaryColor: getIconColor(),
+					url: episodeTrack.link,
+				} ],
+			] ],
+		] ],
+
+		spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ),
+
+		// Summary section.
+		[ 'core/group', {}, [
+			[ 'core/heading', {
+				content: 'Summary',
+				placeholder: __( 'Podcast episode title', 'jetpack' ),
+			} ],
+			[ 'core/paragraph', {
+				placeholder: __( 'Podcast episode summary', 'jetpack' ),
+				content: episodeTrack.description,
+			} ],
+		] ],
+	];
+}
+
+export function basicTemplate( params ) {
+	return createBlocksFromInnerBlocksTemplate( buildPlayerSection( params ) );
+}
+
+export function spotifyBadgeTemplate( params ) {
 	return createBlocksFromInnerBlocksTemplate( [ spotifyTemplate( params ) ] );
 }

--- a/extensions/blocks/anchor-fm/templates/index.js
+++ b/extensions/blocks/anchor-fm/templates/index.js
@@ -60,7 +60,7 @@ function podcastSummarySection( { episodeTrack } ) {
 /*
  * Template parts
  */
-function buildPlayerSection( {
+function episodeBasicTemplate( {
 	spotifyShowUrl,
 	spotifyImageUrl,
 	episodeTrack = {},
@@ -77,7 +77,7 @@ function buildPlayerSection( {
 }
 
 export function basicTemplate( params ) {
-	return createBlocksFromInnerBlocksTemplate( buildPlayerSection( params ) );
+	return createBlocksFromInnerBlocksTemplate( episodeBasicTemplate( params ) );
 }
 
 export function spotifyBadgeTemplate( params ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

~**IMPORTANT**: it branches off from https://github.com/Automattic/jetpack/pull/18033 https://github.com/Automattic/jetpack/pull/18064, so let's hold on.~

This PR adds a basic templating system for the episode blog post. Depending on the action name, it will render a basic template or the Spotify badge.

The basic template adds the current podcast player block, but let's keep in mind we'd like to switch to the player single podcast version once it's ready (https://github.com/Automattic/jetpack/issues/18008)

![image](https://user-images.githubusercontent.com/77539/101912425-7ba2b900-3ba0-11eb-8065-b67ec809d511.png)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Anchor.fm: implement a basic layout for episode blog post.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

361-gh-Automattic/dotcom-manage
p1607567538046400-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post, but passing podcast data in the query string. You can use the following URL, changing the `hostname` if  it's the case:

`http://localhost:8888/wp-admin/post-new.php?action=edit&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q`

You should see the podcast player block, with the podcast data according to the data provided by the query string.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
Anchor.fm: implement a basic layout for episode blog post.