### PR TITLE
Podcasts: Add extra checks to the feed detection

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
@@ -104,8 +104,9 @@ class Jetpack_Podcast_Feed_Locator extends SimplePie_Locator {
 	 * @return boolean Whether enclosures were found.
 	 */
 	private function has_audio_enclosures( $dom ) {
-		$xpath = new DOMXPath( $dom );
-		return count( $xpath->query( "//enclosure[starts-with(@type,'audio/')]" ) ) > 0;
+		$xpath      = new DOMXPath( $dom );
+		$enclosures = $xpath->query( "//enclosure[starts-with(@type,'audio/')]" );
+		return ! $enclosures ? false : $enclosures->length > 0;
 	}
 
 }

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
@@ -17,7 +17,7 @@ class Jetpack_Podcast_Feed_Locator extends SimplePie_Locator {
 	 * @param boolean        $check_html Adds text/html to the mimetypes checked.
 	 */
 	public function is_feed( $file, $check_html = false ) {
-		return parent::is_feed( $file, $check_html ) && self::is_podcast_feed( $file );
+		return parent::is_feed( $file, $check_html ) && $this->is_podcast_feed( $file );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Extension of the SimplePieLocator class, to detect podcast feeds
+ * Extension of the SimplePie_Locator class, to detect podcast feeds
  *
  * @package jetpack
  */

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
@@ -56,7 +56,7 @@ class Jetpack_Podcast_Feed_Locator extends SimplePie_Locator {
 		if ( $disable_entity_loader ) {
 			// This function has been deprecated in PHP 8.0 because in libxml 2.9.0, external entity loading
 			// is disabled by default, so this function is no longer needed to protect against XXE attacks.
-			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated
+			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated, PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated
 			$loader = libxml_disable_entity_loader( true );
 		}
 
@@ -70,7 +70,7 @@ class Jetpack_Podcast_Feed_Locator extends SimplePie_Locator {
 		libxml_use_internal_errors( $errors );
 
 		if ( $disable_entity_loader && isset( $loader ) ) {
-			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated
+			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated, PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated
 			libxml_disable_entity_loader( $loader );
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-feed-locator.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Extension of the SimplePieLocator class, to detect podcast feeds
+ *
+ * @package jetpack
+ */
+
+/**
+ * Class Jetpack_Podcast_Feed_Locator
+ */
+class Jetpack_Podcast_Feed_Locator extends SimplePie_Locator {
+	/**
+	 * Overrides the locator is_feed function to check for
+	 * appropriate podcast elements.
+	 *
+	 * @param SimplePie_File $file The file being checked.
+	 * @param boolean        $check_html Adds text/html to the mimetypes checked.
+	 */
+	public function is_feed( $file, $check_html = false ) {
+		return parent::is_feed( $file, $check_html ) && self::is_podcast_feed( $file );
+	}
+
+	/**
+	 * Checks the contents of the file for elements that make
+	 * it a podcast feed.
+	 *
+	 * @param SimplePie_File $file The file being checked.
+	 */
+	private function is_podcast_feed( $file ) {
+		// If we can't read the DOM assume it's a podcast feed, we'll work
+		// it out later.
+		if ( ! class_exists( 'DOMDocument' ) ) {
+			return true;
+		}
+		$feed_dom = new DOMDocument();
+		$feed_dom->loadXML( $file->body );
+
+		// Do this as either/or but prioritise the itunes namespace. It's pretty likely
+		// that it's a podcast feed we've found if that namespace is present.
+		return $this->has_itunes_ns( $feed_dom ) || $this->has_audio_enclosures( $feed_dom );
+	}
+
+	/**
+	 * Checks the RSS feed for the presence of the itunes podcast namespace.
+	 * It's pretty loose and just checks the URI for itunes.com
+	 *
+	 * @param DOMDocument $dom The XML document to check.
+	 * @return boolean Whether the itunes namespace is defined.
+	 */
+	private function has_itunes_ns( $dom ) {
+		$xpath = new DOMXPath( $dom );
+		foreach ( $xpath->query( 'namespace::*' ) as $node ) {
+			// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			// nodeValue is not valid, but it's part of the DOM API that we don't control.
+			if ( strstr( $node->nodeValue, 'itunes.com' ) ) {
+				return true;
+			}
+			// phpcs:enable
+		}
+		return false;
+	}
+
+	/**
+	 * Checks the RSS feed for the presence of enclosures with an audio mimetype.
+	 *
+	 * @param DOMDocument $dom The XML document to check.
+	 * @return boolean Whether enclosures were found.
+	 */
+	private function has_audio_enclosures( $dom ) {
+		$xpath = new DOMXPath( $dom );
+		return count( $xpath->query( "//enclosure[starts-with(@type,'audio/')]" ) ) > 0;
+	}
+
+}
+

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -164,12 +164,11 @@ class Jetpack_Podcast_Helper {
 	/**
 	 * Loads an RSS feed using `fetch_feed`.
 	 *
-	 * @param string $feed The URL of the feed to fetch.
 	 * @return SimplePie|WP_Error The RSS object or error.
 	 */
-	public function load_feed( $feed ) {
+	public function load_feed() {
 		add_action( 'wp_feed_options', array( __CLASS__, 'set_podcast_locator' ) );
-		$rss = fetch_feed( esc_url_raw( $feed ) );
+		$rss = fetch_feed( $this->feed );
 		remove_action( 'wp_feed_options', array( __CLASS__, 'set_podcast_locator' ) );
 		if ( is_wp_error( $rss ) ) {
 			return new WP_Error( 'invalid_url', __( 'Your podcast couldn\'t be embedded. Please double check your URL.', 'jetpack' ) );

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -164,10 +164,13 @@ class Jetpack_Podcast_Helper {
 	/**
 	 * Loads an RSS feed using `fetch_feed`.
 	 *
+	 * @param string $feed The URL of the feed to fetch.
 	 * @return SimplePie|WP_Error The RSS object or error.
 	 */
-	public function load_feed() {
-		$rss = fetch_feed( $this->feed );
+	public function load_feed( $feed ) {
+		add_action( 'wp_feed_options', array( __CLASS__, 'set_podcast_locator' ) );
+		$rss = fetch_feed( esc_url_raw( $feed ) );
+		remove_action( 'wp_feed_options', array( __CLASS__, 'set_podcast_locator' ) );
 		if ( is_wp_error( $rss ) ) {
 			return new WP_Error( 'invalid_url', __( 'Your podcast couldn\'t be embedded. Please double check your URL.', 'jetpack' ) );
 		}
@@ -177,6 +180,19 @@ class Jetpack_Podcast_Helper {
 		}
 
 		return $rss;
+	}
+
+	/**
+	 * Action handler to set our podcast specific feed locator class on the SimplePie object.
+	 *
+	 * @param SimplePie $feed The SimplePie object, passed by reference.
+	 */
+	public static function set_podcast_locator( &$feed ) {
+		if ( ! class_exists( 'Jetpack_Podcast_Feed_Locator' ) ) {
+			jetpack_require_lib( 'class-jetpack-podcast-feed-locator' );
+		}
+
+		$feed->set_locator_class( 'Jetpack_Podcast_Feed_Locator' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/_inc/lib/mocks/class-simplepie-file.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/mocks/class-simplepie-file.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Implements a basic interface of the SimplePie_Locator class in environments where it doesn't exist.
+ *
+ * @package jetpack
+ */
+
+if ( ! class_exists( 'SimplePie_File' ) ) {
+	/**
+	 * Class SimplePie_Locator
+	 */
+	class SimplePie_File {
+		/**
+		 * Constructor
+		 *
+		 * Stores a response directly into the file body for similating feed markup.
+		 *
+		 * @param string $response Response body.
+		 */
+		public function __construct( $response ) {
+			$this->body = $response;
+		}
+	}
+}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/mocks/class-simplepie-locator.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/mocks/class-simplepie-locator.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Implements a basic interface of the SimplePie_Locator class in environments where it doesn't exist.
+ *
+ * @package jetpack
+ */
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+if ( ! class_exists( 'SimplePie_Locator' ) ) {
+	/**
+	 * Class SimplePie_Locator
+	 */
+	class SimplePie_Locator {
+		/**
+		 * Overrides the locator is_feed function to check for
+		 * appropriate podcast elements.
+		 *
+		 * @param SimplePie_File $file The file being checked.
+		 * @param boolean        $check_html Adds text/html to the mimetypes checked.
+		 */
+		public function is_feed( $file, $check_html = false ) {
+			return true;
+		}
+	}
+}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-podcast-feed-locator.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-podcast-feed-locator.php
@@ -17,6 +17,14 @@ jetpack_require_lib( 'class-jetpack-podcast-feed-locator' );
  * @coversDefaultClass Jetpack_Podcast_Feed_Locator
  */
 class WP_Test_Jetpack_Podcast_Feed_Locator extends WP_UnitTestCase {
+	public function setUp() {
+		if ( ! class_exists( 'DOMDocument' ) ) {
+			$this->markTestSkipped( 'DOMDocument is not available - can\'t run feed tests' );
+		} else {
+			parent::setUp();
+		}
+	}
+
 	/**
 	 * Tests that class extends SimplePie_Locator, so that it can be set as the locator
 	 * class, e.g. `$feed->set_locator_class( 'Jetpack_Podcast_Feed_Locator' )`.
@@ -29,12 +37,11 @@ class WP_Test_Jetpack_Podcast_Feed_Locator extends WP_UnitTestCase {
 	}
 
 	public function test_finds_podcast_feed_with_itunes_ns() {
-		$file = new SimplePie_File(
-			<<<FEED
-			<?xml version="1.0" encoding="UTF-8"?>
-			<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"></rss>
-			FEED
-		);
+		$rss  = <<<FEED
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"></rss>
+FEED;
+		$file = new SimplePie_File( $rss );
 
 		$locator = new Jetpack_Podcast_Feed_Locator( $file );
 
@@ -42,18 +49,17 @@ class WP_Test_Jetpack_Podcast_Feed_Locator extends WP_UnitTestCase {
 	}
 
 	public function test_finds_podcast_feed_with_audio_enclosures() {
-		$file = new SimplePie_File(
-			<<<FEED
-			<?xml version="1.0" encoding="UTF-8"?>
-			<rss>
-				<channel>
-					<item>
-						<enclosure url="https://example.com/audio.mp3" type="audio/mpeg"/>
-					</item>
-				</channel>
-			</rss>
-			FEED
-		);
+		$rss  = <<<FEED
+<?xml version="1.0" encoding="UTF-8"?>
+<rss>
+	<channel>
+		<item>
+			<enclosure url="https://example.com/audio.mp3" type="audio/mpeg"/>
+		</item>
+	</channel>
+</rss>
+FEED;
+		$file = new SimplePie_File( $rss );
 
 		$locator = new Jetpack_Podcast_Feed_Locator( $file );
 
@@ -61,18 +67,17 @@ class WP_Test_Jetpack_Podcast_Feed_Locator extends WP_UnitTestCase {
 	}
 
 	public function test_does_not_locate_non_podcast_feeds() {
-		$file = new SimplePie_File(
-			<<<FEED
-			<?xml version="1.0" encoding="UTF-8"?>
-			<rss>
-				<channel>
-					<item>
-						<title>My Post</title>
-					</item>
-				</channel>
-			</rss>
-			FEED
-		);
+		$rss = <<<FEED
+<?xml version="1.0" encoding="UTF-8"?>
+<rss>
+	<channel>
+		<item>
+			<title>My Post</title>
+		</item>
+	</channel>
+</rss>
+FEED;
+		$file = new SimplePie_File( $rss );
 
 		$locator = new Jetpack_Podcast_Feed_Locator( $file );
 

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-podcast-feed-locator.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-podcast-feed-locator.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Podcast Feed Locator unit tests.
+ *
+ * @package Jetpack
+ */
+
+// phpcs:ignoreFile Squiz.Commenting.FunctionComment.Missing
+
+require_once __DIR__ . '/mocks/class-simplepie-file.php';
+require_once __DIR__ . '/mocks/class-simplepie-locator.php';
+jetpack_require_lib( 'class-jetpack-podcast-feed-locator' );
+
+/**
+ * Class for testing the Jetpack_Podcast_Feed_Locator class.
+ *
+ * @coversDefaultClass Jetpack_Podcast_Feed_Locator
+ */
+class WP_Test_Jetpack_Podcast_Feed_Locator extends WP_UnitTestCase {
+	/**
+	 * Tests that class extends SimplePie_Locator, so that it can be set as the locator
+	 * class, e.g. `$feed->set_locator_class( 'Jetpack_Podcast_Feed_Locator' )`.
+	 */
+	public function test_extends_simple_pie_locator() {
+		$file    = new SimplePie_File( '<?xml version="1.0" encoding="UTF-8"?>' );
+		$locator = new Jetpack_Podcast_Feed_Locator( $file );
+
+		$this->assertInstanceOf( 'SimplePie_Locator', $locator );
+	}
+
+	public function test_finds_podcast_feed_with_itunes_ns() {
+		$file = new SimplePie_File(
+			<<<FEED
+			<?xml version="1.0" encoding="UTF-8"?>
+			<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"></rss>
+			FEED
+		);
+
+		$locator = new Jetpack_Podcast_Feed_Locator( $file );
+
+		$this->assertTrue( $locator->is_feed( $file ) );
+	}
+
+	public function test_finds_podcast_feed_with_audio_enclosures() {
+		$file = new SimplePie_File(
+			<<<FEED
+			<?xml version="1.0" encoding="UTF-8"?>
+			<rss>
+				<channel>
+					<item>
+						<enclosure url="https://example.com/audio.mp3" type="audio/mpeg"/>
+					</item>
+				</channel>
+			</rss>
+			FEED
+		);
+
+		$locator = new Jetpack_Podcast_Feed_Locator( $file );
+
+		$this->assertTrue( $locator->is_feed( $file ) );
+	}
+
+	public function test_does_not_locate_non_podcast_feeds() {
+		$file = new SimplePie_File(
+			<<<FEED
+			<?xml version="1.0" encoding="UTF-8"?>
+			<rss>
+				<channel>
+					<item>
+						<title>My Post</title>
+					</item>
+				</channel>
+			</rss>
+			FEED
+		);
+
+		$locator = new Jetpack_Podcast_Feed_Locator( $file );
+
+		$this->assertFalse( $locator->is_feed( $file ) );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-podcast-feed-locator.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-podcast-feed-locator.php
@@ -17,14 +17,6 @@ jetpack_require_lib( 'class-jetpack-podcast-feed-locator' );
  * @coversDefaultClass Jetpack_Podcast_Feed_Locator
  */
 class WP_Test_Jetpack_Podcast_Feed_Locator extends WP_UnitTestCase {
-	public function setUp() {
-		if ( ! class_exists( 'DOMDocument' ) ) {
-			$this->markTestSkipped( 'DOMDocument is not available - can\'t run feed tests' );
-		} else {
-			parent::setUp();
-		}
-	}
-
 	/**
 	 * Tests that class extends SimplePie_Locator, so that it can be set as the locator
 	 * class, e.g. `$feed->set_locator_class( 'Jetpack_Podcast_Feed_Locator' )`.


### PR DESCRIPTION
Currently, we use `SimplePie`'s default feed locator when a URL that isn't an RSS feed is used in the podcast player block. This means that it can pick up an RSS feed for comments, a category of posts, or something else that isn't the feed of podcast episodes.

#### Changes proposed in this Pull Request:
This PR implements a custom locator class which checks for either the use of the itunes.com namespace in the feeds found, or `enclosure`s with an `audio/` mimetype.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Insert a podcast block
* Provide a URL to a podcast site which has more than one feed. An [example is this site](https://www.tested.com/podcasts/adam-savage-project/amber-ruffin-the-adam-savage-project-11-17-20/), which on the episode pages only has the podcast feed as the `href` of the 'Subscribe' buttons.
* Without this PR the block is converted to a WordPress embed
* With this PR the podcast block should load with a list of episodes from the podcast

It's likely that someone providing a URL to an episode like this wants to embed a player for that specific episode. Some changes need to be made to the podcast block for that, but this is the first step towards it.

#### Proposed changelog entry for your changes:
* Improved the podcast feed detection.
