### PR TITLE
Module list: avoid fatals in PHP 8

### DIFF
--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -135,7 +135,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		/** This filter is already documented in class.jetpack-modules-list-table.php */
 		$modules              = apply_filters( 'jetpack_modules_list_table_items', Jetpack_Admin::init()->get_modules() );
 		$array_of_module_tags = wp_list_pluck( $modules, 'module_tags' );
-		$module_tags          = call_user_func_array( 'array_merge', $array_of_module_tags );
+		$module_tags          = call_user_func_array( 'array_merge', array_values( $array_of_module_tags ) );
 		$module_tags_unique   = array_count_values( $module_tags );
 		ksort( $module_tags_unique );
 

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -135,7 +135,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		/** This filter is already documented in class.jetpack-modules-list-table.php */
 		$modules              = apply_filters( 'jetpack_modules_list_table_items', Jetpack_Admin::init()->get_modules() );
 		$array_of_module_tags = wp_list_pluck( $modules, 'module_tags' );
-		$module_tags          = call_user_func_array( 'array_merge', array_values( $array_of_module_tags ) );
+		$module_tags          = array_merge( ...array_values( $array_of_module_tags ) );
 		$module_tags_unique   = array_count_values( $module_tags );
 		ksort( $module_tags_unique );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* For reference:
PHP Fatal error:  Uncaught ArgumentCountError: array_merge() does not accept unknown named parameters

cc @mzakariya 

#### Jetpack product discussion

* Primary issue: #17166 

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a site running PHP 8, go to `https://mysite.com/w/wp-admin/admin.php?page=jetpack_modules`
* The page should load without any fatals, with a list of modules.

#### Proposed changelog entry for your changes:

* Dashboard: avoid errors on sites using PHP 8.
