### PR TITLE
Connection: setting valid connection owner.

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2127,9 +2127,9 @@ class Manager {
 			return new \WP_Error( 'no_token', 'Error generating token.', 400 );
 		}
 
-		$is_master_user = ! $this->is_active();
+		$is_connection_owner = false === $this->get_connection_owner();
 
-		Utils::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
+		Utils::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_connection_owner );
 
 		/**
 		 * Fires after user has successfully received an auth token.
@@ -2138,7 +2138,7 @@ class Manager {
 		 */
 		do_action( 'jetpack_user_authorized' );
 
-		if ( ! $is_master_user ) {
+		if ( ! $is_connection_owner ) {
 			/**
 			 * Action fired when a secondary user has been authorized.
 			 *

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2127,7 +2127,7 @@ class Manager {
 			return new \WP_Error( 'no_token', 'Error generating token.', 400 );
 		}
 
-		$is_connection_owner = false === $this->get_connection_owner();
+		$is_connection_owner = ! $this->has_connected_owner();
 
 		Utils::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_connection_owner );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When a user gets connected to WP.com, we check if a connection owner exists. If there's no such user, the newly connected user takes over the responsibility.

This commit doesn't modify the behavior, but performs refactoring necessary for Userless Connection to properly function.

Instead of checking if the connection is active (it's "active" with no connection owner in userless mode), we now retrieve a connection owner directly.

#### Jetpack product discussion
`p9dueE-2dB-p2`

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
_I'm providing the instructions to test the current behavior. There's no need to test the userless behavior at the moment._

1. Try to connect Jetpack, make sure the correct user ID set as `master_user` in the option `jetpack_options`.
2. Create another user, connect them to WP.com as a secondary user. Confirm that the connection owner wasn't overwritten and still holds the original value.
3. Disconnect Jetpack, add the constant `define( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME', true );` into `wp-config.php`.
4. Connect Jetpack using the Calypso flow as the user you created on step 2. Confirm that the connection owner is set to their correct user ID.

#### Proposed changelog entry for your changes:
n/a