### PR TITLE
Admin Menu: Account for update count in submenu items

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -146,7 +146,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'count'    => array(
-					'description' => 'Plugin/Theme update count or unread comments count.',
+					'description' => 'Core/Plugin/Theme update count or unread comments count.',
 					'type'        => 'integer',
 				),
 				'icon'     => array(
@@ -158,6 +158,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				),
 				'children' => array(
 					'items' => array(
+						'count'  => array(
+							'description' => 'Core/Plugin/Theme update count or unread comments count.',
+							'type'        => 'integer',
+						),
 						'parent' => array(
 							'type' => 'string',
 						),
@@ -218,16 +222,9 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			'url'   => $this->prepare_menu_item_url( $menu_item[2] ),
 		);
 
-		if ( false !== strpos( $menu_item[0], 'count-' ) ) {
-			preg_match( '/class="(.+\s)?count-(\d*)/', $menu_item[0], $matches );
-
-			$count = absint( $matches[2] );
-			if ( $count > 0 ) {
-				$item['count'] = $count;
-			}
-
-			// Remove count badge HTML from title.
-			$item['title'] = trim( substr( $menu_item[0], 0, strpos( $menu_item[0], '<' ) ) );
+		$update_count = $this->parse_update_count( $item['title'] );
+		if ( ! empty( $update_count ) ) {
+			$item = array_merge( $item, $update_count );
 		}
 
 		return $item;
@@ -251,6 +248,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				'type'   => 'submenu-item',
 				'url'    => $this->prepare_menu_item_url( $submenu_item[2], $menu_item[2] ),
 			);
+
+			$update_count = $this->parse_update_count( $item['title'] );
+			if ( ! empty( $update_count ) ) {
+				$item = array_merge( $item, $update_count );
+			}
 		}
 
 		return $item;
@@ -316,6 +318,30 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		}
 
 		return $url;
+	}
+
+	/**
+	 * Parses the update count from a given menu item title and removes the associated markup.
+	 *
+	 * @param string $title Title to parse.
+	 * @return array
+	 */
+	private function parse_update_count( $title ) {
+		$item = array();
+
+		if ( false !== strpos( $title, 'count-' ) ) {
+			preg_match( '/class="(.+\s)?count-(\d*)/', $title, $matches );
+
+			$count = absint( $matches[2] );
+			if ( $count > 0 ) {
+				$item['count'] = $count;
+			}
+
+			// Remove count badge HTML from title.
+			$item['title'] = trim( substr( $title, 0, strpos( $title, '<' ) ) );
+		}
+
+		return $item;
 	}
 }
 

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -323,6 +323,9 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	/**
 	 * Parses the update count from a given menu item title and removes the associated markup.
 	 *
+	 * "Plugin" and "Updates" menu items have a count badge when there are updates available.
+	 * This method parses that information and adds it to the response.
+	 *
 	 * @param string $title Title to parse.
 	 * @return array
 	 */

--- a/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -220,7 +220,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				array(
 					'parent' => 'upload-php',
 					'slug'   => 'upload-php',
-					'title'  => 'Library',
+					'title'  => 'Library\'s',
 					'type'   => 'submenu-item',
 					'url'    => 'http://example.org/wp-admin/upload.php',
 				),
@@ -232,7 +232,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				array(
 					'parent' => 'upload-php',
 					'slug'   => 'upload-php',
-					'title'  => 'Library\'s',
+					'title'  => 'Library',
 					'type'   => 'submenu-item',
 					'url'    => admin_url( 'upload.php' ),
 					'count'  => 15,

--- a/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -193,7 +193,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 		$prepare_submenu_item = $class->getMethod( 'prepare_submenu_item' );
 		$prepare_submenu_item->setAccessible( true );
 
-		$this->assertEquals(
+		$this->assertSame(
 			$expected,
 			$prepare_submenu_item->invokeArgs( new WPCOM_REST_API_V2_Endpoint_Admin_Menu(), array( $submenu_item, $menu_item ) )
 		);
@@ -219,10 +219,23 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				array( 'Media', 'upload_files', 'upload.php', '', 'menu-top menu-icon-media', 'menu-media', 'dashicons-admin-media' ),
 				array(
 					'parent' => 'upload-php',
+					'slug'   => 'upload-php',
+					'title'  => 'Library',
 					'type'   => 'submenu-item',
+					'url'    => 'http://example.org/wp-admin/upload.php',
+				),
+			),
+			// Submenu item with update count.
+			array(
+				array( 'Library <span class="update-plugins count-15"><span class="update-count">15</span></span>', 'upload_files', 'upload.php' ),
+				array( 'Media', 'upload_files', 'upload.php', '', 'menu-top menu-icon-media', 'menu-media', 'dashicons-admin-media' ),
+				array(
+					'parent' => 'upload-php',
 					'slug'   => 'upload-php',
 					'title'  => 'Library\'s',
+					'type'   => 'submenu-item',
 					'url'    => admin_url( 'upload.php' ),
+					'count'  => 15,
 				),
 			),
 		);
@@ -393,6 +406,62 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				'woocommerce',
 				'__return_true',
 				admin_url( 'admin.php?page=wc-admin&amp;path=customers' ),
+			),
+		);
+	}
+
+	/**
+	 * Tests parsing an update count.
+	 *
+	 * @param string $menu_item Menu item.
+	 * @param string $expected  Parsed menu title & count. Or not.
+	 *
+	 * @throws \ReflectionException Noop.
+	 * @dataProvider menu_item_update_data
+	 * @covers ::parse_update_count
+	 */
+	public function test_parse_update_count( $menu_item, $expected ) {
+		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
+
+		$prepare_menu_item_url = $class->getMethod( 'parse_update_count' );
+		$prepare_menu_item_url->setAccessible( true );
+
+		$this->assertSame(
+			$expected,
+			$prepare_menu_item_url->invokeArgs( new WPCOM_REST_API_V2_Endpoint_Admin_Menu(), array( $menu_item ) )
+		);
+	}
+
+	/**
+	 * Data provider for test_prepare_menu_item_url.
+	 *
+	 * @return \string[][]
+	 */
+	public function menu_item_update_data() {
+		return array(
+			array(
+				'No Updates here',
+				array(),
+			),
+			array(
+				'Zero updates <span class="update-plugins count-0"><span class="update-count">0</span></span>',
+				array(
+					'title' => 'Zero updates',
+				),
+			),
+			array(
+				'Finally some updates <span class="update-plugins count-5"><span class="update-count">5</span></span>',
+				array(
+					'count' => 5,
+					'title' => 'Finally some updates',
+				),
+			),
+			array(
+				'Plugin updates <span class="update-plugins count-5"><span class="plugin-count">5</span></span>',
+				array(
+					'count' => 5,
+					'title' => 'Plugin updates',
+				),
 			),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Core updates are displayed in a submenu item to `index.php`. This PR adds compatibility for that.

So far we've only accounted for update badges in top-level menu items like "Plugins" and "Themes". But WordPress also has a submenu item with an update count called "Updates", which is visible under "Dashboard" when there are updates. This PR now correctly parses these submenu items.

/cc @getdave as this will change the response schema.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Separate out update count parsing into its own method.
* Update item scheme to account for a `count` attribute for submenu items.
* Update unit tests for submenu items to include a case with update count.
* Add unit tests for new method.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Manual testing should not be necessary, unit tests will have it covered.

If you do want to manually test, make sure you have a Jetpack site with available core update and see that the submenu item shows up correctly in the API response.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
