### PR TITLE
Podcast Player: Add the episode image URL to the API response.

### DIFF
--- a/_inc/lib/class-jetpack-podcast-helper.php
+++ b/_inc/lib/class-jetpack-podcast-helper.php
@@ -210,7 +210,7 @@ class Jetpack_Podcast_Helper {
 	}
 
 	/**
-	 * Retrieves an audio enclosure.
+	 * Retrieves an episode's image URL, if it's available.
 	 *
 	 * @param SimplePie_Item $episode SimplePie_Item object, representing a podcast episode.
 	 * @param string         $itunes_ns The itunes namespace, defaulted to the standard 1.0 version.

--- a/_inc/lib/class-jetpack-podcast-helper.php
+++ b/_inc/lib/class-jetpack-podcast-helper.php
@@ -195,6 +195,7 @@ class Jetpack_Podcast_Helper {
 			'type'        => esc_attr( $enclosure->type ),
 			'description' => self::get_plain_text( $episode->get_description() ),
 			'title'       => self::get_plain_text( $episode->get_title() ),
+			'image'       => esc_url( self::get_episode_image_url( $episode ) ),
 		);
 
 		if ( empty( $track['title'] ) ) {
@@ -206,6 +207,21 @@ class Jetpack_Podcast_Helper {
 		}
 
 		return $track;
+	}
+
+	/**
+	 * Retrieves an audio enclosure.
+	 *
+	 * @param SimplePie_Item $episode SimplePie_Item object, representing a podcast episode.
+	 * @param string         $itunes_ns The itunes namespace, defaulted to the standard 1.0 version.
+	 * @return string|null The image URL or null if not found.
+	 */
+	private static function get_episode_image_url( SimplePie_Item $episode, $itunes_ns = 'http://www.itunes.com/dtds/podcast-1.0.dtd' ) {
+		$image = $episode->get_item_tags( $itunes_ns, 'image' );
+		if ( isset( $image[0]['attribs']['']['href'] ) ) {
+			return $image[0]['attribs']['']['href'];
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Part of the itunes mark-up in podcast RSS feeds, allows an image to be set per episode. This change includes these image URLs in the track data that is retrieved and sent in the API request made by the podcast player block.

#### Testing instructions:
* With this PR insert a podcast block
* Give it an RSS feed with images for each episode e.g. https://anchor.fm/s/22b6608/podcast/rss
* Check the network response of the API request to `/wp-json/wpcom/v2/podcast-player` it should include the `image` key for each element of the tracks array:

<img width="662" alt="image" src="https://user-images.githubusercontent.com/96462/101846259-816cb000-3b48-11eb-89af-c20deeec4931.png">


#### Proposed changelog entry for your changes:
N/A