### PR TITLE
Docs: add info about textdomains to the package documentation

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -61,6 +61,26 @@ use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 $logo = new Jetpack_Logo();
 ```
 
+### Package textdomains
+
+Jetpack's packages use the 'jetpack' textdomain for translatable strings. Plugins that use these packages must change the textdomains in the packages when preparing the plugin for release. A few tools that can help automate this process are [node-wp-i18n](https://github.com/cedaro/node-wp-i18n) and [wp-textdomain](https://github.com/timelsass/wp-textdomain).
+
+For example, a plugin could change the textdomain during the Composer `post-autoload-dump` event with the following script in the plugin's `composer.json` file:
+
+`"post-autoload-dump": "node  {path_to_script}/update_textdomain.js"`
+
+where the `update_textdomain.js` file contains something like:
+
+```
+const wpTextdomain = require( 'wp-textdomain' );
+
+wpTextdomain( './vendor/automattic/**/*.php', {
+	domain: 'plugin-textdomain',
+	fix: true,
+	glob: { follow: true },
+} );
+```
+
 ## Deploying packages
 
 While the script we use to deploy the package takes care of everything, we might need to setup some stuff online in GitHub and Packagist. Let's use the Autoloader package as an example. 
@@ -80,9 +100,11 @@ You may run unit tests locally for any given package by running `composer phpuni
 via Jetpack Docker with the command `yarn docker:phpunit:package` for all package unit tests or 
 `yarn docker:phpunit:package packagename` for a specific one. 
 
-## Creating a New Package
+## Developing Jetpack Packages
 
-### Should my code be in a Package?
+### Creating a New Package
+
+#### Should my code be in a Package?
 
 Not sure if your code should be in a Package? Here are some general guidelines we follow when deciding: 
 
@@ -99,3 +121,7 @@ Not sure if your code should be in a Package? Here are some general guidelines w
 ### Package Autoloading
 
 All new Jetpack package development should use classmap autoloading, which allows the class and file names to comply with the WordPress Coding Standards.
+
+### Textdomains
+
+Jetpack packages must use the 'jetpack' textdomain. The consuming plugin is responsible for updating the packages to use the plugin's textdomain.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add info about textdomains to the package documentation.

#### Jetpack product discussion
We've been investigating providing a way for consumer plugins to change the textdomains in the packages. I found a couple of PRs from last year: #12525 and #12471. From the conversations in those PRs, in looks like the final decision was to let consumer plugins provide their own solution for updating textdomains in the packages.

I think this is the best approach. Consumer plugins should choose the tool and process that works best for that plugin, and there's no need for Jetpack to provide a tool for this. Instead, we should update the documentation so that consumer plugins understand that updating the textdomain is their responsibility. We can also provide links to a few tools that may be helpful, which I've done in this PR.

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* No testing is required. Just verify that the documentation update is correct, clear, and doesn't have any typos.

#### Proposed changelog entry for your changes:
* n/a