### PR TITLE
Anchor: Add styles for external icon displayed on the post-publish panel

### DIFF
--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -11,9 +11,12 @@ import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
-import { name } from '.';
-import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
 import { waitForEditor } from '../../shared/wait-for-editor';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
 
 async function insertSpotifyBadge() {
 	const { Jetpack_AnchorFm = {} } = window;
@@ -53,7 +56,7 @@ async function insertSpotifyBadge() {
 }
 
 const ConvertToAudio = () => (
-	<PluginPostPublishPanel>
+	<PluginPostPublishPanel className="anchor-post-publish-outbound-link">
 		<p className="post-publish-panel__postpublish-subheader">
 			<strong>{ __( 'Convert to audio', 'jetpack' ) }</strong>
 		</p>
@@ -61,24 +64,19 @@ const ConvertToAudio = () => (
 		<p>
 			<a href="https://anchor.fm/wordpress" target="_top">
 				{ __( 'Create a podcast episode', 'jetpack' ) }
-				<Icon icon={ external } className="components-external-link__icon" />
+				<Icon icon={ external } className="anchor-post-publish-outbound-link__external_icon" />
 			</a>
 		</p>
 	</PluginPostPublishPanel>
 );
 
 function showPostPublishOutboundLink() {
-	registerPlugin( 'post-publish-anchor-outbound-link', {
+	registerPlugin( 'anchor-post-publish-outbound-link', {
 		render: ConvertToAudio,
 	} );
 }
 
 function initAnchor() {
-	const isExtensionAvailable = getJetpackExtensionAvailability( name )?.available;
-	if ( ! isExtensionAvailable ) {
-		return;
-	}
-
 	const data = window.Jetpack_AnchorFm;
 	if ( typeof data !== 'object' ) {
 		return;

--- a/extensions/blocks/anchor-fm/editor.scss
+++ b/extensions/blocks/anchor-fm/editor.scss
@@ -1,0 +1,7 @@
+.anchor-post-publish-outbound-link .anchor-post-publish-outbound-link__external_icon {
+	width: 1.4em;
+	height: 1.4em;
+	margin: -0.2em 0.1em 0;
+	vertical-align: middle;
+	fill: currentColor;
+}


### PR DESCRIPTION
Follows up https://github.com/Automattic/jetpack/pull/17996.

#### Changes proposed in this Pull Request:
Fixes the styles of the external icon displayed in the post-publish Anchor outbound link for sites using WordPress 5.6 where the `components-external-link__icon` is missing (it has been migrated to CSS-in-JS: https://github.com/WordPress/gutenberg/pull/25751).

Before | After
--- | ---
<img width="281" alt="Screen Shot 2020-12-14 at 12 39 35" src="https://user-images.githubusercontent.com/1233880/102078367-1dc5d980-3e0b-11eb-808f-fe876d1c4782.png"> | <img width="280" alt="Screen Shot 2020-12-14 at 12 44 47" src="https://user-images.githubusercontent.com/1233880/102078378-21596080-3e0b-11eb-880e-1d191014cc72.png">

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Activate the beta blocks:
  - If testing on a JN site, go to Settings > Jetpack Constants and turn on the `JETPACK_BETA_BLOCKS` option.
  - If testing locally, add a new plugin to docker/mu-plugins with `define( 'JETPACK_BETA_BLOCKS', true );`.
- Make sure your testing site is updated to WordPress 5.6.
- Make sure your testing site does NOT use the Gutenberg plugin.
- Start writing a new post and publish it.
- Make sure the external icon displayed in the link prompting users to convert the post into a podcast episode is correctly styled.

#### Proposed changelog entry for your changes:
N/A.
