### PR TITLE
Userless Connection: connecting the primary user

### DIFF
--- a/_inc/client/at-a-glance/connections.jsx
+++ b/_inc/client/at-a-glance/connections.jsx
@@ -16,6 +16,7 @@ import { __, sprintf, _x } from '@wordpress/i18n';
  */
 import {
 	getSiteConnectionStatus,
+	isConnectionOwner,
 	isCurrentUserLinked,
 	isOfflineMode,
 	isFetchingUserData as _isFetchingUserData,
@@ -23,7 +24,6 @@ import {
 } from 'state/connection';
 import {
 	userCanDisconnectSite,
-	userIsMaster,
 	getUserGravatar,
 	getUsername,
 	getSiteIcon,
@@ -83,7 +83,7 @@ export class DashConnections extends Component {
 						) }
 						<div className="jp-connection-settings__text">
 							{ __( 'Your site is connected to WordPress.com.', 'jetpack' ) }
-							{ this.props.userIsMaster && (
+							{ this.props.isConnectionOwner && (
 								<span className="jp-connection-settings__is-owner">
 									<br />
 									<em>{ __( 'You are the Jetpack owner.', 'jetpack' ) }</em>
@@ -110,7 +110,7 @@ export class DashConnections extends Component {
 	 * @returns {string}
 	 */
 	userConnection() {
-		const maybeShowLinkUnlinkBtn = this.props.userIsMaster ? null : (
+		const maybeShowLinkUnlinkBtn = this.props.isConnectionOwner ? null : (
 			<ConnectButton asLink connectUser={ true } from="connection-settings" />
 		);
 
@@ -226,7 +226,7 @@ DashConnections.propTypes = {
 	siteConnectionStatus: PropTypes.any.isRequired,
 	isOfflineMode: PropTypes.bool.isRequired,
 	userCanDisconnectSite: PropTypes.bool.isRequired,
-	userIsMaster: PropTypes.bool.isRequired,
+	isConnectionOwner: PropTypes.bool.isRequired,
 	isLinked: PropTypes.bool.isRequired,
 	userGravatar: PropTypes.any.isRequired,
 	username: PropTypes.any.isRequired,
@@ -237,9 +237,9 @@ export default connect( state => {
 		siteConnectionStatus: getSiteConnectionStatus( state ),
 		isOfflineMode: isOfflineMode( state ),
 		userCanDisconnectSite: userCanDisconnectSite( state ),
-		userIsMaster: userIsMaster( state ),
 		userGravatar: getUserGravatar( state ),
 		username: getUsername( state ),
+		isConnectionOwner: isConnectionOwner( state ),
 		isLinked: isCurrentUserLinked( state ),
 		siteIcon: getSiteIcon( state ),
 		isFetchingUserData: _isFetchingUserData( state ),

--- a/_inc/client/at-a-glance/test/component.js
+++ b/_inc/client/at-a-glance/test/component.js
@@ -15,7 +15,7 @@ describe( 'Connections', () => {
 		siteConnectionStatus: true,
 		isOfflineMode: false,
 		userCanDisconnectSite: true,
-		userIsMaster: true,
+		isConnectionOwner: true,
 		isLinked: true,
 		userGravatar:'https://example.org/avatar.png',
 		username: 'jetpack',
@@ -89,7 +89,7 @@ describe( 'Connections', () => {
 
 	describe( 'when user is not linked', () => {
 
-		const wrapper = shallow( <DashConnections { ...testProps } userIsMaster={ false } isLinked={ false } /> ).find( '.jp-connection-type' ).at( 1 );
+		const wrapper = shallow( <DashConnections { ...testProps } isConnectionOwner={ false } isLinked={ false } /> ).find( '.jp-connection-type' ).at( 1 );
 
 		it( 'shows a link to connect the account', () => {
 			expect( wrapper.find( 'Connect(ConnectButton)' ) ).to.have.length( 1 );

--- a/_inc/client/components/banner/index.jsx
+++ b/_inc/client/components/banner/index.jsx
@@ -21,7 +21,8 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import PlanIcon from 'components/plans/plan-icon';
-import { getCurrentVersion, getUserWpComLogin, userIsMaster } from 'state/initial-state';
+import { getCurrentVersion } from 'state/initial-state';
+import { isCurrentUserLinked, isConnectionOwner } from 'state/connection';
 
 import './style.scss';
 
@@ -41,7 +42,7 @@ class Banner extends Component {
 		plan: PropTypes.string,
 		siteSlug: PropTypes.string,
 		title: PropTypes.string.isRequired,
-		wpcomUserLogin: PropTypes.string,
+		isCurrentUserLinked: PropTypes.string,
 		isConnectionOwner: PropTypes.bool,
 	};
 
@@ -73,7 +74,7 @@ class Banner extends Component {
 				target: 'banner',
 				type: 'upgrade',
 				current_version: currentVersion,
-				is_user_wpcom_connected: this.props.wpcomUserLogin ? 'yes' : 'no',
+				is_user_wpcom_connected: this.props.isCurrentUserLinked ? 'yes' : 'no',
 				is_connection_owner: this.props.isConnectionOwner ? 'yes' : 'no',
 				...eventFeatureProp,
 				...pathProp,
@@ -171,6 +172,6 @@ class Banner extends Component {
 
 export default connect( state => ( {
 	currentVersion: getCurrentVersion( state ),
-	wpcomUserLogin: getUserWpComLogin( state ),
-	isConnectionOwner: userIsMaster( state ),
+	isCurrentUserLinked: isCurrentUserLinked( state ),
+	isConnectionOwner: isConnectionOwner( state ),
 } ) )( Banner );

--- a/_inc/client/components/dev-card/index.jsx
+++ b/_inc/client/components/dev-card/index.jsx
@@ -13,12 +13,11 @@ import { get } from 'lodash';
 import {
 	isDevVersion as _isDevVersion,
 	userCanViewStats,
-	userIsMaster,
 	userCanDisconnectSite,
 	userCanEditPosts,
 } from 'state/initial-state';
 import { getSitePlan } from 'state/site';
-import { isCurrentUserLinked } from 'state/connection';
+import { isConnectionOwner, isCurrentUserLinked } from 'state/connection';
 import {
 	switchPlanPreview,
 	canDisplayDevCard,
@@ -95,42 +94,40 @@ export class DevCard extends React.Component {
 		}
 	};
 
-	maybeShowIsLinkedToggle = () => {
-		if ( ! this.props.isMaster ) {
-			return (
-				<div>
-					<hr />
-					<ul>
-						<li>
-							<label htmlFor="is_linked">
-								<input
-									type="radio"
-									id="is_linked"
-									value="is_linked"
-									name="is_linked"
-									checked={ this.props.isUserLinked }
-									onChange={ this.onPermissionsChange }
-								/>
-								Linked
-							</label>
-						</li>
-						<li>
-							<label htmlFor="is_unlinked">
-								<input
-									type="radio"
-									id="is_unlinked"
-									value="is_unlinked"
-									name="is_unlinked"
-									checked={ ! this.props.isUserLinked }
-									onChange={ this.onPermissionsChange }
-								/>
-								Unlinked
-							</label>
-						</li>
-					</ul>
-				</div>
-			);
-		}
+	showIsLinkedToggle = () => {
+		return (
+			<div>
+				<hr />
+				<ul>
+					<li>
+						<label htmlFor="is_linked">
+							<input
+								type="radio"
+								id="is_linked"
+								value="is_linked"
+								name="is_linked"
+								checked={ this.props.isUserLinked }
+								onChange={ this.onPermissionsChange }
+							/>
+							Linked
+						</label>
+					</li>
+					<li>
+						<label htmlFor="is_unlinked">
+							<input
+								type="radio"
+								id="is_unlinked"
+								value="is_unlinked"
+								name="is_unlinked"
+								checked={ ! this.props.isUserLinked }
+								onChange={ this.onPermissionsChange }
+							/>
+							Unlinked
+						</label>
+					</li>
+				</ul>
+			</div>
+		);
 	};
 
 	render() {
@@ -284,7 +281,7 @@ export class DevCard extends React.Component {
 								id="admin_master"
 								value="admin_master"
 								name="admin_master"
-								checked={ this.props.isMaster }
+								checked={ this.props.isConnectionOwner }
 								onChange={ this.onPermissionsChange }
 							/>
 							Admin (master)
@@ -297,7 +294,7 @@ export class DevCard extends React.Component {
 								id="admin_secondary"
 								value="admin_secondary"
 								name="admin_secondary"
-								checked={ this.props.isAdmin && ! this.props.isMaster }
+								checked={ this.props.isAdmin && ! this.props.isConnectionOwner }
 								onChange={ this.onPermissionsChange }
 							/>
 							Admin (secondary)
@@ -471,7 +468,7 @@ export class DevCard extends React.Component {
 					</li>
 				</ul>
 				{ this.maybeShowStatsToggle() }
-				{ this.maybeShowIsLinkedToggle() }
+				{ this.showIsLinkedToggle() }
 			</Card>
 		);
 	}
@@ -485,7 +482,7 @@ export default connect(
 			canDisplayDevCard: canDisplayDevCard( state ),
 			isUserLinked: isCurrentUserLinked( state ),
 			canViewStats: userCanViewStats( state ),
-			isMaster: userIsMaster( state ),
+			isConnectionOwner: isConnectionOwner( state ),
 			isAdmin: userCanDisconnectSite( state ),
 			canEditPosts: userCanEditPosts( state ),
 			getVaultPressScanThreatCount: () => getVaultPressScanThreatCount( state ),

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -14,15 +14,9 @@ import analytics from 'lib/analytics';
 import Card from 'components/card';
 import Button from 'components/button';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
-import { getSiteConnectionStatus } from 'state/connection';
+import { getSiteConnectionStatus, isCurrentUserLinked, isConnectionOwner } from 'state/connection';
 import getRedirectUrl from 'lib/jp-redirect';
-import {
-	isAtomicSite,
-	isDevVersion as _isDevVersion,
-	getUpgradeUrl,
-	getUserWpComLogin,
-	userIsMaster,
-} from 'state/initial-state';
+import { isAtomicSite, isDevVersion as _isDevVersion, getUpgradeUrl } from 'state/initial-state';
 import JetpackBanner from 'components/jetpack-banner';
 import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
 import {
@@ -43,7 +37,7 @@ class SupportCard extends React.Component {
 			target: 'banner-click',
 			feature: 'support',
 			page: this.props.path,
-			is_user_wpcom_connected: this.props.wpcomUserLogin ? 'yes' : 'no',
+			is_user_wpcom_connected: this.props.isCurrentUserLinked ? 'yes' : 'no',
 			is_connection_owner: this.props.isConnectionOwner ? 'yes' : 'no',
 		} );
 	};
@@ -142,7 +136,7 @@ class SupportCard extends React.Component {
 SupportCard.propTypes = {
 	siteConnectionStatus: PropTypes.any.isRequired,
 	className: PropTypes.string,
-	wpcomUserLogin: PropTypes.string,
+	isCurrentUserLinked: PropTypes.string,
 	isConnectionOwner: PropTypes.bool,
 };
 
@@ -154,7 +148,7 @@ export default connect( state => {
 		isAtomicSite: isAtomicSite( state ),
 		isDevVersion: _isDevVersion( state ),
 		supportUpgradeUrl: getUpgradeUrl( state, 'support' ),
-		wpcomUserLogin: getUserWpComLogin( state ),
-		isConnectionOwner: userIsMaster( state ),
+		isCurrentUserLinked: isCurrentUserLinked( state ),
+		isConnectionOwner: isConnectionOwner( state ),
 	};
 } )( SupportCard );

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -257,6 +257,16 @@ export function isCurrentUserLinked( state ) {
 }
 
 /**
+ * Returns true if current user is connection owner.
+ *
+ * @param  {Object} state Global state tree
+ * @return {bool} true if the current user is connection owner, false otherwise
+ */
+export function isConnectionOwner( state ) {
+	return !! state.jetpack.connection.user.currentUser.isMaster;
+}
+
+/**
  * Checks if the site is currently in offline mode.
  *
  * @param  {Object}  state Global state tree

--- a/_inc/client/state/dev-version/actions.js
+++ b/_inc/client/state/dev-version/actions.js
@@ -88,6 +88,7 @@ export const switchPlanPreview = slug => {
 const adminMasterPerms = {
 	currentUser: {
 		isMaster: true,
+		isConnected: true,
 		permissions: {
 			admin_page: true,
 			connect: true,
@@ -170,6 +171,7 @@ const isLinked = {
 const isUnlinked = {
 	currentUser: {
 		isConnected: false,
+		isMaster: false,
 	},
 };
 

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -135,6 +135,14 @@ export function userCanConnectSite( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'connect', false );
 }
 
+/**
+ * Returns true if current user is connection owner.
+ *
+ * @param  {Object} state Global state tree
+ * @return {bool} true if the current user is connection owner, false otherwise
+ *
+ * @deprecated 9.3.0
+ */
 export function userIsMaster( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, 'isMaster', false );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When a user gets connected in the userless mode (no users connected), we need to recognize them as a connection owner.
This commit adjusts the UI behavior to ensure the React state is updated accordingly.

#### Jetpack product discussion
p9dueE-2dB-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
This PR doesn't change the change the existing behavior in any way, so we mostly need to make sure that it doesn't break anything.
Testing of the userless experience is optional, as this is not user-facing functionality at the moment.

_Regular Jetpack_
1. If you're testing on an existing site, disconnect it and use the Broken Token plugin to make sure that the tokens and the Primary User ID are cleared.
2. Connect the site as a primary user. Go to the Broken Token and confirm that the Primary User ID has been set correctly.
3. Go to Jetpack Dashboard and confirm that the "Connection" cards are displayed correctly:
- "You are the Jetpack owner" shows up
- Your avatar, username, and email show up
- "Unlink me from WordPress.com" doesn't show up
<img width="1053" alt="Screen Shot 2020-12-14 at 2 27 30 PM" src="https://user-images.githubusercontent.com/1341249/102135205-4060ee00-3e1d-11eb-9ec8-4583bb5b0dde.png">

4. Create another user account, login using it.
5. Go to Jetpack Dashboard and connect as a secondary user using the in-place flow, don't reload the page.
6. Confirm that the "Connection" cards display correctly:
- "You are the Jetpack owner" does not shows up
- Your avatar, username, and email show up
- "Unlink me from WordPress.com" also shows up
<img width="1053" alt="Screen Shot 2020-12-14 at 3 36 10 PM" src="https://user-images.githubusercontent.com/1341249/102138564-270e7080-3e22-11eb-8493-98de2593283a.png">

---
_Userless Experience - In-Place Flow_
Disconnect Jetpack from WP.com, use Broken Token to confirm that the tokens and the Primary User ID are cleaned up. Add this constant to `wp-config.php`:
```php
define( 'JETPACK_NO_USER_TEST_MODE', true );
```
1. If you're testing on an existing site, disconnect it and use the Broken Token plugin to make sure that the tokens and the primary user ID are cleared.
2. Click "Set up Jetpack", then skip user authentication step to get into Userless mode.
3. Go to Jetpack Dashboard and click "Link to WordPress.com", then follow the in-place flow. Do not refresh the page, stay in the Dashboard.
4. Confirm that the "Connection" cards are displayed correctly:
- "You are the Jetpack owner" shows up
- Your avatar, username, and email show up
- "Unlink me from WordPress.com" doesn't show up
<img width="1053" alt="Screen Shot 2020-12-14 at 2 27 30 PM" src="https://user-images.githubusercontent.com/1341249/102135205-4060ee00-3e1d-11eb-9ec8-4583bb5b0dde.png">

5. Refresh the page. Confirm that the "Connection" cards are still correct.
6. Go to the Broken Token and confirm that the Primary User ID has been set correctly.
7. Log in as another user, go to Jetpack Dashboard, click "Link to WordPress.com" and go through the in-place flow.
8. Confirm that the "Connection" cards display correctly:
- "You are the Jetpack owner" does not shows up
- Your avatar, username, and email show up
- "Unlink me from WordPress.com" also shows up
<img width="1053" alt="Screen Shot 2020-12-14 at 3 36 10 PM" src="https://user-images.githubusercontent.com/1341249/102138564-270e7080-3e22-11eb-8493-98de2593283a.png">
9. Go to the Broken Token and confirm that the Primary User ID is still correct (not replaced by the secondary user's ID).

---
_Userless Experience - Calypso Flow_
1. Disconnect Jetpack from WP.com, add this constant to `wp-config.php`:
```php
define( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME', true );
```
2. Set up Jetpack, then skip user authentication. Click "Link to WordPress.com", go through the Calypso flow.
3. Go to Jetpack Dashboard, confirm that the "Connection" cards show up correctly.
4. Go to the Broken Token and confirm that the Primary User ID has been set correctly.

#### Proposed changelog entry for your changes:
Connecting the primary user using the "userless" experience.