### PR TITLE
Admin Menu API: Send out plain text characters

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -213,7 +213,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		$item = array(
 			'icon'  => $this->prepare_menu_item_icon( $menu_item[6] ),
 			'slug'  => sanitize_title_with_dashes( $menu_item[2] ),
-			'title' => wptexturize( $menu_item[0] ),
+			'title' => $menu_item[0],
 			'type'  => 'menu-item',
 			'url'   => $this->prepare_menu_item_url( $menu_item[2] ),
 		);
@@ -227,7 +227,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 
 			// Remove count badge HTML from title.
-			$item['title'] = wptexturize( trim( substr( $menu_item[0], 0, strpos( $menu_item[0], '<' ) ) ) );
+			$item['title'] = trim( substr( $menu_item[0], 0, strpos( $menu_item[0], '<' ) ) );
 		}
 
 		return $item;
@@ -247,7 +247,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			$item = array(
 				'parent' => sanitize_title_with_dashes( $menu_item[2] ),
 				'slug'   => sanitize_title_with_dashes( $submenu_item[2] ),
-				'title'  => wptexturize( $submenu_item[0] ),
+				'title'  => $submenu_item[0],
 				'type'   => 'submenu-item',
 				'url'    => $this->prepare_menu_item_url( $submenu_item[2], $menu_item[2] ),
 			);

--- a/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -152,23 +152,23 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 			),
 			// Regular menu item.
 			array(
-				array( 'Media', 'upload_files', 'upload.php', '', 'menu-top menu-icon-media', 'menu-media', 'dashicons-admin-media' ),
+				array( 'Media\'s', 'upload_files', 'upload.php', '', 'menu-top menu-icon-media', 'menu-media', 'dashicons-admin-media' ),
 				array(
 					'type'  => 'menu-item',
 					'icon'  => 'dashicons-admin-media',
 					'slug'  => 'upload-php',
-					'title' => 'Media',
+					'title' => 'Media\'s',
 					'url'   => admin_url( 'upload.php' ),
 				),
 			),
 			// Menu item with update count.
 			array(
-				array( 'Plugins <span class="update-plugins count-5"><span class="plugin-count">5</span></span>', 'moderate_comments', 'plugins.php', '', 'menu-top menu-icon-plugins', 'menu-plugins', 'dashicons-admin-plugins' ),
+				array( 'Plugin\'s <span class="update-plugins count-5"><span class="plugin-count">5</span></span>', 'moderate_comments', 'plugins.php', '', 'menu-top menu-icon-plugins', 'menu-plugins', 'dashicons-admin-plugins' ),
 				array(
 					'type'  => 'menu-item',
 					'icon'  => 'dashicons-admin-plugins',
 					'slug'  => 'plugins-php',
-					'title' => 'Plugins',
+					'title' => 'Plugin\'s',
 					'url'   => admin_url( 'plugins.php' ),
 					'count' => 5,
 				),
@@ -215,13 +215,13 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 			),
 			// Regular submenu item.
 			array(
-				array( 'Library', 'upload_files', 'upload.php' ),
+				array( 'Library\'s', 'upload_files', 'upload.php' ),
 				array( 'Media', 'upload_files', 'upload.php', '', 'menu-top menu-icon-media', 'menu-media', 'dashicons-admin-media' ),
 				array(
 					'parent' => 'upload-php',
 					'type'   => 'submenu-item',
 					'slug'   => 'upload-php',
-					'title'  => 'Library',
+					'title'  => 'Library\'s',
 					'url'    => admin_url( 'upload.php' ),
 				),
 			),


### PR DESCRIPTION
While it might be a good idea for `menu-header.php` to format entities, it is not for this endpoint.

This PR removes the calls to `wptexturize()` to make sure it sends out plain text characters as expected by Calypso.


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18087

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Run php unit tests and make sure they pass:
`$ phpunit --testsuite core-api`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
