### PR TITLE
Instant Search: add polyfill for CustomEvent (IE11)

### DIFF
--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -20,6 +20,23 @@ import { initializeTracks, identifySite, resetTrackingCookies } from './lib/trac
 import { buildFilterAggregations } from './lib/api';
 import { bindCustomizerChanges } from './lib/customize';
 
+// IE11 polyfill for custom events
+// Based on https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+( function () {
+	if ( typeof window.CustomEvent === 'function' ) {
+		return false;
+	}
+
+	function CustomEvent( event, params ) {
+		params = params || { bubbles: false, cancelable: false, detail: null };
+		const evt = document.createEvent( 'CustomEvent' );
+		evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+		return evt;
+	}
+
+	window.CustomEvent = CustomEvent;
+} )();
+
 const injectSearchApp = () => {
 	render(
 		<SearchApp
@@ -44,6 +61,7 @@ const injectSearchApp = () => {
 if ( window[ SERVER_OBJECT_NAME ] ) {
 	bindCustomizerChanges();
 }
+
 document.addEventListener( 'DOMContentLoaded', function () {
 	if ( !! window[ SERVER_OBJECT_NAME ] && 'siteId' in window[ SERVER_OBJECT_NAME ] ) {
 		initializeTracks();

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -26,7 +26,13 @@ import { bindCustomizerChanges } from './lib/customize';
 	if ( typeof window.CustomEvent === 'function' ) {
 		return false;
 	}
-
+	/**
+	 * Polyfills custom DOM events.
+	 *
+	 * @param {object} event - Event.
+	 * @param {object} params - Parameters.
+	 * @returns {object} event
+	 */
 	function CustomEvent( event, params ) {
 		params = params || { bubbles: false, cancelable: false, detail: null };
 		const evt = document.createEvent( 'CustomEvent' );

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -28,7 +28,7 @@ function pushQueryString( queryString, shouldEmitEvent = true ) {
 		}
 		url.search = queryString;
 		window.history.pushState( null, null, url.toString() );
-		shouldEmitEvent && window.dispatchEvent( new Event( 'queryStringChange' ) );
+		shouldEmitEvent && window.dispatchEvent( new CustomEvent( 'queryStringChange' ) );
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Searching, filtering and sorting on Instant Search is currently not working in IE11 because we're creating a `new Event` as part of our query string handling. This PR adds a polyfill that fixes the problem.

Fixes https://github.com/Automattic/jetpack/issues/18079.

<img width="541" alt="Screen Shot 2020-12-15 at 12 11 55" src="https://user-images.githubusercontent.com/17325/102157497-7c12bb00-3ee4-11eb-938e-3fd4b26760b1.png">

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Add a simple polyfill for `CustomEvent`. This fixes search, filter and sort behaviour on IE11.

Background on the solution:
* [Suggested fix](https://stackoverflow.com/a/26596324): "Adding CustomEvent to IE and using that instead works."
* [Polyfill on MDN](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)
* There is a [package for the polyfill](https://www.npmjs.com/package/custom-event-polyfill), but I chose not to use it because it has less concise code.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Login to Browserstack and spin up a IE11 VM.
* Navigate to your Instant Search test site and make sure you can search, filter and sort results as expected.

<img width="752" alt="Screen Shot 2020-12-15 at 14 18 39" src="https://user-images.githubusercontent.com/17325/102156387-584e7580-3ee2-11eb-8d01-c9c713336f1c.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Instant Search: improve compatibility with IE11.
