### PR TITLE
Admin Menu: update Purchases to Upgrades and add submenu

### DIFF
--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -94,7 +94,7 @@ class Admin_Menu {
 
 		$this->add_my_home_menu( $domain, $calypso );
 		$this->add_stats_menu( $domain );
-		$this->add_purchases_menu( $domain );
+		$this->add_upgrades_menu( $domain );
 		$this->add_posts_menu( $domain, $calypso );
 		$this->add_media_menu( $domain, $calypso );
 		$this->add_page_menu( $domain, $calypso );
@@ -259,13 +259,20 @@ class Admin_Menu {
 	}
 
 	/**
-	 * Adds Purchases menu.
+	 * Adds Upgrades menu.
 	 *
 	 * @param string $domain Site domain.
 	 */
-	public function add_purchases_menu( $domain ) {
+	public function add_upgrades_menu( $domain ) {
 		remove_menu_page( 'paid-upgrades.php' );
-		add_menu_page( __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/' . $domain, null, 'dashicons-cart', 4 );
+
+		$menu_slug = 'https://wordpress.com/plans/' . $domain;
+
+		add_menu_page( __( 'Upgrades', 'jetpack' ), __( 'Upgrades', 'jetpack' ), 'manage_options', $menu_slug, null, 'dashicons-cart', 4 );
+		add_submenu_page( $menu_slug, __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', $menu_slug, null, 1 );
+		add_submenu_page( $menu_slug, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $domain, null, 2 );
+		add_submenu_page( $menu_slug, __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $domain, null, 3 );
+
 		$this->migrate_submenus( 'paid-upgrades.php', 'https://wordpress.com/plans/' . $domain );
 	}
 
@@ -582,7 +589,6 @@ class Admin_Menu {
 		}
 
 		if ( $this->is_wpcom_site() || jetpack_is_atomic_site() ) {
-			add_options_page( esc_attr__( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $domain, null, 1 );
 			add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $domain, null, 6 );
 		}
 	}

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -270,7 +270,11 @@ class Admin_Menu {
 
 		add_menu_page( __( 'Upgrades', 'jetpack' ), __( 'Upgrades', 'jetpack' ), 'manage_options', $menu_slug, null, 'dashicons-cart', 4 );
 		add_submenu_page( $menu_slug, __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', $menu_slug, null, 1 );
-		add_submenu_page( $menu_slug, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $domain, null, 2 );
+
+		if ( $this->is_wpcom_site() || jetpack_is_atomic_site() ) {
+			add_submenu_page( $menu_slug, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $domain, null, 2 );
+		}
+
 		add_submenu_page( $menu_slug, __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $domain, null, 3 );
 
 		$this->migrate_submenus( 'paid-upgrades.php', 'https://wordpress.com/plans/' . $domain );

--- a/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -313,14 +313,16 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests add_upgrades_menu
+	 * Tests add_wpcom_upgrades_menu
 	 *
-	 * @covers ::add_upgrades_menu
+	 * @covers ::add_wpcom_upgrades_menu
 	 */
-	public function test_add_upgrades_menu() {
+	public function test_add_wpcom_upgrades_menu() {
 		global $menu, $submenu;
 
+		add_filter( 'jetpack_admin_menu_is_wpcom', '__return_true' );
 		static::$admin_menu->add_upgrades_menu( static::$domain );
+		remove_filter( 'jetpack_admin_menu_is_wpcom', '__return_true' );
 
 		$slug = 'https://wordpress.com/plans/' . static::$domain;
 
@@ -358,6 +360,31 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			'Purchases',
 		);
 		$this->assertContains( $purchases_submenu_item, $submenu[ $slug ] );
+	}
+
+	/**
+	 * Tests add_jetpack_upgrades_menu
+	 *
+	 * @covers ::add_jetpack_upgrades_menu
+	 */
+	public function test_add_jetpack_upgrades_menu() {
+		global $menu, $submenu;
+
+		static::$admin_menu->add_upgrades_menu( static::$domain );
+
+		$slug = 'https://wordpress.com/plans/' . static::$domain;
+
+		$upgrades_menu_item = array(
+			'Upgrades',
+			'manage_options',
+			$slug,
+			'Upgrades',
+			'menu-top toplevel_page_https://wordpress.com/plans/' . static::$domain,
+			'toplevel_page_https://wordpress.com/plans/' . static::$domain,
+			'dashicons-cart',
+		);
+		$this->assertSame( $menu['4.80608'], $upgrades_menu_item );
+		$this->assertArrayNotHasKey( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu );
 	}
 
 	/**

--- a/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -313,27 +313,51 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests add_purchases_menu
+	 * Tests add_upgrades_menu
 	 *
-	 * @covers ::add_purchases_menu
+	 * @covers ::add_upgrades_menu
 	 */
-	public function test_add_purchases_menu() {
+	public function test_add_upgrades_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_purchases_menu( static::$domain );
+		static::$admin_menu->add_upgrades_menu( static::$domain );
 
-		$purchases_menu_item = array(
-			'Purchases',
+		$slug = 'https://wordpress.com/plans/' . static::$domain;
+
+		$upgrades_menu_item = array(
+			'Upgrades',
 			'manage_options',
-			'https://wordpress.com/plans/' . static::$domain,
-			'Purchases',
+			$slug,
+			'Upgrades',
 			'menu-top toplevel_page_https://wordpress.com/plans/' . static::$domain,
 			'toplevel_page_https://wordpress.com/plans/' . static::$domain,
 			'dashicons-cart',
 		);
+		$this->assertSame( $menu['4.80608'], $upgrades_menu_item );
 
-		$this->assertSame( $menu['4.62024'], $purchases_menu_item );
-		$this->assertArrayNotHasKey( 'https://wordpress.com/plans/' . static::$domain, $submenu );
+		$plans_submenu_item = array(
+			'Plans',
+			'manage_options',
+			$slug,
+			'Plans',
+		);
+		$this->assertContains( $plans_submenu_item, $submenu[ $slug ] );
+
+		$domains_submenu_item = array(
+			'Domains',
+			'manage_options',
+			'https://wordpress.com/domains/manage/' . static::$domain,
+			'Domains',
+		);
+		$this->assertContains( $domains_submenu_item, $submenu[ $slug ] );
+
+		$purchases_submenu_item = array(
+			'Purchases',
+			'manage_options',
+			'https://wordpress.com/purchases/subscriptions/' . static::$domain,
+			'Purchases',
+		);
+		$this->assertContains( $purchases_submenu_item, $submenu[ $slug ] );
 	}
 
 	/**
@@ -775,7 +799,6 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		$this->assertNotContains( 'options-discussion.php', $submenu['options-general.php'] );
 		$this->assertNotContains( 'options-writing.php', $submenu['options-general.php'] );
 
-		$this->assertContains( 'Domains', $submenu['options-general.php'][1] );
 		$this->assertContains( 'Hosting Configuration', $submenu['options-general.php'][6] );
 	}
 


### PR DESCRIPTION
This renames "Purchases" to "Upgrades" in the new unified admin menu. It also adds the "Plans" and "Purchases" submenu items, along with moving "Domains" from "Settings" to "Upgrades".

<img width="551" alt="Screen Shot 2020-12-15 at 10 53 52 AM" src="https://user-images.githubusercontent.com/942359/102239166-8f159300-3ec4-11eb-8764-cbbc45cc4af4.png"> 

See: https://github.com/Automattic/wp-calypso/issues/48322
Calypso changes: https://github.com/Automattic/wp-calypso/pull/47465/commits/8d37ca1c32d9ade9a6a46b66a0dfc261dd3d6f83

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Rename "Purchases" to "Upgrades"
* Add the following sub-pages:
 * "Plans" (/plans/{site_slug})
 * "Domains" (/domains/manage/{site_slug})
 * "Purchases" (/purchases/subscriptions/{site_slug})
 * Remove "Domains" from under "Settings"

#### Jetpack product discussion

pbOQVh-KN-p2

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `phpunit --testsuite=masterbar`

To test a simple site:
* Sync these changes with your WordPress.com sandbox and sandbox `public-api.wordpress.com`
* Follow the instructions to test the unified nav under "Testing Simple Sites" here: paYJgx-1af-p2
* Visit `/wp-admin/` for a simple site and verify that the Upgrades menu looks like the screenshot above

To test locally:
* Add a mu-plugin that contains: `add_filter( 'jetpack_load_admin_menu_class', '__return_true' );`
* Make sure your site is connected to wp.com and has the masterbar module activated.
* Visit `/wp-admin/` and verify that the Upgrades menu looks like the screenshot above

#### Proposed changelog entry for your changes:

* None needed.