### PR TITLE
CI: Specify PHP version for all jobs using composer

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,6 +25,11 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '12'
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+        tools: composer
+        coverage: none
 
     - name: Use yarn cache
       uses: actions/cache@v2

--- a/.github/workflows/php-linting.yml
+++ b/.github/workflows/php-linting.yml
@@ -90,7 +90,8 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: intl, json, mbstring, xml
+          tools: composer
+          coverage: none
 
       - name: Get Composer cache directory
         id: composer-cache
@@ -131,6 +132,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+          coverage: none
+
       - name: Get Composer cache directory
         id: composer-cache
         run: |
@@ -164,6 +171,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+          coverage: none
 
       - name: Get Composer cache directory
         id: composer-cache
@@ -211,6 +224,12 @@ jobs:
             depth=$((depth * 2))
             /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth origin ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }}
           done
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+          coverage: none
 
       - name: Get Composer cache directory
         id: composer-cache

--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+          coverage: none
+
       - name: Get Composer cache directory
         id: composer-cache
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
GitHub seems to have added PHP 8.0 as the default version on their job
runners, while our composer.json specifies packages that haven't been
updated for 8.0 yet.

So specifically choose 7.4 for all tests that execute composer and
aren't already specifying a version.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1608061178463100-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Are tests green?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed