### PR TITLE
Instant Search: Add preliminary Redux state; add tests

### DIFF
--- a/modules/search/instant-search/lib/constants.js
+++ b/modules/search/instant-search/lib/constants.js
@@ -10,6 +10,7 @@ export const RESULT_FORMAT_EXPANDED = 'expanded';
 export const RESULT_FORMAT_MINIMAL = 'minimal';
 export const RESULT_FORMAT_PRODUCT = 'product';
 export const MINUTE_IN_MILLISECONDS = 60 * 1000;
+export const DEFAULT_SORT_KEY = 'relevance';
 export const VALID_SORT_KEYS = [ 'newest', 'oldest', 'relevance' ];
 export const VALID_RESULT_FORMAT_KEYS = [
 	RESULT_FORMAT_EXPANDED,

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -1,3 +1,8 @@
+// NOTE: We only import the difference package here for to reduced bundle size.
+//       Do not import the entire lodash library!
+// eslint-disable-next-line lodash/import-scope
+import difference from 'lodash/difference';
+
 /**
  * Internal dependencies
  */
@@ -41,14 +46,17 @@ export function getSelectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?
 // These filter keys are not selectable from sidebar filters
 // In other words, they were selected via filters outside the search sidebar
 export function getUnselectableFilterKeys(
+	widgets = window[ SERVER_OBJECT_NAME ]?.widgets,
 	widgetsOutsideOverlay = window[ SERVER_OBJECT_NAME ]?.widgetsOutsideOverlay
 ) {
-	return extractFilterKeysFromConfiguration( widgetsOutsideOverlay );
+	const selectableKeys = getSelectableFilterKeys( widgets );
+	const keysOutsideOverlay = extractFilterKeysFromConfiguration( widgetsOutsideOverlay );
+	return difference( keysOutsideOverlay, selectableKeys );
 }
 
 function extractFilterKeysFromConfiguration( widgets ) {
 	return (
-		widgets.map( extractFilters ).reduce( ( prev, current ) => prev.concat( current ), [] ) ?? []
+		widgets?.map( extractFilters ).reduce( ( prev, current ) => prev.concat( current ), [] ) ?? []
 	);
 }
 

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -16,8 +16,12 @@ import {
 import { getFilterKeys, getUnselectableFilterKeys, mapFilterToFilterKey } from './filters';
 import { decode } from '../external/query-string-decode';
 
-function getQuery() {
+export function getQuery() {
 	return decode( window.location.search.substring( 1 ), false, false );
+}
+
+export function setQuery( queryObject ) {
+	pushQueryString( encode( queryObject ), false );
 }
 
 function pushQueryString( queryString, shouldEmitEvent = true ) {
@@ -127,14 +131,14 @@ export function getFilterQuery( filterKey ) {
 }
 
 // These filter keys have been activated/selected outside of the overlay sidebar
-export function getPreselectedFilterKeys( overlayWidgets ) {
-	return getUnselectableFilterKeys( overlayWidgets ).filter(
+export function getPreselectedFilterKeys() {
+	return getUnselectableFilterKeys().filter(
 		key => Array.isArray( getFilterQueryByKey( key ) ) && getFilterQueryByKey( key ).length > 0
 	);
 }
 
-export function getPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay ) {
-	const keys = getPreselectedFilterKeys( widgetsInOverlay );
+export function getPreselectedFilters( _, widgetsOutsideOverlay ) {
+	const keys = getPreselectedFilterKeys();
 	return widgetsOutsideOverlay
 		.map( widget => widget.filters )
 		.reduce( ( prev, current ) => prev.concat( current ), [] )

--- a/modules/search/instant-search/lib/test/filters.test.js
+++ b/modules/search/instant-search/lib/test/filters.test.js
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+/* global expect */
+/**
+ * Internal dependencies
+ */
+import { getFilterKeys, getSelectableFilterKeys, getUnselectableFilterKeys } from '../filters';
+
+describe( 'getFilterKeys', () => {
+	const DEFAULT_KEYS = [
+		'post_types',
+		'month_post_date',
+		'month_post_date_gmt',
+		'month_post_modified',
+		'month_post_modified_gmt',
+		'year_post_date',
+		'year_post_date_gmt',
+		'year_post_modified',
+		'year_post_modified_gmt',
+	];
+	test( 'defaults to a fixed array when parameters are null-ish', () => {
+		expect( getFilterKeys( null, undefined ) ).toEqual( DEFAULT_KEYS );
+	} );
+
+	test( 'includes taxonomies from widget configurations', () => {
+		const widgets = [
+			{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
+			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
+			{ filters: [ { type: 'post_type' } ] },
+		];
+		const widgetsOutsideOverlay = [ { filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] } ];
+		expect( getFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [
+			'post_types',
+			'month_post_date',
+			'month_post_date_gmt',
+			'month_post_modified',
+			'month_post_modified_gmt',
+			'year_post_date',
+			'year_post_date_gmt',
+			'year_post_modified',
+			'year_post_modified_gmt',
+			'category',
+			'post_tag',
+		] );
+	} );
+} );
+
+describe( 'getSelectableFilterKeys', () => {
+	test( 'defaults to an empty array on nullish inputs', () => {
+		expect( getSelectableFilterKeys( null ) ).toEqual( [] );
+		expect( getSelectableFilterKeys( undefined ) ).toEqual( [] );
+	} );
+	test( 'extracts filter keys from widgets inside the search overlay sidebar', () => {
+		const widgets = [
+			{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
+			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
+			{ filters: [ { type: 'post_type' } ] },
+		];
+		expect( getSelectableFilterKeys( widgets ) ).toEqual( [
+			'category',
+			'year_post_date',
+			'post_types',
+		] );
+	} );
+} );
+
+describe( 'getUnselectableFilterKeys', () => {
+	test( 'defaults to an empty array on nullish inputs', () => {
+		expect( getUnselectableFilterKeys( null ) ).toEqual( [] );
+		expect( getUnselectableFilterKeys( undefined ) ).toEqual( [] );
+	} );
+	test( 'extracts filter keys from widgets outside the search overlay sidebar', () => {
+		const widgetsOutsideOverlay = [ { filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] } ];
+		expect( getUnselectableFilterKeys( widgetsOutsideOverlay ) ).toEqual( [ 'post_tag' ] );
+	} );
+} );

--- a/modules/search/instant-search/lib/test/filters.test.js
+++ b/modules/search/instant-search/lib/test/filters.test.js
@@ -71,7 +71,24 @@ describe( 'getUnselectableFilterKeys', () => {
 		expect( getUnselectableFilterKeys( undefined ) ).toEqual( [] );
 	} );
 	test( 'extracts filter keys from widgets outside the search overlay sidebar', () => {
+		const widgets = [];
 		const widgetsOutsideOverlay = [ { filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] } ];
-		expect( getUnselectableFilterKeys( widgetsOutsideOverlay ) ).toEqual( [ 'post_tag' ] );
+		expect( getUnselectableFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [ 'post_tag' ] );
+	} );
+	test( 'excludes filter keys included in widgets inside the search overlay sidebar', () => {
+		const widgets = [
+			{ filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] },
+			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
+			{ filters: [ { type: 'post_type' } ] },
+		];
+		const widgetsOutsideOverlay = [
+			{
+				filters: [
+					{ type: 'taxonomy', taxonomy: 'category' },
+					{ type: 'taxonomy', taxonomy: 'post_tag' },
+				],
+			},
+		];
+		expect( getUnselectableFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [ 'category' ] );
 	} );
 } );

--- a/modules/search/instant-search/store/actions.js
+++ b/modules/search/instant-search/store/actions.js
@@ -1,0 +1,119 @@
+/**
+ * Returns an action object used to make a search result request.
+ *
+ * @param {object} options - Search options.
+ *
+ * @returns {object} Action object.
+ */
+export function makeSearchRequest( options ) {
+	return {
+		type: 'MAKE_SEARCH_REQUEST',
+		options,
+	};
+}
+
+/**
+ * Returns an action object used to record a successful search request.
+ *
+ * @param {object} params - Input parameters.
+ * @param {object} params.options - Action options that generated this API response.
+ * @param {object} params.response - API response.
+ *
+ * @returns {object} Action object.
+ */
+export function recordSuccessfulSearchRequest( { options, response } ) {
+	return {
+		type: 'RECORD_SUCCESSFUL_SEARCH_REQUEST',
+		options,
+		response,
+	};
+}
+
+/**
+ * Returns an action object used to record a failed search request.
+ *
+ * @param {object} error - Error from the failed search request.
+ *
+ * @returns {object} Action object.
+ */
+export function recordFailedSearchRequest( error ) {
+	return {
+		type: 'RECORD_FAILED_SEARCH_REQUEST',
+		error,
+	};
+}
+
+/**
+ * Returns an action object used to initialize query value related reducers.
+ *
+ * @param {string} query - Inputted user query.
+ *
+ * @returns {object} Action object.
+ */
+export function initializeQueryValues( { defaultSort } ) {
+	return {
+		type: 'INITIALIZE_QUERY_VALUES',
+		defaultSort,
+	};
+}
+
+/**
+ * Returns an action object used to set a search query value.
+ *
+ * @param {string} query - Inputted user query.
+ * @param {boolean} propagateToWindow - If true, will tell the effects handler to set the search query in the location bar.
+ *
+ * @returns {object} Action object.
+ */
+export function setSearchQuery( query, propagateToWindow = true ) {
+	return {
+		type: 'SET_SEARCH_QUERY',
+		query,
+		propagateToWindow,
+	};
+}
+
+/**
+ * Returns an action object used to set a search sort value.
+ *
+ * @param {string} sort - Sort value.
+ * @param {boolean} propagateToWindow - If true, will tell the effects handler to set the search query in the location bar.
+ *
+ * @returns {object} Action object.
+ */
+export function setSort( sort, propagateToWindow = true ) {
+	return {
+		type: 'SET_SORT',
+		sort,
+		propagateToWindow,
+	};
+}
+
+/**
+ * Returns an action object used to set a search filter.
+ *
+ * @param {string} name - Filter name.
+ * @param {string[]} value - Filter values.
+ * @param {boolean} propagateToWindow - If true, will tell the effects handler to set the search query in the location bar.
+ *
+ * @returns {object} Action object.
+ */
+export function setFilter( name, value, propagateToWindow = true ) {
+	return {
+		type: 'SET_FILTER',
+		name,
+		value,
+		propagateToWindow,
+	};
+}
+
+/**
+ * Returns an action object used to clear all filter values.
+ *
+ * @returns {object} Action object.
+ */
+export function clearFilters() {
+	return {
+		type: 'CLEAR_FILTERS',
+	};
+}

--- a/modules/search/instant-search/store/effects.js
+++ b/modules/search/instant-search/store/effects.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { search } from '../lib/api';
-import { SORT_DIRECTION_ASC, VALID_SORT_KEYS } from '../lib/constants';
+import { DEFAULT_SORT_KEY, SORT_DIRECTION_ASC, VALID_SORT_KEYS } from '../lib/constants';
 import { getFilterKeys } from '../lib/filters';
 import { getQuery, setQuery } from '../lib/query-string';
 import {
@@ -47,7 +47,7 @@ function initializeQueryValues( action, store ) {
 	//
 	// Initialize sort value for the reducer.
 	//
-	let sort = 'revelance';
+	let sort = DEFAULT_SORT_KEY;
 	if ( VALID_SORT_KEYS.includes( queryObject.sort ) ) {
 		// Set sort value from `sort` query value.
 		sort = queryObject.sort;

--- a/modules/search/instant-search/store/effects.js
+++ b/modules/search/instant-search/store/effects.js
@@ -1,0 +1,156 @@
+/**
+ * Internal dependencies
+ */
+import { search } from '../lib/api';
+import { SORT_DIRECTION_ASC, VALID_SORT_KEYS } from '../lib/constants';
+import { getFilterKeys } from '../lib/filters';
+import { getQuery, setQuery } from '../lib/query-string';
+import {
+	recordFailedSearchRequest,
+	recordSuccessfulSearchRequest,
+	setFilter,
+	setSearchQuery,
+	setSort,
+} from './actions';
+
+/**
+ * Effect handler which will fetch search results from the API.
+ *
+ * @param {object} action - Action which had initiated the effect handler.
+ * @param {object} store -  Store instance.
+ */
+function makeSearchAPIRequest( action, store ) {
+	search( action.options )
+		.then( response => {
+			if ( response === null ) {
+				// Request has been cancelled by a more recent request.
+				return;
+			}
+
+			store.dispatch( recordSuccessfulSearchRequest( { options: action.options, response } ) );
+		} )
+		.catch( error => {
+			// eslint-disable-next-line no-console
+			console.error( 'Jetpack Search encountered an error:', error );
+			store.dispatch( recordFailedSearchRequest( error ) );
+		} );
+}
+
+function initializeQueryValues( action, store ) {
+	const queryObject = getQuery();
+
+	//
+	// Initialize search query value for the reducer.
+	//
+	store.dispatch( setSearchQuery( queryObject.s, false ) );
+
+	//
+	// Initialize sort value for the reducer.
+	//
+	let sort = 'revelance';
+	if ( VALID_SORT_KEYS.includes( queryObject.sort ) ) {
+		// Set sort value from `sort` query value.
+		sort = queryObject.sort;
+	} else if ( 'date' === queryObject.orderby ) {
+		// Set sort value from legacy `orderby` query value.
+		sort =
+			typeof queryObject.order === 'string' &&
+			queryObject.order.toUpperCase() === SORT_DIRECTION_ASC
+				? 'oldest'
+				: 'newest';
+	} else if ( 'relevance' === queryObject.orderby ) {
+		// Set sort value from legacy `orderby` query value.
+		sort = 'relevance';
+	} else if ( VALID_SORT_KEYS.includes( action.defaultSort ) ) {
+		// Set sort value from customizer configured default sort value.
+		sort = action.defaultSort;
+	}
+	store.dispatch( setSort( sort, false ) );
+
+	//
+	// Initialize filter value for the reducer.
+	//
+	getFilterKeys()
+		.filter( filterKey => filterKey in queryObject )
+		.forEach( filterKey =>
+			store.dispatch( setFilter( filterKey, queryObject[ filterKey ], false ) )
+		);
+}
+
+/**
+ * Effect handler which will update the location bar's search query string
+ *
+ * @param {object} action - Action which had initiated the effect handler.
+ */
+function updateSearchQueryString( action ) {
+	if ( action.propagateToWindow === false ) {
+		return;
+	}
+
+	const queryObject = getQuery();
+	if ( action.query === '' ) {
+		delete queryObject.s;
+	} else {
+		queryObject.s = action.query;
+	}
+	setQuery( queryObject );
+}
+
+/**
+ * Effect handler which will update the location bar's sort query string
+ *
+ * @param {object} action - Action which had initiated the effect handler.
+ */
+function updateSortQueryString( action ) {
+	if ( action.propagateToWindow === false ) {
+		return;
+	}
+	if ( ! VALID_SORT_KEYS.includes( action.sort ) ) {
+		return;
+	}
+
+	const queryObject = getQuery();
+	queryObject.sort = action.sort;
+
+	// Removes legacy sort query values, just in case.
+	delete queryObject.order;
+	delete queryObject.orderby;
+
+	setQuery( queryObject );
+}
+
+/**
+ * Effect handler which will update the location bar's filter query string
+ *
+ * @param {object} action - Action which had initiated the effect handler.
+ */
+function updateFilterQueryString( action ) {
+	if ( action.propagateToWindow === false ) {
+		return;
+	}
+	if ( ! getFilterKeys().includes( action.name ) ) {
+		return;
+	}
+
+	const queryObject = getQuery();
+	queryObject[ action.name ] = action.value;
+	setQuery( queryObject );
+}
+
+/**
+ * Effect handler which will clear filter queries from the location bar
+ */
+function clearFilterQueryString() {
+	const queryObject = getQuery();
+	getFilterKeys().forEach( key => delete queryObject[ key ] );
+	setQuery( queryObject );
+}
+
+export default {
+	CLEAR_FILTERS: clearFilterQueryString,
+	INITIALIZE_QUERY_VALUES: initializeQueryValues,
+	MAKE_SEARCH_REQUEST: makeSearchAPIRequest,
+	SET_FILTER: updateFilterQueryString,
+	SET_SEARCH_QUERY: updateSearchQueryString,
+	SET_SORT: updateSortQueryString,
+};

--- a/modules/search/instant-search/store/index.js
+++ b/modules/search/instant-search/store/index.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { applyMiddleware, createStore } from 'redux';
+import refx from 'refx';
+
+/**
+ * Internal dependencies
+ */
+import effects from './effects';
+import reducer from './reducer';
+
+const middlewares = [ refx( effects ) ];
+const store = createStore( reducer, {}, applyMiddleware( ...middlewares ) );
+
+export default store;

--- a/modules/search/instant-search/store/reducer/api.js
+++ b/modules/search/instant-search/store/reducer/api.js
@@ -1,0 +1,66 @@
+/**
+ * Reducer for recording if the previous search request yielded an error.
+ *
+ * @param {object} state - Current state.
+ * @param {object} action - Dispatched action.
+ *
+ * @returns {object} Updated state.
+ */
+export function hasError( state = false, action ) {
+	switch ( action.type ) {
+		case 'MAKE_SEARCH_REQUEST':
+		case 'RECORD_SUCCESSFUL_SEARCH_REQUEST':
+			return false;
+		case 'RECORD_FAILED_SEARCH_REQUEST':
+			return true;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer for recording search request state.
+ *
+ * @param {object} state - Current state.
+ * @param {object} action - Dispatched action.
+ *
+ * @returns {object} Updated state.
+ */
+export function isLoading( state = false, action ) {
+	switch ( action.type ) {
+		case 'MAKE_SEARCH_REQUEST':
+			return true;
+		case 'RECORD_SUCCESSFUL_SEARCH_REQUEST':
+		case 'RECORD_FAILED_SEARCH_REQUEST':
+			return false;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer for recording search results.
+ *
+ * @param {object} state - Current state.
+ * @param {object} action - Dispatched action.
+ *
+ * @returns {object} Updated state.
+ */
+export function response( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECORD_SUCCESSFUL_SEARCH_REQUEST': {
+			const newState = { ...action.response };
+			// For paginated results, merge previous search results with new search results.
+			if ( action.options.pageHandle ) {
+				newState.aggregations = {
+					...( 'aggregations' in state && ! Array.isArray( state ) ? state.aggregations : {} ),
+					...( ! Array.isArray( newState.aggregations ) ? newState.aggregations : {} ),
+				};
+				newState.results = [ ...( 'results' in state ? state.results : [] ), ...newState.results ];
+			}
+			return newState;
+		}
+	}
+
+	return state;
+}

--- a/modules/search/instant-search/store/reducer/index.js
+++ b/modules/search/instant-search/store/reducer/index.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { hasError, isLoading, response } from './api';
+import { filters, searchQuery, sort } from './query-string';
+import { serverOptions } from './server-options';
+
+export { filters, hasError, isLoading, response, searchQuery, serverOptions, sort };
+export default combineReducers( {
+	filters,
+	hasError,
+	isLoading,
+	response,
+	searchQuery,
+	serverOptions,
+	sort,
+} );

--- a/modules/search/instant-search/store/reducer/query-string.js
+++ b/modules/search/instant-search/store/reducer/query-string.js
@@ -1,0 +1,73 @@
+/**
+ * Internal dependencies
+ */
+import { VALID_SORT_KEYS } from '../../lib/constants';
+import { getFilterKeys } from '../../lib/filters';
+
+/**
+ * Reducer for keeping track of the user's inputted search query
+ *
+ * @param {object} state - Current state.
+ * @param {object} action - Dispatched action.
+ *
+ * @returns {object} Updated state.
+ */
+export function searchQuery( state = '', action ) {
+	switch ( action.type ) {
+		case 'SET_SEARCH_QUERY':
+			return action.query;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer for keeping track of the user's selected sort type
+ *
+ * @param {object} state - Current state.
+ * @param {object} action - Dispatched action.
+ *
+ * @returns {object} Updated state.
+ */
+export function sort( state = 'relevance', action ) {
+	if ( ! VALID_SORT_KEYS.includes( action.sort ) ) {
+		return state;
+	}
+
+	switch ( action.type ) {
+		case 'SET_SORT':
+			return action.sort;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer for keeping track of the user's selected sort type
+ *
+ * @param {object} state - Current state.
+ * @param {object} action - Dispatched action.
+ *
+ * @returns {object} Updated state.
+ */
+export function filters( state = {}, action ) {
+	switch ( action.type ) {
+		case 'CLEAR_FILTERS':
+			return {};
+		case 'SET_FILTER':
+			if ( ! getFilterKeys().includes( action.name ) || ! Array.isArray( action.value ) ) {
+				return state;
+			}
+			if ( action.value.length === 0 ) {
+				const newState = { ...state };
+				delete newState[ action.name ];
+				return newState;
+			}
+			return {
+				...state,
+				[ action.name ]: action.value,
+			};
+	}
+
+	return state;
+}

--- a/modules/search/instant-search/store/reducer/server-options.js
+++ b/modules/search/instant-search/store/reducer/server-options.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { SERVER_OBJECT_NAME } from '../../lib/constants';
+
+/**
+ * Reducer for storing server-generated values in the Redux store.
+ *
+ * @param {object} state - Current state.
+ *
+ * @returns {object} Updated state.
+ */
+export function serverOptions( state = window[ SERVER_OBJECT_NAME ] ?? {} ) {
+	return state;
+}

--- a/modules/search/instant-search/store/selectors.js
+++ b/modules/search/instant-search/store/selectors.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import { getUnselectableFilterKeys, mapFilterToFilterKey } from '../lib/filters';
+
+export function getResponse( state ) {
+	return state.response;
+}
+
+export function hasError( state ) {
+	return state.hasError;
+}
+
+export function hasNextPage( state ) {
+	return ! hasError( state ) && getResponse( state )?.page_handle;
+}
+
+export function isLoading( state ) {
+	return state.isLoading;
+}
+
+export function getSearchQuery( state ) {
+	return state.searchQuery;
+}
+
+export function getSort( state ) {
+	return state.sort;
+}
+
+export function getFilters( state ) {
+	return state.filters;
+}
+
+export function hasFilters( state ) {
+	return Object.keys( state.filters ).length > 0;
+}
+
+// This selector combines multiple widgets outside overlay into a single widget consisting only of the `filters` key.
+// After combining the widgets, we the filter out all unselected filter values.
+//
+// This is used to render a single SearchFilters component for all filters selected outside the search overlay.
+export function getWidgetOutsideOverlay( state ) {
+	// Both of these values should default to [] when empty; they should never be falsy.
+	if ( ! state.serverOptions.widgetsOutsideOverlay || ! state.serverOptions.widgets ) {
+		return {};
+	}
+	const keys = getUnselectableFilterKeys(
+		state.serverOptions.widgets,
+		state.serverOptions.widgetsOutsideOverlay
+	);
+	const selectedKeys = Object.keys( state.filters ).filter( key => keys.includes( key ) );
+	const filters = state.serverOptions.widgetsOutsideOverlay
+		.map( widget => widget.filters )
+		.reduce( ( prev, current ) => prev.concat( current ), [] )
+		// Server-side filter keys are named differently than client-side; conversion is required.
+		.filter( serverFilter => selectedKeys.includes( mapFilterToFilterKey( serverFilter ) ) );
+
+	return { filters };
+}

--- a/modules/search/instant-search/store/test/reducer.test.js
+++ b/modules/search/instant-search/store/test/reducer.test.js
@@ -1,0 +1,144 @@
+/**
+ * @jest-environment jsdom
+ */
+/* global expect */
+
+/**
+ * Internal dependencies
+ */
+import {
+	clearFilters,
+	makeSearchRequest,
+	recordSuccessfulSearchRequest,
+	recordFailedSearchRequest,
+	setFilter,
+	setSearchQuery,
+	setSort,
+} from '../actions';
+import { filters, hasError, isLoading, response, searchQuery, sort } from '../reducer';
+
+describe( 'hasError Reducer', () => {
+	test( 'defaults to false', () => {
+		const state = hasError( undefined, {} );
+		expect( state ).toBe( false );
+	} );
+	test( 'becomes true when a failed search request is recorded', () => {
+		const state = hasError( undefined, recordFailedSearchRequest( new Error( 'Some error' ) ) );
+		expect( state ).toBe( true );
+	} );
+	test( 'becomes false when a new search request is made', () => {
+		const state = hasError( true, makeSearchRequest( {} ) );
+		expect( state ).toBe( false );
+	} );
+	test( 'becomes false when a successful search request is recorded', () => {
+		const state = hasError( true, recordSuccessfulSearchRequest( {} ) );
+		expect( state ).toBe( false );
+	} );
+} );
+
+describe( 'isLoading Reducer', () => {
+	test( 'defaults to false', () => {
+		const state = isLoading( undefined, {} );
+		expect( state ).toBe( false );
+	} );
+	test( 'becomes true when a new search request is made', () => {
+		const state = isLoading( undefined, makeSearchRequest( {} ) );
+		expect( state ).toBe( true );
+	} );
+	test( 'becomes false when a failed search request is recorded', () => {
+		const state = isLoading( true, recordFailedSearchRequest( new Error( 'Some error' ) ) );
+		expect( state ).toBe( false );
+	} );
+	test( 'becomes false when a successful search request is recorded', () => {
+		const state = isLoading( true, recordSuccessfulSearchRequest( {} ) );
+		expect( state ).toBe( false );
+	} );
+} );
+
+describe( 'response Reducer', () => {
+	const actionOptions = { pageHandle: 'someString' };
+	const actionResponse = {
+		aggregations: { taxonomy_0: { buckets: [] } },
+		results: [ { id: 1, result_type: 'post' } ],
+	};
+	test( 'defaults to an empty object', () => {
+		const state = response( undefined, {} );
+		expect( state ).toEqual( {} );
+	} );
+	test( 'is set to the response value when a successful search request is recorded', () => {
+		const state = response(
+			undefined,
+			recordSuccessfulSearchRequest( {
+				options: actionOptions,
+				response: actionResponse,
+			} )
+		);
+		expect( state ).toEqual( actionResponse );
+	} );
+	test( 'appends aggregations and results to previous paginated results', () => {
+		const state = response(
+			{
+				aggregations: { taxonomy_1: { buckets: [] } },
+				results: [ { id: 2, result_type: 'page' } ],
+			},
+			recordSuccessfulSearchRequest( {
+				options: actionOptions,
+				response: actionResponse,
+			} )
+		);
+		expect( state ).toEqual( {
+			aggregations: { taxonomy_1: { buckets: [] }, taxonomy_0: { buckets: [] } },
+			results: [
+				{ id: 2, result_type: 'page' },
+				{ id: 1, result_type: 'post' },
+			],
+		} );
+	} );
+} );
+
+describe( 'searchQuery Reducer', () => {
+	test( 'defaults to an empty string', () => {
+		const state = searchQuery( undefined, {} );
+		expect( state ).toBe( '' );
+	} );
+	test( 'is updated by a set search query action', () => {
+		const state = searchQuery( undefined, setSearchQuery( 'Some new query' ) );
+		expect( state ).toBe( 'Some new query' );
+	} );
+} );
+
+describe( 'sort Reducer', () => {
+	test( 'defaults to "relevance"', () => {
+		const state = sort( undefined, {} );
+		expect( state ).toBe( 'relevance' );
+	} );
+	test( 'is updated by a set search query action', () => {
+		const state = sort( undefined, setSort( 'newest' ) );
+		expect( state ).toBe( 'newest' );
+	} );
+} );
+
+describe( 'filters Reducer', () => {
+	test( 'defaults to an empty object', () => {
+		const state = filters( undefined, {} );
+		expect( state ).toEqual( {} );
+	} );
+	test( 'is updated by a set filter action', () => {
+		const state = filters( undefined, setFilter( 'post_types', [ 'post' ] ) );
+		expect( state ).toEqual( {
+			post_types: [ 'post' ],
+		} );
+	} );
+	test( 'ignores set filter actions with invalid filter names', () => {
+		const state = filters( undefined, setFilter( 'apple', [ 'tart' ] ) );
+		expect( state ).toEqual( {} );
+	} );
+	test( 'ignores set filter actions with non-array values', () => {
+		const state = filters( undefined, setFilter( 'post_types', 'tart' ) );
+		expect( state ).toEqual( {} );
+	} );
+	test( 'is reset by a clear filters action', () => {
+		const state = filters( { post_types: [ 'post' ] }, clearFilters() );
+		expect( state ).toEqual( {} );
+	} );
+} );

--- a/modules/search/instant-search/store/test/selectors.test.js
+++ b/modules/search/instant-search/store/test/selectors.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+/* global expect */
+
+/**
+ * Internal dependencies
+ */
+import { getWidgetOutsideOverlay } from '../selectors';
+
+describe( 'hasError Reducer', () => {
+	test( 'defaults to an empty object for a clean state', () => {
+		const state = { serverOptions: {} };
+		expect( getWidgetOutsideOverlay( state ) ).toEqual( {} );
+	} );
+
+	test( 'defaults to an empty object when either widget configurations are falsy', () => {
+		expect(
+			getWidgetOutsideOverlay( {
+				serverOptions: {
+					widgets: [],
+					widgetsOutsideOverlay: null,
+				},
+			} )
+		).toEqual( {} );
+		expect(
+			getWidgetOutsideOverlay( {
+				serverOptions: {
+					widgets: undefined,
+					widgetsOutsideOverlay: [],
+				},
+			} )
+		).toEqual( {} );
+	} );
+
+	test( 'extracts filter keys from widgets outside the overlay', () => {
+		const state = {
+			filters: { category: [ '1', '2' ], post_types: [ 'post', 'page' ] },
+			serverOptions: {
+				widgets: [ { filters: [ { type: 'taxonomy', taxonomy: 'category' } ] } ],
+				widgetsOutsideOverlay: [
+					{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
+					{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
+					{ filters: [ { type: 'post_type' } ] },
+				],
+			},
+		};
+		// Category filter is excluded since it's also available in state.serverOptions.widgets.
+		// Year post-date filter is excluded since it's not one of the selected filters in state.filters.
+		expect( getWidgetOutsideOverlay( state ) ).toEqual( {
+			filters: [ { type: 'post_type' } ],
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds a comprehensive Redux state for replacing API request handling and query string manipulation.
* Adds corresponding tests for the new Redux state.
* Adds tests for the filters library.
* Simplifies our Webpack configuration, stops externalizing React imports, and aliases React imports to Preact.

This Redux state will be integrated into our Preact component tree in a follow-up PR.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Run `yarn test-search`; ensure they all pass.
* Apply this change to your Jetpack site with a Jetpack Search subscription. Ensure that the search overlay spawns and behaves as expected.
* Ensure that the filtering functionality, both within and outside the overlay, work as expected.

#### Proposed changelog entry for your changes:
* None.
