### PR TITLE
Admin Menu: Make link destination decision filterable

### DIFF
--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -76,13 +76,19 @@ class Admin_Menu {
 			$this->add_site_card_menu( $domain );
 		}
 
-		/*
+		/**
 		 * Whether links should point to Calypso or wp-admin.
 		 *
+		 * Options:
 		 * true  - Calypso.
 		 * false - wp-admin.
+		 *
+		 * @module masterbar
+		 * @since 9.3.0
+		 *
+		 * @param bool $calypso Whether menu item URLs should point to Calypso.
 		 */
-		$calypso = true;
+		$calypso = apply_filters( 'jetpack_admin_menu_calypso_links', true );
 
 		// Remove separators.
 		remove_menu_page( 'separator1' );

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -88,7 +88,7 @@ class Admin_Menu {
 		 *
 		 * @param bool $calypso Whether menu item URLs should point to Calypso.
 		 */
-		$calypso = apply_filters( 'jetpack_admin_menu_calypso_links', true );
+		$calypso = apply_filters( 'jetpack_admin_menu_use_calypso_links', true );
 
 		// Remove separators.
 		remove_menu_page( 'separator1' );


### PR DESCRIPTION
Making the decision where to point menu item URLs filterable will allow us to ship the feature to atomic without having to wait for 9.4.

This is in preparation of https://github.com/Automattic/wp-calypso/issues/47043.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a filter to the decision point on whether menu URLs should point to Calypso or WP Admin.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Automated tests are probably fine? It's a noop and just shouldn't fatal.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None
