### PR TITLE
Admin Color Schemes: reintroduce TC build and add overrides for nav unification

### DIFF
--- a/modules/masterbar/admin-color-schemes/colors/_overrides.scss
+++ b/modules/masterbar/admin-color-schemes/colors/_overrides.scss
@@ -66,6 +66,10 @@
 	}
 
 	// Site Card
+	 #adminmenu li.toplevel_page_site-card {
+		border-color: $menu-submenu-background; // Calypso --color-sidebar-border
+	}
+
 	.site__info .site__title {
 		color: $menu-text; // Calypso --color-sidebar-text
 	}

--- a/modules/masterbar/admin-color-schemes/colors/_overrides.scss
+++ b/modules/masterbar/admin-color-schemes/colors/_overrides.scss
@@ -17,6 +17,7 @@
 		background: $masterbar-background !important;
 	}
 
+	#wpadminbar .ab-top-menu > li.my-sites > .ab-item,
 	#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item,
 	#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus,
 	#wpadminbar.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,
@@ -46,4 +47,32 @@
 	&:hover, &:focus {
 		color: $menu-submenu-current-text;
 	}
+}
+
+// Nav unification
+.admin-color-aquatic,
+.admin-color-classic-blue,
+.admin-color-classic-bright,
+.admin-color-classic-dark,
+.admin-color-contrast,
+.admin-color-nightfall,
+.admin-color-powder-snow,
+.admin-color-sakura,
+.admin-color-sunset {
+
+	// Masterbar
+	#wpadminbar {
+		box-shadow: inset 0 -1px 0 $masterbar-background; // Calypso --color-masterbar-background
+	}
+
+	// Site Card
+	.site__info .site__title {
+		color: $menu-text; // Calypso --color-sidebar-text
+	}
+
+	#adminmenu .toplevel_page_site-card:hover div.wp-menu-image,
+	#adminmenu .toplevel_page_site-card a:focus div.wp-menu-image {
+		background-color: $menu-current-background; // Calypso --color-sidebar-menu-selected-background
+	}
+
 }

--- a/modules/masterbar/admin-color-schemes/colors/_overrides.scss
+++ b/modules/masterbar/admin-color-schemes/colors/_overrides.scss
@@ -66,7 +66,7 @@
 	}
 
 	// Site Card
-	 #adminmenu li.toplevel_page_site-card {
+	#adminmenu li.toplevel_page_site-card {
 		border-color: $menu-submenu-background; // Calypso --color-sidebar-border
 	}
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"add-textdomain": "wpi18n addtextdomain --textdomain=jetpack --glob-pattern='!(docker|node_modules|tests|tools|vendor){*.php,**/*.php}'",
 		"build": "yarn install-if-deps-outdated && yarn clean && yarn build-client && yarn build-php && yarn build-extensions && yarn build-search && yarn build-packages",
 		"build-client": "gulp",
+		"build-color-schemes-wpcom": "GULP_ENV=wpcom gulp sass:color-schemes",
 		"build-concurrently": "yarn install-if-deps-outdated && yarn clean && yarn concurrently 'yarn build-client' 'yarn build-php' 'yarn build-extensions' 'yarn build-search' 'yarn build-packages'",
 		"build-extensions": "webpack --config ./webpack.config.extensions.js",
 		"build-packages": "webpack --config ./webpack.config.packages.js",

--- a/tools/builder/sass.js
+++ b/tools/builder/sass.js
@@ -55,8 +55,14 @@ gulp.task( 'sass:calypsoify', function ( done ) {
 gulp.task( 'sass:color-schemes', function ( done ) {
 	log( 'Building Color schemes CSS...' );
 
-	const src = './modules/masterbar/admin-color-schemes/colors/**/*.scss';
-	const dest = './_inc/build/masterbar/admin-color-schemes/colors';
+	const src =
+		process.env.GULP_ENV === 'wpcom'
+			? '../masterbar/admin-color-schemes/colors/**/*.scss'
+			: './modules/masterbar/admin-color-schemes/colors/**/*.scss';
+	const dest =
+		process.env.GULP_ENV === 'wpcom'
+			? '../masterbar/admin-color-schemes/colors'
+			: './_inc/build/masterbar/admin-color-schemes/colors';
 
 	return gulp
 		.src( src )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->


### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Reintroduce the TC build for wpcom after Compass build led to issues in production
* Add color schemes overrides for nav unification (for details see https://github.com/Automattic/jetpack/issues/18092)

### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**For Jetpack:**
- In the Jetpack settings ensure that in the `Writing` section the `WordPress.com toolbar` option is active
- Navigate to your user profile in `/wp-admin/profile.php`
- Check if all Calypso color schemes are present
- Compare new color schemes to their Calypso counterparts
- Everything should still look as in https://github.com/Automattic/jetpack/pull/17828

**For WoA:**
- Use Jetpack Beta and activate this branch
- Everything should still look as in https://github.com/Automattic/jetpack/pull/17828

**For Simple:**
- Apply D54346-code (diff for this PR) to your sandbox
- Change color scheme settings in Calypso /me/account to Sakura
- Go to wp-admin and reload. It should display in Sakura colors
- Activate nav unification
- Some changes should be visible (more changes needed in follow up PR):

|Before|After|
|-|-|
|<img width="287" alt="Screenshot 2020-12-16 at 09 49 15" src="https://user-images.githubusercontent.com/1562646/102326066-34dc0700-3f84-11eb-9c59-b969d9d529cc.png">|<img width="287" alt="Screenshot 2020-12-16 at 09 52 29" src="https://user-images.githubusercontent.com/1562646/102326257-75d41b80-3f84-11eb-847e-72a41be9da74.png">|


