### PR TITLE
Site Abstraction Layer - fix get_metadata function

### DIFF
--- a/sal/class.json-api-post-base.php
+++ b/sal/class.json-api-post-base.php
@@ -9,7 +9,8 @@
 
 require_once dirname( __FILE__ ) . '/class.json-api-metadata.php';
 require_once dirname( __FILE__ ) . '/class.json-api-date.php';
-require_once ( ABSPATH . "wp-includes/post.php" );
+require_once ABSPATH . 'wp-admin/includes/post.php';
+require_once ABSPATH . 'wp-includes/post.php';
 
 abstract class SAL_Post {
 	public $post;


### PR DESCRIPTION
Summary:
A fatal error was discovered when testing an internal only page - here is the relevant part of the stacktrace:
```
Fatal error: Uncaught Error: Call to undefined function has_meta() in /home/wpcom/public_html/public.api/rest/sal/class.json-api-post-base.php:123 Stack trace: #0 /home/wpcom/public_html/public.api/rest/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php(264): SAL_Post->get_metadata() #1 /home/wpcom/public_html/public.api/rest/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php(130): 
```

Searching around, it seems that the `has_meta` function is defined not in `wp-includes/post.php` but rather in `wp-admin/includes/post.php`

Differential Revision: D53904-code

This commit syncs r218377-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
* Fixes a potential bug in the posts API endpoint, in which a fatal error could be thrown under certain circumstances, when trying to use the `get_metadata` method.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

As far as I know, the affected code `get_metadata` was only being called in internal pages. Thus it should not affect any other sites. 

#### Proposed changelog entry for your changes:

Fixed a potential bug in the posts API endpoint, in which a fatal error could be thrown under certain circumstances, when trying to use the `get_metadata` method.