### PR TITLE
Color Schemes: Prevent RTL versions of built files

### DIFF
--- a/tools/builder/sass.js
+++ b/tools/builder/sass.js
@@ -70,6 +70,7 @@ gulp.task( 'sass:color-schemes', function ( done ) {
 		.pipe(
 			prepend.prependText( '/* Do not modify this file directly.  It is compiled SASS code. */\n' )
 		)
+		.pipe( prepend.prependText( '/* NOAUTORTL */\n' ) )
 		.pipe( autoprefixer() )
 		.pipe( gulp.dest( dest ) )
 		.on( 'end', function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR adds a new comment into the built CSS of color schemes to prevent autortl script from running on it during wpcom commits. Color scheme CSS files are universal and don't need the RTL version generated.

#### Jetpack product discussion
—

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- checkout this branch
- `yarn build-client`
- open one of color scheme build artifacts and confirm it contains the new code comment

example file to check `_inc/build/masterbar/admin-color-schemes/colors/aquatic/colors.css`

#### Proposed changelog entry for your changes:
none needed