### PR TITLE
Anchor: Support multiple actions

### DIFF
--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -143,4 +143,3 @@ function process_anchor_params() {
 
 add_action( 'init', __NAMESPACE__ . '\register_extension' );
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\process_anchor_params' );
-add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\set_extension_availability' );

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -27,14 +27,18 @@ if ( ! class_exists( 'Jetpack_Podcast_Helper' ) ) {
  * @return boolean Whether the extension is available
  */
 function is_extension_available() {
-	/**
-	 * Filter the availability of the Anchor integration extension for the block editor.
-	 *
-	 * @since 9.3.0
-	 *
-	 * @param boolean $is_available Whether the extension is available.
-	 */
-	return apply_filters( 'jetpack_anchor_integration_availability', false );
+	// Enable on WP.com Simple sites.
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		return true;
+	}
+
+	// Enable on WP.com Atomic sites.
+	if ( jetpack_is_atomic_site() ) {
+		return true;
+	}
+
+	// There are no plans to extend the Anchor integration to Jetpack sites at the moment.
+	return false;
 }
 
 /**

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -11,7 +11,6 @@ namespace Automattic\Jetpack\Extensions\AnchorFm;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
-use Jetpack_Gutenberg;
 use Jetpack_Podcast_Helper;
 
 const FEATURE_NAME = 'anchor-fm';
@@ -22,44 +21,9 @@ if ( ! class_exists( 'Jetpack_Podcast_Helper' ) ) {
 }
 
 /**
- * Determine if the Anchor integration extension for the block editor is available.
- *
- * @return boolean Whether the extension is available
- */
-function is_extension_available() {
-	// Enable on WP.com Simple sites.
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		return true;
-	}
-
-	// Enable on WP.com Atomic sites.
-	if ( jetpack_is_atomic_site() ) {
-		return true;
-	}
-
-	// There are no plans to extend the Anchor integration to Jetpack sites at the moment.
-	return false;
-}
-
-/**
- * Set the availability of the Anchor integration extension for the block editor.
- */
-function set_extension_availability() {
-	if ( is_extension_available() ) {
-		Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
-	} else {
-		Jetpack_Gutenberg::set_extension_unavailable( BLOCK_NAME, 'Not supported' );
-	}
-}
-
-/**
  * Registers Anchor.fm integration for the block editor.
  */
 function register_extension() {
-	if ( ! is_extension_available() ) {
-		return;
-	}
-
 	Blocks::jetpack_register_block( BLOCK_NAME );
 
 	// Register post_meta for connecting Anchor podcasts with posts.
@@ -96,10 +60,6 @@ function register_extension() {
  * Checks URL params to determine the Anchor integration action to perform.
  */
 function process_anchor_params() {
-	if ( ! is_extension_available() ) {
-		return;
-	}
-
 	if (
 		! function_exists( 'get_current_screen' )
 		|| is_null( \get_current_screen() )

--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -100,7 +100,6 @@ function process_anchor_params() {
 				$track = $podcast_helper->get_track_data( $episode_id );
 				if ( ! \is_wp_error( $track ) ) {
 					update_post_meta( $post->ID, 'jetpack_anchor_episode', $episode_id );
-					$data['actions'][] = 'override-welcome-guide';
 
 					if ( 'post-new.php' === $GLOBALS['pagenow'] ) {
 						$data['actions'][] = array(

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -75,19 +75,6 @@ function showPostPublishOutboundLink() {
 	} );
 }
 
-function overrideWelcomeGuide() {
-	addFilter( 'plugins.registerPlugin', 'jetpack/anchor-welcome-guide', ( settings, name ) => {
-		// WP.com uses a custom welcome guide provided by a plugin.
-		// See https://github.com/Automattic/wp-calypso/blob/2e1fe38b7bdbaf3eb997160f83ff71fd781b3fbe/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L173
-		if ( name !== 'wpcom-block-editor-nux' ) {
-			return settings;
-		}
-
-		// TODO: Override welcome guide.
-		return settings;
-	} );
-}
-
 function initAnchor() {
 	const data = window.Jetpack_AnchorFm;
 	if ( typeof data !== 'object' ) {
@@ -105,9 +92,6 @@ function initAnchor() {
 				break;
 			case 'set-episode-title':
 				setEpisodeTitle( actionParams );
-				break;
-			case 'override-welcome-guide':
-				overrideWelcomeGuide();
 				break;
 		}
 	} );

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -1,9 +1,15 @@
 /**
+ * External dependencies
+ */
+import { castArray } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { dispatch, select } from '@wordpress/data';
+import { dispatch } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { addFilter } from '@wordpress/hooks';
 import { external, Icon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
@@ -18,26 +24,17 @@ import { waitForEditor } from '../../shared/wait-for-editor';
  */
 import './editor.scss';
 
-async function insertSpotifyBadge() {
-	const { Jetpack_AnchorFm = {} } = window;
-	const { image, spotifyShowUrl } = Jetpack_AnchorFm;
-	if ( ! spotifyShowUrl ) {
+async function insertSpotifyBadge( { image, url } ) {
+	if ( ! image || ! url ) {
 		return;
 	}
 
-	const { track = {} } = Jetpack_AnchorFm;
-
 	await waitForEditor();
-
-	const { insertBlock } = dispatch( 'core/block-editor' );
-	const { editPost } = dispatch( 'core/editor' );
-	const { isEditedPostNew } = select( 'core/editor' );
-
-	insertBlock(
+	dispatch( 'core/block-editor' ).insertBlock(
 		createBlock( 'core/image', {
 			url: image,
 			linkDestination: 'none',
-			href: spotifyShowUrl,
+			href: url,
 			align: 'center',
 			width: 165,
 			height: 40,
@@ -47,12 +44,14 @@ async function insertSpotifyBadge() {
 		undefined,
 		false
 	);
+}
 
-	// Set the post title when the post is new,
-	// and it can be picked up from the podcast track.
-	if ( isEditedPostNew() && track.title ) {
-		editPost( { title: track.title } );
+async function setEpisodeTitle( { title } ) {
+	if ( ! title ) {
+		return;
 	}
+	await waitForEditor();
+	dispatch( 'core/editor' ).editPost( { title } );
 }
 
 const ConvertToAudio = () => (
@@ -76,20 +75,42 @@ function showPostPublishOutboundLink() {
 	} );
 }
 
+function overrideWelcomeGuide() {
+	addFilter( 'plugins.registerPlugin', 'jetpack/anchor-welcome-guide', ( settings, name ) => {
+		// WP.com uses a custom welcome guide provided by a plugin.
+		// See https://github.com/Automattic/wp-calypso/blob/2e1fe38b7bdbaf3eb997160f83ff71fd781b3fbe/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L173
+		if ( name !== 'wpcom-block-editor-nux' ) {
+			return settings;
+		}
+
+		// TODO: Override welcome guide.
+		return settings;
+	} );
+}
+
 function initAnchor() {
 	const data = window.Jetpack_AnchorFm;
 	if ( typeof data !== 'object' ) {
 		return;
 	}
 
-	switch ( data.action ) {
-		case 'insert-spotify-badge':
-			insertSpotifyBadge();
-			break;
-		case 'show-post-publish-outbound-link':
-			showPostPublishOutboundLink();
-			break;
-	}
+	data.actions.forEach( action => {
+		const [ actionName, actionParams ] = castArray( action );
+		switch ( actionName ) {
+			case 'insert-spotify-badge':
+				insertSpotifyBadge( actionParams );
+				break;
+			case 'show-post-publish-outbound-link':
+				showPostPublishOutboundLink();
+				break;
+			case 'set-episode-title':
+				setEpisodeTitle( actionParams );
+				break;
+			case 'override-welcome-guide':
+				overrideWelcomeGuide();
+				break;
+		}
+	} );
 }
 
 initAnchor();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR applies a small refactor to the Anchor integration in order to make easier for the extension to support multiple actions at once (e.g. set the episode title as the post title and insert the Spotify badge). 

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

- [Spin up a JN site running this branch](https://jurassic.ninja/create/?jetpack-beta&branch=update/anchor-disable-jp).
- Set up Jetpack (choose the Jetpack Free plan).
- Back in WP Admin, go to Settings > Jetpack constants and enable the beta blocks.
- Go to Posts > Add new.
- In the browser JS console, make sure `Jetpack_AnchorFm.actions` is an array.
- Publish the post, and make sure the post-publish panel includes a link prompting users to create a podcast episode.
- Go to `/post-new.php?anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q`.
- Make sure the title of the given episode is set to the post, and the Spotify badge linking to the podcast show is auto-inserted.

#### Proposed changelog entry for your changes:
N/A.