### PR TITLE
Instant Search: Add tests & function defaults for filters

### DIFF
--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -42,19 +42,15 @@ export function getFilterKeys(
 
 // These filter keys are selectable from sidebar filters
 export function getSelectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?.widgets ) {
-	return extractFilterKeysFromConfiguration( widgets );
+	return (
+		widgets?.map( extractFilters ).reduce( ( prev, current ) => prev.concat( current ), [] ) ?? []
+	);
 }
 
 // These filter keys are not selectable from sidebar filters
 // In other words, they were selected via filters outside the search sidebar
 export function getUnselectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?.widgets ) {
 	return difference( getFilterKeys(), getSelectableFilterKeys( widgets ) );
-}
-
-function extractFilterKeysFromConfiguration( widgets ) {
-	return (
-		widgets?.map( extractFilters ).reduce( ( prev, current ) => prev.concat( current ), [] ) ?? []
-	);
 }
 
 function extractFilters( widget ) {

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -45,13 +45,9 @@ export function getSelectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?
 
 // These filter keys are not selectable from sidebar filters
 // In other words, they were selected via filters outside the search sidebar
-export function getUnselectableFilterKeys(
-	widgets = window[ SERVER_OBJECT_NAME ]?.widgets,
-	widgetsOutsideOverlay = window[ SERVER_OBJECT_NAME ]?.widgetsOutsideOverlay
-) {
+export function getUnselectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?.widgets ) {
 	const selectableKeys = getSelectableFilterKeys( widgets );
-	const keysOutsideOverlay = extractFilterKeysFromConfiguration( widgetsOutsideOverlay );
-	return difference( keysOutsideOverlay, selectableKeys );
+	return difference( getFilterKeys(), selectableKeys );
 }
 
 function extractFilterKeysFromConfiguration( widgets ) {

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -48,8 +48,7 @@ export function getSelectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?
 // These filter keys are not selectable from sidebar filters
 // In other words, they were selected via filters outside the search sidebar
 export function getUnselectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?.widgets ) {
-	const selectableKeys = getSelectableFilterKeys( widgets );
-	return difference( getFilterKeys(), selectableKeys );
+	return difference( getFilterKeys(), getSelectableFilterKeys( widgets ) );
 }
 
 function extractFilterKeysFromConfiguration( widgets ) {

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -8,6 +8,8 @@ import difference from 'lodash/difference';
  */
 import { SERVER_OBJECT_NAME } from './constants';
 
+// NOTE: This list is missing custom taxonomy names.
+//       getFilterKeys must be used to get the conclusive list of valid filter keys.
 const FILTER_KEYS = Object.freeze( [
 	// Post types
 	'post_types',
@@ -22,28 +24,40 @@ const FILTER_KEYS = Object.freeze( [
 	'year_post_modified_gmt',
 ] );
 
-export function getFilterKeys() {
+export function getFilterKeys(
+	widgets = window[ SERVER_OBJECT_NAME ]?.widgets,
+	widgetsOutsideOverlay = window[ SERVER_OBJECT_NAME ]?.widgetsOutsideOverlay
+) {
 	// Extract taxonomy names from server widget data
-	const taxonomies = window[ SERVER_OBJECT_NAME ].widgets
+	const taxonomies = [ ...( widgets ?? [] ), ...( widgetsOutsideOverlay ?? [] ) ]
 		.map( w => w.filters )
 		.filter( filters => Array.isArray( filters ) )
 		.reduce( ( filtersA, filtersB ) => filtersA.concat( filtersB ), [] )
 		.filter( filter => filter.type === 'taxonomy' )
 		.map( filter => filter.taxonomy );
-	return [ ...FILTER_KEYS, ...taxonomies ];
+	return [ ...FILTER_KEYS, ...( taxonomies ?? [] ) ];
 }
 
 // These filter keys are selectable from sidebar filters
-function getSelectableFilterKeys( overlayWidgets ) {
-	return overlayWidgets
-		.map( extractFilters )
-		.reduce( ( prev, current ) => prev.concat( current ), [] );
+export function getSelectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?.widgets ) {
+	return extractFilterKeysFromConfiguration( widgets );
 }
 
 // These filter keys are not selectable from sidebar filters
 // In other words, they were selected via filters outside the search sidebar
-export function getUnselectableFilterKeys( overlayWidgets ) {
-	return difference( getFilterKeys(), getSelectableFilterKeys( overlayWidgets ) );
+export function getUnselectableFilterKeys(
+	widgets = window[ SERVER_OBJECT_NAME ]?.widgets,
+	widgetsOutsideOverlay = window[ SERVER_OBJECT_NAME ]?.widgetsOutsideOverlay
+) {
+	const selectableKeys = getSelectableFilterKeys( widgets );
+	const keysOutsideOverlay = extractFilterKeysFromConfiguration( widgetsOutsideOverlay );
+	return difference( keysOutsideOverlay, selectableKeys );
+}
+
+function extractFilterKeysFromConfiguration( widgets ) {
+	return (
+		widgets?.map( extractFilters ).reduce( ( prev, current ) => prev.concat( current ), [] ) ?? []
+	);
 }
 
 function extractFilters( widget ) {

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -29,13 +29,15 @@ export function getFilterKeys(
 	widgetsOutsideOverlay = window[ SERVER_OBJECT_NAME ]?.widgetsOutsideOverlay
 ) {
 	// Extract taxonomy names from server widget data
-	const taxonomies = [ ...( widgets ?? [] ), ...( widgetsOutsideOverlay ?? [] ) ]
+	const keys = new Set( FILTER_KEYS );
+	[ ...( widgets ?? [] ), ...( widgetsOutsideOverlay ?? [] ) ]
 		.map( w => w.filters )
 		.filter( filters => Array.isArray( filters ) )
 		.reduce( ( filtersA, filtersB ) => filtersA.concat( filtersB ), [] )
 		.filter( filter => filter.type === 'taxonomy' )
-		.map( filter => filter.taxonomy );
-	return [ ...FILTER_KEYS, ...( taxonomies ?? [] ) ];
+		.forEach( filter => keys.add( filter.taxonomy ) );
+
+	return [ ...keys ];
 }
 
 // These filter keys are selectable from sidebar filters

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -127,14 +127,14 @@ export function getFilterQuery( filterKey ) {
 }
 
 // These filter keys have been activated/selected outside of the overlay sidebar
-export function getPreselectedFilterKeys( overlayWidgets ) {
-	return getUnselectableFilterKeys( overlayWidgets ).filter(
+export function getPreselectedFilterKeys() {
+	return getUnselectableFilterKeys().filter(
 		key => Array.isArray( getFilterQueryByKey( key ) ) && getFilterQueryByKey( key ).length > 0
 	);
 }
 
-export function getPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay ) {
-	const keys = getPreselectedFilterKeys( widgetsInOverlay );
+export function getPreselectedFilters( _, widgetsOutsideOverlay ) {
+	const keys = getPreselectedFilterKeys();
 	return widgetsOutsideOverlay
 		.map( widget => widget.filters )
 		.reduce( ( prev, current ) => prev.concat( current ), [] )

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -133,6 +133,7 @@ export function getPreselectedFilterKeys() {
 	);
 }
 
+// First parameter is ignored; it's there to preserve the function signature.
 export function getPreselectedFilters( _, widgetsOutsideOverlay ) {
 	const keys = getPreselectedFilterKeys();
 	return widgetsOutsideOverlay

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -127,15 +127,14 @@ export function getFilterQuery( filterKey ) {
 }
 
 // These filter keys have been activated/selected outside of the overlay sidebar
-export function getPreselectedFilterKeys() {
-	return getUnselectableFilterKeys().filter(
+export function getPreselectedFilterKeys( overlayWidgets ) {
+	return getUnselectableFilterKeys( overlayWidgets ).filter(
 		key => Array.isArray( getFilterQueryByKey( key ) ) && getFilterQueryByKey( key ).length > 0
 	);
 }
 
-// First parameter is ignored; it's there to preserve the function signature.
-export function getPreselectedFilters( _, widgetsOutsideOverlay ) {
-	const keys = getPreselectedFilterKeys();
+export function getPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay ) {
+	const keys = getPreselectedFilterKeys( widgetsInOverlay );
 	return widgetsOutsideOverlay
 		.map( widget => widget.filters )
 		.reduce( ( prev, current ) => prev.concat( current ), [] )

--- a/modules/search/instant-search/lib/test/filters.test.js
+++ b/modules/search/instant-search/lib/test/filters.test.js
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+/* global expect */
+/**
+ * Internal dependencies
+ */
+import { getFilterKeys, getSelectableFilterKeys, getUnselectableFilterKeys } from '../filters';
+
+describe( 'getFilterKeys', () => {
+	const DEFAULT_KEYS = [
+		'post_types',
+		'month_post_date',
+		'month_post_date_gmt',
+		'month_post_modified',
+		'month_post_modified_gmt',
+		'year_post_date',
+		'year_post_date_gmt',
+		'year_post_modified',
+		'year_post_modified_gmt',
+	];
+	test( 'defaults to a fixed array when parameters are null-ish', () => {
+		expect( getFilterKeys( null, undefined ) ).toEqual( DEFAULT_KEYS );
+	} );
+
+	test( 'includes taxonomies from widget configurations', () => {
+		const widgets = [
+			{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
+			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
+			{ filters: [ { type: 'post_type' } ] },
+		];
+		const widgetsOutsideOverlay = [ { filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] } ];
+		expect( getFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [
+			'post_types',
+			'month_post_date',
+			'month_post_date_gmt',
+			'month_post_modified',
+			'month_post_modified_gmt',
+			'year_post_date',
+			'year_post_date_gmt',
+			'year_post_modified',
+			'year_post_modified_gmt',
+			'category',
+			'post_tag',
+		] );
+	} );
+} );
+
+describe( 'getSelectableFilterKeys', () => {
+	test( 'defaults to an empty array on nullish inputs', () => {
+		expect( getSelectableFilterKeys( null ) ).toEqual( [] );
+		expect( getSelectableFilterKeys( undefined ) ).toEqual( [] );
+	} );
+	test( 'extracts filter keys from widgets inside the search overlay sidebar', () => {
+		const widgets = [
+			{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
+			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
+			{ filters: [ { type: 'post_type' } ] },
+		];
+		expect( getSelectableFilterKeys( widgets ) ).toEqual( [
+			'category',
+			'year_post_date',
+			'post_types',
+		] );
+	} );
+} );
+
+describe( 'getUnselectableFilterKeys', () => {
+	test( 'defaults to an empty array on nullish inputs', () => {
+		expect( getUnselectableFilterKeys( null ) ).toEqual( [] );
+		expect( getUnselectableFilterKeys( undefined ) ).toEqual( [] );
+	} );
+	test( 'extracts filter keys from widgets outside the search overlay sidebar', () => {
+		const widgets = [];
+		const widgetsOutsideOverlay = [ { filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] } ];
+		expect( getUnselectableFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [ 'post_tag' ] );
+	} );
+	test( 'excludes filter keys included in widgets inside the search overlay sidebar', () => {
+		const widgets = [
+			{ filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] },
+			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
+			{ filters: [ { type: 'post_type' } ] },
+		];
+		const widgetsOutsideOverlay = [
+			{
+				filters: [
+					{ type: 'taxonomy', taxonomy: 'category' },
+					{ type: 'taxonomy', taxonomy: 'post_tag' },
+				],
+			},
+		];
+		expect( getUnselectableFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [ 'category' ] );
+	} );
+} );

--- a/modules/search/instant-search/lib/test/filters.test.js
+++ b/modules/search/instant-search/lib/test/filters.test.js
@@ -66,29 +66,28 @@ describe( 'getSelectableFilterKeys', () => {
 } );
 
 describe( 'getUnselectableFilterKeys', () => {
-	test( 'defaults to an empty array on nullish inputs', () => {
-		expect( getUnselectableFilterKeys( null ) ).toEqual( [] );
-		expect( getUnselectableFilterKeys( undefined ) ).toEqual( [] );
+	test( 'defaults to getFilterKeys() value on nullish inputs', () => {
+		expect( getUnselectableFilterKeys( null ) ).toEqual( getFilterKeys( null, null ) );
+		expect( getUnselectableFilterKeys( undefined ) ).toEqual( getFilterKeys( null, null ) );
 	} );
-	test( 'extracts filter keys from widgets outside the search overlay sidebar', () => {
+	test( 'defaults to getFilterKeys() value on empty inputs', () => {
 		const widgets = [];
-		const widgetsOutsideOverlay = [ { filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] } ];
-		expect( getUnselectableFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [ 'post_tag' ] );
+		expect( getUnselectableFilterKeys( widgets ) ).toEqual( getFilterKeys( null, null ) );
 	} );
-	test( 'excludes filter keys included in widgets inside the search overlay sidebar', () => {
+	test( 'excludes filter keys included by widgets inside the search overlay sidebar', () => {
 		const widgets = [
 			{ filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] },
 			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
 			{ filters: [ { type: 'post_type' } ] },
 		];
-		const widgetsOutsideOverlay = [
-			{
-				filters: [
-					{ type: 'taxonomy', taxonomy: 'category' },
-					{ type: 'taxonomy', taxonomy: 'post_tag' },
-				],
-			},
-		];
-		expect( getUnselectableFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [ 'category' ] );
+		expect( getUnselectableFilterKeys( widgets ) ).toEqual( [
+			'month_post_date',
+			'month_post_date_gmt',
+			'month_post_modified',
+			'month_post_modified_gmt',
+			'year_post_date_gmt',
+			'year_post_modified',
+			'year_post_modified_gmt',
+		] );
 	} );
 } );

--- a/modules/search/instant-search/lib/test/filters.test.js
+++ b/modules/search/instant-search/lib/test/filters.test.js
@@ -23,8 +23,9 @@ describe( 'getFilterKeys', () => {
 		expect( getFilterKeys( null, undefined ) ).toEqual( DEFAULT_KEYS );
 	} );
 
-	test( 'includes taxonomies from widget configurations', () => {
+	test( 'includes taxonomies from widget configurations without duplicates', () => {
 		const widgets = [
+			{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
 			{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
 			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
 			{ filters: [ { type: 'post_type' } ] },


### PR DESCRIPTION
Spun off from #18099.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds testing to a rather confusing `filters` library in Instant Search.
* Adds default parameters to various functions in the library for improved clarity.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this PR to your Jetpack site with Instant Search enabled.
* Ensure that you can apply and deselect search filters via widgets outside the search overlay.
* Ensure that you can apply and deselect search filters via widgets inside the search overlay.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None.
