### PR TITLE
Twitter Threads: Handle incorrectly formatted URLs when generating Twitter Cards

### DIFF
--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -1595,14 +1595,22 @@ class Jetpack_Tweetstorm_Helper {
 	 * @return array The Twitter card data.
 	 */
 	public static function generate_cards( $urls ) {
+		$validator = new Twitter_Validator();
+
 		$requests = array_map(
-			function ( $url ) {
-				return array(
-					'url' => $url,
-				);
+			function ( $url ) use ( $validator ) {
+				if ( $validator->isValidURL( $url ) ) {
+					return array(
+						'url' => $url,
+					);
+				}
+
+				return false;
 			},
 			$urls
 		);
+
+		$requests = array_filter( $requests );
 
 		$results = Requests::request_multiple( $requests );
 
@@ -1629,12 +1637,8 @@ class Jetpack_Tweetstorm_Helper {
 		);
 
 		$cards = array();
-		foreach ( $results as $result ) {
-			if ( count( $result->history ) > 0 ) {
-				$url = $result->history[0]->url;
-			} else {
-				$url = $result->url;
-			}
+		foreach ( $results as $id => $result ) {
+			$url = $requests[ $id ]['url'];
 
 			if ( ! $result->success ) {
 				$cards[ $url ] = array(

--- a/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
+++ b/tests/php/_inc/lib/test-class.jetpack-tweetstorm-helper.php
@@ -2426,13 +2426,46 @@ class WP_Test_Jetpack_Tweetstorm_Helper extends WP_UnitTestCase {
 
 		$expected = array(
 			'https://jetpack.me/'  => array(
-				'description' => 'Essential Security & Performance for WordPress',
+				'description' => 'The ultimate WordPress plugin for security, backups, malware scan, anti-spam, CDN, site search, CRM, Stripe, Facebook, & Instagram',
 				'image'       => 'https://jetpackme.files.wordpress.com/2018/04/cropped-jetpack-favicon-2018.png?w=240',
 				'title'       => 'Jetpack',
 				'type'        => 'summary',
 			),
 			'https://jetpack.com/' => array(
-				'description' => 'Essential Security & Performance for WordPress',
+				'description' => 'The ultimate WordPress plugin for security, backups, malware scan, anti-spam, CDN, site search, CRM, Stripe, Facebook, & Instagram',
+				'image'       => 'https://jetpackme.files.wordpress.com/2018/04/cropped-jetpack-favicon-2018.png?w=240',
+				'title'       => 'Jetpack',
+				'type'        => 'summary',
+			),
+		);
+
+		$cards = Jetpack_Tweetstorm_Helper::generate_cards( $urls );
+
+		$this->assertEqualSetsWithIndex( $expected, $cards );
+	}
+
+	/**
+	 * Test that the return data is keyed by the URLs passed.
+	 *
+	 * @group external-http
+	 */
+	public function test_twitter_cards_with_odd_URLs() {
+		$urls = array(
+			'https://Jetpack.com/',
+			'https://jetpack.com',
+			'jetpack.com/',
+			'JETPACK.com',
+		);
+
+		$expected = array(
+			'https://Jetpack.com/' => array(
+				'description' => 'The ultimate WordPress plugin for security, backups, malware scan, anti-spam, CDN, site search, CRM, Stripe, Facebook, & Instagram',
+				'image'       => 'https://jetpackme.files.wordpress.com/2018/04/cropped-jetpack-favicon-2018.png?w=240',
+				'title'       => 'Jetpack',
+				'type'        => 'summary',
+			),
+			'https://jetpack.com'  => array(
+				'description' => 'The ultimate WordPress plugin for security, backups, malware scan, anti-spam, CDN, site search, CRM, Stripe, Facebook, & Instagram',
 				'image'       => 'https://jetpackme.files.wordpress.com/2018/04/cropped-jetpack-favicon-2018.png?w=240',
 				'title'       => 'Jetpack',
 				'type'        => 'summary',


### PR DESCRIPTION
When generating Twitter Cards, we need to ensure that URLs are well formed before passing them to `Requests`.

Also, the return data previously used the `Requests`-formatted URL as the result key, which could cause the card to not be shown in the preview, if the URL was typed differently.

Fixes #18103.

#### Changes proposed in this Pull Request:
* Improve the URL validation and handling in `Jetpack_Tweetstorm_Helper::generate_cards()`.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Create a new Twitter thread post.
* Type some weirdly formatted URLs in the post (eg, missing protocol, capitalisation).
* Check that there are no PHP errors in your error log.
* Check that the card shows correctly in the thread preview.

I've also added unit tests for this: `yarn docker:phpunit --filter twitter_card --group external-http`

#### Proposed changelog entry for your changes:
* Twitter Threads: Improve how Twitter Cards are generated for embeds in the thread preview.
