### PR TITLE
Default to `defer` instead of `async` recaptcha

### DIFF
--- a/modules/sharedaddy/recaptcha.php
+++ b/modules/sharedaddy/recaptcha.php
@@ -73,7 +73,8 @@ class Jetpack_ReCaptcha {
 	public function get_default_config() {
 		return array(
 			'language'       => get_locale(),
-			'script_async'   => true,
+			'script_async'   => false,
+			'script_defer'   => true,
 			'tag_class'      => 'g-recaptcha',
 			'tag_attributes' => array(
 				'theme'    => 'light',
@@ -188,7 +189,9 @@ class Jetpack_ReCaptcha {
 				data-theme="%s"
 				data-type="%s"
 				data-tabindex="%s"></div>
-			<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=%s"%s></script>
+			' .
+			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+			'<script src="https://www.google.com/recaptcha/api.js?hl=%s"%s%s></script>
 			',
 			esc_attr( $this->config['tag_class'] ),
 			esc_attr( $this->site_key ),
@@ -196,7 +199,8 @@ class Jetpack_ReCaptcha {
 			esc_attr( $this->config['tag_attributes']['type'] ),
 			esc_attr( $this->config['tag_attributes']['tabindex'] ),
 			rawurlencode( $this->config['language'] ),
-			$this->config['script_async'] ? ' async' : ''
+			$this->config['script_async'] && ! $this->config['script_defer'] ? ' async' : '',
+			$this->config['script_defer'] ? ' defer' : ''
 		);
 	}
 }


### PR DESCRIPTION
`recaptcha` script loading now defaults to `defer` instead of `async`.
Deferred scripts have better performance characteristics for our use case, since they will not block the document parser.

Previously, rendering could be blocked by the recaptcha API request, or even the full-on 140KB (gzipped) recaptcha JS request, since that's scheduled async by the recaptcha API.

#### Changes proposed in this Pull Request:
* Add `script_defer` config option to sharing recaptcha
* Make `script_defer` `true` by default
* Make `script_async` `false` by default
* Modify script logic to add `defer` or `async` as configured

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Enable sharing and the email sharing option
* Visit any page where sharing functionality is enabled
* Look at the page HTML and find a script tag starting with `<script src="https://www.google.com/recaptcha/api.js`
* Verify that it has the `defer` attribute
* Change the config to set `script_defer` to false and `script_async` to true
* Reload the page
* Look at the page HTML and find a script tag starting with `<script src="https://www.google.com/recaptcha/api.js`
* Verify that it has the `async` attribute
* Change the config to set both `script_defer` and `script_async` to false
* Reload the page
* Look at the page HTML and find a script tag starting with `<script src="https://www.google.com/recaptcha/api.js`
* Verify that it has neither the `async` nor the `defer` attribute

#### Proposed changelog entry for your changes:
* Sharing: reCAPTCHA library loading is now deferred by default
