### PR TITLE
Instant Search: Add support for filters in Redux store

### DIFF
--- a/bin/eslint-excludelist.json
+++ b/bin/eslint-excludelist.json
@@ -251,7 +251,6 @@
 	"modules/search/instant-search/lib/colors.js",
 	"modules/search/instant-search/lib/customize.js",
 	"modules/search/instant-search/lib/dom.js",
-	"modules/search/instant-search/lib/filters.js",
 	"modules/search/instant-search/lib/query-string.js",
 	"modules/search/instant-search/lib/tracks.js",
 	"modules/sharedaddy/sharing.js",

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -70,6 +70,32 @@ export function mapFilterToFilterKey( filter ) {
 	return null;
 }
 
+export function mapFilterKeyToFilter( filterKey ) {
+	// TODO: Write a test for this function
+	if ( filterKey.includes( 'month' ) ) {
+		return {
+			field: filterKey.split( 'month_' ).pop(),
+			type: 'date_histogram',
+			interval: 'month',
+		};
+	} else if ( filterKey.includes( 'year' ) ) {
+		return {
+			field: filterKey.split( 'year_' ).pop(),
+			type: 'date_histogram',
+			interval: 'year',
+		};
+	} else if ( filterKey === 'post_types' ) {
+		return {
+			type: 'post_type',
+		};
+	}
+
+	return {
+		type: 'taxonomy',
+		taxonomy: filterKey,
+	};
+}
+
 export function mapFilterToType( filter ) {
 	if ( filter.type === 'date_histogram' ) {
 		return 'date';

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -24,6 +24,13 @@ const FILTER_KEYS = Object.freeze( [
 	'year_post_modified_gmt',
 ] );
 
+/**
+ * Returns an array of valid filter key strings.
+ *
+ * @param {object[]} widgets - Array of Jetpack Search widget objects inside the overlay sidebar.
+ * @param {object[]} widgetsOutsideOverlay - Array of Jetpack Search widget objects outside the overlay sidebar.
+ * @returns {string[]} filterKeys
+ */
 export function getFilterKeys(
 	widgets = window[ SERVER_OBJECT_NAME ]?.widgets,
 	widgetsOutsideOverlay = window[ SERVER_OBJECT_NAME ]?.widgetsOutsideOverlay
@@ -40,25 +47,48 @@ export function getFilterKeys(
 	return [ ...keys ];
 }
 
-// These filter keys are selectable from sidebar filters
+/**
+ * Returns an array of filter keys selectable from within the overlay.
+ *
+ * @param {object[]} widgets - Array of Jetpack Search widget objects inside the overlay sidebar.
+ * @returns {string[]} filterKeys
+ */
 export function getSelectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?.widgets ) {
 	return (
-		widgets?.map( extractFilters ).reduce( ( prev, current ) => prev.concat( current ), [] ) ?? []
+		widgets?.map( extractFilterKeys ).reduce( ( prev, current ) => prev.concat( current ), [] ) ??
+		[]
 	);
 }
 
-// These filter keys are not selectable from sidebar filters
-// In other words, they were selected via filters outside the search sidebar
+/**
+ * Returns an array of filter keys not selectable from within the overlay.
+ * In other words, they were either selected via filters outside the search sidebar or entered manually.
+ *
+ * @param {object[]} widgets - Array of Jetpack Search widget objects inside the overlay sidebar.
+ * @returns {string[]} filterKeys
+ */
 export function getUnselectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?.widgets ) {
 	return difference( getFilterKeys(), getSelectableFilterKeys( widgets ) );
 }
 
-function extractFilters( widget ) {
+/**
+ * Returns an array of filter keys from a given widget.
+ *
+ * @param {object} widget - a Jetpack Search widget object
+ * @returns {string[]} filterKeys
+ */
+function extractFilterKeys( widget ) {
 	return widget.filters
 		.map( mapFilterToFilterKey )
 		.filter( filterName => typeof filterName === 'string' );
 }
 
+/**
+ * Returns a filter key given a filter object.
+ *
+ * @param {object} filter - a Jetpack Search filter object
+ * @returns {string} filterKeys
+ */
 export function mapFilterToFilterKey( filter ) {
 	if ( filter.type === 'date_histogram' ) {
 		return `${ filter.interval }_${ filter.field }`;
@@ -70,8 +100,14 @@ export function mapFilterToFilterKey( filter ) {
 	return null;
 }
 
+/**
+ * Returns a filter object corresponding to the filterKey input.
+ * Inverse of `mapFilterToFilterKey`.
+ *
+ * @param {string} filterKey - filter key string to be mapped.
+ * @returns {object} filterObject
+ */
 export function mapFilterKeyToFilter( filterKey ) {
-	// TODO: Write a test for this function
 	if ( filterKey.includes( 'month' ) ) {
 		return {
 			field: filterKey.split( 'month_' ).pop(),
@@ -96,6 +132,12 @@ export function mapFilterKeyToFilter( filterKey ) {
 	};
 }
 
+/**
+ * Returns the type of the inputted filter object.
+ *
+ * @param {object} filter - filter key string to be mapped.
+ * @returns {string} output
+ */
 export function mapFilterToType( filter ) {
 	if ( filter.type === 'date_histogram' ) {
 		return 'date';

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -24,7 +24,7 @@ export function setQuery( queryObject ) {
 	pushQueryString( encode( queryObject ) );
 }
 
-function pushQueryString( queryString ) {
+function pushQueryString( queryString, shouldEmitEvent = true ) {
 	if ( history.pushState ) {
 		const url = new window.URL( window.location.href );
 		if ( window[ SERVER_OBJECT_NAME ] && 'homeUrl' in window[ SERVER_OBJECT_NAME ] ) {

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -16,11 +16,15 @@ import {
 import { getFilterKeys, getUnselectableFilterKeys, mapFilterToFilterKey } from './filters';
 import { decode } from '../external/query-string-decode';
 
-function getQuery() {
+export function getQuery() {
 	return decode( window.location.search.substring( 1 ), false, false );
 }
 
-function pushQueryString( queryString, shouldEmitEvent = true ) {
+export function setQuery( queryObject ) {
+	pushQueryString( encode( queryObject ) );
+}
+
+function pushQueryString( queryString ) {
 	if ( history.pushState ) {
 		const url = new window.URL( window.location.href );
 		if ( window[ SERVER_OBJECT_NAME ] && 'homeUrl' in window[ SERVER_OBJECT_NAME ] ) {

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -20,6 +20,11 @@ export function getQuery() {
 	return decode( window.location.search.substring( 1 ), false, false );
 }
 
+/**
+ * Updates the browser's query string.
+ *
+ * @param {object} queryObject - a query object.
+ */
 export function setQuery( queryObject ) {
 	pushQueryString( encode( queryObject ) );
 }

--- a/modules/search/instant-search/lib/test/filters.test.js
+++ b/modules/search/instant-search/lib/test/filters.test.js
@@ -4,7 +4,12 @@
 /**
  * Internal dependencies
  */
-import { getFilterKeys, getSelectableFilterKeys, getUnselectableFilterKeys } from '../filters';
+import {
+	getFilterKeys,
+	getSelectableFilterKeys,
+	getUnselectableFilterKeys,
+	mapFilterKeyToFilter,
+} from '../filters';
 
 describe( 'getFilterKeys', () => {
 	const DEFAULT_KEYS = [
@@ -89,5 +94,71 @@ describe( 'getUnselectableFilterKeys', () => {
 			'year_post_modified',
 			'year_post_modified_gmt',
 		] );
+	} );
+} );
+
+describe( 'mapFilterKeyToFilter', () => {
+	test( 'handles month-related filter keys', () => {
+		expect( mapFilterKeyToFilter( 'month_post_date' ) ).toEqual( {
+			field: 'post_date',
+			type: 'date_histogram',
+			interval: 'month',
+		} );
+		expect( mapFilterKeyToFilter( 'month_post_date_gmt' ) ).toEqual( {
+			field: 'post_date_gmt',
+			type: 'date_histogram',
+			interval: 'month',
+		} );
+		expect( mapFilterKeyToFilter( 'month_post_modified' ) ).toEqual( {
+			field: 'post_modified',
+			type: 'date_histogram',
+			interval: 'month',
+		} );
+		expect( mapFilterKeyToFilter( 'month_post_modified_gmt' ) ).toEqual( {
+			field: 'post_modified_gmt',
+			type: 'date_histogram',
+			interval: 'month',
+		} );
+	} );
+	test( 'handles year-related filter keys', () => {
+		expect( mapFilterKeyToFilter( 'year_post_date' ) ).toEqual( {
+			field: 'post_date',
+			type: 'date_histogram',
+			interval: 'year',
+		} );
+		expect( mapFilterKeyToFilter( 'year_post_date_gmt' ) ).toEqual( {
+			field: 'post_date_gmt',
+			type: 'date_histogram',
+			interval: 'year',
+		} );
+		expect( mapFilterKeyToFilter( 'year_post_modified' ) ).toEqual( {
+			field: 'post_modified',
+			type: 'date_histogram',
+			interval: 'year',
+		} );
+		expect( mapFilterKeyToFilter( 'year_post_modified_gmt' ) ).toEqual( {
+			field: 'post_modified_gmt',
+			type: 'date_histogram',
+			interval: 'year',
+		} );
+	} );
+	test( 'handles post types filter key', () => {
+		expect( mapFilterKeyToFilter( 'post_types' ) ).toEqual( {
+			type: 'post_type',
+		} );
+	} );
+	test( 'handles taxonomies-related filter keys', () => {
+		expect( mapFilterKeyToFilter( 'page' ) ).toEqual( {
+			type: 'taxonomy',
+			taxonomy: 'page',
+		} );
+		expect( mapFilterKeyToFilter( 'post' ) ).toEqual( {
+			type: 'taxonomy',
+			taxonomy: 'post',
+		} );
+		expect( mapFilterKeyToFilter( 'arcade_reviews' ) ).toEqual( {
+			type: 'taxonomy',
+			taxonomy: 'arcade_reviews',
+		} );
 	} );
 } );

--- a/modules/search/instant-search/store/actions.js
+++ b/modules/search/instant-search/store/actions.js
@@ -89,3 +89,32 @@ export function setSort( sort, propagateToWindow = true ) {
 		propagateToWindow,
 	};
 }
+
+/**
+ * Returns an action object used to set a search filter.
+ *
+ * @param {string} name - Filter name.
+ * @param {string[]} value - Filter values.
+ * @param {boolean} propagateToWindow - If true, will tell the effects handler to set the search query in the location bar.
+ *
+ * @returns {object} Action object.
+ */
+export function setFilter( name, value, propagateToWindow = true ) {
+	return {
+		type: 'SET_FILTER',
+		name,
+		value,
+		propagateToWindow,
+	};
+}
+
+/**
+ * Returns an action object used to clear all filter values.
+ *
+ * @returns {object} Action object.
+ */
+export function clearFilters() {
+	return {
+		type: 'CLEAR_FILTERS',
+	};
+}

--- a/modules/search/instant-search/store/effects.js
+++ b/modules/search/instant-search/store/effects.js
@@ -37,7 +37,7 @@ function makeSearchAPIRequest( action, store ) {
 }
 
 /**
- * Initialize query values.
+ * Initialize query values from the browser's address bar.
  *
  * @param {object} action - Action which had initiated the effect handler.
  * @param {object} store -  Store instance.

--- a/modules/search/instant-search/store/reducer/index.js
+++ b/modules/search/instant-search/store/reducer/index.js
@@ -7,11 +7,12 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import { hasError, isLoading, response } from './api';
-import { searchQuery, sort } from './query-string';
+import { filters, searchQuery, sort } from './query-string';
 import { serverOptions } from './server-options';
 
-export { hasError, isLoading, response, searchQuery, serverOptions, sort };
+export { filters, hasError, isLoading, response, searchQuery, serverOptions, sort };
 export default combineReducers( {
+	filters,
 	hasError,
 	isLoading,
 	response,

--- a/modules/search/instant-search/store/reducer/query-string.js
+++ b/modules/search/instant-search/store/reducer/query-string.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { VALID_SORT_KEYS } from '../../lib/constants';
+import { getFilterKeys } from '../../lib/filters';
 
 /**
  * Reducer for keeping track of the user's inputted search query

--- a/modules/search/instant-search/store/reducer/query-string.js
+++ b/modules/search/instant-search/store/reducer/query-string.js
@@ -40,3 +40,33 @@ export function sort( state = 'relevance', action ) {
 
 	return state;
 }
+
+/**
+ * Reducer for keeping track of the user's selected filter value
+ *
+ * @param {object} state - Current state.
+ * @param {object} action - Dispatched action.
+ *
+ * @returns {object} Updated state.
+ */
+export function filters( state = {}, action ) {
+	switch ( action.type ) {
+		case 'CLEAR_FILTERS':
+			return {};
+		case 'SET_FILTER':
+			if ( ! getFilterKeys().includes( action.name ) || ! Array.isArray( action.value ) ) {
+				return state;
+			}
+			if ( action.value.length === 0 ) {
+				const newState = { ...state };
+				delete newState[ action.name ];
+				return newState;
+			}
+			return {
+				...state,
+				[ action.name ]: action.value,
+			};
+	}
+
+	return state;
+}

--- a/modules/search/instant-search/store/reducer/query-string.js
+++ b/modules/search/instant-search/store/reducer/query-string.js
@@ -54,7 +54,10 @@ export function filters( state = {}, action ) {
 		case 'CLEAR_FILTERS':
 			return {};
 		case 'SET_FILTER':
-			if ( ! getFilterKeys().includes( action.name ) || ! Array.isArray( action.value ) ) {
+			if (
+				! getFilterKeys().includes( action.name ) ||
+				( ! Array.isArray( action.value ) && typeof action.value !== 'string' )
+			) {
 				return state;
 			}
 			if ( action.value.length === 0 ) {
@@ -64,7 +67,7 @@ export function filters( state = {}, action ) {
 			}
 			return {
 				...state,
-				[ action.name ]: action.value,
+				[ action.name ]: typeof action.value === 'string' ? [ action.value ] : action.value,
 			};
 	}
 

--- a/modules/search/instant-search/store/selectors.js
+++ b/modules/search/instant-search/store/selectors.js
@@ -1,14 +1,10 @@
 /**
  * Internal dependencies
  */
-import {
-	getUnselectableFilterKeys,
-	mapFilterKeyToFilter,
-	mapFilterToFilterKey,
-} from '../lib/filters';
+import { getUnselectableFilterKeys, mapFilterKeyToFilter } from '../lib/filters';
 
 /**
- * Get response.
+ * Get the stored API response.
  *
  * @param {object} state - Current state.
  * @returns {object} Response object.
@@ -18,79 +14,84 @@ export function getResponse( state ) {
 }
 
 /**
- * Get hasError flag.
+ * Get the hasError flag.
  *
  * @param {object} state - Current state.
- * @returns {boolean} Flag.
+ * @returns {boolean} hasError - Whether the API returned an erroneous response.
  */
 export function hasError( state ) {
 	return state.hasError;
 }
 
 /**
- * Get hasNextPage flag.
+ * Get the hasNextPage flag.
  *
  * @param {object} state - Current state.
- * @returns {boolean} Flag.
+ * @returns {boolean} hasNextPage - Whether the API contains a page handle for a subsequent page.
  */
 export function hasNextPage( state ) {
 	return ! hasError( state ) && getResponse( state )?.page_handle;
 }
 
 /**
- * Get isLoading flag.
+ * Get the isLoading flag.
  *
  * @param {object} state - Current state.
- * @returns {boolean} Flag.
+ * @returns {boolean} isLoading - Whether the API request is still loading.
  */
 export function isLoading( state ) {
 	return state.isLoading;
 }
 
 /**
- * Get search query.
+ * Get the search query.
  *
  * @param {object} state - Current state.
- * @returns {string} Search query.
+ * @returns {string} searchQuery - The search query entered by the user.
  */
 export function getSearchQuery( state ) {
 	return state.searchQuery;
 }
 
 /**
- * Get sort key.
+ * Get the sort key.
  *
  * @param {object} state - Current state.
- * @returns {string} Sort key.
+ * @returns {string} sort - The selected sort key for the search interface.
  */
 export function getSort( state ) {
 	return state.sort;
 }
 
 /**
- * Get filters.
+ * Get the filters.
  *
  * @param {object} state - Current state.
- * @returns {Array} Filters.
+ * @returns {object} filters - An object mapping filter keys and its selected values.
  */
 export function getFilters( state ) {
 	return state.filters;
 }
 
 /**
- * Get hasFilters flag.
+ * Checks if any filters have been selected.
  *
  * @param {object} state - Current state.
- * @returns {boolean} Flag.
+ * @returns {object} hasFilters - true if any filter has been selected.
  */
 export function hasFilters( state ) {
 	return Object.keys( state.filters ).length > 0;
 }
 
-// This selector combines multiple widgets outside overlay into a single widget consisting only of the `filters` key.
-// After combining the widgets, we the filter out all unselected filter values.
-//
-// This is used to render a single SearchFilters component for all filters selected outside the search overlay.
+/**
+ * This selector combines multiple widgets outside overlay into a single widget consisting only of the `filters` key.
+ * After combining the widgets, we the filter out all unselected filter values.
+ *
+ * This is used to render a single SearchFilters component for all filters selected outside the search overlay.
+ *
+ * @param {object} state - Redux state tree.
+ * @returns {{ filters: object[] }} pseudoWidget - contains `filters`, an array of filter objects selected outside the search overlay.
+ */
 export function getWidgetOutsideOverlay( state ) {
 	// Both of these values should default to [] when empty; they should never be falsy.
 	if ( ! state.serverOptions.widgets || ! state.filters ) {

--- a/modules/search/instant-search/store/selectors.js
+++ b/modules/search/instant-search/store/selectors.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { getUnselectableFilterKeys, mapFilterToFilterKey } from '../lib/filters';
+import {
+	getUnselectableFilterKeys,
+	mapFilterKeyToFilter,
+	mapFilterToFilterKey,
+} from '../lib/filters';
 
 /**
  * Get response.
@@ -89,19 +93,13 @@ export function hasFilters( state ) {
 // This is used to render a single SearchFilters component for all filters selected outside the search overlay.
 export function getWidgetOutsideOverlay( state ) {
 	// Both of these values should default to [] when empty; they should never be falsy.
-	if ( ! state.serverOptions.widgetsOutsideOverlay || ! state.serverOptions.widgets ) {
+	if ( ! state.serverOptions.widgets || ! state.filters ) {
 		return {};
 	}
-	const keys = getUnselectableFilterKeys(
-		state.serverOptions.widgets,
-		state.serverOptions.widgetsOutsideOverlay
-	);
-	const selectedKeys = Object.keys( state.filters ).filter( key => keys.includes( key ) );
-	const filters = state.serverOptions.widgetsOutsideOverlay
-		.map( widget => widget.filters )
-		.reduce( ( prev, current ) => prev.concat( current ), [] )
-		// Server-side filter keys are named differently than client-side; conversion is required.
-		.filter( serverFilter => selectedKeys.includes( mapFilterToFilterKey( serverFilter ) ) );
+	const keys = getUnselectableFilterKeys( state.serverOptions.widgets );
+	const filters = Object.keys( state.filters )
+		.filter( key => keys.includes( key ) )
+		.map( mapFilterKeyToFilter );
 
 	return { filters };
 }

--- a/modules/search/instant-search/store/selectors.js
+++ b/modules/search/instant-search/store/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import { getUnselectableFilterKeys, mapFilterToFilterKey } from '../lib/filters';
+
+/**
  * Get response.
  *
  * @param {object} state - Current state.
@@ -76,4 +81,27 @@ export function getFilters( state ) {
  */
 export function hasFilters( state ) {
 	return Object.keys( state.filters ).length > 0;
+}
+
+// This selector combines multiple widgets outside overlay into a single widget consisting only of the `filters` key.
+// After combining the widgets, we the filter out all unselected filter values.
+//
+// This is used to render a single SearchFilters component for all filters selected outside the search overlay.
+export function getWidgetOutsideOverlay( state ) {
+	// Both of these values should default to [] when empty; they should never be falsy.
+	if ( ! state.serverOptions.widgetsOutsideOverlay || ! state.serverOptions.widgets ) {
+		return {};
+	}
+	const keys = getUnselectableFilterKeys(
+		state.serverOptions.widgets,
+		state.serverOptions.widgetsOutsideOverlay
+	);
+	const selectedKeys = Object.keys( state.filters ).filter( key => keys.includes( key ) );
+	const filters = state.serverOptions.widgetsOutsideOverlay
+		.map( widget => widget.filters )
+		.reduce( ( prev, current ) => prev.concat( current ), [] )
+		// Server-side filter keys are named differently than client-side; conversion is required.
+		.filter( serverFilter => selectedKeys.includes( mapFilterToFilterKey( serverFilter ) ) );
+
+	return { filters };
 }

--- a/modules/search/instant-search/store/test/reducer.test.js
+++ b/modules/search/instant-search/store/test/reducer.test.js
@@ -122,8 +122,14 @@ describe( 'filters Reducer', () => {
 		const state = filters( undefined, {} );
 		expect( state ).toEqual( {} );
 	} );
-	test( 'is updated by a set filter action', () => {
-		const state = filters( undefined, setFilter( 'post_types', [ 'post' ] ) );
+	test( 'is updated by a set filter action with an arrayed value', () => {
+		const state = filters( undefined, setFilter( 'post_types', [ 'post', 'page' ] ) );
+		expect( state ).toEqual( {
+			post_types: [ 'post', 'page' ],
+		} );
+	} );
+	test( 'is updated by a set filter action with a string value', () => {
+		const state = filters( undefined, setFilter( 'post_types', 'post' ) );
 		expect( state ).toEqual( {
 			post_types: [ 'post' ],
 		} );
@@ -132,9 +138,9 @@ describe( 'filters Reducer', () => {
 		const state = filters( undefined, setFilter( 'apple', [ 'tart' ] ) );
 		expect( state ).toEqual( {} );
 	} );
-	test( 'ignores set filter actions with non-array values', () => {
-		const state = filters( undefined, setFilter( 'post_types', 'tart' ) );
-		expect( state ).toEqual( {} );
+	test( 'ignores set filter actions with unexpected value types', () => {
+		expect( filters( undefined, setFilter( 'post_types', 1 ) ) ).toEqual( {} );
+		expect( filters( undefined, setFilter( 'post_types', {} ) ) ).toEqual( {} );
 	} );
 	test( 'is reset by a clear filters action', () => {
 		const state = filters( { post_types: [ 'post' ] }, clearFilters() );

--- a/modules/search/instant-search/store/test/reducer.test.js
+++ b/modules/search/instant-search/store/test/reducer.test.js
@@ -6,13 +6,15 @@
  * Internal dependencies
  */
 import {
+	clearFilters,
 	makeSearchRequest,
 	recordSuccessfulSearchRequest,
 	recordFailedSearchRequest,
 	setSearchQuery,
 	setSort,
+	setFilter,
 } from '../actions';
-import { hasError, isLoading, response, searchQuery, sort } from '../reducer';
+import { filters, hasError, isLoading, response, searchQuery, sort } from '../reducer';
 
 describe( 'hasError Reducer', () => {
 	test( 'defaults to false', () => {
@@ -112,5 +114,30 @@ describe( 'sort Reducer', () => {
 	test( 'is updated by a set search query action', () => {
 		const state = sort( undefined, setSort( 'newest' ) );
 		expect( state ).toBe( 'newest' );
+	} );
+} );
+
+describe( 'filters Reducer', () => {
+	test( 'defaults to an empty object', () => {
+		const state = filters( undefined, {} );
+		expect( state ).toEqual( {} );
+	} );
+	test( 'is updated by a set filter action', () => {
+		const state = filters( undefined, setFilter( 'post_types', [ 'post' ] ) );
+		expect( state ).toEqual( {
+			post_types: [ 'post' ],
+		} );
+	} );
+	test( 'ignores set filter actions with invalid filter names', () => {
+		const state = filters( undefined, setFilter( 'apple', [ 'tart' ] ) );
+		expect( state ).toEqual( {} );
+	} );
+	test( 'ignores set filter actions with non-array values', () => {
+		const state = filters( undefined, setFilter( 'post_types', 'tart' ) );
+		expect( state ).toEqual( {} );
+	} );
+	test( 'is reset by a clear filters action', () => {
+		const state = filters( { post_types: [ 'post' ] }, clearFilters() );
+		expect( state ).toEqual( {} );
 	} );
 } );

--- a/modules/search/instant-search/store/test/selectors.test.js
+++ b/modules/search/instant-search/store/test/selectors.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+/* global expect */
+
+/**
+ * Internal dependencies
+ */
+import { getWidgetOutsideOverlay } from '../selectors';
+
+describe( 'getWidgetOutsideOverlay', () => {
+	test( 'defaults to an empty object for a clean state', () => {
+		const state = { serverOptions: {} };
+		expect( getWidgetOutsideOverlay( state ) ).toEqual( {} );
+	} );
+
+	test( 'defaults to an empty object when either widget configurations are falsy', () => {
+		expect(
+			getWidgetOutsideOverlay( {
+				serverOptions: {
+					widgets: [],
+					widgetsOutsideOverlay: null,
+				},
+			} )
+		).toEqual( {} );
+		expect(
+			getWidgetOutsideOverlay( {
+				serverOptions: {
+					widgets: undefined,
+					widgetsOutsideOverlay: [],
+				},
+			} )
+		).toEqual( {} );
+	} );
+
+	test( 'extracts filter keys from widgets outside the overlay', () => {
+		const state = {
+			filters: { category: [ '1', '2' ], post_types: [ 'post', 'page' ] },
+			serverOptions: {
+				widgets: [ { filters: [ { type: 'taxonomy', taxonomy: 'category' } ] } ],
+				widgetsOutsideOverlay: [
+					{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
+					{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
+					{ filters: [ { type: 'post_type' } ] },
+				],
+			},
+		};
+		// Category filter is excluded since it's also available in state.serverOptions.widgets.
+		// Year post-date filter is excluded since it's not one of the selected filters in state.filters.
+		expect( getWidgetOutsideOverlay( state ) ).toEqual( {
+			filters: [ { type: 'post_type' } ],
+		} );
+	} );
+} );

--- a/modules/search/instant-search/store/test/selectors.test.js
+++ b/modules/search/instant-search/store/test/selectors.test.js
@@ -9,46 +9,39 @@
 import { getWidgetOutsideOverlay } from '../selectors';
 
 describe( 'getWidgetOutsideOverlay', () => {
-	test( 'defaults to an empty object for a clean state', () => {
-		const state = { serverOptions: {} };
-		expect( getWidgetOutsideOverlay( state ) ).toEqual( {} );
+	test( 'defaults to an object with an empty array for the filters value for a clean state', () => {
+		expect( getWidgetOutsideOverlay( { filters: {}, serverOptions: { widgets: [] } } ) ).toEqual( {
+			filters: [],
+		} );
 	} );
 
-	test( 'defaults to an empty object when either widget configurations are falsy', () => {
-		expect(
-			getWidgetOutsideOverlay( {
-				serverOptions: {
-					widgets: [],
-					widgetsOutsideOverlay: null,
-				},
-			} )
-		).toEqual( {} );
-		expect(
-			getWidgetOutsideOverlay( {
-				serverOptions: {
-					widgets: undefined,
-					widgetsOutsideOverlay: [],
-				},
-			} )
-		).toEqual( {} );
-	} );
-
-	test( 'extracts filter keys from widgets outside the overlay', () => {
+	test( 'extracts filters that could not have been selected via overlay widgets', () => {
 		const state = {
-			filters: { category: [ '1', '2' ], post_types: [ 'post', 'page' ] },
+			filters: {
+				category: [ '1', '2' ],
+				post_types: [ 'post', 'page' ],
+				month_post_date: [ '2019-08-01 00:00:00' ],
+				year_post_modified_gmt: [ '2019-01-01 00:00:00' ],
+			},
 			serverOptions: {
 				widgets: [ { filters: [ { type: 'taxonomy', taxonomy: 'category' } ] } ],
-				widgetsOutsideOverlay: [
-					{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
-					{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
-					{ filters: [ { type: 'post_type' } ] },
-				],
 			},
 		};
 		// Category filter is excluded since it's also available in state.serverOptions.widgets.
-		// Year post-date filter is excluded since it's not one of the selected filters in state.filters.
 		expect( getWidgetOutsideOverlay( state ) ).toEqual( {
-			filters: [ { type: 'post_type' } ],
+			filters: [
+				{ type: 'post_type' },
+				{
+					field: 'post_date',
+					interval: 'month',
+					type: 'date_histogram',
+				},
+				{
+					field: 'post_modified_gmt',
+					interval: 'year',
+					type: 'date_histogram',
+				},
+			],
 		} );
 	} );
 } );

--- a/modules/search/instant-search/store/test/selectors.test.js
+++ b/modules/search/instant-search/store/test/selectors.test.js
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-/* global expect */
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Follow-up for #18118 and #18119.

#### Changes proposed in this Pull Request:
* Add support for handling filters in Redux store. Does not integrate with the Instant Search component tree.
* Fixes ESLint warnings for the filters library.
* Adds a new, tested function to the filters library.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

The Redux store is not yet connected up to the Instant Search front end, so this PR should not affect the existing search functionality.

* Review the code and ensure it looks reasonable.
* Run `yarn test-search` and ensure all tests pass.

#### Proposed changelog entry for your changes:
* None.
