### PR TITLE
[try] Anchor.fm: add the badge in the server side

### DIFF
--- a/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/extensions/blocks/anchor-fm/anchor-fm.php
@@ -54,6 +54,33 @@ function register_extension() {
 			'type'         => 'string',
 		)
 	);
+
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended
+	$podcast_id       = isset( $_GET['anchor_podcast'] ) ? sanitize_text_field( wp_unslash( $_GET['anchor_podcast'] ) ) : null;
+	$episode_id       = isset( $_GET['anchor_episode'] ) ? sanitize_text_field( wp_unslash( $_GET['anchor_episode'] ) ) : null;
+	$spotify_show_url = isset( $_GET['spotify_show_url'] ) ? esc_url_raw( wp_unslash( $_GET['spotify_show_url'] ) ) : null;
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	$template_blocks = array();
+
+	if ( ! empty( $spotify_show_url ) ) {
+		$data['spotifyShowUrl'] = $spotify_show_url;
+
+			array_push( $template_blocks,
+				array( 'core/image', array(
+					'url'             => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
+					'linkDestination' => 'none',
+					'href'            => $spotify_show_url,
+					'align'           => 'center',
+					'width'           => 165,
+					'height'          => 40,
+					'className'       => 'is-spotify-podcast-badge',
+				)
+			) );
+	}
+	
+	$post_type_object = get_post_type_object( 'post' );
+	$post_type_object->template = $template_blocks;
 }
 
 /**
@@ -111,20 +138,6 @@ function process_anchor_params() {
 					}
 				}
 			}
-		}
-	}
-
-	if ( ! empty( $spotify_show_url ) ) {
-		$data['spotifyShowUrl'] = $spotify_show_url;
-		if ( get_post_meta( $post->ID, 'jetpack_anchor_spotify_show', true ) !== $spotify_show_url ) {
-			update_post_meta( $post->ID, 'jetpack_anchor_spotify_show', $spotify_show_url );
-			$data['actions'][] = array(
-				'insert-spotify-badge',
-				array(
-					'image' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
-					'url'   => $spotify_show_url,
-				),
-			);
 		}
 	}
 

--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -6,10 +6,8 @@ import { castArray } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
-import { addFilter } from '@wordpress/hooks';
 import { external, Icon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
@@ -23,28 +21,6 @@ import { waitForEditor } from '../../shared/wait-for-editor';
  * Style dependencies
  */
 import './editor.scss';
-
-async function insertSpotifyBadge( { image, url } ) {
-	if ( ! image || ! url ) {
-		return;
-	}
-
-	await waitForEditor();
-	dispatch( 'core/block-editor' ).insertBlock(
-		createBlock( 'core/image', {
-			url: image,
-			linkDestination: 'none',
-			href: url,
-			align: 'center',
-			width: 165,
-			height: 40,
-			className: 'is-spotify-podcast-badge',
-		} ),
-		0,
-		undefined,
-		false
-	);
-}
 
 async function setEpisodeTitle( { title } ) {
 	if ( ! title ) {
@@ -84,9 +60,6 @@ function initAnchor() {
 	data.actions.forEach( action => {
 		const [ actionName, actionParams ] = castArray( action );
 		switch ( actionName ) {
-			case 'insert-spotify-badge':
-				insertSpotifyBadge( actionParams );
-				break;
 			case 'show-post-publish-outbound-link':
 				showPostPublishOutboundLink();
 				break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR exposes an alternative when the Spotify badge is inserted in the editor. In this case, the process is done in the server side.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
