### PR TITLE
Unified Nav: New site link

### DIFF
--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -152,6 +152,8 @@ class Admin_Menu {
 	 * Adds a link to the menu to create a new site.
 	 */
 	public function add_new_site_link() {
+		global $menu;
+
 		if ( jetpack_is_atomic_site() ) {
 			$wpcom_user_data = ( new Connection_Manager() )->get_connected_user_data();
 

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -152,13 +152,21 @@ class Admin_Menu {
 	 * Adds a link to the menu to create a new site.
 	 */
 	public function add_new_site_link() {
-		// Only show the menu on atomic or simple.
-		if ( ! jetpack_is_atomic_site() && ! $this->is_wpcom_site() ) {
+		if ( jetpack_is_atomic_site() ) {
+			$wpcom_user_data = ( new Connection_Manager() )->get_connected_user_data();
+
+			if ( $wpcom_user_data['site_count'] > 1 ) {
+				return;
+			}
+		} elseif ( is_multisite() && count( get_blogs_of_user( get_current_user_id() ) ) > 1 ) {
 			return;
 		}
 
-		// Add the menu item.
-		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start', null, 'dashicons-plus-alt', 98 );
+		// Get last position.
+		$position = key( array_slice( $GLOBALS['menu'], -1 ) );
+
+		$this->add_admin_menu_separator( ++$position );
+		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start', null, 'dashicons-plus-alt', ++$position );
 	}
 
 	/**

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -117,7 +117,7 @@ class Admin_Menu {
 		if ( jetpack_is_atomic_site() ) {
 			$wpcom_user_data = ( new Connection_Manager() )->get_connected_user_data();
 
-			if ( $wpcom_user_data['site_count'] < 2 ) {
+			if ( $wpcom_user_data && $wpcom_user_data['site_count'] < 2 ) {
 				return;
 			}
 		} elseif ( ! is_multisite() || count( get_blogs_of_user( get_current_user_id() ) ) < 2 ) {
@@ -157,7 +157,7 @@ class Admin_Menu {
 		if ( jetpack_is_atomic_site() ) {
 			$wpcom_user_data = ( new Connection_Manager() )->get_connected_user_data();
 
-			if ( $wpcom_user_data['site_count'] > 1 ) {
+			if ( $wpcom_user_data && $wpcom_user_data['site_count'] > 1 ) {
 				return;
 			}
 		} elseif ( is_multisite() && count( get_blogs_of_user( get_current_user_id() ) ) > 1 ) {

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -162,8 +162,11 @@ class Admin_Menu {
 			return;
 		}
 
-		// Get last position.
-		$position = key( array_slice( $GLOBALS['menu'], -1 ) );
+		// Attempt to get last position.
+		$position = 1000;
+		while ( isset( $menu[ $position ] ) ) {
+			$position++;
+		}
 
 		$this->add_admin_menu_separator( ++$position );
 		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start', null, 'dashicons-plus-alt', ++$position );

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -73,6 +73,7 @@ class Admin_Menu {
 		if ( ! $this->is_api_request && ( $this->is_wpcom_site() || jetpack_is_atomic_site() ) ) {
 			$this->add_browse_sites_link();
 			$this->add_site_card_menu( $domain );
+			$this->add_new_site_link();
 		}
 
 		/**
@@ -145,6 +146,19 @@ class Admin_Menu {
 		}
 
 		return $menu;
+	}
+
+	/**
+	 * Adds a link to the menu to create a new site.
+	 */
+	public function add_new_site_link() {
+		// Only show the menu on atomic or simple.
+		if ( ! jetpack_is_atomic_site() && ! $this->is_wpcom_site() ) {
+			return;
+		}
+
+		// Add the menu item.
+		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start', null, 'dashicons-plus-alt', 98 );
 	}
 
 	/**

--- a/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -142,9 +142,9 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->reregister_menu_items();
 
 		$this->assertSame(
-			array( 0, 1, 2, '3.86682', 4, 5, 10, 15, 20, 25, 50, 51, 59, 60, 65, 70, 75, 80, 1001, 1002 ),
 			array_keys( $menu ),
-			'Admin menu should not have unexpected items.'
+			array( 2, 3, '3.86682', 4, 5, 10, 15, 20, 25, 59, 60, 65, 70, 75, 80 ),
+			'Admin menu should not have unexpected top menu items.'
 		);
 
 		$this->assertEquals( static::$menu_data[80], $menu[80], 'Settings menu should stay the same.' );

--- a/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -107,6 +107,31 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests add_admin_menu_separator
+	 *
+	 * @covers ::add_admin_menu_separator
+	 */
+	public function test_add_admin_menu_separator() {
+		global $menu;
+
+		// Start with a clean slate.
+		$temp_menu = $menu;
+		$menu      = array();
+
+		static::$admin_menu->add_admin_menu_separator( 15 );
+		static::$admin_menu->add_admin_menu_separator( 10, 'manage_options' );
+
+		$this->assertSame( array( 10, 15 ), array_keys( $menu ), 'Menu should be ordered by position parameter.' );
+		$this->assertSame( 'manage_options', $menu[10][1] );
+		$this->assertSame( 'separator-custom-5', $menu[10][2] );
+		$this->assertSame( 'read', $menu[15][1] );
+		$this->assertSame( 'separator-custom-4', $menu[15][2] );
+
+		// Restore filtered $menu.
+		$menu = $temp_menu;
+	}
+
+	/**
 	 * Test_Admin_Menu.
 	 *
 	 * @covers ::reregister_menu_items
@@ -117,9 +142,9 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->reregister_menu_items();
 
 		$this->assertSame(
+			array( 0, 1, 2, '3.86682', 4, 5, 10, 15, 20, 25, 50, 51, 59, 60, 65, 70, 75, 80, 1001, 1002 ),
 			array_keys( $menu ),
-			array( 2, 3, '3.86682', 4, 5, 10, 15, 20, 25, 59, 60, 65, 70, 75, 80 ),
-			'Admin menu should not have unexpected top menu items.'
+			'Admin menu should not have unexpected items.'
 		);
 
 		$this->assertEquals( static::$menu_data[80], $menu[80], 'Settings menu should stay the same.' );
@@ -158,6 +183,28 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		$this->assertSame( $menu[0], $browse_sites_menu_item );
 
 		remove_user_from_blog( get_current_user_id(), $blog_id );
+	}
+
+	/**
+	 * Tests add_new_site_link.
+	 *
+	 * @covers ::add_new_site_link
+	 */
+	public function test_add_new_site_link() {
+		global $menu;
+
+		static::$admin_menu->add_new_site_link();
+
+		$new_site_menu_item = array(
+			'Add new site',
+			'read',
+			'https://wordpress.com/start',
+			'Add new site',
+			'menu-top toplevel_page_https://wordpress.com/start',
+			'toplevel_page_https://wordpress.com/start',
+			'dashicons-plus-alt',
+		);
+		$this->assertSame( $menu[1002], $new_site_menu_item ); // 1001 is the separator position, 1002 is the link position
 	}
 
 	/**
@@ -868,30 +915,5 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		// Restore filtered $submenu.
 		$submenu = $temp_submenu;
-	}
-
-	/**
-	 * Tests add_admin_menu_separator
-	 *
-	 * @covers ::add_admin_menu_separator
-	 */
-	public function test_add_admin_menu_separator() {
-		global $menu;
-
-		// Start with a clean slate.
-		$temp_menu = $menu;
-		$menu      = array();
-
-		static::$admin_menu->add_admin_menu_separator( 15 );
-		static::$admin_menu->add_admin_menu_separator( 10, 'manage_options' );
-
-		$this->assertSame( array( 10, 15 ), array_keys( $menu ), 'Menu should be ordered by position parameter.' );
-		$this->assertSame( 'manage_options', $menu[10][1] );
-		$this->assertSame( 'separator-custom-5', $menu[10][2] );
-		$this->assertSame( 'read', $menu[15][1] );
-		$this->assertSame( 'separator-custom-4', $menu[15][2] );
-
-		// Restore filtered $menu.
-		$menu = $temp_menu;
 	}
 }


### PR DESCRIPTION
Relates automattic/wp-calypso#47183

#### Changes proposed in this Pull Request:
* Adds a menu link "Add new site" to the very bottom of the navigation

It uses position 💯  which is below the very last separator https://developer.wordpress.org/reference/functions/add_menu_page/#menu-structure

#### Jetpack product discussion
—

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

##### Simple
* Install the diff
* Sandbox the site
* Open wp-admin and check the menu for a new item

##### Atomic
* Similar to simple but instead use the Jetpack Beta plugin and use this branch `add/new-site-link-nav`

##### Jetpack
For now we don't show the menu item in Jetpack, even with the "wpcom toolbar" module active on the site.

#### Proposed changelog entry for your changes:
none