### PR TITLE
CI: Better handle failure to determine $test_root

### DIFF
--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -43,6 +43,14 @@ if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 	$test_root = '/tmp/wordpress-tests-lib';
 }
 
+if ( ! isset( $test_root ) || ! file_exists( $test_root . '/includes/bootstrap.php' ) ) {
+	echo 'Failed to automatically locate WordPress or wordpress-develop to run tests.' . PHP_EOL;
+	echo PHP_EOL;
+	echo 'Set the WP_DEVELOP_DIR environment variable to point to a copy of WordPress' . PHP_EOL;
+	echo 'or wordpress-develop.' . PHP_EOL;
+	exit( 1 );
+}
+
 echo "Using test root $test_root\n";
 
 // WordPress requires PHPUnit 7.5 or earlier and hacks around a few things to


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We have a bunch of logic to try to find a copy of WordPress or
wordpress-develop. But if that fails, we wind up producing fairly
unhelpful output.

Instead, if auto-detection fails, we should output a useful message to
the user to tell them that and suggest how they might resolve the
matter.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try running `phpunit` in a setup where WP isn't in one of the auto-detected locations.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
