### PR TITLE
Sync: Table Checksum - improvements

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -1279,7 +1279,11 @@ class Replicastore implements Replicastore_Interface {
 			return $range_edges;
 		}
 
-		$object_count = $range_edges['item_count'];
+		$object_count = (int) $range_edges['item_count'];
+
+		if ( 0 === $object_count ) {
+			return array();
+		}
 
 		$bucket_size     = (int) ceil( $object_count / $buckets );
 		$previous_max_id = max( 0, $range_edges['min_range'] );


### PR DESCRIPTION
This PR adds some improvements to the newly introduced functionality in #17567

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Properly return an empty array when the range specified with `min_id` and `max_id` is empty. Previously it returned the checksums of the WHOLE dataset.
* Add a prefix to the key fields when doing detailed checksum query as they can clash with sub-tables (i.e. `comment_id` in `comments` and `commentmeta` tables).
* Add a hardcoded `LIMIT` to return more results when doing the detailed meta checksums. In some cases there's a default limit when not specifying `LIMIT` in the query explicitly.

#### Testing instructions:

* As #17567

#### Proposed changelog entry for your changes:
* As #17567
