### PR TITLE
Jetpack Assistant: Add backend

### DIFF
--- a/projects/packages/options/legacy/class-jetpack-options.php
+++ b/projects/packages/options/legacy/class-jetpack-options.php
@@ -110,9 +110,12 @@ class Jetpack_Options {
 			'sso_first_login',              // (bool)   Is this the first time the user logins via SSO.
 			'dismissed_hints',              // (array)  Part of Plugin Search Hints. List of cards that have been dismissed.
 			'first_admin_view',             // (bool)   Set to true the first time the user views the admin. Usually after the initial connection.
-			'setup_wizard_questionnaire',   // (array)  List of user choices from the setup wizard.
-			'setup_wizard_status',          // (string) Status of the setup wizard.
+			'setup_wizard_questionnaire',   // (array)  (DEPRECATED) List of user choices from the setup wizard.
+			'setup_wizard_status',          // (string) (DEPRECATED) Status of the setup wizard.
 			'licensing_error',              // (string) Last error message occurred while attaching licenses that is yet to be surfaced to the user.
+			'recommendations_data',         // (array)  The user choice and other data for the recommendations.
+			'recommendations_enabled',      // (bool)   Whether the recommendations are enabled or not.
+			'recommendations_step',         // (string) The current step of the recommendations.
 		);
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -302,6 +302,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'isAtomicSite'               => jetpack_is_atomic_site(),
 				'plan'                       => Jetpack_Plan::get(),
 				'showBackups'                => Jetpack::show_backups_ui(),
+				'showRecommendations'        => Jetpack_Recommendations::is_enabled(),
 				'showSetupWizard'            => $this->show_setup_wizard(),
 				'isMultisite'                => is_multisite(),
 				'dateFormat'                 => get_option( 'date_format' ),
@@ -326,6 +327,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'calypsoEnv'                  => Jetpack::get_calypso_env(),
 			'products'                    => Jetpack::get_products_for_purchase(),
 			'setupWizardStatus'           => Jetpack_Options::get_option( 'setup_wizard_status', 'not-started' ),
+			'recommendationsStep'         => Jetpack_Core_Json_Api_Endpoints::get_recommendations_step(),
 			'isSafari'                    => $is_safari,
 			'doNotUseConnectionIframe'    => Constants::is_true( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME' ),
 			'licensing'                   => array(

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Utilities related to the Jetpack Recommendations
+ *
+ * @package jetpack
+ */
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
+/**
+ * Contains utilities related to the Jetpack Recommendations.
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Jetpack_Recommendations class
+ */
+class Jetpack_Recommendations {
+	/**
+	 * Returns a boolean indicating if the Jetpack Recommendations are enabled.
+	 *
+	 * @since 9.3.0
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		$recommendations_enabled = Jetpack_Options::get_option( 'recommendations_enabled', null );
+
+		// If the option is already set, just return the cached value.
+		// Otherwise calculate it and store it before returning it.
+		if ( null !== $recommendations_enabled ) {
+			return $recommendations_enabled;
+		}
+
+		if ( ! Jetpack::connection()->is_connected() ) {
+			return new WP_Error( 'site_not_connected', esc_html__( 'Site not connected.', 'jetpack' ) );
+		}
+
+		$blog_id = Jetpack_Options::get_option( 'id' );
+
+		$request_path = sprintf( '/sites/%s/jetpack-recommendations/site-registered-date', $blog_id );
+		$result       = Client::wpcom_json_api_request_as_blog(
+			$request_path,
+			2,
+			array(
+				'headers' => array( 'content-type' => 'application/json' ),
+			),
+			null,
+			'wpcom'
+		);
+
+		$body = json_decode( wp_remote_retrieve_body( $result ) );
+		if ( 200 === wp_remote_retrieve_response_code( $result ) ) {
+			$site_registered_date = $body->site_registered_date;
+		} else {
+			$connection           = new Connection_Manager( 'jetpack' );
+			$site_registered_date = $connection->get_assumed_site_creation_date();
+		}
+
+		$recommendations_start_date = gmdate( 'Y-m-d H:i:s', strtotime( '2020-12-01 00:00:00' ) );
+		$recommendations_enabled    = $site_registered_date > $recommendations_start_date;
+
+		Jetpack_Options::update_option( 'recommendations_enabled', $recommendations_enabled );
+
+		return $recommendations_enabled;
+	}
+
+	/**
+	 * Initializes the Recommendations step according to the Setup Wizard state, and then clears the
+	 * Setup Wizard state.
+	 */
+	private static function initialize_jetpack_recommendations() {
+		if ( Jetpack_Options::get_option( 'recommendations_step' ) ) {
+			return;
+		}
+
+		$setup_wizard_status = Jetpack_Options::get_option( 'setup_wizard_status' );
+		if ( 'completed' === $setup_wizard_status ) {
+			Jetpack_Options::update_option( 'recommendations_step', 'completed' );
+		}
+
+		Jetpack_Options::delete_option( array( 'setup_wizard_questionnaire', 'setup_wizard_status' ) );
+	}
+
+	/**
+	 * Get the data for the recommendations
+	 *
+	 * @return array Recommendations data
+	 */
+	public static function get_recommendations_data() {
+		self::initialize_jetpack_recommendations();
+
+		return Jetpack_Options::get_option( 'recommendations_data', (object) array() );
+	}
+
+	/**
+	 * Update the data for the recommendations
+	 *
+	 * @param WP_REST_Request $data The data.
+	 */
+	public static function update_recommendations_data( $data ) {
+		if ( ! empty( $data ) ) {
+			Jetpack_Options::update_option( 'recommendations_data', $data );
+		}
+	}
+
+	/**
+	 * Get the data for the recommendations
+	 *
+	 * @return array Recommendations data
+	 */
+	public static function get_recommendations_step() {
+		self::initialize_jetpack_recommendations();
+
+		return array(
+			'step' => Jetpack_Options::get_option( 'recommendations_step', 'not-started' ),
+		);
+	}
+
+	/**
+	 * Update the step for the recommendations
+	 *
+	 * @param WP_REST_Request $step The step.
+	 */
+	public static function update_recommendations_step( $step ) {
+		if ( ! empty( $step ) ) {
+			Jetpack_Options::update_option( 'recommendations_step', $step );
+		}
+	}
+}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -2,17 +2,11 @@
 /**
  * Utilities related to the Jetpack Recommendations
  *
- * @package jetpack
+ * @package Jetpack
  */
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-
-/**
- * Contains utilities related to the Jetpack Recommendations.
- *
- * @package Jetpack
- */
 
 /**
  * Jetpack_Recommendations class

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-wizard.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-wizard.php
@@ -19,12 +19,10 @@ class Jetpack_Wizard {
 		 * Determines if the Setup Wizard is displayed or not.
 		 *
 		 * @since 8.5.0
+		 * @deprecated 9.4.0
 		 *
 		 * @param array $jetpack_show_setup_wizard If true, the Setup Wizard will be displayed. Otherwise it will not display.
 		 */
-		return apply_filters( 'jetpack_show_setup_wizard', false )
-			&& Jetpack::is_active()
-			&& current_user_can( 'jetpack_manage_modules' )
-			&& 'completed' !== Jetpack_Options::get_option( 'setup_wizard_status' );
+		return false;
 	}
 }

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -619,6 +619,66 @@ class Jetpack_Core_Json_Api_Endpoints {
 			)
 		);
 
+		register_rest_route(
+			'jetpack/v4',
+			'/recommendations/data',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => __CLASS__ . '::get_recommendations_data',
+					'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => __CLASS__ . '::update_recommendations_data',
+					'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+					'args'                => array(
+						'data' => array(
+							'required'          => true,
+							'type'              => 'object',
+							'validate_callback' => __CLASS__ . '::validate_recommendations_data',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'/recommendations/step',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => __CLASS__ . '::get_recommendations_step',
+					'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => __CLASS__ . '::update_recommendations_step',
+					'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+					'args'                => array(
+						'step' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'validate_callback' => __CLASS__ . '::validate_string',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'/recommendations/upsell',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => __CLASS__ . '::get_recommendations_upsell',
+					'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
+				),
+			)
+		);
+
 		/*
 		 * Get and update the last licensing error message.
 		 */
@@ -705,6 +765,87 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
+	 * Get the data for the recommendations
+	 *
+	 * @return array Recommendations data
+	 */
+	public static function get_recommendations_data() {
+		return Jetpack_Recommendations::get_recommendations_data();
+	}
+
+	/**
+	 * Update the data for the recommendations
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return bool true
+	 */
+	public static function update_recommendations_data( $request ) {
+		$data = $request['data'];
+		Jetpack_Recommendations::update_recommendations_data( $data );
+
+		return true;
+	}
+
+	/**
+	 * Get the data for the recommendations
+	 *
+	 * @return array Recommendations data
+	 */
+	public static function get_recommendations_step() {
+		return Jetpack_Recommendations::get_recommendations_step();
+	}
+
+	/**
+	 * Update the step for the recommendations
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return bool true
+	 */
+	public static function update_recommendations_step( $request ) {
+		$step = $request['step'];
+		Jetpack_Recommendations::update_recommendations_step( $step );
+
+		return true;
+	}
+
+	/**
+	 * Get the upsell for the recommendations
+	 *
+	 * @return string The response from the wpcom upsell endpoint as a JSON object
+	 */
+	public static function get_recommendations_upsell() {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+		if ( ! $blog_id ) {
+			return new WP_Error( 'site_not_registered', esc_html__( 'Site not registered.', 'jetpack' ) );
+		}
+
+		$request_path  = sprintf( '/sites/%s/jetpack-recommendations/upsell?locale=' . get_user_locale(), $blog_id );
+		$wpcom_request = Client::wpcom_json_api_request_as_user(
+			$request_path,
+			'2',
+			array(
+				'method'  => 'GET',
+				'headers' => array(
+					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+				),
+			)
+		);
+
+		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
+		if ( 200 === $response_code ) {
+			return json_decode( wp_remote_retrieve_body( $wpcom_request ) );
+		} else {
+			return new WP_Error(
+				'failed_to_fetch_data',
+				esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
+				array( 'status' => $response_code )
+			);
+		}
+	}
+
+	/**
 	 * Validate the answers on the setup wizard questionnaire
 	 *
 	 * @param array           $value Value to check received by request.
@@ -721,6 +862,38 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		foreach ( $value as $answer_key => $answer ) {
 			if ( is_string( $answer ) ) {
+				$validate = self::validate_string( $answer, $request, $param );
+			} else {
+				$validate = self::validate_boolean( $answer, $request, $param );
+			}
+
+			if ( is_wp_error( $validate ) ) {
+				return $validate;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate the recommendations data
+	 *
+	 * @param array           $value Value to check received by request.
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 * @param string          $param Name of the parameter passed to endpoint holding $value.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function validate_recommendations_data( $value, $request, $param ) {
+		if ( ! is_array( $value ) ) {
+			/* translators: Name of a parameter that must be an object */
+			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be an object.', 'jetpack' ), $param ) );
+		}
+
+		foreach ( $value as $answer ) {
+			if ( is_array( $answer ) ) {
+				$validate = self::validate_array_of_strings( $answer, $request, $param );
+			} elseif ( is_string( $answer ) ) {
 				$validate = self::validate_string( $answer, $request, $param );
 			} else {
 				$validate = self::validate_boolean( $answer, $request, $param );
@@ -3085,6 +3258,26 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( ! is_string( $value ) ) {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be a string.', 'jetpack' ), $param ) );
 		}
+		return true;
+	}
+
+	/**
+	 * Validates that the parameter is an array of strings.
+	 *
+	 * @param array           $value Value to check.
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 * @param string          $param Name of the parameter passed to the endpoint holding $value.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function validate_array_of_strings( $value, $request, $param ) {
+		foreach ( $value as $array_item ) {
+			$validate = self::validate_string( $array_item, $request, $param );
+			if ( is_wp_error( $validate ) ) {
+				return $validate;
+			}
+		}
+
 		return true;
 	}
 

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -44,7 +44,6 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-data.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-client-server.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-user-agent.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-post-images.php';
-require_once JETPACK__PLUGIN_DIR . 'class.jetpack-error.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-heartbeat.php';
 require_once JETPACK__PLUGIN_DIR . 'class.photon.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.photon.php';

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -44,6 +44,7 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-data.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-client-server.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-user-agent.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-post-images.php';
+require_once JETPACK__PLUGIN_DIR . 'class.jetpack-error.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-heartbeat.php';
 require_once JETPACK__PLUGIN_DIR . 'class.photon.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.photon.php';
@@ -59,6 +60,7 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
 
+jetpack_require_lib( 'class-jetpack-recommendations' );
 jetpack_require_lib( 'class-jetpack-wizard' );
 require_once JETPACK__PLUGIN_DIR . 'class-jetpack-wizard-banner.php';
 

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -1033,6 +1033,65 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test saving and retrieving the recommendations data.
+	 *
+	 * @since 9.3.0
+	 */
+	public function test_recommendations_data() {
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_configure_modules' );
+		wp_set_current_user( $user->ID );
+
+		$test_data = array(
+			'param1' => 'val1',
+			'param2' => 'val2',
+		);
+
+		$response = $this->create_and_get_request(
+			'recommendations/data',
+			array(
+				'data' => $test_data,
+			),
+			'POST'
+		);
+		$this->assertResponseStatus( 200, $response );
+		$this->assertTrue( $response->get_data() );
+
+		$response = $this->create_and_get_request( 'recommendations/data', array(), 'GET' );
+		$this->assertResponseStatus( 200, $response );
+		$this->assertResponseData( $test_data, $response );
+	}
+
+	/**
+	 * Test saving and retrieving the recommendations step.
+	 *
+	 * @since 9.3.0
+	 */
+	public function test_recommendations_step() {
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_configure_modules' );
+		wp_set_current_user( $user->ID );
+
+		$test_data = 'step-1';
+
+		$response = $this->create_and_get_request(
+			'recommendations/step',
+			array(
+				'step' => $test_data,
+			),
+			'POST'
+		);
+		$this->assertResponseStatus( 200, $response );
+		$this->assertTrue( $response->get_data() );
+
+		$response = $this->create_and_get_request( 'recommendations/step', array(), 'GET' );
+		$this->assertResponseStatus( 200, $response );
+		$this->assertResponseData( array( 'step' => $test_data ), $response );
+	}
+
+	/**
 	 * Test saving and retrieving the Setup Wizard questionnaire responses.
 	 *
 	 * @since 9.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds the plugin-side backend for the new Jetpack Assistant.

Includes:
* REST endpoints for storing and retrieving client data. (Just a JSON object for the client side to work with to persist various state)
* REST endpoints for storing and retrieving the current step of the assistant.
* REST endpoint for retrieving copy and prices for the upsell.
* Utilities for determining if the Jetpack Assistant should be enabled.
* Functionality to hide the Assistant for sites that already completed the prior Setup Wizard

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
MT: p1HpG7-asW-p2
Design: p6TEKc-4cJ-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Since this is only the backend, it is only necessary to do code review this PR. Functional testing will have to be done later PR with client side functionality.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* General: Add new Jetpack Recommendations wizard to help you get started with our recommended features of Jetpack.