### PR TITLE
AnchorFM: Add impression and click tracking to CTA

### DIFF
--- a/extensions/blocks/anchor-fm/editor.js
+++ b/extensions/blocks/anchor-fm/editor.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { castArray } from 'lodash';
+import { useEffect, useCallback } from 'react';
 
 /**
  * WordPress dependencies
@@ -17,6 +18,7 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import { waitForEditor } from '../../shared/wait-for-editor';
 import { basicTemplate, spotifyBadgeTemplate } from './templates';
+import analytics from '../../../_inc/client/lib/analytics';
 
 /**
  * Style dependencies
@@ -58,20 +60,29 @@ async function setEpisodeTitle( { title } ) {
 	dispatch( 'core/editor' ).editPost( { title } );
 }
 
-const ConvertToAudio = () => (
-	<PluginPostPublishPanel className="anchor-post-publish-outbound-link">
-		<p className="post-publish-panel__postpublish-subheader">
-			<strong>{ __( 'Convert to audio', 'jetpack' ) }</strong>
-		</p>
-		<p>{ __( 'Let your readers listen to your post.', 'jetpack' ) }</p>
-		<p>
-			<a href="https://anchor.fm/wordpress" target="_top">
-				{ __( 'Create a podcast episode', 'jetpack' ) }
-				<Icon icon={ external } className="anchor-post-publish-outbound-link__external_icon" />
-			</a>
-		</p>
-	</PluginPostPublishPanel>
-);
+const ConvertToAudio = () => {
+	useEffect( () => {
+		analytics.tracks.recordEvent( 'jetpack_editor_block_anchor_fm_post_publish_impression' );
+	}, [] );
+	const handleClick = useCallback(
+		() => analytics.tracks.recordEvent( 'jetpack_editor_block_anchor_fm_post_publish_click' ),
+		[]
+	);
+	return (
+		<PluginPostPublishPanel className="anchor-post-publish-outbound-link">
+			<p className="post-publish-panel__postpublish-subheader">
+				<strong>{ __( 'Convert to audio', 'jetpack' ) }</strong>
+			</p>
+			<p>{ __( 'Let your readers listen to your post.', 'jetpack' ) }</p>
+			<div role="link" tabIndex={ 0 } onClick={ handleClick } onKeyDown={ handleClick }>
+				<a href="https://anchor.fm/wordpress" target="_top">
+					{ __( 'Create a podcast episode', 'jetpack' ) }
+					<Icon icon={ external } className="anchor-post-publish-outbound-link__external_icon" />
+				</a>
+			</div>
+		</PluginPostPublishPanel>
+	);
+};
 
 function showPostPublishOutboundLink() {
 	registerPlugin( 'anchor-post-publish-outbound-link', {


### PR DESCRIPTION
Fixes #373-gh-Automattic/dotcom-manage

#### Changes proposed in this Pull Request:
This PR adds two new events to track the AnchorFM CTA on a post-publish screen on the editor sidebar. One for impressions and one for clicks.

Screenshots may contain sensitive information, so only showing the record
<img width="420" alt="Screen Shot 2020-12-19 at 12 24 16 AM" src="https://user-images.githubusercontent.com/66652282/102681588-9670c100-4190-11eb-909f-7f872fc93067.png">
<img width="600" alt="Screen Shot 2020-12-19 at 12 23 55 AM" src="https://user-images.githubusercontent.com/66652282/102681591-9c66a200-4190-11eb-91b4-9a33564be9ca.png">


#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
Yes, this tracks the impressions for AnchorFM CTA in the post-publish editor sidebar, as well as the clicks for that CTA.

#### Testing instructions:
- Activate the beta blocks:
  - If testing on a JN site, go to Settings > Jetpack Constants and turn on the `JETPACK_BETA_BLOCKS` option.
  - If testing locally, add a new plugin to docker/mu-plugins with `define( 'JETPACK_BETA_BLOCKS', true );`.
- Start writing a new post and publish it.
- Make sure the post-publish panel displays a link prompting users to convert the post into a podcast episode. 
- Click on the link.
- Wait 5 minutes and go on Tracks and search for these two events: `jetpack_editor_block_anchor_fm_post_publish_click` and `jetpack_editor_block_anchor_fm_post_publish_impression`. You should see records of both of them

#### Proposed changelog entry for your changes:
Adds tracking to AnchorFM CTA post-publish screen on the editor sidebar