### PR TITLE
Conversation: remove unneeded `entry-content` CSS class

### DIFF
--- a/extensions/blocks/conversation/edit.js
+++ b/extensions/blocks/conversation/edit.js
@@ -12,6 +12,7 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	BlockControls,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import {
 	Panel,
@@ -43,6 +44,8 @@ function ConversationEdit ( {
 } ) {
 	const { participants = [], showTimestamps, className: classNameAttr } = attributes;
 	const containerRef = useRef();
+
+	const blockProps = useBlockProps( { ref: containerRef, className } );
 
 	// Set initial conversation participants.
 	useEffect( () => {
@@ -99,7 +102,7 @@ function ConversationEdit ( {
 
 	return (
 		<TranscriptionContext.Provider value={ contextProvision }>
-			<div ref={ containerRef } className={ className }>
+			<div { ...blockProps }>
 				<BlockControls>
 					<ToolbarGroup>
 						<ParticipantsDropdown

--- a/extensions/blocks/conversation/save.js
+++ b/extensions/blocks/conversation/save.js
@@ -9,13 +9,10 @@ import classnames from 'classnames';
 import { InnerBlocks } from '@wordpress/block-editor';
 
 export default function save ( { attributes } ) {
-	const baseClassName = 'wp-block-jetpack-conversation';
-
 	return (
 		<div
 			className={ classnames(
-				baseClassName,
-				'entry-content',
+				'wp-block-jetpack-conversation',
 				{
 					'show-timestamps': attributes?.showTimestamp,
 				}

--- a/extensions/blocks/dialogue/dialogue.php
+++ b/extensions/blocks/dialogue/dialogue.php
@@ -241,6 +241,6 @@ function render_block( $dialogue_attrs, $block_content, $block ) {
 				: ''
 			) .
 		'</div>' .
-		'<div>' . $attrs['content'] . '</div>' .
+		'<p>' . $attrs['content'] . '</p>' .
 	'</div>';
 }

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -12,6 +12,7 @@ import {
 	InspectorControls,
 	RichText,
 	BlockControls,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 
@@ -90,6 +91,7 @@ export default function DialogueEdit ( {
 	const transcritionBridge = useContext( ConversationContext );
 
 	const baseClassName = 'wp-block-jetpack-dialogue';
+	const blockProps = useBlockProps( { className: baseClassName } );
 
 	/**
 	 * Helper to check if the gven style is set, or not.
@@ -155,7 +157,7 @@ export default function DialogueEdit ( {
 	}
 
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<BlockControls>
 				{ currentParticipant && isFocusedOnParticipantLabel && (
 					<ToolbarGroup>

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -248,6 +248,7 @@ export default function DialogueEdit ( {
 
 			<RichText
 				identifier="content"
+				tagName="p"
 				className={ `${ baseClassName }__content` }
 				value={ content }
 				onChange={ ( value ) =>

--- a/extensions/blocks/dialogue/style.scss
+++ b/extensions/blocks/dialogue/style.scss
@@ -39,6 +39,11 @@
 	}
 }
 
+// dialogue content.
+.block-editor-block-list__block .wp-block-jetpack-dialogue__content {
+	margin-top: 0;
+}
+
 // Conversation styles.
 .wp-block-jetpack-conversation.is-style-column {
 	.wp-block-jetpack-dialogue {

--- a/extensions/blocks/dialogue/style.scss
+++ b/extensions/blocks/dialogue/style.scss
@@ -17,6 +17,7 @@
 		padding: 6px 12px;
 		text-align: right;
 		font-size: 16px;
+		white-space: nowrap;
 	}
 }
 
@@ -41,7 +42,7 @@
 
 // dialogue content.
 .block-editor-block-list__block .wp-block-jetpack-dialogue__content {
-	margin-top: 0;
+	margin: 0 0 1em 0;
 }
 
 // Conversation styles.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

_This PR is part of the [follow-up tasks](https://github.com/Automattic/jetpack/issues/18123) after merging `conversation`/`dialogue` blocks._

This PR removes the `entry-content` class from the conversation block markup. We don't want to apply all styles defined for this class in the conversation block. ~In case we want to polish the styles, we can do it in the block itself.~
Also, it applies block properties using the `useBlockProps()` hook, and tweak a little bit some styles.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation: remove unneeded `entry-content` CSS class.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test editing a conversation block. You shouldn't see big changes there, no bugs either.
