### PR TITLE
Refactor Custom VideoPress Field as Object in REST api

### DIFF
--- a/_inc/lib/core-api/wpcom-fields/attachment-fields-videopress.php
+++ b/_inc/lib/core-api/wpcom-fields/attachment-fields-videopress.php
@@ -10,7 +10,7 @@
  *
  * { # Attachment Object
  *   ...
- *   jetpack_videopress_guid: (string) VideoPress identifier
+ *   jetpack_videopress: (object) VideoPress data
  *   ...
  * }
  *
@@ -18,7 +18,7 @@
  */
 class WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WPCOM_REST_API_V2_Field_Controller {
 	/**
-	 * The REST Object Type to which the jetpack_videopress_guid field will be added.
+	 * The REST Object Type to which the jetpack_videopress field will be added.
 	 *
 	 * @var string
 	 */
@@ -29,7 +29,7 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WPCOM_REST_API_V2_Fi
 	 *
 	 * @var string $field_name
 	 */
-	protected $field_name = 'jetpack_videopress_guid';
+	protected $field_name = 'jetpack_videopress';
 
 	/**
 	 * Registers the jetpack_videopress field and adds a filter to remove it for attachments that are not videos.
@@ -47,10 +47,10 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WPCOM_REST_API_V2_Fi
 		return array(
 			'$schema'     => 'http://json-schema.org/draft-04/schema#',
 			'title'       => $this->field_name,
-			'type'        => 'string',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
-			'description' => __( 'Unique VideoPress ID', 'jetpack' ),
+			'description' => __( 'VideoPress Data', 'jetpack' ),
 		);
 	}
 
@@ -71,13 +71,13 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WPCOM_REST_API_V2_Fi
 
 		$post_id = absint( $attachment['id'] );
 
-		$videopress_guid = $this->get_videopress_guid( $post_id, $blog_id );
+		$videopress = $this->get_videopress_data( $post_id, $blog_id );
 
-		if ( ! $videopress_guid ) {
-			return '';
+		if ( ! $videopress ) {
+			return array();
 		}
 
-		return $videopress_guid;
+		return $videopress;
 	}
 
 	/**
@@ -90,8 +90,12 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WPCOM_REST_API_V2_Fi
 	 *
 	 * @return string
 	 */
-	public function get_videopress_guid( $attachment_id, $blog_id ) {
-		return video_get_info_by_blogpostid( $blog_id, $attachment_id )->guid;
+	public function get_videopress_data( $attachment_id, $blog_id ) {
+		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id );
+		return array(
+			'guid'   => $info->guid,
+			'rating' => $info->rating,
+		);
 	}
 
 	/**
@@ -106,7 +110,7 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WPCOM_REST_API_V2_Fi
 	}
 
 	/**
-	 * Removes the jetpack_videopress_guid field from the response if the
+	 * Removes the jetpack_videopress field from the response if the
 	 * given attachment is not a video.
 	 *
 	 * @param WP_REST_Response $response Response from the attachment endpoint.

--- a/extensions/blocks/videopress/edit.js
+++ b/extensions/blocks/videopress/edit.js
@@ -125,7 +125,7 @@ const VideoPressEdit = CoreVideoEdit =>
 				}
 
 				this.setState( { media } );
-				const guid = get( media, 'jetpack_videopress_guid' );
+				const guid = get( media, 'jetpack_videopress.guid' );
 				if ( guid ) {
 					setAttributes( { guid } );
 				} else {

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -540,6 +540,12 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 
 	// Since this is a VideoPress post, lt's fill out the rest of the object.
 	$video_info->guid = get_post_meta( $post_id, 'videopress_guid', true );
+	$meta             = wp_get_attachment_metadata( $post_id );
+
+	if ( $meta && isset( $meta['videopress'] ) ) {
+		$videopress_meta    = $meta['videopress'];
+		$video_info->rating = $videopress_meta['rating'];
+	}
 
 	if ( videopress_is_finished_processing( $post_id ) ) {
 		$video_info->finish_date_gmt = date( 'Y-m-d H:i:s' );

--- a/tests/php/core-api/wpcom-fields/test-attachment-fields-videopress.php
+++ b/tests/php/core-api/wpcom-fields/test-attachment-fields-videopress.php
@@ -11,7 +11,7 @@ require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-te
  */
 class Test_WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WP_Test_Jetpack_REST_Testcase {
 	/**
-	 * Checks that the jetpack_videopress_guid field is included in the schema
+	 * Checks that the jetpack_videopress field is included in the schema
 	 */
 	public function test_attachment_fields_videopress_get_schema() {
 		$plugin = new WPCOM_REST_API_V2_Attachment_VideoPress_Field();
@@ -20,28 +20,33 @@ class Test_WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WP_Test_Jetpack
 		$this->assertSame(
 			array(
 				'$schema'     => 'http://json-schema.org/draft-04/schema#',
-				'title'       => 'jetpack_videopress_guid',
-				'type'        => 'string',
+				'title'       => 'jetpack_videopress',
+				'type'        => 'object',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-				'description' => __( 'Unique VideoPress ID', 'jetpack' ),
+				'description' => __( 'VideoPress Data', 'jetpack' ),
 			),
 			$schema
 		);
 	}
 
 	/**
-	 * Checks that the jetpack_videopress_guid field is filled with the VideoPress GUID
+	 * Checks that the jetpack_videopress field is filled with the VideoPress GUID
 	 */
 	public function test_attachment_fields_videopress_get() {
 		$mock = $this->getMockBuilder( 'WPCOM_REST_API_V2_Attachment_VideoPress_Field' )
-						->setMethods( array( 'get_videopress_guid' ) )
+						->setMethods( array( 'get_videopress_data' ) )
 						->getMock();
 
 		$mock->expects( $this->exactly( 1 ) )
-				->method( 'get_videopress_guid' )
+				->method( 'get_videopress_data' )
 				->will(
-					$this->returnValue( 'mocked_videopress_guid' )
+					$this->returnValue(
+						array(
+							'guid'   => 'mocked_videopress_guid',
+							'rating' => 'G',
+						)
+					)
 				);
 
 		$attachment_id = $this->factory->attachment->create_upload_object( dirname( dirname( __DIR__ ) ) . '/jetpack-icon.jpg', 0 );
@@ -49,13 +54,19 @@ class Test_WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WP_Test_Jetpack
 			'id' => $attachment_id,
 		);
 		$request       = new WP_REST_Request( 'GET', sprintf( '/wp/v2/media/%d', $attachment_id ) );
-		$guid          = $mock->get( $object, $request );
+		$data          = $mock->get( $object, $request );
 
-		$this->assertSame( 'mocked_videopress_guid', $guid );
+		$this->assertSame(
+			array(
+				'guid'   => 'mocked_videopress_guid',
+				'rating' => 'G',
+			),
+			$data
+		);
 	}
 
 	/**
-	 * Checks that the jetpack_videopress_guid field is removed for non videos
+	 * Checks that the jetpack_videopress field is removed for non videos
 	 */
 	public function test_attachment_fields_videopress_remove_for_non_videos() {
 		$plugin                     = new WPCOM_REST_API_V2_Attachment_VideoPress_Field();
@@ -63,9 +74,12 @@ class Test_WPCOM_REST_API_V2_Attachment_VideoPress_Field extends WP_Test_Jetpack
 		$attachment->post_mime_type = 'non-video/test';
 		$response                   = new stdClass();
 		$response->data             = array(
-			'jetpack_videopress_guid' => 'my-guid',
+			'jetpack_videopress' => array(
+				'guid'   => 'my-guid',
+				'rating' => 'G',
+			),
 		);
 		$response                   = $plugin->remove_field_for_non_videos( $response, $attachment );
-		$this->assertArrayNotHasKey( 'jetpack_videopress_guid', $response->data );
+		$this->assertArrayNotHasKey( 'jetpack_videopress', $response->data );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The `jetpack_videopress_guid` field was renamed to `jetpack_videopress` and made into an object that can store multiple properties
* This change is to facilitate the use of the new `rating` property in https://github.com/Automattic/jetpack/pull/17659 instead of creating a new custom field and requiring redundant query code and logic

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**phpunit**
`yarn docker:phpunit --filter Test_WPCOM_REST_API_V2_Attachment_VideoPress_Field`

**Manual**
1. Apply this PR to your dev environment
2. Run `yarn build-extensions`
3. Ensure you have a paid Jetpack plan that includes video hosting
4. Enable `Enable high-speed, ad-free video player` in Jetpack > Settings > Performance
5. In a post, add a `/video` block and upload a new video
6. Once the video has uploaded, verify you are seeing the Jetpack Video block and not the core video block (you should see the VideoPress player in your post)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Refactored the `jetpack_videopress_guid` property of the `/wp/v2/media/:id` endpoint into an object named `jetpack_videopress`, with `guid` as one of its properties
