### PR TITLE
Dialogue: improve UX when creating new blocks

### DIFF
--- a/extensions/blocks/conversation/edit.js
+++ b/extensions/blocks/conversation/edit.js
@@ -69,18 +69,8 @@ function ConversationEdit ( {
 		updateParticipants,
 		getParticipantIndex: ( slug ) =>
 			participants.map( ( part ) => part.participantSlug ).indexOf( slug ),
-		getNextParticipantIndex: ( slug, offset = 0 ) => {
-			const index = contextProvision.getParticipantIndex( slug ) + offset;
-			if ( index < 0 ) {
-				return 0;
-			}
-
-			if ( ( index + 1 ) >= participants.length ) {
-				return 0;
-			}
-
-			return index + 1;
-		},
+		getNextParticipantIndex: ( slug, offset = 0 ) => (
+			contextProvision.getParticipantIndex( slug ) + 1 + offset ) % participants.length,
 		getNextParticipantSlug: ( slug, offset = 0 ) =>
 			participants[ contextProvision.getNextParticipantIndex( slug, offset ) ]?.participantSlug,
 

--- a/extensions/blocks/conversation/edit.js
+++ b/extensions/blocks/conversation/edit.js
@@ -69,7 +69,7 @@ function ConversationEdit ( {
 		updateParticipants,
 		getParticipantIndex: ( slug ) =>
 			participants.map( ( part ) => part.participantSlug ).indexOf( slug ),
-		getNextParticpantIndex: ( slug, offset = 0 ) => {
+		getNextParticipantIndex: ( slug, offset = 0 ) => {
 			const index = contextProvision.getParticipantIndex( slug ) + offset;
 			if ( index < 0 ) {
 				return 0;
@@ -82,7 +82,7 @@ function ConversationEdit ( {
 			return index + 1;
 		},
 		getNextParticipantSlug: ( slug, offset = 0 ) =>
-			participants[ contextProvision.getNextParticpantIndex( slug, offset ) ]?.participantSlug,
+			participants[ contextProvision.getNextParticipantIndex( slug, offset ) ]?.participantSlug,
 
 		attributes: {
 			showTimestamps,

--- a/extensions/blocks/conversation/edit.js
+++ b/extensions/blocks/conversation/edit.js
@@ -2,12 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	useEffect,
-	useRef,
-	useCallback,
-	useMemo,
-} from '@wordpress/element';
+import { useEffect, useRef, useCallback } from '@wordpress/element';
 import {
 	InnerBlocks,
 	InspectorControls,
@@ -70,7 +65,7 @@ function ConversationEdit ( {
 
 	// Context bridge.
 	const contextProvision = {
-		setAttributes: useMemo( () => setAttributes, [ setAttributes ] ),
+		setAttributes,
 		updateParticipants,
 
 		attributes: {

--- a/extensions/blocks/conversation/edit.js
+++ b/extensions/blocks/conversation/edit.js
@@ -67,6 +67,22 @@ function ConversationEdit ( {
 	const contextProvision = {
 		setAttributes,
 		updateParticipants,
+		getParticipantIndex: ( slug ) =>
+			participants.map( ( part ) => part.participantSlug ).indexOf( slug ),
+		getNextParticpantIndex: ( slug, offset = 0 ) => {
+			const index = contextProvision.getParticipantIndex( slug ) + offset;
+			if ( index < 0 ) {
+				return 0;
+			}
+
+			if ( ( index + 1 ) >= participants.length ) {
+				return 0;
+			}
+
+			return index + 1;
+		},
+		getNextParticipantSlug: ( slug, offset = 0 ) =>
+			participants[ contextProvision.getNextParticpantIndex( slug, offset ) ].participantSlug,
 
 		attributes: {
 			showTimestamps,

--- a/extensions/blocks/conversation/edit.js
+++ b/extensions/blocks/conversation/edit.js
@@ -82,7 +82,7 @@ function ConversationEdit ( {
 			return index + 1;
 		},
 		getNextParticipantSlug: ( slug, offset = 0 ) =>
-			participants[ contextProvision.getNextParticpantIndex( slug, offset ) ].participantSlug,
+			participants[ contextProvision.getNextParticpantIndex( slug, offset ) ]?.participantSlug,
 
 		attributes: {
 			showTimestamps,

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -60,6 +60,7 @@ export default function DialogueEdit ( {
 	attributes,
 	setAttributes,
 	instanceId,
+	clientId,
 	context,
 	onReplace,
 	mergeBlocks,
@@ -73,6 +74,12 @@ export default function DialogueEdit ( {
 		placeholder,
 	} = attributes;
 	const [ isFocusedOnParticipantLabel, setIsFocusedOnParticipantLabel ] = useState( false );
+
+	// Pick the previous block atteobutes from the state.
+	const prevBlock = useSelect( select => {
+		const prevPartClientId = select( 'core/block-editor' ).getPreviousBlockClientId( clientId );
+		return select( 'core/block-editor' ).getBlock( prevPartClientId );
+	}, [] );
 
 	// Block context integration.
 	const participantsFromContext = context[ 'jetpack/conversation-participants' ];
@@ -88,6 +95,22 @@ export default function DialogueEdit ( {
 
 	// Conversation context. A bridge between dialogue and conversation blocks.
 	const transcritionBridge = useContext( ConversationContext );
+
+	// Set initial attributes according to the context.
+	useEffect( () => {
+		// Bail when block already has an slug,
+		// or participant doesn't exist.
+		if ( participantSlug || ! participants?.length || ! transcritionBridge ) {
+			return;
+		}
+
+		const nextParticipantSlug = transcritionBridge.getNextParticipantSlug( prevBlock?.attributes?.participantSlug );
+
+		setAttributes( {
+			...( prevBlock?.attributes || {} ),
+			participantSlug: nextParticipantSlug,
+		} );
+	}, [ participantSlug, participants, prevBlock, setAttributes, transcritionBridge ] );
 
 	const showTimestamp = isCustomParticipant ? showTimestampLocally : showTimestampGlobally;
 

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -262,13 +262,9 @@ export default function DialogueEdit ( {
 						return createBlock( blockNameFallback );
 					}
 
-					if ( ! value ) {
-						return createBlock( blockName );
-					}
-
 					return createBlock( blockName, {
 						...attributes,
-						content: value,
+						content: value || '',
 					} );
 				} }
 				onReplace={ onReplace }

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -94,24 +94,24 @@ export default function DialogueEdit ( {
 	const participantLabel = isCustomParticipant ? participant : currentParticipant?.participant;
 
 	// Conversation context. A bridge between dialogue and conversation blocks.
-	const transcritionBridge = useContext( ConversationContext );
+	const conversationBridge = useContext( ConversationContext );
 
 	// Set initial attributes according to the context.
 	useEffect( () => {
 		// Bail when block already has an slug,
 		// or participant doesn't exist.
-		if ( participantSlug || ! participants?.length || ! transcritionBridge ) {
+		if ( participantSlug || ! participants?.length || ! conversationBridge ) {
 			return;
 		}
 
-		const nextParticipantSlug = transcritionBridge.getNextParticipantSlug( prevBlock?.attributes?.participantSlug );
+		const nextParticipantSlug = conversationBridge.getNextParticipantSlug( prevBlock?.attributes?.participantSlug );
 
 		setAttributes( {
 			...( prevBlock?.attributes || {} ),
 			participantSlug: nextParticipantSlug,
 			content: '',
 		} );
-	}, [ participantSlug, participants, prevBlock, setAttributes, transcritionBridge ] );
+	}, [ participantSlug, participants, prevBlock, setAttributes, conversationBridge ] );
 
 	const showTimestamp = isCustomParticipant ? showTimestampLocally : showTimestampGlobally;
 
@@ -145,7 +145,7 @@ export default function DialogueEdit ( {
 			return setAttributes( { [ style ]: ! attributes[ style ] } );
 		}
 
-		transcritionBridge.updateParticipants( {
+		conversationBridge.updateParticipants( {
 			participantSlug: currentParticipantSlug,
 			[ style ]: ! currentParticipant[ style ],
 		} );
@@ -178,7 +178,7 @@ export default function DialogueEdit ( {
 			return setAttributes( { showTimestamp: value } );
 		}
 
-		transcritionBridge.setAttributes( { showTimestamps: value } );
+		conversationBridge.setAttributes( { showTimestamps: value } );
 	}
 
 	return (
@@ -296,7 +296,7 @@ export default function DialogueEdit ( {
 				onReplace={ ( blocks, ...args ) => {
 					// If transcription bridge doesn't exist,
 					// then run the default replace process.
-					if ( ! transcritionBridge ) {
+					if ( ! conversationBridge ) {
 						return onReplace( blocks, ...args );
 					}
 
@@ -318,7 +318,7 @@ export default function DialogueEdit ( {
 					// with the next participant slug.
 
 					// Pick up the next participant slug.
-					const nextParticipantSlug = transcritionBridge.getNextParticipantSlug( attributes.participantSlug );
+					const nextParticipantSlug = conversationBridge.getNextParticipantSlug( attributes.participantSlug );
 
 					// Update new block attributes.
 					blocks[ 1 ].attributes = {

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -292,6 +292,10 @@ export default function DialogueEdit ( {
 					} );
 				} }
 				onReplace={ ( blocks, ...args ) => {
+					if ( ! transcritionBridge ) {
+						return onReplace( blocks, ...args );
+					}
+
 					if (
 						blocks[ 0 ]?.name === blockNameFallback &&
 						blocks[ 1 ]?.name === blockNameFallback &&

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -292,6 +292,15 @@ export default function DialogueEdit ( {
 					} );
 				} }
 				onReplace={ ( blocks, ...args ) => {
+					if (
+						blocks[ 0 ]?.name === blockNameFallback &&
+						blocks[ 1 ]?.name === blockNameFallback &&
+						! blocks[ 0 ]?.attributes.content &&
+						! blocks[ 1 ]?.attributes.content
+					) {
+						return onReplace( [ blocks[ 0 ] ], ...args );
+					}
+
 					// pick up the next participant slug.
 					const nextParticipantSlug = transcritionBridge.getNextParticipantSlug( attributes.participantSlug );
 

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -109,6 +109,7 @@ export default function DialogueEdit ( {
 		setAttributes( {
 			...( prevBlock?.attributes || {} ),
 			participantSlug: nextParticipantSlug,
+			content: '',
 		} );
 	}, [ participantSlug, participants, prevBlock, setAttributes, transcritionBridge ] );
 

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -24,7 +24,7 @@ import {
 	ToolbarButton,
 } from '@wordpress/components';
 import { useContext, useState, useEffect } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -298,6 +298,7 @@ export default function DialogueEdit ( {
 						! blocks[ 0 ]?.attributes.content &&
 						! blocks[ 1 ]?.attributes.content
 					) {
+						dispatch( 'core/block-editor' ).selectBlock( blocks[ 0 ].clientId );
 						return onReplace( [ blocks[ 0 ] ], ...args );
 					}
 

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -292,11 +292,17 @@ export default function DialogueEdit ( {
 						content: value,
 					} );
 				} }
+
 				onReplace={ ( blocks, ...args ) => {
+					// If transcription bridge doesn't exist,
+					// then run the default replace process.
 					if ( ! transcritionBridge ) {
 						return onReplace( blocks, ...args );
 					}
 
+					// Detect if the block content is empty.
+					// If so, keep only one paragraph block,
+					// in order to avoid duplicated blocks.
 					if (
 						blocks[ 0 ]?.name === blockNameFallback &&
 						blocks[ 1 ]?.name === blockNameFallback &&
@@ -307,7 +313,11 @@ export default function DialogueEdit ( {
 						return onReplace( [ blocks[ 0 ] ], ...args );
 					}
 
-					// pick up the next participant slug.
+					// When creating a new dialogue block in a `conversation` context,
+					// try to assign the dialogue participant
+					// with the next participant slug.
+
+					// Pick up the next participant slug.
 					const nextParticipantSlug = transcritionBridge.getNextParticipantSlug( attributes.participantSlug );
 
 					// Update new block attributes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

_This PR is part of the [follow-up tasks](https://github.com/Automattic/jetpack/issues/18123) after merging `conversation`/`dialogue` blocks._

This PR improves the UX when creating new `dialogue block.
Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: improve UX when creating new blocks.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new `conversation` block
* Edit the participant names in order to make the testing easier to understand
* Confirm that it creates a new dialogue block when pressing ENTER, where
  * it picks up the next participant from the conversation block. If it's the last one, it will pick the first in the list.
  * If it breaks the block in the middle, the text os properly applied to both blocks 
  * It copies the timestamp of the selected block
* It behaves similarly when the new diaogue block is inserted and the previous block is a dialogue too.

https://user-images.githubusercontent.com/77539/102926887-97497180-4474-11eb-9474-c04e3951d00d.mov

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Dialogue: improve UX when creating new blocks.
