### PR TITLE
Connection Manager UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ phpcs.xml
 /vendor/class-version-selector.php
 /vendor/jetpack-autoloader
 /vendor/nojimage
+/packages/connection-ui/build

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -824,6 +824,7 @@ class Jetpack {
 
 		if ( ! $this->connection_manager ) {
 			$this->connection_manager = new Connection_Manager( 'jetpack' );
+			Automattic\Jetpack\ConnectionUI\Admin::init();
 		}
 
 		/*

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"automattic/jetpack-compat": "@dev",
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-connection-ui": "dev-add/connection-ui",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-device-detection": "@dev",
 		"automattic/jetpack-error": "@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a04612dcf4920d7ecefa0f6d5f719e91",
+    "content-hash": "21fdd0e88a5cfd69a58f52742efc10f1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -309,6 +309,31 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-connection-ui",
+            "version": "dev-add/connection-ui",
+            "dist": {
+                "type": "path",
+                "url": "./packages/connection-ui",
+                "reference": "a48ec2def6ba3c2c88b96c3d94b94c6a55f6ab3b"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Connection UI",
             "transport-options": {
                 "relative": true
             }
@@ -1652,6 +1677,7 @@
         "automattic/jetpack-compat": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-connection": 20,
+        "automattic/jetpack-connection-ui": 20,
         "automattic/jetpack-constants": 20,
         "automattic/jetpack-device-detection": 20,
         "automattic/jetpack-error": 20,

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,12 +5,16 @@ const path = require( 'path' );
 
 module.exports = {
 	preset: '@automattic/calypso-build',
-	roots: [ '<rootDir>/extensions/', '<rootDir>/modules/search/instant-search' ],
+	roots: [
+		'<rootDir>/extensions/',
+		'<rootDir>/modules/search/instant-search',
+		'<rootDir>/packages/connection-ui/',
+	],
 	transform: {
 		'\\.[jt]sx?$': path.join( __dirname, 'tests', 'jest-extensions-babel-transform' ),
 		'\\.(gif|jpg|jpeg|png|svg|scss|sass|css)$': require.resolve(
 			'@automattic/calypso-build/jest/transform/asset'
 		),
 	},
-	coverageDirectory: "coverage/extensions"
+	coverageDirectory: 'coverage/extensions',
 };

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 		"test-adminpage": "yarn test-client && yarn test-gui",
 		"test-adminpage-and-extensions-and-search": "yarn concurrently 'yarn test-adminpage' 'yarn test-extensions' 'yarn test-search'",
 		"test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client tests/runner.js",
+		"test-connection-ui": "jest packages/connection-ui",
 		"test-decrypt-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./tests/e2e/config/encrypted.enc -out ./tests/e2e/config/local-test.js",
 		"test-e2e": "NODE_CONFIG_DIR='./tests/e2e/config' NODE_CONFIG_ENV=test JEST_PUPPETEER_CONFIG=tests/e2e/jest-puppeteer.config.js jest --config tests/e2e/jest.config.js --runInBand --verbose",
 		"test-encrypt-config": "openssl enc -md sha1 -aes-256-cbc -pass env:CONFIG_KEY -in ./tests/e2e/config/local-test.js -out ./tests/e2e/config/encrypted.enc",

--- a/packages/connection-ui/_inc/actions/connection-status.js
+++ b/packages/connection-ui/_inc/actions/connection-status.js
@@ -1,0 +1,19 @@
+export const CONNECTION_STATUS_ACTIVE = 'CONNECTION_STATUS_ACTIVE';
+export const CONNECTION_STATUS_INACTIVE = 'CONNECTION_STATUS_INACTIVE';
+export const CONNECTION_STATUS_REFRESHING = 'CONNECTION_STATUS_REFRESHING';
+export const CONNECTION_STATUS_REFRESHED = 'CONNECTION_STATUS_REFRESHED';
+
+export const connectionStatusActions = {
+	connectionStatusSetActive: () => {
+		return { type: CONNECTION_STATUS_ACTIVE };
+	},
+	connectionStatusSetInactive: () => {
+		return { type: CONNECTION_STATUS_INACTIVE };
+	},
+	connectionStatusRefreshing: () => {
+		return { type: CONNECTION_STATUS_REFRESHING };
+	},
+	connectionStatusRefreshed: () => {
+		return { type: CONNECTION_STATUS_REFRESHED };
+	},
+};

--- a/packages/connection-ui/_inc/actions/connection-status.js
+++ b/packages/connection-ui/_inc/actions/connection-status.js
@@ -2,6 +2,7 @@ export const CONNECTION_STATUS_ACTIVE = 'CONNECTION_STATUS_ACTIVE';
 export const CONNECTION_STATUS_INACTIVE = 'CONNECTION_STATUS_INACTIVE';
 export const CONNECTION_STATUS_REFRESHING = 'CONNECTION_STATUS_REFRESHING';
 export const CONNECTION_STATUS_REFRESHED = 'CONNECTION_STATUS_REFRESHED';
+export const CONNECTION_STATUS_REFRESHED_RESET = 'CONNECTION_STATUS_REFRESHED_RESET';
 
 export const connectionStatusActions = {
 	connectionStatusSetActive: () => {
@@ -15,5 +16,8 @@ export const connectionStatusActions = {
 	},
 	connectionStatusRefreshed: () => {
 		return { type: CONNECTION_STATUS_REFRESHED };
+	},
+	connectionStatusRefreshedReset: () => {
+		return { type: CONNECTION_STATUS_REFRESHED_RESET };
 	},
 };

--- a/packages/connection-ui/_inc/actions/index.js
+++ b/packages/connection-ui/_inc/actions/index.js
@@ -2,9 +2,11 @@
  * Internal dependencies
  */
 import { connectionStatusActions } from './connection-status';
+import { pluginActions } from './plugins';
 
 const actions = {
 	...connectionStatusActions,
+	...pluginActions,
 };
 
 export default actions;

--- a/packages/connection-ui/_inc/actions/index.js
+++ b/packages/connection-ui/_inc/actions/index.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { connectionStatusActions } from './connection-status';
+
+const actions = {
+	...connectionStatusActions,
+};
+
+export default actions;

--- a/packages/connection-ui/_inc/actions/plugins.js
+++ b/packages/connection-ui/_inc/actions/plugins.js
@@ -1,0 +1,20 @@
+export const PLUGIN_CONNECTED = 'PLUGIN_CONNECTED';
+export const PLUGIN_DISCONNECTED = 'PLUGIN_DISCONNECTED';
+
+export const PLUGIN_REQUEST_IN_PROGRESS = 'PLUGIN_REQUEST_IN_PROGRESS';
+export const PLUGIN_REQUEST_DONE = 'PLUGIN_REQUEST_DONE';
+
+export const pluginActions = {
+	pluginConnected: slug => {
+		return { type: PLUGIN_CONNECTED, data: { slug } };
+	},
+	pluginDisconnected: slug => {
+		return { type: PLUGIN_DISCONNECTED, data: { slug } };
+	},
+	pluginRequestInProgress: () => {
+		return { type: PLUGIN_REQUEST_IN_PROGRESS };
+	},
+	pluginRequestDone: () => {
+		return { type: PLUGIN_REQUEST_DONE };
+	},
+};

--- a/packages/connection-ui/_inc/admin.js
+++ b/packages/connection-ui/_inc/admin.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import ReactDOM from 'react-dom';
+import React from 'react';
+import { registerStore } from '@wordpress/data';
+import { Provider } from 'react-redux';
+
+/**
+ * The initial renderer function.
+ */
+function render() {
+	const container = document.getElementById( 'jetpack-connection-ui-container' );
+
+	const reducer = function ( state = {}, action ) {
+		return state;
+	};
+
+	ReactDOM.render(
+		<div>
+			<Provider store={ registerStore( 'jetpack-connection-ui', { reducer } ) } />
+			Hello World 🌍
+		</div>,
+		container
+	);
+}
+
+render();

--- a/packages/connection-ui/_inc/admin.jsx
+++ b/packages/connection-ui/_inc/admin.jsx
@@ -4,12 +4,14 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
 import { registerStore } from '@wordpress/data';
-import { Provider } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import Admin from "./components/admin";
+import Admin from './components/admin';
+import { STORE_ID, storeConfig } from './store';
+
+registerStore( STORE_ID, storeConfig );
 
 /**
  * The initial renderer function.
@@ -21,18 +23,7 @@ function render() {
 		return;
 	}
 
-	const reducer = function ( state = {}, action ) {
-		return state;
-	};
-
-	ReactDOM.render(
-		<div>
-			<Provider store={ registerStore( 'jetpack-connection-ui', { reducer } ) }>
-				<Admin />
-			</Provider>
-		</div>,
-		container
-	);
+	ReactDOM.render( <Admin />, container );
 }
 
 render();

--- a/packages/connection-ui/_inc/admin.jsx
+++ b/packages/connection-ui/_inc/admin.jsx
@@ -7,10 +7,19 @@ import { registerStore } from '@wordpress/data';
 import { Provider } from 'react-redux';
 
 /**
+ * Internal dependencies
+ */
+import Admin from "./components/admin";
+
+/**
  * The initial renderer function.
  */
 function render() {
 	const container = document.getElementById( 'jetpack-connection-ui-container' );
+
+	if ( null === container ) {
+		return;
+	}
 
 	const reducer = function ( state = {}, action ) {
 		return state;
@@ -18,8 +27,9 @@ function render() {
 
 	ReactDOM.render(
 		<div>
-			<Provider store={ registerStore( 'jetpack-connection-ui', { reducer } ) } />
-			Hello World 🌍
+			<Provider store={ registerStore( 'jetpack-connection-ui', { reducer } ) }>
+				<Admin />
+			</Provider>
 		</div>,
 		container
 	);

--- a/packages/connection-ui/_inc/components/admin/index.jsx
+++ b/packages/connection-ui/_inc/components/admin/index.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Header from '../header';
+import './style.scss';
+import Section from '../section';
+
+/**
+ * The Connection IU Admin App.
+ *
+ * @returns {JSX.Element} The header component.
+ */
+export default function Admin() {
+	return (
+		<React.Fragment>
+			<Header />
+
+			<Section title="Refresh Connection" />
+		</React.Fragment>
+	);
+}

--- a/packages/connection-ui/_inc/components/admin/index.jsx
+++ b/packages/connection-ui/_inc/components/admin/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -9,6 +10,8 @@ import React from 'react';
 import Header from '../header';
 import './style.scss';
 import Section from '../section';
+import Card from '../card';
+import Refresh from '../refresh';
 
 /**
  * The Connection IU Admin App.
@@ -20,7 +23,11 @@ export default function Admin() {
 		<React.Fragment>
 			<Header />
 
-			<Section title="Refresh Connection" />
+			<Section title={ __( 'Refresh Connection', 'jetpack' ) }>
+				<Card>
+					<Refresh />
+				</Card>
+			</Section>
 		</React.Fragment>
 	);
 }

--- a/packages/connection-ui/_inc/components/admin/index.jsx
+++ b/packages/connection-ui/_inc/components/admin/index.jsx
@@ -3,15 +3,18 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import Header from '../header';
+import { STORE_ID } from '../../store';
 import './style.scss';
+import Header from '../header';
 import Section from '../section';
 import Card from '../card';
 import Refresh from '../refresh';
+import Plugin from '../plugin';
 
 /**
  * The Connection IU Admin App.
@@ -19,6 +22,15 @@ import Refresh from '../refresh';
  * @returns {JSX.Element} The header component.
  */
 export default function Admin() {
+	const plugins = useSelect( select => select( STORE_ID ).getPlugins(), [] );
+
+	const isRequestInProgress = useSelect( select => select( STORE_ID ).isRequestInProgress(), [] );
+
+	const { isActive, isRegistered, isRefreshing } = useSelect(
+		select => select( STORE_ID ).getConnectionStatus(),
+		[]
+	);
+
 	return (
 		<React.Fragment>
 			<Header />
@@ -27,6 +39,17 @@ export default function Admin() {
 				<Card>
 					<Refresh />
 				</Card>
+			</Section>
+
+			<Section
+				title={ __( 'Manage Connections', 'jetpack' ) }
+				faded={ ! isActive || ! isRegistered || isRefreshing }
+			>
+				{ plugins.map( plugin => (
+					<Card>
+						<Plugin plugin={ plugin } siteConnected={ isActive && isRegistered } />
+					</Card>
+				) ) }
 			</Section>
 		</React.Fragment>
 	);

--- a/packages/connection-ui/_inc/components/admin/style.scss
+++ b/packages/connection-ui/_inc/components/admin/style.scss
@@ -2,4 +2,9 @@
 	max-width: 800px;
 	margin-left: auto;
 	margin-right: auto;
+
+	p {
+		font-size: 1.23em;
+		line-height: 1.5em;
+	}
 }

--- a/packages/connection-ui/_inc/components/admin/style.scss
+++ b/packages/connection-ui/_inc/components/admin/style.scss
@@ -7,4 +7,8 @@
 		font-size: 1.23em;
 		line-height: 1.5em;
 	}
+
+	button {
+		border-radius: 3px;
+	}
 }

--- a/packages/connection-ui/_inc/components/admin/style.scss
+++ b/packages/connection-ui/_inc/components/admin/style.scss
@@ -1,0 +1,5 @@
+#jetpack-connection-ui-container {
+	max-width: 800px;
+	margin-left: auto;
+	margin-right: auto;
+}

--- a/packages/connection-ui/_inc/components/card/index.jsx
+++ b/packages/connection-ui/_inc/components/card/index.jsx
@@ -12,18 +12,17 @@ import './style.scss';
  * The Section component.
  *
  * @param {object} props         The properties.
- * @param {string} props.title   The section title.
  * @param {array} props.children The section title.
  * @returns {JSX.Element}        The Section component.
  */
-export default function Section( props ) {
-	const { title, children } = props;
+const Card = props => {
+	const { children } = props;
 
 	return (
-		<div className="jetpack-cui__section">
-			<h2>{ title }</h2>
-
-			{ children && <div className="jetpack-cui__section-body">{ children }</div> }
+		<div className="jetpack-cui__card">
+			{ children && <div className="jetpack-cui__card-body">{ children }</div> }
 		</div>
 	);
-}
+};
+
+export default Card;

--- a/packages/connection-ui/_inc/components/card/style.scss
+++ b/packages/connection-ui/_inc/components/card/style.scss
@@ -1,0 +1,12 @@
+@import "../../definitions";
+
+#jetpack-connection-ui-container .jetpack-cui__card {
+	.jetpack-cui__card-body {
+		@include clearfix;
+
+		background: white;
+		border: 1px solid #CCD0D4;
+		box-sizing: border-box;
+		padding: 8px 30px;
+	}
+}

--- a/packages/connection-ui/_inc/components/card/style.scss
+++ b/packages/connection-ui/_inc/components/card/style.scss
@@ -1,6 +1,8 @@
 @import "../../definitions";
 
 #jetpack-connection-ui-container .jetpack-cui__card {
+	margin-bottom: 24px;
+
 	.jetpack-cui__card-body {
 		@include clearfix;
 
@@ -8,5 +10,9 @@
 		border: 1px solid #CCD0D4;
 		box-sizing: border-box;
 		padding: 8px 30px;
+
+		p {
+			max-width: 65%;
+		}
 	}
 }

--- a/packages/connection-ui/_inc/components/header/index.jsx
+++ b/packages/connection-ui/_inc/components/header/index.jsx
@@ -14,7 +14,7 @@ import './style.scss';
  *
  * @returns {JSX.Element} The header component.
  */
-export default function Header() {
+const Header = () => {
 	return (
 		<div className="jetpack-cui__header">
 			<h1>{ __( 'Connection Manager', 'jetpack' ) }</h1>
@@ -29,4 +29,6 @@ export default function Header() {
 			</p>
 		</div>
 	);
-}
+};
+
+export default Header;

--- a/packages/connection-ui/_inc/components/header/index.jsx
+++ b/packages/connection-ui/_inc/components/header/index.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * The Connection UI header.
+ *
+ * @returns {JSX.Element} The header component.
+ */
+export default function Header() {
+	return (
+		<div className="jetpack-cui__header">
+			<h1>{ __( 'Connection Manager', 'jetpack' ) }</h1>
+
+			<p>
+				{ __(
+					'The Connection Manager handles all your WordPress.com connections in one place.\
+						Here is where you can disconnect or connect features that require a WordPress.com connection,\
+						as well as, refresh all the reconnections at once in case of connection issues.',
+					'jetpack'
+				) }
+			</p>
+		</div>
+	);
+}

--- a/packages/connection-ui/_inc/components/header/style.scss
+++ b/packages/connection-ui/_inc/components/header/style.scss
@@ -1,11 +1,7 @@
 #jetpack-connection-ui-container .jetpack-cui__header {
 	h1 {
 		text-align: left;
-		font-size: 4em;
-	}
-
-	p {
-		font-size: 1.35em;
-		margin-top: 3em;
+		font-size: 4.6em;
+		line-height: 1.2em;
 	}
 }

--- a/packages/connection-ui/_inc/components/header/style.scss
+++ b/packages/connection-ui/_inc/components/header/style.scss
@@ -1,0 +1,11 @@
+#jetpack-connection-ui-container .jetpack-cui__header {
+	h1 {
+		text-align: left;
+		font-size: 4em;
+	}
+
+	p {
+		font-size: 1.35em;
+		margin-top: 3em;
+	}
+}

--- a/packages/connection-ui/_inc/components/header/test/__snapshots__/header.test.jsx.snap
+++ b/packages/connection-ui/_inc/components/header/test/__snapshots__/header.test.jsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Displays the header 1`] = `
+<div
+  className="jetpack-cui__header"
+>
+  <h1>
+    Connection Manager
+  </h1>
+  <p>
+    The Connection Manager handles all your WordPress.com connections in one place.						Here is where you can disconnect or connect features that require a WordPress.com connection,						as well as, refresh all the reconnections at once in case of connection issues.
+  </p>
+</div>
+`;

--- a/packages/connection-ui/_inc/components/header/test/header.test.jsx
+++ b/packages/connection-ui/_inc/components/header/test/header.test.jsx
@@ -1,0 +1,19 @@
+/* global expect */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render } from '@testing-library/preact';
+import renderer from 'react-test-renderer';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import Header from '../index';
+
+test( 'Displays the header', () => {
+	const tree = renderer.create( <Header /> ).toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/packages/connection-ui/_inc/components/plugin/index.jsx
+++ b/packages/connection-ui/_inc/components/plugin/index.jsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Button } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { STORE_ID } from '../../store';
+
+const doSwitchPlugin = (
+	slug,
+	connect,
+	disconnect,
+	pluginConnectedAction,
+	pluginDisconnectedAction,
+	pluginRequestInProgressAction,
+	pluginRequestDoneAction
+) => {
+	pluginRequestInProgressAction();
+
+	apiFetch( {
+		path: '/jetpack/v4/connection/connect_disconnect_plugin',
+		method: 'POST',
+		data: { slug, connect, disconnect },
+	} ).then( result => {
+		if ( result.success ) {
+			connect && pluginConnectedAction( slug );
+			disconnect && pluginDisconnectedAction( slug );
+			pluginRequestDoneAction();
+
+			return;
+		}
+
+		throw new Error( 'Invalid API response' );
+	} );
+};
+
+/**
+ * The Plugin component.
+ *
+ * @param {object} props                The properties.
+ * @param {object} props.plugin         The plugin object.
+ * @param {boolean} props.siteConnected Is the site connected to WP.com.
+ * @returns {JSX.Element} The Plugin component.
+ *
+ * @todo Disable the Connect/Disconnect button during a request.
+ */
+const Plugin = props => {
+	const { plugin, siteConnected } = props;
+	const {
+		pluginConnected,
+		pluginDisconnected,
+		pluginRequestInProgress,
+		pluginRequestDone,
+	} = useDispatch( STORE_ID );
+
+	const switchPlugin = useCallback(
+		() =>
+			siteConnected
+				? doSwitchPlugin(
+						plugin.slug,
+						! plugin.isConnected,
+						plugin.isConnected,
+						pluginConnected,
+						pluginDisconnected,
+						pluginRequestInProgress,
+						pluginRequestDone
+				  )
+				: null,
+		[
+			siteConnected,
+			plugin,
+			pluginConnected,
+			pluginDisconnected,
+			pluginRequestInProgress,
+			pluginRequestDone,
+		]
+	);
+
+	return (
+		<div className="jetpack-cui__plugin">
+			<p>
+				{ plugin.name }
+				<br />
+				{ siteConnected && plugin.isConnected && <span className="dot-connected">Connected</span> }
+			</p>
+
+			<Button
+				disabled={ ! siteConnected }
+				onClick={ switchPlugin }
+				className={ plugin.isConnected ? 'connected' : 'disconnected' }
+			>
+				{ plugin.isConnected ? 'Disconnect' : 'Connect' }
+			</Button>
+		</div>
+	);
+};
+
+export default Plugin;

--- a/packages/connection-ui/_inc/components/plugin/style.scss
+++ b/packages/connection-ui/_inc/components/plugin/style.scss
@@ -1,0 +1,41 @@
+#jetpack-connection-ui-container .jetpack-cui__plugin {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	button {
+		width: 102px;
+		justify-content: center;
+		box-shadow: none;
+
+		&.connected, &.disconnected {
+			&:hover {
+				background: #eee;
+			}
+		}
+
+		&.connected {
+			background: #F1F1F1;
+			border: 1px solid #016087;
+			color: #016087;
+		}
+
+		&.disconnected {
+			background: #F3F5F6;
+			border: 1px solid #B52727;
+			color: #B52727;
+		}
+	}
+
+	.dot-connected {
+		font-size: 0.9em;
+		line-height: 1.4em;
+
+		&::before {
+			content: '•';
+			color: #00BE28;
+			font-size: 1.5em;
+			margin-right: 5px;
+		}
+	}
+}

--- a/packages/connection-ui/_inc/components/refresh/index.jsx
+++ b/packages/connection-ui/_inc/components/refresh/index.jsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { STORE_ID } from '../../store';
+
+/**
+ * Send the connection refresh API request and handle the response.
+ *
+ * @param {function} refreshingAction - The `connectionStatusRefreshing` action.
+ * @param {function} refreshedAction - The `connectionStatusRefreshed` action.
+ */
+function doRefresh( refreshingAction, refreshedAction ) {
+	refreshingAction();
+
+	apiFetch( {
+		path: '/jetpack/v4/connection/reconnect',
+		method: 'POST',
+		data: { from: 'connection-ui' },
+	} ).then( result => {
+		switch ( result.status ) {
+			case 'in_progress':
+				if ( result.authorizeUrl ) {
+					window.location.href = result.authorizeUrl.replace(
+						'jetpack.authorize_iframe',
+						'jetpack.authorize'
+					);
+					return;
+				}
+
+				throw new Error( 'Authorize URL is missing' );
+			case 'completed':
+				refreshedAction();
+				return;
+		}
+
+		throw new Error( 'Invalid API response' );
+	} );
+}
+
+/**
+ * The Refresh component.
+ *
+ * @returns {JSX.Element} - The Section component.
+ */
+const Refresh = () => {
+	const { connectionStatusRefreshing, connectionStatusRefreshed } = useDispatch( STORE_ID );
+	const { isActive, isRegistered, isRefreshing } = useSelect(
+		select => select( STORE_ID ).getConnectionStatus(),
+		[]
+	);
+
+	const refreshConnection = useCallback(
+		() =>
+			isActive &&
+			isRegistered &&
+			doRefresh( connectionStatusRefreshing, connectionStatusRefreshed ),
+		[ isActive, isRegistered, connectionStatusRefreshed, connectionStatusRefreshing ]
+	);
+
+	return (
+		<div className="jetpack-cui__refresh">
+			<p>
+				{ __(
+					'Refresh all the connections to WordPress.com at once without having to disconnect any of them.',
+					'jetpack'
+				) }
+			</p>
+
+			{ isActive && isRegistered ? (
+				<Button isPrimary onClick={ refreshConnection }>
+					Refresh Connection
+				</Button>
+			) : (
+				<Button isPrimary disabled>
+					{ isRefreshing ? 'Refreshing...' : 'Not Connected' }
+				</Button>
+			) }
+		</div>
+	);
+};
+
+export default Refresh;

--- a/packages/connection-ui/_inc/components/refresh/style.scss
+++ b/packages/connection-ui/_inc/components/refresh/style.scss
@@ -6,4 +6,12 @@
 	p {
 		max-width: 65%;
 	}
+
+	button {
+		&.refreshed {
+			background: #00A32A;
+			border: 1px solid #00A32A;
+			color: white;
+		}
+	}
 }

--- a/packages/connection-ui/_inc/components/refresh/style.scss
+++ b/packages/connection-ui/_inc/components/refresh/style.scss
@@ -3,11 +3,10 @@
 	justify-content: space-between;
 	align-items: center;
 
-	p {
-		max-width: 65%;
-	}
-
 	button {
+		width: 143px;
+		justify-content: center;
+
 		&.refreshed {
 			background: #00A32A;
 			border: 1px solid #00A32A;

--- a/packages/connection-ui/_inc/components/refresh/style.scss
+++ b/packages/connection-ui/_inc/components/refresh/style.scss
@@ -1,0 +1,9 @@
+#jetpack-connection-ui-container .jetpack-cui__refresh {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	p {
+		max-width: 65%;
+	}
+}

--- a/packages/connection-ui/_inc/components/section/index.jsx
+++ b/packages/connection-ui/_inc/components/section/index.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+//import './style.scss';
+
+/**
+ * The Section component.
+ *
+ * @param {object} props         The properties.
+ * @param {string} props.title   The section title.
+ * @param {array} props.children The section title.
+ * @returns {JSX.Element}        The Section component.
+ */
+export default function Section( props ) {
+	const { title, children } = props;
+
+	return (
+		<div className="jetpack-cui__section">
+			<h2>{ title }</h2>
+
+			{ children && <div className="jetpack-cui__section-body">{ children }</div> }
+		</div>
+	);
+}

--- a/packages/connection-ui/_inc/components/section/index.jsx
+++ b/packages/connection-ui/_inc/components/section/index.jsx
@@ -14,13 +14,14 @@ import './style.scss';
  * @param {object} props         The properties.
  * @param {string} props.title   The section title.
  * @param {array} props.children The section title.
+ * @param {boolean} props.faded  Makes the section faded out.
  * @returns {JSX.Element}        The Section component.
  */
 export default function Section( props ) {
-	const { title, children } = props;
+	const { title, children, faded } = props;
 
 	return (
-		<div className="jetpack-cui__section">
+		<div className={ 'jetpack-cui__section ' + ( faded && 'faded' ) }>
 			<h2>{ title }</h2>
 
 			{ children && <div className="jetpack-cui__section-body">{ children }</div> }

--- a/packages/connection-ui/_inc/components/section/style.scss
+++ b/packages/connection-ui/_inc/components/section/style.scss
@@ -1,0 +1,7 @@
+#jetpack-connection-ui-container .jetpack-cui__section {
+	margin-top: 40px;
+
+	h2 {
+		margin: 0 0 8px 0;
+	}
+}

--- a/packages/connection-ui/_inc/components/section/style.scss
+++ b/packages/connection-ui/_inc/components/section/style.scss
@@ -1,6 +1,10 @@
 #jetpack-connection-ui-container .jetpack-cui__section {
 	margin-top: 40px;
 
+	&.faded {
+		opacity: 0.5;
+	}
+
 	h2 {
 		margin: 0 0 8px 0;
 	}

--- a/packages/connection-ui/_inc/definitions.scss
+++ b/packages/connection-ui/_inc/definitions.scss
@@ -1,0 +1,7 @@
+@mixin clearfix {
+	&:after {
+		content: "";
+		display: table;
+		clear: both;
+	}
+}

--- a/packages/connection-ui/_inc/reducers/connection-status.js
+++ b/packages/connection-ui/_inc/reducers/connection-status.js
@@ -6,6 +6,7 @@ import {
 	CONNECTION_STATUS_INACTIVE,
 	CONNECTION_STATUS_REFRESHING,
 	CONNECTION_STATUS_REFRESHED,
+	CONNECTION_STATUS_REFRESHED_RESET,
 } from '../actions/connection-status';
 
 const connectionStatus = ( state = {}, action ) => {
@@ -25,12 +26,19 @@ const connectionStatus = ( state = {}, action ) => {
 				...state,
 				isActive: false,
 				isRefreshing: true,
+				isRefreshed: false,
 			};
 		case CONNECTION_STATUS_REFRESHED:
 			return {
 				...state,
 				isActive: true,
 				isRefreshing: false,
+				isRefreshed: true,
+			};
+		case CONNECTION_STATUS_REFRESHED_RESET:
+			return {
+				...state,
+				isRefreshed: false,
 			};
 	}
 

--- a/packages/connection-ui/_inc/reducers/connection-status.js
+++ b/packages/connection-ui/_inc/reducers/connection-status.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import {
+	CONNECTION_STATUS_ACTIVE,
+	CONNECTION_STATUS_INACTIVE,
+	CONNECTION_STATUS_REFRESHING,
+	CONNECTION_STATUS_REFRESHED,
+} from '../actions/connection-status';
+
+const connectionStatus = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case CONNECTION_STATUS_ACTIVE:
+			return {
+				...state,
+				isActive: true,
+			};
+		case CONNECTION_STATUS_INACTIVE:
+			return {
+				...state,
+				isActive: false,
+			};
+		case CONNECTION_STATUS_REFRESHING:
+			return {
+				...state,
+				isActive: false,
+				isRefreshing: true,
+			};
+		case CONNECTION_STATUS_REFRESHED:
+			return {
+				...state,
+				isActive: true,
+				isRefreshing: false,
+			};
+	}
+
+	return state;
+};
+
+export default connectionStatus;

--- a/packages/connection-ui/_inc/reducers/index.js
+++ b/packages/connection-ui/_inc/reducers/index.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import connectionStatus from './connection-status';
+
+const reducer = combineReducers( {
+	connectionStatus,
+} );
+
+export default reducer;

--- a/packages/connection-ui/_inc/reducers/index.js
+++ b/packages/connection-ui/_inc/reducers/index.js
@@ -7,9 +7,11 @@ import { combineReducers } from '@wordpress/data';
  * Internal dependencies
  */
 import connectionStatus from './connection-status';
+import plugins from './plugins';
 
 const reducer = combineReducers( {
 	connectionStatus,
+	plugins,
 } );
 
 export default reducer;

--- a/packages/connection-ui/_inc/reducers/plugins.js
+++ b/packages/connection-ui/_inc/reducers/plugins.js
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+import {
+	PLUGIN_CONNECTED,
+	PLUGIN_DISCONNECTED,
+	PLUGIN_REQUEST_IN_PROGRESS,
+	PLUGIN_REQUEST_DONE,
+} from '../actions/plugins';
+
+const plugins = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case PLUGIN_CONNECTED:
+			if ( action.data && action.data.slug ) {
+				return {
+					...state,
+					all: ( state.all || [] ).map( plugin => {
+						plugin.slug === action.data.slug && ( plugin.isConnected = true );
+						return plugin;
+					} ),
+				};
+			}
+			break;
+		case PLUGIN_DISCONNECTED:
+			if ( action.data && action.data.slug ) {
+				return {
+					...state,
+					all: ( state.all || [] ).map( plugin => {
+						plugin.slug === action.data.slug && ( plugin.isConnected = false );
+						return plugin;
+					} ),
+				};
+			}
+			break;
+		case PLUGIN_REQUEST_IN_PROGRESS:
+			return {
+				...state,
+				isRequestInProgress: true,
+			};
+		case PLUGIN_REQUEST_DONE:
+			return {
+				...state,
+				isRequestInProgress: false,
+			};
+	}
+
+	return state;
+};
+
+export default plugins;

--- a/packages/connection-ui/_inc/selectors/connection-status.js
+++ b/packages/connection-ui/_inc/selectors/connection-status.js
@@ -1,7 +1,5 @@
 const connectionStatusSelectors = {
-	getConnectionStatus: state => {
-		return state.connectionStatus || {};
-	},
+	getConnectionStatus: state => state.connectionStatus || {},
 };
 
 export default connectionStatusSelectors;

--- a/packages/connection-ui/_inc/selectors/connection-status.js
+++ b/packages/connection-ui/_inc/selectors/connection-status.js
@@ -1,0 +1,7 @@
+const connectionStatusSelectors = {
+	getConnectionStatus: state => {
+		return state.connectionStatus || {};
+	},
+};
+
+export default connectionStatusSelectors;

--- a/packages/connection-ui/_inc/selectors/index.js
+++ b/packages/connection-ui/_inc/selectors/index.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import connectionStatusSelectors from './connection-status';
+
+const selectors = {
+	...connectionStatusSelectors,
+};
+
+export default selectors;

--- a/packages/connection-ui/_inc/selectors/index.js
+++ b/packages/connection-ui/_inc/selectors/index.js
@@ -2,9 +2,11 @@
  * Internal dependencies
  */
 import connectionStatusSelectors from './connection-status';
+import pluginSelectors from './plugins';
 
 const selectors = {
 	...connectionStatusSelectors,
+	...pluginSelectors,
 };
 
 export default selectors;

--- a/packages/connection-ui/_inc/selectors/plugins.js
+++ b/packages/connection-ui/_inc/selectors/plugins.js
@@ -1,0 +1,6 @@
+const pluginSelectors = {
+	getPlugins: state => state.plugins.all || [],
+	isRequestInProgress: state => state.plugins.isRequestInProgress || false,
+};
+
+export default pluginSelectors;

--- a/packages/connection-ui/_inc/store.js
+++ b/packages/connection-ui/_inc/store.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import reducer from './reducers';
+import actions from './actions';
+import selectors from './selectors';
+
+export const STORE_ID = 'jetpack-connection-ui';
+export const storeConfig = {
+	reducer,
+	actions,
+	selectors,
+	initialState: window.CUI_INITIAL_STATE || {},
+};

--- a/packages/connection-ui/composer.json
+++ b/packages/connection-ui/composer.json
@@ -1,0 +1,22 @@
+{
+	"name": "automattic/jetpack-connection-ui",
+	"description": "Jetpack Connection UI",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"automattic/jetpack-connection": "@dev"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*"
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
+}

--- a/packages/connection-ui/src/class-admin.php
+++ b/packages/connection-ui/src/class-admin.php
@@ -57,7 +57,10 @@ class Admin {
 			$build_assets = require_once __DIR__ . '/../build/index.asset.php';
 			wp_enqueue_script( 'jetpack_connection_ui_script', plugin_dir_url( __DIR__ ) . 'build/index.js', $build_assets['dependencies'], $build_assets['version'], true );
 
-			wp_enqueue_style( 'jetpack_connection_ui_style', plugin_dir_url( __DIR__ ) . 'build/index.css', array(), $build_assets['version'] );
+			wp_set_script_translations( 'react-jetpack_connection_ui_script', 'jetpack' );
+			wp_add_inline_script( 'jetpack_connection_ui_script', $this->get_initial_state(), 'before' );
+
+			wp_enqueue_style( 'jetpack_connection_ui_style', plugin_dir_url( __DIR__ ) . 'build/index.css', array( 'wp-components' ), $build_assets['version'] );
 			wp_style_add_data( 'jetpack_connection_ui_style', 'rtl', plugin_dir_url( __DIR__ ) . 'build/index.rtl.css' );
 		}
 	}
@@ -69,6 +72,15 @@ class Admin {
 		?>
 		<div id="jetpack-connection-ui-container"></div>
 		<?php
+	}
+
+	/**
+	 * Return the rendered initial state JavaScript code.
+	 *
+	 * @return string
+	 */
+	private function get_initial_state() {
+		return ( new Initial_State() )->render();
 	}
 
 }

--- a/packages/connection-ui/src/class-admin.php
+++ b/packages/connection-ui/src/class-admin.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * The Connection UI Admin Area.
+ *
+ * @package automattic/jetpack-connection-ui
+ */
+
+namespace Automattic\Jetpack\ConnectionUI;
+
+/**
+ * The Connection UI Admin Area
+ */
+class Admin {
+
+	/**
+	 * Construction.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_submenu_page' ), 1000 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Initialize the UI.
+	 */
+	public static function init() {
+		add_action(
+			'plugins_loaded',
+			function () {
+				new static();
+			}
+		);
+	}
+
+	/**
+	 * Register's submenu.
+	 */
+	public function register_submenu_page() {
+		add_menu_page(
+			'Connection Manager',
+			'Connection Manager',
+			'manage_options',
+			'wpcom-connection-manager',
+			array( $this, 'render_ui' ),
+			'dashicons-networking',
+			4
+		);
+	}
+
+	/**
+	 * Enqueue scripts!
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public function enqueue_scripts( $hook ) {
+		if ( strpos( $hook, 'toplevel_page_wpcom-connection-manager' ) === 0 ) {
+			$build_assets = require_once __DIR__ . '/../build/index.asset.php';
+			wp_enqueue_script( 'jetpack_connection_ui_script', plugin_dir_url( __DIR__ ) . 'build/index.js', $build_assets['dependencies'], $build_assets['version'], true );
+		}
+	}
+
+	/**
+	 * Render UI.
+	 */
+	public function render_ui() {
+		?>
+		<div id="jetpack-connection-ui-container"></div>
+		<?php
+	}
+
+}

--- a/packages/connection-ui/src/class-admin.php
+++ b/packages/connection-ui/src/class-admin.php
@@ -36,13 +36,13 @@ class Admin {
 	 * Register's submenu.
 	 */
 	public function register_submenu_page() {
-		add_menu_page(
+		add_submenu_page(
+			'tools.php',
 			'Connection Manager',
 			'Connection Manager',
 			'manage_options',
 			'wpcom-connection-manager',
 			array( $this, 'render_ui' ),
-			'dashicons-networking',
 			4
 		);
 	}
@@ -53,9 +53,12 @@ class Admin {
 	 * @param string $hook Page hook.
 	 */
 	public function enqueue_scripts( $hook ) {
-		if ( strpos( $hook, 'toplevel_page_wpcom-connection-manager' ) === 0 ) {
+		if ( strpos( $hook, 'tools_page_wpcom-connection-manager' ) === 0 ) {
 			$build_assets = require_once __DIR__ . '/../build/index.asset.php';
 			wp_enqueue_script( 'jetpack_connection_ui_script', plugin_dir_url( __DIR__ ) . 'build/index.js', $build_assets['dependencies'], $build_assets['version'], true );
+
+			wp_enqueue_style( 'jetpack_connection_ui_style', plugin_dir_url( __DIR__ ) . 'build/index.css', array(), $build_assets['version'] );
+			wp_style_add_data( 'jetpack_connection_ui_style', 'rtl', plugin_dir_url( __DIR__ ) . 'build/index.rtl.css' );
 		}
 	}
 

--- a/packages/connection-ui/src/class-initial-state.php
+++ b/packages/connection-ui/src/class-initial-state.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\ConnectionUI;
 
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Connection\Plugin_Storage;
 use Automattic\Jetpack\Connection\REST_Connector;
 
 /**
@@ -37,7 +38,38 @@ class Initial_State {
 	private function get_data() {
 		return array(
 			'connectionStatus' => REST_Connector::connection_status( false ) + array( 'isRefreshing' => false ),
+			'plugins'          => array(
+				'all' => $this->get_plugins(),
+			),
 		);
+	}
+
+	/**
+	 * Retrieve the list of plugins, and mark them as connected/disconnected.
+	 *
+	 * @return array
+	 */
+	private function get_plugins() {
+		$plugins          = Plugin_Storage::get_all();
+		$disabled_plugins = Plugin_Storage::get_all_disabled_plugins();
+
+		if ( is_wp_error( $plugins ) ) {
+			$plugins = array();
+		}
+
+		array_walk(
+			$plugins,
+			function ( &$plugin, $slug ) use ( $disabled_plugins ) {
+				$plugin = array(
+					'slug'        => $slug,
+					'name'        => empty( $plugin['name'] ) ? $slug : $plugin['name'],
+					'urlInfo'     => empty( $plugin['url_info'] ) ? null : $plugin['url_info'],
+					'isConnected' => ! in_array( $slug, $disabled_plugins, true ),
+				);
+			}
+		);
+
+		return array_values( $plugins );
 	}
 
 	/**

--- a/packages/connection-ui/src/class-initial-state.php
+++ b/packages/connection-ui/src/class-initial-state.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * The React initial state.
+ *
+ * @package automattic/jetpack-connection-ui
+ */
+
+namespace Automattic\Jetpack\ConnectionUI;
+
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Connection\REST_Connector;
+
+/**
+ * The React initial state.
+ */
+class Initial_State {
+
+	/**
+	 * The connection manager object.
+	 *
+	 * @var Manager
+	 */
+	private $manager;
+
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		$this->manager = new Manager();
+	}
+
+	/**
+	 * Get the initial state data.
+	 *
+	 * @return array
+	 */
+	private function get_data() {
+		return array(
+			'connectionStatus' => REST_Connector::connection_status( false ) + array( 'isRefreshing' => false ),
+		);
+	}
+
+	/**
+	 * Render the initial state into a JavaScript variable.
+	 *
+	 * @return string
+	 */
+	public function render() {
+		return 'var CUI_INITIAL_STATE=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $this->get_data() ) ) . '"));';
+	}
+
+}

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -271,7 +271,7 @@ class REST_Connector {
 				$redirect_url = null;
 
 				if ( ! empty( $request['from'] ) && 'connection-ui' === $request['from'] ) {
-					$redirect_url = admin_url( 'tools.php?page=wpcom-connection-manager' );
+					$redirect_url = admin_url( 'tools.php?page=wpcom-connection-manager#refreshed' );
 				}
 
 				$response['status']       = 'in_progress';

--- a/webpack.config.packages.js
+++ b/webpack.config.packages.js
@@ -1,4 +1,23 @@
+/**
+ * External dependencies
+ */
+const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
+const StaticSiteGeneratorPlugin = require( 'static-site-generator-webpack-plugin' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+const baseConfigs = {
+	connection: getBaseWebpackConfig(
+		{ WP: false },
+		{
+			entry: {}, // We'll override later
+			'output-filename': '[name].js',
+			'output-path': path.join( __dirname, './packages/connection-ui/build' ),
+		}
+	),
+};
 
 module.exports = [
 	{
@@ -18,5 +37,22 @@ module.exports = [
 			path: path.resolve( __dirname, 'packages/lazy-images/src/js' ),
 			filename: 'intersectionobserver-polyfill.min.js',
 		},
+	},
+	{
+		...baseConfigs.connection,
+		resolve: {
+			...baseConfigs.connection.resolve,
+			modules: [ path.resolve( __dirname, '_inc/client' ), 'node_modules' ],
+		},
+		node: {
+			fs: 'empty',
+			process: true,
+		},
+		devtool: isDevelopment ? 'source-map' : false,
+		entry: { index: path.join( __dirname, './packages/connection-ui/_inc/admin.js' ) },
+		plugins: [
+			...baseConfigs.connection.plugins,
+			new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
+		],
 	},
 ];

--- a/webpack.config.packages.js
+++ b/webpack.config.packages.js
@@ -49,7 +49,7 @@ module.exports = [
 			process: true,
 		},
 		devtool: isDevelopment ? 'source-map' : false,
-		entry: { index: path.join( __dirname, './packages/connection-ui/_inc/admin.js' ) },
+		entry: { index: path.join( __dirname, './packages/connection-ui/_inc/admin.jsx' ) },
 		plugins: [
 			...baseConfigs.connection.plugins,
 			new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The Connection UI

#### Jetpack product discussion
p9dueE-1vM-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Using plugins like Client Example and Jetpack Boost to test it will require symlinking the latest version of `jetpack-connection` from those plugins.
An alternative would be to create a plugin with following code, which will emulate having two plugins that use the connection:

<details>
<summary>Unfold the plugin</summary>

```php
<?php
/** Plugin Name: Jetpack Connection Manager Test 1 */

use Automattic\Jetpack\Config;

add_action( 'plugins_loaded', function() {
	$config = new Config();
	$config->ensure(
		'connection',
		array(
			'slug'     => 'plugin-1',
			'name'     => 'Plugin 1',
			'url_info' => 'https://github.com/Automattic/jurassic-tube-backend'
		)
	);

	$config = new Config();
	$config->ensure(
		'connection',
		array(
			'slug'     => 'plugin-2',
			'name'     => 'Plugin 2',
			'url_info' => 'https://github.com/Automattic/jurassic-tube'
		)
	);
}, 1 );
```
</details>

**This is the UI you should see:**
<img width="420" alt="Screen Shot 2021-01-08 at 4 55 24 PM" src="https://user-images.githubusercontent.com/1341249/104200786-aa55be80-53ee-11eb-87a4-d35f2973908e.png">


1. Connect Jetpack, go to "Tools -> Connection Manager".
2. Click "Refresh Connection". Confirm that the button has changed the label and no longer clickable. You will be taken to the Calypso flow for reconnecting (no in-place flow yet).
3. After reconnecting you'll be redirected back to Connection Manager. The "Refresh Connection" button should become green for 5 seconds.
4. Use the "Broken Token" plugin to set an invalid blog token.
5. Click "Refresh Connection" again. The button should be disabled, and then turn green. Use "Broken Token" plugin to confirm that the blog token has been restored.
6. Click "Disconnect" for a plugin. The button label should change to "Connect".
7. Reload the page, confirm that the disconnected state persists for that plugin.
8. If you're testing on actual plugins (e.g. Client Example or Jetpack Boost), try "disconnecting" them from Connection Manager and confirm that they get softly disconnected.
9. Try connecting them back, and confirm that the plugins are connected again with no need to go through the connection flow.

#### Proposed changelog entry for your changes:
* User Interface for managing connection to the WordPress.com
