### PR TITLE
EU Cookie Widget: Ensure the widget exists before trying to call a method on it

### DIFF
--- a/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -5,7 +5,7 @@
 		),
 		overlay = document.getElementById( 'eu-cookie-law' ),
 		widget = document.querySelector( '.widget_eu_cookie_law_widget' ),
-		inCustomizer = widget.hasAttribute( 'data-customize-widget-id' ),
+		inCustomizer = widget && widget.hasAttribute( 'data-customize-widget-id' ),
 		getScrollTop,
 		initialScrollPosition,
 		scrollFunction;


### PR DESCRIPTION
Fixes #17560. 

There are cases when the cookie banner JS is loaded but the banner not present in the DOM (I had an example on a checkout page). Introduced in #16927, we try to access a method on `null`. When combined with JS concattenation this can cause a cascade of missing JS, causing other random failures.

#### Testing instructions:
1. Ensure you have extra widgets turned on in Jetpack settings.
2. Add the "Cookies & Consent" widget to your site into a widget area that's not available on all pages.
3. Accept the Cookie warning somewhere on the site.
4. Go to a page without the EU cookie in the widget area.
5. Observe that no JS error warning appears.

#### Proposed changelog entry for your changes:

* Widgets: avoid JavaScript errors when displaying the Cookies & Consent Widget.

#### Privacy:
No implications.