### PR TITLE
Contact Form: remove unnecessary calls to wp_transition_post_status

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -616,14 +616,12 @@ function grunion_ajax_spam() {
 	if ( $_POST['make_it'] == 'spam' ) {
 		$post->post_status = 'spam';
 		$status            = wp_insert_post( $post );
-		wp_transition_post_status( 'spam', 'publish', $post );
 
 		/** This action is already documented in modules/contact-form/admin.php */
 		do_action( 'contact_form_akismet', 'spam', $akismet_values );
 	} elseif ( $_POST['make_it'] == 'ham' ) {
 		$post->post_status = 'publish';
 		$status            = wp_insert_post( $post );
-		wp_transition_post_status( 'publish', 'spam', $post );
 
 		/** This action is already documented in modules/contact-form/admin.php */
 		do_action( 'contact_form_akismet', 'ham', $akismet_values );

--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -831,6 +831,7 @@ add_action( 'admin_enqueue_scripts', 'grunion_add_admin_scripts' );
 function grunion_check_for_spam_button() {
 	// Nonce name.
 	$nonce_name = 'jetpack_check_feedback_spam_' . (string) get_current_blog_id();
+
 	// Get HTML for the button.
 	$button_html  = get_submit_button(
 		__( 'Check for Spam', 'jetpack' ),

--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -831,7 +831,6 @@ add_action( 'admin_enqueue_scripts', 'grunion_add_admin_scripts' );
 function grunion_check_for_spam_button() {
 	// Nonce name.
 	$nonce_name = 'jetpack_check_feedback_spam_' . (string) get_current_blog_id();
-
 	// Get HTML for the button.
 	$button_html  = get_submit_button(
 		__( 'Check for Spam', 'jetpack' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
In the `grunion_ajax_spam()` method, we call `wp_insert_post()` then call `wp_transition_post_status()`. `wp_transition_post_status()` is also [called in `wp_insert_post`](https://core.trac.wordpress.org/browser/tags/5.6/src/wp-includes/post.php#L4209), causing the [actions](https://core.trac.wordpress.org/browser/tags/5.6/src/wp-includes/post.php#L4892) in `wp_transition_post_status()` to be fired twice.

Let's fix this by removing the `wp_transition_post_status()` calls from `grunion_ajax_spam()`.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

To test this change, we’ll add a hook on the `transition_post_status` action, which is [fired](https://core.trac.wordpress.org/browser/tags/5.6/src/wp-includes/post.php#L4902) in `wp_transition_post_status`. We'll use that hook to verify that the action is fired only once when a feedback post is marked as spam or not spam.

1. Add this snippet or something similar to your test site:
```
add_action( 'transition_post_status', 'test_post_status_change', 10, 3 );

function test_post_status_change( $new_status, $old_status, $post ) {
	error_log( ‘changing status of post ‘ . $post->ID . ‘ from ‘ . $old_status . ‘ to ‘ . $new_status);
}

```

2. Install, activate, and connect the stable branch of Jetpack.
3. Create a new post with a Contact Form.
4. Navigate to the post created in step 2. Fill out and submit the contact form.
5. Navigate to `wp-admin -> Feedback`.
6. Hover over the feedback post and click `Spam` to change the post’s status to `spam`.
7. Check the error log and notice that the `transition_post_status` action was fired twice.
8. Navigate to `wp-admin -> Feedback` and click the spam link. Hover over the feedback post and click `Not Spam` to change the post’s status to `published`.
9. Check the error log and notice that the `transition_post_status` action was fired twice.
10. Apply this branch.
11. Repeat steps 5 - 9. Verify that the `transition_post_status` action was fired just once for each post status change.

#### Proposed changelog entry for your changes:
I don't think a changelog entry is actually needed for these changes, but here's an proposed changelog entry just in case:
* Contact Form: prevent post status transition actions from firing twice when the post status is changed.
