### PR TITLE
Autoloader: Don't cache deactivating plugins

### DIFF
--- a/packages/autoloader/src/class-autoloader.php
+++ b/packages/autoloader/src/class-autoloader.php
@@ -74,10 +74,12 @@ class Autoloader {
 					return;
 				}
 
-				// Load the active plugins fresh since the list we have above might not contain
+				// Load the active plugins fresh since the list we pulled earlier might not contain
 				// plugins that were activated but did not reset the autoloader. This happens
-				// because they were already included in the cache.
-				$active_plugins = $plugins_handler->get_active_plugins();
+				// when a plugin is in the cache but not "active" when the autoloader loads.
+				// We also want to make sure that plugins which are deactivating are not
+				// considered "active" so that they will be removed from the cache now.
+				$active_plugins = $plugins_handler->get_active_plugins( false );
 
 				// The paths should be sorted for easy comparisons with those loaded from the cache.
 				// Note we don't need to sort the cached entries because they're already sorted.

--- a/packages/autoloader/src/class-plugin-locator.php
+++ b/packages/autoloader/src/class-plugin-locator.php
@@ -59,11 +59,12 @@ class Plugin_Locator {
 	}
 
 	/**
-	 * Checks for plugins that are being activated in this request and returns all that it finds.
+	 * Checks for plugins in the `action` request parameter.
 	 *
+	 * @param string[] $allowed_actions The actions that we're allowed to return plugins for.
 	 * @return array $plugin_paths The list of absolute paths we've found.
 	 */
-	public function find_activating_this_request() {
+	public function find_using_request_action( $allowed_actions ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 
 		/**
@@ -77,11 +78,15 @@ class Plugin_Locator {
 			return array();
 		}
 
-		$plugin_slugs = array();
-
 		$action = isset( $_REQUEST['action'] ) ? wp_unslash( $_REQUEST['action'] ) : false;
+		if ( ! in_array( $action, $allowed_actions, true ) ) {
+			return array();
+		}
+
+		$plugin_slugs = array();
 		switch ( $action ) {
 			case 'activate':
+			case 'deactivate':
 				if ( empty( $_REQUEST['plugin'] ) ) {
 					break;
 				}
@@ -90,6 +95,7 @@ class Plugin_Locator {
 				break;
 
 			case 'activate-selected':
+			case 'deactivate-selected':
 				if ( empty( $_REQUEST['checked'] ) ) {
 					break;
 				}
@@ -98,6 +104,7 @@ class Plugin_Locator {
 				break;
 		}
 
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		return $this->convert_plugins_to_paths( $plugin_slugs );
 	}
 

--- a/packages/autoloader/src/class-plugins-handler.php
+++ b/packages/autoloader/src/class-plugins-handler.php
@@ -73,7 +73,8 @@ class Plugins_Handler {
 			}
 		}
 
-		$plugins = $this->plugin_locator->find_activating_this_request();
+		// These actions contain plugins that are being activated during this request.
+		$plugins = $this->plugin_locator->find_using_request_action( array( 'activate', 'activate-selected' ) );
 		foreach ( $plugins as $path ) {
 			$active_plugins[ $path ] = $path;
 		}

--- a/packages/autoloader/tests/php/tests/integration/test-autoloader-scenarios.php
+++ b/packages/autoloader/tests/php/tests/integration/test-autoloader-scenarios.php
@@ -260,6 +260,28 @@ class Test_Autoloader_Scenarios extends TestCase {
 	}
 
 	/**
+	 * Tests that the autoloader does not cache plugins that are deactivating in the request.
+	 */
+	public function test_autoloader_does_not_cache_deactivating_plugins() {
+		// Make sure to cache the plugin so that the cache is dirty on shutdown.
+		$this->cache_plugins( array( 'plugin_current' ) );
+
+		// Make sure that we're deactivating the plugin in the request.
+		$_REQUEST['_wpnonce'] = '123abc';
+		$_REQUEST['action']   = 'deactivate';
+		$_REQUEST['plugin']   = 'plugin_current/plugin_current.php';
+
+		$this->activate_plugin( 'plugin_current' );
+
+		$this->load_autoloader( 'plugin_current' );
+
+		$this->shutdown_autoloader( true );
+
+		$this->assertAutoloaderVersion( '2.6.0.0' );
+		$this->assertAutoloaderCache( array() );
+	}
+
+	/**
 	 * Generates a new autoloader from the current source files for the "plugin_current" plugin.
 	 *
 	 * @param string $plugin The plugin to generate the autoloader for.

--- a/packages/autoloader/tests/php/tests/unit/test-plugin-locator.php
+++ b/packages/autoloader/tests/php/tests/unit/test-plugin-locator.php
@@ -177,32 +177,59 @@ class Test_Plugin_Locator extends TestCase {
 	}
 
 	/**
-	 * Tests that plugins activating this request are not discovered if a nonce is not set.
+	 * Tests that plugins in request parameters are not discovered if a nonce is not set.
 	 */
-	public function test_activating_this_request_does_nothing_without_nonce() {
+	public function test_using_request_action_returns_nothing_without_nonce() {
 		$_REQUEST['action'] = 'activate';
 		$_REQUEST['plugin'] = 'dummy_current/dummy_current.php';
 
-		$plugin_paths = $this->locator->find_activating_this_request();
+		$plugin_paths = $this->locator->find_using_request_action( array( 'activate' ) );
+
+		$this->assertTrue( is_array( $plugin_paths ) );
+		$this->assertEmpty( $plugin_paths );
+
+		$_REQUEST['action'] = 'deactivate';
+		$_REQUEST['plugin'] = 'dummy_current/dummy_current.php';
+
+		$plugin_paths = $this->locator->find_using_request_action( array( 'deactivate' ) );
+
+		$this->assertTrue( is_array( $plugin_paths ) );
+		$this->assertEmpty( $plugin_paths );
+
+		$_REQUEST['action']  = 'activate-selected';
+		$_REQUEST['checked'] = array( 'dummy_current/dummy_current.php' );
+
+		$plugin_paths = $this->locator->find_using_request_action( array( 'activate-selected' ) );
 
 		$this->assertTrue( is_array( $plugin_paths ) );
 		$this->assertEmpty( $plugin_paths );
 	}
 
 	/**
-	 * Tests that plugins activating this request are not discovered if there aren't any.
+	 * Tests that plugins in the request action are not found if the action is not found.
 	 */
-	public function test_activating_this_request_does_nothing_without_parameters() {
-		$plugin_paths = $this->locator->find_activating_this_request();
+	public function test_using_request_action_returns_nothing_without_action() {
+		$_REQUEST['_wpnonce'] = '123abc';
+		$_REQUEST['action']   = '';
+
+		$plugin_paths = $this->locator->find_using_request_action( array( 'activate' ) );
+
+		$this->assertTrue( is_array( $plugin_paths ) );
+		$this->assertEmpty( $plugin_paths );
+
+		$_REQUEST['action'] = 'activate';
+		$_REQUEST['plugin'] = 'dummy_current\\\\dummy_current.php';
+
+		$plugin_paths = $this->locator->find_using_request_action( array() );
 
 		$this->assertTrue( is_array( $plugin_paths ) );
 		$this->assertEmpty( $plugin_paths );
 	}
 
 	/**
-	 * Tests that single plugins activating this request are found.
+	 * Tests that plugins in the request action can be found for single actions.
 	 */
-	public function test_activating_this_request_works_for_single() {
+	public function test_using_request_action_works_for_single() {
 		$_REQUEST['_wpnonce'] = '123abc';
 		$_REQUEST['action']   = 'activate';
 		$_REQUEST['plugin']   = 'dummy_current\\\\dummy_current.php';
@@ -215,7 +242,7 @@ class Test_Plugin_Locator extends TestCase {
 			)
 			->willReturnOnConsecutiveCalls( false, TEST_DATA_PATH . '/plugins/dummy_current' );
 
-		$plugin_paths = $this->locator->find_activating_this_request();
+		$plugin_paths = $this->locator->find_using_request_action( array( 'activate' ) );
 
 		$this->assertTrue( is_array( $plugin_paths ) );
 		$this->assertCount( 1, $plugin_paths );
@@ -223,9 +250,9 @@ class Test_Plugin_Locator extends TestCase {
 	}
 
 	/**
-	 * Tests that multiple plugins activating this request are found.
+	 * Tests that plugins in the request action can be found for multiple actions.
 	 */
-	public function test_activating_this_request_works_for_multiple() {
+	public function test_using_request_action_works_for_multiple() {
 		$_REQUEST['_wpnonce'] = '123abc';
 		$_REQUEST['action']   = 'activate-selected';
 		$_REQUEST['checked']  = array( 'dummy_current\\\\dummy_current.php' );
@@ -238,7 +265,7 @@ class Test_Plugin_Locator extends TestCase {
 			)
 			->willReturnOnConsecutiveCalls( false, TEST_DATA_PATH . '/plugins/dummy_current' );
 
-		$plugin_paths = $this->locator->find_activating_this_request();
+		$plugin_paths = $this->locator->find_using_request_action( array( 'activate-selected' ) );
 
 		$this->assertTrue( is_array( $plugin_paths ) );
 		$this->assertCount( 1, $plugin_paths );

--- a/packages/autoloader/tests/php/tests/unit/test-plugins-handler.php
+++ b/packages/autoloader/tests/php/tests/unit/test-plugins-handler.php
@@ -71,10 +71,16 @@ class Test_Plugins_Handler extends TestCase {
 			->method( 'find_using_option' )
 			->with( 'active_plugins', false )
 			->willReturn( array( TEST_DATA_PATH . '/plugins/dummy_current' ) );
-		$this->plugin_locator->expects( $this->once() )
+		$this->plugin_locator->expects( $this->exactly( 2 ) )
 			->method( 'find_using_request_action' )
-			->with( array( 'activate', 'activate-selected' ) )
-			->willReturn( array( TEST_DATA_PATH . '/plugins/dummy_dev' ) );
+			->withConsecutive(
+				array( array( 'activate', 'activate-selected' ) ),
+				array( array( 'deactivate', 'deactivate-selected' ) )
+			)
+			->willReturnOnConsecutiveCalls(
+				array( TEST_DATA_PATH . '/plugins/dummy_dev' ),
+				array()
+			);
 		$this->plugin_locator->expects( $this->once() )
 			->method( 'find_current_plugin' )
 			->willReturn( TEST_DATA_PATH . '/plugins/dummy_newer' );
@@ -110,10 +116,16 @@ class Test_Plugins_Handler extends TestCase {
 				array( TEST_DATA_PATH . '/plugins/dummy_current' ),
 				array( TEST_DATA_PATH . '/plugins/dummy_newer' )
 			);
-		$this->plugin_locator->expects( $this->once() )
+		$this->plugin_locator->expects( $this->exactly( 2 ) )
 			->method( 'find_using_request_action' )
-			->with( array( 'activate', 'activate-selected' ) )
-			->willReturn( array( TEST_DATA_PATH . '/plugins/dummy_dev' ) );
+			->withConsecutive(
+				array( array( 'activate', 'activate-selected' ) ),
+				array( array( 'deactivate', 'deactivate-selected' ) )
+			)
+			->willReturnOnConsecutiveCalls(
+				array( TEST_DATA_PATH . '/plugins/dummy_dev' ),
+				array()
+			);
 		$this->plugin_locator->expects( $this->once() )
 			->method( 'find_current_plugin' )
 			->willReturn( TEST_DATA_PATH . '/plugins' );
@@ -140,10 +152,16 @@ class Test_Plugins_Handler extends TestCase {
 			->method( 'find_using_option' )
 			->with( 'active_plugins', false )
 			->willReturn( array() );
-		$this->plugin_locator->expects( $this->once() )
+		$this->plugin_locator->expects( $this->exactly( 2 ) )
 			->method( 'find_using_request_action' )
-			->with( array( 'activate', 'activate-selected' ) )
-			->willReturn( array() );
+			->withConsecutive(
+				array( array( 'activate', 'activate-selected' ) ),
+				array( array( 'deactivate', 'deactivate-selected' ) )
+			)
+			->willReturnOnConsecutiveCalls(
+				array(),
+				array()
+			);
 		$this->plugin_locator->expects( $this->once() )
 			->method( 'find_current_plugin' )
 			->willReturn( TEST_DATA_PATH . '/plugins/dummy_newer' );
@@ -173,10 +191,16 @@ class Test_Plugins_Handler extends TestCase {
 			->method( 'find_using_option' )
 			->with( 'active_plugins', false )
 			->willReturn( array() );
-		$this->plugin_locator->expects( $this->once() )
+		$this->plugin_locator->expects( $this->exactly( 2 ) )
 			->method( 'find_using_request_action' )
-			->with( array( 'activate', 'activate-selected' ) )
-			->willReturn( array() );
+			->withConsecutive(
+				array( array( 'activate', 'activate-selected' ) ),
+				array( array( 'deactivate', 'deactivate-selected' ) )
+			)
+			->willReturnOnConsecutiveCalls(
+				array(),
+				array()
+			);
 		$this->plugin_locator->expects( $this->once() )
 			->method( 'find_current_plugin' )
 			->willReturn( TEST_DATA_PATH . '/plugins/dummy_newer' );
@@ -187,6 +211,74 @@ class Test_Plugins_Handler extends TestCase {
 
 		global $jetpack_autoloader_activating_plugins_paths;
 		$this->assertEmpty( $jetpack_autoloader_activating_plugins_paths );
+	}
+
+	/**
+	 * Tests that the active plugin list includes those are deactivating
+	 */
+	public function test_gets_active_plugins_includes_deactivating() {
+		global $jetpack_autoloader_activating_plugins_paths;
+		$jetpack_autoloader_activating_plugins_paths = array();
+		$this->plugin_locator->expects( $this->once() )
+			->method( 'find_using_option' )
+			->with( 'active_plugins', false )
+			->willReturn( array() );
+		$this->plugin_locator->expects( $this->exactly( 2 ) )
+			->method( 'find_using_request_action' )
+			->withConsecutive(
+				array( array( 'activate', 'activate-selected' ) ),
+				array( array( 'deactivate', 'deactivate-selected' ) )
+			)
+			->willReturnOnConsecutiveCalls(
+				array(),
+				array( TEST_DATA_PATH . '/plugins/dummy_newer' )
+			);
+		$this->plugin_locator->expects( $this->once() )
+			->method( 'find_current_plugin' )
+			->willReturn( TEST_DATA_PATH . '/plugins/dummy_current' );
+
+		$plugin_paths = $this->plugins_handler->get_active_plugins();
+
+		$this->assertEquals(
+			array(
+				TEST_DATA_PATH . '/plugins/dummy_newer',
+				TEST_DATA_PATH . '/plugins/dummy_current',
+			),
+			$plugin_paths
+		);
+	}
+
+	/**
+	 * Tests that the active plugin list excludes those that are deactivating.
+	 */
+	public function test_gets_active_plugins_excludes_deactivating() {
+		global $jetpack_autoloader_activating_plugins_paths;
+		$jetpack_autoloader_activating_plugins_paths = array();
+		$this->plugin_locator->expects( $this->once() )
+			->method( 'find_using_option' )
+			->with( 'active_plugins', false )
+			->willReturn( array( TEST_DATA_PATH . '/plugins/dummy_newer' ) );
+		$this->plugin_locator->expects( $this->exactly( 2 ) )
+			->method( 'find_using_request_action' )
+			->withConsecutive(
+				array( array( 'activate', 'activate-selected' ) ),
+				array( array( 'deactivate', 'deactivate-selected' ) )
+			)
+			->willReturnOnConsecutiveCalls(
+				array( TEST_DATA_PATH . '/plugins/dummy_dev' ),
+				array(
+					TEST_DATA_PATH . '/plugins/dummy_current',
+					TEST_DATA_PATH . '/plugins/dummy_newer',
+					TEST_DATA_PATH . '/plugins/dummy_dev',
+				)
+			);
+		$this->plugin_locator->expects( $this->once() )
+			->method( 'find_current_plugin' )
+			->willReturn( TEST_DATA_PATH . '/plugins/dummy_current' );
+
+		$plugin_paths = $this->plugins_handler->get_active_plugins( false );
+
+		$this->assertEmpty( $plugin_paths );
 	}
 
 	/**

--- a/packages/autoloader/tests/php/tests/unit/test-plugins-handler.php
+++ b/packages/autoloader/tests/php/tests/unit/test-plugins-handler.php
@@ -72,7 +72,8 @@ class Test_Plugins_Handler extends TestCase {
 			->with( 'active_plugins', false )
 			->willReturn( array( TEST_DATA_PATH . '/plugins/dummy_current' ) );
 		$this->plugin_locator->expects( $this->once() )
-			->method( 'find_activating_this_request' )
+			->method( 'find_using_request_action' )
+			->with( array( 'activate', 'activate-selected' ) )
 			->willReturn( array( TEST_DATA_PATH . '/plugins/dummy_dev' ) );
 		$this->plugin_locator->expects( $this->once() )
 			->method( 'find_current_plugin' )
@@ -110,7 +111,8 @@ class Test_Plugins_Handler extends TestCase {
 				array( TEST_DATA_PATH . '/plugins/dummy_newer' )
 			);
 		$this->plugin_locator->expects( $this->once() )
-			->method( 'find_activating_this_request' )
+			->method( 'find_using_request_action' )
+			->with( array( 'activate', 'activate-selected' ) )
 			->willReturn( array( TEST_DATA_PATH . '/plugins/dummy_dev' ) );
 		$this->plugin_locator->expects( $this->once() )
 			->method( 'find_current_plugin' )
@@ -139,7 +141,8 @@ class Test_Plugins_Handler extends TestCase {
 			->with( 'active_plugins', false )
 			->willReturn( array() );
 		$this->plugin_locator->expects( $this->once() )
-			->method( 'find_activating_this_request' )
+			->method( 'find_using_request_action' )
+			->with( array( 'activate', 'activate-selected' ) )
 			->willReturn( array() );
 		$this->plugin_locator->expects( $this->once() )
 			->method( 'find_current_plugin' )
@@ -171,7 +174,8 @@ class Test_Plugins_Handler extends TestCase {
 			->with( 'active_plugins', false )
 			->willReturn( array() );
 		$this->plugin_locator->expects( $this->once() )
-			->method( 'find_activating_this_request' )
+			->method( 'find_using_request_action' )
+			->with( array( 'activate', 'activate-selected' ) )
 			->willReturn( array() );
 		$this->plugin_locator->expects( $this->once() )
 			->method( 'find_current_plugin' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In #17667 we added a cache containing all of the active plugins on shutdown to prevent unnecessary autoloader resets. A consequence of this change is that deactivated plugins will be present in the autoloader cache for the first request following their deactivation. This is generally harmless since we're only populating the autoloader with their class manifests, but in some cases, it might lead to undesirable behavior. 

With WooCommerce and its autoloaded feature plugins we have the following scenario (I'll note that the impact of this is harmless but I don't see a reason we shouldn't be more defensive.):
* WooCommerce with embedded Blocks 1.1
* WooCommerce Blocks 1.2
* When the Blocks plugin is deactivated the embedded Blocks will think it is version 1.2 in the first request following deactivation.

This PR adds a mechanism for detecting plugins that are deactivating in the request and does not save them to the cache. We're using the `action` request parameter here as well and so it's worth noting this does not work for the CLI. I considered using [register_deactivation_hook](https://developer.wordpress.org/reference/functions/register_deactivation_hook/) but felt that dealing with all of the potential usages of `deactivate_plugins()` might lead to other bugs.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Add `add_filter( 'wp_redirect', '__return_false' );` as a filter. This is necessary so that after deactivating the plugin we don't invalidate the cache with a refresh.
* Ensure that the autoloader `jetpack_autoloader_plugin_paths` transient cache does not contain plugins deactivated using the plugin interface.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Autoloader: ensure deactivating plugins aren't cached.
