### PR TITLE
Anchor.fm: add conversation block to simple template

### DIFF
--- a/extensions/blocks/anchor-fm/templates/index.js
+++ b/extensions/blocks/anchor-fm/templates/index.js
@@ -47,12 +47,38 @@ function podcastSection( { episodeTrack } ) {
 function podcastSummarySection( { episodeTrack } ) {
 	return [ 'core/group', {}, [
 		[ 'core/heading', {
+			level: 3,
 			content: 'Summary',
 			placeholder: __( 'Podcast episode title', 'jetpack' ),
 		} ],
 		[ 'core/paragraph', {
 			placeholder: __( 'Podcast episode summary', 'jetpack' ),
 			content: episodeTrack.description,
+		} ],
+	] ];
+}
+
+function podcastConversationSection() {
+	return [ 'jetpack/conversation', {}, [
+		[ 'core/heading', {
+			level: 3,
+			content: 'Transcription',
+			placeholder: __( 'Podcast episode transcription', 'jetpack' ),
+		} ],
+		[ 'jetpack/dialogue', {
+			placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+			participantSlug: 'participant-0',
+			hasBoldStyle: true
+		} ],
+		[ 'jetpack/dialogue', {
+			placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+			participantSlug: 'participant-1',
+			hasBoldStyle: true
+		} ],
+		[ 'jetpack/dialogue', {
+			placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+			participantSlug: 'participant-2',
+			hasBoldStyle: true
 		} ],
 	] ];
 }
@@ -72,6 +98,7 @@ function episodeBasicTemplate( {
 	}
 
 	tpl.push( podcastSummarySection( { episodeTrack } ) );
+	tpl.push( podcastConversationSection() );
 
 	return tpl;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

~IMPORTANT~
=========
~This PR was branched off https://github.com/Automattic/jetpack/pull/18046, so let's hold on until #18046 merges.~


This PR adds is part of the anchor.fm -> WordPress.com flow, adding a `conversation` block when a new site episode post is created.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Anchor.fm: add conversation block to simple template

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post, but passing podcast data in the query string. You can use the following URL, changing the hostname if it's the case:
http://localhost:8888/wp-admin/post-new.php?action=edit&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q

* Among some blocks, you should see the `conversation` block, with the `Transcription` heading and three `dialogue` blocks:

Conversation block | Outline
---------|----------
![image](https://user-images.githubusercontent.com/77539/103543931-116af480-4e7e-11eb-838e-b3abc6486520.png) | ![image](https://user-images.githubusercontent.com/77539/103543998-26e01e80-4e7e-11eb-820a-932b5bbf1409.png)



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Anchor.fm: add conversation block to simple template
