### PR TITLE
Preventing CSS output when no elements

### DIFF
--- a/modules/theme-tools/content-options/post-details.php
+++ b/modules/theme-tools/content-options/post-details.php
@@ -40,6 +40,11 @@ function jetpack_post_details_enqueue_scripts() {
 		$elements[] = $comment;
 	}
 
+	// No need to output any CSS if there are no elements.
+	if ( empty( $elements ) ) {
+		return;
+	}
+
 	// Get the list of classes.
 	$elements = implode( ', ', $elements );
 


### PR DESCRIPTION
Fixes #18198

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Returning before outputting CSS if no `$elements`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The testing is different for each theme. However, I've tested the fix myself and it is working perfectly fine.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Preventing content options post details CSS output when there are no selectors to bind to