### PR TITLE
Add checksum_disable as a valid param of sync/settings endpoint

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -564,7 +564,7 @@ $sync_settings_response = array(
 	'post_meta_whitelist'      => '(array|string|bool=false) List of post meta to be included in sync. Send "empty" to unset.',
 	'comment_meta_whitelist'   => '(array|string|bool=false) List of comment meta to be included in sync. Send "empty" to unset.',
 	'disable'                  => '(int|bool=false) Set to 1 or true to disable sync entirely.',
-	'checksum_disable'         => '(int|bool=false) Set to 1 or true to disable sync entirely.',
+	'checksum_disable'         => '(int|bool=false) Set to 1 or true to disable checksums entirely.',
 	'render_filtered_content'  => '(int|bool=true) Set to 1 or true to render filtered content.',
 	'max_enqueue_full_sync'    => '(int|bool=false) Maximum number of rows to enqueue during each full sync process',
 	'max_queue_size_full_sync' => '(int|bool=false) Maximum queue size that full sync is allowed to use',

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -564,6 +564,7 @@ $sync_settings_response = array(
 	'post_meta_whitelist'      => '(array|string|bool=false) List of post meta to be included in sync. Send "empty" to unset.',
 	'comment_meta_whitelist'   => '(array|string|bool=false) List of comment meta to be included in sync. Send "empty" to unset.',
 	'disable'                  => '(int|bool=false) Set to 1 or true to disable sync entirely.',
+	'checksum_disable'         => '(int|bool=false) Set to 1 or true to disable sync entirely.',
 	'render_filtered_content'  => '(int|bool=true) Set to 1 or true to render filtered content.',
 	'max_enqueue_full_sync'    => '(int|bool=false) Maximum number of rows to enqueue during each full sync process',
 	'max_queue_size_full_sync' => '(int|bool=false) Maximum queue size that full sync is allowed to use',


### PR DESCRIPTION
The sync/settings endpoint allows remote update of sync settings to optimize sync behavior. This update allows for the enabling/disabling of checksums.

#### Changes proposed in this Pull Request:
* 9.3 includes the addition of a checksum_disable option that can toggle if a site allows checksum validation. This exposes it to the sync/settings API for management.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Require D54844 and D54845 for testing
Verify that you can toggle the "Disable Checksums" option in Jetpack Debugger and it persists on save.

#### Proposed changelog entry for your changes:
* N/A - this change is under the umbrella of Sync Checksums.
