### PR TITLE
Podcast Player: Single Episode Options 

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -39,10 +39,11 @@ class Jetpack_Podcast_Helper {
 	 * @return array|WP_Error  The player data or a error object.
 	 */
 	public function get_player_data( $args = array() ) {
-		$guid = ! empty( $args['guid'] ) ? $args['guid'] : false;
+		$guid  = ! empty( $args['guid'] ) ? $args['guid'] : '';
+		$query = ! empty( $args['query'] ) ? $args['query'] : '';
 
 		// Try loading data from the cache.
-		$transient_key = 'jetpack_podcast_' . md5( $this->feed . $guid ? "-$guid" : '' );
+		$transient_key = 'jetpack_podcast_' . md5( $this->feed . ":id:$guid:query:$query" );
 		$player_data   = get_transient( $transient_key );
 
 		// Fetch data if we don't have any cached.
@@ -55,11 +56,11 @@ class Jetpack_Podcast_Helper {
 			}
 
 			// Get tracks or a single episode.
-			if ( false !== $guid ) {
+			if ( ! empty( $guid ) ) {
 				$track  = $this->get_track_data( $guid );
 				$tracks = is_wp_error( $track ) ? null : array( $track );
-			} elseif ( ! empty( $args['query'] ) ) {
-				$tracks = $this->search_tracks( $args['query'] );
+			} elseif ( ! empty( $query ) ) {
+				$tracks = $this->search_tracks( $query );
 				$tracks = is_wp_error( $tracks ) ? null : $tracks;
 			} else {
 				$tracks = $this->get_track_list();

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
@@ -42,13 +42,19 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 						return current_user_can( 'edit_posts' );
 					},
 					'args'                => array(
-						'url' => array(
+						'url'  => array(
 							'description'       => __( 'The Podcast RSS feed URL.', 'jetpack' ),
 							'type'              => 'string',
 							'required'          => 'true',
 							'validate_callback' => function ( $param ) {
 								return wp_http_validate_url( $param );
 							},
+						),
+						'guid' => array(
+							'description'       => __( 'The unique identifier of a podcast episode', 'jetpack' ),
+							'type'              => 'string',
+							'required'          => 'false',
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
 					'schema'              => array( $this, 'get_public_item_schema' ),
@@ -64,7 +70,7 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 	 * @return WP_REST_Response The REST API response.
 	 */
 	public function get_player_data( $request ) {
-		$player_data = ( new Jetpack_Podcast_Helper( $request['url'] ) )->get_player_data();
+		$player_data = ( new Jetpack_Podcast_Helper( $request['url'] ) )->get_player_data( empty( $request['guid'] ) ? false : $request['guid'] );
 
 		if ( is_wp_error( $player_data ) ) {
 			return rest_ensure_response( $player_data );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
@@ -50,6 +50,12 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 								return wp_http_validate_url( $param );
 							},
 						),
+						'q'    => array(
+							'description'       => __( 'A query term to search the available episodes', 'jetpack' ),
+							'type'              => 'string',
+							'required'          => 'false',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
 						'guid' => array(
 							'description'       => __( 'The unique identifier of a podcast episode', 'jetpack' ),
 							'type'              => 'string',
@@ -70,7 +76,14 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 	 * @return WP_REST_Response The REST API response.
 	 */
 	public function get_player_data( $request ) {
-		$player_data = ( new Jetpack_Podcast_Helper( $request['url'] ) )->get_player_data( empty( $request['guid'] ) ? false : $request['guid'] );
+		$helper = new Jetpack_Podcast_Helper( $request['url'] );
+		if ( isset( $request['guid'] ) ) {
+			$player_data = $helper->get_player_data( array( 'guid' => $request['guid'] ) );
+		} elseif ( ! empty( $request['q'] ) ) {
+			$player_data = $helper->get_player_data( array( 'query' => $request['q'] ) );
+		} else {
+			$player_data = $helper->get_player_data();
+		}
 
 		if ( is_wp_error( $player_data ) ) {
 			return rest_ensure_response( $player_data );

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
@@ -9,12 +9,12 @@ import { PODCAST_FEED, EMBED_BLOCK } from './constants';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
-export const fetchPodcastFeed = async url => {
+export const fetchPodcastFeed = async ( { url, guid } ) => {
 	// First try calling our endpoint for Podcast parsing.
 	let feedData, feedError;
 	try {
 		feedData = await apiFetch( {
-			path: addQueryArgs( '/wpcom/v2/podcast-player', { url } ),
+			path: addQueryArgs( '/wpcom/v2/podcast-player', { url, guid } ),
 		} );
 	} catch ( err ) {
 		// We are not rethrowing the error just yet so we can try the embed too.

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
@@ -9,12 +9,12 @@ import { PODCAST_FEED, EMBED_BLOCK } from './constants';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
-export const fetchPodcastFeed = async ( { url, guid } ) => {
+export const fetchPodcastFeed = async ( { url, guid, query } ) => {
 	// First try calling our endpoint for Podcast parsing.
 	let feedData, feedError;
 	try {
 		feedData = await apiFetch( {
-			path: addQueryArgs( '/wpcom/v2/podcast-player', { url, guid } ),
+			path: addQueryArgs( '/wpcom/v2/podcast-player', { url, guid, q: query } ),
 		} );
 	} catch ( err ) {
 		// We are not rethrowing the error just yet so we can try the embed too.

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/attributes.js
@@ -21,6 +21,9 @@ export default {
 		type: 'integer',
 		default: 5,
 	},
+	singleEpisode: {
+		type: 'object',
+	},
 	showCoverArt: {
 		type: 'boolean',
 		default: true,

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/episode-selector.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/episode-selector.js
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import { map, debounce, omit, find } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
+import { ComboboxControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { isURL, prependHTTP } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { makeCancellable } from '../utils';
+import { PODCAST_FEED } from '../constants';
+import { fetchPodcastFeed } from '../api';
+
+export default function EpisodeSelector( { feedUrl, onSelected, episodeDetails } ) {
+	const [ episodeCache, setEpisodeCache ] = useState( {} );
+	const [ isLoading, setIsLoading ] = useState( false );
+    const [ options, setOptions ] = useState( [] );
+	const [ fieldValue, setFieldValue ] = useState();
+	const currentUrl = useRef( feedUrl );
+
+	const cancellableFetch = useRef();
+	const fetchEpisodes = useCallback(
+		debounce( ( feedUrl, query ) => {
+			cancellableFetch.current?.cancel();
+			setIsLoading( true );
+			cancellableFetch.current = makeCancellable( fetchPodcastFeed( { url: feedUrl, query } ) );
+			cancellableFetch.current.promise.then(
+				response => {
+					setIsLoading( false );
+					if ( response?.isCanceled || response?.type !== PODCAST_FEED || ! response?.data.tracks ) {
+						return;
+					}
+					// Update the episode cache with the returned episodes, which will cause the options be to be updated.
+					updateEpisodeCache( response.data.tracks );
+				},
+				error => {
+					setIsLoading( false );
+					if ( error?.isCanceled ) {
+						return;
+					}
+					//TODO: Sort out the error messaging
+				}
+			);
+		}, 300 ),
+		[]
+	);
+	const reset = useCallback(
+		debounce( () => {
+			setEpisodeCache( () => {} );
+			onChange( null );
+		}, 300 ),
+		[]
+	);
+
+	// Reset when the feed URL changes.
+	useEffect( () => {
+		if ( currentUrl.current !== feedUrl ) {
+			reset();
+			currentUrl.current = feedUrl;
+		}
+	}, [ feedUrl ] );
+
+	// Let's keep a cache of all the episodes we've seen so the filter options doesn't change too much.
+	const updateEpisodeCache = ( episodes ) => {
+		const episodesMap = episodes.reduce( 
+			( obj, episode ) => ( { ...obj, [episode.guid]: episode } ),
+			{}
+		);
+		setEpisodeCache( cache => ( { ...cache, ...episodesMap } ) );
+	};
+
+	// Make sure we have the selected episode details in the cache and in the filter options.
+	// They may have been passed in and not (yet) come back from the API.
+	useEffect( () => {
+		if ( ! episodeDetails?.guid ) {
+			return;
+		}
+		updateEpisodeCache( [ episodeDetails ] );
+	}, [ episodeDetails ] );
+
+	useEffect( () => {
+		const newOptions =  map( episodeCache, episode => ( { ...episode, label: episode.title, value: episode.guid } ) );
+		setOptions( newOptions );
+	}, [ episodeCache ] );
+
+	const onChange = ( selectedGuid ) => {
+		if ( ! selectedGuid ) {
+			onSelected && onSelected( undefined );
+			return;
+		}
+		const selectedEpisode = omit( find( options, [ 'guid', selectedGuid ] ), [ 'label', 'value' ] );
+		if ( selectedEpisode ) {
+			onSelected && onSelected( selectedEpisode );
+		}
+	};
+
+	useEffect( () => {
+		const prependedURL = prependHTTP( feedUrl );
+
+		if ( isURL( prependedURL ) ) {
+			fetchEpisodes( prependedURL, fieldValue );
+		}
+		return () => { cancellableFetch.current?.cancel(); }
+	}, [ feedUrl, fieldValue ] );
+
+	return (
+        <ComboboxControl
+			className={ classnames( 'episode-selector', { 'is-loading': isLoading } ) } 
+            label={ __( "Select an episode (optional)", 'jetpack' ) }
+            value={ episodeDetails?.guid }
+            onChange={ onChange }
+            options={ options }
+			onFilterValueChange={ setFieldValue }
+		/>
+    );
+}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/episode-selector.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/episode-selector.js
@@ -19,28 +19,37 @@ import { makeCancellable } from '../utils';
 import { PODCAST_FEED } from '../constants';
 import { fetchPodcastFeed } from '../api';
 
-export default function EpisodeSelector( { feedUrl, onSelected, episodeDetails } ) {
-	// If the commbobox control is unavailable, then don't render
-	if ( undefined === ComboboxControl ) {
-		return null;
-	}
-
+function EpisodeSelector( { feedUrl, onSelected, episodeDetails } ) {
 	const [ episodeCache, setEpisodeCache ] = useState( {} );
 	const [ isLoading, setIsLoading ] = useState( false );
-    const [ options, setOptions ] = useState( [] );
+	const [ options, setOptions ] = useState( [] );
 	const [ fieldValue, setFieldValue ] = useState();
 	const currentUrl = useRef( feedUrl );
 
 	const cancellableFetch = useRef();
+
+	// Let's keep a cache of all the episodes we've seen so the filter options doesn't change too much.
+	const updateEpisodeCache = episodes => {
+		const episodesMap = episodes.reduce(
+			( obj, episode ) => ( { ...obj, [ episode.guid ]: episode } ),
+			{}
+		);
+		setEpisodeCache( cache => ( { ...cache, ...episodesMap } ) );
+	};
+
 	const fetchEpisodes = useCallback(
-		debounce( ( feedUrl, query ) => {
+		debounce( ( url, query ) => {
 			cancellableFetch.current?.cancel();
 			setIsLoading( true );
-			cancellableFetch.current = makeCancellable( fetchPodcastFeed( { url: feedUrl, query } ) );
+			cancellableFetch.current = makeCancellable( fetchPodcastFeed( { url, query } ) );
 			cancellableFetch.current.promise.then(
 				response => {
 					setIsLoading( false );
-					if ( response?.isCanceled || response?.type !== PODCAST_FEED || ! response?.data.tracks ) {
+					if (
+						response?.isCanceled ||
+						response?.type !== PODCAST_FEED ||
+						! response?.data.tracks
+					) {
 						return;
 					}
 					// Update the episode cache with the returned episodes, which will cause the options be to be updated.
@@ -57,6 +66,18 @@ export default function EpisodeSelector( { feedUrl, onSelected, episodeDetails }
 		}, 300 ),
 		[]
 	);
+
+	const onChange = selectedGuid => {
+		if ( ! selectedGuid ) {
+			onSelected && onSelected( undefined );
+			return;
+		}
+		const selectedEpisode = omit( find( options, [ 'guid', selectedGuid ] ), [ 'label', 'value' ] );
+		if ( selectedEpisode ) {
+			onSelected && onSelected( selectedEpisode );
+		}
+	};
+
 	const reset = useCallback(
 		debounce( () => {
 			setEpisodeCache( () => {} );
@@ -71,16 +92,7 @@ export default function EpisodeSelector( { feedUrl, onSelected, episodeDetails }
 			reset();
 			currentUrl.current = feedUrl;
 		}
-	}, [ feedUrl ] );
-
-	// Let's keep a cache of all the episodes we've seen so the filter options doesn't change too much.
-	const updateEpisodeCache = ( episodes ) => {
-		const episodesMap = episodes.reduce( 
-			( obj, episode ) => ( { ...obj, [episode.guid]: episode } ),
-			{}
-		);
-		setEpisodeCache( cache => ( { ...cache, ...episodesMap } ) );
-	};
+	}, [ feedUrl, reset ] );
 
 	// Make sure we have the selected episode details in the cache and in the filter options.
 	// They may have been passed in and not (yet) come back from the API.
@@ -92,20 +104,13 @@ export default function EpisodeSelector( { feedUrl, onSelected, episodeDetails }
 	}, [ episodeDetails ] );
 
 	useEffect( () => {
-		const newOptions =  map( episodeCache, episode => ( { ...episode, label: episode.title, value: episode.guid } ) );
+		const newOptions = map( episodeCache, episode => ( {
+			...episode,
+			label: episode.title,
+			value: episode.guid,
+		} ) );
 		setOptions( newOptions );
 	}, [ episodeCache ] );
-
-	const onChange = ( selectedGuid ) => {
-		if ( ! selectedGuid ) {
-			onSelected && onSelected( undefined );
-			return;
-		}
-		const selectedEpisode = omit( find( options, [ 'guid', selectedGuid ] ), [ 'label', 'value' ] );
-		if ( selectedEpisode ) {
-			onSelected && onSelected( selectedEpisode );
-		}
-	};
 
 	useEffect( () => {
 		const prependedURL = prependHTTP( feedUrl );
@@ -113,17 +118,21 @@ export default function EpisodeSelector( { feedUrl, onSelected, episodeDetails }
 		if ( isURL( prependedURL ) ) {
 			fetchEpisodes( prependedURL, fieldValue );
 		}
-		return () => { cancellableFetch.current?.cancel(); }
-	}, [ feedUrl, fieldValue ] );
+		return () => {
+			cancellableFetch.current?.cancel();
+		};
+	}, [ feedUrl, fieldValue, fetchEpisodes ] );
 
 	return (
-        <ComboboxControl
-			className={ classnames( 'episode-selector', { 'is-loading': isLoading } ) } 
-            label={ __( "Select an episode (optional)", 'jetpack' ) }
-            value={ episodeDetails?.guid }
-            onChange={ onChange }
-            options={ options }
+		<ComboboxControl
+			className={ classnames( 'episode-selector', { 'is-loading': isLoading } ) }
+			label={ __( 'Select an episode (optional)', 'jetpack' ) }
+			value={ episodeDetails?.guid }
+			onChange={ onChange }
+			options={ options }
 			onFilterValueChange={ setFieldValue }
 		/>
-    );
+	);
 }
+
+export default props => ( undefined === ComboboxControl ? null : <EpisodeSelector { ...props } /> );

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/episode-selector.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/episode-selector.js
@@ -20,6 +20,11 @@ import { PODCAST_FEED } from '../constants';
 import { fetchPodcastFeed } from '../api';
 
 export default function EpisodeSelector( { feedUrl, onSelected, episodeDetails } ) {
+	// If the commbobox control is unavailable, then don't render
+	if ( undefined === ComboboxControl ) {
+		return null;
+	}
+
 	const [ episodeCache, setEpisodeCache ] = useState( {} );
 	const [ isLoading, setIsLoading ] = useState( false );
     const [ options, setOptions ] = useState( [] );

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
@@ -102,7 +102,6 @@ const PodcastPlayerEdit = ( {
 
 	const fetchFeed = useCallback(
 		( urlToFetch, guid ) => {
-			console.log( 'url', urlToFetch, 'guid', guid );
 			cancellableFetch.current?.cancel();
 			cancellableFetch.current = makeCancellable( fetchPodcastFeed( { url: urlToFetch, guid } ) );
 			cancellableFetch.current.promise.then(
@@ -147,7 +146,10 @@ const PodcastPlayerEdit = ( {
 			return;
 		}
 		if ( feedData.tracks ) {
-			if ( ! isEqual( feedData.tracks[ 0 ], singleEpisode ) && singleEpisode.guid === feedData.tracks[0].guid ) {
+			if (
+				! isEqual( feedData.tracks[ 0 ], singleEpisode ) &&
+				singleEpisode.guid === feedData.tracks[ 0 ].guid
+			) {
 				setAttributes( { singleEpisode: feedData.tracks[ 0 ] } );
 			}
 		} else {
@@ -299,15 +301,15 @@ const PodcastPlayerEdit = ( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>
-					{ ! episodeGuid && ( 
-					<RangeControl
-						label={ __( 'Number of items', 'jetpack' ) }
-						value={ itemsToShow }
-						onChange={ value => setAttributes( { itemsToShow: value } ) }
-						min={ DEFAULT_MIN_ITEMS }
-						max={ DEFAULT_MAX_ITEMS }
-						required
-					/>
+					{ ! episodeGuid && (
+						<RangeControl
+							label={ __( 'Number of items', 'jetpack' ) }
+							value={ itemsToShow }
+							onChange={ value => setAttributes( { itemsToShow: value } ) }
+							min={ DEFAULT_MIN_ITEMS }
+							max={ DEFAULT_MAX_ITEMS }
+							required
+						/>
 					) }
 					<ToggleControl
 						label={ __( 'Show Cover Art', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/editor.scss
@@ -23,10 +23,14 @@
 
 // Placeholder styles
 .jetpack-podcast-player__placeholder {
+	.components-placeholder__fieldset form {
+		flex-direction: column;
+	}
 	.components-base-control,
 	.components-base-control__field {
 		display: flex;
 		flex-grow: 1;
+		flex-direction: column;
 	}
 
 	.components-base-control__field {
@@ -35,5 +39,20 @@
 
 	.components-placeholder__learn-more {
 		margin-top: 1em;
+		flex-grow: 1;
+	}
+
+	.components-form-token-field__suggestions-list {
+		margin: 0;
+		padding: 0;
+	}
+	
+	.components-combobox-control {
+		margin-top: 5px;
+	}
+
+	.embed-actions {
+		display: flex;
+		flex-direction: row;
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -99,9 +99,12 @@ function render_block( $attributes, $content ) {
 
 	// Sanitize the URL.
 	$attributes['url'] = esc_url_raw( $attributes['url'] );
-	$player_data       = ( new Jetpack_Podcast_Helper( $attributes['url'] ) )->get_player_data(
-		isset( $attributes['singleEpisode']['guid'] ) ? $attributes['singleEpisode']['guid'] : false
-	);
+	$helper            = new Jetpack_Podcast_Helper( $attributes['url'] );
+	if ( isset( $attributes['singleEpisode']['guid'] ) ) {
+		$player_data = $helper->get_player_data( array( 'guid' => $attributes['singleEpisode']['guid'] ) );
+	} else {
+		$player_data = $helper->get_player_data();
+	}
 
 	if ( is_wp_error( $player_data ) ) {
 		return render_error( $player_data->get_error_message() );

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -48,6 +48,9 @@ function register_block() {
 					'type'    => 'boolean',
 					'default' => true,
 				),
+				'singleEpisode'          => array(
+					'type' => 'object',
+				),
 			),
 			'render_callback' => __NAMESPACE__ . '\render_block',
 		)
@@ -96,10 +99,17 @@ function render_block( $attributes, $content ) {
 
 	// Sanitize the URL.
 	$attributes['url'] = esc_url_raw( $attributes['url'] );
-	$player_data       = ( new Jetpack_Podcast_Helper( $attributes['url'] ) )->get_player_data();
+	$player_data       = ( new Jetpack_Podcast_Helper( $attributes['url'] ) )->get_player_data(
+		isset( $attributes['singleEpisode']['guid'] ) ? $attributes['singleEpisode']['guid'] : false
+	);
 
 	if ( is_wp_error( $player_data ) ) {
 		return render_error( $player_data->get_error_message() );
+	}
+
+	// If we haven't managed to get the episode details fallback to what is saved in the attribute.
+	if ( empty( $player_data['tracks'] ) && isset( $attributes['singleEpisode'] ) ) {
+		$player_data['tracks'] = $attributes['singleEpisode'];
 	}
 
 	return render_player( $player_data, $attributes );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change allows the block to be set to display a single podcast
episode. It also adds the ability to search the feed for episodes
matching a query term.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This is a general improvement to an existing block and part of a larger piece of work to improve podcasting features on WordPress.com.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
As there's no UI currently, I've been testing this by hand editing the block attributes, and making network requests to the podcast-player endpoint, using the dev-tools. 

I'll write some more detailed testing instructions as this gets easier.


#### Proposed changelog entry for your changes:
* Updated the podcast block so that it can be used for a specific single episode.

Fixes https://github.com/Automattic/jetpack/issues/18008
