### PR TITLE
Slideshow Unit Test: Parent teardown is required

### DIFF
--- a/tests/php/modules/shortcodes/test-class.slideshow.php
+++ b/tests/php/modules/shortcodes/test-class.slideshow.php
@@ -48,6 +48,8 @@ class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 		if ( ! defined( 'TESTING_IN_JETPACK' ) || ! TESTING_IN_JETPACK ) {
 			restore_current_blog();
 		}
+
+		parent::tearDown();
 	}
 
 	/**


### PR DESCRIPTION
In merging D49499-code, linting on WP.com failed due to the lack of `parent::tearDown()`

#### Changes proposed in this Pull Request:
* Calls the parent teardown.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Do the tests pass?
*

#### Proposed changelog entry for your changes:
* n/a
