### PR TITLE
Reorg: Add a dummy "jetpack.php" to the monorepo, and update docs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -368,3 +368,14 @@ jobs:
         env:
           FILES: ${{ needs.changed_files.outputs.js_excluded_files }}
         run: yarn lint-changed --git-branch=${{ github.event.pull_request.base.sha }} $(jq -rn --argjson files "$FILES" '$files[]')
+
+
+  ### Checks that copied files (e.g. readme, license) are in sync
+  # Local equivalent: `./tools/check-copied-files.sh`
+  copied_files:
+    name: Copied files are in sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: ./tools/check-copied-files.sh

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -47,7 +47,7 @@ To get a local WordPress site up and running you need a web server (Apache, Ngin
 
 	This would be the easiest and most straight-forward way to start your journey in Jetpack development. Docker offers a containerized install of WordPress with all of its dependencies installed and set up. You just need to start working on the plugin code. 
 	
-	To set up your environment with Docker, follow the [Docker environment for Jetpack Development guide](../docker/README.md).
+	To set up your environment with Docker, follow the [Docker environment for Jetpack Development guide](../tools/docker/README.md).
 
 * ### VVV
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: Jetpack Monorepo (not a real plugin)
+ * Plugin URI: https://github.com/Automattic/jetpack#jetpack-monorepo
+ * Description: The Jetpack Monorepo is not a plugin. Don't try to use it as one. See the Jetpack Monorepo documentation for instructions on correctly installing Jetpack.
+ * Author: Automattic
+ * License: GPL2+
+ * Text Domain: jetpack
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Notify the admin that the Jetpack Monorepo is not a plugin,
+ * if they tried to install it as one.
+ */
+function jetpack_monorepo_is_not_a_plugin() {
+	echo '<div class="notice notice-error"><p>';
+	printf(
+		wp_kses(
+			/* translators: Link to Jetpack installation instructions. */
+			__( 'The Jetpack Monorepo is not a plugin, and should not be installed as one. See <a href="%s">the Jetpack Monorepo documentation</a> for instructions on correctly installing Jetpack.', 'jetpack' ),
+			array(
+				'a' => array( 'href' => array() ),
+			)
+		),
+		esc_url( 'https://github.com/Automattic/jetpack#jetpack-monorepo' )
+	);
+	echo "</p></div>\n";
+}
+
+add_action( 'admin_notices', 'jetpack_monorepo_is_not_a_plugin' );

--- a/projects/plugins/jetpack/LICENSE.txt
+++ b/projects/plugins/jetpack/LICENSE.txt
@@ -1,0 +1,357 @@
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+===================================
+
+
+GNU GENERAL PUBLIC LICENSE
+   Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+		Preamble
+
+The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+GNU GENERAL PUBLIC LICENSE
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+a) You must cause the modified files to carry prominent notices
+stating that you changed the files and the date of any change.
+
+b) You must cause any work that you distribute or publish, that in
+whole or in part contains or is derived from the Program or any
+part thereof, to be licensed as a whole at no charge to all third
+parties under the terms of this License.
+
+c) If the modified program normally reads commands interactively
+when run, you must cause it, when started running for such
+interactive use in the most ordinary way, to print or display an
+announcement including an appropriate copyright notice and a
+notice that there is no warranty (or else, saying that you provide
+a warranty) and that users may redistribute the program under
+these conditions, and telling the user how to view a copy of this
+License.  (Exception: if the Program itself is interactive but
+does not normally print such an announcement, your work based on
+the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+a) Accompany it with the complete corresponding machine-readable
+source code, which must be distributed under the terms of Sections
+1 and 2 above on a medium customarily used for software interchange; or,
+
+b) Accompany it with a written offer, valid for at least three
+years, to give any third party, for a charge no more than your
+cost of physically performing source distribution, a complete
+machine-readable copy of the corresponding source code, to be
+distributed under the terms of Sections 1 and 2 above on a medium
+customarily used for software interchange; or,
+
+c) Accompany it with the information you received as to the offer
+to distribute corresponding source code.  (This alternative is
+allowed only for noncommercial distribution and only if you
+received the program in object code or executable form with such
+an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+		NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+ END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+<one line to give the program's name and a brief idea of what it does.>
+Copyright (C) <year>  <name of author>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+Gnomovision version 69, Copyright (C) year name of author
+Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+This is free software, and you are welcome to redistribute it
+under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+`Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+<signature of Ty Coon>, 1 April 1989
+Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/projects/plugins/jetpack/readme.md
+++ b/projects/plugins/jetpack/readme.md
@@ -43,14 +43,4 @@ Need to report a security vulnerability? Go to [https://automattic.com/security/
 
 Jetpack is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt).
 
-## Team
-
-Jetpack is developed and maintained by various teams at Automattic. The Jetpack Crew responsible for coordinating everything is comprised of @anomiex, @bisko, @brbrr, @dereksmart, @fgiannar, @jeherve, @kbrown9, @kraftbj, @leogermani, @mdbitz, @sergeymitr and @zinigor.
-
-Contributions have been and continue to be made by dozens of other Automatticians, like:
-
-@aldavigdis, @allendav, @apeatling, @azaozz, @bazza, @beaulebens, @briancolinger, @cfinke, @daniloercoli, @chaosexanima, @ebinnion, @enejb, @eoigal, @georgestephanis, @gibrown, @gititon, @gravityrail, @jasmussen, @jblz, @jeffgolenski, @jeherve, @jessefriedman, @joanrho, @justinshreve, @keoshi, @koke, @kovshenin, @kraftbj, @lancewillett, @lezama, @martinremy, @mdawaffe, @MichaelArestad, @mtias, @mcsf, @mdawaffe, @nickmomrik, @obenland, @oskosk, @pento, @roccotripaldi, @stephdau, @Viper007Bond, @xyu and @yoavf.
-
-Our _awesome_ happiness engineers are @a8ck3n, @aheckler, @almoyen, @annezazuu, @bikedorkjon, @cena, @chaselivingston, @chickenn00dle, @coder-karen, @codestor4, @csonnek, @danjjohnson, @dericleeyy, @gaurav1984, @gsmumbo, @htdat, @jenhooks, @jeremypaavola, @joeboydston, @joendotcom, @lizthefair, @macmanx2, @madhattermattic, @mbhthompson, @mzakariya, @NujabesSoul, @ntpixels, @pmciano, @rachelsquirrel, @rcowles, @richardmtl, @snowmads, @stefmattana, and @tmmbecker.
-
-Interested in working on awesome open-source code all day? [Join us](https://automattic.com/work-with-us/)!
+<!-- end sync section -->

--- a/projects/plugins/jetpack/readme.md
+++ b/projects/plugins/jetpack/readme.md
@@ -1,0 +1,56 @@
+# Jetpack
+
+[![License](https://poser.pugx.org/automattic/jetpack/license.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
+[![Code Climate](https://codeclimate.com/github/Automattic/jetpack/badges/gpa.svg)](https://codeclimate.com/github/Automattic/jetpack)
+
+[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of WordPress.com.
+
+For more information, check out [jetpack.com](https://jetpack.com/).
+
+## How to install Jetpack plugin on your site
+
+To install the Jetpack plugin on your site, [follow the instructions on this page](https://jetpack.com/install/).
+
+### Installation From Git Repo
+
+A pre-built version of Jetpack is available at [Automattic/jetpack-production](https://github.com/Automattic/jetpack-production).
+
+For development, you might instead use [the Jetpack Monorepo](https://github.com/Automattic/jetpack#jetpack-monorepo). See documentation there for further instructions.
+
+### Installation from the Jetpack Beta plugin
+
+If you cannot build the Jetpack plugin yourself, you can rely on [the Jetpack Beta plugin](https://github.com/Automattic/jetpack-beta/archive/master.zip) to install pre-built versions of Jetpack for you. To use the plugin, follow the instructions here:
+
+1. Go to Plugins > Add New in your dashboard.
+2. Install the Jetpack plugin.
+3. Go to Plugins > Add New > Upload Plugin.
+4. Upload and activate [this plugin](https://github.com/Automattic/jetpack-beta/archive/master.zip).
+5. Go to Jetpack > Beta and pick the version of Jetpack you would like to run on your site.
+
+## Contribute
+
+Thank you for thinking about contributing to Jetpack! See [the Jetpack Monorepo](https://github.com/Automattic/jetpack#contribute) for details on contributing.
+
+## Get Help
+
+Do you need help installing Jetpack, or do you have questions about one of the Jetpack modules? You can [search through our documentation here](https://jetpack.com/support/). If you don't find the answers you're looking for, you can [send us an email](https://jetpack.com/contact-support/) or [start a new thread in the WordPress.org support forums](https://wordpress.org/support/plugin/jetpack#new-post).
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+Jetpack is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt).
+
+## Team
+
+Jetpack is developed and maintained by various teams at Automattic. The Jetpack Crew responsible for coordinating everything is comprised of @anomiex, @bisko, @brbrr, @dereksmart, @fgiannar, @jeherve, @kbrown9, @kraftbj, @leogermani, @mdbitz, @sergeymitr and @zinigor.
+
+Contributions have been and continue to be made by dozens of other Automatticians, like:
+
+@aldavigdis, @allendav, @apeatling, @azaozz, @bazza, @beaulebens, @briancolinger, @cfinke, @daniloercoli, @chaosexanima, @ebinnion, @enejb, @eoigal, @georgestephanis, @gibrown, @gititon, @gravityrail, @jasmussen, @jblz, @jeffgolenski, @jeherve, @jessefriedman, @joanrho, @justinshreve, @keoshi, @koke, @kovshenin, @kraftbj, @lancewillett, @lezama, @martinremy, @mdawaffe, @MichaelArestad, @mtias, @mcsf, @mdawaffe, @nickmomrik, @obenland, @oskosk, @pento, @roccotripaldi, @stephdau, @Viper007Bond, @xyu and @yoavf.
+
+Our _awesome_ happiness engineers are @a8ck3n, @aheckler, @almoyen, @annezazuu, @bikedorkjon, @cena, @chaselivingston, @chickenn00dle, @coder-karen, @codestor4, @csonnek, @danjjohnson, @dericleeyy, @gaurav1984, @gsmumbo, @htdat, @jenhooks, @jeremypaavola, @joeboydston, @joendotcom, @lizthefair, @macmanx2, @madhattermattic, @mbhthompson, @mzakariya, @NujabesSoul, @ntpixels, @pmciano, @rachelsquirrel, @rcowles, @richardmtl, @snowmads, @stefmattana, and @tmmbecker.
+
+Interested in working on awesome open-source code all day? [Join us](https://automattic.com/work-with-us/)!

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -308,4 +308,4 @@ Our Cookie and Consent Banner can help you comply with GDPR. The European Unionâ
 
 --------
 
-[See the previous changelogs here](https://raw.githubusercontent.com/Automattic/jetpack/master/changelog.txt).
+[See the previous changelogs here](https://raw.githubusercontent.com/Automattic/jetpack/master/projects/plugin/jetpack/changelog.txt)

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ Need to report a security vulnerability? Go to [https://automattic.com/security/
 
 Jetpack is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt).
 
+<!-- end sync section -->
 ## Team
 
 Jetpack is developed and maintained by various teams at Automattic. The Jetpack Crew responsible for coordinating everything is comprised of @anomiex, @bisko, @brbrr, @dereksmart, @fgiannar, @jeherve, @kbrown9, @kraftbj, @leogermani, @mdbitz, @sergeymitr and @zinigor.

--- a/readme.md
+++ b/readme.md
@@ -1,29 +1,25 @@
-# Jetpack
+# Jetpack Monorepo
 
 [![License](https://poser.pugx.org/automattic/jetpack/license.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
 [![Code Climate](https://codeclimate.com/github/Automattic/jetpack/badges/gpa.svg)](https://codeclimate.com/github/Automattic/jetpack)
 
-[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of WordPress.com.
-
-For more information, check out [jetpack.com](https://jetpack.com/).
+This is the Jetpack Monorepo. It contains source code for the Jetpack plugin, the Jetpack composer packages, and other things.
 
 ## How to install Jetpack plugin on your site
 
-To install the Jetpack plugin on your site, [follow the instructions on this page](https://jetpack.com/install/).
+**If you are not planning on developing with Jetpack, you should install Jetpack from pre-built sources.** Details on that may be found [on this page](https://github.com/Automattic/jetpack-production#jetpack).
 
-### Installation From Git Repo
+### Installation From Git Monorepo
 
-To use this plugin on your site, you will need to build every JS and CSS first. To do so, [follow the instructions here](./docs/development-environment.md).
+To run the Jetpack plugin from the monorepo, you'll first need to build the JS and CSS. To do so, [follow the instructions here](./docs/development-environment.md).
 
-### Installation from the Jetpack Beta plugin
+If you're using the [Docker development environment](./docs/development-environment.md#docker-supported-recommended), you should then be all set.
 
-If you cannot build the Jetpack plugin yourself, you can rely on [the Jetpack Beta plugin](https://github.com/Automattic/jetpack-beta/archive/master.zip) to install pre-built versions of Jetpack for you. To use the plugin, follow the instructions here:
-
-1. Go to Plugins > Add New in your dashboard.
-2. Install the Jetpack plugin.
-3. Go to Plugins > Add New > Upload Plugin.
-4. Upload and activate [this plugin](https://github.com/Automattic/jetpack-beta/archive/master.zip).
-5. Go to Jetpack > Beta and pick the version of Jetpack you would like to run on your site.
+If not, you'll need to create a link to the Jetpack plugin from your WordPress `wp-content/plugins` folder. You'll need to know the filesystem path to the monorepo checkout and to your WordPress installation. Then, on Linux or Mac OS X, open a terminal and use `ln -s` to create the link, something like
+```
+ln -s /path/to/jetpack-monorepo/projects/plugins/jetpack /path/to/wordpress/wp-content/plugins/jetpack
+```
+On Windows (Vista and later), open an Administrator Command Prompt window and use `mklink /D` similarly.
 
 ## Contribute
 
@@ -35,10 +31,6 @@ Thank you for thinking about contributing to Jetpack! If you're unsure of anythi
 - [Translate Jetpack in your language](./docs/translations.md).
 
 To clarify these expectations, Jetpack has adopted the code of conduct defined by the Contributor Covenant. It can be read in full [here](CODE-OF-CONDUCT.md).
-
-## Get Help
-
-Do you need help installing Jetpack, or do you have questions about one of the Jetpack modules? You can [search through our documentation here](https://jetpack.com/support/). If you don't find the answers you're looking for, you can [send us an email](https://jetpack.com/contact-support/) or [start a new thread in the WordPress.org support forums](https://wordpress.org/support/plugin/jetpack#new-post).
 
 ## Security
 

--- a/tools/check-copied-files.sh
+++ b/tools/check-copied-files.sh
@@ -70,7 +70,7 @@ compare () {
 	fi
 }
 
-compare readme.md projects/plugins/jetpack/readme.md '^## Security'
+compare readme.md projects/plugins/jetpack/readme.md '^## Security' '^<!-- end sync section -->$'
 compare LICENSE.txt projects/plugins/jetpack/LICENSE.txt
 
 exit $EXIT

--- a/tools/check-copied-files.sh
+++ b/tools/check-copied-files.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -eo pipefail
+
+cd "$( dirname "${BASH_SOURCE[0]}" )/.."
+
+EXIT=0
+
+# Compare two files, with optional delimiters.
+# $1 - First file.
+# $2 - Second file.
+# $3 - (optional) Starting delimiter. If empty, comparison starts at the start of the files.
+# $4 - (optional) Ending delimiter. If empty, comparison runs to the end of the files.
+compare () {
+	FAIL=
+	for F in "$1" "$2"; do
+		for D in "$3" "$4"; do
+			if [[ -n "$D" ]] && ! grep -q "$D" "$F"; then
+				[[ -z "$FAIL" ]] && printf '\n'
+				if [[ -n "$CI" ]]; then
+					printf '::error file=%s::' "$F"
+				fi
+				echo "Did not find delimiter \`$D\` in $F."
+				FAIL=1
+			fi
+		done
+	done
+	if [[ -n "$FAIL" ]]; then
+		EXIT=1
+		return
+	fi
+
+	if [[ -n "$CI" && -n "$3" ]]; then
+		LA=$(grep --line-number --max-count=1 "$3" "$1")
+		LB=$(grep --line-number --max-count=1 "$3" "$2")
+	else
+		LA=1
+		LB=1
+	fi
+
+	if [[ -n "$3" && -n "$4" ]]; then
+		MSG="Files $1 and $2 must be identical between \`$3\` and \`$4\`."
+		A=$(sed -n -e "/$3/,/$4/p" "$1")
+		B=$(sed -n -e "/$3/,/$4/p" "$2")
+	elif [[ -n "$3" ]]; then
+		MSG="Files $1 and $2 must be identical from \`$3\` on."
+		A=$(sed -n -e "/$3/,\$p" "$1")
+		B=$(sed -n -e "/$3/,\$p" "$2")
+	elif [[ -n "$4" ]]; then
+		MSG="Files $1 and $2 must be identical up to \`$4\`."
+		A=$(sed -n -e "1,/$4/p" "$1")
+		B=$(sed -n -e "1,/$4/p" "$2")
+	else
+		MSG="Files $1 and $2 must be identical."
+		A=$(< "$1" )
+		B=$(< "$2" )
+	fi
+
+	if [[ "$A" != "$B" ]]; then
+		printf '\n'
+		if [[ -n "$CI" ]]; then
+			printf "::error file=%s,line=%d::%s\\n" "$1" "${LA%%:*}" "$MSG"
+			printf "::error file=%s,line=%d::%s\\n" "$2" "${LB%%:*}" "$MSG"
+		else
+			echo "$MSG"
+		fi
+
+		diff -u /dev/fd/3 --label "$1" /dev/fd/4 --label "$2" 3<<<"$A" 4<<<"$B" || true
+		EXIT=1
+	fi
+}
+
+compare readme.md projects/plugins/jetpack/readme.md '^## Security'
+compare LICENSE.txt projects/plugins/jetpack/LICENSE.txt
+
+exit $EXIT

--- a/tools/pre-commit-hook.js
+++ b/tools/pre-commit-hook.js
@@ -306,6 +306,19 @@ function checkComposerLock() {
 }
 
 /**
+ * Check that copied files are in sync.
+ */
+function runCheckCopiedFiles() {
+	const result = spawnSync( './tools/check-copied-files.sh', [], {
+		shell: true,
+		stdio: 'inherit',
+	} );
+	if ( result && result.status ) {
+		checkFailed( '' );
+	}
+}
+
+/**
  * Exit script
  *
  * @param {number} exitCodePassed - Shell exit code.
@@ -314,6 +327,8 @@ function exit( exitCodePassed ) {
 	capturePreCommitTreeHash();
 	process.exit( exitCodePassed );
 }
+
+runCheckCopiedFiles();
 
 dirtyFiles.forEach( file =>
 	console.log(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
People used to the old way of doing things may try to check out the monorepo directly in their WordPress `wp-content/plugins` folder, or they may already be doing so. That will no longer work to install Jetpack.

To make the failure case a little more user-friendly, we add a dummy `jetpack.php` to the monorepo root so WordPress will find a plugin. All this plugin does is display an admin notice telling the user they're doing it wrong and pointing them to relevant documentation on how to do it right.

Said documentation needs to exist. So this PR also moves the existing Jetpack readme.md to the Jetpack plugin, and creates a new readme.md for the monorepo in the monorepo root. Once we get to the point of creating the built "Automattic/jetpack-production" mirror repo, the Jetpack-specific readme.md will show up there too.

Since both the Jetpack-specific readme.md and the Monorepo readme.md want to refer to a LICENSE.txt, we also need to copy that into the Jetpack plugin. Again, this will ensure the "Automattic/jetpack-production" mirror repo has LICENSE.txt too once we create it.

And since there's now a fairly significant duplication of content between the Monorepo and Jetpack in readme.md and LICENSE.txt, let's add a pre-commit and CI check to ensure those remain in sync in the future.

And while I was looking at it, I updated a few doc refs in other files too.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1199714989172614-as-1199714989172649

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try putting the monorepo into the WordPress plugins directory. With the docker env, you can do that like
    * Set up the docker env as usual.
    * `yarn docker:sh`, then `ln -s /usr/local/src/jetpack-monorepo /var/www/html/wp-content/plugins/jetpack-monorepo`
* Go into the WP admin and enable the "Jetpack Monorepo (not a real plugin)" plugin.
* See the admin notice. The link included won't link to the right place of course.

* View the changes to the docs, see that they look appropriate. In particular, look at [the Monorepo readme](https://github.com/Automattic/jetpack/blob/reorg/add-dummy-jetpack.php/readme.md) and [the Jetpack plugin readme](https://github.com/Automattic/jetpack/blob/reorg/add-dummy-jetpack.php/projects/plugins/jetpack/readme.md).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed, this will be subsumed by the reorg.
