### PR TITLE
Admin Menu: Switch Customizer and Theme links

### DIFF
--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -258,7 +258,6 @@ class Admin_Menu {
 		$appearance_cap     = $user_can_customize ? 'customize' : 'edit_theme_options';
 		$customize_slug     = $calypso ? 'https://wordpress.com/customize/' . $this->domain : 'customize.php';
 		$themes_slug        = $calypso ? 'https://wordpress.com/themes/' . $this->domain : 'themes.php';
-		$appearance_slug    = $user_can_customize ? $customize_slug : $themes_slug;
 		$customize_url      = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' ); // phpcs:ignore
 
 		remove_menu_page( 'themes.php' );
@@ -266,41 +265,41 @@ class Admin_Menu {
 		remove_submenu_page( 'themes.php', 'theme-editor.php' );
 		remove_submenu_page( 'themes.php', $customize_url );
 
-		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), $appearance_cap, $appearance_slug, null, 'dashicons-admin-appearance', 60 );
-		add_submenu_page( $appearance_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $customize_slug, null, 5 );
-		add_submenu_page( $appearance_slug, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', $themes_slug, null, 10 );
+		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), $appearance_cap, $themes_slug, null, 'dashicons-admin-appearance', 60 );
+		add_submenu_page( $themes_slug, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', $themes_slug, null, 5 );
+		add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $customize_slug, null, 10 );
 
 		if ( current_theme_supports( 'custom-header' ) && $user_can_customize ) {
 			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_url );
 			remove_submenu_page( 'themes.php', $customize_header_url );
 
-			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $appearance_slug );
-			add_submenu_page( $appearance_slug, __( 'Header', 'jetpack' ), __( 'Header', 'jetpack' ), $appearance_cap, esc_url( $customize_header_url ), null, 15 );
+			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_url );
+			add_submenu_page( $themes_slug, __( 'Header', 'jetpack' ), __( 'Header', 'jetpack' ), $appearance_cap, esc_url( $customize_header_url ), null, 15 );
 		}
 
 		if ( current_theme_supports( 'custom-background' ) && $user_can_customize ) {
 			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $customize_url );
 			remove_submenu_page( 'themes.php', $customize_background_url );
 
-			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $appearance_slug );
-			add_submenu_page( $appearance_slug, esc_attr__( 'Background', 'jetpack' ), __( 'Background', 'jetpack' ), $appearance_cap, esc_url( $customize_background_url ), null, 20 );
+			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $customize_url );
+			add_submenu_page( $themes_slug, esc_attr__( 'Background', 'jetpack' ), __( 'Background', 'jetpack' ), $appearance_cap, esc_url( $customize_background_url ), null, 20 );
 		}
 
 		if ( current_theme_supports( 'widgets' ) ) {
 			remove_submenu_page( 'themes.php', 'widgets.php' );
 
-			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $appearance_slug );
-			add_submenu_page( $appearance_slug, esc_attr__( 'Widgets', 'jetpack' ), __( 'Widgets', 'jetpack' ), $appearance_cap, esc_url( $customize_menu_url ), null, 20 );
+			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $customize_url );
+			add_submenu_page( $themes_slug, esc_attr__( 'Widgets', 'jetpack' ), __( 'Widgets', 'jetpack' ), $appearance_cap, esc_url( $customize_menu_url ), null, 20 );
 		}
 
 		if ( current_theme_supports( 'menus' ) || current_theme_supports( 'widgets' ) ) {
 			remove_submenu_page( 'themes.php', 'nav-menus.php' );
 
-			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $appearance_slug );
-			add_submenu_page( $appearance_slug, esc_attr__( 'Menus', 'jetpack' ), __( 'Menus', 'jetpack' ), $appearance_cap, esc_url( $customize_menu_url ), null, 20 );
+			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $customize_url );
+			add_submenu_page( $themes_slug, esc_attr__( 'Menus', 'jetpack' ), __( 'Menus', 'jetpack' ), $appearance_cap, esc_url( $customize_menu_url ), null, 20 );
 		}
 
-		$this->migrate_submenus( 'themes.php', $appearance_slug );
+		$this->migrate_submenus( 'themes.php', $themes_slug );
 	}
 
 	/**

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -255,7 +255,7 @@ class Admin_Menu {
 	 */
 	public function add_appearance_menu( $calypso = true ) {
 		$user_can_customize = current_user_can( 'customize' );
-		$appearance_cap     = $user_can_customize ? 'customize' : 'edit_theme_options';
+		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
 		$customize_slug     = $calypso ? 'https://wordpress.com/customize/' . $this->domain : 'customize.php';
 		$themes_slug        = $calypso ? 'https://wordpress.com/themes/' . $this->domain : 'themes.php';
 		$customize_url      = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' ); // phpcs:ignore
@@ -273,30 +273,30 @@ class Admin_Menu {
 			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_url );
 			remove_submenu_page( 'themes.php', $customize_header_url );
 
-			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_url );
-			add_submenu_page( $themes_slug, __( 'Header', 'jetpack' ), __( 'Header', 'jetpack' ), $appearance_cap, esc_url( $customize_header_url ), null, 15 );
+			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_slug );
+			add_submenu_page( $themes_slug, __( 'Header', 'jetpack' ), __( 'Header', 'jetpack' ), 'customize', esc_url( $customize_header_url ), null, 15 );
 		}
 
 		if ( current_theme_supports( 'custom-background' ) && $user_can_customize ) {
 			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $customize_url );
 			remove_submenu_page( 'themes.php', $customize_background_url );
 
-			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $customize_url );
-			add_submenu_page( $themes_slug, esc_attr__( 'Background', 'jetpack' ), __( 'Background', 'jetpack' ), $appearance_cap, esc_url( $customize_background_url ), null, 20 );
+			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $customize_slug );
+			add_submenu_page( $themes_slug, esc_attr__( 'Background', 'jetpack' ), __( 'Background', 'jetpack' ), 'customize', esc_url( $customize_background_url ), null, 20 );
 		}
 
 		if ( current_theme_supports( 'widgets' ) ) {
 			remove_submenu_page( 'themes.php', 'widgets.php' );
 
-			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $customize_url );
-			add_submenu_page( $themes_slug, esc_attr__( 'Widgets', 'jetpack' ), __( 'Widgets', 'jetpack' ), $appearance_cap, esc_url( $customize_menu_url ), null, 20 );
+			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $customize_slug );
+			add_submenu_page( $themes_slug, esc_attr__( 'Widgets', 'jetpack' ), __( 'Widgets', 'jetpack' ), 'customize', esc_url( $customize_menu_url ), null, 20 );
 		}
 
 		if ( current_theme_supports( 'menus' ) || current_theme_supports( 'widgets' ) ) {
 			remove_submenu_page( 'themes.php', 'nav-menus.php' );
 
-			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $customize_url );
-			add_submenu_page( $themes_slug, esc_attr__( 'Menus', 'jetpack' ), __( 'Menus', 'jetpack' ), $appearance_cap, esc_url( $customize_menu_url ), null, 20 );
+			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $customize_slug );
+			add_submenu_page( $themes_slug, esc_attr__( 'Menus', 'jetpack' ), __( 'Menus', 'jetpack' ), 'customize', esc_url( $customize_menu_url ), null, 20 );
 		}
 
 		$this->migrate_submenus( 'themes.php', $themes_slug );

--- a/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -436,11 +436,11 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_appearance_menu( static::$domain );
 
-		$slug = 'https://wordpress.com/customize/' . static::$domain;
+		$slug = 'https://wordpress.com/themes/' . static::$domain;
 
 		$appearance_menu_item = array(
 			'Appearance',
-			'customize',
+			'switch_themes',
 			$slug,
 			'Appearance',
 			'menu-top toplevel_page_' . $slug,
@@ -451,14 +451,6 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		$this->assertSame( $menu[60], $appearance_menu_item );
 		$this->assertArrayNotHasKey( 'themes.php', $submenu );
 
-		$customize_submenu_item = array(
-			'Customize',
-			'customize',
-			'https://wordpress.com/customize/' . static::$domain,
-			'Customize',
-		);
-		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
-
 		$themes_submenu_item = array(
 			'Themes',
 			'switch_themes',
@@ -466,6 +458,14 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			'Themes',
 		);
 		$this->assertContains( $themes_submenu_item, $submenu[ $slug ] );
+
+		$customize_submenu_item = array(
+			'Customize',
+			'customize',
+			'https://wordpress.com/customize/' . static::$domain,
+			'Customize',
+		);
+		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
 
 		$widgets_submenu_item = array(
 			'Widgets',


### PR DESCRIPTION
This was updated in the tracking spreadsheet but I didn't catch it until now.

Fixes #18206

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Rearranges the submenu link order between Themes and Customize menu items.
* Updates the parent slug for submenu pages
* Updates unit tests to reflect the change.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Jetpack:
* On your Jetpack site, enable the admin menu with `add_filter( 'jetpack_load_admin_menu_class', '__return_true' );`
* Make sure the "Appearance" menu item links to wordpress.com/themes/site_name
* Verify that "Themes" is the first submenu item and "Customize" the second.

Atomic:
* On an Atomic site, enable Jetpack beta and switch to this branch
* Enable the admin menu with `add_filter( 'jetpack_load_admin_menu_class', '__return_true' );`
* Make sure the "Appearance" menu item links to wordpress.com/themes/site_name
* Verify that "Themes" is the first submenu item and "Customize" the second.

WP.com:
* Apply D54892-code to your sandbox.
* Make sure the "Appearance" menu item links to wordpress.com/themes/site_name
* Verify that "Themes" is the first submenu item and "Customize" the second.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
