### PR TITLE
Codesniffer: Unpin composer deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,10 @@
 		{
 			"depTypeList": [ "monorepo:wordpress", "monorepo:react" ],
 			"groupName": "React and WordPress monorepos"
+		},
+		{
+			"paths": [ "packages/codesniffer/composer.json" ],
+			"rangeStrategy": "replace"
 		}
 	]
 }

--- a/packages/codesniffer/composer.json
+++ b/packages/codesniffer/composer.json
@@ -4,11 +4,11 @@
 	"type": "phpcodesniffer-standard",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
-		"mediawiki/mediawiki-codesniffer": "34.0.0",
-		"phpcompatibility/phpcompatibility-wp": "2.1.0",
-		"sirbrillig/phpcs-variable-analysis": "2.10.0",
-		"wp-coding-standards/wpcs": "2.3.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+		"mediawiki/mediawiki-codesniffer": "^34.0",
+		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"sirbrillig/phpcs-variable-analysis": "^2.10",
+		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
For libraries, it's better to use ranges so as to not send your users to
dependency hell.

Also, reconfigure renovate to not pin them again. It seems that by
default it looks at the 'type' in composer.json to decide whether it
should pin or maintain ranges, and it doesn't recognize
"phpcodesniffer-standard" as a kind it should do ranges for.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None linkable.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing should change. Post-merge we should make sure renovate doesn't try to re-pin the dependencies here.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
