### PR TITLE
Reorg: Write to jetpack-production

### DIFF
--- a/.github/actions/update-project/update-project.sh
+++ b/.github/actions/update-project/update-project.sh
@@ -144,6 +144,10 @@ for plugin in projects/plugins/*; do
 
 	cp -r "${PROJECT_DIR}/." .
 
+	if [ "$NAME" == 'jetpack' ]; then
+	./tools/prepare-build-branch.sh
+	fi
+
 	if [ -n "$(git status --porcelain)" ]; then
 
 		echo  "  Committing $NAME to $NAME's mirror repository"

--- a/.github/actions/update-project/update-project.sh
+++ b/.github/actions/update-project/update-project.sh
@@ -43,14 +43,14 @@ echo "Cloning folders in projects/packages and pushing to Automattic package rep
 for package in projects/packages/*; do
 	[ -d "$package" ] || continue # We are only interested in directories (i.e. packages)
 
-	cd $BASE
-
 	# Only keep the package's name
 	NAME=${package##*/}
+	PROJECT_DIR="${BASE}/projects/packages/${NAME}"
 
+	cd ${PROJECT_DIR}
 	echo " Name: $NAME"
 
-	CLONE_DIR="__${NAME}__clone__"
+	CLONE_DIR="${BASE}/__${NAME}__clone__"
 	echo "  Clone dir: $CLONE_DIR"
 
 	# Check if a remote exists for that package.
@@ -62,6 +62,8 @@ for package in projects/packages/*; do
 	git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/automattic/jetpack-$NAME.git $CLONE_DIR
 
 	echo "  Cloning of ${NAME} completed"
+  echo "  Building project"
+  yarn_build
 
 	cd $CLONE_DIR
 
@@ -73,11 +75,11 @@ for package in projects/packages/*; do
 
 	find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
 
-	echo "  Copying from ${BASE}/projects/packages/${NAME}/."
+	echo "  Copying from ${PROJECT_DIR}/."
 
-	cp -r $BASE/projects/packages/$NAME/. .
+	cp -r $PROJECT_DIR/. .
 
-	yarn_build
+
 
 	# Before we commit any changes, ensure that the repo has the basics we need for any package.
 	if $COMPOSER_JSON_EXISTED && [ ! -f "composer.json" ]; then
@@ -108,9 +110,13 @@ for plugin in projects/plugins/*; do
 	# Only keep the plugin's name
 	NAME=${plugin##*/}
 
+	PROJECT_DIR="${BASE}/projects/plugins/${NAME}"
+
+	cd "${PROJECT_DIR}"
+
 	echo " Name: $NAME"
 
-	CLONE_DIR="__${NAME}__clone__"
+	CLONE_DIR="${BASE}/__${NAME}__clone__"
 	echo "  Clone dir: $CLONE_DIR"
 
 	if [ "$NAME" == 'jetpack' ]; then
@@ -127,16 +133,16 @@ for plugin in projects/plugins/*; do
 	git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/automattic/$GIT_SLUG.git $CLONE_DIR
 
 	echo "  Cloning of ${NAME} completed"
+  echo "  Building project"
+  yarn_build
 
 	cd $CLONE_DIR
 
 	find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
 
-	echo "  Copying from ${BASE}/projects/plugins/${NAME}/."
+	echo "  Copying from ${PROJECT_DIR}/."
 
-	cp -r $BASE/projects/plugins/$NAME/. .
-
-	yarn_build
+	cp -r "${PROJECT_DIR}/." .
 
 	if [ -n "$(git status --porcelain)" ]; then
 
@@ -149,5 +155,5 @@ for plugin in projects/plugins/*; do
 		echo "  No changes, skipping $NAME"
 	fi
 
-	cd $BASE
+	cd "${BASE}"
 done

--- a/.github/actions/update-project/update-project.sh
+++ b/.github/actions/update-project/update-project.sh
@@ -62,8 +62,8 @@ for package in projects/packages/*; do
 	git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/automattic/jetpack-$NAME.git $CLONE_DIR
 
 	echo "  Cloning of ${NAME} completed"
-  echo "  Building project"
-  yarn_build
+	echo "  Building project"
+	yarn_build
 
 	cd $CLONE_DIR
 
@@ -133,8 +133,8 @@ for plugin in projects/plugins/*; do
 	git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/automattic/$GIT_SLUG.git $CLONE_DIR
 
 	echo "  Cloning of ${NAME} completed"
-  echo "  Building project"
-  yarn_build
+	echo "  Building project"
+	yarn_build
 
 	cd $CLONE_DIR
 

--- a/.github/actions/update-project/update-project.sh
+++ b/.github/actions/update-project/update-project.sh
@@ -125,12 +125,12 @@ for plugin in projects/plugins/*; do
 		GIT_SLUG="jetpack-${NAME}";
 	fi
 	# Check if a remote exists for that package.
-	$( git ls-remote --exit-code -h "https://github.com/automattic/${GIT_SLUG}.git" >/dev/null 2>&1 ) || continue
+	$( git ls-remote --exit-code -h "https://github.com/Automattic/${GIT_SLUG}.git" >/dev/null 2>&1 ) || continue
 	echo "  ${NAME} exists. Let's clone it."
 
 	# clone, delete files in the clone, and copy (new) files over
 	# this handles file deletions, additions, and changes seamlessly
-	git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/automattic/$GIT_SLUG.git $CLONE_DIR
+	git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/Automattic/$GIT_SLUG.git $CLONE_DIR
 
 	echo "  Cloning of ${NAME} completed"
 	echo "  Building project"

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -2,13 +2,13 @@ name: Update a package when it is updated in the monorepo
 on:
   push:
     branches:
-      - master # Every time a PR is merged to master.
+      - master # Every time a PR is merged to master
     paths:
       - 'projects/packages/**' # Only when package files are modified.
       - 'projects/plugins/**' # Only when plugin files are modified.
 
 jobs:
-  update_package:
+  update_project:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
@@ -17,5 +17,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        shell: bash -l {0}
         run: |
-          sh ./.github/actions/update-project/update-project.sh
+          nvm install
+          nvm use
+          ./.github/actions/update-project/update-project.sh

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -12,13 +12,34 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+          coverage: none
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - name: Use yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: /home/runner/.cache/yarn/v6
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Use composer cache
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.composer/cache/files
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
       - name: Keep Jetpack Projects up to date
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        shell: bash -l {0}
-        run: |
-          nvm install
-          nvm use
-          ./.github/actions/update-project/update-project.sh
+        run: ./.github/actions/update-project/update-project.sh

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -5,6 +5,7 @@ on:
       - master # Every time a PR is merged to master.
     paths:
       - 'projects/packages/**' # Only when package files are modified.
+      - 'projects/plugins/**' # Only when plugin files are modified.
 
 jobs:
   update_package:
@@ -12,9 +13,9 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@master
-      - name: Keep Jetpack Packages up to date
+      - name: Keep Jetpack Projects up to date
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         run: |
-          sh ./.github/actions/update-package/update-package.sh
+          sh ./.github/actions/update-project/update-project.sh


### PR DESCRIPTION
In this branch, we take the monorepo and spit out a built version of jetpack to the https://github.com/automattic/jetpack-production mirror repo.

This is a not-DRY modification and duplication of the package->mirror script that is already used in production with some changes.

- For anything with a `package.json` file, it will run `yarn build-production-concurrently` so if we need JS build steps for a package before being available for clients outside of the monorepo, this could handle that as long as the package as that script defined. This is a bit hacky since if there is a package.json and it doesn't have that script, it'll break. I think we need a datastore for each project's canonical best development and production build scripts. I'd like to tackle that outside of this though.
- It continues the convention of foldername -> jetpack-foldername for the repo, but adds in an exception for `jetpack` to use `jetpack-production` instead of `jetpack-jetpack`. The same datastore as above could hold the correct repo for each project.
- For Jetpack, it also runs the `projects/plugins/jetpack/tools/prepare-build-branch.sh` script to clean up the filetree before comitting to the mirror repo.

#### Changes proposed in this Pull Request:
* Allows for projects/plugins to be built to a mirror directory.
* Creates a special case for jetpack -> jetpack-production

#### Jetpack product discussion
1199714989172614-as-1199732467231541

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* TBA
*

#### Proposed changelog entry for your changes:
* n/a