### PR TITLE
Redirect Settings menu to calypso

### DIFF
--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -369,22 +369,21 @@ class Admin_Menu {
 	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
 	 */
 	public function add_options_menu( $calypso = true ) {
-		$options_slug = $calypso ? 'https://wordpress.com/settings/general/' . $this->domain : 'options-general.php';
-
-		if ( current_user_can( 'manage_options' ) ) {
-			remove_menu_page( 'options-general.php' );
-			remove_submenu_page( 'options-general.php', 'options-general.php' );
-
-			if ( $calypso ) {
-				remove_submenu_page( 'options-general.php', 'options-discussion.php' );
-				remove_submenu_page( 'options-general.php', 'options-writing.php' );
-			}
-
-			add_menu_page( esc_attr__( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_options', $options_slug, null, 'dashicons-admin-settings', 80 );
-			add_submenu_page( $options_slug, esc_attr__( 'General', 'jetpack' ), __( 'General', 'jetpack' ), 'manage_options', $options_slug, null, 10 );
-
-			$this->migrate_submenus( 'options-general.php', $options_slug );
+		if ( ! $calypso ) {
+			return;
 		}
+
+		$options_slug = 'https://wordpress.com/settings/general/' . $this->domain;
+
+		remove_menu_page( 'options-general.php' );
+		remove_submenu_page( 'options-general.php', 'options-general.php' );
+		remove_submenu_page( 'options-general.php', 'options-discussion.php' );
+		remove_submenu_page( 'options-general.php', 'options-writing.php' );
+
+		add_menu_page( esc_attr__( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_options', $options_slug, null, 'dashicons-admin-settings', 80 );
+		add_submenu_page( $options_slug, esc_attr__( 'General', 'jetpack' ), __( 'General', 'jetpack' ), 'manage_options', $options_slug, null, 10 );
+
+		$this->migrate_submenus( 'options-general.php', $options_slug );
 	}
 
 	/**

--- a/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-admin-menu.php
@@ -106,7 +106,7 @@ class Admin_Menu {
 		$this->add_plugins_menu();
 		$this->add_users_menu( $calypso );
 		$this->add_tools_menu( $calypso );
-		$this->add_options_menu();
+		$this->add_options_menu( $calypso );
 
 		ksort( $GLOBALS['menu'] );
 	}
@@ -369,9 +369,21 @@ class Admin_Menu {
 	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
 	 */
 	public function add_options_menu( $calypso = true ) {
-		if ( $calypso ) {
-			remove_submenu_page( 'options-general.php', 'options-discussion.php' );
-			remove_submenu_page( 'options-general.php', 'options-writing.php' );
+		$options_slug = $calypso ? 'https://wordpress.com/settings/general/' . $this->domain : 'options-general.php';
+
+		if ( current_user_can( 'manage_options' ) ) {
+			remove_menu_page( 'options-general.php' );
+			remove_submenu_page( 'options-general.php', 'options-general.php' );
+
+			if ( $calypso ) {
+				remove_submenu_page( 'options-general.php', 'options-discussion.php' );
+				remove_submenu_page( 'options-general.php', 'options-writing.php' );
+			}
+
+			add_menu_page( esc_attr__( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_options', $options_slug, null, 'dashicons-admin-settings', 80 );
+			add_submenu_page( $options_slug, esc_attr__( 'General', 'jetpack' ), __( 'General', 'jetpack' ), 'manage_options', $options_slug, null, 10 );
+
+			$this->migrate_submenus( 'options-general.php', $options_slug );
 		}
 	}
 

--- a/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -139,7 +139,6 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			'Admin menu should not have unexpected top menu items.'
 		);
 
-		$this->assertEquals( static::$menu_data[80], $menu[80], 'Settings menu should stay the same.' );
 		$this->assertEquals( static::$submenu_data[''], $submenu[''], 'Submenu items without parent should stay the same.' );
 	}
 

--- a/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -627,10 +627,19 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_options_menu() {
 		global $submenu;
 
+		$slug = 'https://wordpress.com/settings/general/' . static::$domain;
 		static::$admin_menu->add_options_menu( static::$domain );
 
-		$this->assertNotContains( 'options-discussion.php', $submenu['options-general.php'] );
-		$this->assertNotContains( 'options-writing.php', $submenu['options-general.php'] );
+		$this->assertNotContains( 'options-discussion.php', $submenu[ $slug ] );
+		$this->assertNotContains( 'options-writing.php', $submenu[ $slug ] );
+
+		$general_submenu_item = array(
+			'General',
+			'manage_options',
+			$slug,
+			'General',
+		);
+		$this->assertContains( $general_submenu_item, $submenu[ $slug ] );
 	}
 
 	/**

--- a/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -486,11 +486,20 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_options_menu() {
 		global $submenu;
 
+		$slug = 'https://wordpress.com/settings/general/' . static::$domain;
 		static::$admin_menu->add_options_menu( static::$domain );
 
-		$this->assertNotContains( 'options-discussion.php', $submenu['options-general.php'] );
-		$this->assertNotContains( 'options-writing.php', $submenu['options-general.php'] );
+		$this->assertNotContains( 'options-discussion.php', $submenu[ $slug ] );
+		$this->assertNotContains( 'options-writing.php', $submenu[ $slug ] );
 
-		$this->assertContains( 'Hosting Configuration', $submenu['options-general.php'][6] );
+		$general_submenu_item = array(
+			'General',
+			'manage_options',
+			$slug,
+			'General',
+		);
+		$this->assertContains( $general_submenu_item, $submenu[ $slug ] );
+
+		$this->assertContains( 'Hosting Configuration', $submenu[ $slug ][6] );
 	}
 }

--- a/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -534,11 +534,20 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_options_menu() {
 		global $submenu;
 
+		$slug = 'https://wordpress.com/settings/general/' . static::$domain;
 		static::$admin_menu->add_options_menu( static::$domain );
 
-		$this->assertNotContains( 'options-discussion.php', $submenu['options-general.php'] );
-		$this->assertNotContains( 'options-writing.php', $submenu['options-general.php'] );
+		$this->assertNotContains( 'options-discussion.php', $submenu[ $slug ] );
+		$this->assertNotContains( 'options-writing.php', $submenu[ $slug ] );
 
-		$this->assertContains( 'Hosting Configuration', $submenu['options-general.php'][6] );
+		$general_submenu_item = array(
+			'General',
+			'manage_options',
+			$slug,
+			'General',
+		);
+		$this->assertContains( $general_submenu_item, $submenu[ $slug ] );
+
+		$this->assertContains( 'Hosting Configuration', $submenu[ $slug ][6] );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18216

As [this spreadsheet](https://docs.google.com/spreadsheets/d/1i640dQt4vs2XYgqRA4YEH69ssR9UNcFJx49HUss0-q0/edit#gid=0) suggests, Settings should redirect to Calypso.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes link direction of Setting menu to Calypso rather than wp-admin

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

## Manually
* Enable nav-unification (paYJgx-1af-p2)

**Simple**
* Apply D54949-code in your sandbox

**Atomic**
* Use Jetpack Beta and select the current branch

**Result:**
* Inspect the Settings submenu, nothing should have changed except from the fact that Settings redirects to calypso now

## Automated
run `yarn docker:phpunit --filter Admin_Menu`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Settings menu now redirects to Calypso Settings when Dashboard Customizations are enabled.