### PR TITLE
Crowdsignal: update shortcode survey URL in using block editor

### DIFF
--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -511,12 +511,20 @@ if (
 						$inline = false;
 					}
 
-					$survey = preg_replace( '/[^a-f0-9]/i', '', $attributes['survey'] );
+					$survey_url = '';
 
-					if ( 'crowdsignal.com' === $attributes['site'] ) {
-						$survey_url = 'https://survey.fm/' . $survey;
+					if ( 'true' !== $attributes['survey'] ) {
+						$survey = preg_replace( '/[^a-f0-9]/i', '', $attributes['survey'] );
+
+						if ( 'crowdsignal.com' === $attributes['site'] ) {
+							$survey_url = 'https://survey.fm/' . $survey;
+						} else {
+							$survey_url = 'https://polldaddy.com/s/' . $survey;
+						}
 					} else {
-						$survey_url = 'https://polldaddy.com/s/' . $survey;
+						if ( isset( $attributes['domain'] ) && isset( $attributes['id'] ) ) {
+							$survey_url = 'https://' . $attributes['domain'] . '.survey.fm/' . $attributes['id'];
+						}
 					}
 
 					$survey_link = sprintf(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When embedding a Crowdsignal survey in the block editor it doesn't use the shortcode to fetch the embed code, but when the post is saved the shortcode is run. The survey link was incorrect because it was expecting a URL in a different, older format we don't use any more. This patch supports calling the shortcode normally, and by the block editor REST API.

#### Jetpack product discussion
Ref: p1609789666043200-slack-C01CSBEN0QZ

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
In modules/shortcodes/crowdsignal.php go to the end of the crowdsignal_shortcode function and just above "return $this->get_async_code" add error_log( "survey_url: $survey_url" );
Create a post and paste a Crowdsignal survey URL (Try http://donncha.survey.fm/test-test-3 if you don't have a CS account) into a block.
Click "Save draft" and you should see the broken survey URL in your error log. It should be https://survey.fm/e.
Apply patch.
Modify the post, (add 1 to the post title) and click "Save draft" again.
You should see the correct survey URL in the log.

#### Proposed changelog entry for your changes:
Fix Crowdsignal survey shortcode when using the block editor.