### PR TITLE
Dialogue: focus on rich text component when created

### DIFF
--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -124,21 +124,24 @@ export default function DialogueEdit ( {
 
 	// Try to focus the RichText component when mounted.
 	useEffect( () => {
+		// Bail if component is not selected.
 		if ( ! isSelected ) {
 			return;
 		}
 
+		// Bail if context reference is not valid.
 		if ( ! richTextRef?.current ) {
 			return;
 		}
 
+		// Bail if context is not empty.
 		if ( content?.length ) {
 			return;
 		}
 
-		setTimeout( () => {
-			richTextRef.current.focus();
-		}, 0 );
+		// Focus the rich text component,
+		// through a delay hack.
+		setTimeout( () => richTextRef.current.focus(), 250 );
 	}, [ isSelected, content ] );
 
 	const showTimestamp = isCustomParticipant ? showTimestampLocally : showTimestampGlobally;

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -132,10 +132,14 @@ export default function DialogueEdit ( {
 			return;
 		}
 
+		if ( content?.length ) {
+			return;
+		}
+
 		setTimeout( () => {
 			richTextRef.current.focus();
 		}, 0 );
-	}, [ isSelected ] );
+	}, [ isSelected, content ] );
 
 	const showTimestamp = isCustomParticipant ? showTimestampLocally : showTimestampGlobally;
 

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -305,6 +305,12 @@ export default function DialogueEdit( {
 				className={ `${ baseClassName }__content` }
 				value={ content }
 				onChange={ value => setAttributes( { content: value } ) }
+				onClick={ ( event ) => {
+					if ( ! event.target ) {
+						return;
+					}
+					event.target.focus();
+				} }
 				onMerge={ mergeBlocks }
 				onSplit={ value => {
 					if ( ! content?.length ) {

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -69,6 +69,7 @@ export default function DialogueEdit ( {
 	context,
 	onReplace,
 	mergeBlocks,
+	isSelected,
 } ) {
 	const {
 		participant,
@@ -120,6 +121,21 @@ export default function DialogueEdit ( {
 			content: '',
 		} );
 	}, [ participantSlug, participants, prevBlock, setAttributes, conversationBridge ] );
+
+	// Try to focus the RichText component when mounted.
+	useEffect( () => {
+		if ( ! isSelected ) {
+			return;
+		}
+
+		if ( ! richTextRef?.current ) {
+			return;
+		}
+
+		setTimeout( () => {
+			richTextRef.current.focus();
+		}, 0 );
+	}, [ isSelected ] );
 
 	const showTimestamp = isCustomParticipant ? showTimestampLocally : showTimestampGlobally;
 

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -23,7 +23,12 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 } from '@wordpress/components';
-import { useContext, useState, useEffect } from '@wordpress/element';
+import {
+	useContext,
+	useState,
+	useEffect,
+	useRef,
+ } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 
 /**
@@ -74,6 +79,9 @@ export default function DialogueEdit ( {
 		placeholder,
 	} = attributes;
 	const [ isFocusedOnParticipantLabel, setIsFocusedOnParticipantLabel ] = useState( false );
+	const richTextRef = useRef();
+	const baseClassName = 'wp-block-jetpack-dialogue';
+	const blockProps = useBlockProps( { className } );
 
 	// Pick the previous block atteobutes from the state.
 	const prevBlock = useSelect( select => {
@@ -114,9 +122,6 @@ export default function DialogueEdit ( {
 	}, [ participantSlug, participants, prevBlock, setAttributes, conversationBridge ] );
 
 	const showTimestamp = isCustomParticipant ? showTimestampLocally : showTimestampGlobally;
-
-	const baseClassName = 'wp-block-jetpack-dialogue';
-	const blockProps = useBlockProps( { className: baseClassName } );
 
 	/**
 	 * Helper to check if the gven style is set, or not.
@@ -274,6 +279,7 @@ export default function DialogueEdit ( {
 			</div>
 
 			<RichText
+				ref={ richTextRef }
 				identifier="content"
 				tagName="p"
 				className={ `${ baseClassName }__content` }

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -8,12 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	InspectorControls,
-	RichText,
-	BlockControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { InspectorControls, RichText, BlockControls, useBlockProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 
 import {
@@ -23,12 +18,7 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 } from '@wordpress/components';
-import {
-	useContext,
-	useState,
-	useEffect,
-	useRef,
- } from '@wordpress/element';
+import { useContext, useState, useEffect, useLayoutEffect, useRef } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 
 /**
@@ -48,7 +38,10 @@ import {
 import { formatUppercase } from '../../shared/icons';
 
 function getParticipantBySlug( participants, slug ) {
-	const participant = find( participants, ( contextParticipant ) => contextParticipant.participantSlug === slug );
+	const participant = find(
+		participants,
+		contextParticipant => contextParticipant.participantSlug === slug
+	);
 	if ( participant ) {
 		return participant;
 	}
@@ -60,7 +53,7 @@ function getParticipantBySlug( participants, slug ) {
 const blockName = 'jetpack/dialogue';
 const blockNameFallback = 'core/paragraph';
 
-export default function DialogueEdit ( {
+export default function DialogueEdit( {
 	className,
 	attributes,
 	setAttributes,
@@ -95,7 +88,9 @@ export default function DialogueEdit ( {
 	const showTimestampGlobally = context[ 'jetpack/conversation-showTimestamps' ];
 
 	// Participants list.
-	const participants = participantsFromContext?.length ? participantsFromContext : defaultParticipants;
+	const participants = participantsFromContext?.length
+		? participantsFromContext
+		: defaultParticipants;
 
 	const isCustomParticipant = !! participant && ! participantSlug;
 	const currentParticipantSlug = isCustomParticipant ? defaultParticipantSlug : participantSlug;
@@ -113,7 +108,9 @@ export default function DialogueEdit ( {
 			return;
 		}
 
-		const nextParticipantSlug = conversationBridge.getNextParticipantSlug( prevBlock?.attributes?.participantSlug );
+		const nextParticipantSlug = conversationBridge.getNextParticipantSlug(
+			prevBlock?.attributes?.participantSlug
+		);
 
 		setAttributes( {
 			...( prevBlock?.attributes || {} ),
@@ -123,26 +120,27 @@ export default function DialogueEdit ( {
 	}, [ participantSlug, participants, prevBlock, setAttributes, conversationBridge ] );
 
 	// Try to focus the RichText component when mounted.
-	useEffect( () => {
+	const hasContent = content?.length > 0;
+	const richTextRefCurrent = richTextRef?.current;
+	useLayoutEffect( () => {
 		// Bail if component is not selected.
 		if ( ! isSelected ) {
 			return;
 		}
 
 		// Bail if context reference is not valid.
-		if ( ! richTextRef?.current ) {
+		if ( ! richTextRefCurrent ) {
 			return;
 		}
 
 		// Bail if context is not empty.
-		if ( content?.length ) {
+		if ( hasContent ) {
 			return;
 		}
 
-		// Focus the rich text component,
-		// through a delay hack.
-		setTimeout( () => richTextRef.current.focus(), 250 );
-	}, [ isSelected, content ] );
+		// Focus the rich text component
+		richTextRefCurrent.focus();
+	}, [ isSelected, hasContent, richTextRefCurrent ] );
 
 	const showTimestamp = isCustomParticipant ? showTimestampLocally : showTimestampGlobally;
 
@@ -253,9 +251,10 @@ export default function DialogueEdit ( {
 
 					<PanelBody title={ __( 'Timestamp', 'jetpack' ) }>
 						<ToggleControl
-							label={ isCustomParticipant
-								? __( 'Show', 'jetpack' )
-								: __( 'Show conversation timestamps', 'jetpack' )
+							label={
+								isCustomParticipant
+									? __( 'Show', 'jetpack' )
+									: __( 'Show conversation timestamps', 'jetpack' )
 							}
 							checked={ showTimestamp }
 							onChange={ setShowTimestamp }
@@ -265,9 +264,7 @@ export default function DialogueEdit ( {
 							<TimestampControl
 								className={ baseClassName }
 								value={ timestamp }
-								onChange={ ( newTimestampValue ) =>
-									setAttributes( { timestamp: newTimestampValue } )
-								}
+								onChange={ newTimestampValue => setAttributes( { timestamp: newTimestampValue } ) }
 							/>
 						) }
 					</PanelBody>
@@ -293,7 +290,7 @@ export default function DialogueEdit ( {
 					<TimestampDropdown
 						className={ baseClassName }
 						value={ timestamp }
-						onChange={ ( newTimestampValue ) => {
+						onChange={ newTimestampValue => {
 							setAttributes( { timestamp: newTimestampValue } );
 						} }
 						shortLabel={ true }
@@ -307,11 +304,9 @@ export default function DialogueEdit ( {
 				tagName="p"
 				className={ `${ baseClassName }__content` }
 				value={ content }
-				onChange={ ( value ) =>
-					setAttributes( { content: value } )
-				}
+				onChange={ value => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
-				onSplit={ ( value ) => {
+				onSplit={ value => {
 					if ( ! content?.length ) {
 						return createBlock( blockNameFallback );
 					}
@@ -321,7 +316,6 @@ export default function DialogueEdit ( {
 						content: value,
 					} );
 				} }
-
 				onReplace={ ( blocks, ...args ) => {
 					// If transcription bridge doesn't exist,
 					// then run the default replace process.
@@ -347,7 +341,9 @@ export default function DialogueEdit ( {
 					// with the next participant slug.
 
 					// Pick up the next participant slug.
-					const nextParticipantSlug = conversationBridge.getNextParticipantSlug( attributes.participantSlug );
+					const nextParticipantSlug = conversationBridge.getNextParticipantSlug(
+						attributes.participantSlug
+					);
 
 					// Update new block attributes.
 					blocks[ 1 ].attributes = {
@@ -358,9 +354,7 @@ export default function DialogueEdit ( {
 
 					onReplace( blocks, ...args );
 				} }
-				onRemove={
-					onReplace ? () => onReplace( [] ) : undefined
-				}
+				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 				placeholder={ placeholder || __( 'Write dialogue…', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
 				isSelected={ ! isFocusedOnParticipantLabel }

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, RichText, BlockControls, useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, RichText, BlockControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 
 import {
@@ -75,7 +75,6 @@ export default function DialogueEdit( {
 	const [ isFocusedOnParticipantLabel, setIsFocusedOnParticipantLabel ] = useState( false );
 	const richTextRef = useRef();
 	const baseClassName = 'wp-block-jetpack-dialogue';
-	const blockProps = useBlockProps( { className } );
 
 	// Pick the previous block atteobutes from the state.
 	const prevBlock = useSelect( select => {
@@ -208,7 +207,7 @@ export default function DialogueEdit( {
 	}
 
 	return (
-		<div { ...blockProps }>
+		<div className={ className }>
 			<BlockControls>
 				{ currentParticipant && isFocusedOnParticipantLabel && (
 					<ToolbarGroup>
@@ -305,12 +304,6 @@ export default function DialogueEdit( {
 				className={ `${ baseClassName }__content` }
 				value={ content }
 				onChange={ value => setAttributes( { content: value } ) }
-				onMouseDown={ ( event ) => {
-					if ( ! event.target ) {
-						return;
-					}
-					event.target.focus();
-				} }
 				onMerge={ mergeBlocks }
 				onSplit={ value => {
 					if ( ! content?.length ) {

--- a/extensions/blocks/dialogue/edit.js
+++ b/extensions/blocks/dialogue/edit.js
@@ -305,7 +305,7 @@ export default function DialogueEdit( {
 				className={ `${ baseClassName }__content` }
 				value={ content }
 				onChange={ value => setAttributes( { content: value } ) }
-				onClick={ ( event ) => {
+				onMouseDown={ ( event ) => {
 					if ( ! event.target ) {
 						return;
 					}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR implements an auto-focus behavior to the dialogue block. It will happen when:

1) block is mounted
2) block is selected
3) block is not empty

Fixes https://github.com/Automattic/jetpack/issues/18228

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: focus on content when it's convenient

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/18176#issuecomment-755746402

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try to test the experience described [here](https://github.com/Automattic/jetpack/pull/18176#issuecomment-755746402). Confirm that now, every time that dialogue block is created, it makes focus on the block content component.

#### Proposed changelog entry for your changes:
n/a