### PR TITLE
ESLint: Add --max-warnings=0 to `yarn lint-required`

### DIFF
--- a/modules/search/instant-search/components/test/.eslintrc.js
+++ b/modules/search/instant-search/components/test/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+	extends: [ 'plugin:jest/recommended' ],
+	env: { jest: true },
+	rules: {
+		'jsdoc/check-tag-names': [
+			1, // Recommended
+			{ definedTags: [ 'jest-environment' ] },
+		],
+	},
+};

--- a/modules/search/instant-search/lib/test/.eslintrc.js
+++ b/modules/search/instant-search/lib/test/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+	extends: [ 'plugin:jest/recommended' ],
+	env: { jest: true },
+	rules: {
+		'jsdoc/check-tag-names': [
+			1, // Recommended
+			{ definedTags: [ 'jest-environment' ] },
+		],
+	},
+};

--- a/modules/search/instant-search/lib/test/filters.test.js
+++ b/modules/search/instant-search/lib/test/filters.test.js
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-/* global expect */
 /**
  * Internal dependencies
  */

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"lint": "yarn lint-file .",
 		"lint-changed": "tools/eslint-changed.js --ext .js,.jsx --git",
 		"lint-file": "eslint --ext .js,.jsx",
-		"lint-required": "node -e \"const fs = require('fs'); fs.copyFileSync('.eslintignore','.eslintignore-required'); const w=fs.createWriteStream('.eslintignore-required',{flags:'a'}); w.write('\\n# bin/eslint-excludelist.json\\n'); w.end(JSON.parse(fs.readFileSync('bin/eslint-excludelist.json','utf8')).join('\\n')+'\\n')\" && yarn lint --ignore-path .eslintignore-required",
+		"lint-required": "node -e \"const fs = require('fs'); fs.copyFileSync('.eslintignore','.eslintignore-required'); const w=fs.createWriteStream('.eslintignore-required',{flags:'a'}); w.write('\\n# bin/eslint-excludelist.json\\n'); w.end(JSON.parse(fs.readFileSync('bin/eslint-excludelist.json','utf8')).join('\\n')+'\\n')\" && yarn lint --max-warnings=0 --ignore-path .eslintignore-required",
 		"php:autofix": "composer phpcs:fix",
 		"php:compatibility": "composer phpcs:compatibility",
 		"php:lint": "composer phpcs:lint",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We want warnings to fail CI for these files. Unfortunately eslint defaults to not returning failure for warnings.

Then fix one warning that had gotten committed by adding an .eslintrc.js to modules/**/test/ to configure eslint for jest, including proper recognition of "@jest-environment".

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do tests pass, with no eslint warnings reported?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed, developer only.
