### PR TITLE
Conversation: set bold format for new participant

### DIFF
--- a/extensions/blocks/conversation/edit.js
+++ b/extensions/blocks/conversation/edit.js
@@ -94,6 +94,7 @@ function ConversationEdit ( {
 				{
 					participant: newSpakerValue,
 					participantSlug: newParticipantSlug,
+					hasBoldStyle: true,
 				},
 			],
 		} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR sets the `hasBoldStyle` attribute as default when a new participant is added.

Fixes #18222

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation: set bold format for new participant

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create/edit a new conversation block
* Add a new participant
* Add a new dialogue block, setting the participant with the new one
* Confirm that it is bold as default.

before | after
-------|-----
![image](https://user-images.githubusercontent.com/77539/103943054-2eb6f180-5110-11eb-8677-7928aee06d86.png) | ![image](https://user-images.githubusercontent.com/77539/103943024-26f74d00-5110-11eb-962f-4f8e7c11899e.png)


Take a look [at this video](https://github.com/Automattic/jetpack/pull/18176#issuecomment-755414890) to see the issue.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
n/a
