### PR TITLE
Masterbar: Account for link destination setting

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -78,37 +78,32 @@ class Admin_Menu {
 			$this->is_api_request = defined( 'REST_REQUEST' ) && REST_REQUEST;
 		}
 
-		/**
+		/*
 		 * Whether links should point to Calypso or wp-admin.
 		 *
 		 * Options:
-		 * true  - Calypso.
-		 * false - wp-admin.
-		 *
-		 * @module masterbar
-		 * @since 9.3.0
-		 *
-		 * @param bool $calypso Whether menu item URLs should point to Calypso.
+		 * false - Calypso (Default).
+		 * true  - wp-admin.
 		 */
-		$calypso = apply_filters( 'jetpack_admin_menu_use_calypso_links', true );
+		$wp_admin = $this->should_link_to_wp_admin();
 
 		// Remove separators.
 		remove_menu_page( 'separator1' );
 
-		$this->add_my_home_menu( $calypso );
+		$this->add_my_home_menu( $wp_admin );
 		$this->add_stats_menu();
 		$this->add_upgrades_menu();
-		$this->add_posts_menu( $calypso );
-		$this->add_media_menu( $calypso );
-		$this->add_page_menu( $calypso );
-		$this->add_testimonials_menu( $calypso );
-		$this->add_portfolio_menu( $calypso );
-		$this->add_comments_menu( $calypso );
-		$this->add_appearance_menu( $calypso );
+		$this->add_posts_menu( $wp_admin );
+		$this->add_media_menu( $wp_admin );
+		$this->add_page_menu( $wp_admin );
+		$this->add_testimonials_menu( $wp_admin );
+		$this->add_portfolio_menu( $wp_admin );
+		$this->add_comments_menu( $wp_admin );
+		$this->add_appearance_menu( $wp_admin );
 		$this->add_plugins_menu();
-		$this->add_users_menu( $calypso );
-		$this->add_tools_menu( $calypso );
-		$this->add_options_menu( $calypso );
+		$this->add_users_menu( $wp_admin );
+		$this->add_tools_menu( $wp_admin );
+		$this->add_options_menu( $wp_admin );
 
 		ksort( $GLOBALS['menu'] );
 	}
@@ -116,12 +111,12 @@ class Admin_Menu {
 	/**
 	 * Adds My Home menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_my_home_menu( $calypso = true ) {
+	public function add_my_home_menu( $wp_admin = false ) {
 		global $submenu;
 
-		$menu_slug = $calypso ? 'https://wordpress.com/home/' . $this->domain : 'index.php';
+		$menu_slug = $wp_admin ? 'index.php' : 'https://wordpress.com/home/' . $this->domain;
 
 		remove_menu_page( 'index.php' );
 		remove_submenu_page( 'index.php', 'index.php' );
@@ -173,10 +168,10 @@ class Admin_Menu {
 	/**
 	 * Adds Posts menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_posts_menu( $calypso = true ) {
-		if ( ! $calypso ) {
+	public function add_posts_menu( $wp_admin = false ) {
+		if ( $wp_admin ) {
 			return;
 		}
 
@@ -203,13 +198,13 @@ class Admin_Menu {
 	/**
 	 * Adds Media menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_media_menu( $calypso = true ) {
+	public function add_media_menu( $wp_admin = false ) {
 		remove_submenu_page( 'upload.php', 'upload.php' );
 		remove_submenu_page( 'upload.php', 'media-new.php' );
 
-		if ( $calypso ) {
+		if ( ! $wp_admin ) {
 			$menu_slug = 'https://wordpress.com/media/' . $this->domain;
 
 			remove_menu_page( 'upload.php' );
@@ -228,10 +223,10 @@ class Admin_Menu {
 	/**
 	 * Adds Page menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_page_menu( $calypso = true ) {
-		if ( ! $calypso ) {
+	public function add_page_menu( $wp_admin = false ) {
+		if ( $wp_admin ) {
 			return;
 		}
 
@@ -258,29 +253,29 @@ class Admin_Menu {
 	/**
 	 * Adds Testimonials menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_testimonials_menu( $calypso = true ) {
-		$this->add_custom_post_type_menu( 'jetpack-testimonial', $calypso );
+	public function add_testimonials_menu( $wp_admin = false ) {
+		$this->add_custom_post_type_menu( 'jetpack-testimonial', $wp_admin );
 	}
 
 	/**
 	 * Adds Portfolio menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_portfolio_menu( $calypso = true ) {
-		$this->add_custom_post_type_menu( 'jetpack-portfolio', $calypso );
+	public function add_portfolio_menu( $wp_admin = false ) {
+		$this->add_custom_post_type_menu( 'jetpack-portfolio', $wp_admin );
 	}
 
 	/**
 	 * Adds a custom post type menu.
 	 *
 	 * @param string $post_type Custom post type.
-	 * @param bool   $calypso   Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool   $wp_admin  Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_custom_post_type_menu( $post_type, $calypso = true ) {
-		if ( ! $calypso ) {
+	public function add_custom_post_type_menu( $post_type, $wp_admin = false ) {
+		if ( $wp_admin ) {
 			return;
 		}
 
@@ -335,10 +330,10 @@ class Admin_Menu {
 	/**
 	 * Adds Comments menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_comments_menu( $calypso = true ) {
-		if ( ! $calypso || ! current_user_can( 'edit_posts' ) ) {
+	public function add_comments_menu( $wp_admin = false ) {
+		if ( $wp_admin || ! current_user_can( 'edit_posts' ) ) {
 			return;
 		}
 
@@ -369,13 +364,13 @@ class Admin_Menu {
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $calypso = true ) {
+	public function add_appearance_menu( $wp_admin = false ) {
 		$user_can_customize = current_user_can( 'customize' );
 		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
-		$customize_slug     = $calypso ? 'https://wordpress.com/customize/' . $this->domain : 'customize.php';
-		$themes_slug        = $calypso ? 'https://wordpress.com/themes/' . $this->domain : 'themes.php';
+		$customize_slug     = $wp_admin ? 'customize.php' : 'https://wordpress.com/customize/' . $this->domain;
+		$themes_slug        = $wp_admin ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
 		$customize_url      = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' ); // phpcs:ignore
 		remove_menu_page( 'themes.php' );
 		remove_submenu_page( 'themes.php', 'themes.php' );
@@ -448,12 +443,12 @@ class Admin_Menu {
 	/**
 	 * Adds Users menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_users_menu( $calypso = true ) {
-		$users_slug   = $calypso ? 'https://wordpress.com/people/team/' . $this->domain : 'users.php';
+	public function add_users_menu( $wp_admin = false ) {
+		$users_slug   = $wp_admin ? 'users.php' : 'https://wordpress.com/people/team/' . $this->domain;
 		$add_new_slug = 'https://wordpress.com/people/new/' . $this->domain;
-		$profile_slug = $calypso ? 'https://wordpress.com/me' : 'profile.php';
+		$profile_slug = $wp_admin ? 'profile.php' : 'https://wordpress.com/me';
 
 		if ( current_user_can( 'list_users' ) ) {
 			remove_menu_page( 'users.php' );
@@ -482,10 +477,10 @@ class Admin_Menu {
 	/**
 	 * Adds Tools menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_tools_menu( $calypso = true ) {
-		if ( ! $calypso ) {
+	public function add_tools_menu( $wp_admin = false ) {
+		if ( $wp_admin ) {
 			return;
 		}
 
@@ -512,10 +507,10 @@ class Admin_Menu {
 	/**
 	 * Adds Settings menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_options_menu( $calypso = true ) {
-		if ( ! $calypso ) {
+	public function add_options_menu( $wp_admin = false ) {
+		if ( $wp_admin ) {
 			return;
 		}
 
@@ -612,5 +607,14 @@ class Admin_Menu {
 	 */
 	public function dequeue_scripts() {
 		wp_dequeue_script( 'a8c_wpcom_masterbar_overrides' ); // Initially loaded in modules/masterbar/masterbar/class-masterbar.php.
+	}
+
+	/**
+	 * Whether to use wp-admin pages rather than Calypso.
+	 *
+	 * @return bool
+	 */
+	public function should_link_to_wp_admin() {
+		return get_user_option( 'jetpack_admin_menu_link_destination' );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -208,25 +208,25 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	/**
 	 * Adds Tools menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_tools_menu( $calypso = true ) {
-		$menu_slug = $calypso ? 'https://wordpress.com/marketing/tools/' . $this->domain : 'tools.php';
+	public function add_tools_menu( $wp_admin = false ) {
+		$menu_slug = $wp_admin ? 'tools.php' : 'https://wordpress.com/marketing/tools/' . $this->domain;
 
 		add_submenu_page( $menu_slug, esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'manage_options', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 5 );
 		add_submenu_page( $menu_slug, esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 10 );
 
-		parent::add_tools_menu( $calypso );
+		parent::add_tools_menu( $wp_admin );
 	}
 
 	/**
 	 * Adds Settings menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_options_menu( $calypso = true ) {
+	public function add_options_menu( $wp_admin = false ) {
 		add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
-		parent::add_options_menu( $calypso );
+		parent::add_options_menu( $wp_admin );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -261,13 +261,13 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	/**
 	 * Adds Users menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_users_menu( $calypso = true ) {
-		$users_slug   = $calypso ? 'https://wordpress.com/people/team/' . $this->domain : 'users.php';
+	public function add_users_menu( $wp_admin = false ) {
+		$users_slug   = $wp_admin ? 'users.php' : 'https://wordpress.com/people/team/' . $this->domain;
 		$add_new_slug = 'https://wordpress.com/people/new/' . $this->domain;
-		$profile_slug = $calypso ? 'https://wordpress.com/me' : 'grofiles-editor';
-		$account_slug = $calypso ? 'https://wordpress.com/me/account' : 'grofiles-user-settings';
+		$profile_slug = $wp_admin ? 'grofiles-editor' : 'https://wordpress.com/me';
+		$account_slug = $wp_admin ? 'grofiles-user-settings' : 'https://wordpress.com/me/account';
 
 		if ( current_user_can( 'list_users' ) ) {
 			remove_menu_page( 'users.php' );
@@ -290,7 +290,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 					return 'users.php' === $parent_file ? $users_slug : $parent_file;
 				}
 			);
-		} elseif ( $calypso ) {
+		} elseif ( ! $wp_admin ) {
 			remove_menu_page( 'profile.php' );
 			remove_submenu_page( 'profile.php', 'grofiles-editor' );
 			remove_submenu_page( 'profile.php', 'grofiles-user-settings' );
@@ -311,10 +311,10 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	/**
 	 * Adds Tools menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_tools_menu( $calypso = true ) {
-		$menu_slug = $calypso ? 'https://wordpress.com/marketing/tools/' . $this->domain : 'tools.php';
+	public function add_tools_menu( $wp_admin = false ) {
+		$menu_slug = $wp_admin ? 'tools.php' : 'https://wordpress.com/marketing/tools/' . $this->domain;
 
 		remove_submenu_page( 'tools.php', 'export.php' );
 
@@ -322,15 +322,15 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		add_submenu_page( $menu_slug, esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 10 );
 		add_submenu_page( $menu_slug, esc_attr__( 'Export', 'jetpack' ), __( 'Export', 'jetpack' ), 'export', 'https://wordpress.com/export/' . $this->domain, null, 20 );
 
-		parent::add_tools_menu( $calypso );
+		parent::add_tools_menu( $wp_admin );
 	}
 
 	/**
 	 * Adds Settings menu.
 	 *
-	 * @param bool $calypso Optional. Whether links should point to Calypso or wp-admin. Default true (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_options_menu( $calypso = true ) {
+	public function add_options_menu( $wp_admin = false ) {
 		add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
 		// Replace sharing menu if it exists. See Publicize_UI::sharing_menu.
@@ -338,6 +338,22 @@ class WPcom_Admin_Menu extends Admin_Menu {
 			add_options_page( esc_attr__( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/sharing-buttons/' . $this->domain, null, 30 );
 		}
 
-		parent::add_options_menu( $calypso );
+		parent::add_options_menu( $wp_admin );
+	}
+
+	/**
+	 * Whether to use wp-admin pages rather than Calypso.
+	 *
+	 * @return bool
+	 */
+	public function should_link_to_wp_admin() {
+		$result = false; // Calypso.
+
+		$user_attribute = get_user_attribute( get_current_user_id(), 'calypso_preferences' );
+		if ( ! empty( $user_attribute['linkDestination'] ) ) {
+			$result = $user_attribute['linkDestination'];
+		}
+
+		return $result;
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -168,7 +168,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_my_home_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_my_home_menu( static::$domain );
+		static::$admin_menu->add_my_home_menu( false );
 
 		$slug = 'https://wordpress.com/home/' . static::$domain;
 
@@ -200,7 +200,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			0 => array( 'Home', 'read', 'index.php' ),
 		);
 
-		static::$admin_menu->add_my_home_menu( static::$domain );
+		static::$admin_menu->add_my_home_menu( false );
 
 		$this->assertArrayNotHasKey( 'https://wordpress.com/home/' . static::$domain, $submenu );
 	}
@@ -213,7 +213,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_stats_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_stats_menu( static::$domain );
+		static::$admin_menu->add_stats_menu();
 
 		$menu_title = __( 'Stats', 'jetpack' );
 
@@ -286,7 +286,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_jetpack_upgrades_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_upgrades_menu( static::$domain );
+		static::$admin_menu->add_upgrades_menu();
 
 		$slug = 'https://wordpress.com/plans/' . static::$domain;
 
@@ -311,7 +311,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_posts_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_posts_menu( static::$domain );
+		static::$admin_menu->add_posts_menu( false );
 
 		$posts_menu_item = array(
 			'Posts',
@@ -335,7 +335,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_media_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_media_menu( static::$domain );
+		static::$admin_menu->add_media_menu( false );
 
 		$slug = 'https://wordpress.com/media/' . static::$domain;
 
@@ -375,7 +375,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_page_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_page_menu( static::$domain );
+		static::$admin_menu->add_page_menu( false );
 
 		$posts_menu_item = array(
 			'Pages',
@@ -461,14 +461,14 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		// Only users that can edit posts get to see the comments menu.
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
 		$menu = array();
-		static::$admin_menu->add_comments_menu( static::$domain );
+		static::$admin_menu->add_comments_menu( false );
 		$this->assertEmpty( $menu );
 
 		// Reset.
 		wp_set_current_user( static::$user_id );
 		$menu = static::$menu_data;
 
-		static::$admin_menu->add_comments_menu( static::$domain );
+		static::$admin_menu->add_comments_menu( false );
 
 		$comments_menu_item = array(
 			'Comments <span class="awaiting-mod count-0"><span class="pending-count" aria-hidden="true">0</span><span class="comments-in-moderation-text screen-reader-text">0 Comments in moderation</span></span>',
@@ -492,7 +492,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_appearance_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_appearance_menu( static::$domain );
+		static::$admin_menu->add_appearance_menu( false );
 
 		$slug = 'https://wordpress.com/themes/' . static::$domain;
 
@@ -554,7 +554,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'editor' ) ) );
 		$menu = array();
 
-		static::$admin_menu->add_users_menu( true );
+		static::$admin_menu->add_users_menu( false );
 
 		$this->assertEmpty( $menu );
 
@@ -562,7 +562,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		wp_set_current_user( static::$user_id );
 		$menu = static::$menu_data;
 
-		static::$admin_menu->add_users_menu( static::$domain );
+		static::$admin_menu->add_users_menu( false );
 
 		$slug = 'https://wordpress.com/people/team/' . static::$domain;
 
@@ -620,7 +620,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		global $menu, $submenu;
 
 		$slug = 'https://wordpress.com/marketing/tools/' . static::$domain;
-		static::$admin_menu->add_tools_menu( static::$domain );
+		static::$admin_menu->add_tools_menu( false );
 
 		$tools_menu_item = array(
 			'Tools',
@@ -671,7 +671,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		global $submenu;
 
 		$slug = 'https://wordpress.com/settings/general/' . static::$domain;
-		static::$admin_menu->add_options_menu( static::$domain );
+		static::$admin_menu->add_options_menu( false );
 
 		$this->assertNotContains( 'options-discussion.php', $submenu[ $slug ] );
 		$this->assertNotContains( 'options-writing.php', $submenu[ $slug ] );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -401,7 +401,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		// Don't show post types that don't want to be shown.
 		$revision = get_post_type_object( 'revision' );
-		static::$admin_menu->add_custom_post_type_menu( $revision, true );
+		static::$admin_menu->add_custom_post_type_menu( $revision, false );
 
 		$last_item = array_pop( $menu );
 		$this->assertNotSame( 'https://wordpress.com/types/revision/' . static::$domain, $last_item[2] );
@@ -414,7 +414,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 				'menu_position' => 2020,
 			)
 		);
-		static::$admin_menu->add_custom_post_type_menu( 'custom_test_type', true );
+		static::$admin_menu->add_custom_post_type_menu( 'custom_test_type', false );
 
 		// Clean up.
 		unregister_post_type( 'custom_test_type' );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -324,7 +324,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'editor' ) ) );
 		$menu = array();
 
-		static::$admin_menu->add_users_menu( true );
+		static::$admin_menu->add_users_menu( false );
 
 		$this->assertEmpty( $menu );
 
@@ -332,7 +332,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		wp_set_current_user( static::$user_id );
 		$menu = static::$menu_data;
 
-		static::$admin_menu->add_users_menu( static::$domain );
+		static::$admin_menu->add_users_menu( false );
 
 		$slug = 'https://wordpress.com/people/team/' . static::$domain;
 
@@ -390,7 +390,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		global $menu, $submenu;
 
 		$slug = 'https://wordpress.com/marketing/tools/' . static::$domain;
-		static::$admin_menu->add_tools_menu( static::$domain );
+		static::$admin_menu->add_tools_menu( false );
 
 		$tools_menu_item = array(
 			'Tools',
@@ -464,7 +464,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		global $submenu;
 
 		$slug = 'https://wordpress.com/settings/general/' . static::$domain;
-		static::$admin_menu->add_options_menu( static::$domain );
+		static::$admin_menu->add_options_menu( false );
 
 		$this->assertNotContains( 'options-discussion.php', $submenu[ $slug ] );
 		$this->assertNotContains( 'options-writing.php', $submenu[ $slug ] );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -300,7 +300,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		global $menu, $submenu;
 
 		add_filter( 'wp_get_update_data', array( $this, 'mock_update_data' ) );
-		static::$admin_menu->add_plugins_menu( static::$domain );
+		static::$admin_menu->add_plugins_menu();
 		remove_filter( 'wp_get_update_data', array( $this, 'mock_update_data' ) );
 
 		$slug  = 'https://wordpress.com/plugins/' . static::$domain;
@@ -354,7 +354,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'editor' ) ) );
 		$menu = array();
 
-		static::$admin_menu->add_users_menu( true );
+		static::$admin_menu->add_users_menu( false );
 
 		$profile_menu_item = array(
 			'My Profile',
@@ -380,7 +380,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		wp_set_current_user( static::$user_id );
 		$menu = static::$menu_data;
 
-		static::$admin_menu->add_users_menu( static::$domain );
+		static::$admin_menu->add_users_menu( false );
 
 		$slug = 'https://wordpress.com/people/team/' . static::$domain;
 
@@ -438,7 +438,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		global $menu, $submenu;
 
 		$slug = 'https://wordpress.com/marketing/tools/' . static::$domain;
-		static::$admin_menu->add_tools_menu( static::$domain );
+		static::$admin_menu->add_tools_menu( false );
 
 		$tools_menu_item = array(
 			'Tools',
@@ -520,7 +520,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		global $submenu;
 
 		$slug = 'https://wordpress.com/settings/general/' . static::$domain;
-		static::$admin_menu->add_options_menu( static::$domain );
+		static::$admin_menu->add_options_menu( false );
 
 		$this->assertNotContains( 'options-discussion.php', $submenu[ $slug ] );
 		$this->assertNotContains( 'options-writing.php', $submenu[ $slug ] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/47043

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Switches from Calypso poistive to wp-admin positive to determine link destination.
* Updates unit tests to account for this ^ switch.
* Introduces a user_option for Jetpack and Atomic sites to determine link destination.
* Uses existing `calypsoPreference` setting on dotcom to determine link destination.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Atomic:
* [Install & activate the Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/). Switch to this branch.
* Reload wp-admin and double-check that menu items still link to Calypso.
* Using `_cli`, add the user option: `$ wp user meta update USER_ID jetpack_admin_menu_link_destination 1`
* Reload wp-admin and double-check that menu items now link to wp-admin screens.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
None needed.
