### PR TITLE
Render Stripe nudge on frontend for Premium Content block

### DIFF
--- a/extensions/blocks/premium-content/_inc/access-check.php
+++ b/extensions/blocks/premium-content/_inc/access-check.php
@@ -27,6 +27,18 @@ function membership_checks() {
 }
 
 /**
+ * Determines if the site has a plan that supports the
+ * Premium Content block.
+ *
+ * @return bool
+ */
+function required_plan_checks() {
+    $availability = \Jetpack_Gutenberg::get_availability();
+    $slug         = 'premium-content/container';
+    return ( isset( $availability[ $slug ] ) && $availability[ $slug ]['available'] );
+}
+
+/**
  * Determines if the block should be rendered. Returns true
  * if the block passes all required checks, or if the user is
  * an editor.

--- a/extensions/blocks/premium-content/premium-content.php
+++ b/extensions/blocks/premium-content/premium-content.php
@@ -80,30 +80,22 @@ function render_block( $attributes, $content ) {
  * @return string Final content to render.
  */
 function render_stripe_nudge() {
-	$connect_url = '';
-	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
-		jetpack_require_lib( 'memberships' );
-
-		$blog_id = get_current_blog_id();
-		$settings = (array) get_memberships_settings_for_site($blog_id);
-
-		$connect_url = $settings['connect_url'];
-		$description = _('Connect to Stripe to use this block on your site.', 'jetpack');
-		$button_text  = _('Connect', 'jetpack');
-	} else {
-		// On Jetpack, redirect them to the post in the editor in
-		// order to connect Stripe.
-		$connect_url = get_edit_post_link( get_the_ID() );
-		$description = _('Connect to Stripe to use this block on your site.', 'jetpack');
-		$button_text  = _('Edit', 'jetpack');
+	if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+		// The Premium Content block should not be supported on Jetpack sites;
+		// check just in case.
+		return '';
 	}
+
+	jetpack_require_lib( 'memberships' );
+	$blog_id = get_current_blog_id();
+	$settings = (array) get_memberships_settings_for_site($blog_id);
 
 	jetpack_require_lib('components');
 	return \Jetpack_Components::render_frontend_nudge(
 		array(
-			'checkoutUrl' => $connect_url,
-			'description' => $description,
-			'buttonText'  => $buttonText,
+			'checkoutUrl' => $settings['connect_url'],
+			'description' => _('Connect to Stripe to use this block on your site.', 'jetpack'),
+			'buttonText'  => _('Connect', 'jetpack'),
 		)
 	);
 }

--- a/extensions/blocks/premium-content/premium-content.php
+++ b/extensions/blocks/premium-content/premium-content.php
@@ -89,13 +89,13 @@ function render_stripe_nudge() {
 
 		$connect_url = $settings['connect_url'];
 		$description = _('Connect to Stripe to use this block on your site.', 'jetpack');
-		$buttonText  = _('Connect', 'jetpack');
+		$button_text  = _('Connect', 'jetpack');
 	} else {
 		// On Jetpack, redirect them to the post in the editor in
 		// order to connect Stripe.
 		$connect_url = get_edit_post_link( get_the_ID() );
 		$description = _('Connect to Stripe to use this block on your site.', 'jetpack');
-		$buttonText  = _('Edit', 'jetpack');
+		$button_text  = _('Edit', 'jetpack');
 	}
 
 	jetpack_require_lib('components');


### PR DESCRIPTION
Renders a Stripe nudge on the frontend for admin users, if the
upgrade nudge is not already being displayed.

Adds a Stripe nudge on the frontend for the Premium Content block. When Stripe is not connected, the block will still render on the frontend for admin users, and the Stripe nudge will be displayed -- unless the upgrade nudge is already being displayed.

Notes:
* The block should not be available on Jetpack at all

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 176-gh-Automattic/view-design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a Stripe nudge on the frontend for Premium Content.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow test set-up instructions from #17907 for Jetpack and wpcom. Note that there are changes to `class.jetpack-gutenberg.php` or `class-blocks.php` in the parent branch (`update/enable-frontend-upgrade-nudges`) which need to be synced manually to the sandbox when you are testing wpcom.

**Test scenarios**:

<img width="654" alt="Screen Shot 2021-01-07 at 7 05 33 PM" src="https://user-images.githubusercontent.com/63313398/103970398-0aaddd00-511d-11eb-9b7b-55636201a854.png">

Jetpack
* Simply verify that you cannot add a Premium Content block.

Wpcom
* On a wpcom site with a free plan, add a Premium Content block.
* Preview the block in the frontend and verify that the block is displayed with an Upgrade nudge (no Stripe nudge).
* Upgrade the site to a Personal plan.
* View the post on the frontend again and verify that you now see the Stripe nudge.
* Open the post in an incognito window and verify that you cannot see the block or the nudge.
* Go back to the editor and connect Stripe.
* Preview the block and verify that it is displayed with no nudges.
* Revisit the post in an incognito window and verify that you can now see the block.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
