### PR TITLE
Story block: Limit title length during playback

### DIFF
--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -480,6 +480,11 @@
 			.wp-story-title {
 				font-size: 14px;
 				font-weight: 600;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				display: -webkit-box;
+				-webkit-line-clamp: 2;
+				-webkit-box-orient: vertical;
 
 				@media ( max-width: $break-medium ) {
 					font-size: 12px;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -494,6 +494,8 @@
 			.wp-story-exit-fullscreen {
 				margin-left: auto;
 				order: 3;
+				min-width: 24px;
+				min-height: 24px;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
During Story playback, limits the post title displayed at the top to two lines to prevent overflowing text for long titles:

![long-title-fix](https://user-images.githubusercontent.com/9613966/103975859-90329b00-51b8-11eb-9984-40752a7ba8eb.png)

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Create or edit a story and give the post an extremely long title
*Play the story and verify that 
* Check a few other browsers (I've checked Mac Chrome, Firefox, and Safari, Android Chrome, iOS Safari, and Edge).

#### Proposed changelog entry for your changes:
No changelog needed.