### PR TITLE
Sharing: JS is no longer dependent on jQuery

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -943,7 +943,7 @@ function sharing_display( $text = '', $echo = false ) {
 					'_inc/build/sharedaddy/sharing.min.js',
 					'modules/sharedaddy/sharing.js'
 				),
-				array( 'jquery' ),
+				array(),
 				$ver,
 				false
 			);


### PR DESCRIPTION
Follow-up to #17864

In 17864, the JS was refactored to no longer depend on jQuery; however, we missed removing the dependency from the enqueue.

See D55030-code for the discovery while getting everything back in sync with WP.com.

#### Changes proposed in this Pull Request:
* Remove jQuery dep.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Same as #17864

#### Proposed changelog entry for your changes:
* none, to be handled via 17864.
