### PR TITLE
Admin: display a notice when the dev versions of packages aren't loaded

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/index.jsx
@@ -31,10 +31,11 @@ import {
 	userCanConnectSite,
 	userIsSubscriber,
 	getConnectionErrors,
+	showDevPackagesNotice,
 } from 'state/initial-state';
 import { getLicensingError, clearLicensingError } from 'state/licensing';
 import { getSiteDataErrors } from 'state/site';
-import { JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
+import { JETPACK_CONTACT_BETA_SUPPORT, JETPACK_AUTOLOAD_DEV_INFO } from 'constants/urls';
 import JetpackStateNotices from './state-notices';
 import JetpackConnectionErrors from './jetpack-connection-errors';
 import NoticeAction from 'components/notice/notice-action.jsx';
@@ -66,6 +67,34 @@ export class DevVersionNotice extends React.Component {
 DevVersionNotice.propTypes = {
 	isDevVersion: PropTypes.bool.isRequired,
 	userIsSubscriber: PropTypes.bool.isRequired,
+};
+
+export class DevPackagesNotice extends React.Component {
+	static displayName = 'DevPackagesNotice';
+
+	render() {
+		if ( this.props.showDevPackagesNotice ) {
+			return (
+				<SimpleNotice
+					showDismiss={ false }
+					text={ __(
+						"You should set the JETPACK_AUTOLOAD_DEV constant to true to ensure that Jetpack's development packages are used.",
+						'jetpack'
+					) }
+				>
+					<NoticeAction href={ JETPACK_AUTOLOAD_DEV_INFO } external={ true }>
+						{ __( 'More info', 'jetpack' ) }
+					</NoticeAction>
+				</SimpleNotice>
+			);
+		}
+
+		return false;
+	}
+}
+
+DevPackagesNotice.propTypes = {
+	showDevPackagesNotice: PropTypes.bool.isRequired,
 };
 
 export class StagingSiteNotice extends React.Component {
@@ -231,6 +260,7 @@ class JetpackNotices extends React.Component {
 					isDevVersion={ this.props.isDevVersion }
 					userIsSubscriber={ this.props.userIsSubscriber }
 				/>
+				<DevPackagesNotice showDevPackagesNotice={ this.props.showDevPackagesNotice } />
 				<OfflineModeNotice
 					siteConnectionStatus={ this.props.siteConnectionStatus }
 					siteOfflineMode={ this.props.siteOfflineMode }
@@ -289,6 +319,7 @@ export default connect(
 			siteDataErrors: getSiteDataErrors( state ),
 			isReconnectingSite: isReconnectingSite( state ),
 			licensingError: getLicensingError( state ),
+			showDevPackagesNotice: showDevPackagesNotice( state ),
 		};
 	},
 	dispatch => {

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/component.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { DevVersionNotice } from '../index';
+import { DevPackagesNotice, DevVersionNotice } from '../index';
 import { PlanConflictWarning } from '../plan-conflict-warning';
 
 describe( 'PlanConflictWarning', () => {
@@ -109,6 +109,20 @@ describe( 'DevVersionNotice', () => {
 		const wrapper = shallow( <DevVersionNotice isDevVersion={ true } userIsSubscriber={ false } /> );
 		expect( wrapper.prop( 'text' ) ).to.equal(
 			"You are currently running a development version of Jetpack."
+		);
+	} );
+} );
+
+describe( 'DevPackagesNotice', () => {
+	it( 'should not render when showDevPackagesNotice is false', () => {
+		const wrapper = shallow( <DevPackagesNotice showDevPackagesNotice={ false } /> );
+		expect( wrapper.isEmptyRender() ).to.equal( true );
+	} );
+
+	it( 'should render the DevPackagesNotice when showDevPackagesNotice is true', () => {
+		const wrapper = shallow( <DevPackagesNotice showDevPackagesNotice={ true } /> );
+		expect( wrapper.prop( 'text' ) ).to.equal(
+			"You should set the JETPACK_AUTOLOAD_DEV constant to true to ensure that Jetpack's development packages are used."
 		);
 		expect( wrapper.find( 'SimpleNotice' ).length ).to.equal(1);
 		expect( wrapper.find( 'NoticeAction' ).length ).to.equal(1);

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/component.js
@@ -110,6 +110,8 @@ describe( 'DevVersionNotice', () => {
 		expect( wrapper.prop( 'text' ) ).to.equal(
 			"You are currently running a development version of Jetpack."
 		);
+		expect( wrapper.find( 'SimpleNotice' ).length ).to.equal(1);
+		expect( wrapper.find( 'NoticeAction' ).length ).to.equal(1);
 	} );
 } );
 

--- a/projects/plugins/jetpack/_inc/client/constants/urls.js
+++ b/projects/plugins/jetpack/_inc/client/constants/urls.js
@@ -6,3 +6,5 @@ import getRedirectUrl from 'lib/jp-redirect';
 export const imagePath = window.Initial_State.pluginBaseUrl + '/images/';
 export const JETPACK_CONTACT_SUPPORT = getRedirectUrl( 'jetpack-contact-support' );
 export const JETPACK_CONTACT_BETA_SUPPORT = getRedirectUrl( 'jetpack-contact-support-beta-group' );
+export const JETPACK_AUTOLOAD_DEV_INFO =
+	'https://github.com/Automattic/jetpack/tree/master/packages/autoloader#working-with-development-versions-of-packages';

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -472,3 +472,16 @@ export function isSafari( state ) {
 export function doNotUseConnectionIframe( state ) {
 	return !! state.jetpack.initialState.doNotUseConnectionIframe;
 }
+
+/**
+ * Check if the DevPackagesNotice should be displayed. This notice is displayed when a
+ * development version of Jetpack is active but the development versions of the packages
+ * are not being used.
+ *
+ * @param {object} state - Global state tree.
+ *
+ * @returns {boolean} True if the notice should be displayed, else false.
+ */
+export function showDevPackagesNotice( state ) {
+	return !! state.jetpack.initialState.showDevPackagesNotice;
+}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/admin-pages/test-class-jetpack-react-page.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/admin-pages/test-class-jetpack-react-page.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Jetpack_React_Page unit tests.
+ *
+ * @package Jetpack
+ */
+
+jetpack_require_lib( 'admin-pages/class.jetpack-react-page' );
+
+/**
+ * Class for testing the Jetpack_React_Page class.
+ */
+class WP_Test_Jetpack_React_Page extends WP_UnitTestCase {
+
+	/**
+	 * Tests the Jetpack_React_Page::show_dev_packages_notice method.
+	 *
+	 * @dataProvider data_provider_show_dev_packages_notice
+	 *
+	 * @param bool $jp_dev_version Whether the Jetpack verision is a development version.
+	 * @param bool $change_autoloader Whether the autoloader classmap should be changed so i doesn't
+	 *                                match Jetpack's classmap file.
+	 * @param bool $expected_output The expected output of the Jetpack_React_Page::show_dev_package_notice method.
+	 */
+	public function test_show_dev_packages_notice( $jp_dev_version, $change_autoloader, $expected_output ) {
+		global $jetpack_autoloader_loader;
+
+		if ( $change_autoloader ) {
+			$real_autoloader = clone $jetpack_autoloader_loader;
+			$this->change_autoloader_classmap();
+		}
+
+		if ( $jp_dev_version ) {
+			add_filter( 'jetpack_development_version', '__return_true' );
+		} else {
+			add_filter( 'jetpack_development_version', '__return_false' );
+		}
+
+		$output = ( new Jetpack_React_Page() )->show_dev_packages_notice();
+
+		if ( $change_autoloader ) {
+			// Restore the original autoloader.
+			$jetpack_autoloader_loader = $real_autoloader;
+		}
+
+		$this->assertEquals( $expected_output, $output );
+	}
+
+	/**
+	 * Changes the autoloader's in-memory classmap so that it doesn't match
+	 * Jetpack's classmap file.
+	 *
+	 * In the 'Automattic\Jetpack\Autoloader\AutoloadGenerator' path, replaces
+	 * 'jetpack' with 'not-jetpack'.
+	 */
+	private function change_autoloader_classmap() {
+		global $jetpack_autoloader_loader;
+
+		array_walk(
+			$jetpack_autoloader_loader,
+			function ( &$value, $key ) {
+				if ( substr( $key, -strlen( 'classmap' ) ) === 'classmap' ) {
+					$current_path = $value['Automattic\Jetpack\Autoloader\AutoloadGenerator']['path'];
+					$new_path     = str_replace( 'jetpack', 'not-jetpack', $current_path );
+					$value['Automattic\Jetpack\Autoloader\AutoloadGenerator']['path'] = $new_path;
+				}
+			}
+		);
+	}
+
+	/**
+	 * Data provider for test_show_dev_packages_notice.
+	 *
+	 * @return array An array containing the test data:
+	 *   [
+	 *     'jp_dev_version' => (bool) Whether the Jetpack verison is a development version.
+	 *     'change_autoloader' => (bool) Whether the autoloader classmap should be changed.
+	 *     'expected_output' => The expected output of Jetpack_React_Page::show_dev_packages_notice.
+	 * ]
+	 */
+	public function data_provider_show_dev_packages_notice() {
+		return array(
+			array(
+				'jp_dev_version'    => true,
+				'change_autoloader' => false,
+				'expected_output'   => false,
+			),
+			array(
+				'jp_dev_version'    => false,
+				'change_autoloader' => true,
+				'expected_output'   => false,
+			),
+			array(
+				'jp_dev_version'    => true,
+				'change_autoloader' => true,
+				'expected_output'   => true,
+			),
+		);
+	}
+}


### PR DESCRIPTION
By default, the Jetpack autoloader prefers to use stable versions of packages. This behavior can be overridden using the `JETPACK_AUTOLOAD_DEV` constant. When that constant is true, the autoloader will use the first dev version that it locates.

Developers must remember to set the `JETPACK_AUTOLOAD_DEV` constant when testing development branches of Jetpack while other plugins that use Jetpack packages are installed.

#### Changes proposed in this Pull Request:
Add a notice that recommends that the `JETPACK_AUTOLOAD_DEV` constant be set to true when all of these conditions are met:

 - Jetpack is a dev version. (Stable versions of Jetpack should not have dev versions of packages.)
 - The JETPACK_AUTOLOAD_DEV constant is not set.
 - At least one of Jetpack's packages classes was not selected by the autoloader.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install this branch and activate Jetpack. (You can connect if you'd like, it doesn't matter for this test.)
2. Navigate to `wp-admin -> Jetpack`. You should see the `You are currently running a development version of Jetpack.` notice. You should **not** see the `You should set the JETPACK_AUTOLOAD_DEV constant to true to ensure that Jetpack's development packages are used.` notice.
3. Install and activate WooCommerce. WC uses Jetpack packages.
4. Navigate to `wp-admin -> Jetpack`. You should see the `You are currently running a development version of Jetpack.` notice. You should also see the `You should set the JETPACK_AUTOLOAD_DEV constant to true to ensure that Jetpack's development packages are used.` notice.
5. Click the "More info" link in the notice and verify that you're taken to the "Working with Development Versions of Packages" section of the autoloader package's readme.
6. Open your `wp-config.php` file and add `define( 'JETPACK_AUTOLOAD_DEV', true );`.
7. Navigate to `wp-admin -> Jetpack`. You should see the `You are currently running a development version of Jetpack.` notice. You should **not** see the `You should set the JETPACK_AUTOLOAD_DEV constant to true to ensure that Jetpack's development packages are used.` notice.
8. Open your site's `jetpack/jetpack.php` file, and change the `JETPACK__VERSION` constant to a stable version, such as '9.4`.
9. Navigate to `wp-admin -> Jetpack`. You should not see either of the notices.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* tbd
