### PR TITLE
Instant Search: add product-specific sorting to product results

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -122,6 +122,12 @@ class SearchApp extends Component {
 
 	getSort = () => getSortQuery( this.props.initialSort );
 
+	getResultFormat = () => {
+		// Override the result format from the query string if result_format= is specified
+		const resultFormatQuery = getResultFormatQuery();
+		return resultFormatQuery || this.state.overlayOptions.resultFormat;
+	};
+
 	hasActiveQuery() {
 		return getSearchQuery() !== '' || hasFilter();
 	}
@@ -227,6 +233,7 @@ class SearchApp extends Component {
 			filter,
 			pageHandle,
 			query,
+			resultFormat: this.getResultFormat(),
 			siteId: this.props.options.siteId,
 			sort,
 			postsPerPage: this.props.options.postsPerPage,
@@ -270,8 +277,7 @@ class SearchApp extends Component {
 	};
 
 	render() {
-		// Override the result format from the query string if result_format= is specified
-		const resultFormatQuery = getResultFormatQuery();
+		const resultFormat = this.getResultFormat();
 
 		return createPortal(
 			<Overlay
@@ -299,7 +305,7 @@ class SearchApp extends Component {
 					postTypes={ this.props.options.postTypes }
 					query={ getSearchQuery() }
 					response={ this.state.response }
-					resultFormat={ resultFormatQuery || this.state.overlayOptions.resultFormat }
+					resultFormat={ resultFormat }
 					showPoweredBy={ this.state.overlayOptions.showPoweredBy }
 					sort={ this.getSort() }
 					widgets={ this.props.options.widgets }

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -87,7 +87,13 @@ const SearchBox = props => {
 						</span>
 					</div>
 				) }
-				{ props.enableSort && <SearchSort onChange={ props.onChangeSort } value={ props.sort } /> }
+				{ props.enableSort && (
+					<SearchSort
+						onChange={ props.onChangeSort }
+						resultFormat={ props.resultFormat }
+						value={ props.sort }
+					/>
+				) }
 			</div>
 		</Fragment>
 	);

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -65,6 +65,7 @@ class SearchForm extends Component {
 						onChangeQuery={ this.onChangeQuery }
 						onChangeSort={ this.onChangeSort }
 						query={ getSearchQuery() }
+						resultFormat={ this.props.resultFormat }
 						shouldRestoreFocus
 						showFilters={ this.state.showFilters }
 						sort={ this.props.sort }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -89,6 +89,7 @@ class SearchResults extends Component {
 					onChangeSort={ this.props.onChangeSort }
 					overlayTrigger={ this.props.overlayTrigger }
 					response={ this.props.response }
+					resultFormat={ this.props.resultFormat }
 					sort={ this.props.sort }
 					widgets={ this.props.widgets }
 					widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }

--- a/modules/search/instant-search/components/search-sort.jsx
+++ b/modules/search/instant-search/components/search-sort.jsx
@@ -8,7 +8,7 @@ import { h, Component } from 'preact';
 /**
  * Internal dependencies
  */
-import { SORT_OPTIONS } from '../lib/constants';
+import { getSortOptions } from '../lib/sort';
 
 export default class SearchSort extends Component {
 	handleKeyPress = event => {
@@ -25,9 +25,10 @@ export default class SearchSort extends Component {
 	};
 
 	render() {
+		const sortOptions = getSortOptions( this.props.resultFormat );
 		return (
 			<div className="jetpack-instant-search__box-filter-order">
-				{ [ ...SORT_OPTIONS.entries() ].map( ( [ sortKey, label ] ) => (
+				{ [ ...sortOptions.entries() ].map( ( [ sortKey, label ] ) => (
 					<a
 						class={ `jetpack-instant-search__box-filter-option ${
 							this.props.value === sortKey ? 'is-selected' : ''

--- a/modules/search/instant-search/components/search-sort.jsx
+++ b/modules/search/instant-search/components/search-sort.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { h, Component } from 'preact';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ export default class SearchSort extends Component {
 			this.props.onChange( event.currentTarget.dataset.value );
 		}
 	};
+
 	handleClick = event => {
 		if ( this.props.value !== event.currentTarget.value ) {
 			event.preventDefault();
@@ -24,10 +26,45 @@ export default class SearchSort extends Component {
 		}
 	};
 
+	handleSelectChange = event => {
+		if ( this.props.value !== event.currentTarget.value ) {
+			event.preventDefault();
+			this.props.onChange( event.currentTarget.value );
+		}
+	};
+
 	render() {
 		const sortOptions = getSortOptions( this.props.resultFormat );
+
+		// If there are more than 3 sort options, use a select
+		if ( sortOptions.size > 3 ) {
+			return (
+				<div className="jetpack-instant-search__sort">
+					<label htmlFor="jetpack-instant-search__sort-select">
+						{ __( 'Sort by: ', 'jetpack' ) }
+					</label>
+					<select
+						id="jetpack-instant-search__sort-select"
+						onBlur={ this.handleSelectChange }
+						onChange={ this.handleSelectChange }
+					>
+						{ [ ...sortOptions.entries() ].map( ( [ sortKey, label ] ) => (
+							<option
+								value={ sortKey }
+								key={ sortKey }
+								selected={ this.props.value === sortKey ? 'selected' : '' }
+							>
+								{ label }
+							</option>
+						) ) }
+					</select>
+				</div>
+			);
+		}
+
 		return (
 			<div className="jetpack-instant-search__box-filter-order">
+				<div className="screen-reader-text">{ __( 'Sort by: ', 'jetpack' ) }</div>
 				{ [ ...sortOptions.entries() ].map( ( [ sortKey, label ] ) => (
 					<a
 						class={ `jetpack-instant-search__box-filter-option ${

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -171,7 +171,12 @@ function generateApiQueryString( {
 
 	switch ( resultFormat ) {
 		case 'product':
-			fields = fields.concat( [ 'wc.price' ] );
+			fields = fields.concat( [
+				'wc.price',
+				'wc.sale_price',
+				'wc.currency_symbol',
+				'wc.currency_position',
+			] );
 	}
 
 	return encode(

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -143,6 +143,11 @@ const SORT_QUERY_MAP = new Map( [
 	[ 'relevance', 'score_default' ],
 ] );
 function mapSortToApiValue( sort ) {
+	// Some sorts don't need to be mapped
+	if ( [ 'price_asc', 'price_desc', 'rating_desc' ].includes( sort ) ) {
+		return sort;
+	}
+
 	return SORT_QUERY_MAP.get( sort, 'score_default' );
 }
 

--- a/modules/search/instant-search/lib/constants.js
+++ b/modules/search/instant-search/lib/constants.js
@@ -11,7 +11,15 @@ export const RESULT_FORMAT_MINIMAL = 'minimal';
 export const RESULT_FORMAT_PRODUCT = 'product';
 export const MINUTE_IN_MILLISECONDS = 60 * 1000;
 export const RELEVANCE_SORT_KEY = 'relevance';
-export const VALID_SORT_KEYS = [ 'newest', 'oldest', RELEVANCE_SORT_KEY ];
+// @todo extract this to a function that uses SORT_OPTIONS and PRODUCT_SORT_OPTIONS to avoid duplication
+export const VALID_SORT_KEYS = [
+	'newest',
+	'oldest',
+	RELEVANCE_SORT_KEY,
+	'price_asc',
+	'price_desc',
+	'rating_desc',
+];
 export const VALID_RESULT_FORMAT_KEYS = [
 	RESULT_FORMAT_EXPANDED,
 	RESULT_FORMAT_MINIMAL,
@@ -21,4 +29,9 @@ export const SORT_OPTIONS = new Map( [
 	[ RELEVANCE_SORT_KEY, __( 'Relevance', 'jetpack' ) ],
 	[ 'newest', __( 'Newest', 'jetpack' ) ],
 	[ 'oldest', __( 'Oldest', 'jetpack' ) ],
+] );
+export const PRODUCT_SORT_OPTIONS = new Map( [
+	[ 'price_asc', __( 'Price: low to high', 'jetpack' ) ],
+	[ 'price_desc', __( 'Price: high to low', 'jetpack' ) ],
+	[ 'rating_desc', __( 'Rating', 'jetpack' ) ],
 ] );

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { PRODUCT_SORT_OPTIONS, RESULT_FORMAT_PRODUCT, SORT_OPTIONS } from './constants';
+
+/**
+ * Get the available sort options for the provided result format
+ *
+ * @param   {string} resultFormat - Result format
+ * @returns {Map} - Sort options
+ */
+export function getSortOptions( resultFormat = null ) {
+	if ( resultFormat !== RESULT_FORMAT_PRODUCT ) {
+		return SORT_OPTIONS;
+	}
+
+	// For product results, add additional product sort options
+	return new Map( [ ...SORT_OPTIONS, ...PRODUCT_SORT_OPTIONS ] );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

For the product search result format, add extra sorting options relevant to Woo products.

<img width="258" alt="Screen Shot 2021-01-12 at 16 04 16" src="https://user-images.githubusercontent.com/17325/104264105-dd33ab80-54ef-11eb-84ad-ea4824841552.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Go to a test site with Instant Search set up. Perform a search and add `&result_format=product` to the query string. A sort dropdown should be shown containing additional product sort options.

#### Proposed changelog entry for your changes:
Not required. The product search results are not yet selectable by the end user.
