### PR TITLE
Lazily load reCAPTCHA for email sharing

### DIFF
--- a/modules/sharedaddy/recaptcha.php
+++ b/modules/sharedaddy/recaptcha.php
@@ -75,6 +75,7 @@ class Jetpack_ReCaptcha {
 			'language'       => get_locale(),
 			'script_async'   => false,
 			'script_defer'   => true,
+			'script_lazy'    => false,
 			'tag_class'      => 'g-recaptcha',
 			'tag_attributes' => array(
 				'theme'    => 'light',
@@ -181,26 +182,42 @@ class Jetpack_ReCaptcha {
 	 * @return string
 	 */
 	public function get_recaptcha_html() {
-		return sprintf(
+		$url = sprintf(
+			'https://www.google.com/recaptcha/api.js?hl=%s',
+			rawurlencode( $this->config['language'] )
+		);
+
+		$html = sprintf(
 			'
 			<div
 				class="%s"
 				data-sitekey="%s"
 				data-theme="%s"
 				data-type="%s"
-				data-tabindex="%s"></div>
-			' .
-			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-			'<script src="https://www.google.com/recaptcha/api.js?hl=%s"%s%s></script>
+				data-tabindex="%s"
+				data-lazy="%s"
+				data-url="%s"></div>
 			',
 			esc_attr( $this->config['tag_class'] ),
 			esc_attr( $this->site_key ),
 			esc_attr( $this->config['tag_attributes']['theme'] ),
 			esc_attr( $this->config['tag_attributes']['type'] ),
 			esc_attr( $this->config['tag_attributes']['tabindex'] ),
-			rawurlencode( $this->config['language'] ),
-			$this->config['script_async'] && ! $this->config['script_defer'] ? ' async' : '',
-			$this->config['script_defer'] ? ' defer' : ''
+			$this->config['script_lazy'] ? 'true' : 'false',
+			esc_attr( $url )
 		);
+
+		if ( ! $this->config['script_lazy'] ) {
+			$html = $html . sprintf(
+				// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+				'<script src="%s"%s%s></script>
+				',
+				$url,
+				$this->config['script_async'] && ! $this->config['script_defer'] ? ' async' : '',
+				$this->config['script_defer'] ? ' defer' : ''
+			);
+		}
+
+		return $html;
 	}
 }

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -258,14 +258,14 @@ function sharing_global_resources_save() {
 function sharing_email_dialog() {
 	require_once plugin_dir_path( __FILE__ ) . 'recaptcha.php';
 
-	$recaptcha = new Jetpack_ReCaptcha( RECAPTCHA_PUBLIC_KEY, RECAPTCHA_PRIVATE_KEY );
+	$recaptcha = new Jetpack_ReCaptcha( RECAPTCHA_PUBLIC_KEY, RECAPTCHA_PRIVATE_KEY, array( 'script_lazy' => true ) );
 	echo $recaptcha->get_recaptcha_html(); // xss ok
 }
 
 function sharing_email_check( $true, $post, $data ) {
 	require_once plugin_dir_path( __FILE__ ) . 'recaptcha.php';
 
-	$recaptcha = new Jetpack_ReCaptcha( RECAPTCHA_PUBLIC_KEY, RECAPTCHA_PRIVATE_KEY );
+	$recaptcha = new Jetpack_ReCaptcha( RECAPTCHA_PUBLIC_KEY, RECAPTCHA_PRIVATE_KEY, array( 'script_lazy' => true ) );
 	$response  = ! empty( $_POST['g-recaptcha-response'] ) ? $_POST['g-recaptcha-response'] : '';
 	$result    = $recaptcha->verify( $response, $_SERVER['REMOTE_ADDR'] );
 

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -8,6 +8,7 @@
 
 ( function () {
 	var currentScript = document.currentScript;
+	var recaptchaScriptAdded = false;
 
 	// -------------------------- UTILITY FUNCTIONS -------------------------- //
 
@@ -563,6 +564,16 @@
 				emailButton.addEventListener( 'click', function ( event ) {
 					event.preventDefault();
 					event.stopPropagation();
+
+					// Load reCAPTCHA if needed.
+					if ( typeof grecaptcha !== 'object' && ! recaptchaScriptAdded ) {
+						var configEl = document.querySelector( '.g-recaptcha' );
+
+						if ( configEl && configEl.getAttribute( 'data-lazy' ) === 'true' ) {
+							recaptchaScriptAdded = true;
+							loadScript( decodeURI( configEl.getAttribute( 'data-url' ) ) );
+						}
+					}
 
 					var url = emailButton.getAttribute( 'href' );
 					var currentDomain = window.location.protocol + '//' + window.location.hostname + '/';

--- a/tests/php/modules/sharedaddy/test-class.recaptcha.php
+++ b/tests/php/modules/sharedaddy/test-class.recaptcha.php
@@ -6,9 +6,14 @@ class WP_Test_Jetpack_ReCaptcha extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->site_key   = 'sitekey';
-		$this->secret_key = 'secretkey';
-		$this->recaptcha  = new Jetpack_ReCaptcha( $this->site_key, $this->secret_key );
+		$this->site_key       = 'sitekey';
+		$this->secret_key     = 'secretkey';
+		$this->recaptcha      = new Jetpack_ReCaptcha( $this->site_key, $this->secret_key );
+		$this->recaptcha_lazy = new Jetpack_ReCaptcha(
+			$this->site_key,
+			$this->secret_key,
+			array( 'script_lazy' => true )
+		);
 	}
 
 	public function test_get_default_config() {
@@ -98,6 +103,21 @@ class WP_Test_Jetpack_ReCaptcha extends WP_UnitTestCase {
 		$this->assertContains( '<script', $html );
 		$this->assertContains( $config['language'], $html );
 		$this->assertContains( '</script>', $html );
+	}
+
+	/**
+	 * Test reCAPTCHA lazy loading.
+	 */
+	public function test_get_recaptcha_html_lazy() {
+		$config = $this->recaptcha_lazy->get_default_config();
+		$html   = $this->recaptcha_lazy->get_recaptcha_html();
+
+		// Make sure div tag appears with expected attributes.
+		$this->assertContains( '<div', $html );
+		$this->assertContains( $this->site_key, $html );
+		// Make sure script URL contains expected language.
+		$this->assertContains( $config['language'], $html );
+		$this->assertContains( '</div>', $html );
 	}
 
 	public function pre_http_request_response_success() {


### PR DESCRIPTION
When an email sharing button is present, reCAPTCHA currently gets loaded unconditionally on page load. This can be problematic, since it uses a large amount of JS, which needlessly competes for resources during the critical page load time.

This PR instead delays reCAPTCHA loading until a user actually clicks to open the email sharing dialog, ensuring that only this tiny percentage of users pays the JS cost, and at a much less critical time.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add lazy loading option in `recaptcha.php`.
* Use lazy loading option in email sharing
* Add test for lazy loading option

Note: the lazy loading option is not enabled by default in `recaptcha.php`, so that it doesn't affect some files that make use of `recaptcha.php` and live outside of Jetpack. It's instead explicitly enabled it in `sharedaddy.php`.

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Apply this PR to your test site
* Enable sharing and add email sharing buttons to your test site
* Open the Network tab in DevTools in your browser
* Load a post on your test site.
* Verify that `https://www.google.com/recaptcha` was NOT loaded
* Verify that `https://www.gstatic.com/recaptcha/releases/<release>/recaptcha__<locale>.js` was NOT loaded
* Click the email sharing button
* Verify that the form shows up, and it includes the recaptcha dialog
* Verify that `https://www.google.com/recaptcha` was loaded
* Verify that `https://www.gstatic.com/recaptcha/releases/<release>/recaptcha__<locale>.js` was loaded (multiple times, most likely)
* Verify that the dialog works normally

#### Proposed changelog entry for your changes:
* Sharing: Google reCAPTCHA is now only loaded when opening the email sharing dialog
