### PR TITLE
Allow cleanup tool to run on OSX

### DIFF
--- a/tools/cleanup-excludelists.sh
+++ b/tools/cleanup-excludelists.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 cd $(dirname "${BASH_SOURCE[0]}")/..
 
-TEMP=$(mktemp --tmpdir cleanup-excludelists-XXXXXXXX)
+TEMP=$(mktemp cleanup-excludelists-XXXXXXXX)
 if [[ ! -e "$TEMP" ]]; then
 	exit 1
 fi

--- a/tools/cleanup-excludelists.sh
+++ b/tools/cleanup-excludelists.sh
@@ -4,7 +4,8 @@ set -eo pipefail
 
 cd $(dirname "${BASH_SOURCE[0]}")/..
 
-TEMP=$(mktemp cleanup-excludelists-XXXXXXXX)
+TMPDIR="${TMPDIR:-/tmp}"
+TEMP=$(mktemp "${TMPDIR%/}/cleanup-excludelists-XXXXXXXX")
 if [[ ! -e "$TEMP" ]]; then
 	exit 1
 fi


### PR DESCRIPTION
The cleanup tool uses `mktemp` which has different accepted args on Linux vs OS X. On OS X, there is no `tmpdir` arg, so the `cleanup-excludelist.sh` script fails.

#### Changes proposed in this Pull Request:
* Removes the args, which works on OS X.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On OS X, run `./tools/cleanup-excludelist.sh`.
* On Linux, run `./tools/cleanup-excludelist.sh`.
I haven't tested this on Linux.

#### Proposed changelog entry for your changes:
* n/a
