### PR TITLE
Tracking: get connected user data from the Connection package

### DIFF
--- a/projects/packages/tracking/legacy/class-jetpack-tracks-client.php
+++ b/projects/packages/tracking/legacy/class-jetpack-tracks-client.php
@@ -5,6 +5,8 @@
  * @package Jetpack
  */
 
+use Automattic\Jetpack\Connection\Manager;
+
 /**
  * Jetpack_Tracks_Client
  *
@@ -214,7 +216,7 @@ class Jetpack_Tracks_Client {
 	 * @return array|bool
 	 */
 	public static function get_connected_user_tracks_identity() {
-		$user_data = Jetpack::get_connected_user_data();
+		$user_data = ( new Manager() )->get_connected_user_data();
 		if ( ! $user_data ) {
 			return false;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The `Jetpack_Tracks_Client::get_connected_user_tracks_identity` method currently calls `Jetpack::get_connected_user_data`. This prevents the Tracking package from being used without Jetpack. If a consumer plugin called this method without Jetpack installed on the site, a fatal would occur.

The Connection package provides the `Manager::get_connected_user_data` method. The two `get_connected_user_data` methods are the same, so use Manager's method instead.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install this branch, activate Jetpack, and connect.
2. The `Jetpack_Tracks_Client::get_connected_user_tracks_identity` method [is used](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php#L322) in 
`Jetpack_React_Page::get_initial_state`. Navigate to the Jetpack dashboard to trigger a `Jetpack_React_Page::get_initial_state` call. Verify that no errors were generated in the debug log.
3. If you have React Developer Tools installed in your browser, you can verify that the connected user data is in the React app's initial state:
   a. Open the inspector.
   b. Select the Main component to see its props.
   c. Look at the `tracksUserData` prop and verify that its value is correct.

#### Proposed changelog entry for your changes:
* n/a - I don't think this change requires a changelog entry.
