### PR TITLE
Masterbar: Use site_url for stats chart

### DIFF
--- a/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -173,7 +173,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		if ( ! $this->is_api_request ) {
 			$menu_title .= sprintf(
 				'<img class="sidebar-unified__sparkline" width="80" height="20" src="%1$s" alt="%2$s">',
-				esc_url( home_url( 'wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=' . get_current_blog_id() ) ),
+				esc_url( site_url( 'wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=' . get_current_blog_id() ) ),
 				esc_attr__( 'Hourly views', 'jetpack' )
 			);
 		}


### PR DESCRIPTION
Stat chart seems to be tied to site URL and not the publicly domain.
See https://lobby.vip.wordpress.com/wordpress-com-documentation/home_url-vs-site_url/

Props @RealCarFax.
Fixes #18299.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use `site_url` rather than `home_url`. 

Before | After
------------ | -------------
![Screen Shot 2021-01-11 at 2 28 36 PM](https://user-images.githubusercontent.com/1398304/104245627-7348d280-5419-11eb-8a2e-e95d89f97767.png) | ![Screen Shot 2021-01-11 at 2 29 01 PM](https://user-images.githubusercontent.com/1398304/104245648-7cd23a80-5419-11eb-89a6-cb685fa78d00.png)


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the phab diff to your sandbox and sandbox a site with a custom domain and without a custom domain
* With Nav Unification active, make sure that both sites have the stats graph show up correctly.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
