### PR TITLE
SEO Tools: Defensive coding to prevent notices

### DIFF
--- a/modules/seo-tools/jetpack-seo.php
+++ b/modules/seo-tools/jetpack-seo.php
@@ -128,16 +128,20 @@ class Jetpack_SEO {
 			$obj = get_queried_object();
 
 			$meta['description'] = sprintf(
+				/* translators: first property is an user's display name, the second is the site's title. */
 				_x( 'Read all of the posts by %1$s on %2$s', 'Read all of the posts by Author Name on Blog Title', 'jetpack' ),
-				$obj->display_name,
+				( is_object( $obj ) && property_exists( $obj, 'display_name' ) ) ? $obj->display_name : __( 'the author', 'jetpack' ),
 				get_bloginfo( 'title' )
 			);
 		} elseif ( is_tag() || is_category() || is_tax() ) {
-			$obj = get_queried_object();
+			$obj         = get_queried_object();
+			$description = '';
 
-			$description = get_term_field( 'description', $obj->term_id, $obj->taxonomy, 'raw' );
+			if ( is_object( $obj ) && property_exists( $obj, 'term_id' ) && property_exists( $obj, 'taxonomy' ) ) {
+				$description = get_term_field( 'description', $obj->term_id, $obj->taxonomy, 'raw' );
+			}
 
-			if ( ! is_wp_error( $description ) && '' != $description ) {
+			if ( ! is_wp_error( $description ) && ! empty( $description ) ) {
 				$meta['description'] = wp_trim_words( $description );
 			} else {
 				$authors = $this->get_authors();

--- a/modules/seo-tools/jetpack-seo.php
+++ b/modules/seo-tools/jetpack-seo.php
@@ -130,18 +130,18 @@ class Jetpack_SEO {
 			$meta['description'] = sprintf(
 				/* translators: first property is an user's display name, the second is the site's title. */
 				_x( 'Read all of the posts by %1$s on %2$s', 'Read all of the posts by Author Name on Blog Title', 'jetpack' ),
-				( is_object( $obj ) && property_exists( $obj, 'display_name' ) ) ? $obj->display_name : __( 'the author', 'jetpack' ),
+				isset( $obj->display_name ) ? $obj->display_name : __( 'the author', 'jetpack' ),
 				get_bloginfo( 'title' )
 			);
 		} elseif ( is_tag() || is_category() || is_tax() ) {
 			$obj         = get_queried_object();
 			$description = '';
 
-			if ( is_object( $obj ) && property_exists( $obj, 'term_id' ) && property_exists( $obj, 'taxonomy' ) ) {
+			if ( isset( $obj->term_id ) && isset( $obj->taxonomy ) ) {
 				$description = get_term_field( 'description', $obj->term_id, $obj->taxonomy, 'raw' );
 			}
 
-			if ( ! is_wp_error( $description ) && ! empty( $description ) ) {
+			if ( ! is_wp_error( $description ) && $description ) {
 				$meta['description'] = wp_trim_words( $description );
 			} else {
 				$authors = $this->get_authors();


### PR DESCRIPTION
Fixes a notice seen on w.org:
```
E_NOTICE: Trying to get property 'taxonomy' of non-object in /home/public_html/wp-content/plugins/jetpack/modules/seo-tools/jetpack-seo.php:138
```


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Verify that the variable in an object and has the expected properties.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Haven't duplicated it yet.

#### Proposed changelog entry for your changes:
* SEO Tools: prevent a PHP notice in some situations involving taxonomy or author pages.
