### PR TITLE
Add mirror-repo information to all current composer packages

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -33,8 +33,7 @@ for project in projects/packages/* projects/plugins/*; do
 
 	GIT_SLUG=$(jq -r '.extra["mirror-repo"] // ""' composer.json)
 	if [[ -z "$GIT_SLUG" ]]; then
-		echo "::error::Failed to determine project repo name from composer.json"
-		EXIT=1
+		echo "Failed to determine project repo name from composer.json, skipping"
 		continue
 	fi
 	echo "Repo name: $GIT_SLUG"

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -31,7 +31,7 @@ for project in projects/packages/* projects/plugins/*; do
 		continue
 	fi
 
-	GIT_SLUG=$(jq -r '.extra["mirror-repo"] // ( .name | sub( "^automattic/"; "Automattic/" ) )' composer.json)
+	GIT_SLUG=$(jq -r '.extra["mirror-repo"] // ""' composer.json)
 	if [[ -z "$GIT_SLUG" ]]; then
 		echo "::error::Failed to determine project repo name from composer.json"
 		EXIT=1

--- a/composer.lock
+++ b/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "ac27fa3a6634874143014f575b62632e6d04f983"
+                "reference": "f6f6dd8a67119576dfa73fe4d20562725bfd0bbe"
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
@@ -26,6 +26,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "phpcodesniffer-standard",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-codesniffer"
+            },
             "autoload": {
                 "psr-4": {
                     "Automattic\\Jetpack\\Sniffs\\": "Jetpack/Sniffs"

--- a/projects/packages/a8c-mc-stats/composer.json
+++ b/projects/packages/a8c-mc-stats/composer.json
@@ -25,5 +25,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-a8c-mc-stats"
+	}
 }

--- a/projects/packages/abtest/composer.json
+++ b/projects/packages/abtest/composer.json
@@ -30,5 +30,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-abtest"
+	}
 }

--- a/projects/packages/analyzer/composer.json
+++ b/projects/packages/analyzer/composer.json
@@ -24,5 +24,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-analyzer"
+	}
 }

--- a/projects/packages/assets/composer.json
+++ b/projects/packages/assets/composer.json
@@ -28,5 +28,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-assets"
+	}
 }

--- a/projects/packages/autoloader/composer.json
+++ b/projects/packages/autoloader/composer.json
@@ -27,5 +27,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-autoloader"
+	}
 }

--- a/projects/packages/autoloader/composer.json
+++ b/projects/packages/autoloader/composer.json
@@ -17,9 +17,6 @@
 			"Automattic\\Jetpack\\Autoloader\\": "src"
 		}
 	},
-	"extra": {
-		"class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin"
-	},
 	"scripts": {
 		"phpunit": [
 			"@composer install",
@@ -29,6 +26,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
 		"mirror-repo": "Automattic/jetpack-autoloader"
 	}
 }

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -13,5 +13,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-backup"
+	}
 }

--- a/projects/packages/blocks/composer.json
+++ b/projects/packages/blocks/composer.json
@@ -27,5 +27,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-blocks"
+	}
 }

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -25,5 +25,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-codesniffer"
+	}
 }

--- a/projects/packages/compat/composer.json
+++ b/projects/packages/compat/composer.json
@@ -22,5 +22,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-compat"
+	}
 }

--- a/projects/packages/config/composer.json
+++ b/projects/packages/config/composer.json
@@ -9,5 +9,8 @@
 		"classmap": [
 			"src/"
 		]
+	},
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-config"
 	}
 }

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -38,5 +38,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-connection"
+	}
 }

--- a/projects/packages/constants/composer.json
+++ b/projects/packages/constants/composer.json
@@ -20,5 +20,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-constants"
+	}
 }

--- a/projects/packages/device-detection/composer.json
+++ b/projects/packages/device-detection/composer.json
@@ -19,5 +19,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-device-detection"
+	}
 }

--- a/projects/packages/error/composer.json
+++ b/projects/packages/error/composer.json
@@ -19,5 +19,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-error"
+	}
 }

--- a/projects/packages/heartbeat/composer.json
+++ b/projects/packages/heartbeat/composer.json
@@ -28,5 +28,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-heartbeat"
+	}
 }

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -36,5 +36,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-jitm"
+	}
 }

--- a/projects/packages/lazy-images/composer.json
+++ b/projects/packages/lazy-images/composer.json
@@ -30,5 +30,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-lazy-images"
+	}
 }

--- a/projects/packages/licensing/composer.json
+++ b/projects/packages/licensing/composer.json
@@ -30,5 +30,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-licensing"
+	}
 }

--- a/projects/packages/logo/composer.json
+++ b/projects/packages/logo/composer.json
@@ -19,5 +19,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-logo"
+	}
 }

--- a/projects/packages/options/composer.json
+++ b/projects/packages/options/composer.json
@@ -21,5 +21,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-options"
+	}
 }

--- a/projects/packages/partner/composer.json
+++ b/projects/packages/partner/composer.json
@@ -26,5 +26,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-partner"
+	}
 }

--- a/projects/packages/redirect/composer.json
+++ b/projects/packages/redirect/composer.json
@@ -28,5 +28,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-redirect"
+	}
 }

--- a/projects/packages/roles/composer.json
+++ b/projects/packages/roles/composer.json
@@ -26,5 +26,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-roles"
+	}
 }

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -26,5 +26,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-status"
+	}
 }

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -22,5 +22,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-sync"
+	}
 }

--- a/projects/packages/terms-of-service/composer.json
+++ b/projects/packages/terms-of-service/composer.json
@@ -29,5 +29,8 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-terms-of-service"
+	}
 }

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -30,5 +30,8 @@
 		]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-tracking"
+	}
 }

--- a/projects/plugins/debug-helper/composer.json
+++ b/projects/plugins/debug-helper/composer.json
@@ -4,5 +4,8 @@
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"minimum-stability": "dev",
-	"require": {}
+	"require": {},
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-debug-helper"
+	}
 }

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -12,12 +12,15 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "9bfb1aa0f01da872ea8c176b0b38a8bb7b7051df"
+                "reference": "6eee4d7a5e731b0faf800bda4800337bdb781b2a"
             },
             "require-dev": {
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-a8c-mc-stats"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -43,7 +46,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/abtest",
-                "reference": "5e403fd81e5c322796ca1407341a81c7e5a65e46"
+                "reference": "113087dbb16ab1d151b84960347273280d710bfc"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -54,6 +57,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-abtest"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -82,7 +88,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "7efa513121185c90a438ccf235f1b65f634eb62a"
+                "reference": "93935a55c9da4f4d50f16d3eef8627bf49a423f5"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -92,6 +98,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-assets"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -117,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "e6fd3eacb67a0add0c397463f106396a85b66406"
+                "reference": "25696631debb8f46bee0d3b0cbd02a92931a4b0b"
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0"
@@ -127,7 +136,8 @@
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin"
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
+                "mirror-repo": "Automattic/jetpack-autoloader"
             },
             "autoload": {
                 "classmap": [
@@ -157,9 +167,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "69733464fcefcb51342908dcdd6db6feb285c180"
+                "reference": "2cfeb67da9ea0fa6980d6f35f483a69926891fc9"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-backup"
+            },
             "autoload": {
                 "files": [
                     "actions.php"
@@ -182,13 +195,16 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "f5127ace65b294802fd6d3ba13de9d8ca4837b27"
+                "reference": "ac50cb3379b53ac3148d35804f7a98eed4eb3152"
             },
             "require-dev": {
                 "automattic/wordbless": "dev-master",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-blocks"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -217,12 +233,15 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/compat",
-                "reference": "32e206d3b83a843f65b381ee460573208570af0b"
+                "reference": "3ac292c1a9a82cb585f8bf1b50ccb908cba7ab86"
             },
             "require-dev": {
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-compat"
+            },
             "autoload": {
                 "files": [
                     "functions.php"
@@ -251,9 +270,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "2276f5efe5e29fff5c373e9b7a272d7d007005f4"
+                "reference": "711b4d5008cbd3ce2354e58e4ff4b1441234889a"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-config"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -273,7 +295,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ff4e5605623c0faa6000d9691496f116fee98bd3"
+                "reference": "8eb0c46ea88a099247fb43e6a4d9f0823ef18701"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -288,6 +310,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-connection"
+            },
             "autoload": {
                 "files": [
                     "legacy/load-ixr.php"
@@ -320,13 +345,16 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "ae159fdb1b045cdf2875ed587782203f5ae52248"
+                "reference": "2d0c1e51e3c85cbc4f2dc1c95b81729524d7b0aa"
             },
             "require-dev": {
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-constants"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -352,12 +380,15 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "d7b51065dd1f9a69ff7b1f5d78d40f461ece11da"
+                "reference": "3fb490f2a3cb6a071b4dcd346e94e2da139d8e78"
             },
             "require-dev": {
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-device-detection"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -383,12 +414,15 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/error",
-                "reference": "0b871ba15caa7fdb87ec222cdd2f37e0ecc04ecb"
+                "reference": "376067daa3b8af94e1b5ddb09065f658daf22cdf"
             },
             "require-dev": {
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-error"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -414,7 +448,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/heartbeat",
-                "reference": "ff91bf284c8b71856d9cf23652c37f0107797455"
+                "reference": "a2902505dbae754bdbdf48909ed328ad4ac697c5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -424,6 +458,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-heartbeat"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -449,7 +486,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "c1e3e5049d1e3de1a7343136dbef43f7181a6b40"
+                "reference": "07d7f38c2e57898be6b58e3057a1b0b7846dcfff"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -467,6 +504,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-jitm"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -492,7 +532,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/lazy-images",
-                "reference": "59413e8615f8d8773bd5d4fdc10a8774ddb87f27"
+                "reference": "e153dcb295bb7d9df78de49cdc4c8d7cc5ec06a7"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -503,6 +543,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-lazy-images"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -531,7 +574,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "977bc8aed9e8eccfd552287094c45f66ca78cf7c"
+                "reference": "de22ed7f8f6e0924d89ac45908b79f24ab0db95e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -542,6 +585,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-licensing"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -570,12 +616,15 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "c93ff0bb312f32e25fbf71c6555e719297868175"
+                "reference": "eb58628884d68bc62c384201505e84f42eea3811"
             },
             "require-dev": {
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-logo"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -601,7 +650,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/options",
-                "reference": "c369cee23808f673eea3b88a4afa262c21bd7dd3"
+                "reference": "84a33019fa7b96309115fd3b00dfed443f79ae79"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -610,6 +659,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-options"
+            },
             "autoload": {
                 "classmap": [
                     "legacy"
@@ -629,13 +681,16 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "0ec7c91d658797b5262d68cb2e91bf40c37ad99c"
+                "reference": "9821df864467d93c57242f62f0b7798614b12d32"
             },
             "require-dev": {
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-partner"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -661,7 +716,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "e1af6b7f48c45b0f0be0cba55ee9e7d583ee09ce"
+                "reference": "01b000c360dcbdc9f7332fcf3ae3d18e6fb9fc44"
             },
             "require": {
                 "automattic/jetpack-status": "@dev"
@@ -671,6 +726,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-redirect"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -696,13 +754,16 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "8fcd9e3f1f5e50e43e52a12d974c968b0ff695a1"
+                "reference": "478c1102e2e83ac6e102cd933a09a0d92a5651ec"
             },
             "require-dev": {
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-roles"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -728,13 +789,16 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "672624ca66bb9435c5db9d16ef749c7f7997bddd"
+                "reference": "eb4b403e0b657dbf7d63758bea839f166f3e4766"
             },
             "require-dev": {
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-status"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -760,7 +824,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "c79e43785c0f1b6f0e9f8873bb6e588ecda5f61b"
+                "reference": "bc078fce760ff212732ad407fdf00ab04b1446f7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -770,6 +834,9 @@
                 "automattic/jetpack-status": "@dev"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-sync"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -789,7 +856,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/terms-of-service",
-                "reference": "d645fa0ba05faebc72a60d5e32e2b5a1944b15db"
+                "reference": "5ff3c9e198479dbb9219f72adba7003ea9a79359"
             },
             "require": {
                 "automattic/jetpack-options": "@dev",
@@ -800,6 +867,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-terms-of-service"
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -825,7 +895,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "59f736a60432a39181eaec1173ae1fc17ebc7a29"
+                "reference": "ca3947eb0377d47276fc16086114ded89f2adedd"
             },
             "require": {
                 "automattic/jetpack-options": "@dev",
@@ -836,6 +906,9 @@
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-tracking"
+            },
             "autoload": {
                 "classmap": [
                     "legacy",


### PR DESCRIPTION
Builds on top of #18313's framework and defines a mirror repo for all existing Composer packages.

#### Changes proposed in this Pull Request:
* Define mirror repos.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* See 18313.
*

#### Proposed changelog entry for your changes:
* n/a
