### PR TITLE
Multisite: avoid Fatals on sites using WPMUDEV domain mapping

### DIFF
--- a/3rd-party/class-domain-mapping.php
+++ b/3rd-party/class-domain-mapping.php
@@ -153,7 +153,7 @@ class Domain_Mapping {
 	 * @return Domainmap_Utils
 	 */
 	public function get_domain_mapping_utils_instance() {
-		return domain_map::utils();
+		return \domain_map::utils();
 	}
 }
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Follow-up from #18061

Our changes in namespacing caused this issue, since we're relying on an external class here.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

This requires a bit of a setup, since you'd need to be using [this plugin](https://github.com/wpmudev/domain-mapping) on a Multisite instance.

Once you've set that up, you shouldn't see any Fatals on your site.

#### Proposed changelog entry for your changes:

* Multisite: avoid Fatals on sites using WPMUDEV domain mapping
