### PR TITLE
AudioPlayer: add currentTime locking system

### DIFF
--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -178,11 +178,11 @@ export class PodcastPlayer extends Component {
 	};
 
 	handleJump = () => {
-		this.setState( { currentTime: this.state.currentTime - 5 } );
+		this.setState( { currentTime: String( this.state.currentTime - 5 ) } );
 	};
 
 	handleSkip = () => {
-		this.setState( { currentTime: this.state.currentTime + 30 } );
+		this.setState( { currentTime: String( this.state.currentTime + 30 ) } );
 	};
 
 	render() {

--- a/extensions/shared/components/audio-player/README.md
+++ b/extensions/shared/components/audio-player/README.md
@@ -24,7 +24,26 @@ The URL of the audio file to play. In the case of the podcast player, this is al
 
 #### `currentTime`
 
-Used in conjunction with `onTimeChange` this tracks the current position in the audio file, and can be set to a value in order to jump back and forth.
+Use this property to set the current time of the audio file declaratively.
+It's very important to keep in mind that the variable type needs to be a String in order to propagate the value to the audio element. A very common case is to jump back and forth.
+It was designed this way to avoid a race condition, when the `currentTime` property is connected, from the parent component,
+with the `onTimeChange()` callback.
+
+```es6
+function ParentPlayer() {
+	const [ currentTime, setCurrentTime ] = useState( 0 );
+
+	<AudioPlayer
+		currentTime={ currentTime }
+		onTimeChange={ setCurrentTime }
+	>
+
+	<Button
+		onClick={ () => setCurrentTime( '30' ) }
+	>
+		Set current position to 30s
+	<Button/>
+}
 
 #### `onTimeChange`
 

--- a/extensions/shared/components/audio-player/index.jsx
+++ b/extensions/shared/components/audio-player/index.jsx
@@ -142,21 +142,26 @@ function AudioPlayer( {
 	//Check current time against prop and potentially jump
 	useEffect( () => {
 		const audio = audioRef.current;
-
 		// If there's no audio component or we're not controlling time with the `currentTime` prop,
 		// then bail early.
 		if ( ! currentTime || ! audio ) {
 			return;
 		}
 
-		// We only want to change the play position if the difference between our current play position
-		// and the prop is greater than 1. We're throttling the time change events to once per second, so
-		// if the floored time has changed by more than a second, we haven't received an event in the past
-		// two seconds. That's unlikely and so a change of more than a second should be as a result of us
-		// wanting to update the position, so we set the audio element's current time as a result.
-		if ( Math.abs( Math.floor( currentTime - audio.currentTime ) ) > 1 ) {
-			audio.currentTime = currentTime;
+		// Bail early when not a String.
+		// It accepts only String value types to update the
+		// current time of the audio source.
+		if ( typeof currentTime !== 'string' ) {
+			return;
 		}
+
+		const castCurrentTime = Number( currentTime );
+		// Bail early if it is not a valid number.
+		if ( isNaN( castCurrentTime ) ) {
+			return;
+		}
+
+		audio.currentTime = currentTime;
 	}, [ audioRef, currentTime ] );
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR fixes an issue that happens when the user tries to move the current position of the player by clicking on the porogress bar.

#### How does it work
_(copied from Readme.md file)

------------------------------------
#### `currentTime`

Use this property to set the current time of the audio file declaratively.
It's very important to keep in mind that the variable type needs to be a String in order to propagate the value to the audio element. A very common case is to jump back and forth.
It was designed this way to avoid a race condition, when the `currentTime` property is connected, from the parent component,
with the `onTimeChange()` callback.

```es6
function ParentPlayer() {
	const [ currentTime, setCurrentTime ] = useState( 0 );
	<AudioPlayer
		currentTime={ currentTime }
		onTimeChange={ setCurrentTime }
	>
	<Button
		onClick={ () => setCurrentTime( '30' ) }
	>
		Set current position to 30s
	<Button/>
}
```

------------------------------------

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* AudioPlayer: add currentTime locking system

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1610559413068000-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a podcast player block

**before**

* once the block is rendered, try to move the current time by clicking on the progress bar., trying to reproduce a bug. In short, the position is not properly applied to the player

https://user-images.githubusercontent.com/77539/104499700-3f59e280-55bc-11eb-8d6f-8deb5e4b0146.mov

**after**

* do the same described before. The player position should be applied properly.
* Confirm you can go forward and go back by clicking on the respective buttons:

![image](https://user-images.githubusercontent.com/77539/104499817-687a7300-55bc-11eb-9507-97e6a60dc152.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* AudioPlayer: add updating current time locking system
