### PR TITLE
Audio Player: Fix the firing of multiple conflicting time changes

### DIFF
--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
@@ -130,11 +130,15 @@ function AudioPlayer( {
 		}
 		//Add time change event listener
 		const audio = audioRef.current;
-		const throttledTimeChange = throttle( time => onTimeChange( time ), 1000 );
+		const throttledTimeChange = throttle( time => onTimeChange( time ), 1000, {
+			leading: true,
+			trailing: false,
+		} );
 		const onTimeUpdate = e => throttledTimeChange( e.target.currentTime );
 		onTimeChange && audio?.addEventListener( 'timeupdate', onTimeUpdate );
 
 		return () => {
+			throttledTimeChange.cancel();
 			audio?.removeEventListener( 'timeupdate', onTimeUpdate );
 		};
 	}, [ audioRef, onTimeChange ] );


### PR DESCRIPTION
It was seen that if you click around on the timeline of the audio
player, that from time to time, the click will be ignored and the audio
will jump back to the previous position.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This change updates the options passed to `throttle` as the problem
seemed to be caused by the prop changing every second and a click
happening within the second, this led to two calls to the throttled
function, on the leading and trailing edge of the time period.

It's probably not strictly necessary, but it also cancels the throttled
function in the unmount callback of the `useEffect`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Insert a podcast block and set it up with an RSS feed.
* Set an episode playing and click around on the timeline.
* From time to time you should see that the time change event on the timeline gets ignored and it jumps back to the previous position.
* With this PR do the same, and it should fix the problem.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
N/A as this fixes a problem in code that is yet to be released.
