### PR TITLE
e2e Tests: Run with detectOpenHandles

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"test-adminpage-and-extensions-and-search": "yarn concurrently 'yarn test-adminpage' 'yarn test-extensions' 'yarn test-search'",
 		"test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client tests/runner.js",
 		"test-decrypt-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./tests/e2e/config/encrypted.enc -out ./tests/e2e/config/local-test.js",
-		"test-e2e": "NODE_CONFIG_DIR='./tests/e2e/config' NODE_CONFIG_ENV=test JEST_PUPPETEER_CONFIG=tests/e2e/jest-puppeteer.config.js jest --config tests/e2e/jest.config.js --runInBand --verbose",
+		"test-e2e": "NODE_CONFIG_DIR='./tests/e2e/config' NODE_CONFIG_ENV=test JEST_PUPPETEER_CONFIG=tests/e2e/jest-puppeteer.config.js jest --config tests/e2e/jest.config.js --runInBand --verbose --detectOpenHandles",
 		"test-encrypt-config": "openssl enc -md sha1 -aes-256-cbc -pass env:CONFIG_KEY -in ./tests/e2e/config/local-test.js -out ./tests/e2e/config/encrypted.enc",
 		"test-extensions": "jest extensions",
 		"test-gui": "NODE_ENV=test NODE_PATH=tests:_inc/client tests/runner.js gui",


### PR DESCRIPTION
Our e2e tests are running really slow sometimes (1h+) and it sounds like we have some async operations that may be hanging:

```
Test Suites: 5 failed, 5 total
Tests:       0 total
Snapshots:   0 total
Time:        1742.979 s
Ran all test suites.
Jest did not exit one second after the test run has completed.
This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

This runs the e2e tests with `--detectOpenHandles` to see what we can learn from it.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
