### PR TITLE
Reorg: Remove temp branch from executing action

### DIFF
--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -2,8 +2,7 @@ name: Update a package when it is updated in the monorepo
 on:
   push:
     branches:
-      - master # Every time a PR is merged to master
-      - feature/reorg # Also feature/reorg, temporarily
+      - master # Every time a PR is merged to master.
     paths:
       - 'projects/packages/**' # Only when package files are modified.
       - 'projects/plugins/**' # Only when plugin files are modified.


### PR DESCRIPTION
During the reorg work, we had Github push to a branch of the mirror repos. We no longer need this.

#### Changes proposed in this Pull Request:
* Removes temporary code.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* None
*

#### Proposed changelog entry for your changes:
* n/a
