### PR TITLE
 Conversation Block: Fix Column Style Alignment

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -48,21 +48,30 @@
 // Conversation styles.
 .wp-block-jetpack-conversation.is-style-column {
 	.wp-block-jetpack-dialogue {
-		display: flex;
-		.wp-block-jetpack-dialogue__meta {
-			display: block;
-			align-items: initial;
+		margin: 0 0 1em 0;
+
+		.wp-block-jetpack-dialogue__meta::after {
+			content: ': ';
 		}
 
-		.wp-block-jetpack-dialogue__participant {
-			text-align: right;
-			margin-right: 12px;
+		.wp-block-jetpack-dialogue__timestamp {
+			padding: 6px 0 6px 6px;
+
+			button {
+				padding-right: 0px;
+			}
+
+			&::before {
+				content: ' (';
+			}
+
+			&::after {
+				content: ')';
+			}
 		}
 
-		.components-dropdown,
-		.wp-block-jetpack-dialogue__timestamp-dropdown {
-			text-align: right;
-			display: block;
+		div, p {
+			display: inline;
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18277 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes alignment issues in "Column" style of the block by moving timestamp to the right of participant name, and wrapping dialogue text to approximate a more common transcript format. For example, see [distributed.blog](https://distributed.blog/2020/12/16/episode-26-jack-dorsey-and-remote-collaboration/).
* Needs an update after  #18247 is merged.

View | Before | After
----- | ------ | -----
Editor | <img width="685" alt="Screen Shot 2021-01-14 at 1 25 55 PM" src="https://user-images.githubusercontent.com/1689238/104632679-12fd9f00-566c-11eb-9050-f94473f0536f.png"> |  <img width="652" alt="Screen Shot 2021-01-14 at 12 27 29 PM" src="https://user-images.githubusercontent.com/1689238/104632760-2e68aa00-566c-11eb-8326-8f9f60088a01.png">
Published | <img width="645" alt="Screen Shot 2021-01-14 at 1 25 35 PM" src="https://user-images.githubusercontent.com/1689238/104632715-1db83400-566c-11eb-8921-3e761c2d80c7.png"> | <img width="611" alt="Screen Shot 2021-01-14 at 12 27 16 PM" src="https://user-images.githubusercontent.com/1689238/104632776-345e8b00-566c-11eb-98fa-17eb1cc4c0de.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect a test site to Jetpack and enable beta blocks.
* Add a Conversation Block to a post.
* Select one of the Dialogue Blocks in the Conversation Block
* In the Block settings sidebar, select the "Column" style:

<img width="143" alt="Screen Shot 2021-01-14 at 1 31 43 PM" src="https://user-images.githubusercontent.com/1689238/104633232-dbdbbd80-566c-11eb-8b0a-f61c158cbd86.png">

* Check the alignment with "Show conversation timestamps" both enabled and disabled:

<img width="280" alt="Screen Shot 2021-01-11 at 5 36 27 PM" src="https://user-images.githubusercontent.com/1689238/104246271-b0ba5980-5433-11eb-9802-c192dbb48f03.png">

* Check that the "Row" style is aligned and unaffected.
* Test using a variety of browsers and screen sizes.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* No changelog entry needed; this is an update to the Conversation & Dialogue blocks that are in beta.
