### PR TITLE
Actions: Improve build-artifacts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,6 +22,8 @@ jobs:
       with:
         name: jetpack-dev
         path: /tmp/artifact/to-upload
+        # Only need to retain for a day since the beta builder slurps it up to distribute.
+        retention-days: 1
     # Find the PR associated with this push, if there is one.
     - uses: jwalton/gh-find-current-pr@v1
       id: findPr

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -2,19 +2,6 @@ name: Build artifacts
 on: push
 
 jobs:
-  build_master_job:
-    name: Master
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout Jetpack
-        uses: actions/checkout@master
-      - name: Build production version
-        uses: automattic/action-jetpack-build-to-branch@master
-        with:
-          branch_pull: 'master'
-          branch_push: 'master-built'
-          commit_message: 'Automated production build from master'
   build_beta:
     name: Beta
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Removes the step to build to `master-built`. We deprecate that and push everyone to https://github.com/automattic/jetpack-production
* Set the retention time for the artifact to 1d. The beta server grabs the zip and saves it there, so we don't need it for any length of time.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Check the action log.
*

#### Proposed changelog entry for your changes:
* n/a
