### PR TITLE
Connection: in-place flow privacy policy

### DIFF
--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -153,10 +153,11 @@ class REST_Connector {
 		$connection = new Manager();
 
 		$connection_status = array(
-			'isActive'     => $connection->is_active(),
-			'isStaging'    => $status->is_staging_site(),
-			'isRegistered' => $connection->is_connected(),
-			'offlineMode'  => array(
+			'isActive'          => $connection->is_active(),
+			'isStaging'         => $status->is_staging_site(),
+			'isRegistered'      => $connection->is_connected(),
+			'hasConnectedOwner' => $connection->has_connected_owner(),
+			'offlineMode'       => array(
 				'isActive'        => $status->is_offline_mode(),
 				'constant'        => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
 				'url'             => $status->is_local_site(),
@@ -164,7 +165,7 @@ class REST_Connector {
 				'filter'          => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
 				'wpLocalConstant' => defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV,
 			),
-			'isPublic'     => '1' == get_option( 'blog_public' ), // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+			'isPublic'          => '1' == get_option( 'blog_public' ), // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 		);
 
 		if ( $rest_response ) {

--- a/projects/plugins/jetpack/_inc/client/components/auth-iframe/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/auth-iframe/index.jsx
@@ -16,6 +16,7 @@ import {
 	fetchUserConnectionData,
 	authorizeUserInPlaceSuccess,
 	isAuthorizingUserInPlace,
+	hasConnectedOwner,
 } from 'state/connection';
 
 import './style.scss';
@@ -29,6 +30,7 @@ export class AuthIframe extends React.Component {
 		width: PropTypes.string,
 		scrollToIframe: PropTypes.bool,
 		onAuthorized: PropTypes.func,
+		hasConnectedOwner: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -75,7 +77,13 @@ export class AuthIframe extends React.Component {
 	render = () => {
 		// The URL looks like https://jetpack.wordpress.com/jetpack.authorize_iframe/1/. We need to include the trailing
 		// slash below so that we don't end up with something like /jetpack.authorize_iframe_iframe/
-		const src = this.props.connectUrl.replace( 'authorize/', 'authorize_iframe/' );
+		let src = this.props.connectUrl.replace( 'authorize/', 'authorize_iframe/' );
+		let height = this.props.height;
+
+		if ( this.props.hasConnectedOwner ) {
+			src += '&display-tos';
+			height = ( parseInt( height ) + 50 ).toString();
+		}
 
 		return (
 			<div ref="iframeWrap" className="dops-card fade-in jp-iframe-wrap">
@@ -87,7 +95,7 @@ export class AuthIframe extends React.Component {
 						ref="iframe"
 						title={ this.props.title }
 						width={ this.props.width }
-						height={ this.props.height }
+						height={ height }
 						src={ src }
 					></iframe>
 				) }
@@ -102,6 +110,7 @@ export default connect(
 			fetchingConnectUrl: _isFetchingConnectUrl( state ),
 			connectUrl: _getConnectUrl( state ),
 			isAuthorizingInPlace: isAuthorizingUserInPlace( state ),
+			hasConnectedOwner: hasConnectedOwner( state ),
 		};
 	},
 	dispatch => {

--- a/projects/plugins/jetpack/_inc/client/state/connection/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/connection/reducer.js
@@ -267,6 +267,16 @@ export function isConnectionOwner( state ) {
 }
 
 /**
+ * Returns true if the site has a connected owner.
+ *
+ * @param  {object} state - Global state tree
+ * @returns {boolean} true if the site has an owner connected, false otherwise
+ */
+export function hasConnectedOwner( state ) {
+	return get( state.jetpack.connection.status, [ 'siteConnected', 'hasConnectedOwner' ], false );
+}
+
+/**
  * Checks if the site is currently in offline mode.
  *
  * @param  {Object}  state Global state tree


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The commit adds TOS links to the in-place connection flow for users who do not see it when initiating the flow.

It happens if:
- a secondary user links their WordPress account to WP.com.
- any user (including the connection owner) "restores" the connection, and has to go through the In-Place flow to reconnect.

Requires D55311-code to function.

#### Jetpack product discussion
p9dueE-2lt-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
There's no need to pull the WP.com diff and test the full solution.
Instead, we could just use the changes introduced by this PR: adding a flag into the In-Place Connection iframe informing WP.com that ToS information needs to be displayed.

_Make sure to run `yarn build` if you're testing locally._

1. Disconnect Jetpack (if connected).
2. Go to Jetpack Dashboard and initiate the connection process via in-place flow. Don't complete it, keep the iframe open.
3. When the iframe loads, use the iframe confirm that its URL doesn't contain the `display-tos` GET parameter.
4. Complete the connection process.
5. Log into Jetpack Dashboard as another user (non-connected to Jetpack).
6. Initiate the secondary user in-place connection flow, keep the iframe open.
7. Confirm that the iframe URL contains the `display-tos` GET parameter.

__An example of the GET parameter being present:__
<img width="608" alt="Screen Shot 2021-01-14 at 4 38 18 PM" src="https://user-images.githubusercontent.com/1341249/104657654-f589fe80-5686-11eb-8f97-6a8e7a2f8a52.png">

#### Proposed changelog entry for your changes:
n/a