### PR TITLE
Dialogue block: Fix dialogue column alignment

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -10,6 +10,7 @@
 		padding: 0;
 		line-height: 17px;
 		line-height: var( --global--line-height-body );
+		overflow-wrap: anywhere;
 	}
 
 	.wp-block-jetpack-dialogue__timestamp {
@@ -22,7 +23,6 @@
 }
 
 .wp-block-jetpack-dialogue__participant {
-	white-space: nowrap;
 	padding: 3px 0;
 	height: auto;
 	line-height: 1.2;
@@ -49,9 +49,11 @@
 .wp-block-jetpack-conversation.is-style-column {
 	.wp-block-jetpack-dialogue {
 		display: flex;
+
 		.wp-block-jetpack-dialogue__meta {
 			display: block;
 			align-items: initial;
+			flex: 0 0 20%;
 		}
 
 		.wp-block-jetpack-dialogue__participant {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18277 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Wrap the participant names in a fixed-width column.

Before | After
------- | ----
![image](https://user-images.githubusercontent.com/1689238/104937943-675e9280-597c-11eb-8ef9-10c903ca1bb2.png) | ![image (1)](https://user-images.githubusercontent.com/1689238/104937939-662d6580-597c-11eb-822f-85f3ff529f45.png)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/pull/18348

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect a test site to Jetpack and enable beta blocks.
* Add a Conversation Block to a post.
* Select one of the Dialogue Blocks in the Conversation Block
* In the Block settings sidebar, select the "Column" style.

* Check the alignment with "Show conversation timestamps" both enabled and disabled:

<img width="280" alt="Screen Shot 2021-01-11 at 5 36 27 PM" src="https://user-images.githubusercontent.com/1689238/104246271-b0ba5980-5433-11eb-9802-c192dbb48f03.png">

* Check that the "Row" style is aligned and unaffected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* No changelog entry needed; this is an update to the Conversation & Dialogue blocks that are in beta.
