### PR TITLE
Publicize: Allow clearing Publicize custom message if a post title has been set

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/publicize/form-unwrapped.js
+++ b/projects/plugins/jetpack/extensions/blocks/publicize/form-unwrapped.js
@@ -41,8 +41,9 @@ class PublicizeFormUnwrapped extends Component {
 
 	onMessageChange = event => {
 		const { messageChange } = this.props;
-		this.setState( { hasEditedShareMessage: true } );
-		messageChange( event );
+		const hasEditedShareMessage = true;
+		this.setState( { hasEditedShareMessage } );
+		messageChange( event, hasEditedShareMessage );
 	};
 
 	render() {

--- a/projects/plugins/jetpack/extensions/blocks/publicize/form.js
+++ b/projects/plugins/jetpack/extensions/blocks/publicize/form.js
@@ -54,10 +54,11 @@ const PublicizeForm = compose( [
 		 *
 		 * @param {object} event Change event data from textarea element.
 		 */
-		messageChange( event ) {
+		messageChange( event, hasEditedShareMessage ) {
 			dispatch( 'core/editor' ).editPost( {
 				meta: {
 					jetpack_publicize_message: event.target.value,
+					jetpack_publicize_hasEditedShareMessage: hasEditedShareMessage,
 				},
 			} );
 		},

--- a/projects/plugins/jetpack/extensions/blocks/publicize/store/selectors.js
+++ b/projects/plugins/jetpack/extensions/blocks/publicize/store/selectors.js
@@ -259,9 +259,14 @@ export function getShareMessage() {
 	const meta = getEditedPostAttribute( 'meta' );
 	const postTitle = getEditedPostAttribute( 'title' );
 	const message = get( meta, [ 'jetpack_publicize_message' ], '' );
+	const hasEditedShareMessage = get( meta, [ 'jetpack_publicize_hasEditedShareMessage' ], false );
 
 	if ( message ) {
 		return message.substr( 0, getShareMessageMaxLength() );
+	}
+
+	if ( hasEditedShareMessage && message === '' ) {
+		return '';
 	}
 
 	if ( postTitle ) {


### PR DESCRIPTION
When a post has a title added, the Publicize "Customize your message" input will autofill with that post title if a custom sharing message has not already been set.

Currently, if a post has a title added, and users select and then try to delete (not type over) all of the text in the custom sharing message input, it will immediately fill with the post title text.

This change will track if the custom message input has been edited, and if it has, allows a user to select and delete all text, even when the post has a title added to it.

#### Changes proposed in this Pull Request:

* Allow fully clearing the Publicize custom message even if a post title has been set. Not being able to delete all selected text can be confusing to users.

#### Jetpack product discussion

* None, open to discussion

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* After pulling down proposed changes, make sure to rebuild Jetpack (e.g. `yarn build`) as JS files have been modified.
* On a Jetpack connected site, with a connected sharing service (e.g. Twitter), create a new post and give the post a title.
* Click on the Jetpack icon to view the Publicize sharing options.
* Verify that you are able to select all text in the "Customize your message" text area and completely clear that text area (i.e. by typing Backspace or Delete, not by typing over with new text).

**Before screenshot:**

![before](https://user-images.githubusercontent.com/15803018/104671160-7ef6fc00-569a-11eb-9ccd-3b6685d5592d.gif)

**After screenshot:**

![after](https://user-images.githubusercontent.com/15803018/104671167-81595600-569a-11eb-8d4e-16b2a7cdfacb.gif)

#### Proposed changelog entry for your changes:

* None

#### Context:

User report: 6312-gh-Automattic/jpop-issues

Looks like prior behavior would have been changed in: https://github.com/Automattic/jetpack/pull/16699