### PR TITLE
REST API: Fix user connection data without owner

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -1590,10 +1590,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function get_user_connection_data() {
 		require_once( JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class.jetpack-react-page.php' );
 
+		$connection_owner   = ( new Connection_Manager() )->get_connection_owner();
+		$owner_display_name = false === $connection_owner ? null : $connection_owner->data->display_name;
+
 		$response = array(
-//			'othersLinked'    => Jetpack::get_other_linked_admins(),
 			'currentUser'     => jetpack_current_user_data(),
-			'connectionOwner' => ( new Connection_Manager() )->get_connection_owner()->data->display_name,
+			'connectionOwner' => $owner_display_name,
 		);
 		return rest_ensure_response( $response );
 	}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -1075,7 +1075,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	public function test_get_user_connection_data_without_master_user() {
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user( 'administrator' );
-		$user->add_cap( 'jetpack_configure_modules' );
 		wp_set_current_user( $user->ID );
 		// No master user set.
 		$response = $this->create_and_get_request( 'connection/data' );

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -1066,4 +1066,22 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseStatus( 200, $response );
 		$this->assertEquals( 'foo', $response->get_data() );
 	}
+
+	/**
+	 * Test fetching user connection data without a connection owner.
+	 *
+	 * @since 9.4
+	 */
+	public function test_get_user_connection_data_without_master_user() {
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_configure_modules' );
+		wp_set_current_user( $user->ID );
+		// No master user set.
+		$response = $this->create_and_get_request( 'connection/data' );
+		$this->assertResponseStatus( 200, $response );
+
+		$response_data = $response->get_data();
+		$this->assertNull( $response_data['connectionOwner'] );
+	}
 } // class end


### PR DESCRIPTION
This PR fixes a PHP notice when trying to fetch user connection data while a connection owner does not exist (user-less).

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the `get_user_connection_data` method in `Jetpack_Core_Json_Api_Endpoints` to properly handle cases where the connection owner does not exist.
* Adds a corresponding unit test 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Manual

**Before applying this fix:** 
* Start with a fresh Jetpack site
* Enable user-less connection mode by setting `JETPACK_NO_USER_TEST_MODE` ( in `wp-config.php` or via Settings -> Jetpack Constants)
* Set up Jetpack in user-less mode (aka skip user authentication)
* Go to Jetpack Dashboard and notice the following notice when fetching: `jetpack/v4/connection/data`:
The notice will be visible either in `debug.log` or in your browser console, Network tab -> XHR -> `GET wp-json/jetpack/v4/connection/data`:

**PHP Notice:  Trying to get property 'display_name' of non-object in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php on line 1598**

* Switch to this branch and confirm that the Notice is gone.

### Automated

```php
phpunit --filter=test_get_user_connection_data_without_master_user
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* REST API: fix PHP notice when fetching user connection data without a connection owner.
