### PR TITLE
Connection: Accept blog token on 'jetpack.disconnectBlog'

### DIFF
--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -61,6 +61,7 @@ class Jetpack_XMLRPC_Server {
 			'jetpack.remoteProvision'  => array( $this, 'remote_provision' ),
 			'jetpack.idcUrlValidation' => array( $this, 'validate_urls_for_idc_mitigation' ),
 			'jetpack.unlinkUser'       => array( $this, 'unlink_user' ),
+			'jetpack.disconnectBlog'   => array( $this, 'disconnect_blog' ),
 		);
 
 		if ( class_exists( 'Jetpack' ) ) {
@@ -76,7 +77,6 @@ class Jetpack_XMLRPC_Server {
 			$jetpack_methods = array_merge(
 				$jetpack_methods,
 				array(
-					'jetpack.disconnectBlog'  => array( $this, 'disconnect_blog' ),
 					'jetpack.testAPIUserCode' => array( $this, 'test_api_user_code' ),
 				)
 			);

--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -61,7 +61,6 @@ class Jetpack_XMLRPC_Server {
 			'jetpack.remoteProvision'  => array( $this, 'remote_provision' ),
 			'jetpack.idcUrlValidation' => array( $this, 'validate_urls_for_idc_mitigation' ),
 			'jetpack.unlinkUser'       => array( $this, 'unlink_user' ),
-			'jetpack.disconnectBlog'   => array( $this, 'disconnect_blog' ),
 		);
 
 		if ( class_exists( 'Jetpack' ) ) {
@@ -69,6 +68,7 @@ class Jetpack_XMLRPC_Server {
 			$jetpack_methods['jetpack.testConnection']    = array( $this, 'test_connection' );
 			$jetpack_methods['jetpack.featuresAvailable'] = array( $this, 'features_available' );
 			$jetpack_methods['jetpack.featuresEnabled']   = array( $this, 'features_enabled' );
+			$jetpack_methods['jetpack.disconnectBlog']    = array( $this, 'disconnect_blog' );
 		}
 
 		$this->user = $this->login();

--- a/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
@@ -981,6 +981,7 @@ EXPECTED;
 			'jetpack.testConnection',
 			'jetpack.featuresAvailable',
 			'jetpack.featuresEnabled',
+			'jetpack.disconnectBlog',
 		);
 
 		$allowed = array(


### PR DESCRIPTION
This PR adds the possibility to make an XMLRPC request to `jetpack.disconnectBlog` using a blog token. User token is still supported.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves the `jetpack.disconnectBlog` outside of the login logic in `Jetpack_XMLRPC_Server`

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1VI-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
**Manual**
27e39-pb/ (OneBin)

**Automated**
```
phpunit --filter=test_classic_xmlrpc_when_active_and_signed_with_no_user
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* No changelog entry needed: The `jetpack.disconnectBlog` method now is also accessible with a blog token (WPCOM)