### PR TITLE
i18n: enforce the use of the jetpack textdomain

### DIFF
--- a/projects/plugins/jetpack/_inc/client/.eslintrc.js
+++ b/projects/plugins/jetpack/_inc/client/.eslintrc.js
@@ -3,4 +3,13 @@ module.exports = {
 	// JavaScript files inside this folder are meant to be transpiled by Webpack.
 	root: true,
 	extends: [ '../../.eslintrc.js', 'plugin:@wordpress/eslint-plugin/i18n' ],
+	rules: {
+		// Enforce the use of the Jetpack textdomain.
+		'@wordpress/i18n-text-domain': [
+			'error',
+			{
+				'allowedTextDomain': 'jetpack',
+			}
+		],
+	},
 };

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -211,7 +211,7 @@ class SiteStatsComponent extends React.Component {
 							>
 								<span className="jp-form-toggle-explanation">
 									{ __(
-										'Include a small chart in your admin bar with a 48-hour traffic snapshot'
+										'Include a small chart in your admin bar with a 48-hour traffic snapshot', 'jetpack'
 									) }
 								</span>
 							</CompactFormToggle>

--- a/projects/plugins/jetpack/extensions/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/.eslintrc.js
@@ -30,5 +30,13 @@ module.exports = {
 		// Don't require JSDoc on functions.
 		// Jetpack Extensions are often self-explanatory functional React components.
 		'jsdoc/require-jsdoc': 0,
+
+		// Enforce the use of the Jetpack textdomain.
+		'@wordpress/i18n-text-domain': [
+			'error',
+			{
+				'allowedTextDomain': 'jetpack',
+			}
+		],
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/index.js
@@ -269,7 +269,7 @@ export const childBlocks = [
 			title: __( 'Date Picker', 'jetpack' ),
 			keywords: [
 				__( 'Calendar', 'jetpack' ),
-				__( 'day month year', 'block search term', 'jetpack' ),
+				_x( 'day month year', 'block search term', 'jetpack' ),
 			],
 			description: __( 'The best way to set a date. Add a date picker.', 'jetpack' ),
 			icon: renderMaterialIcon(

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -135,7 +135,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 						</PanelBody>
 
 						<PanelBody
-							title={ __( 'Timestamps', 'context' ) }
+							title={ __( 'Timestamps', 'jetpack' ) }
 							className={ `${ baseClassName }__timestamps` }
 						>
 							<ToggleControl

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
@@ -216,13 +216,13 @@ class MailchimpSubscribeEdit extends Component {
 				<PanelBody title={ __( 'Signup Location Tracking', 'jetpack' ) }>
 					<TextControl
 						label={ __( 'Signup Field Tag', 'jetpack' ) }
-						placeholder={ __( 'SIGNUP' ) }
+						placeholder={ __( 'SIGNUP', 'jetpack' ) }
 						value={ signupFieldTag }
 						onChange={ value => setAttributes( { signupFieldTag: value } ) }
 					/>
 					<TextControl
 						label={ __( 'Signup Field Value', 'jetpack' ) }
-						placeholder={ __( 'website' ) }
+						placeholder={ __( 'website', 'jetpack' ) }
 						value={ signupFieldValue }
 						onChange={ value => setAttributes( { signupFieldValue: value } ) }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/edit.js
@@ -126,7 +126,7 @@ class PinterestEdit extends Component {
 			return (
 				<div className="wp-block-embed is-loading">
 					<Spinner />
-					<p>{ __( 'Embedding…' ) }</p>
+					<p>{ __( 'Embedding…', 'jetpack' ) }</p>
 				</div>
 			);
 		}

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -268,7 +268,7 @@ class MembershipsButtonEdit extends Component {
 		);
 		const minimumPriceNote = sprintf(
 			/* translators: placeholder is a price. */
-			__( 'Minimum allowed price is %s.' ),
+			__( 'Minimum allowed price is %s.', 'jetpack' ),
 			minPrice
 		);
 		return (

--- a/projects/plugins/jetpack/extensions/blocks/story/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/edit.native.js
@@ -177,8 +177,8 @@ const StoryEdit = ( { attributes, isSelected, clientId, setAttributes, onFocus }
 			<MediaPlaceholder
 				icon={ <BlockIcon icon={ icon } /> }
 				labels={ {
-					title: __( 'Story' ),
-					instructions: __( 'ADD MEDIA' ),
+					title: __( 'Story', 'jetpack' ),
+					instructions: __( 'ADD MEDIA', 'jetpack' ),
 				} }
 				allowedTypes={ [ MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO ] }
 				onFocus={ onFocus }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -303,7 +303,7 @@ function SubscriptionEdit( props ) {
 				) }
 
 				<PanelBody
-					title={ __( 'Text Settings' ) }
+					title={ __( 'Text Settings', 'jetpack' ) }
 					initialOpen={ false }
 					className="wp-block-jetpack-subscriptions__textpanel"
 				>
@@ -375,7 +375,7 @@ function SubscriptionEdit( props ) {
 				</PanelBody>
 
 				<PanelBody
-					title={ __( 'Display Settings' ) }
+					title={ __( 'Display Settings', 'jetpack' ) }
 					initialOpen={ false }
 					className="wp-block-jetpack-subscriptions__displaypanel"
 				>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -336,7 +336,7 @@ const VideoPressEdit = CoreVideoEdit =>
 									</p>
 									{ !! poster && (
 										<Button onClick={ this.onRemovePoster } isLink isDestructive>
-											{ __( 'Remove Poster Image' ) }
+											{ __( 'Remove Poster Image', 'jetpack' ) }
 										</Button>
 									) }
 								</BaseControl>


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Now that we've added an eslint plugin to monitor for i18n issues in our js files (see #16455 and #16516), let's start enforcing a rule: translatable strings should always include the jetpack textdomain.

This PR adds the rule to both the React dashboard and the extensions, and fixes instances where we had wrong strings until now.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Do the tests pass?
* Check the different blocks impacted by the change; the strings should remain correct.

#### Proposed changelog entry for your changes:
* N/A