### PR TITLE
Reorg: Rename root-level project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
-	"name": "Jetpack",
-	"version": "9.4.0-alpha",
+	"name": "Jetpack_Monorepo",
 	"private": true,
-	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
+	"description": "[Jetpack](https://jetpack.com/) is a set of WordPress plugins that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/issues"


### PR DESCRIPTION
We shouldn't have two projects named the same.

#### Changes proposed in this Pull Request:
* Some build tools will balk at two projects with the same name. The renames the monorepo.

#### Jetpack product discussion
p1610704784177500-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* n/a
*

#### Proposed changelog entry for your changes:
* n/a