### PR TITLE
Mirroring: Preserve file permissions by uploading a .tar.xz as the build artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       # This is the official workaround: https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
       # It'll also make it faster to upload and download though, so maybe it's a win anyway.
       - name: Create archive
-        run: tar --owner=0 --group=0 --xz -cvvf build.tar.xz -C "${{ steps.build.outputs.build-base }}" --transform 's,^\./,build,' .
+        run: tar --owner=0 --group=0 --xz -cvvf build.tar.xz -C "${{ steps.build.outputs.build-base }}" --transform 's,^\.,build,' .
 
       - name: Store build as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,17 @@ jobs:
         id: build
         run: .github/files/build-all-projects.sh
 
+      # GitHub's artifact stuff doesn't preserve permissions or file case. Sigh.
+      # This is the official workaround: https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
+      # It'll also make it faster to upload and download though, so maybe it's a win anyway.
+      - name: Create archive
+        run: tar --owner=0 --group=0 --xz -cvvf build.tar.xz -C "${{ steps.build.outputs.build-base }}" --transform 's,^\./,build,' .
+
       - name: Store build as artifact
         uses: actions/upload-artifact@v2
         with:
           name: jetpack-build
-          path: ${{ steps.build.outputs.build-base }}
+          path: build.tar.xz
           # Only need to retain for a day since the beta builder slurps it up to distribute.
           retention-days: 1
 
@@ -65,7 +71,8 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: jetpack-build
-          path: build
+      - name: Extract build archive
+        run: tar --xz -xvvf build.tar.xz
 
       # The beta plugin needs the base directory name to be "jetpack-dev"
       - name: Extract Jetpack
@@ -122,7 +129,8 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: jetpack-build
-          path: build
+      - name: Extract build archive
+        run: tar --xz -xvvf build.tar.xz
 
       - name: Wait for prior instances of the workflow to finish
         uses: softprops/turnstyle@v1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
GitHub's artifact mechanism does not preserve file permissions (or case,
but presumably if that were a problem we'd have known about it before
now).

The [official workaround](https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files) is to use `tar` to collect your files and
upload that archive file as the artifact. So let's do that. As a bonus,
it might speed up the artifact upload and download.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Look at the "jetpack-build" artifact in the Build workflow. Yes, unfortunately it'll download the .tar.xz inside a zip. [There's no way around that](https://github.com/actions/upload-artifact#zipped-artifact-downloads).
* Post-merge, see if the mirroring made https://github.com/Automattic/jetpack-codesniffer/blob/master/tests/php/ci-can-run.sh executable again.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
