### PR TITLE
Story block: Playback fixes

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/story/player/progress-bar.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/progress-bar.js
@@ -24,7 +24,7 @@ export const ProgressBar = ( {
 	let firstReachableSlideIndex = 0;
 	let lastReachableSlideIndex = slides.length - 1;
 
-	if ( currentSlideIndex < middleBullet ) {
+	if ( slides.length <= maxBullets || currentSlideIndex < middleBullet ) {
 		currentBulletIndex = currentSlideIndex;
 		lastReachableSlideIndex = bulletCount - 1;
 	} else if ( currentSlideIndex > slides.length - middleBullet ) {

--- a/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
@@ -639,6 +639,7 @@
 		background-repeat: no-repeat;
 		background-position: left center;
 		background-size: 100% auto;
+		display: none;
 
 		@supports not (backdrop-filter: none) {
 			filter: blur(18px);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

A few fixes to playback for the Story block:

* There is an intermittent issue on some browsers (mostly Chrome it seems) where the background scrim flickers when playing a story. The background has two layers: a blank, black background and the current slide magnified and blurred. We found that simply hiding the blurred slide and just keeping the blank background seems to resolve the issue, so going with that for now.
* The ellipsis behavior during playback for long stories introduced in #17708 was incorrectly being applied in some cases to shorter stories, causing odd behavior. Here's a demonstration for a three-slide story:

![story-player-bullet-issue](https://user-images.githubusercontent.com/9613966/104794514-73ffb100-57eb-11eb-93d0-260195d26366.gif)

This looks to have been a calculation error, and was only happening for odd-numbered stories below the max bullet limit. Should be resolved by this PR.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* The flickering issue is hard to reproduce. Instead, play a story on a desktop browser and confirm that the background is plain black.
* Create a story with three slides and try to reproduce the issue from the gif above without this change. With this change, confirm that the progress bar behaves normally.

#### Proposed changelog entry for your changes:
No changelog needed.
