### PR TITLE
Beta to Experimental -- AnchorFM Editor Integration 

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -168,7 +168,7 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\process_anchor_params' );
 add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
-		return array_merge(
+		return array_diff(
 			$extensions,
 			array(
 				'anchor-fm',

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -164,3 +164,15 @@ function process_anchor_params() {
 
 add_action( 'init', __NAMESPACE__ . '\register_extension' );
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\process_anchor_params' );
+// Populate the available extensions with anchor-fm.
+add_filter(
+	'jetpack_set_available_extensions',
+	function ( $extensions ) {
+		return array_merge(
+			$extensions,
+			array(
+				'anchor-fm',
+			)
+		);
+	}
+);

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -164,15 +164,3 @@ function process_anchor_params() {
 
 add_action( 'init', __NAMESPACE__ . '\register_extension' );
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\process_anchor_params' );
-// Populate the available extensions with anchor-fm.
-add_filter(
-	'jetpack_set_available_extensions',
-	function ( $extensions ) {
-		return array_diff(
-			$extensions,
-			array(
-				'anchor-fm',
-			)
-		);
-	}
-);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -40,11 +40,11 @@
 	],
 	"beta": [
 		"amazon",
-		"anchor-fm",
 		"conversation",
 		"dialogue"
 	],
 	"experimental": [
+		"anchor-fm",
 		"seo",
 		"premium-content"
 	],


### PR DESCRIPTION
Fixes 371-gh-Automattic/dotcom-manage

#### Changes proposed in this Pull Request:
Moves the AnchorFM extension from beta to experimental

#### Jetpack product discussion
371-gh-Automattic/dotcom-manage

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

- Make a testing post in the block editor and save it.
- Open the post for editing and add three GET params to the URL — `anchor_podcast`, `anchor_episode`, and `spotify_show_url`:
  - for convenience, you can use: `&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https://open.spotify.com/show/6HTZdaDHjqXKDE4acYffoD?si=EVfDYETjQCu7pasVG5D73Q`
 - Click on the editor body. Make sure the AnchorFM extension shows.

#### Proposed changelog entry for your changes:
Moves the AnchorFM extension from beta to experimental