### PR TITLE
Admin Page: better handle i18n for disconnection warnings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-termination-dialog/features.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-termination-dialog/features.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _n } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -110,10 +110,25 @@ class JetpackTerminationDialogFeatures extends Component {
 
 	render() {
 		const { isDevVersion, purpose, siteBenefits, connectedPlugins } = this.props;
-
 		const siteBenefitCount = siteBenefits.length;
-
 		const jetpackSupportURl = isDevVersion ? JETPACK_CONTACT_BETA_SUPPORT : JETPACK_CONTACT_SUPPORT;
+
+		const connectedPluginsTitle =
+			1 === connectedPlugins.length
+				? __(
+						'The Jetpack Connection is also used by another plugin, and it will lose connection.',
+						'jetpack'
+				  )
+				: sprintf(
+						/* translators: placeholder is a number. */
+						_n(
+							'The Jetpack Connection is also used by %d other plugin, and it will lose connection.',
+							'The Jetpack Connection is also used by %d other plugins, and they will lose connection.',
+							connectedPlugins.length,
+							'jetpack'
+						),
+						connectedPlugins.length
+				  );
 
 		return (
 			<Card className="jetpack-termination-dialog__features">
@@ -164,14 +179,7 @@ class JetpackTerminationDialogFeatures extends Component {
 				) }
 				{ connectedPlugins.length > 0 && (
 					<div className="jetpack-termination-dialog__generic-info">
-						<h2>
-							{ _n(
-								'The Jetpack Connection is also used by another plugin, and it will lose connection.',
-								'The Jetpack Connection is also used by other plugins, and they will lose connection.',
-								connectedPlugins.length,
-								'jetpack'
-							) }
-						</h2>
+						<h2>{ connectedPluginsTitle }</h2>
 						{ this.renderConnectedPlugins( connectedPlugins ) }
 					</div>
 				) }


### PR DESCRIPTION
Fixes #18391


#### Changes proposed in this Pull Request:

* Let's ensure that we display the right string regardless of the language and the number of connected plugins.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a site connected to WordPress.com and running this branch.
* Add and activate a test plugin like this one:

```php
<?php
/** Plugin Name: Jetpack Connection Test Plugin (1) */
add_action( 'plugins_loaded', function() {
        ( new Automattic\Jetpack\Config() )->ensure(
                'connection',
                array(
                      	'slug' => 'jetpack-connection-test-1',
                        'name' => 'Jetpack Connection Test Plugin (1)'
                )
        );
}, 1 );
```

* Go to Jetpack > Dashboard, and click on the Manage connection link towards the end of the page.
* You should see this:
![image](https://user-images.githubusercontent.com/426388/104928138-9687fa80-59a2-11eb-97b6-6039ef0b619e.png)

* Now add and activate a second plugin:

```php
<?php
/** Plugin Name: Jetpack Connection Test Plugin (2) */
add_action( 'plugins_loaded', function() {
        ( new Automattic\Jetpack\Config() )->ensure(
                'connection',
                array(
                      	'slug' => 'jetpack-connection-test-2',
                        'name' => 'Jetpack Connection Test Plugin (2)'
                )
        );
}, 1 );
```
* You should now see this:
![image](https://user-images.githubusercontent.com/426388/104928027-6f312d80-59a2-11eb-8a48-9a9007f18850.png)



#### Proposed changelog entry for your changes:

* N/A
