### PR TITLE
Connection package: Guard against reading a `$GLOBALS` variable that might not exist.

### DIFF
--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2428,7 +2428,7 @@ class Manager {
 	 * @return array the same array, since this method doesn't add or remove anything.
 	 */
 	public function xmlrpc_methods( $methods ) {
-		$this->raw_post_data = $GLOBALS['HTTP_RAW_POST_DATA'];
+		$this->raw_post_data = isset( $GLOBALS['HTTP_RAW_POST_DATA'] ) ? $GLOBALS['HTTP_RAW_POST_DATA'] : null;
 		return $methods;
 	}
 


### PR DESCRIPTION
Fixes #17917 

I started noticing a notice of `Undefined index: HTTP_RAW_POST_DATA` today. This should make sure these notices are not generated.

#### Changes proposed in this Pull Request:

* Add an `isset` guard over `$GLOBALS['HTTP_RAW_POST_DATA']`

#### Jetpack product discussion

N/a

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Checkout branch
* Enable `WP_DEBUG` in `wp-config.php`
* Start a Full sync from WPCOM 
* Watch the error log on your local site

#### Proposed changelog entry for your changes:

* Fix a possible notice of undefined variable when making XMLRPC requests.
