### PR TITLE
Jetpack ES query builder: fix ignored weightings

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
+++ b/projects/plugins/jetpack/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
@@ -94,6 +94,14 @@ class Jetpack_WPES_Query_Builder {
 	 * @return void
 	 */
 	public function add_weighting_function( $function ) {
+		//check for danger
+		if ( isset( $function['random_score'] ) ) {
+			return $this;
+		}
+		if ( isset( $function['script_score'] ) ) {
+			return $this;
+		}
+
 		$this->weighting_functions[] = $function;
 
 		return $this;
@@ -285,7 +293,7 @@ class Jetpack_WPES_Query_Builder {
 
 		// If there are any function score adjustments, then combine those
 		if ( $this->functions || $this->decays || $this->scripts || $this->weighting_functions ) {
-			$weighting_functions = array();
+			$weighting_functions = $this->weighting_functions;
 
 			if ( $this->functions ) {
 				foreach ( $this->functions as $function_type => $configs ) {

--- a/projects/plugins/jetpack/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
+++ b/projects/plugins/jetpack/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
@@ -94,7 +94,7 @@ class Jetpack_WPES_Query_Builder {
 	 * @return void
 	 */
 	public function add_weighting_function( $function ) {
-		//check for danger
+		// check for danger.
 		if ( isset( $function['random_score'] ) ) {
 			return $this;
 		}


### PR DESCRIPTION
Any weightings that were getting applied to the query with add_weighting_function() were not being added to the query. This fixes that bug and also adds a few checks to prevent adding weightings that we don't support (scripts and randomization). No place in Jetpack is using these and I doubt any customers are either, but we use it in a few places on wpcom and are planning some more.

This is a part of landing D51036. I've tested it manually there. Don't have any good test coverage yet, but it is fairly minor also.

