### PR TITLE
CI: Add timeouts for all jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ jobs:
   build:
     name: Build all projects
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # 2021-01-18: Successful runs seem to take 5-7 minutes
     steps:
       - uses: actions/checkout@v2
 
@@ -62,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    timeout-minutes: 15  # 2021-01-18: Successful runs seem to usually take ~2 minutes, but sometimes the upload is slow and it takes 12.
     steps:
       - uses: actions/checkout@v2
         with:
@@ -120,17 +122,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/master'
+    # Not setting a job-level timeout because it would be kind of pointless with the blocking step. Set a step timeout for all other steps instead.
     steps:
       - uses: actions/checkout@v2
         with:
           path: monorepo
+        timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
 
       - name: Download build artifact
         uses: actions/download-artifact@v2
         with:
           name: jetpack-build
+        timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
       - name: Extract build archive
         run: tar --xz -xvvf build.tar.xz
+        timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
 
       - name: Wait for prior instances of the workflow to finish
         uses: softprops/turnstyle@v1
@@ -144,3 +150,4 @@ jobs:
           USER_NAME: matticbot
           BUILD_BASE: ${{ github.workspace }}/build
         run: .github/files/push-all-projects.sh
+        timeout-minutes: 5  # 2021-01-18: Successful runs seem to take about half a minute.

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -18,6 +18,7 @@ jobs:
   coverage:
     name: "Code coverage"
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # 2021-01-18: Successful runs seem to take ~20 minutes
     services:
       database:
         image: mysql:5.6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 7  # 2021-01-18: Successful runs seem to take 3-5 minutes
 
     strategy:
       fail-fast: false

--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -9,6 +9,7 @@ jobs:
   lock:
     name: "composer.lock is up to date"
     runs-on: ubuntu-latest
+    timeout-minutes: 2  # 2021-01-18: Successful runs seem to take ~15 seconds
     steps:
       - uses: actions/checkout@v2
 
@@ -40,6 +41,7 @@ jobs:
   json:
     name: Monorepo package version refs
     runs-on: ubuntu-latest
+    timeout-minutes: 1  # 2021-01-18: Successful runs take just a few seconds
     steps:
       - uses: actions/checkout@v2
       - name: Tool versions

--- a/.github/workflows/dangerci.yml
+++ b/.github/workflows/dangerci.yml
@@ -7,6 +7,7 @@ jobs:
   dangerci:
     name: "Danger CI"
     runs-on: ubuntu-latest
+    timeout-minutes: 4  # 2021-01-18: Successful runs seem to take 1-2 minutes
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,7 @@ jobs:
   e2e-tests:
     name: "E2E tests: with ${{ matrix.gutenberg }} plugin"
     runs-on: ubuntu-latest
+    timeout-minutes: 20  # 2021-01-18: Successful runs seem to take 9-12 minutes
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -11,6 +11,7 @@ jobs:
     name: "Label PRs"
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
     steps:
       - uses: actions/labeler@v3
         with:
@@ -19,6 +20,7 @@ jobs:
   #   name: "Review check"
   #   runs-on: ubuntu-latest
   #   if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == '[Status] Needs Review'
+  #   timeout-minutes: 1  # 2021-01-18: Successful runs probably take a few seconds
   #   steps:
   #     - name: Comment
   #       uses: actions/github-script@0.8.0
@@ -35,6 +37,7 @@ jobs:
     name: "Manage labels and assignees"
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -9,6 +9,7 @@ jobs:
   js-tests:
     name: "test dashboard, extensions and search"
     runs-on: ubuntu-latest
+    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~2 minutes
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -30,6 +31,7 @@ jobs:
   build:
     name: "Build dashboard & extensions"
     runs-on: ubuntu-latest
+    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~3 minutes
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,7 @@ jobs:
   changed_files:
     name: detect changed files
     runs-on: ubuntu-latest
+    timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
     outputs:
       # Whether any PHP files have changed.
       php: ${{ steps.filter.outputs.php == 'true' }}
@@ -139,6 +140,7 @@ jobs:
     needs: changed_files
     if: needs.changed_files.outputs.php || needs.changed_files.outputs.misc_php
     continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: 3  # 2021-01-18: Successful runs seem to take ~1 minute
 
     strategy:
       fail-fast: false
@@ -193,6 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.php || needs.changed_files.outputs.misc_php
+    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
       - uses: actions/checkout@v2
@@ -235,6 +238,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.php || needs.changed_files.outputs.misc_php
+    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
       - uses: actions/checkout@v2
@@ -281,6 +285,7 @@ jobs:
     needs: changed_files
     if: needs.changed_files.outputs.php_excluded_files != '[]'
     continue-on-error: true
+    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
       # We don't need full git history, but phpcs-changed does need everything up to the merge-base.
@@ -333,6 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.js || needs.changed_files.outputs.misc_js
+    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
       - uses: actions/checkout@v2
@@ -362,6 +368,7 @@ jobs:
     needs: changed_files
     if: needs.changed_files.outputs.js_excluded_files != '[]'
     continue-on-error: true
+    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
       # We don't need full git history, but eslint-changed does need everything up to the merge-base.
@@ -394,6 +401,7 @@ jobs:
   copied_files:
     name: Copied files are in sync
     runs-on: ubuntu-latest
+    timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds.
 
     steps:
       - uses: actions/checkout@v2
@@ -406,6 +414,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.excludelist
+    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~3 minutes. Hopefully this will only ever decrease.
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -11,6 +11,7 @@ jobs:
   changed_files:
     name: detect changed files
     runs-on: ubuntu-latest
+    timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds.
     outputs:
       php: ${{ steps.filter.outputs.php }}
       misc: ${{ steps.filter.outputs.misc }}
@@ -38,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc == 'true'
+    timeout-minutes: 5  # 2021-01-18: Successful runs seem to take ~1 minute.
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,6 +21,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: 15  # 2021-01-18: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 master run, ~5.5-6 for 7.x and 8.0.
     env:
       WP_BRANCH: ${{ matrix.wp }}
       PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/required-review.yml
+++ b/.github/workflows/required-review.yml
@@ -5,6 +5,7 @@ jobs:
     name: Checking required reviews
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    timeout-minutes: 1  # 2021-01-18: Successful runs seem to take ~15 seconds.
     steps:
       - name: Check for required review approval
         uses: automattic/action-required-review@master


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
I started by looking at the last few successful runs of each job to get
an idea of how long they tend to take, then added some extra based on
gut feeling so most of the numbers wound up rather arbitrary.

Feel free to change them if something seems off. Hopefully this doesn't wind up being a major source of test flakiness in the future.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Team meeting 2021-01-18. 1138708815542418-as-1199606265177798

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do tests run, and seem to have enough headroom on the timeouts?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.