### PR TITLE
Assets: Fixing the URL for Jetpack Docker environment.

### DIFF
--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -117,7 +117,7 @@ class Assets {
 		if ( ! empty( $file_parts['host'] ) ) {
 			$url = $path;
 		} else {
-			$plugin_path = empty( $package_path ) ? Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) : $package_path;
+			$plugin_path = ( empty( $package_path ) || self::is_forcing_jetpack_path( $package_path ) ) ? Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) : $package_path;
 
 			$url = plugins_url( $path, $plugin_path );
 		}
@@ -221,5 +221,16 @@ class Assets {
 		$static_counter = abs( crc32( basename( $url ) ) % 3 );
 
 		return preg_replace( '|://[^/]+?/|', "://s$static_counter.wp.com/", $url );
+	}
+
+	/**
+	 * Returns `true` if this package is loaded from inside the Jetpack Docker environment.
+	 *
+	 * @param string $package_path Path to the file requesting the asset.
+	 *
+	 * @return bool
+	 */
+	public static function is_forcing_jetpack_path( $package_path ) {
+		return 'on' === strtolower( getenv( 'WP_JETPACK_DOCKER' ) ) && 0 === strpos( $package_path, '/usr/local/src/jetpack-monorepo' );
 	}
 }

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -104,7 +104,7 @@ class JITM {
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		wp_register_style(
 			'jetpack-jitm-css',
-			plugins_url( "assets/jetpack-admin-jitm{$min}.css", __DIR__ ),
+			Assets::get_file_url_for_environment( 'vendor/automattic/jetpack-jitm/assets/jetpack-admin-jitm.min.css', 'vendor/automattic/jetpack-jitm/assets/jetpack-admin-jitm.css', __FILE__ ),
 			false,
 			self::PACKAGE_VERSION .
 			'-201243242'
@@ -115,7 +115,7 @@ class JITM {
 
 		wp_enqueue_script(
 			'jetpack-jitm-new',
-			Assets::get_file_url_for_environment( '_inc/build/jetpack-jitm.min.js', '_inc/jetpack-jitm.js' ),
+			Assets::get_file_url_for_environment( '_inc/build/jetpack-jitm.min.js', '_inc/jetpack-jitm.js', __FILE__ ),
 			array( 'jquery' ),
 			self::PACKAGE_VERSION,
 			true

--- a/tools/docker/default.env
+++ b/tools/docker/default.env
@@ -20,6 +20,7 @@ WP_ADMIN_EMAIL=wordpress@example.com
 # If this site is or will be publicly accessible, change WP_ADMIN_PASSWORD to something unique and secure
 WP_ADMIN_PASSWORD=wordpress
 WP_TITLE=HelloWord
+WP_JETPACK_DOCKER=on
 
 # Database - No changes necessary
 MYSQL_HOST=db:3306


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- New environment variable `WP_JETPACK_DOCKER`.
- Adjusting the `Assets` package to fix asset URL's for Jetpack Docker environment.
- JITM styles are loaded via the `Assets` package.

#### Jetpack product discussion
tbd

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Load the Jetpack Dashboard. 
2. Open the page source code, find the `<link>` tag for the CSS file: `jetpack-admin-jitm.min.css`
3. Confirm that the file is loaded via the incorrect URL that contains `/usr/local/src/jetpack-monorepo/projects/packages/jitm`.
4. Rebuild the container to add the environment variable `WP_JETPACK_DOCKER`:
```bash
yarn docker:up
```
5. Reload the Jetpack Dashboard. Find the same CSS file `jetpack-admin-jitm.min.css` and confirm that it loads successfully.

#### Proposed changelog entry for your changes:
n/a