### PR TITLE
Add additional selectors to allow slideshow to work with Gallery block refactor

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1629,6 +1629,26 @@ jQuery( document ).ready( function ( $ ) {
 			if ( ! $( this ).jp_carousel( 'testForData', e.currentTarget ) ) {
 				return;
 			}
+			// Check if the image is linked so we can disable carousel for custom linked images
+			var parentHref = $( e.target ).parent().attr( 'href' );
+			if ( parentHref ) {
+				var valid = false;
+				if (
+					parentHref.split( '?' )[ 0 ] === $( e.target ).attr( 'data-orig-file' ).split( '?' )[ 0 ]
+				) {
+					valid = true;
+				}
+
+				// if link points to 'Attachment Page' allow it
+				if ( parentHref === $( e.target ).attr( 'data-permalink' ) ) {
+					valid = true;
+				}
+
+				// links to 'Custom URL' or 'Media File' when flag not set are not valid
+				if ( ! valid ) {
+					return;
+				}
+			}
 
 			// Do not open the modal if we are looking at a gallery caption from before WP5, which may contain a link.
 			if ( $( e.target ).parent().hasClass( 'gallery-caption' ) ) {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -563,7 +563,7 @@ jQuery( document ).ready( function ( $ ) {
 
 	var methods = {
 		testForData: function ( gallery ) {
-			gallery = $( gallery ); // make sure we have it as a jQuery object.
+			gallery = $( gallery );
 			return ! ( ! gallery.length || ! gallery.data( 'carousel-extra' ) );
 		},
 
@@ -1624,7 +1624,7 @@ jQuery( document ).ready( function ( $ ) {
 	// register the event listener for starting the gallery
 	$( document.body ).on(
 		'click.jp-carousel',
-		'div.gallery, div.tiled-gallery, ul.wp-block-gallery, ul.blocks-gallery-grid, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery',
+		'div.gallery, div.tiled-gallery, ul.wp-block-gallery, ul.blocks-gallery-grid, figure.blocks-gallery-grid, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery',
 		function ( e ) {
 			if ( ! $( this ).jp_carousel( 'testForData', e.currentTarget ) ) {
 				return;
@@ -1651,10 +1651,12 @@ jQuery( document ).ready( function ( $ ) {
 			e.stopPropagation();
 			$( this ).jp_carousel( 'open', {
 				start_index: $( this )
-					.find( '.gallery-item, .tiled-gallery-item, .blocks-gallery-item, .tiled-gallery__item' )
+					.find(
+						'.gallery-item, .tiled-gallery-item, .blocks-gallery-item, .tiled-gallery__item, .wp-block-image'
+					)
 					.index(
 						$( e.target ).parents(
-							'.gallery-item, .tiled-gallery-item, .blocks-gallery-item, .tiled-gallery__item'
+							'.gallery-item, .tiled-gallery-item, .blocks-gallery-item, .tiled-gallery__item, .wp-block-image'
 						)
 					),
 			} );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -543,9 +543,10 @@ class Jetpack_Carousel {
 			 */
 			$extra_data = apply_filters( 'jp_carousel_add_data_to_container', $extra_data );
 			foreach ( (array) $extra_data as $data_key => $data_values ) {
-				$html = str_replace( '<div ', '<div ' . esc_attr( $data_key ) . "='" . json_encode( $data_values ) . "' ", $html );
-				$html = str_replace( '<ul class="wp-block-gallery', '<ul ' . esc_attr( $data_key ) . "='" . json_encode( $data_values ) . "' class=\"wp-block-gallery", $html );
-				$html = str_replace( '<ul class="blocks-gallery-grid', '<ul ' . esc_attr( $data_key ) . "='" . json_encode( $data_values ) . "' class=\"blocks-gallery-grid", $html );
+				$html = str_replace( '<div ', '<div ' . esc_attr( $data_key ) . "='" . wp_json_encode( $data_values ) . "' ", $html );
+				$html = str_replace( '<ul class="wp-block-gallery', '<ul ' . esc_attr( $data_key ) . "='" . wp_json_encode( $data_values ) . "' class=\"wp-block-gallery", $html );
+				$html = str_replace( '<ul class="blocks-gallery-grid', '<ul ' . esc_attr( $data_key ) . "='" . wp_json_encode( $data_values ) . "' class=\"blocks-gallery-grid", $html );
+				$html = str_replace( '<figure class="wp-block-gallery blocks-gallery-grid', '<figure ' . esc_attr( $data_key ) . "='" . wp_json_encode( $data_values ) . "' class=\"wp-block-gallery  blocks-gallery-grid", $html );
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* The refactor of the Gallery block changes the block structure so this PR adds additional selectors so the block will be compatible with the slideshow block if and when it lands

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

- Check the [Gallery refactor PR](https://github.com/WordPress/gutenberg/pull/25940) to a local Jetpack dev env
- Switch on the option to `Display images in a full-screen carousel gallery` in Jetpack Settings -> Writing
- Add a gallery with images and view in front end and notice that clicking on an image does not open the carousel
- Check out this PR and reload the gallery front end and the carousel should now launch and the first image shown should be the one that was clicked on
- Also check that Images that have a custom link added link through to the custom link instead of opening the carousel
- Change the Gutenberg pluging version back to master and install another gallery and make sure carousel links still work with the old gallery format

before:

![cbefore](https://user-images.githubusercontent.com/3629020/104975716-512a0280-5a60-11eb-8495-51a75e9f0aca.gif)

after:

![cafter](https://user-images.githubusercontent.com/3629020/104975726-55eeb680-5a60-11eb-91d4-eefa05b83b0c.gif)

#### Proposed changelog entry for your changes:
* Additional css selectors ahead of change to the Gutenberg core Gallery block.

