### PR TITLE
Dialogue: replace wp_kses with wp_kses_post

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/dialogue.php
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/dialogue.php
@@ -48,16 +48,7 @@ function filter_content( $content ) {
 		return '';
 	}
 
-	return wp_kses_post(
-		$content,
-		array(
-			'small'  => true,
-			'strong' => true,
-			'b'      => true,
-			'em'     => true,
-			'br'     => true,
-		)
-	);
+	return wp_kses_post( $content );
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/dialogue.php
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/dialogue.php
@@ -48,7 +48,7 @@ function filter_content( $content ) {
 		return '';
 	}
 
-	return wp_kses(
+	return wp_kses_post(
 		$content,
 		array(
 			'small'  => true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

replace `wp_kses` with `wp_kses_post`.

Fixes #18298

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: replace wp_kses with wp_kses_post.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the dialogue content is parsed properly by the server-side, confirming that the block content looks good ni the front-end.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
n/a
