### PR TITLE
Docker: Add a mu-plugin to fix monorepo package URLs

### DIFF
--- a/tools/docker/mu-plugins/.gitignore
+++ b/tools/docker/mu-plugins/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !debug.php
 !avoid-plugin-deletion.php
+!fix-monorepo-plugin_url.php
 !jetpack-debug-helper-loader.php
 !/jetpack-debug-helper
 

--- a/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
+++ b/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Plugin Name: Fix monorepo plugins_url
+ * Description: In the Jetpack Docker dev environment, plugins_url fails for packages becuase the symlinks from vendor cause it to be unable to find the "plugin" that the URL is supposed to be relative to.
+ * Version: 1.0
+ * Author: Automattic
+ * Author URI: https://automattic.com/
+ * Text Domain: jetpack
+ *
+ * @package Jetpack.
+ */
+
+namespace Jetpack\Docker\MuPlugin\FixMonorepoPluginsUrl;
+
+use Automattic\Jetpack\Constants as Jetpack_Constants;
+
+/**
+ * Fix the plugins_url in the Docker dev environment.
+ *
+ * @param string $url    The complete URL to the plugins directory including scheme and path.
+ * @param string $path   Path relative to the URL to the plugins directory. Blank string
+ *                       if no path is specified.
+ * @param string $plugin The plugin file path to be relative to. Blank string if no plugin
+ *                       is specified.
+ * @return string Filtered URL
+ */
+function jetpack_docker_plugins_url( $url, $path, $plugin ) {
+	global $wp_plugin_paths;
+	static $monorepo, $packages;
+
+	if ( ! isset( $monorepo ) ) {
+		// Determine the path to the monorepo based on the path to Jetpack.
+		$monorepo = dirname( dirname( dirname( Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_DIR' ) ) ) ) . '/';
+		$packages = $monorepo . 'projects/packages/';
+	}
+
+	if ( strpos( $url, $packages ) !== false && strpos( $plugin, $packages ) === 0 ) {
+		// Look through available monorepo plugins until we find one with the plugin symlink.
+		$suffix      = '/vendor/automattic/jetpack-' . substr( $plugin, strlen( $packages ) );
+		$real_plugin = realpath( $plugin );
+		if ( false !== $real_plugin ) {
+			foreach ( $wp_plugin_paths as $dir ) {
+				if ( realpath( $dir . $suffix ) === $real_plugin ) {
+					return plugins_url( $path, $dir . $suffix );
+				}
+			}
+		}
+	}
+
+	return $url;
+}
+add_filter( 'plugins_url', __NAMESPACE__ . '\jetpack_docker_plugins_url', 1, 3 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Since our Docker environment will probably have the monorepo packages
symlinked, WordPress's `plugins_url()` can't find the plugin their paths
belong to and so winds up including the full path in the URL.

This adds a mu-plugin that filters `plugins_url()` for this case,
adjusting the passed `$plugin` to go through the symlink in Jetpack's
vendor directory.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-2ms-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using the Docker dev environment, open the Jetpack Dashboard, look for the `<link rel='stylesheet' id='jetpack-jitm-css-css'`, and make sure it points to a correct URL.
* Try the same in other environments, e.g. Jurassic Ninja.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.