### PR TITLE
CI: Tell shivammathur/setup-php to install phpdbg for the code coverage job

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -39,7 +39,7 @@ jobs:
           php-version: "7.3"
           tools: composer
           coverage: none
-          extensions: mysql, imagick
+          extensions: mysql, imagick, phpdbg
       - uses: actions/setup-node@v2
         with:
           node-version: '12'
@@ -54,6 +54,17 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
+
+      - name: Tool versions
+        run: |
+          which php
+          php --version
+          which phpdbg
+          phpdbg --version
+          which composer
+          composer --version
+          which yarn
+          yarn --version
 
       # As suggested here https://github.com/codeclimate/test-reporter/issues/406#issuecomment-578483422
       - name: Set ENV for CodeClimate (pull_request)

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -39,7 +39,7 @@ jobs:
           php-version: "7.3"
           tools: composer
           coverage: none
-          extensions: mysql, imagick, phpdbg
+          extensions: mysql, imagick
       - uses: actions/setup-node@v2
         with:
           node-version: '12'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The code coverage job uses phpdbg, which is not installed by default by
shivammathur/setup-php@v2. So it winds up using a PHP 8.0 version of
phpdbg, which produces tokens that break the old version of PHP's code
coverage scanner.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See if code coverage on #18432 passes now.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
