### PR TITLE
Conversation: Fix Block Doesn't Load When Running WordPress 5.5

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -7,7 +7,6 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	BlockControls,
-	useBlockProps,
 } from '@wordpress/block-editor';
 import { Panel, PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
 
@@ -29,9 +28,6 @@ const TRANSCRIPTION_TEMPLATE = [
 
 function ConversationEdit( { className, attributes, setAttributes } ) {
 	const { participants = [], showTimestamps, className: classNameAttr } = attributes;
-	const containerRef = useRef();
-
-	const blockProps = useBlockProps( { ref: containerRef, className } );
 
 	// Set initial conversation participants.
 	useEffect( () => {
@@ -105,7 +101,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 
 	return (
 		<TranscriptionContext.Provider value={ contextProvision }>
-			<div { ...blockProps }>
+			<div className={ className }>
 				<BlockControls>
 					<ToolbarGroup>
 						<ParticipantsDropdown

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef, useCallback } from '@wordpress/element';
+import { useEffect, useCallback } from '@wordpress/element';
 import {
 	InnerBlocks,
 	InspectorControls,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18431

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove useBlockProps to fix WordPress 5.5 compatibility issue

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/18247#issuecomment-759651672

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect a site to Jetpack and enable beta blocks.
* Use the Jetpack Live Branches WP Downgrade option or the [WP Downgrade plugin](https://wordpress.org/plugins/wp-downgrade/) or `yarn docker:wp core update —version=5.5 —force` to downgrade to WordPress 5.5
* Add a Conversation block to a post.
* Inspect the block div and check that it has this class: `wp-block-jetpack-conversation`
* Check that the block is functional and has the same class in WordPress 5.6

For reference, this is what the div looked like before:
<img width="333" alt="Screen Shot 2021-01-19 at 2 45 23 PM" src="https://user-images.githubusercontent.com/1689238/105086943-be8d6180-5a67-11eb-9546-354b53ba8b25.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* No changelog entry needed; this is an update to a beta block.
