### PR TITLE
Conversation/Dialogue: handling participants enhancements 

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
@@ -1,13 +1,4 @@
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
 export default {
-	participant: {
-		type: 'string',
-		default: __( 'Participant', 'jetpack' ),
-	},
 	participantSlug: {
 		type: 'string',
 	},
@@ -15,24 +6,10 @@ export default {
 		type: 'string',
 		default: '00:00',
 	},
-	showTimestamp: {
-		type: 'boolean',
-		default: false,
-	},
 	placeholder: {
 		type: 'string',
 	},
 	content: {
 		type: 'string',
-	},
-	hasBoldStyle: {
-		type: 'boolean',
-		default: true,
-	},
-	hasItalicStyle: {
-		type: 'boolean',
-	},
-	hasUppercaseStyle: {
-		type: 'boolean',
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -5,7 +5,6 @@ import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
-	TextControl,
 	SelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -28,31 +27,6 @@ function ParticipantsMenu( { participants, className, onSelect, participantSlug 
 	);
 }
 
-export function ParticipantControl( { className, participantValue, onChange } ) {
-	return (
-		<div className={ `${ className }__custom-participant` }>
-			<div className={ `${ className }__text-button-container` }>
-				<TextControl
-					label={ __( 'Custom', 'jetpack' ) }
-					value={ participantValue }
-					onChange={ participant =>
-						onChange( {
-							participantSlug: null,
-							participant,
-						} )
-					}
-					onFocus={ ( { target } ) =>
-						onChange( {
-							participantSlug: null,
-							participant: target?.value,
-						} )
-					}
-				/>
-			</div>
-		</div>
-	);
-}
-
 export function ParticipantsControl( { participants, participantSlug: slug, onSelect } ) {
 	return (
 		<SelectControl
@@ -70,9 +44,7 @@ export function ParticipantsControl( { participants, participantSlug: slug, onSe
 function ParticipantsSelector( {
 	className,
 	participants,
-	participant,
 	onSelect,
-	onChange,
 	participantSlug,
 } ) {
 	return (
@@ -82,12 +54,6 @@ function ParticipantsSelector( {
 				participants={ participants }
 				onSelect={ onSelect }
 				participantSlug={ participantSlug }
-			/>
-
-			<ParticipantControl
-				className={ className }
-				participantValue={ participant }
-				onChange={ onChange }
 			/>
 		</Fragment>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -94,7 +94,7 @@ function ParticipantsSelector( {
 }
 
 export default function ParticipantsDropdown( props ) {
-	const { label, position = 'bottom left', labelClassName, icon = null } = props;
+	const { label, position = 'bottom', labelClassName, icon = null } = props;
 
 	return (
 		<DropdownMenu

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -8,15 +8,17 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 
-function ParticipantsMenu( { participants, className, onSelect, participantSlug } ) {
+function ParticipantsMenu( { participants, className, onSelect, participantSlug, onClose } ) {
 	return (
 		<MenuGroup className={ `${ className }__participants-selector` }>
 			{ participants.map( ( { participant, participantSlug: slug } ) => (
 				<MenuItem
 					key={ slug }
-					onClick={ () => onSelect( { participantSlug: slug } ) }
+					onClick={ () => {
+						onSelect( { participantSlug: slug } );
+						onClose();
+					} }
 					isSelected={ participantSlug === slug }
 					icon={ participantSlug === slug ? 'yes' : null }
 				>
@@ -41,24 +43,6 @@ export function ParticipantsControl( { participants, participantSlug: slug, onSe
 	);
 }
 
-function ParticipantsSelector( {
-	className,
-	participants,
-	onSelect,
-	participantSlug,
-} ) {
-	return (
-		<Fragment>
-			<ParticipantsMenu
-				className={ className }
-				participants={ participants }
-				onSelect={ onSelect }
-				participantSlug={ participantSlug }
-			/>
-		</Fragment>
-	);
-}
-
 export default function ParticipantsDropdown( props ) {
 	const { label, position = 'bottom', labelClassName, icon = null } = props;
 
@@ -73,7 +57,7 @@ export default function ParticipantsDropdown( props ) {
 			} }
 			icon={ icon }
 		>
-			{ () => <ParticipantsSelector { ...props } /> }
+			{ ( { onClose } ) => <ParticipantsMenu { ...props } onClose={ onClose } /> }
 		</DropdownMenu>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -11,11 +11,16 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 
-function ParticipantsMenu( { participants, className, onSelect } ) {
+function ParticipantsMenu( { participants, className, onSelect, participantSlug } ) {
 	return (
 		<MenuGroup className={ `${ className }__participants-selector` }>
-			{ participants.map( ( { participant, participantSlug } ) => (
-				<MenuItem key={ participantSlug } onClick={ () => onSelect( { participantSlug } ) }>
+			{ participants.map( ( { participant, participantSlug: slug } ) => (
+				<MenuItem
+					key={ slug }
+					onClick={ () => onSelect( { participantSlug: slug } ) }
+					isSelected={ participantSlug === slug }
+					icon={ participantSlug === slug ? 'yes' : null }
+				>
 					{ participant }
 				</MenuItem>
 			) ) }
@@ -62,13 +67,21 @@ export function ParticipantsControl( { participants, participantSlug: slug, onSe
 	);
 }
 
-function ParticipantsSelector( { className, participants, participant, onSelect, onChange } ) {
+function ParticipantsSelector( {
+	className,
+	participants,
+	participant,
+	onSelect,
+	onChange,
+	participantSlug,
+} ) {
 	return (
 		<Fragment>
 			<ParticipantsMenu
 				className={ className }
 				participants={ participants }
 				onSelect={ onSelect }
+				participantSlug={ participantSlug }
 			/>
 
 			<ParticipantControl
@@ -81,7 +94,7 @@ function ParticipantsSelector( { className, participants, participant, onSelect,
 }
 
 export default function ParticipantsDropdown( props ) {
-	const { participantLabel, position = 'bottom left', labelClassName, icon = null } = props;
+	const { label, position = 'bottom left', labelClassName, icon = null } = props;
 
 	return (
 		<DropdownMenu
@@ -90,7 +103,7 @@ export default function ParticipantsDropdown( props ) {
 			} }
 			toggleProps={ {
 				className: labelClassName,
-				children: <span>{ participantLabel }</span>,
+				children: <span>{ label }</span>,
 			} }
 			icon={ icon }
 		>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -28,14 +28,10 @@ import { useSelect, dispatch } from '@wordpress/data';
 import './editor.scss';
 import ParticipantsDropdown, {
 	ParticipantsControl,
-	ParticipantControl,
 } from './components/participants-control';
 import TimestampControl, { TimestampDropdown } from './components/timestamp-control';
 import ConversationContext from '../conversation/components/context';
-import {
-	slug as defaultParticipantSlug,
-	list as defaultParticipants,
-} from '../conversation/participants.json';
+import { list as defaultParticipants } from '../conversation/participants.json';
 import { formatUppercase } from '../../shared/icons';
 
 function getParticipantBySlug( participants, slug ) {
@@ -66,10 +62,8 @@ export default function DialogueEdit( {
 	isSelected,
 } ) {
 	const {
-		participant,
 		participantSlug,
 		timestamp,
-		showTimestamp: showTimestampLocally,
 		content,
 		placeholder,
 	} = attributes;
@@ -92,10 +86,9 @@ export default function DialogueEdit( {
 		? participantsFromContext
 		: defaultParticipants;
 
-	const isCustomParticipant = !! participant && ! participantSlug;
-	const currentParticipantSlug = isCustomParticipant ? defaultParticipantSlug : participantSlug;
+	const currentParticipantSlug = participantSlug;
 	const currentParticipant = getParticipantBySlug( participants, currentParticipantSlug );
-	const participantLabel = isCustomParticipant ? participant : currentParticipant?.participant;
+	const participantLabel = currentParticipant?.participant;
 
 	// Conversation context. A bridge between dialogue and conversation blocks.
 	const conversationBridge = useContext( ConversationContext );
@@ -142,56 +135,20 @@ export default function DialogueEdit( {
 		richTextRefCurrent.focus();
 	}, [ isSelected, hasContent, richTextRefCurrent ] );
 
-	const showTimestamp = isCustomParticipant ? showTimestampLocally : showTimestampGlobally;
+	const showTimestamp = showTimestampGlobally;
 
-	/**
-	 * Helper to check if the gven style is set, or not.
-	 * It handles local and global (conversation) level.
-	 *
-	 * @param {string} style - style to check.
-	 * @returns {boolean} True if the style is defined. Otherwise, False.
-	 */
 	function hasStyle( style ) {
-		if ( isCustomParticipant || ! participantsFromContext ) {
-			return attributes?.[ style ];
-		}
-
 		return currentParticipant?.[ style ];
 	}
 
-	/**
-	 * Helper to toggle the value of the given style
-	 * It handles local and global (conversation) level.
-	 *
-	 * @param {string} style - style to toggle.
-	 * @returns {void}
-	 */
 	function toggleParticipantStyle( style ) {
-		if ( isCustomParticipant || ! participantsFromContext ) {
-			return setAttributes( { [ style ]: ! attributes[ style ] } );
-		}
-
 		conversationBridge.updateParticipants( {
 			participantSlug: currentParticipantSlug,
 			[ style ]: ! currentParticipant[ style ],
 		} );
 	}
 
-	/**
-	 * Helper to build the CSS classes for the participant label.
-	 * It handles local and global (conversation) level.
-	 *
-	 * @returns {string} Participant CSS class.
-	 */
 	function getParticipantLabelClass() {
-		if ( isCustomParticipant || ! participantsFromContext ) {
-			return classnames( `${ baseClassName }__participant`, {
-				[ 'has-bold-style' ]: attributes?.hasBoldStyle,
-				[ 'has-italic-style' ]: attributes?.hasItalicStyle,
-				[ 'has-uppercase-style' ]: attributes?.hasUppercaseStyle,
-			} );
-		}
-
 		return classnames( `${ baseClassName }__participant`, {
 			[ 'has-bold-style' ]: currentParticipant?.hasBoldStyle,
 			[ 'has-italic-style' ]: currentParticipant?.hasItalicStyle,
@@ -200,10 +157,6 @@ export default function DialogueEdit( {
 	}
 
 	function setShowTimestamp( value ) {
-		if ( isCustomParticipant || ! participantsFromContext ) {
-			return setAttributes( { showTimestamp: value } );
-		}
-
 		conversationBridge.setAttributes( { showTimestamps: value } );
 	}
 
@@ -239,7 +192,6 @@ export default function DialogueEdit( {
 						participants={ participants }
 						label={ __( 'Participant', 'jetpack' ) }
 						participantSlug={ participantSlug }
-						participant={ participant }
 						onSelect={ setAttributes }
 						onChange={ setAttributes }
 					/>
@@ -255,20 +207,11 @@ export default function DialogueEdit( {
 							participantSlug={ participantSlug || '' }
 							onSelect={ setAttributes }
 						/>
-						<ParticipantControl
-							className={ className }
-							participantValue={ participant }
-							onChange={ setAttributes }
-						/>
 					</PanelBody>
 
 					<PanelBody title={ __( 'Timestamp', 'jetpack' ) }>
 						<ToggleControl
-							label={
-								isCustomParticipant
-									? __( 'Show', 'jetpack' )
-									: __( 'Show conversation timestamps', 'jetpack' )
-							}
+							label={ __( 'Show conversation timestamps', 'jetpack' ) }
 							checked={ showTimestamp }
 							onChange={ setShowTimestamp }
 						/>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -230,6 +230,19 @@ export default function DialogueEdit( {
 						/>
 					</ToolbarGroup>
 				) }
+
+				<ToolbarGroup>
+					<ParticipantsDropdown
+						id={ `dialogue-${ instanceId }-participants-dropdown` }
+						className={ baseClassName }
+						participants={ participants }
+						label={ __( 'Participant', 'jetpack' ) }
+						participantSlug={ participantSlug }
+						participant={ participant }
+						onSelect={ setAttributes }
+						onChange={ setAttributes }
+					/>
+				</ToolbarGroup>
 			</BlockControls>
 
 			<InspectorControls>
@@ -277,7 +290,7 @@ export default function DialogueEdit( {
 						className={ baseClassName }
 						labelClassName={ getParticipantLabelClass() }
 						participants={ participants }
-						participantLabel={ participantLabel }
+						label={ participantLabel }
 						participantSlug={ participantSlug }
 						participant={ participant }
 						onSelect={ setAttributes }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -163,6 +163,17 @@ export default function DialogueEdit( {
 	return (
 		<div className={ className }>
 			<BlockControls>
+				<ToolbarGroup>
+					<ParticipantsDropdown
+						id={ `dialogue-${ instanceId }-participants-dropdown` }
+						className={ baseClassName }
+						participants={ participants }
+						label={ __( 'Participant', 'jetpack' ) }
+						participantSlug={ participantSlug }
+						onSelect={ setAttributes }
+					/>
+				</ToolbarGroup>
+
 				{ currentParticipant && isFocusedOnParticipantLabel && (
 					<ToolbarGroup>
 						<ToolbarButton
@@ -184,17 +195,6 @@ export default function DialogueEdit( {
 						/>
 					</ToolbarGroup>
 				) }
-
-				<ToolbarGroup>
-					<ParticipantsDropdown
-						id={ `dialogue-${ instanceId }-participants-dropdown` }
-						className={ baseClassName }
-						participants={ participants }
-						label={ __( 'Participant', 'jetpack' ) }
-						participantSlug={ participantSlug }
-						onSelect={ setAttributes }
-					/>
-				</ToolbarGroup>
 			</BlockControls>
 
 			<InspectorControls>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -193,7 +193,6 @@ export default function DialogueEdit( {
 						label={ __( 'Participant', 'jetpack' ) }
 						participantSlug={ participantSlug }
 						onSelect={ setAttributes }
-						onChange={ setAttributes }
 					/>
 				</ToolbarGroup>
 			</BlockControls>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -17,6 +17,7 @@ import {
 	ToggleControl,
 	ToolbarGroup,
 	ToolbarButton,
+	Button,
 } from '@wordpress/components';
 import { useContext, useState, useEffect, useLayoutEffect, useRef } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
@@ -284,19 +285,12 @@ export default function DialogueEdit( {
 			</InspectorControls>
 
 			<div className={ `${ baseClassName }__meta` }>
-				<div onFocus={ () => setIsFocusedOnParticipantLabel( true ) }>
-					<ParticipantsDropdown
-						id={ `dialogue-${ instanceId }-participants-dropdown` }
-						className={ baseClassName }
-						labelClassName={ getParticipantLabelClass() }
-						participants={ participants }
-						label={ participantLabel }
-						participantSlug={ participantSlug }
-						participant={ participant }
-						onSelect={ setAttributes }
-						onChange={ setAttributes }
-					/>
-				</div>
+				<Button
+					onFocus={ () => setIsFocusedOnParticipantLabel( true ) }
+					className={ getParticipantLabelClass() }
+				>
+					{ participantLabel }
+				</Button>
 
 				{ showTimestamp && (
 					<TimestampDropdown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR introduces some changes in order to enhance the block participants edition.  Most releat changes:

* Remove participants dropdown from the editor canvas
The participants dropdown has been removed from the editor canvas, in the Dialogue context.

* Add participants dropdown in the block toolbar.


* Remove custom participant from `Dialogue` block:
All participants belong to the conversation block, which means are edited globally in that context. From the `Dialogue` context, the user just can pick up from the block toolbar.

**Screenshot**
<img src="https://user-images.githubusercontent.com/77539/105092899-a1b15800-5a80-11eb-92ce-3d5b620d0a8f.png" width="400px" />

Fixes https://github.com/Automattic/jetpack/issues/18283

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation/Dialogue: handling participants enhancements 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a conversation block with some dialogue blocks there
* Confirm the changes introduced by this PR

#### Dialogue - Editor Canvas / Block Toolbar
Before | After
------|------
![image](https://user-images.githubusercontent.com/77539/105093863-2650a600-5a82-11eb-8e3c-c22a0d00d2ea.png) | ![image](https://user-images.githubusercontent.com/77539/105093674-e2f63780-5a81-11eb-8d6e-bcaae321ff14.png)

#### Dialogue - Sidebar
Before | After
------|------
![image](https://user-images.githubusercontent.com/77539/105093888-2ea8e100-5a82-11eb-87e6-3ceefd1accfc.png) | ![image](https://user-images.githubusercontent.com/77539/105093742-f7d2cb00-5a81-11eb-9f48-7048d34cbd2d.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
