### PR TITLE
Admin Menu: Declare admin_page_hooks global

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -76,7 +76,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 */
 	public function get_item( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// All globals need to be declared for menu items to properly register.
-		global $menu, $submenu, $_wp_menu_nopriv, $_wp_submenu_nopriv; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		global $admin_page_hooks, $menu, $submenu, $_wp_menu_nopriv, $_wp_submenu_nopriv; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
 		// Make an attempt to not have the menu order altered.
 		add_filter( 'custom_menu_order', '__return_false', 99999 );


### PR DESCRIPTION
This fixes a bug on dotcom, where submenu items didn't get the correct parent prefix associated with their page hook. That resulted in menu URLs being computed incorrectly, essentially just returning their menu slug.

I _think_ the bug was introduced with https://github.com/Automattic/jetpack/pull/18376, but I can't say for sure. Reverting it locally didn't seem to change anything. I'm also not sure which globals really need declaring ahead of generating the menu, so far we've opted for a more conservative approach where we add globals as needed to fix bugs or maintain parity with wp-admin's output.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Imports `$admin_page_hooks` global before generating the admin menu.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D55665-code on your wpcom sandbox and sandbox public-api
* With nav unification activated, load your test site in Calypso and make sure that Settings > Polls and Settings > Ratings have a wp-admin URL

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
None needed.
