### PR TITLE
WIP: Experiment with block styles to add masonry layout to refactored core gallery

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/gallery-styles/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/gallery-styles/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockStyle } from '@wordpress/blocks';
+import './view.js';
+
+registerBlockStyle( 'core/gallery', {
+	name: 'masonry',
+	label: 'Masonry',
+} );
+
+registerBlockStyle( 'core/gallery', {
+	name: 'tiled',
+	label: 'Tiled',
+} );

--- a/projects/plugins/jetpack/extensions/blocks/gallery-styles/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/gallery-styles/index.js
@@ -8,8 +8,3 @@ registerBlockStyle( 'core/gallery', {
 	name: 'masonry',
 	label: 'Masonry',
 } );
-
-registerBlockStyle( 'core/gallery', {
-	name: 'tiled',
-	label: 'Tiled',
-} );

--- a/projects/plugins/jetpack/extensions/blocks/gallery-styles/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/gallery-styles/view.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './view.scss';

--- a/projects/plugins/jetpack/extensions/blocks/gallery-styles/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/gallery-styles/view.scss
@@ -1,0 +1,76 @@
+.wp-block-gallery.blocks-gallery-grid.has-nested-images.is-style-masonry{
+	display: block;
+	columns: 6 200px;
+	column-gap: 1rem;
+	figure.wp-block-image:not(#individual-image) {
+		display: block;
+		width: 150px;
+    	margin: 0 1rem 1rem 0;
+		width: 100%;
+		text-align: center;
+
+		> div:not(.components-drop-zone) {
+			display: block;
+		}
+	} 
+    @for $i from 1 through 36 { 
+    	figure.wp-block-image:nth-child(#{$i}) {
+    		$h: (random(400) + 100) + px;
+    		height: $h;
+			line-height: $h;
+		}
+	}
+
+	.blocks-gallery-caoption, .components-form-file-upload {
+		column-span: all;
+	}
+}
+
+.wp-block-gallery.blocks-gallery-grid.has-nested-images.is-style-tiled{
+	display: grid;
+	grid-gap: 4px;
+	grid-template-columns: repeat( 6, 1fr );
+	grid-auto-rows: 200px;
+
+	.blocks-gallery-item {
+		width: 100%;
+		margin: 0;
+	}
+
+	figure.wp-block-image:not(#individual-image) {
+		grid-column: auto / span 2;
+		display: block;
+		width: 100%;
+		height: 100%;
+		> div:not(.components-drop-zone) {
+			display: block;
+		}
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 1 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 5 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 7 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 14 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 17 ),
+	.figure.wp-block-image:not(#individual-image):nth-child( 30n + 23 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 25 ) {
+		grid-column: auto / span 4;
+		grid-row: auto / span 2;
+	}
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 8 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 9 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 10 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 11 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 18 ) {
+		grid-row: auto / span 2;
+	}
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 12 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 13 ) {
+		grid-column: auto / span 3;
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/gallery-styles/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/gallery-styles/view.scss
@@ -1,76 +1,29 @@
-.wp-block-gallery.blocks-gallery-grid.has-nested-images.is-style-masonry{
+.wp-block-gallery.blocks-gallery-grid.has-nested-images.is-style-masonry {
 	display: block;
-	columns: 6 200px;
+	columns: 3 200px;
 	column-gap: 1rem;
-	figure.wp-block-image:not(#individual-image) {
-		display: block;
+	figure.wp-block-image:not( #individual-image ) {
+		display: inline-block;
 		width: 150px;
-    	margin: 0 1rem 1rem 0;
-		width: 100%;
-		text-align: center;
-
-		> div:not(.components-drop-zone) {
-			display: block;
-		}
-	} 
-    @for $i from 1 through 36 { 
-    	figure.wp-block-image:nth-child(#{$i}) {
-    		$h: (random(400) + 100) + px;
-    		height: $h;
-			line-height: $h;
-		}
-	}
-
-	.blocks-gallery-caoption, .components-form-file-upload {
-		column-span: all;
-	}
-}
-
-.wp-block-gallery.blocks-gallery-grid.has-nested-images.is-style-tiled{
-	display: grid;
-	grid-gap: 4px;
-	grid-template-columns: repeat( 6, 1fr );
-	grid-auto-rows: 200px;
-
-	.blocks-gallery-item {
-		width: 100%;
-		margin: 0;
-	}
-
-	figure.wp-block-image:not(#individual-image) {
-		grid-column: auto / span 2;
-		display: block;
+		margin: 0 8px 8px 0;
 		width: 100%;
 		height: 100%;
-		> div:not(.components-drop-zone) {
+		text-align: center;
+
+		> div:not( .components-drop-zone ) {
 			display: block;
-		}
-		img {
-			width: 100%;
 			height: 100%;
-			object-fit: cover;
 		}
 	}
 
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 1 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 5 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 7 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 14 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 17 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 23 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 25 ) {
-		grid-column: auto / span 4;
-		grid-row: auto / span 2;
+	.blocks-gallery-caoption,
+	.components-form-file-upload {
+		column-span: all;
 	}
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 8 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 9 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 10 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 11 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 18 ) {
-		grid-row: auto / span 2;
-	}
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 12 ),
-	figure.wp-block-image:not(#individual-image):nth-child( 30n + 13 ) {
-		grid-column: auto / span 3;
+
+	@for $column-count from 1 through 8 {
+		&.columns-#{$column-count} {
+			columns: $column-count 200px;
+		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/gallery-styles/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/gallery-styles/view.scss
@@ -57,7 +57,7 @@
 	figure.wp-block-image:not(#individual-image):nth-child( 30n + 7 ),
 	figure.wp-block-image:not(#individual-image):nth-child( 30n + 14 ),
 	figure.wp-block-image:not(#individual-image):nth-child( 30n + 17 ),
-	.figure.wp-block-image:not(#individual-image):nth-child( 30n + 23 ),
+	figure.wp-block-image:not(#individual-image):nth-child( 30n + 23 ),
 	figure.wp-block-image:not(#individual-image):nth-child( 30n + 25 ) {
 		grid-column: auto / span 4;
 		grid-row: auto / span 2;

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -9,6 +9,7 @@ import './shared/external-media';
 import './extended-blocks/core-embed';
 import './extended-blocks/paid-blocks';
 import './shared/styles/slideshow-fix.scss';
+import './blocks/gallery-styles';
 
 // Register media source store to the centralized data registry.
 import './store/media-source';

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -39,7 +39,8 @@
 		"wordads"
 	],
 	"beta": [
-		"amazon"
+		"amazon",
+		"gallery-styles"
 	],
 	"experimental": [
 		"anchor-fm",


### PR DESCRIPTION
**Edit:** Just going to focus on Masonry for now and put Tiled on the back burner
#### Changes proposed in this Pull Request:

This is currently just a proof of concept PR to start discussion about the feasibility of rationalising the various gallery formats down to a series of style variations on the refactored gallery block. The gallery refactor makes the gallery block a wrapper of the image blocks, so this approach would mean that all galleries inherit all the functionality of the base image block.

CSS is currently rough and hard coded for the sake of getting a PoC together, so don't worry about reviewing at this stage.

#### Things we need to explore

- Are block styles the best approach or would block variations be better
- The ability to add custom settings for the different styles
 
#### Jetpack product discussion
P2 link coming soon

#### Testing instructions:
To test you will need to check out this PR along with the Gallery refactor PR from https://github.com/WordPress/gutenberg/pull/25940 into a local dev environment
Add a gallery and images and you should see 2 style options in right panel, Default & Masonry and each should apply a different layout

![galeria](https://user-images.githubusercontent.com/3629020/105124631-675ac000-5b3f-11eb-9876-2729a80e8f5b.gif)


