### PR TITLE
Fix Subscriptions Block applyFallbackStyles when rendered in a Disabled context

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -56,14 +56,14 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	const buttonBackgroundColorValue = buttonBackgroundColor && buttonBackgroundColor.color;
 	const textColorValue = textColor && textColor.color;
 
-	const buttonNode = node.querySelector( '[contenteditable="true"]' );
+	const buttonNode = node.querySelector( '.wp-block-jetpack-subscriptions__button' );
 
 	return {
 		fallbackButtonBackgroundColor:
 			buttonBackgroundColorValue || ! node
 				? undefined
-				: getComputedStyle( buttonNode ).backgroundColor,
-		fallbackTextColor: textColorValue || ! node ? undefined : getComputedStyle( buttonNode ).color,
+				: buttonNode && getComputedStyle( buttonNode ).backgroundColor,
+		fallbackTextColor: textColorValue || ! node ? undefined : buttonNode && getComputedStyle( buttonNode ).color,
 	};
 } );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

When rendered in a [Disabled](https://developer.wordpress.org/block-editor/components/disabled/) context, the button within the jetpack/subscriptions block will have [contenteditable set to false](https://github.com/WordPress/gutenberg/blob/a834386cace67b05e147c3d39710c58d0e17168d/packages/components/src/disabled/index.js#L65), so the query for the button node in `applyFallbackStyles` will return null. If the block does not have a text or background color value set, then the block will error out, because `getComputedStyles` cannot be called with `null`.

The main situation where this error will appear is if you are rendering a subscriptions block within a block or pattern preview, where the subscriptions block does not have any color settings applied (e.g. as reported in https://github.com/Automattic/wp-calypso/issues/48888). The solution here is to update the selector to use a class instead, and check that the `buttonNode` is truthy before calling `getComputedStyle`.

Fixes #https://github.com/Automattic/wp-calypso/issues/48888

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* In the Subscriptions block, update the selector used to query for the button node in `applyFallbackStyles` to use the class name for the subscribe button, instead of contenteditable.
* Check that `buttonNode` is truthy before calling `getComputedStyle`.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to a wpcom sandbox and go to create a new page
* In the page layout selector (starter page templates) select the Bowen layout under the Blog category
* The subscription form should render correctly

#### Before

![image](https://user-images.githubusercontent.com/14988353/105134672-e271a580-5b42-11eb-960e-aa591f257e16.png)

#### After

![image](https://user-images.githubusercontent.com/14988353/105134537-b48c6100-5b42-11eb-8cd5-cbf71869694a.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fix Subscriptions block error when displayed within a Disabled context, such as a block or pattern preview
