### PR TITLE
anchor.fm: check conversation block availability

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -139,7 +139,7 @@ function podcastConversationSection() {
 				'core/heading',
 				{
 					level: 3,
-					content: 'Transcription',
+					content: __( 'Transcription', 'jetpack' ),
 					placeholder: __( 'Podcast episode transcription', 'jetpack' ),
 				},
 			],

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -90,8 +91,48 @@ function podcastSummarySection( { episodeTrack } ) {
 }
 
 function podcastConversationSection() {
+	const conversationBlockId = 'jetpack/conversation';
+	const isConversationBlockAvailable = select( 'core/blocks' ).getBlockType( conversationBlockId );
+
+	// Check if `jetpack/conversation` block is register.
+	if ( ! isConversationBlockAvailable ) {
+		// When it is not, return a fallback core-blocks composition.
+		return [
+			'core/group',
+			{},
+			[
+				[
+					'core/heading',
+					{
+						level: 3,
+						content: 'Transcription',
+						placeholder: __( 'Podcast episode transcription', 'jetpack' ),
+					},
+				],
+				[
+					'core/paragraph',
+					{
+						placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+					},
+				],
+				[
+					'core/paragraph',
+					{
+						placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+					},
+				],
+				[
+					'core/paragraph',
+					{
+						placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+					},
+				],
+			],
+		];
+	}
+
 	return [
-		'jetpack/conversation',
+		conversationBlockId,
 		{},
 		[
 			[

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -105,7 +105,7 @@ function podcastConversationSection() {
 					'core/heading',
 					{
 						level: 3,
-						content: 'Transcription',
+						content: __( 'Transcription', 'jetpack' ),
 						placeholder: __( 'Podcast episode transcription', 'jetpack' ),
 					},
 				],

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -91,8 +91,8 @@ function podcastSummarySection( { episodeTrack } ) {
 }
 
 function podcastConversationSection() {
-	const conversationBlockId = 'jetpack/conversation';
-	const isConversationBlockAvailable = select( 'core/blocks' ).getBlockType( conversationBlockId );
+	const conversationBlockName = 'jetpack/conversation';
+	const isConversationBlockAvailable = select( 'core/blocks' ).getBlockType( conversationBlockName );
 
 	// Check if `jetpack/conversation` block is register.
 	if ( ! isConversationBlockAvailable ) {
@@ -132,7 +132,7 @@ function podcastConversationSection() {
 	}
 
 	return [
-		conversationBlockId,
+		conversationBlockName,
 		{},
 		[
 			[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

With the changes in this PR, the app will check if the `jetpack/conversation` block is available before building the episode template. In case the block is not available, it will create a fallback composition based on core blocks.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* anchor.fm: check conversation block availability

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try to recreate a scenario where anchor.fm extension is available but conversation block is not. 
* Use a similar link to the following to create a new episode post:
`http://localhost/wp-admin/post-new.php?action=edit&anchor_podcast=22b6608&anchor_episode=e324a06c-3148-43a4-85d8-34c0d8222138&spotify_show_url=https%3A%2F%2Fopen.spotify.com%2Fshow%2F6HTZdaDHjqXKDE4acYffoD%3Fsi%3DEVfDYETjQCu7pasVG5D73Q`
* You should see the basic template rendered, but the _Transcription _ section will be composed of core blocks.

No available | Available
------|--------
<img src="https://user-images.githubusercontent.com/77539/105168625-22ac3600-5af9-11eb-9443-418a0d146d1b.png" width="600px" /> | <img src="https://user-images.githubusercontent.com/77539/105169354-2f7d5980-5afa-11eb-81be-339b17b6ce9b.png" width="600px" />


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
n/a