### PR TITLE
Jetpack Sync: Checksums: Use a better way to fetch and validate fields against table

### DIFF
--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -269,15 +269,18 @@ class Table_Checksum {
 	private function validate_fields_against_table( $fields ) {
 		global $wpdb;
 
+		$valid_fields = array();
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$result = $wpdb->get_row( "SELECT * FROM {$this->table} LIMIT 1", ARRAY_A );
-		if ( ! is_array( $result ) ) {
-			throw new Exception( 'Unexpected $wpdb->query output: not array' );
+		$result = $wpdb->get_results( "SHOW COLUMNS FROM {$this->table}", ARRAY_A );
+
+		foreach ( $result as $result_row ) {
+			$valid_fields[] = $result_row['Field'];
 		}
 
 		// Check if the fields are actually contained in the table.
 		foreach ( $fields as $field_to_check ) {
-			if ( ! array_key_exists( $field_to_check, $result ) ) {
+			if ( ! in_array( $field_to_check, $valid_fields, true ) ) {
 				throw new Exception( "Invalid field name: field '{$field_to_check}' doesn't exist in table {$this->table}" );
 			}
 		}


### PR DESCRIPTION
The previous way where we select a single row from the table and then check the returned fields, doesn't work very well in two cases:

1. When there is no data in the table, which will result in an empty response and the validation will fail
2. When there is too much data in the table and the DB will reply with `The SELECT would examine more than MAX_JOIN_SIZE rows;`

This way we only fetch the columns from the table and it isn't prone to the cases above.

#### Changes proposed in this Pull Request:

* Fetch field/column names by using `SHOW COLUMNS FROM <table>` and validate against it

#### Jetpack product discussion
N/a

#### Does this pull request change what data or activity we track or use?
N/a

#### Testing instructions:

* Apply diff to your WPCOM sandbox and Jetpack site
* Make sure that the checksum process works correctly

#### Proposed changelog entry for your changes:

* Jetpack Sync: Better field name validation when calculating checksums on tables.
