### PR TITLE
Contact Form Block: Add shortcode transform

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/contact-form/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/index.js
@@ -15,6 +15,7 @@ import edit from './edit';
 import defaultAttributes from './attributes';
 import variations from './variations';
 import deprecated from './deprecated';
+import transforms from './transforms';
 import JetpackField from './components/jetpack-field';
 import JetpackFieldTextarea from './components/jetpack-field-textarea';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
@@ -50,28 +51,7 @@ export const settings = {
 	save: InnerBlocks.Content,
 	variations,
 	category: 'grow',
-	transforms: {
-		from: [
-			{
-				type: 'shortcode',
-				tag: 'contact-form',
-				attributes: {
-					subject: {
-						type: 'string',
-						shortcode: ( { named: { subject } } ) => {
-							return subject;
-						},
-					},
-					to: {
-						type: 'string',
-						shortcode: ( { named: { to } } ) => {
-							return to;
-						},
-					},
-				}
-			},
-		]
-	},
+	transforms,
 	deprecated,
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/index.js
@@ -50,6 +50,28 @@ export const settings = {
 	save: InnerBlocks.Content,
 	variations,
 	category: 'grow',
+	transforms: {
+		from: [
+			{
+				type: 'shortcode',
+				tag: 'contact-form',
+				attributes: {
+					subject: {
+						type: 'string',
+						shortcode: ( { named: { subject } } ) => {
+							return subject;
+						},
+					},
+					to: {
+						type: 'string',
+						shortcode: ( { named: { to } } ) => {
+							return to;
+						},
+					},
+				}
+			},
+		]
+	},
 	deprecated,
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
@@ -6,133 +6,135 @@ import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 const getAttributeValue = ( tag, att, content ) => {
-	const dbqts = content.match( new RegExp( `\\[${tag}[^\\]]* ${att}="([^"]*)"`, 'im' ) );
-    if ( dbqts != null && dbqts.length > 0 ) {
-        return dbqts[ 1 ];
-    }
+	const doubleQuotes = content.match( new RegExp( `\\[${ tag }[^\\]]* ${ att }="([^"]*)"`, 'im' ) );
+	if ( doubleQuotes != null && doubleQuotes.length > 0 ) {
+		return doubleQuotes[ 1 ];
+	}
 
-	const sinqts = content.match( new RegExp( `\\[${tag}[^\\]]* ${att}='([^']*)'`, 'im' ) );
-	if ( sinqts != null && sinqts.length > 0 ) {
-		return sinqts[ 1 ];
-    }
+	const singleQuotes = content.match( new RegExp( `\\[${ tag }[^\\]]* ${ att }='([^']*)'`, 'im' ) );
+	if ( singleQuotes != null && singleQuotes.length > 0 ) {
+		return singleQuotes[ 1 ];
+	}
 
-	const noqts = content.match( new RegExp( `\\[${tag}[^\\]]* ${att}=([^\\s]*)\\s`, 'im' ) );
-    if ( noqts != null && noqts.length > 0 ) {
-       return noqts[ 1 ];
-    }
+	const noQuotes = content.match( new RegExp( `\\[${ tag }[^\\]]* ${ att }=([^\\s]*)\\s`, 'im' ) );
+	if ( noQuotes != null && noQuotes.length > 0 ) {
+		return noQuotes[ 1 ];
+	}
 
 	return false;
 };
 
-const getContactFieldBlockName = ( type ) => {
-    const prefix = 'jetpack';
+const getContactFieldBlockName = type => {
+	const prefix = 'jetpack';
 
-    switch ( type ) {
-        case 'text': case 'url':
-            return `${prefix}/field-text`;
-        case 'textarea':
-            return `${prefix}/field-textarea`;
-        case 'radio':
-            return `${prefix}/field-radio`;
-        case 'checkbox':
-            return `${prefix}/field-checkbox`;
-        case 'select':
-            return `${prefix}/field-select`;
-        case 'email':
-            return `${prefix}/field-email`;
-        case 'name':
-            return `${prefix}/field-name`;
-        default:
-            return `${prefix}/field-text`;
-    }
+	const fieldTypes = {
+		text: `${ prefix }/field-text`,
+		url: `${ prefix }/field-text`,
+		textarea: `${ prefix }/field-textarea`,
+		radio: `${ prefix }/field-radio`,
+		checkbox: `${ prefix }/field-checkbox`,
+		select: `${ prefix }/field-select`,
+		email: `${ prefix }/field-email`,
+		name: `${ prefix }/field-name`,
+		default: `${ prefix }/field-text`,
+	};
+	return fieldTypes[ type ] ? fieldTypes[ type ] : fieldTypes.default;
 };
 
-const transformContactFormShortcode = ( shortcode ) => {
-    const blockAttrs = {
-        to: getAttributeValue( 'contact-form', 'to', shortcode ),
-        subject: getAttributeValue( 'contact-form', 'subject', shortcode ),
-        submitButtonText: getAttributeValue( 'contact-form', 'submit_button_text', shortcode )
-    };
+const transformContactFormShortcode = shortcode => {
+	const blockAttrs = {
+		to: getAttributeValue( 'contact-form', 'to', shortcode ),
+		subject: getAttributeValue( 'contact-form', 'subject', shortcode ),
+		submitButtonText: getAttributeValue( 'contact-form', 'submit_button_text', shortcode ),
+	};
 
-    return {
-        blockName: 'jetpack/contact-form',
-        attrs: pickBy( blockAttrs, identity )
-    };
+	return {
+		blockName: 'jetpack/contact-form',
+		attrs: pickBy( blockAttrs, identity ),
+	};
 };
 
-const transformContactFieldShortcode = ( shortcode ) => {
-    const blockAttrs = {
-        label: getAttributeValue( 'contact-field', 'label', shortcode ),
-        placeholder: getAttributeValue( 'contact-field', 'placeholder', shortcode ),
-        required: getAttributeValue( 'contact-field', 'required', shortcode ),
-        options: getAttributeValue( 'contact-field', 'options', shortcode ),
-    };
+const transformContactFieldShortcode = shortcode => {
+	const blockAttrs = {
+		label: getAttributeValue( 'contact-field', 'label', shortcode ),
+		placeholder: getAttributeValue( 'contact-field', 'placeholder', shortcode ),
+		required: getAttributeValue( 'contact-field', 'required', shortcode ),
+		options: getAttributeValue( 'contact-field', 'options', shortcode ),
+	};
 
-    const blockName = getContactFieldBlockName( getAttributeValue( 'contact-field', 'type', shortcode ) );
+	const blockName = getContactFieldBlockName(
+		getAttributeValue( 'contact-field', 'type', shortcode )
+	);
 
-    // Split block option values into an array.
-    if ( blockAttrs.options ) {
-        blockAttrs.options = blockAttrs.options.split( ',' );
-    }
+	// Split block option values into an array.
+	if ( blockAttrs.options ) {
+		blockAttrs.options = blockAttrs.options.split( ',' );
+	}
 
-    return createBlock( blockName, pickBy( blockAttrs, identity ) );
+	return createBlock( blockName, pickBy( blockAttrs, identity ) );
 };
 
 const blockData = {
-    root: {},
-    innerBlocks: []
+	root: {},
+	innerBlocks: [],
 };
 
 export default {
-    from: [
-        {
-            type: 'raw',
-            priority: 1,
-            isMatch: ( node ) => {
-                if (
-                    node.nodeName === 'P' &&
-                    ( /\[contact-form(\s.*?)?\](?:([^\[]+)?)?/g.test( node.textContent ) ||
-                    /\[contact-field(\s.*?)?\](?:([^\[]+)?)?/g.test( node.textContent ) ||
-                    /\[\/contact-form]/g.test( node.textContent ) )
-                ) {
-                    return true;
-                }
+	from: [
+		{
+			type: 'raw',
+			priority: 1,
+			isMatch: node => {
+				if (
+					node.nodeName === 'P' &&
+					( /\[contact-form(\s.*?)?\](?:([^\[]+)?)?/g.test( node.textContent ) ||
+						/\[contact-field(\s.*?)?\](?:([^\[]+)?)?/g.test( node.textContent ) ||
+						/\[\/contact-form]/g.test( node.textContent ) )
+				) {
+					return true;
+				}
 
-                return false;
-            },
-            transform: ( node ) => {
-                const shortCode = node.textContent;
+				return false;
+			},
+			transform: node => {
+				const shortCode = node.textContent.replace( '<br>', '' );
 
-                if ( shortCode.includes( '[contact-form' ) ) {
-                    blockData.root = {};
-                    blockData.innerBlocks = [];
+				if ( shortCode.includes( '[contact-form' ) ) {
+					blockData.root = {};
+					blockData.innerBlocks = [];
 
-                    blockData.root = transformContactFormShortcode( shortCode );
-                }
+					blockData.root = transformContactFormShortcode( shortCode );
+				}
 
-                if ( shortCode.includes( '[contact-field' ) ) {
-                    blockData.innerBlocks.push( transformContactFieldShortcode( shortCode ) );
-                }
+				if ( shortCode.includes( '[contact-field' ) ) {
+					const fields = shortCode.match( /(\[contact-field[\s\S]*?\/])/g );
 
-                if ( shortCode.includes( '[/contact-form]' ) ) {
-                    blockData.innerBlocks.push(
-                        createBlock( 'jetpack/button', {
-                            element: 'button',
-					        text: blockData.root.attrs.submitButtonText || __( 'Contact Us', 'jetpack' ),
-				        } )
-                    );
+					if ( fields.length > 0 ) {
+						fields.forEach( field => {
+							blockData.innerBlocks.push( transformContactFieldShortcode( field ) );
+						} );
+					}
+				}
 
-                    const block = createBlock(
-                        blockData.root.blockName,
-                        blockData.root.attrs,
-                        blockData.innerBlocks
-                    );
+				if ( shortCode.includes( '[/contact-form]' ) ) {
+					blockData.innerBlocks.push(
+						createBlock( 'jetpack/button', {
+							element: 'button',
+							text: blockData.root.attrs.submitButtonText || __( 'Contact Us', 'jetpack' ),
+						} )
+					);
 
-                    return block;
-                }
+					const block = createBlock(
+						blockData.root.blockName,
+						blockData.root.attrs,
+						blockData.innerBlocks
+					);
 
-                return false;
-            }
-        }
-    ]
+					return block;
+				}
+
+				return false;
+			},
+		},
+	],
 };

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
@@ -85,6 +85,7 @@ export default {
 			type: 'raw',
 			priority: 1,
 			isMatch: node => {
+				/* eslint-disable no-useless-escape */
 				if (
 					node.nodeName === 'P' &&
 					( /\[contact-form(\s.*?)?\](?:([^\[]+)?)?/g.test( node.textContent ) ||
@@ -93,6 +94,7 @@ export default {
 				) {
 					return true;
 				}
+				/* eslint-enable no-useless-escape */
 
 				return false;
 			},

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
@@ -7,17 +7,17 @@ import { __ } from '@wordpress/i18n';
 
 const getAttributeValue = ( tag, att, content ) => {
 	const doubleQuotes = content.match( new RegExp( `\\[${ tag }[^\\]]* ${ att }="([^"]*)"`, 'im' ) );
-	if ( doubleQuotes != null && doubleQuotes.length > 0 ) {
+	if ( doubleQuotes && doubleQuotes.length ) {
 		return doubleQuotes[ 1 ];
 	}
 
 	const singleQuotes = content.match( new RegExp( `\\[${ tag }[^\\]]* ${ att }='([^']*)'`, 'im' ) );
-	if ( singleQuotes != null && singleQuotes.length > 0 ) {
+	if ( singleQuotes && singleQuotes.length ) {
 		return singleQuotes[ 1 ];
 	}
 
 	const noQuotes = content.match( new RegExp( `\\[${ tag }[^\\]]* ${ att }=([^\\s]*)\\s`, 'im' ) );
-	if ( noQuotes != null && noQuotes.length > 0 ) {
+	if ( noQuotes && noQuotes.length ) {
 		return noQuotes[ 1 ];
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
@@ -104,6 +104,9 @@ export default {
                 const shortCode = node.textContent;
 
                 if ( shortCode.includes( '[contact-form' ) ) {
+                    blockData.root = {};
+                    blockData.innerBlocks = [];
+
                     blockData.root = transformContactFormShortcode( shortCode );
                 }
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { pickBy, identity } from 'lodash';
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+const getAttributeValue = ( tag, att, content ) => {
+	var re = new RegExp( `\\[${tag}[^\\]]* ${att}="([^"]*)"`, 'im' );
+	var result = content.match( re );
+
+    if ( result != null && result.length > 0 ) {
+        return result[ 1] ;
+    }
+
+	re = new RegExp( `\\[${tag}[^\\]]* ${att}='([^']*)'`, 'im' );
+	result = content.match( re );
+	if ( result != null && result.length > 0 ) {
+		return result[ 1 ];
+    }
+
+	re = new RegExp(`\\[${tag}[^\\]]* ${att}=([^\\s]*)\\s`, 'im');
+	result = content.match( re );
+
+    if ( result != null && result.length > 0 ) {
+       return result[ 1 ];
+    }
+
+	return false;
+};
+
+const getContactFieldBlockName = ( type ) => {
+    const prefix = 'jetpack';
+
+    switch ( type ) {
+        case 'text': case 'url':
+            return `${prefix}/field-text`;
+        case 'textarea':
+            return `${prefix}/field-textarea`;
+        case 'radio':
+            return `${prefix}/field-radio`;
+        case 'checkbox':
+            return `${prefix}/field-checkbox`;
+        case 'select':
+            return `${prefix}/field-select`;
+        case 'email':
+            return `${prefix}/field-email`;
+        case 'name':
+            return `${prefix}/field-name`;
+        default:
+            return `${prefix}/field-text`;
+    }
+};
+
+const transformContactFormShortcode = ( shortcode ) => {
+    const blockAttrs = {
+        to: getAttributeValue( 'contact-form', 'to', shortcode ),
+        subject: getAttributeValue( 'contact-form', 'subject', shortcode ),
+        submitButtonText: getAttributeValue( 'contact-form', 'submit_button_text', shortcode )
+    };
+
+    return {
+        blockName: 'jetpack/contact-form',
+        attrs: pickBy( blockAttrs, identity )
+    };
+};
+
+const transformContactFieldShortcode = ( shortcode ) => {
+    const blockAttrs = {
+        label: getAttributeValue( 'contact-field', 'label', shortcode ),
+        placeholder: getAttributeValue( 'contact-field', 'placeholder', shortcode ),
+        required: getAttributeValue( 'contact-field', 'required', shortcode ),
+        options: getAttributeValue( 'contact-field', 'options', shortcode ),
+    };
+
+    const blockName = getContactFieldBlockName( getAttributeValue( 'contact-field', 'type', shortcode ) );
+
+    return createBlock( blockName, pickBy( blockAttrs, identity ) );
+};
+
+const blockData = {
+    root: {},
+    innerBlocks: []
+};
+
+export default {
+    from: [
+        {
+            type: 'raw',
+            isMatch: ( node ) => {
+                if (
+                    node.nodeName === 'P' &&
+                    ( /\[contact-form(\s.*?)?\](?:([^\[]+)?\[\/contact-form\])?/g.test( node.textContent ) ||
+                    /\[contact-field(\s.*?)?\](?:([^\[]+)?\[\/contact-field\])?/g.test( node.textContent ) ||
+                    /\[\/contact-form]/g.test( node.textContent ) )
+                ) {
+                    return true;
+                }
+
+                return false;
+            },
+            transform: ( node ) => {
+                const shortCode = node.textContent;
+
+                if ( shortCode.includes( '[contact-form' ) ) {
+                    blockData.root = transformContactFormShortcode( shortCode );
+                    return;
+                }
+
+                if ( shortCode.includes( '[contact-field' ) ) {
+                    blockData.innerBlocks.push( transformContactFieldShortcode( shortCode ) );
+                    return;
+                }
+
+                if ( shortCode.includes( '[/contact-form]' ) ) {
+                    blockData.innerBlocks.push(
+                        createBlock( 'jetpack/button', {
+                            element: 'button',
+					        text: blockData.root.attrs.submitButtonText || __( 'Contact Us', 'jetpack' ),
+				        } )
+                    );
+
+                    const block = createBlock(
+                        blockData.root.blockName,
+                        blockData.root.attrs,
+                        blockData.innerBlocks
+                    );
+
+                    return block;
+                }
+
+                return false;
+            },
+            priority: 1
+        }
+    ]
+};

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/transforms.js
@@ -33,6 +33,7 @@ const getContactFieldBlockName = type => {
 		textarea: `${ prefix }/field-textarea`,
 		radio: `${ prefix }/field-radio`,
 		checkbox: `${ prefix }/field-checkbox`,
+		'checkbox-multiple': `${ prefix }/field-checkbox-multiple`,
 		select: `${ prefix }/field-select`,
 		email: `${ prefix }/field-email`,
 		name: `${ prefix }/field-name`,
@@ -109,9 +110,9 @@ export default {
 				}
 
 				if ( shortCode.includes( '[contact-field' ) ) {
-					const fields = shortCode.match( /(\[contact-field[\s\S]*?\/])/g );
+					const fields = shortCode.match( /(\[contact-field[\s\S]*?\/?])/g );
 
-					if ( fields.length > 0 ) {
+					if ( fields && fields.length > 0 ) {
 						fields.forEach( field => {
 							blockData.innerBlocks.push( transformContactFieldShortcode( field ) );
 						} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/18210

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a block transform so that a contact form shortcode added to a classic block will transform into a contact form block. Previously this would transform only into a shortcode block.

| Before      | After |
| ----------- | ----------- |
|  ![2021-01-21 13 52 58](https://user-images.githubusercontent.com/1464705/105417374-603fba80-5bf0-11eb-8c84-9a2d23029760.gif) |  ![2021-01-21 13 35 19](https://user-images.githubusercontent.com/1464705/105417350-55852580-5bf0-11eb-8b1d-4077f240b0ef.gif) |

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Note you will need to make a Gutenberg edit to test this:** I'm working on a core change that will let a raw transform override a shortcode transform when the priority is set higher.

* Edit `gutenberg/packages/block-library/src/shortcode/transforms.js` and completely remove the `from [ ... ]` entry.
* Rebuild gutenberg.
* Check out and build this branch and create a new post
* Copy this shortcode: https://cloudup.com/ceaECtt3X5Z
* Insert a classic block and paste the shortcode
* Click the "Convert to blocks" button
* Confirm that the shortcode is converted accurately into a form block.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* No changelog needed.
