### PR TITLE
Anchor.fm: checks Spotify badge URL

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -57,7 +57,14 @@ function register_extension() {
 }
 
 function is_spotify_url_valid( $url ) {
+	// Check if URL is empty.
 	if ( empty( $url ) ) {
+		return false;
+	}
+
+	// Check if URL belongs to expected hostname.
+	$host = wp_parse_url( $url, PHP_URL_HOST );
+	if ( $host !== 'open.spotify.com' ) {
 		return false;
 	}
 
@@ -102,7 +109,6 @@ function process_anchor_params() {
 	if ( $insert_spotify_badge ) {
 		$data['spotifyShowUrl'] = $spotify_show_url;
 		if ( get_post_meta( $post->ID, 'jetpack_anchor_spotify_show', true ) !== $spotify_show_url ) {
-			$insert_spotify_badge = true;
 			update_post_meta( $post->ID, 'jetpack_anchor_spotify_show', $spotify_show_url );
 		}
 	}
@@ -133,7 +139,7 @@ function process_anchor_params() {
 							array(
 								'episodeTrack'    => $track,
 								'spotifyImageUrl' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
-								'spotifyShowUrl'  => $spotify_show_url,
+								'spotifyShowUrl'  => $insert_spotify_badge ? $spotify_show_url : false,
 							),
 						);
 					}

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -56,6 +56,13 @@ function register_extension() {
 	);
 }
 
+/**
+ * Checks if the given URL is valid to
+ * be used in the Spotigy badge.
+ *
+ * @param {string} $url - URL to check.
+ * @return {boolean} True is the URL is valid. Otherwise, False.
+ */
 function is_spotify_url_valid( $url ) {
 	// Check if URL is empty.
 	if ( empty( $url ) ) {
@@ -64,7 +71,7 @@ function is_spotify_url_valid( $url ) {
 
 	// Check if URL belongs to expected hostname.
 	$host = wp_parse_url( $url, PHP_URL_HOST );
-	if ( $host !== 'open.spotify.com' ) {
+	if ( 'open.spotify.com' !== $host ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -56,6 +56,14 @@ function register_extension() {
 	);
 }
 
+function is_spotify_url_valid( $url ) {
+	if ( empty( $url ) ) {
+		return false;
+	}
+
+	return true;
+}
+
 /**
  * Checks URL params to determine the Anchor integration action to perform.
  */
@@ -90,8 +98,8 @@ function process_anchor_params() {
 	);
 
 	// add / update Spotify Badge URL.
-	$insert_spotify_badge = false;
-	if ( ! empty( $spotify_show_url ) ) {
+	$insert_spotify_badge = is_spotify_url_valid( $spotify_show_url );
+	if ( $insert_spotify_badge ) {
 		$data['spotifyShowUrl'] = $spotify_show_url;
 		if ( get_post_meta( $post->ID, 'jetpack_anchor_spotify_show', true ) !== $spotify_show_url ) {
 			$insert_spotify_badge = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR checks the Spotify URL before inserting the badge in order to prevent an invalid URL.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Anchor.fm: checks Spotify badge URL

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1611176029052500-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Created an episode post from an URL, but changing the host. 
* Confirm that the badge is not inserted when the host doesn't match what's expected.
* Confirm it works as expected with the proper host.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
n/a
