### PR TITLE
SSO: fixing authentication with custom login page URL's.

### DIFF
--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -915,6 +915,11 @@ class Jetpack_SSO {
 	 * @return string            The WordPress.com SSO URL.
 	 */
 	function get_sso_url_or_die( $reauth = false, $args = array() ) {
+		$custom_login_url = $this->get_custom_login_url();
+		if ( $custom_login_url ) {
+			$args['login_url'] = rawurlencode( $custom_login_url );
+		}
+
 		if ( empty( $reauth ) ) {
 			$sso_redirect = $this->build_sso_url( $args );
 		} else {
@@ -1125,6 +1130,30 @@ class Jetpack_SSO {
 	 **/
 	public function get_user_data( $user_id ) {
 		return get_user_meta( $user_id, 'wpcom_user_data', true );
+	}
+
+	/**
+	 * Check if the site has a custom login page URL, and return it.
+	 * If default login page URL is used (`wp-login.php`), `null` will be returned.
+	 *
+	 * @return string|null
+	 */
+	private function get_custom_login_url() {
+		$login_url = wp_login_url();
+
+		if ( 'wp-login.php' === substr( $login_url, 0, -12 ) ) {
+			// No custom URL found.
+			return null;
+		}
+
+		$site_url = trailingslashit( site_url() );
+
+		if ( 0 !== strpos( $login_url, $site_url ) ) {
+			// Something went wrong, we can't properly extract the custom URL.
+			return null;
+		}
+
+		return str_ireplace( $site_url, '', $login_url );
 	}
 }
 

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -915,7 +915,7 @@ class Jetpack_SSO {
 	 * @return string            The WordPress.com SSO URL.
 	 */
 	function get_sso_url_or_die( $reauth = false, $args = array() ) {
-		$custom_login_url = $this->get_custom_login_url();
+		$custom_login_url = Jetpack_SSO_Helpers::get_custom_login_url();
 		if ( $custom_login_url ) {
 			$args['login_url'] = rawurlencode( $custom_login_url );
 		}
@@ -1130,30 +1130,6 @@ class Jetpack_SSO {
 	 **/
 	public function get_user_data( $user_id ) {
 		return get_user_meta( $user_id, 'wpcom_user_data', true );
-	}
-
-	/**
-	 * Check if the site has a custom login page URL, and return it.
-	 * If default login page URL is used (`wp-login.php`), `null` will be returned.
-	 *
-	 * @return string|null
-	 */
-	private function get_custom_login_url() {
-		$login_url = wp_login_url();
-
-		if ( 'wp-login.php' === substr( $login_url, 0, -12 ) ) {
-			// No custom URL found.
-			return null;
-		}
-
-		$site_url = trailingslashit( site_url() );
-
-		if ( 0 !== strpos( $login_url, $site_url ) ) {
-			// Something went wrong, we can't properly extract the custom URL.
-			return null;
-		}
-
-		return str_ireplace( $site_url, '', $login_url );
 	}
 }
 

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-helpers.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-helpers.php
@@ -321,6 +321,31 @@ class Jetpack_SSO_Helpers {
 			array( 'jetpack_json_api_original_query' => $original_request )
 		);
 	}
+
+		/**
+		 * Check if the site has a custom login page URL, and return it.
+		 * If default login page URL is used (`wp-login.php`), `null` will be returned.
+		 *
+		 * @return string|null
+		 */
+		public static function get_custom_login_url() {
+			$login_url = wp_login_url();
+
+			if ( 'wp-login.php' === substr( $login_url, -12 ) ) {
+				// No custom URL found.
+				return null;
+			}
+
+			$site_url = trailingslashit( site_url() );
+
+			if ( 0 !== strpos( $login_url, $site_url ) ) {
+				// Something went wrong, we can't properly extract the custom URL.
+				return null;
+			}
+
+			// Extracting the "path" part of the URL, because we don't need the `site_url` part.
+			return str_ireplace( $site_url, '', $login_url );
+		}
 }
 
 endif;

--- a/projects/plugins/jetpack/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/projects/plugins/jetpack/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -346,6 +346,24 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the `get_custom_login_url()` helper.
+	 */
+	public function test_get_custom_login_url() {
+		$login_url_default = Jetpack_SSO_Helpers::get_custom_login_url();
+
+		$custom_url_expected = 'test-login-url/';
+
+		$custom_url_filter = function ( $login_url ) use ( $custom_url_expected ) {
+			return str_replace( 'wp-login.php', $custom_url_expected, $login_url );
+		};
+		add_filter( 'login_url', $custom_url_filter );
+		$login_url_custom = Jetpack_SSO_Helpers::get_custom_login_url();
+
+		static::assertNull( $login_url_default );
+		static::assertEquals( $custom_url_expected, $login_url_custom );
+	}
+
+	/**
 	 * Return string '1'.
 	 *
 	 * @return string


### PR DESCRIPTION
If the login page URL has been changed from `wp-login.php` to a custom one, WP.com redirects users back to `wp-login.php`, which throws "error 404". Therefore, Jetpack SSO will not work.

This PR and D55722-code fix the issue by sending along the custom login URL (if there's one). Then WP.com will redirect users not to `wp-login.php`, but to that custom path.

Fixes #17782

#### Changes proposed in this Pull Request:
* Detect custom login page URL
* Pass it to WP.com along with other SSO data
* WP.com will use it to redirect the user back to the Jetpack site

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Connect Jetpack, enable SSO (Jetpack -> Settings -> Security -> WordPress.com login -> Allow users to log in...)
2. Install the [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/) plugin, set a custom login page URL (Settings -> WPS Hide Login).
3. Logout from the WP admin area, and try to login using SSO. After being redirected back to the Jetpack site, you should see the 404 page. You should not get logged into the admin area.
4. Switch to your sandbox and checkout the diff D55722-code. Make sure that the domain `wordpress.com` is mapped to the sandbox.
5. Go back to the custom login page URL and try to login using the SSO again. You should be successfully logged in and redirected to your site's `/wp-admin/`.

#### Proposed changelog entry for your changes:
* Jetpack SSO: support of custom login page URL's.