### PR TITLE
Masterbar: Use user_option rather than Connection_Manager

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-
 /**
  * Class Atomic_Admin_Menu.
  */
@@ -51,9 +49,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds the site switcher link if user has more than one site.
 	 */
 	public function add_browse_sites_link() {
-		$wpcom_user_data = ( new Connection_Manager() )->get_connected_user_data();
-
-		if ( empty( $wpcom_user_data['site_count'] ) || $wpcom_user_data['site_count'] < 2 ) {
+		$site_count = get_user_option( 'wpcom_site_count' );
+		if ( ! $site_count || $site_count < 2 ) {
 			return;
 		}
 
@@ -87,8 +84,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_new_site_link() {
 		global $menu;
 
-		$wpcom_user_data = ( new Connection_Manager() )->get_connected_user_data();
-		if ( empty( $wpcom_user_data['site_count'] ) || $wpcom_user_data['site_count'] > 1 ) {
+		$site_count = get_user_option( 'wpcom_site_count' );
+		if ( $site_count && $site_count > 1 ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -136,7 +136,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 0, $menu );
 
 		// Give user a second site.
-		set_transient( 'jetpack_connected_user_data_' . static::$user_id, array( 'site_count' => 2 ) );
+		update_user_option( static::$user_id, 'wpcom_site_count', 2 );
 
 		static::$admin_menu->add_browse_sites_link();
 
@@ -151,7 +151,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		);
 		$this->assertSame( $menu[0], $browse_sites_menu_item );
 
-		delete_transient( 'jetpack_connected_user_data_' . static::$user_id );
+		delete_user_option( static::$user_id, 'wpcom_site_count' );
 	}
 
 	/**
@@ -163,7 +163,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		global $menu;
 
 		// Set jetpack user data.
-		set_transient( 'jetpack_connected_user_data_' . static::$user_id, array( 'site_count' => 1 ) );
+		update_user_option( static::$user_id, 'wpcom_site_count', 1 );
 
 		static::$admin_menu->add_new_site_link();
 
@@ -178,7 +178,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		);
 		$this->assertSame( $menu[1002], $new_site_menu_item ); // 1001 is the separator position, 1002 is the link position
 
-		delete_transient( 'jetpack_connected_user_data_' . static::$user_id );
+		delete_user_option( static::$user_id, 'wpcom_site_count' );
 	}
 
 	/**


### PR DESCRIPTION
The way user meta data is saved was recently changed on Atomic (590-gh-Automattic/wpcomsh). This PR updates the atomic-admin-menu class to obtain the information it needs from the new sources.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Replaces uses of `Connection_Manager::get_connected_user_data()` with a new user option.
* Updates unit tests to use the new user option.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the Jetpack Beta plugin on an Atomic site and switch to this branch.
* Verify that the "Browse Sites" link still shows up when you have more than one site.
* Verify that the "Add new site" link still shows up when you don't have more than one site.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
Not needed.