### PR TITLE
Instant Search: Fix build-search by restoring empty resolution to node's fs

### DIFF
--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -50,6 +50,9 @@ module.exports = {
 			path.resolve( __dirname, '../node_modules' ),
 		],
 	},
+	node: {
+		fs: 'empty',
+	},
 	devtool: isDevelopment ? 'source-map' : false,
 	plugins: [
 		...baseWebpackConfig.plugins,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Without this change, `yarn build-search` throws an error code because Webpack can't resolve `fs`.
* With this change, `fs` is resolved as [an empty object](https://v4.webpack.js.org/configuration/node/#node).

This fix has already been applied to WPCOM.

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Run `yarn build-search` in the Jetpack plugin directory. Ensure that it completes without raising an error code.
* Also try running `yarn build-search` without this change to see the error code being raised.

#### Proposed changelog entry for your changes:
* None.