### PR TITLE
Instant Search: Improve history navigation handling, open results in current window

### DIFF
--- a/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.jsx
@@ -20,8 +20,6 @@ const PathBreadcrumbs = ( { className, onClick, url } ) => {
 				className="jetpack-instant-search__path-breadcrumb-link"
 				href={ `//${ url }` }
 				onClick={ onClick }
-				rel="noopener noreferrer"
-				target="_blank"
 			>
 				{ splitDomainPath( url ).map( ( piece, index, pieces ) => (
 					<span className="jetpack-instant-search__path-breadcrumb-piece">

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -10,6 +10,7 @@ import { createPortal } from 'preact/compat';
 // eslint-disable-next-line lodash/import-scope
 import debounce from 'lodash/debounce';
 import { connect } from 'react-redux';
+import stringify from 'fast-json-stable-stringify';
 
 /**
  * Internal dependencies
@@ -70,12 +71,13 @@ class SearchApp extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( prevProps.searchQuery !== this.props.searchQuery ) {
-			this.onChangeSearchQuery();
-		}
-
-		if ( prevProps.sort !== this.props.sort || prevProps.filters !== this.props.filters ) {
-			this.onChangeSortOrFilters();
+		if (
+			prevProps.searchQuery !== this.props.searchQuery ||
+			prevProps.sort !== this.props.sort ||
+			// Note the special handling for filters prop, which use object values.
+			stringify( prevProps.filters ) !== stringify( this.props.filters )
+		) {
+			this.onChangeQueryString();
 		}
 	}
 
@@ -240,24 +242,17 @@ class SearchApp extends Component {
 		} );
 	};
 
-	onChangeSearchQuery = () => {
-		this.getResults();
-
-		if ( this.props.searchQuery !== null && ! this.state.showResults ) {
-			this.showResults();
-		}
-
-		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
-			input.value = this.props.searchQuery;
-		} );
-	};
-
-	onChangeSortOrFilters = () => {
+	onChangeQueryString = () => {
 		this.getResults();
 
 		if ( this.hasActiveQuery() && ! this.state.showResults ) {
 			this.showResults();
 		}
+
+		this.props.searchQuery !== null &&
+			document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
+				input.value = this.props.searchQuery;
+			} );
 	};
 
 	loadNextPage = () => {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -157,6 +157,15 @@ class SearchApp extends Component {
 	handleSubmit = event => {
 		event.preventDefault();
 		this.handleInput.flush();
+
+		// handleInput didn't respawn the overlay. Do it manually -- form submission must spawn an overlay.
+		if ( ! this.state.showResults ) {
+			const value = event.target.querySelector( this.props.themeOptions.searchInputSelector )
+				?.value;
+			// Don't do a falsy check; empty string is an allowed value.
+			typeof value === 'string' && this.props.setSearchQuery( value );
+			this.showResults();
+		}
 	};
 
 	handleKeydown = event => {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -152,6 +152,7 @@ class SearchApp extends Component {
 		this.props.initializeQueryValues( {
 			defaultSort: this.props.defaultSort,
 		} );
+		this.hasActiveQuery() ? this.showResults() : this.hideResults();
 	};
 
 	handleSubmit = event => {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -16,7 +16,11 @@ import { connect } from 'react-redux';
  */
 import Overlay from './overlay';
 import SearchResults from './search-results';
-import { getResultFormatQuery, restorePreviousHref } from '../lib/query-string';
+import {
+	getResultFormatQuery,
+	hasSearchQueryStringKey,
+	restorePreviousHref,
+} from '../lib/query-string';
 import {
 	initializeQueryValues,
 	makeSearchRequest,
@@ -144,7 +148,7 @@ class SearchApp extends Component {
 	};
 
 	hasActiveQuery() {
-		return this.props.searchQuery !== '' || this.props.hasFilters;
+		return this.props.searchQuery !== '' || this.props.hasFilters || hasSearchQueryStringKey();
 	}
 
 	handleBrowserHistoryNavigation = () => {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -207,6 +207,7 @@ class SearchApp extends Component {
 
 	handleOverlayTriggerClick = event => {
 		event.stopImmediatePropagation();
+		this.props.setSearchQuery( '' );
 		this.showResults();
 	};
 

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -89,7 +89,7 @@ class SearchApp extends Component {
 	addEventListeners() {
 		bindCustomizerChanges( this.handleOverlayOptionsUpdate );
 
-		window.addEventListener( 'popstate', this.handleBrowserHistoryNavigation );
+		window.addEventListener( 'popstate', this.handleHistoryNavigation );
 
 		// Add listeners for input and submit
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
@@ -108,7 +108,7 @@ class SearchApp extends Component {
 	}
 
 	removeEventListeners() {
-		window.removeEventListener( 'popstate', this.handleBrowserHistoryNavigation );
+		window.removeEventListener( 'popstate', this.handleHistoryNavigation );
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.removeEventListener( 'submit', this.handleSubmit );
@@ -150,7 +150,7 @@ class SearchApp extends Component {
 		return this.props.searchQuery !== null || this.props.hasFilters;
 	}
 
-	handleBrowserHistoryNavigation = () => {
+	handleHistoryNavigation = () => {
 		// Treat history navigation as brand new query values; re-initialize.
 		this.props.initializeQueryValues( {
 			defaultSort: this.props.defaultSort,

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -214,6 +214,7 @@ class SearchApp extends Component {
 		this.showResults();
 	};
 
+	// Treat overlay trigger clicks to be equivalent to setting an empty string search query.
 	handleOverlayTriggerClick = event => {
 		event.stopImmediatePropagation();
 		this.props.setSearchQuery( '' );

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -69,13 +69,12 @@ class SearchApp extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if (
-			prevProps.isSearchParamPresent !== this.props.isSearchParamPresent ||
-			prevProps.searchQuery !== this.props.searchQuery ||
-			prevProps.sort !== this.props.sort ||
-			prevProps.filters !== this.props.filters
-		) {
-			this.onChangeQueryString();
+		if ( prevProps.searchQuery !== this.props.searchQuery ) {
+			this.onChangeSearchQuery();
+		}
+
+		if ( prevProps.sort !== this.props.sort || prevProps.filters !== this.props.filters ) {
+			this.onChangeSortOrFilters();
 		}
 	}
 
@@ -220,17 +219,22 @@ class SearchApp extends Component {
 	showResults = () => {
 		this.setState( { showResults: true } );
 		this.preventBodyScroll();
+
+		// If we've arrived via a filter or sort only, make sure the search query is set
+		if ( this.props.searchQuery === null ) {
+			this.props.setSearchQuery( '' );
+		}
 	};
 
 	hideResults = () => {
 		this.restoreBodyScroll();
 		restorePreviousHref( this.props.initialHref, () => {
 			this.setState( { showResults: false } );
+			this.props.setSearchQuery( null );
 		} );
-		this.props.setSearchQuery( null );
 	};
 
-	onChangeQueryString = () => {
+	onChangeSearchQuery = () => {
 		this.getResults();
 
 		if ( this.props.searchQuery !== null && ! this.state.showResults ) {
@@ -240,6 +244,14 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.value = this.props.searchQuery;
 		} );
+	};
+
+	onChangeSortOrFilters = () => {
+		this.getResults();
+
+		if ( this.hasActiveQuery() && ! this.state.showResults ) {
+			this.showResults();
+		}
 	};
 
 	loadNextPage = () => {
@@ -311,7 +323,6 @@ export default connect(
 		hasFilters: hasFilters( state ),
 		hasNextPage: hasNextPage( state ),
 		isLoading: isLoading( state ),
-
 		response: getResponse( state ),
 		searchQuery: getSearchQuery( state ),
 		sort: getSort( state ),
@@ -321,7 +332,6 @@ export default connect(
 		initializeQueryValues,
 		makeSearchRequest,
 		setFilter,
-
 		setSearchQuery,
 		setSort,
 	}

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -54,9 +54,7 @@ class SearchApp extends Component {
 			showResults: this.props.initialShowResults,
 		};
 		this.getResults = debounce( this.getResults, 200 );
-		this.props.initializeQueryValues( {
-			defaultSort: this.props.defaultSort,
-		} );
+		this.props.initializeQueryValues();
 	}
 
 	componentDidMount() {
@@ -150,10 +148,7 @@ class SearchApp extends Component {
 	handleHistoryNavigation = () => {
 		// Treat history navigation as brand new query values; re-initialize.
 		// Note that this re-initialization will trigger onChangeQueryString via side effects.
-		this.props.initializeQueryValues( {
-			defaultSort: this.props.defaultSort,
-			isHistoryNavigation: true,
-		} );
+		this.props.initializeQueryValues( { isHistoryNavigation: true } );
 	};
 
 	handleSubmit = event => {
@@ -324,7 +319,7 @@ class SearchApp extends Component {
 }
 
 export default connect(
-	state => ( {
+	( state, props ) => ( {
 		filters: getFilters( state ),
 		hasActiveQuery: hasActiveQuery( state ),
 		hasError: hasError( state ),
@@ -333,7 +328,7 @@ export default connect(
 		isLoading: isLoading( state ),
 		response: getResponse( state ),
 		searchQuery: getSearchQuery( state ),
-		sort: getSort( state ),
+		sort: getSort( state, props.defaultSort ),
 		widgetOutsideOverlay: getWidgetOutsideOverlay( state ),
 	} ),
 	{

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -32,10 +32,10 @@ import {
 	getSearchQuery,
 	getSort,
 	getWidgetOutsideOverlay,
+	hasActiveQuery,
 	hasError,
-	hasFilters,
-	isHistoryNavigation,
 	hasNextPage,
+	isHistoryNavigation,
 	isLoading,
 } from '../store/selectors';
 import { bindCustomizerChanges } from '../lib/customize';
@@ -66,7 +66,7 @@ class SearchApp extends Component {
 		this.addEventListeners();
 		this.disableAutocompletion();
 
-		if ( this.hasActiveQuery() ) {
+		if ( this.props.hasActiveQuery ) {
 			this.showResults();
 		}
 	}
@@ -146,10 +146,6 @@ class SearchApp extends Component {
 		const resultFormatQuery = getResultFormatQuery();
 		return resultFormatQuery || this.state.overlayOptions.resultFormat;
 	};
-
-	hasActiveQuery() {
-		return this.props.searchQuery !== null || this.props.hasFilters;
-	}
 
 	handleHistoryNavigation = () => {
 		// Treat history navigation as brand new query values; re-initialize.
@@ -252,10 +248,10 @@ class SearchApp extends Component {
 	onChangeQueryString = isHistoryNav => {
 		this.getResults();
 
-		if ( this.hasActiveQuery() && ! this.state.showResults ) {
+		if ( this.props.hasActiveQuery && ! this.state.showResults ) {
 			this.showResults();
 		}
-		if ( ! this.hasActiveQuery() && isHistoryNav ) {
+		if ( ! this.props.hasActiveQuery && isHistoryNav ) {
 			this.hideResults( isHistoryNav );
 		}
 
@@ -330,8 +326,8 @@ class SearchApp extends Component {
 export default connect(
 	state => ( {
 		filters: getFilters( state ),
+		hasActiveQuery: hasActiveQuery( state ),
 		hasError: hasError( state ),
-		hasFilters: hasFilters( state ),
 		isHistoryNavigation: isHistoryNavigation( state ),
 		hasNextPage: hasNextPage( state ),
 		isLoading: isLoading( state ),

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -25,6 +25,7 @@ import {
 	initializeQueryValues,
 	makeSearchRequest,
 	setFilter,
+	setSearchParamPresent,
 	setSearchQuery,
 	setSort,
 } from '../store/actions';
@@ -38,6 +39,7 @@ import {
 	hasFilters,
 	hasNextPage,
 	isLoading,
+	isSearchParamPresent,
 } from '../store/selectors';
 import { bindCustomizerChanges } from '../lib/customize';
 import './search-app.scss';
@@ -74,6 +76,7 @@ class SearchApp extends Component {
 
 	componentDidUpdate( prevProps ) {
 		if (
+			prevProps.isSearchParamPresent !== this.props.isSearchParamPresent ||
 			prevProps.searchQuery !== this.props.searchQuery ||
 			prevProps.sort !== this.props.sort ||
 			prevProps.filters !== this.props.filters
@@ -148,7 +151,9 @@ class SearchApp extends Component {
 	};
 
 	hasActiveQuery() {
-		return this.props.searchQuery !== '' || this.props.hasFilters || hasSearchQueryStringKey();
+		return (
+			this.props.searchQuery !== '' || this.props.hasFilters || this.props.isSearchParamPresent
+		);
 	}
 
 	handleBrowserHistoryNavigation = () => {
@@ -235,6 +240,9 @@ class SearchApp extends Component {
 	onChangeQueryString = () => {
 		this.getResults();
 
+		// Store whether we have the ?s= param in the query string
+		this.props.setSearchParamPresent( hasSearchQueryStringKey() );
+
 		if ( this.hasActiveQuery() && ! this.state.showResults ) {
 			this.showResults();
 		}
@@ -313,10 +321,18 @@ export default connect(
 		hasFilters: hasFilters( state ),
 		hasNextPage: hasNextPage( state ),
 		isLoading: isLoading( state ),
+		isSearchParamPresent: isSearchParamPresent( state ),
 		response: getResponse( state ),
 		searchQuery: getSearchQuery( state ),
 		sort: getSort( state ),
 		widgetOutsideOverlay: getWidgetOutsideOverlay( state ),
 	} ),
-	{ initializeQueryValues, makeSearchRequest, setFilter, setSearchQuery, setSort }
+	{
+		initializeQueryValues,
+		makeSearchRequest,
+		setFilter,
+		setSearchParamPresent,
+		setSearchQuery,
+		setSort,
+	}
 )( SearchApp );

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -18,6 +18,7 @@ import Overlay from './overlay';
 import SearchResults from './search-results';
 import { getResultFormatQuery, restorePreviousHref } from '../lib/query-string';
 import {
+	clearQueryValues,
 	initializeQueryValues,
 	makeSearchRequest,
 	setFilter,
@@ -229,18 +230,13 @@ class SearchApp extends Component {
 	showResults = () => {
 		this.setState( { showResults: true } );
 		this.preventBodyScroll();
-
-		// If we've arrived via a filter or sort only, make sure the search query is set
-		if ( this.props.searchQuery === null ) {
-			this.props.setSearchQuery( '' );
-		}
 	};
 
 	hideResults = () => {
 		this.restoreBodyScroll();
 		restorePreviousHref( this.props.initialHref, () => {
 			this.setState( { showResults: false } );
-			this.props.setSearchQuery( null );
+			this.props.clearQueryValues();
 		} );
 	};
 
@@ -339,6 +335,7 @@ export default connect(
 		widgetOutsideOverlay: getWidgetOutsideOverlay( state ),
 	} ),
 	{
+		clearQueryValues,
 		initializeQueryValues,
 		makeSearchRequest,
 		setFilter,

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -16,16 +16,11 @@ import { connect } from 'react-redux';
  */
 import Overlay from './overlay';
 import SearchResults from './search-results';
-import {
-	getResultFormatQuery,
-	hasSearchQueryStringKey,
-	restorePreviousHref,
-} from '../lib/query-string';
+import { getResultFormatQuery, restorePreviousHref } from '../lib/query-string';
 import {
 	initializeQueryValues,
 	makeSearchRequest,
 	setFilter,
-	setSearchParamPresent,
 	setSearchQuery,
 	setSort,
 } from '../store/actions';
@@ -39,7 +34,6 @@ import {
 	hasFilters,
 	hasNextPage,
 	isLoading,
-	isSearchParamPresent,
 } from '../store/selectors';
 import { bindCustomizerChanges } from '../lib/customize';
 import './search-app.scss';
@@ -151,9 +145,7 @@ class SearchApp extends Component {
 	};
 
 	hasActiveQuery() {
-		return (
-			this.props.searchQuery !== '' || this.props.hasFilters || this.props.isSearchParamPresent
-		);
+		return this.props.searchQuery !== null || this.props.hasFilters;
 	}
 
 	handleBrowserHistoryNavigation = () => {
@@ -235,15 +227,13 @@ class SearchApp extends Component {
 		restorePreviousHref( this.props.initialHref, () => {
 			this.setState( { showResults: false } );
 		} );
+		this.props.setSearchQuery( null );
 	};
 
 	onChangeQueryString = () => {
 		this.getResults();
 
-		// Store whether we have the ?s= param in the query string
-		this.props.setSearchParamPresent( hasSearchQueryStringKey() );
-
-		if ( this.hasActiveQuery() && ! this.state.showResults ) {
+		if ( this.props.searchQuery !== null && ! this.state.showResults ) {
 			this.showResults();
 		}
 
@@ -321,7 +311,7 @@ export default connect(
 		hasFilters: hasFilters( state ),
 		hasNextPage: hasNextPage( state ),
 		isLoading: isLoading( state ),
-		isSearchParamPresent: isSearchParamPresent( state ),
+
 		response: getResponse( state ),
 		searchQuery: getSearchQuery( state ),
 		sort: getSort( state ),
@@ -331,7 +321,7 @@ export default connect(
 		initializeQueryValues,
 		makeSearchRequest,
 		setFilter,
-		setSearchParamPresent,
+
 		setSearchQuery,
 		setSort,
 	}

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
@@ -38,8 +38,6 @@ export default function SearchResultExpanded( props ) {
 						className="jetpack-instant-search__search-result-title-link jetpack-instant-search__search-result-expanded__title-link"
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						onClick={ props.onClick }
-						rel="noopener noreferrer"
-						target="_blank"
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>
@@ -64,8 +62,6 @@ export default function SearchResultExpanded( props ) {
 					className="jetpack-instant-search__search-result-expanded__image-link"
 					href={ `//${ fields[ 'permalink.url.raw' ] }` }
 					onClick={ props.onClick }
-					rel="noopener noreferrer"
-					target="_blank"
 				>
 					{ firstImage ? (
 						// NOTE: Wouldn't it be amazing if we filled the container's background

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-minimal.jsx
@@ -112,8 +112,6 @@ class SearchResultMinimal extends Component {
 						className="jetpack-instant-search__search-result-title-link jetpack-instant-search__search-result-minimal-title-link"
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						onClick={ this.props.onClick }
-						rel="noopener noreferrer"
-						target="_blank"
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
@@ -37,12 +37,7 @@ class SearchResultProduct extends Component {
 
 		return (
 			<li className="jetpack-instant-search__search-result jetpack-instant-search__search-result-product">
-				<a
-					href={ `//${ fields[ 'permalink.url.raw' ] }` }
-					onClick={ this.props.onClick }
-					rel="noopener noreferrer"
-					target="_blank"
-				>
+				<a href={ `//${ fields[ 'permalink.url.raw' ] }` } onClick={ this.props.onClick }>
 					{ firstImage ? (
 						<PhotonImage
 							alt=""
@@ -59,8 +54,6 @@ class SearchResultProduct extends Component {
 						className="jetpack-instant-search__search-result-title-link"
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						onClick={ this.props.onClick }
-						rel="noopener noreferrer"
-						target="_blank"
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: title } }
 					/>

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/api.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/api.js
@@ -196,6 +196,10 @@ function generateApiQueryString( {
 	postsPerPage = 10,
 	adminQueryFilter,
 } ) {
+	if ( query === null ) {
+		query = '';
+	}
+
 	let fields = [
 		'date',
 		'permalink.url.raw',

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -45,6 +45,17 @@ export function getResultFormatQuery() {
 	return query.result_format;
 }
 
+/**
+ * Check for a parameter named 's' in the query string.
+ *
+ * @returns {boolean} Has 's' in the query string
+ */
+export function hasSearchQueryStringKey() {
+	const query = getQuery();
+
+	return 's' in query;
+}
+
 export function restorePreviousHref( initialHref, callback ) {
 	if ( history.pushState ) {
 		window.history.pushState( null, null, initialHref );

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -45,17 +45,6 @@ export function getResultFormatQuery() {
 	return query.result_format;
 }
 
-/**
- * Check for a parameter named 's' in the query string.
- *
- * @returns {boolean} Has 's' in the query string
- */
-export function hasSearchQueryStringKey() {
-	const query = getQuery();
-
-	return 's' in query;
-}
-
 export function restorePreviousHref( initialHref, callback ) {
 	if ( history.pushState ) {
 		window.history.pushState( null, null, initialHref );

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -11,6 +11,12 @@ import { SERVER_OBJECT_NAME, VALID_RESULT_FORMAT_KEYS } from './constants';
 import { getFilterKeys } from './filters';
 import { decode } from '../external/query-string-decode';
 
+/**
+ * Parses the address bar's query string into an object.
+ *
+ * @param {string} search - raw query string prepended with '?'
+ * @returns {object} queryObject - a query object.
+ */
 export function getQuery( search = window.location.search ) {
 	return decode( search.substring( 1 ), false, false );
 }
@@ -40,6 +46,11 @@ function pushQueryString( queryString ) {
 	}
 }
 
+/**
+ * Returns a result format value from the query string. Used to override the site's configured result format.
+ *
+ * @returns {null|string} resultFormatQuery
+ */
 export function getResultFormatQuery() {
 	const query = getQuery();
 
@@ -50,6 +61,13 @@ export function getResultFormatQuery() {
 	return query.result_format;
 }
 
+/**
+ * Navigates the window to a specified location with all search-related query values stirpped out.
+ *
+ * @param {string} initialHref - Target location to navigate to via push/replaceState.
+ * @param {Function} callback - Callback to be invoked if initialHref didn't include any search queries.
+ * @param {boolean} replaceState - Flag to toggle replaceState or pushState invocation. Useful if this function's being invoked due to history navigation.
+ */
 export function restorePreviousHref( initialHref, callback, replaceState = false ) {
 	if ( history.pushState && history.replaceState ) {
 		const url = new URL( initialHref );

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -16,7 +16,7 @@ export function getQuery() {
 }
 
 /**
- * Updates the browser's query string.
+ * Updates the browser's query string via a query object.
  *
  * @param {object} queryObject - a query object.
  */
@@ -24,6 +24,11 @@ export function setQuery( queryObject ) {
 	pushQueryString( encode( queryObject ) );
 }
 
+/**
+ * Updates the browser's query string via an encoded query string.
+ *
+ * @param {string} queryString - an encoded query string.
+ */
 function pushQueryString( queryString ) {
 	if ( history.pushState ) {
 		const url = new window.URL( window.location.href );

--- a/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
@@ -59,20 +59,6 @@ export function initializeQueryValues( { defaultSort } ) {
 }
 
 /**
- * Returns an action object used to set whether a search param is present in the URL.
- *
- * @param {boolean} isSearchParamPresent - Is the search param present? (?s=).
- *
- * @returns {object} Action object.
- */
-export function setSearchParamPresent( isSearchParamPresent ) {
-	return {
-		type: 'SET_SEARCH_PARAM_PRESENT',
-		isSearchParamPresent,
-	};
-}
-
-/**
  * Returns an action object used to set a search query value.
  *
  * @param {string} query - Inputted user query.

--- a/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
@@ -80,7 +80,7 @@ export function setSearchQuery( query, propagateToWindow = true ) {
  * Returns an action object used to set a search sort value.
  *
  * @param {string} sort - Sort value.
- * @param {boolean} propagateToWindow - If true, will tell the effects handler to set the search query in the location bar.
+ * @param {boolean} propagateToWindow - If true, will tell the effects handler to set the query string in the location bar.
  *
  * @returns {object} Action object.
  */
@@ -97,7 +97,7 @@ export function setSort( sort, propagateToWindow = true ) {
  *
  * @param {string} name - Filter name.
  * @param {string[]} value - Filter values.
- * @param {boolean} propagateToWindow - If true, will tell the effects handler to set the search query in the location bar.
+ * @param {boolean} propagateToWindow - If true, will tell the effects handler to set the query string in the location bar.
  *
  * @returns {object} Action object.
  */
@@ -113,12 +113,13 @@ export function setFilter( name, value, propagateToWindow = true ) {
 /**
  * Returns an action object used to clear all filter values.
  *
+ * @param {boolean} propagateToWindow - If true, will tell the effects handler to update the query string in the location bar.
  * @returns {object} Action object.
  */
-export function clearFilters() {
+export function clearFilters( propagateToWindow = true ) {
 	return {
 		type: 'CLEAR_FILTERS',
-		propagateToWindow: true,
+		propagateToWindow,
 	};
 }
 

--- a/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
@@ -118,3 +118,14 @@ export function clearFilters() {
 		type: 'CLEAR_FILTERS',
 	};
 }
+
+/**
+ * Returns an action object used to clear all query values. Invoked when the search modal is dismissed.
+ *
+ * @returns {object} Action object.
+ */
+export function clearQueryValues() {
+	return {
+		type: 'CLEAR_QUERY_VALUES',
+	};
+}

--- a/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
@@ -59,6 +59,20 @@ export function initializeQueryValues( { defaultSort } ) {
 }
 
 /**
+ * Returns an action object used to set whether a search param is present in the URL.
+ *
+ * @param {boolean} isSearchParamPresent - Is the search param present? (?s=).
+ *
+ * @returns {object} Action object.
+ */
+export function setSearchParamPresent( isSearchParamPresent ) {
+	return {
+		type: 'SET_SEARCH_PARAM_PRESENT',
+		isSearchParamPresent,
+	};
+}
+
+/**
  * Returns an action object used to set a search query value.
  *
  * @param {string} query - Inputted user query.

--- a/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
@@ -48,13 +48,15 @@ export function recordFailedSearchRequest( error ) {
  *
  * @param {object} params - Input parameters.
  * @param {object} params.defaultSort - Default sort value configured in the customizer.
+ * @param {boolean} params.isHistoryNavigation - True if this action is invoked via history navigation.
  *
  * @returns {object} Action object.
  */
-export function initializeQueryValues( { defaultSort } ) {
+export function initializeQueryValues( { defaultSort, isHistoryNavigation = false } ) {
 	return {
 		type: 'INITIALIZE_QUERY_VALUES',
 		defaultSort,
+		isHistoryNavigation,
 	};
 }
 
@@ -116,6 +118,7 @@ export function setFilter( name, value, propagateToWindow = true ) {
 export function clearFilters() {
 	return {
 		type: 'CLEAR_FILTERS',
+		propagateToWindow: true,
 	};
 }
 

--- a/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
@@ -47,15 +47,13 @@ export function recordFailedSearchRequest( error ) {
  * Returns an action object used to initialize query value related reducers.
  *
  * @param {object} params - Input parameters.
- * @param {object} params.defaultSort - Default sort value configured in the customizer.
  * @param {boolean} params.isHistoryNavigation - True if this action is invoked via history navigation.
  *
  * @returns {object} Action object.
  */
-export function initializeQueryValues( { defaultSort, isHistoryNavigation = false } ) {
+export function initializeQueryValues( { isHistoryNavigation = false } = {} ) {
 	return {
 		type: 'INITIALIZE_QUERY_VALUES',
-		defaultSort,
 		isHistoryNavigation,
 	};
 }

--- a/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
@@ -9,6 +9,7 @@ import {
 	recordFailedSearchRequest,
 	recordSuccessfulSearchRequest,
 	setFilter,
+	setSearchParamPresent,
 	setSearchQuery,
 	setSort,
 } from './actions';
@@ -48,6 +49,8 @@ function initializeQueryValues( action, store ) {
 	//
 	// Initialize search query value for the reducer.
 	//
+	store.dispatch( setSearchParamPresent( 's' in queryObject ) );
+
 	if ( queryObject.s ) {
 		store.dispatch( setSearchQuery( queryObject.s, false ) );
 	}

--- a/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
@@ -50,6 +50,8 @@ function initializeQueryValues( action, store ) {
 	//
 	if ( 's' in queryObject ) {
 		store.dispatch( setSearchQuery( queryObject.s, false ) );
+	} else {
+		store.dispatch( setSearchQuery( null, false ) );
 	}
 
 	//

--- a/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
@@ -96,11 +96,7 @@ function updateSearchQueryString( action ) {
 	}
 
 	const queryObject = getQuery();
-	if ( action.query === '' ) {
-		delete queryObject.s;
-	} else {
-		queryObject.s = action.query;
-	}
+	queryObject.s = action.query;
 	setQuery( queryObject );
 }
 

--- a/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
@@ -9,7 +9,6 @@ import {
 	recordFailedSearchRequest,
 	recordSuccessfulSearchRequest,
 	setFilter,
-	setSearchParamPresent,
 	setSearchQuery,
 	setSort,
 } from './actions';
@@ -49,9 +48,7 @@ function initializeQueryValues( action, store ) {
 	//
 	// Initialize search query value for the reducer.
 	//
-	store.dispatch( setSearchParamPresent( 's' in queryObject ) );
-
-	if ( queryObject.s ) {
+	if ( 's' in queryObject ) {
 		store.dispatch( setSearchQuery( queryObject.s, false ) );
 	}
 
@@ -99,7 +96,13 @@ function updateSearchQueryString( action ) {
 	}
 
 	const queryObject = getQuery();
-	queryObject.s = action.query;
+
+	if ( action.query !== null ) {
+		queryObject.s = action.query;
+	} else {
+		delete queryObject.s;
+	}
+
 	setQuery( queryObject );
 }
 

--- a/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
@@ -6,6 +6,7 @@ import { RELEVANCE_SORT_KEY, SORT_DIRECTION_ASC, VALID_SORT_KEYS } from '../lib/
 import { getFilterKeys } from '../lib/filters';
 import { getQuery, setQuery } from '../lib/query-string';
 import {
+	clearFilters,
 	recordFailedSearchRequest,
 	recordSuccessfulSearchRequest,
 	setFilter,
@@ -80,6 +81,7 @@ function initializeQueryValues( action, store ) {
 	//
 	// Initialize filter value for the reducer.
 	//
+	store.dispatch( clearFilters( false ) );
 	getFilterKeys()
 		.filter( filterKey => filterKey in queryObject )
 		.forEach( filterKey =>
@@ -151,8 +153,14 @@ function updateFilterQueryString( action ) {
 
 /**
  * Effect handler which will clear filter queries from the location bar
+ *
+ * @param {object} action - Action which had initiated the effect handler.
  */
-function clearFilterQueryString() {
+function clearFilterQueryString( action ) {
+	if ( action.propagateToWindow === false ) {
+		return;
+	}
+
 	const queryObject = getQuery();
 	getFilterKeys().forEach( key => delete queryObject[ key ] );
 	setQuery( queryObject );

--- a/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { search } from '../lib/api';
-import { RELEVANCE_SORT_KEY, SORT_DIRECTION_ASC, VALID_SORT_KEYS } from '../lib/constants';
+import { SORT_DIRECTION_ASC, VALID_SORT_KEYS } from '../lib/constants';
 import { getFilterKeys } from '../lib/filters';
 import { getQuery, setQuery } from '../lib/query-string';
 import {
@@ -58,7 +58,7 @@ function initializeQueryValues( action, store ) {
 	//
 	// Initialize sort value for the reducer.
 	//
-	let sort = RELEVANCE_SORT_KEY;
+	let sort;
 	if ( VALID_SORT_KEYS.includes( queryObject.sort ) ) {
 		// Set sort value from `sort` query value.
 		sort = queryObject.sort;
@@ -72,11 +72,8 @@ function initializeQueryValues( action, store ) {
 	} else if ( 'relevance' === queryObject.orderby ) {
 		// Set sort value from legacy `orderby` query value.
 		sort = 'relevance';
-	} else if ( VALID_SORT_KEYS.includes( action.defaultSort ) ) {
-		// Set sort value from customizer configured default sort value.
-		sort = action.defaultSort;
 	}
-	store.dispatch( setSort( sort, false ) );
+	typeof sort === 'string' && store.dispatch( setSort( sort, false ) );
 
 	//
 	// Initialize filter value for the reducer.

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/history.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/history.js
@@ -1,0 +1,25 @@
+/**
+ * Returns true if the query string change was performed by a history navigation.
+ *
+ * @param {object} state - Current state.
+ * @param {object} action - Dispatched action.
+ *
+ * @returns {object} Updated state.
+ */
+export function isHistoryNavigation( state = false, action ) {
+	switch ( action.type ) {
+		case 'INITIALIZE_QUERY_VALUES':
+			// Triggered by SearchApp.handleHistoryNavigation.
+			return action.isHistoryNavigation;
+		case 'SET_SEARCH_QUERY':
+		case 'SET_SORT':
+		case 'CLEAR_FILTERS':
+		case 'SET_FILTER':
+			// A query string update is invoked to the window, creating a history state.
+			// In other words, the query string change was performed by UI interaction.
+			// It was *not* performed by a history navigation.
+			return action.propagateToWindow ? false : state;
+	}
+
+	return state;
+}

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/index.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/index.js
@@ -9,12 +9,23 @@ import { combineReducers } from 'redux';
 import { hasError, isLoading, response } from './api';
 import { filters, searchQuery, sort } from './query-string';
 import { serverOptions } from './server-options';
+import { isHistoryNavigation } from './history';
 
-export { filters, hasError, isLoading, response, searchQuery, serverOptions, sort };
+export {
+	filters,
+	hasError,
+	isHistoryNavigation,
+	isLoading,
+	response,
+	searchQuery,
+	serverOptions,
+	sort,
+};
 export default combineReducers( {
 	filters,
 	hasError,
 	isLoading,
+	isHistoryNavigation,
 	response,
 	searchQuery,
 	serverOptions,

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/index.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/index.js
@@ -7,7 +7,7 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import { hasError, isLoading, response } from './api';
-import { filters, searchQuery, sort } from './query-string';
+import { filters, isSearchParamPresent, searchQuery, sort } from './query-string';
 import { serverOptions } from './server-options';
 
 export { filters, hasError, isLoading, response, searchQuery, serverOptions, sort };
@@ -15,6 +15,7 @@ export default combineReducers( {
 	filters,
 	hasError,
 	isLoading,
+	isSearchParamPresent,
 	response,
 	searchQuery,
 	serverOptions,

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/index.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/index.js
@@ -7,7 +7,7 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import { hasError, isLoading, response } from './api';
-import { filters, isSearchParamPresent, searchQuery, sort } from './query-string';
+import { filters, searchQuery, sort } from './query-string';
 import { serverOptions } from './server-options';
 
 export { filters, hasError, isLoading, response, searchQuery, serverOptions, sort };
@@ -15,7 +15,6 @@ export default combineReducers( {
 	filters,
 	hasError,
 	isLoading,
-	isSearchParamPresent,
 	response,
 	searchQuery,
 	serverOptions,

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
@@ -5,23 +5,6 @@ import { VALID_SORT_KEYS } from '../../lib/constants';
 import { getFilterKeys } from '../../lib/filters';
 
 /**
- * Reducer for keeping track of whether the search param is present (?s=)
- *
- * @param {object} state - Current state.
- * @param {object} action - Dispatched action.
- *
- * @returns {object} Updated state.
- */
-export function isSearchParamPresent( state = false, action ) {
-	switch ( action.type ) {
-		case 'SET_SEARCH_PARAM_PRESENT':
-			return action.isSearchParamPresent;
-	}
-
-	return state;
-}
-
-/**
  * Reducer for keeping track of the user's inputted search query
  *
  * @param {object} state - Current state.
@@ -29,7 +12,7 @@ export function isSearchParamPresent( state = false, action ) {
  *
  * @returns {object} Updated state.
  */
-export function searchQuery( state = '', action ) {
+export function searchQuery( state = null, action ) {
 	switch ( action.type ) {
 		case 'SET_SEARCH_QUERY':
 			return action.query;

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
@@ -16,6 +16,11 @@ export function searchQuery( state = null, action ) {
 	switch ( action.type ) {
 		case 'SET_SEARCH_QUERY':
 			return action.query;
+		case 'SET_FILTER':
+		case 'SET_SORT':
+			return action.propagateToWindow ? '' : state;
+		case 'CLEAR_QUERY_VALUES':
+			return null;
 	}
 
 	return state;
@@ -30,13 +35,15 @@ export function searchQuery( state = null, action ) {
  * @returns {object} Updated state.
  */
 export function sort( state = 'relevance', action ) {
-	if ( ! VALID_SORT_KEYS.includes( action.sort ) ) {
-		return state;
-	}
-
 	switch ( action.type ) {
-		case 'SET_SORT':
+		case 'SET_SORT': {
+			if ( ! VALID_SORT_KEYS.includes( action.sort ) ) {
+				return state;
+			}
 			return action.sort;
+		}
+		case 'CLEAR_QUERY_VALUES':
+			return 'relevance';
 	}
 
 	return state;
@@ -53,6 +60,7 @@ export function sort( state = 'relevance', action ) {
 export function filters( state = {}, action ) {
 	switch ( action.type ) {
 		case 'CLEAR_FILTERS':
+		case 'CLEAR_QUERY_VALUES':
 			return {};
 		case 'SET_FILTER':
 			if (

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
@@ -5,6 +5,23 @@ import { VALID_SORT_KEYS } from '../../lib/constants';
 import { getFilterKeys } from '../../lib/filters';
 
 /**
+ * Reducer for keeping track of whether the search param is present (?s=)
+ *
+ * @param {object} state - Current state.
+ * @param {object} action - Dispatched action.
+ *
+ * @returns {object} Updated state.
+ */
+export function isSearchParamPresent( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_SEARCH_PARAM_PRESENT':
+			return action.isSearchParamPresent;
+	}
+
+	return state;
+}
+
+/**
  * Reducer for keeping track of the user's inputted search query
  *
  * @param {object} state - Current state.

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
@@ -16,12 +16,6 @@ export function searchQuery( state = null, action ) {
 	switch ( action.type ) {
 		case 'SET_SEARCH_QUERY':
 			return action.query;
-		case 'SET_FILTER':
-		case 'SET_SORT':
-			if ( state === null && action.propagateToWindow ) {
-				return '';
-			}
-			return state;
 		case 'CLEAR_QUERY_VALUES':
 			return null;
 	}
@@ -37,7 +31,7 @@ export function searchQuery( state = null, action ) {
  *
  * @returns {object} Updated state.
  */
-export function sort( state = 'relevance', action ) {
+export function sort( state = null, action ) {
 	switch ( action.type ) {
 		case 'SET_SORT': {
 			if ( ! VALID_SORT_KEYS.includes( action.sort ) ) {
@@ -46,7 +40,7 @@ export function sort( state = 'relevance', action ) {
 			return action.sort;
 		}
 		case 'CLEAR_QUERY_VALUES':
-			return 'relevance';
+			return null;
 	}
 
 	return state;

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/query-string.js
@@ -18,7 +18,10 @@ export function searchQuery( state = null, action ) {
 			return action.query;
 		case 'SET_FILTER':
 		case 'SET_SORT':
-			return action.propagateToWindow ? '' : state;
+			if ( state === null && action.propagateToWindow ) {
+				return '';
+			}
+			return state;
 		case 'CLEAR_QUERY_VALUES':
 			return null;
 	}

--- a/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
@@ -104,3 +104,13 @@ export function getWidgetOutsideOverlay( state ) {
 
 	return { filters };
 }
+
+/**
+ * Returns true if the query string change was performed by a history navigation.
+ *
+ * @param {object} state - Current state.
+ * @returns {boolean} isHistoryNavigation.
+ */
+export function isHistoryNavigation( state ) {
+	return state.isHistoryNavigation;
+}

--- a/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
@@ -44,6 +44,16 @@ export function isLoading( state ) {
 }
 
 /**
+ * Check if the search param is present (?s=)
+ *
+ * @param {object} state - Current state.
+ * @returns {boolean} isPresent - True if the search param is present.
+ */
+export function isSearchParamPresent( state ) {
+	return state.isSearchParamPresent;
+}
+
+/**
  * Get the search query.
  *
  * @param {object} state - Current state.

--- a/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
@@ -44,16 +44,6 @@ export function isLoading( state ) {
 }
 
 /**
- * Check if the search param is present (?s=)
- *
- * @param {object} state - Current state.
- * @returns {boolean} isPresent - True if the search param is present.
- */
-export function isSearchParamPresent( state ) {
-	return state.isSearchParamPresent;
-}
-
-/**
  * Get the search query.
  *
  * @param {object} state - Current state.

--- a/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { RELEVANCE_SORT_KEY } from '../lib/constants';
 import { getUnselectableFilterKeys, mapFilterKeyToFilter } from '../lib/filters';
 
 /**
@@ -60,7 +61,7 @@ export function getSearchQuery( state ) {
  * @returns {string} sort - The selected sort key for the search interface.
  */
 export function getSort( state ) {
-	return state.sort;
+	return typeof state.sort === 'string' ? state.sort : RELEVANCE_SORT_KEY;
 }
 
 /**
@@ -81,6 +82,16 @@ export function getFilters( state ) {
  */
 export function hasFilters( state ) {
 	return Object.keys( state.filters ).length > 0;
+}
+
+/**
+ * Checks if there is an active search-related query values.
+ *
+ * @param {object} state - Current state.
+ * @returns {object} hasActiveQuery - true if any search-related query value has been defined.
+ */
+export function hasActiveQuery( state ) {
+	return getSearchQuery( state ) !== null || hasFilters( state ) || state.sort !== null;
 }
 
 /**

--- a/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/selectors.js
@@ -58,10 +58,15 @@ export function getSearchQuery( state ) {
  * Get the sort key.
  *
  * @param {object} state - Current state.
+ * @param {string?} defaultSort - Default sort order specified via the Customizer.
  * @returns {string} sort - The selected sort key for the search interface.
  */
-export function getSort( state ) {
-	return typeof state.sort === 'string' ? state.sort : RELEVANCE_SORT_KEY;
+export function getSort( state, defaultSort ) {
+	// Default non-string defaultSort to 'relevance'
+	if ( typeof defaultSort !== 'string' ) {
+		defaultSort = RELEVANCE_SORT_KEY;
+	}
+	return typeof state.sort === 'string' ? state.sort : defaultSort;
 }
 
 /**

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -96,9 +96,9 @@ describe( 'response Reducer', () => {
 } );
 
 describe( 'searchQuery Reducer', () => {
-	test( 'defaults to an empty string', () => {
+	test( 'defaults to null', () => {
 		const state = searchQuery( undefined, {} );
-		expect( state ).toBe( '' );
+		expect( state ).toBe( null );
 	} );
 	test( 'is updated by a set search query action', () => {
 		const state = searchQuery( undefined, setSearchQuery( 'Some new query' ) );

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -7,6 +7,7 @@
  */
 import {
 	clearFilters,
+	clearQueryValues,
 	makeSearchRequest,
 	recordSuccessfulSearchRequest,
 	recordFailedSearchRequest,
@@ -104,6 +105,28 @@ describe( 'searchQuery Reducer', () => {
 		const state = searchQuery( undefined, setSearchQuery( 'Some new query' ) );
 		expect( state ).toBe( 'Some new query' );
 	} );
+	test( 'is set to an empty string by a set filter query action propagating to the window', () => {
+		const state = searchQuery( undefined, setFilter( 'post_types', [ 'post', 'page' ] ) );
+		expect( state ).toBe( '' );
+	} );
+	test( 'is set to an empty string by a set sort query action propagating to the window', () => {
+		const state = searchQuery( undefined, setSort( 'newest' ) );
+		expect( state ).toBe( '' );
+	} );
+	test( 'is unchanged by a set filter query or set sort query actions not propagating to the window', () => {
+		expect( searchQuery( undefined, setFilter( 'post_types', [ 'post', 'page' ], false ) ) ).toBe(
+			null
+		);
+		expect( searchQuery( 'hello', setFilter( 'post_types', [ 'post', 'page' ], false ) ) ).toBe(
+			'hello'
+		);
+		expect( searchQuery( undefined, setSort( 'newest', false ) ) ).toBe( null );
+		expect( searchQuery( 'hello', setSort( 'newest', false ) ) ).toBe( 'hello' );
+	} );
+	test( 'is set to null by a clear query values action', () => {
+		const state = searchQuery( undefined, clearQueryValues() );
+		expect( state ).toBe( null );
+	} );
 } );
 
 describe( 'sort Reducer', () => {
@@ -114,6 +137,10 @@ describe( 'sort Reducer', () => {
 	test( 'is updated by a set search query action', () => {
 		const state = sort( undefined, setSort( 'newest' ) );
 		expect( state ).toBe( 'newest' );
+	} );
+	test( 'is set to "relevance" by a clear query values action', () => {
+		const state = sort( undefined, clearQueryValues() );
+		expect( state ).toBe( 'relevance' );
 	} );
 } );
 
@@ -144,6 +171,10 @@ describe( 'filters Reducer', () => {
 	} );
 	test( 'is reset by a clear filters action', () => {
 		const state = filters( { post_types: [ 'post' ] }, clearFilters() );
+		expect( state ).toEqual( {} );
+	} );
+	test( 'is reset by a clear query values action', () => {
+		const state = filters( { post_types: [ 'post' ] }, clearQueryValues() );
 		expect( state ).toEqual( {} );
 	} );
 } );

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -216,10 +216,7 @@ describe( 'isHistoryNavigation Reducer', () => {
 			false
 		);
 		expect( isHistoryNavigation( undefined, setSort( 'newest', false ) ) ).toBe( false );
-
-		// NOTE: clearFilters is omitted here because it doesn't have a configurable propagateToWindow parameter.
-		//       clearFilters is always used to propagate to the window in its current useage.
-
+		expect( isHistoryNavigation( undefined, clearFilters( false ) ) ).toBe( false );
 		expect(
 			isHistoryNavigation( undefined, setFilter( 'post_types', [ 'post', 'page' ], false ) )
 		).toBe( false );

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -14,8 +14,17 @@ import {
 	setSearchQuery,
 	setSort,
 	setFilter,
+	initializeQueryValues,
 } from '../actions';
-import { filters, hasError, isLoading, response, searchQuery, sort } from '../reducer';
+import {
+	filters,
+	hasError,
+	isHistoryNavigation,
+	isLoading,
+	response,
+	searchQuery,
+	sort,
+} from '../reducer';
 
 describe( 'hasError Reducer', () => {
 	test( 'defaults to false', () => {
@@ -176,5 +185,43 @@ describe( 'filters Reducer', () => {
 	test( 'is reset by a clear query values action', () => {
 		const state = filters( { post_types: [ 'post' ] }, clearQueryValues() );
 		expect( state ).toEqual( {} );
+	} );
+} );
+
+describe( 'isHistoryNavigation Reducer', () => {
+	test( 'defaults to false', () => {
+		expect( isHistoryNavigation( undefined, {} ) ).toBe( false );
+	} );
+
+	test( 'is updated by initializing query values action', () => {
+		expect(
+			isHistoryNavigation( undefined, initializeQueryValues( { isHistoryNavigation: false } ) )
+		).toBe( false );
+		expect(
+			isHistoryNavigation( undefined, initializeQueryValues( { isHistoryNavigation: true } ) )
+		).toBe( true );
+	} );
+
+	test( 'is set to false when a query value update propagates to the window', () => {
+		expect( isHistoryNavigation( undefined, setSearchQuery( 'Some new query' ) ) ).toBe( false );
+		expect( isHistoryNavigation( undefined, setSort( 'newest' ) ) ).toBe( false );
+		expect( isHistoryNavigation( undefined, clearFilters() ) ).toBe( false );
+		expect( isHistoryNavigation( undefined, setFilter( 'post_types', [ 'post', 'page' ] ) ) ).toBe(
+			false
+		);
+	} );
+
+	test( 'ignores query value updates not propagating to the window', () => {
+		expect( isHistoryNavigation( undefined, setSearchQuery( 'Some new query', false ) ) ).toBe(
+			false
+		);
+		expect( isHistoryNavigation( undefined, setSort( 'newest', false ) ) ).toBe( false );
+
+		// NOTE: clearFilters is omitted here because it doesn't have a configurable propagateToWindow parameter.
+		//       clearFilters is always used to propagate to the window in its current useage.
+
+		expect(
+			isHistoryNavigation( undefined, setFilter( 'post_types', [ 'post', 'page' ], false ) )
+		).toBe( false );
 	} );
 } );

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -114,26 +114,6 @@ describe( 'searchQuery Reducer', () => {
 		const state = searchQuery( undefined, setSearchQuery( 'Some new query' ) );
 		expect( state ).toBe( 'Some new query' );
 	} );
-	test( 'is set to an empty string by a set filter query action propagating to the window only if the search query is currently null', () => {
-		expect( searchQuery( undefined, setFilter( 'post_types', [ 'post', 'page' ] ) ) ).toBe( '' );
-		expect(
-			searchQuery( 'this does not get overwritten', setFilter( 'post_types', [ 'post', 'page' ] ) )
-		).toBe( 'this does not get overwritten' );
-	} );
-	test( 'is set to an empty string by a set sort query action propagating to the window', () => {
-		const state = searchQuery( undefined, setSort( 'newest' ) );
-		expect( state ).toBe( '' );
-	} );
-	test( 'is unchanged by a set filter query or set sort query actions not propagating to the window', () => {
-		expect( searchQuery( undefined, setFilter( 'post_types', [ 'post', 'page' ], false ) ) ).toBe(
-			null
-		);
-		expect( searchQuery( 'hello', setFilter( 'post_types', [ 'post', 'page' ], false ) ) ).toBe(
-			'hello'
-		);
-		expect( searchQuery( undefined, setSort( 'newest', false ) ) ).toBe( null );
-		expect( searchQuery( 'hello', setSort( 'newest', false ) ) ).toBe( 'hello' );
-	} );
 	test( 'is set to null by a clear query values action', () => {
 		const state = searchQuery( undefined, clearQueryValues() );
 		expect( state ).toBe( null );
@@ -141,17 +121,17 @@ describe( 'searchQuery Reducer', () => {
 } );
 
 describe( 'sort Reducer', () => {
-	test( 'defaults to "relevance"', () => {
+	test( 'defaults to null', () => {
 		const state = sort( undefined, {} );
-		expect( state ).toBe( 'relevance' );
+		expect( state ).toBe( null );
 	} );
 	test( 'is updated by a set search query action', () => {
 		const state = sort( undefined, setSort( 'newest' ) );
 		expect( state ).toBe( 'newest' );
 	} );
 	test( 'is set to "relevance" by a clear query values action', () => {
-		const state = sort( undefined, clearQueryValues() );
-		expect( state ).toBe( 'relevance' );
+		expect( sort( undefined, clearQueryValues() ) ).toBe( null );
+		expect( sort( 'newest', clearQueryValues() ) ).toBe( null );
 	} );
 } );
 

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -129,7 +129,7 @@ describe( 'sort Reducer', () => {
 		const state = sort( undefined, setSort( 'newest' ) );
 		expect( state ).toBe( 'newest' );
 	} );
-	test( 'is set to "relevance" by a clear query values action', () => {
+	test( 'is set to null by a clear query values action', () => {
 		expect( sort( undefined, clearQueryValues() ) ).toBe( null );
 		expect( sort( 'newest', clearQueryValues() ) ).toBe( null );
 	} );

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -114,9 +114,11 @@ describe( 'searchQuery Reducer', () => {
 		const state = searchQuery( undefined, setSearchQuery( 'Some new query' ) );
 		expect( state ).toBe( 'Some new query' );
 	} );
-	test( 'is set to an empty string by a set filter query action propagating to the window', () => {
-		const state = searchQuery( undefined, setFilter( 'post_types', [ 'post', 'page' ] ) );
-		expect( state ).toBe( '' );
+	test( 'is set to an empty string by a set filter query action propagating to the window only if the search query is currently null', () => {
+		expect( searchQuery( undefined, setFilter( 'post_types', [ 'post', 'page' ] ) ) ).toBe( '' );
+		expect(
+			searchQuery( 'this does not get overwritten', setFilter( 'post_types', [ 'post', 'page' ] ) )
+		).toBe( 'this does not get overwritten' );
 	} );
 	test( 'is set to an empty string by a set sort query action propagating to the window', () => {
 		const state = searchQuery( undefined, setSort( 'newest' ) );

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/selectors.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/selectors.test.js
@@ -5,7 +5,48 @@
 /**
  * Internal dependencies
  */
-import { getWidgetOutsideOverlay } from '../selectors';
+import { RELEVANCE_SORT_KEY } from '../../lib/constants';
+import { getSort, getWidgetOutsideOverlay, hasActiveQuery } from '../selectors';
+
+describe( 'getSort', () => {
+	test( 'defaults to "relevance" if state value is not a string', () => {
+		expect( getSort( {} ) ).toEqual( RELEVANCE_SORT_KEY );
+		expect( getSort( { sort: 1 } ) ).toEqual( RELEVANCE_SORT_KEY );
+		expect( getSort( { sort: null } ) ).toEqual( RELEVANCE_SORT_KEY );
+		expect( getSort( { sort: {} } ) ).toEqual( RELEVANCE_SORT_KEY );
+	} );
+	test( 'returns the state value if it is a string', () => {
+		expect( getSort( { sort: 'some string' } ) ).toEqual( 'some string' );
+		expect( getSort( { sort: 'relevance' } ) ).toEqual( 'relevance' );
+	} );
+} );
+
+describe( 'hasActiveQuery', () => {
+	test( 'returns false if reducers are at their initial values', () => {
+		expect( hasActiveQuery( { searchQuery: null, filters: {}, sort: null } ) ).toEqual( false );
+	} );
+	test( 'returns true if there is a defined search query', () => {
+		expect( hasActiveQuery( { searchQuery: '', filters: {}, sort: null } ) ).toEqual( true );
+		expect( hasActiveQuery( { searchQuery: 'hello', filters: {}, sort: null } ) ).toEqual( true );
+		expect( hasActiveQuery( { searchQuery: null, filters: {}, sort: null } ) ).toEqual( false );
+	} );
+	test( 'returns true if there are defined filters', () => {
+		expect(
+			hasActiveQuery( {
+				searchQuery: null,
+				filters: { post_types: [ 'post', 'page' ] },
+				sort: null,
+			} )
+		).toEqual( true );
+		expect( hasActiveQuery( { searchQuery: null, filters: {}, sort: null } ) ).toEqual( false );
+	} );
+	test( 'returns true if there is a defined sort value', () => {
+		expect( hasActiveQuery( { searchQuery: null, filters: {}, sort: 'relevance' } ) ).toEqual(
+			true
+		);
+		expect( hasActiveQuery( { searchQuery: null, filters: {}, sort: null } ) ).toEqual( false );
+	} );
+} );
 
 describe( 'getWidgetOutsideOverlay', () => {
 	test( 'defaults to an object with an empty array for the filters value for a clean state', () => {

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/selectors.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/selectors.test.js
@@ -15,6 +15,19 @@ describe( 'getSort', () => {
 		expect( getSort( { sort: null } ) ).toEqual( RELEVANCE_SORT_KEY );
 		expect( getSort( { sort: {} } ) ).toEqual( RELEVANCE_SORT_KEY );
 	} );
+	test( 'if specified, defaults to a specified defaultSort when the state value is not a string', () => {
+		expect( getSort( {}, 'abc' ) ).toEqual( 'abc' );
+		expect( getSort( { sort: 1 }, 'abc' ) ).toEqual( 'abc' );
+		expect( getSort( { sort: null }, 'abc' ) ).toEqual( 'abc' );
+		expect( getSort( { sort: {} }, 'abc' ) ).toEqual( 'abc' );
+	} );
+	test( 'if a non-string defaultSort value is specified, defaults to "relevance" instead', () => {
+		expect( getSort( {}, {} ) ).toEqual( 'relevance' );
+		expect( getSort( {}, 1 ) ).toEqual( 'relevance' );
+		expect( getSort( {}, null ) ).toEqual( 'relevance' );
+		expect( getSort( {}, true ) ).toEqual( 'relevance' );
+		expect( getSort( {}, undefined ) ).toEqual( 'relevance' );
+	} );
 	test( 'returns the state value if it is a string', () => {
 		expect( getSort( { sort: 'some string' } ) ).toEqual( 'some string' );
 		expect( getSort( { sort: 'relevance' } ) ).toEqual( 'relevance' );

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -219,7 +219,6 @@
 	"projects/plugins/jetpack/modules/search/instant-search/lib/colors.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/customize.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/dom.js",
-	"projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/tracks.js",
 	"projects/plugins/jetpack/modules/shortcodes/js/jmpress.js",
 	"projects/plugins/jetpack/modules/shortcodes/js/recipes-printthis.js",


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/18455.
Fixes #18555.
Fixes #18701.
Fixes #18667.
Fixes 1250-gh-Automattic/p2.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Open search results in the current tab rather than opening a new tab with `target="_blank"`.
* Fixes integration with browser history navigation (back/forward). For example, if you search without a query, click a result link, then hit back, the search overlay will now reappear.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
On a site with Instant Search enabled, ensure that search result links all open in the same window (including image links). When you press the back button, the search modal should be redisplayed, even if you did not originally specify a search query.

On a site with a search modal trigger (like Twenty Twenty), make sure that the search modal opens with the URL `/?s=`. Make sure this is removed when the modal is closed.

<img width="1413" alt="Screen Shot 2021-01-27 at 14 07 09" src="https://user-images.githubusercontent.com/17325/105927519-08e69200-60a9-11eb-9bfd-8ba9a0fdb1a0.png">

#### Proposed changelog entry for your changes:
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Instant Search: open search result links in the current window rather than opening a new one.
* Instant Search: improves compatibility with browser forward/back navigation.