### PR TITLE
Anchor.fm: align podcast vertical int the middle

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -37,8 +37,9 @@ function podcastSection( { episodeTrack } ) {
 		},
 		[
 			[
-				'core/column',
-				{ width: '30%' },
+				'core/column', {
+					width: '30%',
+				},
 				[
 					[
 						'core/image',
@@ -49,8 +50,10 @@ function podcastSection( { episodeTrack } ) {
 				],
 			],
 			[
-				'core/column',
-				{ width: '70%' },
+				'core/column', {
+					width: '70%',
+					verticalAlignment: 'center',
+				},
 				[
 					[
 						'jetpack/podcast-player',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR set the podcast player vertically aligned in the middle with respect to the column when the episode is created.

Fixes #18469

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Anchor.fm: align podcast vertical int the middle

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start to create a new episode from anchor.fm
* Confirm that the podcast player is vertically aligned in the middle of the column

Aligment toolbar button | Middle is activated
![image](https://user-images.githubusercontent.com/77539/105381427-c119c380-5bed-11eb-9c10-1f7b1ad3c570.png) | ![image](https://user-images.githubusercontent.com/77539/105381510-d8f14780-5bed-11eb-9b51-08f371aba4ac.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
n/a
