### PR TITLE
Anchor.fm: set episode content with enrich text

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -162,6 +162,28 @@ class Jetpack_Podcast_Helper {
 	}
 
 	/**
+	 * Formats strings as safe HTML.
+	 *
+	 * @param string $str Input string.
+	 * @return string HTML text string.
+	 */
+	protected function get_rich_text( $str ) {
+		// Trim string and return if empty.
+		$str = trim( (string) $str );
+		if ( empty( $str ) ) {
+			return '';
+		}
+
+		// Make sure HTML is safe.
+		$str = wp_kses_post( $str );
+
+		// Replace all entities with their characters, including all types of quotes.
+		$str = html_entity_decode( $str, ENT_QUOTES );
+
+		return $str;
+	}
+
+	/**
 	 * Loads an RSS feed using `fetch_feed`.
 	 *
 	 * @return SimplePie|WP_Error The RSS object or error.
@@ -217,14 +239,15 @@ class Jetpack_Podcast_Helper {
 
 		// Build track data.
 		$track = array(
-			'id'          => wp_unique_id( 'podcast-track-' ),
-			'link'        => esc_url( $episode->get_link() ),
-			'src'         => esc_url( $enclosure->link ),
-			'type'        => esc_attr( $enclosure->type ),
-			'description' => $this->get_plain_text( $episode->get_description() ),
-			'title'       => $this->get_plain_text( $episode->get_title() ),
-			'image'       => esc_url( $this->get_episode_image_url( $episode ) ),
-			'guid'        => $this->get_plain_text( $episode->get_id() ),
+			'id'                 => wp_unique_id( 'podcast-track-' ),
+			'link'               => esc_url( $episode->get_link() ),
+			'src'                => esc_url( $enclosure->link ),
+			'type'               => esc_attr( $enclosure->type ),
+			'description'        => $this->get_plain_text( $episode->get_description() ),
+			'enrich_description' => $this->get_rich_text( $episode->get_description() ),
+			'title'              => $this->get_plain_text( $episode->get_title() ),
+			'image'              => esc_url( $this->get_episode_image_url( $episode ) ),
+			'guid'               => $this->get_plain_text( $episode->get_id() ),
 		);
 
 		if ( empty( $track['title'] ) ) {

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -146,36 +146,39 @@ class Jetpack_Podcast_Helper {
 	 * @return string Plain text string.
 	 */
 	protected function get_plain_text( $str ) {
-		// Trim string and return if empty.
-		$str = trim( (string) $str );
-		if ( empty( $str ) ) {
-			return '';
-		}
-
-		// Make sure there are no tags.
-		$str = wp_strip_all_tags( $str );
-
-		// Replace all entities with their characters, including all types of quotes.
-		$str = html_entity_decode( $str, ENT_QUOTES );
-
-		return $str;
+		return $this->sanitize_and_decode_text( $str, true );
 	}
 
 	/**
 	 * Formats strings as safe HTML.
 	 *
 	 * @param string $str Input string.
-	 * @return string HTML text string.
+	 * @return string HTML text string safe for post_content.
 	 */
-	protected function get_rich_text( $str ) {
+	protected function get_html_text( $str ) {
+		return $this->sanitize_and_decode_text( $str, false );
+	}
+
+	/**
+	 * Strip unallowed html tags and decode entities.
+	 *
+	 * @param string  $str Input string.
+	 * @param boolean $strip_all_tags Strip all tags, otherwise allow post_content safe tags.
+	 * @return string Sanitized and decoded text.
+	 */
+	protected function sanitize_and_decode_text( $str, $strip_all_tags = true ) {
 		// Trim string and return if empty.
 		$str = trim( (string) $str );
 		if ( empty( $str ) ) {
 			return '';
 		}
 
-		// Make sure HTML is safe.
-		$str = wp_kses_post( $str );
+		if ( $strip_all_tags ) {
+			// Make sure there are no tags.
+			$str = wp_strip_all_tags( $str );
+		} else {
+			$str = wp_kses_post( $str );
+		}
 
 		// Replace all entities with their characters, including all types of quotes.
 		$str = html_entity_decode( $str, ENT_QUOTES );
@@ -239,15 +242,15 @@ class Jetpack_Podcast_Helper {
 
 		// Build track data.
 		$track = array(
-			'id'                 => wp_unique_id( 'podcast-track-' ),
-			'link'               => esc_url( $episode->get_link() ),
-			'src'                => esc_url( $enclosure->link ),
-			'type'               => esc_attr( $enclosure->type ),
-			'description'        => $this->get_plain_text( $episode->get_description() ),
-			'enrich_description' => $this->get_rich_text( $episode->get_description() ),
-			'title'              => $this->get_plain_text( $episode->get_title() ),
-			'image'              => esc_url( $this->get_episode_image_url( $episode ) ),
-			'guid'               => $this->get_plain_text( $episode->get_id() ),
+			'id'               => wp_unique_id( 'podcast-track-' ),
+			'link'             => esc_url( $episode->get_link() ),
+			'src'              => esc_url( $enclosure->link ),
+			'type'             => esc_attr( $enclosure->type ),
+			'description'      => $this->get_plain_text( $episode->get_description() ),
+			'description_html' => $this->get_html_text( $episode->get_description() ),
+			'title'            => $this->get_plain_text( $episode->get_title() ),
+			'image'            => esc_url( $this->get_episode_image_url( $episode ) ),
+			'guid'             => $this->get_plain_text( $episode->get_id() ),
 		);
 
 		if ( empty( $track['title'] ) ) {

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -353,29 +353,33 @@ class Jetpack_Podcast_Helper {
 			'items'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'id'          => array(
+					'id'               => array(
 						'description' => __( 'The episode id. Generated per request, not globally unique.', 'jetpack' ),
 						'type'        => 'string',
 					),
-					'link'        => array(
+					'link'             => array(
 						'description' => __( 'The external link for the episode.', 'jetpack' ),
 						'type'        => 'string',
 						'format'      => 'uri',
 					),
-					'src'         => array(
+					'src'              => array(
 						'description' => __( 'The audio file URL of the episode.', 'jetpack' ),
 						'type'        => 'string',
 						'format'      => 'uri',
 					),
-					'type'        => array(
+					'type'             => array(
 						'description' => __( 'The mime type of the episode.', 'jetpack' ),
 						'type'        => 'string',
 					),
-					'description' => array(
+					'description'      => array(
 						'description' => __( 'The episode description, in plaintext.', 'jetpack' ),
 						'type'        => 'string',
 					),
-					'title'       => array(
+					'description_html' => array(
+						'description' => __( 'The episode description, with allowed html tags.', 'jetpack' ),
+						'type'        => 'string',
+					),
+					'title'            => array(
 						'description' => __( 'The episode title.', 'jetpack' ),
 						'type'        => 'string',
 					),

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -86,7 +86,7 @@ function podcastSummarySection( { episodeTrack } ) {
 				'core/paragraph',
 				{
 					placeholder: __( 'Podcast episode summary', 'jetpack' ),
-					content: episodeTrack.description,
+					content: episodeTrack.enrich_description,
 				},
 			],
 		],

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -86,7 +86,7 @@ function podcastSummarySection( { episodeTrack } ) {
 				'core/paragraph',
 				{
 					placeholder: __( 'Podcast episode summary', 'jetpack' ),
-					content: episodeTrack.enrich_description,
+					content: episodeTrack.description_html,
 				},
 			],
 		],
@@ -95,7 +95,9 @@ function podcastSummarySection( { episodeTrack } ) {
 
 function podcastConversationSection() {
 	const conversationBlockName = 'jetpack/conversation';
-	const isConversationBlockAvailable = select( 'core/blocks' ).getBlockType( conversationBlockName );
+	const isConversationBlockAvailable = select( 'core/blocks' ).getBlockType(
+		conversationBlockName
+	);
 
 	// Check if `jetpack/conversation` block is register.
 	if ( ! isConversationBlockAvailable ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR allows renders the episode content with enrich text (save HTML) instead of plain text.

Fixes https://github.com/Automattic/jetpack/issues/18470

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Anchor.fm: set episode content with enrich text

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an episode podcast post form anchor.fm
* Confirm the episode summary is rendered with HTML< paying attention to links, paragraphs, etc

**before** | **after**
---------|----------
<img width="600" src="https://user-images.githubusercontent.com/77539/105385204-d4c72900-5bf1-11eb-85d5-a0f27761338e.png" /> | <img width="600" alt="Screen Shot 2021-01-21 at 2 05 34 PM" src="https://user-images.githubusercontent.com/77539/105385222-ddb7fa80-5bf1-11eb-922a-e9b022567008.png">

* Confirm that podcast player content is still rendered with plain text

<img src="https://user-images.githubusercontent.com/77539/105385285-f2948e00-5bf1-11eb-9807-31b0d7202d27.png" width="500px" />

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
n/a
