### PR TITLE
Masterbar: avoid notices when no plan is available on site.

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -937,7 +937,7 @@ class Masterbar {
 				array(
 					'url'   => $plans_url,
 					'id'    => 'wp-admin-bar-plan-badge',
-					'label' => $plan['product_name_short'],
+					'label' => ! empty( $plan['product_name_short'] ) ? $plan['product_name_short'] : esc_html__( 'Free', 'jetpack' ),
 				)
 			);
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Avoid a PHP notice when trying to display plan information about a site without a plan.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Create a new Ephemeral site with the Jetpack Beta plugin, running `master`
* Enable nav-unification on that site with:
```php
add_filter( 'jetpack_load_admin_menu_class', '__return_true' );

// no calypso links though
add_filter( 'jetpack_admin_menu_use_calypso_links', '__return_false' );
```
* Connect the site to WordPress.com, but do not pick a plan.
* Go to Jetpack > Settings > Writing, enable the WordPress.com toolbar.
* Notice the PHP notice when viewing the dashboard.
* Switch to this branch, the notices should disappear.

#### Proposed changelog entry for your changes:

* N/A
