### PR TITLE
Anchor.fm: show episode summary with post_content safe html

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -179,6 +179,28 @@ class Jetpack_Podcast_Helper {
 	}
 
 	/**
+	 * Formats strings as safe HTML.
+	 *
+	 * @param string $str Input string.
+	 * @return string HTML text string.
+	 */
+	protected function get_rich_text( $str ) {
+		// Trim string and return if empty.
+		$str = trim( (string) $str );
+		if ( empty( $str ) ) {
+			return '';
+		}
+
+		// Make sure HTML is safe.
+		$str = wp_kses_post( $str );
+
+		// Replace all entities with their characters, including all types of quotes.
+		$str = html_entity_decode( $str, ENT_QUOTES );
+
+		return $str;
+	}
+
+	/**
 	 * Loads an RSS feed using `fetch_feed`.
 	 *
 	 * @return SimplePie|WP_Error The RSS object or error.
@@ -234,14 +256,15 @@ class Jetpack_Podcast_Helper {
 
 		// Build track data.
 		$track = array(
-			'id'          => wp_unique_id( 'podcast-track-' ),
-			'link'        => esc_url( $episode->get_link() ),
-			'src'         => esc_url( $enclosure->link ),
-			'type'        => esc_attr( $enclosure->type ),
-			'description' => $this->get_plain_text( $episode->get_description() ),
-			'title'       => $this->get_plain_text( $episode->get_title() ),
-			'image'       => esc_url( $this->get_episode_image_url( $episode ) ),
-			'guid'        => $this->get_plain_text( $episode->get_id() ),
+			'id'                 => wp_unique_id( 'podcast-track-' ),
+			'link'               => esc_url( $episode->get_link() ),
+			'src'                => esc_url( $enclosure->link ),
+			'type'               => esc_attr( $enclosure->type ),
+			'description'        => $this->get_plain_text( $episode->get_description() ),
+			'enrich_description' => $this->get_rich_text( $episode->get_description() ),
+			'title'              => $this->get_plain_text( $episode->get_title() ),
+			'image'              => esc_url( $this->get_episode_image_url( $episode ) ),
+			'guid'               => $this->get_plain_text( $episode->get_id() ),
 		);
 
 		if ( empty( $track['title'] ) ) {

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -393,7 +393,7 @@ class Jetpack_Podcast_Helper {
 						'type'        => 'string',
 					),
 					'description_html' => array(
-						'description' => __( 'The episode description, with allowed html tags.', 'jetpack' ),
+						'description' => __( 'The episode description with allowed html tags.', 'jetpack' ),
 						'type'        => 'string',
 					),
 					'title'            => array(

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -163,36 +163,39 @@ class Jetpack_Podcast_Helper {
 	 * @return string Plain text string.
 	 */
 	protected function get_plain_text( $str ) {
-		// Trim string and return if empty.
-		$str = trim( (string) $str );
-		if ( empty( $str ) ) {
-			return '';
-		}
-
-		// Make sure there are no tags.
-		$str = wp_strip_all_tags( $str );
-
-		// Replace all entities with their characters, including all types of quotes.
-		$str = html_entity_decode( $str, ENT_QUOTES );
-
-		return $str;
+		return $this->sanitize_and_decode_text( $str, true );
 	}
 
 	/**
 	 * Formats strings as safe HTML.
 	 *
 	 * @param string $str Input string.
-	 * @return string HTML text string.
+	 * @return string HTML text string safe for post_content.
 	 */
-	protected function get_rich_text( $str ) {
+	protected function get_html_text( $str ) {
+		return $this->sanitize_and_decode_text( $str, false );
+	}
+
+	/**
+	 * Strip unallowed html tags and decode entities.
+	 *
+	 * @param string  $str Input string.
+	 * @param boolean $strip_all_tags Strip all tags, otherwise allow post_content safe tags.
+	 * @return string Sanitized and decoded text.
+	 */
+	protected function sanitize_and_decode_text( $str, $strip_all_tags = true ) {
 		// Trim string and return if empty.
 		$str = trim( (string) $str );
 		if ( empty( $str ) ) {
 			return '';
 		}
 
-		// Make sure HTML is safe.
-		$str = wp_kses_post( $str );
+		if ( $strip_all_tags ) {
+			// Make sure there are no tags.
+			$str = wp_strip_all_tags( $str );
+		} else {
+			$str = wp_kses_post( $str );
+		}
 
 		// Replace all entities with their characters, including all types of quotes.
 		$str = html_entity_decode( $str, ENT_QUOTES );
@@ -256,15 +259,15 @@ class Jetpack_Podcast_Helper {
 
 		// Build track data.
 		$track = array(
-			'id'                 => wp_unique_id( 'podcast-track-' ),
-			'link'               => esc_url( $episode->get_link() ),
-			'src'                => esc_url( $enclosure->link ),
-			'type'               => esc_attr( $enclosure->type ),
-			'description'        => $this->get_plain_text( $episode->get_description() ),
-			'enrich_description' => $this->get_rich_text( $episode->get_description() ),
-			'title'              => $this->get_plain_text( $episode->get_title() ),
-			'image'              => esc_url( $this->get_episode_image_url( $episode ) ),
-			'guid'               => $this->get_plain_text( $episode->get_id() ),
+			'id'               => wp_unique_id( 'podcast-track-' ),
+			'link'             => esc_url( $episode->get_link() ),
+			'src'              => esc_url( $enclosure->link ),
+			'type'             => esc_attr( $enclosure->type ),
+			'description'      => $this->get_plain_text( $episode->get_description() ),
+			'description_html' => $this->get_html_text( $episode->get_description() ),
+			'title'            => $this->get_plain_text( $episode->get_title() ),
+			'image'            => esc_url( $this->get_episode_image_url( $episode ) ),
+			'guid'             => $this->get_plain_text( $episode->get_id() ),
 		);
 
 		if ( empty( $track['title'] ) ) {

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -370,29 +370,33 @@ class Jetpack_Podcast_Helper {
 			'items'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'id'          => array(
+					'id'               => array(
 						'description' => __( 'The episode id. Generated per request, not globally unique.', 'jetpack' ),
 						'type'        => 'string',
 					),
-					'link'        => array(
+					'link'             => array(
 						'description' => __( 'The external link for the episode.', 'jetpack' ),
 						'type'        => 'string',
 						'format'      => 'uri',
 					),
-					'src'         => array(
+					'src'              => array(
 						'description' => __( 'The audio file URL of the episode.', 'jetpack' ),
 						'type'        => 'string',
 						'format'      => 'uri',
 					),
-					'type'        => array(
+					'type'             => array(
 						'description' => __( 'The mime type of the episode.', 'jetpack' ),
 						'type'        => 'string',
 					),
-					'description' => array(
+					'description'      => array(
 						'description' => __( 'The episode description, in plaintext.', 'jetpack' ),
 						'type'        => 'string',
 					),
-					'title'       => array(
+					'description_html' => array(
+						'description' => __( 'The episode description, with allowed html tags.', 'jetpack' ),
+						'type'        => 'string',
+					),
+					'title'            => array(
 						'description' => __( 'The episode title.', 'jetpack' ),
 						'type'        => 'string',
 					),

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -92,7 +92,7 @@ function podcastSummarySection( { episodeTrack } ) {
 				'core/paragraph',
 				{
 					placeholder: __( 'Podcast episode summary', 'jetpack' ),
-					content: episodeTrack.enrich_description,
+					content: episodeTrack.description_html,
 				},
 			],
 		],

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -92,7 +92,7 @@ function podcastSummarySection( { episodeTrack } ) {
 				'core/paragraph',
 				{
 					placeholder: __( 'Podcast episode summary', 'jetpack' ),
-					content: episodeTrack.description,
+					content: episodeTrack.enrich_description,
 				},
 			],
 		],


### PR DESCRIPTION
Fixes #18470 

Builds on #18474

#### Changes proposed in this Pull Request:

* Adds a `description_html` to /podcast-player endpoint, filtering the episode description with `wp_kses_post`
* Uses that description for the episode summary when creating a single episode post for anchor.fm podcasts

#### Jetpack product discussion

pbAPfg-PF-p2

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Create a new episode post, using a link like `http://localhost:8000/wp-admin/post-new.php?anchor_episode=547d02ae-abde-462d-92af-3de55ed5bcd2&anchor_podcast=22b6608`
* See that the summary in the post contains links and line breaks
* Turn on the episode description in the podcast player block, and confirm it still uses the 
* Publish the post, and confirm the same on the front-end


**before** | **after**
---------|----------
<img width="600" src="https://user-images.githubusercontent.com/77539/105385204-d4c72900-5bf1-11eb-85d5-a0f27761338e.png" /> | <img width="600" alt="Screen Shot 2021-01-21 at 2 05 34 PM" src="https://user-images.githubusercontent.com/77539/105385222-ddb7fa80-5bf1-11eb-922a-e9b022567008.png">

#### Proposed changelog entry for your changes:
* Anchor.fm block: allow safe html in episode summary
