### PR TITLE
Instant Search: open search results in current tab

### DIFF
--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -163,7 +163,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),
 			'excludedPostTypes'     => $excluded_post_types,
-			'searchResultTarget'    => '_blank',
+			'searchResultTarget'    => '_self',
 
 			// widget info.
 			'hasOverlayWidgets'     => count( $overlay_widget_ids ) > 0,

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -163,6 +163,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),
 			'excludedPostTypes'     => $excluded_post_types,
+			'searchResultTarget'    => '_blank',
 
 			// widget info.
 			'hasOverlayWidgets'     => count( $overlay_widget_ids ) > 0,

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -280,6 +280,7 @@ class SearchApp extends Component {
 					response={ this.props.response }
 					resultFormat={ resultFormat }
 					searchQuery={ this.props.searchQuery }
+					searchResultTarget={ this.props.options.searchResultTarget }
 					showPoweredBy={ this.state.overlayOptions.showPoweredBy }
 					sort={ this.props.sort }
 					widgets={ this.props.options.widgets }

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
@@ -25,7 +25,7 @@ export default function SearchResultExpanded( props ) {
 		: fields[ 'image.url.raw' ];
 	return (
 		<li
-			className={ `jetpack-instant-search__result-expanded 
+			className={ `jetpack-instant-search__result-expanded
 			jetpack-instant-search__result-expanded--${ fields.post_type }
 			${ ! firstImage ? 'jetpack-instant-search__result-expanded--no-image' : '' }` }
 		>
@@ -36,7 +36,7 @@ export default function SearchResultExpanded( props ) {
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						onClick={ props.onClick }
 						rel="noopener noreferrer"
-						target="_blank"
+						target={ this.props.target }
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>
@@ -62,7 +62,7 @@ export default function SearchResultExpanded( props ) {
 					href={ `//${ fields[ 'permalink.url.raw' ] }` }
 					onClick={ props.onClick }
 					rel="noopener noreferrer"
-					target="_blank"
+					target={ this.props.target }
 				>
 					{ firstImage ? (
 						// NOTE: Wouldn't it be amazing if we filled the container's background

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-minimal.jsx
@@ -107,7 +107,7 @@ class SearchResultMinimal extends Component {
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						onClick={ this.props.onClick }
 						rel="noopener noreferrer"
-						target="_blank"
+						target={ this.props.target }
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
@@ -40,7 +40,7 @@ class SearchResultProduct extends Component {
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						onClick={ this.props.onClick }
 						rel="noopener noreferrer"
-						target="_blank"
+						target={ this.props.target }
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: title } }
 					/>
@@ -50,7 +50,7 @@ class SearchResultProduct extends Component {
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						onClick={ this.props.onClick }
 						rel="noopener noreferrer"
-						target="_blank"
+						target={ this.props.target }
 					>
 						<PhotonImage
 							alt=""

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
@@ -72,7 +72,7 @@ class SearchResults extends Component {
 					// eslint-disable-next-line react/no-danger
 					dangerouslySetInnerHTML={ {
 						__html: `
-							.jetpack-instant-search__search-results .jetpack-instant-search__search-results-primary mark { 
+							.jetpack-instant-search__search-results .jetpack-instant-search__search-results-primary mark {
 								color: ${ textColor };
 								background-color: ${ highlightColor };
 							}
@@ -133,6 +133,7 @@ class SearchResults extends Component {
 								railcar={ this.props.isVisible ? result.railcar : null }
 								result={ result }
 								resultFormat={ this.props.resultFormat }
+								target={ this.props.searchResultTarget }
 							/>
 						) ) }
 					</ol>


### PR DESCRIPTION
Fixes #18455
Fixes https://github.com/Automattic/p2/issues/1250

#### Changes proposed in this Pull Request:
- Add a prop down the `SearchApp` tree that determines search result targets
- Set a default value of `_self` in the PHP code that builds the default options.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

TBD

#### Proposed changelog entry for your changes:

* Instant Search: open search result links in the current window rather than opening a new one by default.