### PR TITLE
Anchor.FM: Pass the cover art and feed URL to the episode template

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -120,12 +120,15 @@ function process_anchor_params() {
 						);
 
 						$self_links = $rss->get_links( 'self' );
+						$cover      = $rss->get_image_url();
+						$cover      = ! empty( $cover ) ? esc_url( $cover ) : null;
 
 						// Add insert basic template action.
 						$data['actions'][] = array(
 							'insert-episode-template',
 							array(
 								'feedUrl'         => ! empty( $self_links ) ? esc_url_raw( $self_links[0] ) : $feed,
+								'coverImage'      => $cover,
 								'episodeTrack'    => $track,
 								'spotifyImageUrl' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
 								'spotifyShowUrl'  => $spotify_show_url,

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -119,10 +119,13 @@ function process_anchor_params() {
 							),
 						);
 
+						$self_links = $rss->get_links( 'self' );
+
 						// Add insert basic template action.
 						$data['actions'][] = array(
 							'insert-episode-template',
 							array(
+								'feedUrl'         => ! empty( $self_links ) ? esc_url_raw( $self_links[0] ) : $feed,
 								'episodeTrack'    => $track,
 								'spotifyImageUrl' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
 								'spotifyShowUrl'  => $spotify_show_url,

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -121,14 +121,13 @@ function process_anchor_params() {
 
 						$self_links = $rss->get_links( 'self' );
 						$cover      = $rss->get_image_url();
-						$cover      = ! empty( $cover ) ? esc_url( $cover ) : null;
 
 						// Add insert basic template action.
 						$data['actions'][] = array(
 							'insert-episode-template',
 							array(
 								'feedUrl'         => ! empty( $self_links ) ? esc_url_raw( $self_links[0] ) : $feed,
-								'coverImage'      => $cover,
+								'coverImage'      => ! empty( $cover ) ? esc_url( $cover ) : null,
 								'episodeTrack'    => $track,
 								'spotifyImageUrl' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
 								'spotifyShowUrl'  => $spotify_show_url,

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -27,8 +27,8 @@ function spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) {
 	];
 }
 
-function podcastSection( { episodeTrack } ) {
-	const { image, link, guid } = episodeTrack;
+function podcastSection( { episodeTrack, feedUrl } ) {
+	const { image, guid } = episodeTrack;
 
 	return [
 		'core/columns',
@@ -37,7 +37,8 @@ function podcastSection( { episodeTrack } ) {
 		},
 		[
 			[
-				'core/column', {
+				'core/column',
+				{
 					width: '30%',
 				},
 				[
@@ -50,7 +51,8 @@ function podcastSection( { episodeTrack } ) {
 				],
 			],
 			[
-				'core/column', {
+				'core/column',
+				{
 					width: '70%',
 					verticalAlignment: 'center',
 				},
@@ -60,7 +62,7 @@ function podcastSection( { episodeTrack } ) {
 						{
 							customPrimaryColor: getIconColor(),
 							hexPrimaryColor: getIconColor(),
-							url: link,
+							url: feedUrl,
 							selectedEpisodes: guid ? [ { guid } ] : [],
 							showCoverArt: false,
 							showEpisodeTitle: false,
@@ -183,8 +185,8 @@ function podcastConversationSection() {
 /*
  * Template parts
  */
-function episodeBasicTemplate( { spotifyShowUrl, spotifyImageUrl, episodeTrack = {} } ) {
-	const tpl = [ podcastSection( { episodeTrack } ) ];
+function episodeBasicTemplate( { spotifyShowUrl, spotifyImageUrl, episodeTrack = {}, feedUrl } ) {
+	const tpl = [ podcastSection( { episodeTrack, feedUrl } ) ];
 
 	if ( spotifyShowUrl && spotifyImageUrl ) {
 		tpl.push( spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) );

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -27,7 +27,7 @@ function spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) {
 	];
 }
 
-function podcastSection( { episodeTrack, feedUrl } ) {
+function podcastSection( { episodeTrack, feedUrl, coverImage } ) {
 	const { image, guid } = episodeTrack;
 
 	return [
@@ -45,7 +45,7 @@ function podcastSection( { episodeTrack, feedUrl } ) {
 					[
 						'core/image',
 						{
-							url: image ? image : null,
+							url: image ? image : coverImage,
 						},
 					],
 				],
@@ -185,8 +185,14 @@ function podcastConversationSection() {
 /*
  * Template parts
  */
-function episodeBasicTemplate( { spotifyShowUrl, spotifyImageUrl, episodeTrack = {}, feedUrl } ) {
-	const tpl = [ podcastSection( { episodeTrack, feedUrl } ) ];
+function episodeBasicTemplate( {
+	spotifyShowUrl,
+	spotifyImageUrl,
+	episodeTrack = {},
+	feedUrl,
+	coverImage,
+} ) {
+	const tpl = [ podcastSection( { episodeTrack, feedUrl, coverImage } ) ];
 
 	if ( spotifyShowUrl && spotifyImageUrl ) {
 		tpl.push( spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18477

#### Changes proposed in this Pull Request:

This change passes the cover art URL and the feed URL to the front end so that they can be used when populating the podcast episode template. 

#### Jetpack product discussion

This is a bug fix.

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
As explained in #18477:

* Go to ` /wp-admin/post-new.php?anchor_episode=89113006-542a-11eb-b4f3-c3757114ae55&anchor_podcast=5243218` on a development site with beta extensions enabled.
* Notice that the cover image block and the podcast player are both displayed as placeholders
* Apply this change and go to the above URL again. The new post should have blocks set up correctly.

#### Proposed changelog entry for your changes:
Not needed as this is a bug with a feature that's not yet launched.
