### PR TITLE
Require plan_check for WhatsApp block

### DIFF
--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -44,6 +44,7 @@ class Jetpack_Plan {
 				'opentable',
 				'calendly',
 				'send-a-message',
+				'whatsapp-button',
 				'social-previews',
 
 				'core/video',

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/send-a-message.php
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/send-a-message.php
@@ -25,7 +25,6 @@ function register_block() {
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render_block',
-			'plan_check'      => true,
 		)
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/whatsapp-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/whatsapp-button.php
@@ -22,7 +22,10 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 function register_block() {
 	Blocks::jetpack_register_block(
 		BLOCK_NAME,
-		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_block',
+			'plan_check'      => true,
+		)
 	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
@@ -68,7 +68,7 @@ $icon-background-color: #fff;
 }
 
 .jetpack-upgrade-plan__hidden {
-	opacity: 0;
+	visibility: hidden;
 }
 
 // Tweak Banner depending on the context.

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -26,7 +26,7 @@
 		"repeat-visitor",
 		"revue",
 		"send-a-message",
-		"send-a-message/whatsapp-button",
+		"whatsapp-button",
 		"sharing",
 		"shortlinks",
 		"simple-payments",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 6262-gh-Automattic/jpop-issues

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The `whatsapp-button` block is only meant to be inserted as a child of parent block `send-a-message`, and both should only be available on paid plans. This is managed by setting `plan_check` at block registration on `send-a-message`. You're able to circumvent the plan checks, however, by opening the code editor and removing the parent `send-a-message` block.

This PR closes that loophole by moving the `plan_check` from the parent down to the child.

\*\***This should not be merged into the `update/enable-frontend-upgrade-nudges` branch. I'll rebase on master before merging. The intent is to allow easier testing the block with the new upgrade nudges for now.**\*\*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. First apply D55983-code to your sandbox
2. Sync this branch to your sandbox with a8c-wp-env
3. Manually update the `wp-content/mu-plugins/jetpack/class.jetpack-gutenberg.php` file in your sandbox to match the [class.jetpack-gutenberg.php](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/class.jetpack-gutenberg.php) file in your local jetpack. _(You need this to test the upgrade nudges. This code has been merged to master but not deployed to wpcom yet, and the a8c-wp-env will not automatically sync this for you.)_

For Wpcom:
* On a free site, create a post and add a WhatsApp block.
* Verify that you see an upgrade nudge in the editor
* Open the post on the frontend and verify that you see the block on the frontend, with an upgrade nudge
* Return to the post and enter the Code Editor
* Remove the `send-a-message` block wrapping the WhatsApp block
* Exit the Code Editor and verify that you still see an upgrade nudge in the editor
* View the post in the frontend again and verify that you still see the upgrade nudge


#### Screenshots

**View of the block in the code editor -- highlighted code should be removed:**
<img width="1010" alt="Screen Shot 2021-01-21 at 4 59 56 PM" src="https://user-images.githubusercontent.com/63313398/105431389-604cb400-5c0a-11eb-8626-f91642675c7e.png">
<img width="1005" alt="Screen Shot 2021-01-21 at 5 00 08 PM" src="https://user-images.githubusercontent.com/63313398/105431395-62167780-5c0a-11eb-806a-f6eb40f87be3.png">

**Normal WhatsApp block in the editor:**
<img width="828" alt="Screen Shot 2021-01-21 at 4 46 15 PM" src="https://user-images.githubusercontent.com/63313398/105431583-bae61000-5c0a-11eb-97e3-b3852abc9f0d.png">

**WhatsApp block in the editor when the parent SendAMessage has been removed:**
<img width="848" alt="Screen Shot 2021-01-21 at 4 46 36 PM" src="https://user-images.githubusercontent.com/63313398/105431617-ca655900-5c0a-11eb-962f-df21e4dd2475.png">


**Blocks on the frontend:**
<img width="771" alt="Screen Shot 2021-01-26 at 1 17 15 PM" src="https://user-images.githubusercontent.com/63313398/105907199-8e027600-5fd9-11eb-8138-3187e88d0772.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*