### PR TITLE
Map block: Remove resize event listener when component is unmounted

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/map/component.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/component.js
@@ -113,6 +113,7 @@ export class Map extends Component {
 	}
 	componentWillUnmount() {
 		this.debouncedSizeMap.cancel();
+		window.removeEventListener( 'resize', this.debouncedSizeMap );
 	}
 	componentDidUpdate( prevProps ) {
 		const {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

If using the Map block in a custom block preview (for example as part of a pattern in the page layout picker in: https://github.com/Automattic/wp-calypso/pull/49101), when the user switches their pattern selection and the Map block is unmounted, the `resize` listener continues to fire if the user resizes the window. This results in a TypeError in the console, because the DOM element for the Map component is no longer around:

![image](https://user-images.githubusercontent.com/14988353/105445885-1f65a580-5cc5-11eb-8205-ceb8d48df9e8.png)

The fix is to add a `removeEventListener` call when the component is unmounted.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* In the Map block's main component, add a `window.removeEventListener` call to remove the resize listener when the component is unmounted.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* For an example where the bug occurred apply https://github.com/Automattic/wp-calypso/pull/49101 in a sandbox, and go to add a new page.
* Select a page layout that includes the Map component (the second last one under the Contact heading).
* Then, select a different page layout.
* Resize the window.
* Without this change applied, you should see an error message similar to the screenshot above
* With the change applied, particular error should not appear

Test for regressions:

* Insert the Map block (or a pattern containing it) into a post or page
* Resize the editor, and the Map block should resize
* Publish the post or page, and check that resizing the window resizes the Map block

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fix bug where Map block resize event listener was not removed when component unmounts
