### PR TITLE
Dialogue: fix participant and timestamp color issue

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -11,6 +11,7 @@
 		line-height: 17px;
 		line-height: var( --global--line-height-body );
 		overflow-wrap: anywhere;
+		color: inherit;
 	}
 
 	.wp-block-jetpack-dialogue__timestamp {
@@ -19,6 +20,7 @@
 		text-align: right;
 		font-size: 16px;
 		white-space: nowrap;
+		color: inherit;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR fixes an issue about the color of the participant and timestamp label of the Dialogue component, in the editor canvas context.
Fixes https://github.com/Automattic/jetpack/issues/18488

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Dialogue: fix participant and timestamp color issue

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate the Spearhead theme
* create/edit a conversation block.
* Confirm now you see the participant and timestamp there

before | after
------|-------
![image](https://user-images.githubusercontent.com/77539/105490469-96824600-5c93-11eb-96c7-3594fb009839.png) | ![image](https://user-images.githubusercontent.com/77539/105490931-4d7ec180-5c94-11eb-82ed-5375bc547d9d.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
