### PR TITLE
Podcast Player: Selected Episode Changes

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
@@ -9,7 +9,7 @@ import { PODCAST_FEED, EMBED_BLOCK } from './constants';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
-export const fetchPodcastFeed = async ( { url, guids } ) => {
+export const fetchPodcastFeed = async ( { url, guids = [] } ) => {
 	// First try calling our endpoint for Podcast parsing.
 	let feedData, feedError;
 	try {

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
@@ -283,14 +283,16 @@ const PodcastPlayerEdit = ( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>
-					<RangeControl
-						label={ __( 'Number of items', 'jetpack' ) }
-						value={ itemsToShow }
-						onChange={ value => setAttributes( { itemsToShow: value } ) }
-						min={ DEFAULT_MIN_ITEMS }
-						max={ DEFAULT_MAX_ITEMS }
-						required
-					/>
+					{ 0 === selectedEpisodes.length && (
+						<RangeControl
+							label={ __( 'Number of items', 'jetpack' ) }
+							value={ itemsToShow }
+							onChange={ value => setAttributes( { itemsToShow: value } ) }
+							min={ DEFAULT_MIN_ITEMS }
+							max={ DEFAULT_MAX_ITEMS }
+							required
+						/>
+					) }
 
 					<ToggleControl
 						label={ __( 'Show Cover Art', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
@@ -98,8 +98,8 @@ const PodcastPlayerEdit = ( {
 	const [ isInteractive, setIsInteractive ] = useState( false );
 
 	const fetchFeed = useCallback(
-		( urlToFetch, guids = [] ) => {
-			cancellableFetch.current = makeCancellable( fetchPodcastFeed( { url: urlToFetch, guids } ) );
+		requestParams => {
+			cancellableFetch.current = makeCancellable( fetchPodcastFeed( requestParams ) );
 
 			cancellableFetch.current.promise.then(
 				response => {
@@ -155,10 +155,10 @@ const PodcastPlayerEdit = ( {
 
 		// Clean current podcast feed and fetch a new one.
 		setFeedData( {} );
-		fetchFeed(
+		fetchFeed( {
 			url,
-			selectedEpisodes.map( episode => episode.guid )
-		);
+			guids: selectedEpisodes.map( episode => episode.guid ),
+		} );
 		return () => cancellableFetch?.current?.cancel?.();
 	}, [ fetchFeed, removeAllNotices, url, selectedEpisodes ] );
 
@@ -204,7 +204,7 @@ const PodcastPlayerEdit = ( {
 			 * @see {@link https://github.com/Automattic/jetpack/pull/15213}
 			 */
 			if ( prependedURL === url ) {
-				fetchFeed( url );
+				fetchFeed( { url } );
 			} else {
 				setAttributes( { url: prependedURL } );
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This is a follow up to #18380. It does two things:

* Changes the parameters to the `fetchFeed` callback so that it accepts one object, [as suggested here](https://github.com/Automattic/jetpack/pull/18380#discussion_r561793341).
* [Removes the control to set the number of episodes to display](https://github.com/Automattic/jetpack/pull/18380#pullrequestreview-573619358) when the `selectedEpisodes` attribute is defined

#### Jetpack product discussion
This is part of the Anchor FM work, but also a general improvement to an existing feature.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
The same as #18380:

* Paste a link to create a new post that includes anchor_podcast and anchor_episode query parameters
For example: http://localhost:8000/wp-admin/post-new.php?anchor_episode=547d02ae-abde-462d-92af-3de55ed5bcd2&anchor_podcast=22b6608
* You should see a single player embedded in the episode.
* Additionally selecting the block and looking at the sidebar controls, the range control to select the number of episodes should not be present.
* Insert a podcast player block and set the feed. It should display the default 5 episodes, and the control to set the number of episodes should be shown in the sidebar.

#### Proposed changelog entry for your changes:
This is not a publicly accessible feature yet, so a change log is unnecessary.