### PR TITLE
Masterbar: Improve menu items when Nav Unification is enabled

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -277,3 +277,31 @@
 #wpadminbar #wp-admin-bar-menu-toggle {
 	display: none;
 }
+
+@media screen and (max-width: 782px) {
+	#wp-toolbar > ul > li {
+		display: block;
+	}
+
+	#wpadminbar .ab-top-menu > li > .ab-item {
+		box-sizing: border-box;
+		line-height: 32px;
+	}
+
+	#wpadminbar #wp-admin-bar-ab-new-post > .ab-item {
+		box-sizing: inherit;
+	}
+
+	#wpadminbar #wp-admin-bar-my-account > .ab-item {
+		padding: 7px 15px;
+		width: auto;
+	}
+
+	#wpadminbar .quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
+		display: block;
+		right: auto;
+		left: auto;
+		position: static;
+		margin-top: 3px;
+	}
+}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -86,6 +86,7 @@
 
 #adminmenu .toplevel_page_site-card.has-site-icon img {
 	padding: 0;
+	max-width: 100%;
 }
 
 #adminmenu .toplevel_page_site-card:hover div.wp-menu-image,

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -821,7 +821,7 @@ class Masterbar {
 				'parent' => 'root-default',
 				'id'     => 'blog',
 				'title'  => _n( 'My Site', 'My Sites', $this->user_site_count, 'jetpack' ),
-				'href'   => '#',
+				'href'   => 'https://wordpress.com/sites/' . $this->primary_site_url,
 				'meta'   => array(
 					'class' => 'my-sites mb-trackable',
 				),

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -441,12 +441,17 @@ class Masterbar {
 				'parent' => 'root-default',
 				'id'     => 'newdash',
 				'title'  => esc_html__( 'Reader', 'jetpack' ),
-				'href'   => '#',
+				'href'   => 'https://wordpress.com/read',
 				'meta'   => array(
 					'class' => 'mb-trackable',
 				),
 			)
 		);
+
+		/** This filter is documented in modules/masterbar.php */
+		if ( apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
+			return;
+		}
 
 		$wp_admin_bar->add_menu(
 			array(
@@ -606,12 +611,17 @@ class Masterbar {
 				'id'     => 'my-account',
 				'parent' => 'top-secondary',
 				'title'  => $avatar . '<span class="ab-text">' . esc_html__( 'Me', 'jetpack' ) . '</span>',
-				'href'   => '#',
+				'href'   => 'https://wordpress.com/me',
 				'meta'   => array(
 					'class' => $class,
 				),
 			)
 		);
+
+		/** This filter is documented in modules/masterbar.php */
+		if ( apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
+			return;
+		}
 
 		$id = 'user-actions';
 		$wp_admin_bar->add_group(
@@ -827,6 +837,11 @@ class Masterbar {
 				),
 			)
 		);
+
+		/** This filter is documented in modules/masterbar.php */
+		if ( apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
+			return;
+		}
 
 		if ( $this->user_site_count > 1 ) {
 			$wp_admin_bar->add_menu(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/49122

#### Changes proposed in this Pull Request:

- Set the same admin bar link destinations that we use for Simple sites. These new links are ignored when the Nav Unification is disabled (since we display a custom menu when clicking on any menu item), but are used when enabled, effectively fixing the issues described in https://github.com/Automattic/wp-calypso/issues/49122 and p7DVsv-ago-p2#comment-33901 that was preventing users from managing their site, their reader subscriptions and their account.
- Display the same menu items on small viewports that we display on Simple sites when the Nav Unification is enabled.
- Small CSS fix so larger site icons don't exceed the max width allowed.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

_Atomic_
* Use the Jetpack Beta plugin on an Atomic site and switch to this branch.
* On the frontend (any viewport):
    * Make sure "My Sites" redirects you to My Home in Calypso.
    * Make sure "Reader" redirects you to the Calypso Reader.
    * Make sure "Me" redirects you to your account page Calypso.
* On the admin (all viewports):
    * Make sure "My Sites" does not redirect to any place.
    * Make sure "Reader" redirects you to the Calypso Reader.
    * Make sure "Me" redirects you to your account page Calypso.

_Jetpack_
* Make sure the WordPress.com toolbar module is enabled.
* Make sure the Nav Unification is disabled (add `add_filter( 'jetpack_load_admin_menu_class', '__return_false' );`.
* On the frontend (desktop viewport):
    * Make sure "My Sites" shows a sidebar menu hidden on the left.
    * Make sure "Reader" shows a sidebar menu hidden on the left.
    * Make sure "Me" shows a sidebar menu hidden on the right.
* On the frontend (mobile viewport):
    * Make sure "My Sites" and "Reader" are hidden.
    * Make sure "Me" shows a sidebar menu hidden on the right.
* On the admin (desktop viewport):
    * Make sure "My Sites" shows a sidebar menu hidden on the left.
    * Make sure "Reader" shows a sidebar menu hidden on the left.
    * Make sure "Me" shows a sidebar menu hidden on the right.
* On the admin (mobile viewport):
    * Make sure "My Sites" ad "Reader" are hidden.
    * Make sure there is a new "Toggle menu" option that displays the admin menu.
    * Make sure "Me" shows a sidebar menu hidden on the right.
* Make sure the Nav Unification is enabled (add `add_filter( 'jetpack_load_admin_menu_class', '__return_true' );`.
* On the frontend (desktop viewport):
    * Make sure "My Sites" redirects you to Stats in Calypso (My Home is not supported on Jetpack sites).
    * Make sure "Reader" redirects you to the Calypso Reader.
    * Make sure "Me" redirects you to your account page Calypso.
* On the frontend (mobile viewport):
    * Make sure "My Sites" and "Reader" are hidden.
    * Make sure "Me" redirects you to your account page Calypso.
* On the admin (desktop viewport):
    * Make sure "My Sites" redirects you to Stats in Calypso (My Home is not supported on Jetpack sites).
    * Make sure "Reader" redirects you to the Calypso Reader.
    * Make sure "Me" redirects you to your account page Calypso.
* On the admin (mobile viewport):
    * Make sure "My Sites" opens the Admin menu.
    * Make sure "Reader" redirects you to the Calypso Reader.
    * Make sure "Me" redirects you to your account page Calypso.

#### Proposed changelog entry for your changes:
N/A.