### PR TITLE
Editor nudges: use colors from Color Studio

### DIFF
--- a/projects/plugins/jetpack/extensions/shared/components/upgrade-nudge/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/upgrade-nudge/style.scss
@@ -1,4 +1,5 @@
 @import '../../styles/gutenberg-base-styles.scss';
+@import "~@automattic/color-studio/dist/color-variables";
 
 .jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper {
 	display: flex;
@@ -6,13 +7,13 @@
 	align-items: center;
 	font-size: 14px;
 	height: 48px;
-	background: black;
+	background: $studio-black;
 	padding: 0 20px;
 	border-radius: 2px;
-	box-shadow: 0 0 1px inset #fff; }
+	box-shadow: 0 0 1px inset $studio-white; }
 	.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .banner-title,
 	.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .banner-description {
-		color: #fff; }
+		color: $studio-white; }
 	.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .jetpack-upgrade-plan-banner__title,
 	.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .jetpack-upgrade-plan-banner__description {
 		margin-right: 10px; }
@@ -22,13 +23,13 @@
 		margin-left: auto;
 		height: 28px; }
 		.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .components-button.is-primary {
-			background: #e34c84;
-			color: #fff; }
+			background: $studio-pink-40;
+			color: $studio-white; }
 		.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .components-button.is-primary:hover {
-			background: #eb6594; }
+			background: $studio-pink-30; }
 		.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .components-button.is-primary.is-busy {
 			background-size: 100px 100%;
-			background-image: linear-gradient(-45deg, #e34c84 28%, #ab235a 28%, #ab235a 72%, #e34c84 72%); }
+			background-image: linear-gradient(-45deg, $studio-pink-40 28%, $studio-pink-60 28%, $studio-pink-60 72%, $studio-pink-40 72%); }
 
 .jetpack-upgrade-plan-banner.block-editor-block-list__block {
 	margin-top: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* See discussion here:
See https://github.com/Automattic/jetpack/pull/18239#discussion_r562751038

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Apply D55864-code to your sandbox.
* Sandbox a free WordPress.com site.
* Open the editor and insert a Premium Content block.
* You should see an upgrade nudge with all its colors.

![image](https://user-images.githubusercontent.com/426388/105520501-1384de00-5cdb-11eb-9126-e8e7e6429287.png)


#### Proposed changelog entry for your changes:

* No
