### PR TITLE
Docker: Fix the monorepo package URLs fix.

### DIFF
--- a/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
+++ b/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
@@ -28,6 +28,10 @@ function jetpack_docker_plugins_url( $url, $path, $plugin ) {
 	global $wp_plugin_paths;
 	static $monorepo, $packages;
 
+	if ( ! class_exists( 'Jetpack' ) ) {
+		return $url;
+	}
+
 	if ( ! isset( $monorepo ) ) {
 		// Determine the path to the monorepo based on the path to Jetpack.
 		$monorepo = dirname( dirname( dirname( Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_DIR' ) ) ) ) . '/';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This is a minor fix that allows the mu-plugin "Fix monorepo plugins_url" to function with Jetpack plugin deactivated.

See #18432

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Pull the branch and go to Jetpack Dashboard. Verify that the file `jetpack-admin-jitm.min.css` is loaded correctly.
2. Disable the Jetpack plugin. The site should not fatal 🙂 

#### Proposed changelog entry for your changes:
n/a