### PR TITLE
WPCOM sync - adding cloudflare_analytics as valid site settings field

### DIFF
--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -404,6 +404,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						? get_lang_id_by_code( wpcom_l10n_get_blog_locale_variant( $blog_id, true ) )
 						: get_option( 'lang_id' ),
 						'wga'                              => $this->get_google_analytics(),
+						'cloudflare_analytics'             => get_option( 'cloudflare_analytics' ),
 						'disabled_likes'                   => (bool) get_option( 'disabled_likes' ),
 						'disabled_reblogs'                 => (bool) get_option( 'disabled_reblogs' ),
 						'jetpack_comment_likes_enabled'    => (bool) get_option( 'jetpack_comment_likes_enabled', false ),
@@ -487,7 +488,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 			}
 		}
-
 		return $response;
 
 	}
@@ -660,6 +660,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					if ( $is_wpcom ) {
 						$business_plugins = WPCOM_Business_Plugins::instance();
 						$business_plugins->activate_plugin( 'wp-google-analytics' );
+					}
+					break;
+
+				case 'cloudflare_analytics':
+					if ( ! isset( $value['code'] ) || ! preg_match( '/^$|^[a-fA-F0-9]+$/i', $value['code'] ) ) {
+						return new WP_Error( 'invalid_code', 'Invalid Cloudflare Analytics ID' );
+					}
+
+					if ( update_option( $key, $value ) ) {
+						$updated[ $key ] = $value;
 					}
 					break;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -665,7 +665,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'cloudflare_analytics':
 					if ( ! isset( $value['code'] ) || ! preg_match( '/^$|^[a-fA-F0-9]+$/i', $value['code'] ) ) {
-						return new WP_Error( 'invalid_code', 'Invalid Cloudflare Analytics ID' );
+						return new WP_Error( 'invalid_code', __( 'Invalid Cloudflare Analytics ID', 'jetpack' ) );
 					}
 
 					if ( update_option( $key, $value ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -72,6 +72,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'lang_id'                                 => '(int) ID for language blog is written in',
 		'locale'                                  => '(string) locale code for language blog is written in',
 		'wga'                                     => '(array) Google Analytics Settings',
+		'cloudflare_analytics'                    => '(array) Cloudflare Analytics Settings',
 		'disabled_likes'                          => '(bool) Are likes globally disabled (they can still be turned on per post)?',
 		'disabled_reblogs'                        => '(bool) Are reblogs disabled on posts?',
 		'jetpack_comment_likes_enabled'           => '(bool) Are comment likes enabled for all comments?',


### PR DESCRIPTION
Differential revision: D55521-code

This commit syncs r219912-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR updates the site settings JSON endpoint to allow storing of a Cloudflare Analytics tracking ID; it is a sync from a WPCOM revision.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm actually not sure what the exact process is for testing changes to API endpoints within Jetpack compared to testing the API on a WPCOM site. But you should be able to make a request to the site settings endpoint containing the body

```
{cloudflare_analytics: {code: "715d4d275266427cb78934b7919e73e6"}}
```

You should then be able to test that the site in question has a `cloudflare_analytics` site option set with this information.

See D55521-code for context/instructions there.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Added cloudflare_analytics as a valid field for site settings API POST request.