### PR TITLE
Masterbar: Limit site icon to 32px

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -72,7 +72,11 @@
 	transition-property: background-image,background-color;
 	transition-duration: .2s;
 	width: 32px;
+}
 
+#adminmenu .toplevel_page_site-card .wp-menu-image img {
+	height: auto;
+	max-width: 100%;
 }
 
 #adminmenu a.toplevel_page_site-card:hover,


### PR DESCRIPTION
This fixes a bug where legacy site icons can overflow their container, if no smaller sizes are available.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Limits site icons to their container size, 32px.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Atomic:
1. Apply this diff 
2. Set a site icon on your test site, if you haven't yet.
3. In dev-tools, change the image url to use a `150x150` or `300x300` size.
4. Make sure the visible image stays at 32px.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
None needed,
