### PR TITLE
Conversation: add Timestamps button to toolbar

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -8,7 +8,7 @@ import {
 	InspectorControls,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { Panel, PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
+import { Panel, PanelBody, ToggleControl, ToolbarButton, ToolbarGroup } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -112,6 +112,15 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 							onDelete={ deleteParticipant }
 							onAdd={ addNewParticipant }
 						/>
+					</ToolbarGroup>
+
+					<ToolbarGroup>
+						<ToolbarButton
+							isActive={ showTimestamps }
+							onClick={ () => setAttributes( { showTimestamps: ! showTimestamps } ) }
+						>
+							{ __( 'Timestamps', 'jetpack' ) }
+						</ToolbarButton>
 					</ToolbarGroup>
 				</BlockControls>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

It adds the `Timestamps` button to the block toolbar.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation: add Timestamps button to the toolbar

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

NO

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add/edit a Conversation block
* Once selected, confirm you see the `Timestamps` button
* Confirm it works as expected.

<img src="https://user-images.githubusercontent.com/77539/105551380-6d88a200-5ce1-11eb-9c50-2bdf4ab0aab1.png" width="500px" />
<img src="https://user-images.githubusercontent.com/77539/105551422-75e0dd00-5ce1-11eb-9fb5-2ab321f1af9d.png" width="500px" />


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
N/A
