### PR TITLE
Build: Remove yarn check check

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"docker:up": "yarn docker:compose up",
 		"docker:update-core-unit-tests": "yarn docker:compose exec wordpress svn up /tmp/wordpress-develop/tests/phpunit/data/ /tmp/wordpress-develop/tests/phpunit/includes",
 		"docker:wp": "yarn docker:compose exec wordpress wp --allow-root --path=/var/www/html/",
-		"install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files --production=false --frozen-lockfile",
+		"install-if-deps-outdated": "yarn install --check-files --production=false --frozen-lockfile",
 		"lint": "yarn lint-file .",
 		"lint-changed": "tools/eslint-changed.js --ext .js,.jsx --git",
 		"lint-file": "eslint --ext .js,.jsx",

--- a/projects/packages/lazy-images/package.json
+++ b/projects/packages/lazy-images/package.json
@@ -18,7 +18,7 @@
 		"build-production-js": "NODE_ENV=production BABEL_ENV=production yarn build-js && yarn validate-es5 ./src/",
 		"clean": "true",
 		"distclean": "rm -rf node_modules && yarn clean",
-		"install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files --production=false --frozen-lockfile",
+		"install-if-deps-outdated": "yarn install --check-files --production=false --frozen-lockfile",
 		"validate-es5": "eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore"
 	},
 	"devDependencies": {

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -35,7 +35,7 @@
 		"clean-extensions": "rm -rf _inc/blocks/ ",
 		"clean-search": "rm -rf _inc/build/instant-search/* ",
 		"distclean": "rm -rf node_modules && yarn clean",
-		"install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files --production=false --frozen-lockfile",
+		"install-if-deps-outdated": "yarn install --check-files --production=false --frozen-lockfile",
 		"test-adminpage": "yarn test-client && yarn test-gui",
 		"test-adminpage-and-extensions-and-search": "yarn concurrently 'yarn test-adminpage' 'yarn test-extensions' 'yarn test-search'",
 		"test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client tests/runner.js",


### PR DESCRIPTION
`yarn check` is buggy and deprecated. See https://classic.yarnpkg.com/en/docs/cli/check/#toc-yarn-check

`yarn install --check-files`, which we already have in the script, is the successor.

#### Changes proposed in this Pull Request:
* Remove deprecated yarn command.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* `yarn build`
* Does it still work after the initial step (calling `install-if-deps-outdated`).

#### Proposed changelog entry for your changes:
* n/a
