### PR TITLE
Ensure success page is displayed for Contact Form submissions from AMP pages

### DIFF
--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -341,7 +341,7 @@ class Grunion_Contact_Form_Plugin {
 	public static function gutenblock_render_form( $atts, $content ) {
 
 		// Render fallback in other contexts than frontend (i.e. feed, emails, API, etc.), unless the form is being submitted.
-		if ( ! jetpack_is_frontend() && ! isset( $_POST['contact-form-id'] ) ) {
+		if ( ! jetpack_is_frontend() && ! isset( $_POST['contact-form-id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return sprintf(
 				'<div class="%1$s"><a href="%2$s" target="_blank" rel="noopener noreferrer">%3$s</a></div>',
 				esc_attr( Blocks::classes( 'contact-form', $atts ) ),

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -339,8 +339,9 @@ class Grunion_Contact_Form_Plugin {
 	}
 
 	public static function gutenblock_render_form( $atts, $content ) {
-		// Render fallback in other contexts than frontend (i.e. feed, emails, API, etc.).
-		if ( ! jetpack_is_frontend() ) {
+
+		// Render fallback in other contexts than frontend (i.e. feed, emails, API, etc.), unless the form is being submitted.
+		if ( ! jetpack_is_frontend() && ! isset( $_POST['contact-form-id'] ) ) {
 			return sprintf(
 				'<div class="%1$s"><a href="%2$s" target="_blank" rel="noopener noreferrer">%3$s</a></div>',
 				esc_attr( Blocks::classes( 'contact-form', $atts ) ),


### PR DESCRIPTION
Fixes https://github.com/ampproject/amp-wp/issues/5803. 

When forms are submitted on AMP pages, the `amp-form` component issues an XHR request and is expecting a JSON response, as AMP prefers that success messages be displayed via Ajax if not performing a redirect. The XHR form submission request from AMP pages is resulting in the form not being successfully parsed as `jetpack_is_frontend()` returns `false` due to `wp_is_json_request()` returning `true`. The end result is that, while the form submission succeeds, the computed `contact-form-hash` is different and the success message is not displayed on the redirected AMP page.

Non-AMP Success Page | AMP Success Page
-------------------------|--------------------
`contact-form-id=2153`, `contact-form-sent=2218`, `contact-form-hash=407e1055a32766b664c507ac56aa03ded090b01d`, `_wpnonce=ec2fb80b9c` | `contact-form-id=2153`, `contact-form-sent=2216`, `contact-form-hash=d6fa1b4dbbb12ed8c1c3031a66fae797b5c6daf8`, `_wpnonce=5edd94bc14`, `amp=1`
![image](https://user-images.githubusercontent.com/134745/105624425-7313e400-5dd6-11eb-8023-ddc03c6cf441.png) | ![image](https://user-images.githubusercontent.com/134745/105624405-4b248080-5dd6-11eb-934e-5183969b40de.png)

#### Changes proposed in this Pull Request:

* Discounting `jetpack_is_frontend()` in `Grunion_Contact_Form_Plugin::gutenblock_render_form()` if doing a contact form submission (where `$_POST['contact-form-id']` is set). This fixes redirection to the success page when submitting from AMP pages.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a contact form block to a page.
2. View the AMP version of the page.
3. Submit the form.
4. Notice that no success message is displayed.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fix Contact Form submission compatibility with AMP.
