### PR TITLE
Docker: Don't try to be so fancy in the monorepo plugins_url fix

### DIFF
--- a/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
+++ b/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
@@ -12,8 +12,6 @@
 
 namespace Jetpack\Docker\MuPlugin\FixMonorepoPluginsUrl;
 
-use Automattic\Jetpack\Constants as Jetpack_Constants;
-
 /**
  * Fix the plugins_url in the Docker dev environment.
  *
@@ -26,17 +24,9 @@ use Automattic\Jetpack\Constants as Jetpack_Constants;
  */
 function jetpack_docker_plugins_url( $url, $path, $plugin ) {
 	global $wp_plugin_paths;
-	static $monorepo, $packages;
 
-	if ( ! class_exists( 'Jetpack' ) ) {
-		return $url;
-	}
-
-	if ( ! isset( $monorepo ) ) {
-		// Determine the path to the monorepo based on the path to Jetpack.
-		$monorepo = dirname( dirname( dirname( Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_DIR' ) ) ) ) . '/';
-		$packages = $monorepo . 'projects/packages/';
-	}
+	$monorepo = '/usr/local/src/jetpack-monorepo/';
+	$packages = $monorepo . 'projects/packages/';
 
 	if ( strpos( $url, $packages ) !== false && strpos( $plugin, $packages ) === 0 ) {
 		// Look through available monorepo plugins until we find one with the plugin symlink.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The monorepo path is hard-coded as /usr/local/src/jetpack-monorepo/ in a
few places in the Docker config. Let's just hard-code it here too
instead of adding dependencies trying to be fancy.

Fixes #18513

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#18513

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Same as #18499.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
