### PR TITLE
Conversation/Dialogue: new enhancements round

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -27,7 +27,7 @@ const TRANSCRIPTION_TEMPLATE = [
 ];
 
 function ConversationEdit( { className, attributes, setAttributes } ) {
-	const { participants = [], showTimestamps, className: classNameAttr } = attributes;
+	const { participants = [], showTimestamps } = attributes;
 
 	// Set initial conversation participants.
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useCallback } from '@wordpress/element';
+import { useEffect, useCallback, useMemo } from '@wordpress/element';
 import {
 	InnerBlocks,
 	InspectorControls,
@@ -54,9 +54,11 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		[ setAttributes, participants ]
 	);
 
+	const setBlockAttributes = useCallback( setAttributes, [] );
+
 	// Context bridge.
-	const contextProvision = {
-		setAttributes,
+	const contextProvision = useMemo( () => ( {
+		setAttributes: setBlockAttributes,
 		updateParticipants,
 		getParticipantIndex: slug => participants.map( part => part.participantSlug ).indexOf( slug ),
 		getNextParticipantIndex: ( slug, offset = 0 ) =>
@@ -66,9 +68,8 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 
 		attributes: {
 			showTimestamps,
-			classNameAttr,
 		},
-	};
+	} ), [ participants, setBlockAttributes, showTimestamps, updateParticipants ] );
 
 	function deleteParticipant( deletedParticipantSlug ) {
 		setAttributes( {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/example.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/example.js
@@ -68,7 +68,7 @@ export default {
 	attributes: {
 		participants,
 		showTimestamps: true,
-		className: 'is-style-column',
+		className: 'is-style-row',
 	},
 	innerBlocks: template,
 };

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -19,7 +19,7 @@ import {
 	ToolbarButton,
 	Button,
 } from '@wordpress/components';
-import { useContext, useState, useEffect, useLayoutEffect, useRef } from '@wordpress/element';
+import { useContext, useState, useEffect, useRef } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -62,7 +62,6 @@ export default function DialogueEdit( {
 	context,
 	onReplace,
 	mergeBlocks,
-	isSelected,
 } ) {
 	const {
 		participantSlug,
@@ -115,29 +114,6 @@ export default function DialogueEdit( {
 			content: '',
 		} );
 	}, [ participantSlug, participants, prevBlock, setAttributes, conversationBridge ] );
-
-	// Try to focus the RichText component when mounted.
-	const hasContent = content?.length > 0;
-	const richTextRefCurrent = richTextRef?.current;
-	useLayoutEffect( () => {
-		// Bail if component is not selected.
-		if ( ! isSelected ) {
-			return;
-		}
-
-		// Bail if context reference is not valid.
-		if ( ! richTextRefCurrent ) {
-			return;
-		}
-
-		// Bail if context is not empty.
-		if ( hasContent ) {
-			return;
-		}
-
-		// Focus the rich text component
-		richTextRefCurrent.focus();
-	}, [ isSelected, hasContent, richTextRefCurrent ] );
 
 	function hasStyle( style ) {
 		return currentParticipant?.[ style ];

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -38,16 +38,10 @@ import { MediaPlayerToolbarControl } from '../../shared/components/media-player-
 import { convertSecondsToTimeCode } from '../../shared/components/media-player-control/utils';
 
 function getParticipantBySlug( participants, slug ) {
-	const participant = find(
+	return find(
 		participants,
 		contextParticipant => contextParticipant.participantSlug === slug
 	);
-	if ( participant ) {
-		return participant;
-	}
-
-	// Fallback participant. First one in the list.
-	return participants?.[ 0 ];
 }
 
 const blockName = 'jetpack/dialogue';
@@ -123,6 +117,23 @@ export default function DialogueEdit( {
 			content: '',
 		} );
 	}, [ participantSlug, participants, prevBlock, setAttributes, conversationBridge ] );
+
+	// Update participant slug in case
+	// the participant is removed globally.
+	// from the Conversation block.
+	useEffect( () => {
+		if ( ! participants?.length ) {
+			return;
+		}
+
+		// Check if the participant has been removed from Conversation.
+		if ( currentParticipant ) {
+			return;
+		}
+
+		// Set first participant as default.
+		setAttributes( { participantSlug: participants[ 0 ].participantSlug } );
+	}, [ participants, currentParticipant, setAttributes ] );
 
 	function hasStyle( style ) {
 		return currentParticipant?.[ style ];

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -75,8 +75,10 @@ export default function DialogueEdit( {
 
 	const { prevBlock, mediaSource } = useSelect( select => {
 		const prevPartClientId = select( 'core/block-editor' ).getPreviousBlockClientId( clientId );
+		const previousBlock = select( 'core/block-editor' ).getBlock( prevPartClientId );
+
 		return {
-			prevBlock: select( 'core/block-editor' ).getBlock( prevPartClientId ),
+			prevBlock: previousBlock?.name === blockName ? previousBlock : null,
 			mediaSource: select( MEDIA_SOURCE_STORE_ID ).getDefaultMediaSource(),
 		};
 	}, [] );
@@ -99,8 +101,15 @@ export default function DialogueEdit( {
 	// Set initial attributes according to the context.
 	useEffect( () => {
 		// Bail when block already has an slug,
-		// or participant doesn't exist.
-		if ( participantSlug || ! participants?.length || ! conversationBridge ) {
+		// or when there is not a dialogue pre block.
+		// or when there are not particpants,
+		// or there is not conversation bridge.
+		if (
+			participantSlug ||
+			! prevBlock ||
+			! participants?.length ||
+			! conversationBridge
+		) {
 			return;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR implements a few enhancements to the `Conversation` and `Dialogue` blocks:

* **Conversation: use row style for example.** https://github.com/Automattic/jetpack/commit/196a22670c6622bad86a11965b06110a652c8b58
This is a quick fix for 425-gh-Automattic/dotcom-manage

<img src="https://user-images.githubusercontent.com/77539/105728028-71e3d380-5f0a-11eb-8fea-b81243fedd4a.png" width="300px" />

The idea is simply to switch the block style to `row` in the example. We can iterate with a better solution soon.

* **Dialogue: remove focusing always the block content.** https://github.com/Automattic/jetpack/commit/f2627e0e450c1df31f312b705137ffbd1ec152e0

I've removed this improvement because I considered it not necessary. Basically, the idea was to make focus always on the block content when the block was selected, independently of the component/area where the event happened.
I think it's better to leave the choice to the user. If they want to make focus on the content, simply need to select it :-)

* **Dialogue: improve selector getting the previous block** https://github.com/Automattic/jetpack/commit/a8522a444e29512998e07575f93b192c031d7e01
The app tries to select the previous dialogue block to pick up the timestamp and the _next_ participant slug. I've added an additional condition which checks the `jetpack/dialogue` block name. 

* **Dialogue: update participant slug when removed** https://github.com/Automattic/jetpack/commit/0f9ebbbfbd672daf5f8582993fafbfe76a23d144
This commit updates the participant slug of the Dialogue block when its current one is removed from the `Conversation`. The new value will be the first participant slug of the participant's list.

before | after
-----|------
<img width="950" alt="Screen Shot 2021-01-25 at 12 50 55 PM" src="https://user-images.githubusercontent.com/77539/105729580-28948380-5f0c-11eb-84b4-cb4ca04f142d.png"> | <img width="962" alt="Screen Shot 2021-01-25 at 12 51 48 PM" src="https://user-images.githubusercontent.com/77539/105729570-26322980-5f0c-11eb-85f7-28b3c9e74e3d.png">

* Conversation: memoize bridge object https://github.com/Automattic/jetpack/commit/336bd15845ed587f8f21d7933f01dc6d84cd15fd
This commit memorize the object passed through the context from the `Conversation` Block to the `Dialogue` block.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation/Dialogue: new enhancements round

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Take a look at the changes list below, and check it works as expected. Basically and beyond the visual changes, you should check the app doesn't break.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
n/a