### PR TITLE
Recommendations: shortcircuit early when in Offline Mode

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Status;
 
 /**
  * Jetpack_Recommendations class
@@ -20,6 +21,11 @@ class Jetpack_Recommendations {
 	 * @return bool
 	 */
 	public static function is_enabled() {
+		// Shortcircuit early if we are in offline mode.
+		if ( ( new Status() )->is_offline_mode() ) {
+			return false;
+		}
+
 		$recommendations_enabled = Jetpack_Options::get_option( 'recommendations_enabled', null );
 
 		// If the option is already set, just return the cached value.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* We do not need to show those recommendations to folks that are not connected to WordPress.com.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a site, set up offline mode (https://jetpack.com/support/development-mode/)
* Visit Jetpack > Dashboard
* You should not see the Recommadations tab.

#### Proposed changelog entry for your changes:

* N/A
