### PR TITLE
Dialogue: select participant by clicking on the component.

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -247,6 +247,7 @@ export default function DialogueEdit( {
 			<div className={ `${ baseClassName }__meta` }>
 				<Button
 					onFocus={ () => setIsFocusedOnParticipantLabel( true ) }
+					onClick={ () => setIsFocusedOnParticipantLabel( true ) }
 					className={ getParticipantLabelClass() }
 				>
 					{ participantLabel }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR fixes an issue in FF. The participant style is not detected when clicking on the participant component, but just in focus. This PR allows selecting it by clicking on it.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: select participant by clicking on the component.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In FF, create a dialogue component
* Select the participant component by clicking on it
* Confirm you see, and also can apply formats to the participant, from the toolbar
<img width="532" alt="Screen Shot 2021-01-25 at 3 28 32 PM" src="https://user-images.githubusercontent.com/77539/105749362-11609080-5f22-11eb-942c-7bac25339fd7.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
