### PR TITLE
Dialog block: output custom css classes only on container

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/dialogue.php
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/dialogue.php
@@ -213,12 +213,16 @@ function render_block( $attrs, $block_content, $block ) {
 	$participants     = get_participantes_list( $block, $default_participants );
 	$participant_slug = get_participant_slug( $sanitized_attrs, $block, $default_participants );
 	$participant_name = get_participant_name( $participants, $participant_slug, $sanitized_attrs );
-	$css_classname    = Blocks::classes( FEATURE_NAME, $attrs );
+	// Class list includes custom classes defined in block settings.
+	$block_class_list = Blocks::classes( FEATURE_NAME, $attrs );
+	// Only the generated class name for the block, without custom classes.
+	$block_class = $block_class_list ? explode( ' ', $block_class_list )[0] : '';
 
 	$markup = sprintf(
-		'<div class="%1$s"><div class="%1$s__meta"><div class="%2$s">%3$s</div>',
-		esc_attr( $css_classname ),
-		esc_attr( build_participant_css_classes( $participants, $participant_slug, $sanitized_attrs, $css_classname ) ),
+		'<div class="%1$s"><div class="%2$s__meta"><div class="%3$s">%4$s</div>',
+		esc_attr( $block_class_list ),
+		esc_attr( $block_class ),
+		esc_attr( build_participant_css_classes( $participants, $participant_slug, $sanitized_attrs, $block_class ) ),
 		esc_html( $participant_name )
 	);
 
@@ -226,7 +230,7 @@ function render_block( $attrs, $block_content, $block ) {
 	if ( $sanitized_attrs['show_timestamp'] ) {
 		$markup .= sprintf(
 			'<div class="%1$s__timestamp"><a href="#" class="%1$s__timestamp_link" data-timestamp="%2$s">%3$s</a></div>',
-			esc_attr( $css_classname ),
+			esc_attr( $block_class ),
 			convert_time_code_to_seconds( $sanitized_attrs['timestamp'] ),
 			esc_attr( $sanitized_attrs['timestamp'] )
 		);

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/dialogue.php
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/dialogue.php
@@ -216,7 +216,7 @@ function render_block( $attrs, $block_content, $block ) {
 	// Class list includes custom classes defined in block settings.
 	$block_class_list = Blocks::classes( FEATURE_NAME, $attrs );
 	// Only the generated class name for the block, without custom classes.
-	$block_class = $block_class_list ? explode( ' ', $block_class_list )[0] : '';
+	$block_class = explode( ' ', $block_class_list )[0];
 
 	$markup = sprintf(
 		'<div class="%1$s"><div class="%2$s__meta"><div class="%3$s">%4$s</div>',


### PR DESCRIPTION
Fixes #18295

#### Changes proposed in this Pull Request:

Outputs the custom css classes added to dialog block settings only on the block container, not the inner elements.

<img width="275" alt="Screen Shot 2021-01-25 at 13 39 55" src="https://user-images.githubusercontent.com/1699996/105756887-d4d96880-5f12-11eb-9788-6371fc35ac29.png">

<img width="600" alt="Screen Shot 2021-01-25 at 13 39 01" src="https://user-images.githubusercontent.com/1699996/105756891-d571ff00-5f12-11eb-84fe-ac0417674c27.png">

#### Does this pull request change what data or activity we track or use?

No

* Insert a conversation block
* Set a custom class on one of the dialog blocks
* Verify the class is output only on the container div, and not on other `<div>`s in the block, when the block is rendered on the front-end

#### Proposed changelog entry for your changes:

- Dialog block: fix how custom css classes are output
