### PR TITLE
Anchor.FM: Get most recent episode when no GUID is passed.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -98,10 +98,10 @@ class Jetpack_Podcast_Helper {
 	/**
 	 * Gets a specific track from the supplied feed URL.
 	 *
-	 * @param {string=} $guid    The GUID of the track. Omit or pass a falsey value to get the most recent track.
+	 * @param string $guid    The GUID of the track.
 	 * @return {array|WP_Error}  The track object or an error object.
 	 */
-	public function get_track_data( $guid = null ) {
+	public function get_track_data( $guid ) {
 		// Try loading track data from the cache.
 		$transient_key = 'jetpack_podcast_' . md5( "$this->feed::$guid" );
 		$track_data    = get_transient( $transient_key );
@@ -117,7 +117,7 @@ class Jetpack_Podcast_Helper {
 
 			// Loop over all tracks to find the one.
 			foreach ( $rss->get_items() as $track ) {
-				if ( empty( $guid ) || $guid === $track->get_id() ) {
+				if ( $guid === $track->get_id() ) {
 					$track_data = $this->setup_tracks_callback( $track );
 					break;
 				}
@@ -125,9 +125,7 @@ class Jetpack_Podcast_Helper {
 
 			if ( false === $track_data ) {
 				return new WP_Error( 'no_track', __( 'The track was not found.', 'jetpack' ) );
-			} elseif ( empty( $guid ) ) {
-				// Update the transient key if we have a track and no GUID was passed in.
-				$transient_key = 'jetpack_podcast_' . md5( "$this->feed::" . $track_data['guid'] );
+
 			}
 			// Cache for 1 hour.
 			set_transient( $transient_key, $track_data, HOUR_IN_SECONDS );

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -98,10 +98,10 @@ class Jetpack_Podcast_Helper {
 	/**
 	 * Gets a specific track from the supplied feed URL.
 	 *
-	 * @param string $guid     The GUID of the track.
+	 * @param string $guid     The GUID of the track. Omit or pass a falsey value to get the most recent track.
 	 * @return array|WP_Error  The track object or an error object.
 	 */
-	public function get_track_data( $guid ) {
+	public function get_track_data( $guid = null ) {
 		// Try loading track data from the cache.
 		$transient_key = 'jetpack_podcast_' . md5( "$this->feed::$guid" );
 		$track_data    = get_transient( $transient_key );
@@ -117,7 +117,7 @@ class Jetpack_Podcast_Helper {
 
 			// Loop over all tracks to find the one.
 			foreach ( $rss->get_items() as $track ) {
-				if ( $guid === $track->get_id() ) {
+				if ( empty( $guid ) || $guid === $track->get_id() ) {
 					$track_data = $this->setup_tracks_callback( $track );
 					break;
 				}
@@ -125,8 +125,10 @@ class Jetpack_Podcast_Helper {
 
 			if ( false === $track_data ) {
 				return new WP_Error( 'no_track', __( 'The track was not found.', 'jetpack' ) );
+			} elseif ( empty( $guid ) ) {
+				// Update the transient key if we have a track and no GUID was passed in.
+				$transient_key = 'jetpack_podcast_' . md5( "$this->feed::" . $track_data['guid'] );
 			}
-
 			// Cache for 1 hour.
 			set_transient( $transient_key, $track_data, HOUR_IN_SECONDS );
 		}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -98,8 +98,8 @@ class Jetpack_Podcast_Helper {
 	/**
 	 * Gets a specific track from the supplied feed URL.
 	 *
-	 * @param string $guid    The GUID of the track.
-	 * @return {array|WP_Error}  The track object or an error object.
+	 * @param string $guid     The GUID of the track.
+	 * @return array|WP_Error  The track object or an error object.
 	 */
 	public function get_track_data( $guid ) {
 		// Try loading track data from the cache.
@@ -125,8 +125,8 @@ class Jetpack_Podcast_Helper {
 
 			if ( false === $track_data ) {
 				return new WP_Error( 'no_track', __( 'The track was not found.', 'jetpack' ) );
-
 			}
+
 			// Cache for 1 hour.
 			set_transient( $transient_key, $track_data, HOUR_IN_SECONDS );
 		}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -98,8 +98,8 @@ class Jetpack_Podcast_Helper {
 	/**
 	 * Gets a specific track from the supplied feed URL.
 	 *
-	 * @param string $guid     The GUID of the track. Omit or pass a falsey value to get the most recent track.
-	 * @return array|WP_Error  The track object or an error object.
+	 * @param {string=} $guid    The GUID of the track. Omit or pass a falsey value to get the most recent track.
+	 * @return {array|WP_Error}  The track object or an error object.
 	 */
 	public function get_track_data( $guid = null ) {
 		// Try loading track data from the cache.

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -105,34 +105,32 @@ function process_anchor_params() {
 		if ( ! \is_wp_error( $rss ) ) {
 			update_post_meta( $post->ID, 'jetpack_anchor_podcast', $podcast_id );
 
-			if ( ! empty( $episode_id ) ) {
-				$track = $podcast_helper->get_track_data( $episode_id );
-				if ( ! \is_wp_error( $track ) ) {
-					update_post_meta( $post->ID, 'jetpack_anchor_episode', $episode_id );
+			$track = $podcast_helper->get_track_data( $episode_id );
+			if ( ! \is_wp_error( $track ) ) {
+				update_post_meta( $post->ID, 'jetpack_anchor_episode', $track['guid'] );
 
-					if ( 'post-new.php' === $GLOBALS['pagenow'] ) {
-						$data['actions'][] = array(
-							'set-episode-title',
-							array(
-								'title' => $track['title'],
-							),
-						);
+				if ( 'post-new.php' === $GLOBALS['pagenow'] ) {
+					$data['actions'][] = array(
+						'set-episode-title',
+						array(
+							'title' => $track['title'],
+						),
+					);
 
-						$self_links = $rss->get_links( 'self' );
-						$cover      = $rss->get_image_url();
+					$self_links = $rss->get_links( 'self' );
+					$cover      = $rss->get_image_url();
 
-						// Add insert basic template action.
-						$data['actions'][] = array(
-							'insert-episode-template',
-							array(
-								'feedUrl'         => ! empty( $self_links ) ? esc_url_raw( $self_links[0] ) : $feed,
-								'coverImage'      => ! empty( $cover ) ? esc_url( $cover ) : null,
-								'episodeTrack'    => $track,
-								'spotifyImageUrl' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
-								'spotifyShowUrl'  => esc_url_raw( $valid_spotify_url ),
-							),
-						);
-					}
+					// Add insert basic template action.
+					$data['actions'][] = array(
+						'insert-episode-template',
+						array(
+							'feedUrl'         => ! empty( $self_links ) ? esc_url_raw( $self_links[0] ) : $feed,
+							'coverImage'      => ! empty( $cover ) ? esc_url( $cover ) : null,
+							'episodeTrack'    => $track,
+							'spotifyImageUrl' => Assets::staticize_subdomain( 'https://wordpress.com/i/spotify-badge.svg' ),
+							'spotifyShowUrl'  => esc_url_raw( $valid_spotify_url ),
+						),
+					);
 				}
 			}
 		}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-podcast-helper.php
@@ -30,7 +30,7 @@ class WP_Test_Jetpack_Podcast_Helper extends WP_UnitTestCase {
 			->method( 'load_feed' )
 			->will( $this->returnValue( new WP_Error( 'feed_error', 'Feed error.' ) ) );
 
-		$error = $podcast_helper->get_track_data( '' );
+		$error = $podcast_helper->get_track_data( 'invalid_id' );
 		$this->assertWPError( $error );
 		$this->assertSame( $error->get_error_code(), 'feed_error' );
 		$this->assertSame( $error->get_error_message(), 'Feed error.' );
@@ -86,7 +86,7 @@ class WP_Test_Jetpack_Podcast_Helper extends WP_UnitTestCase {
 			);
 
 		// Can't find an episode.
-		$error = $podcast_helper->get_track_data( '' );
+		$error = $podcast_helper->get_track_data( 'invalid_id' );
 		$this->assertWPError( $error );
 		$this->assertSame( $error->get_error_code(), 'no_track' );
 		$this->assertSame( $error->get_error_message(), 'The track was not found.' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18514

#### Changes proposed in this Pull Request:
This makes the `anchor_episode` parameter optional. When it's not supplied we'll create the episode post using the most recent episode of the podcast. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

This is part of the Anchor.FM integration project.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:

* Go to `/wp-admin/post-new.php?anchor_podcast=5243218` on your development site, ensuring that you have the beta/experimental features enabled.
* You'll be presented with a blank post.
* With this branch, do the same thing,  and you should see a new post in the editor, populated with the latest episode of the podcast.

#### Proposed changelog entry for your changes:
Not required, as this is a change to the Anchor.FM integration, which is launched.
