### PR TITLE
Anchor.fm: parse podcast summary into blocks

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -3,7 +3,7 @@
  */
 import { createBlocksFromInnerBlocksTemplate, pasteHandler } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { _x, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -81,7 +81,7 @@ function podcastSummarySection( { episodeTrack } ) {
 			'core/heading',
 			{
 				level: 3,
-				content: 'Summary',
+				content: _x( 'Summary', 'noun: summary of a podcast episode', 'jetpack' ),
 				placeholder: __( 'Podcast episode title', 'jetpack' ),
 			},
 		],

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createBlocksFromInnerBlocksTemplate, rawHandler } from '@wordpress/blocks';
+import { createBlocksFromInnerBlocksTemplate, pasteHandler } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -76,7 +76,7 @@ function podcastSection( { episodeTrack, feedUrl, coverImage } ) {
 }
 
 function podcastSummarySection( { episodeTrack } ) {
-	const summaryBlocks = rawHandler( { HTML: episodeTrack.description_html } );
+	const summaryBlocks = pasteHandler( { HTML: episodeTrack.description_html, mode: 'BLOCKS' } );
 	return [
 		'core/group',
 		{},

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -76,22 +76,31 @@ function podcastSection( { episodeTrack, feedUrl, coverImage } ) {
 }
 
 function podcastSummarySection( { episodeTrack } ) {
-	const summaryBlocks = pasteHandler( { HTML: episodeTrack.description_html, mode: 'BLOCKS' } );
-	return [
-		'core/group',
-		{},
+	const sectionBlocks = [
 		[
-			[
-				'core/heading',
-				{
-					level: 3,
-					content: 'Summary',
-					placeholder: __( 'Podcast episode title', 'jetpack' ),
-				},
-			],
-			...summaryBlocks,
+			'core/heading',
+			{
+				level: 3,
+				content: 'Summary',
+				placeholder: __( 'Podcast episode title', 'jetpack' ),
+			},
 		],
 	];
+
+	const summaryBlocks = pasteHandler( { HTML: episodeTrack.description_html, mode: 'BLOCKS' } );
+
+	if ( summaryBlocks.length ) {
+		sectionBlocks.push( ...summaryBlocks );
+	} else {
+		sectionBlocks.push( [
+			'core/paragraph',
+			{
+				placeholder: __( 'Podcast episode summary', 'jetpack' ),
+			},
+		] );
+	}
+
+	return [ 'core/group', {}, sectionBlocks ];
 }
 
 function podcastConversationSection() {

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
+import { createBlocksFromInnerBlocksTemplate, rawHandler } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -76,6 +76,7 @@ function podcastSection( { episodeTrack, feedUrl, coverImage } ) {
 }
 
 function podcastSummarySection( { episodeTrack } ) {
+	const summaryBlocks = rawHandler( { HTML: episodeTrack.description_html } );
 	return [
 		'core/group',
 		{},
@@ -88,13 +89,7 @@ function podcastSummarySection( { episodeTrack } ) {
 					placeholder: __( 'Podcast episode title', 'jetpack' ),
 				},
 			],
-			[
-				'core/paragraph',
-				{
-					placeholder: __( 'Podcast episode summary', 'jetpack' ),
-					content: episodeTrack.description_html,
-				},
-			],
+			...summaryBlocks,
 		],
 	];
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

We've noticed that several Anchor.fm podcast descriptions contain multiple paragraph tags, and thus using a single paragraph block for the entire summary causes block invalidation errors, since https://github.com/Automattic/jetpack/pull/18481.

This change uses the `pasteHandler` from `@wordpress/blocks` to parse the episode description into multiple blocks, when appropriate.

<img width="350" alt="image" src="https://user-images.githubusercontent.com/1699996/105765560-3ce17c00-5f1e-11eb-9fcd-8ca37d3c6c65.png">


#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new podcast episode post where the description has multiple `<p>` tags within it (for example `/wp-admin/post-new.php?anchor_episode=2dded3cd-b9ef-4e9e-8721-d0c1773a57a3&anchor_podcast=ffd7ec4`)
* Save the draft post
* Refresh the editor page in your browser
* See that no block validation errors are triggered, and that the episode description is parsed into multiple paragraph blocks

#### Proposed changelog entry for your changes:

n/a since the changelog from https://github.com/Automattic/jetpack/pull/18481 still applies.
