### PR TITLE
Beta Plugin: Add composer.json for the beta plugin

### DIFF
--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -1,0 +1,38 @@
+{
+	"name": "automattic/jetpack-beta",
+	"description": "Serves beta and PR branches of Jetpack to a WordPress install near you!",
+	"homepage": "https://jetpack.com/",
+	"type": "wordpress-plugin",
+	"license": "GPL-2.0-or-later",
+	"support": {
+		"issues": "https://github.com/Automattic/jetpack/issues"
+	},
+	"require": {},
+	"scripts": {
+		"pre-update-cmd": [
+			"@putenv COMPOSER_ROOT_VERSION=dev-monorepo"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"autoload": {},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"config": {
+		"sort-packages": true
+	},
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-beta",
+		"release-branch-prefix": "jetpack-beta",
+		"version-constants": {
+			"JPBETA_VERSION": "jetpack-beta.php"
+		}
+	}
+}


### PR DESCRIPTION
Allows the GitHub actions for the monorepo to function as expected.