### PR TITLE
Do not recompute availability in render callbacks

### DIFF
--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -932,14 +932,13 @@ class Jetpack_Gutenberg {
 	 *
 	 * @since 8.4.0
 	 *
-	 * @param string $slug The slug for the block.
+	 * @param array $availability_for_block The availability for the block.
 	 *
 	 * @return bool
 	 */
-	public static function should_show_frontend_preview( $slug ) {
-		$availability = self::get_availability();
+	public static function should_show_frontend_preview( $availability_for_block ) {
 		return (
-			isset( $availability[ $slug ]['details']['required_plan'] )
+			isset( $availability_for_block['details']['required_plan'] )
 			&& current_user_can( 'manage_options' )
 			&& ! is_feed()
 		);
@@ -1072,7 +1071,10 @@ class Jetpack_Gutenberg {
 			}
 
 			// A preview of the block is rendered for admins on the frontend with an upgrade nudge.
-			if ( self::should_show_frontend_preview( $bare_slug ) ) {
+			if (
+				isset( $availability[ $bare_slug ] ) &&
+				self::should_show_frontend_preview( $availability[ $bare_slug ] )
+			) {
 				$upgrade_nudge = self::upgrade_nudge( $availability[ $bare_slug ]['details']['required_plan'] );
 				$block_preview = call_user_func( $render_callback, $prepared_attributes, $block_content );
 				return $upgrade_nudge . $block_preview;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -33,7 +33,7 @@ function membership_checks() {
  * @return bool
  */
 function required_plan_checks() {
-	$availability = \Jetpack_Gutenberg::get_availability();
+	$availability = \Jetpack_Gutenberg::get_cached_availability();
 	$slug         = 'premium-content/container';
 	return ( isset( $availability[ $slug ] ) && $availability[ $slug ]['available'] );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 209-gh-Automattic/view-design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The `should_show_frontend_preview` method was calculating the complete list of block availability each time it was run -- once for each premium block being rendered on a post. This was causing the page to crash if more than a few premium blocks were inserted.

The `get_render_callback_with_availability_check` function that calls this code already calculates block availability; this PR updates the code to pass the availability through instead of recalculating it.

Since `get_render_callback_with_availability_check` is _also_ called once per paid block, this PR also introduces a `get_cached_availability` function to prevent re-registration of blocks/recalculation of availability each time.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Reproducing the error
It may be useful to verify that you can see the error first. To do so, you'll need to pull master and sandbox a free wpcom site. If using the `a8c-wp-env` to sync your changes, you'll need to ssh into your sandbox and manually copy over the `jetpack/projects/plugins/jetpack/class.jetpack-gutenberg.php` file to `wp-content/mu-plugins/jetpack/class.jetpack-gutenberg.php`.

Then verify that you can see the error by following these steps:
1. Create a new post, add a WhatsApp block, and save the post.
2. Open the post preview in a new tab and verify that you can see the block with the upgrade nudge on the frontend.
3. Return to the editor and add five more WhatsApp blocks.
4. Save the post and refresh the page. **The page fails to load, and there are TypeErrors in the console**
5. Refresh the preview you have open in the other tab. **The page crashes with Fatal error: Allowed memory size exhausted**

##### Testing the fix
Pull this branch locally. You will need to manually copy the `class.jetpack-gutenberg.php` file over to your sandbox again.

Follow the same testing instructions as above, and verify that you can load the post with six WhatsApp blocks in the editor _and_ in the frontend preview.

<img width="806" alt="Screen Shot 2021-01-25 at 3 54 56 PM" src="https://user-images.githubusercontent.com/63313398/105780627-bb8de780-5f25-11eb-87c4-3a28293527ae.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*