### PR TITLE
Photon: Enable resize parameters for VideoPress poster images

### DIFF
--- a/projects/plugins/jetpack/functions.photon.php
+++ b/projects/plugins/jetpack/functions.photon.php
@@ -125,16 +125,6 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		|| wp_parse_url( $custom_photon_url, PHP_URL_HOST ) === $image_url_parts['host']
 		|| $is_wpcom_image
 	) {
-		/*
-		 * VideoPress Poster images should only keep one param, ssl.
-		 */
-		if (
-			is_array( $args )
-			&& 'videos.files.wordpress.com' === strtolower( $image_url_parts['host'] )
-		) {
-			$args = array_intersect_key( array( 'ssl' => 1 ), $args );
-		}
-
 		$photon_url = add_query_arg( $args, $image_url );
 		return jetpack_photon_url_scheme( $photon_url, $scheme );
 	}

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-xmlrpc.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-xmlrpc.php
@@ -167,8 +167,7 @@ class VideoPress_XMLRPC {
 			return false;
 		}
 
-		// We add ssl => 1 to make sure that the videos.files.wordpress.com domain is parsed as photon.
-		$poster = apply_filters( 'jetpack_photon_url', $poster, array( 'ssl' => 1 ), 'https' );
+		$poster = apply_filters( 'jetpack_photon_url', $poster );
 
 		$meta                         = wp_get_attachment_metadata( $post_id );
 		$meta['videopress']['poster'] = $poster;

--- a/projects/plugins/jetpack/modules/videopress/utility-functions.php
+++ b/projects/plugins/jetpack/modules/videopress/utility-functions.php
@@ -635,8 +635,7 @@ function video_image_url_by_guid( $guid, $format ) {
 
 	$meta = wp_get_attachment_metadata( $post->ID );
 
-	// We add ssl => 1 to make sure that the videos.files.wordpress.com domain is parsed as photon.
-	$poster = apply_filters( 'jetpack_photon_url', $meta['videopress']['poster'], array( 'ssl' => 1 ), 'https' );
+	$poster = apply_filters( 'jetpack_photon_url', $meta['videopress']['poster'] );
 
 	return $poster;
 }

--- a/projects/plugins/jetpack/tests/php/test_functions.photon.php
+++ b/projects/plugins/jetpack/tests/php/test_functions.photon.php
@@ -343,4 +343,34 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 		$this->assertFalse( jetpack_photon_banned_domains( false, 'https://s.w.org/style/images/wp-header-logo-2x.png' ) );
 	}
 
+	/**
+	 * Tests that Photon will rely on native resizing for WordPress.com images.
+	 *
+	 * @author aforcier
+	 * @covers ::jetpack_photon_url
+	 * @since  9.5.0
+	 */
+	public function test_photonizing_wordpress_url() {
+		$url = jetpack_photon_url( 'https://jetpack.files.wordpress.com/abcd1234/poster_image.jpg', array( 'w' => 500 ) );
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $args );
+		$this->assertSame( '500', $args['w'], 'WordPress.com image source should have given params applied.' );
+		$this->assertArrayNotHasKey( 'ssl', $args, 'WordPress.com image source should not have an ssl query string.' );
+		$this->assertSame( 'jetpack.files.wordpress.com', wp_parse_url( $url )['host'], 'WordPress.com image source should not be wrapped in Photon URL.' );
+	}
+
+	/**
+	 * Tests that Photon will rely on native resizing for VideoPress poster images.
+	 *
+	 * @author aforcier
+	 * @covers ::jetpack_photon_url
+	 * @since  9.5.0
+	 */
+	public function test_photonizing_videopress_url() {
+		$url = jetpack_photon_url( 'https://videos.files.wordpress.com/abcd1234/poster_image.jpg', array( 'w' => 500 ) );
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $args );
+		$this->assertSame( '500', $args['w'], 'VideoPress poster image source should have given params applied.' );
+		$this->assertArrayNotHasKey( 'ssl', $args, 'VideoPress poster image source should not have an ssl query string.' );
+		$this->assertSame( 'videos.files.wordpress.com', wp_parse_url( $url )['host'], 'VideoPress poster image source should not be wrapped in Photon URL.' );
+	}
+
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR re-enables image resize parameters for VideoPress poster URLs.

This was previously disabled in https://github.com/Automattic/jetpack/pull/12764, because resize parameters sent to videos.files.wordpress.com didn't use to work (and resulted in a 404 error). This has since been fixed server-side (see D49897-code and pxWta-Rs-p2), so this PR undoes the now-unneeded exclusion so that poster URLs can be resized once again.

I also undid some related behavior that applied the `ssl=1` parameter to VideoPress poster URLs. I believe this is a holdover from when Photon was used for resizing the URLs (before the wpcom-images project - p3topS-mu-p2). All WP.com URLs are always SSL-enabled, so the parameter should not be needed - it's not applied to other *.files.wordpress.com URLs and we should now generally be able to treat videos.files.wordpress.com the same way as those. If you think I've missed something there though please let me know. 

Nothing is really broken without this change - but it should make for an optimization whenever a VideoPress poster URL is shown directly and simplifies some now-unneeded/misleading complexity.

(Extra background/motivation: I dug into Photon/wpcom-images resize parameters in order to support Stories preview images better, since the Reader was attempting to resize images generated by the Story block and resulting in 404 errors. The change in this current PR isn't strictly relevant to Stories, but the exception in Photon handling was one of the pieces/workarounds I noticed along the way to understanding what the issue was and I'm following up on now.)

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Run the unit tests, and:

* Enable VideoPress
* Upload a video and obtain its poster URL from the media library
* Create a post, add an image block, and give it the poster URL
* Publish and view the post
* Without this PR, the image tag has no size attributes and the URL has no params:
```html
<img src="https://videos.files.wordpress.com/b6S2MrM0/wp-1599351274486_hd.original.jpg" alt="">
```
* With this PR, the image loads correctly and the URL has resize parameters
```html
<img src="https://videos.files.wordpress.com/b6S2MrM0/wp-1599351274486_hd.original.jpg?w=580" alt="" width="580" height="1031">
```

You can also optionally do the same check for a Story block, with these requirements:
* The first slide of the story must be a VideoPress video
* You need to disable JS on the page so the static fallback is rendered (this is what the Reader gets)
By inspecting the div with class `wp-story-slide` you can compare the image URL before and after:

Before:
```html
<img loading="lazy" title="wp-1603841857378-mp4" alt="" class="wp-block-jetpack-story_image wp-story-image wp-story-crop-wide" src="https://videos.files.wordpress.com/Ua5EgvAv/wp-1603841857378_hd.original.jpg" width="1080" height="1920">
```

After:
```html
<img loading="lazy" title="wp-1603841857378-mp4" alt="" class="wp-block-jetpack-story_image wp-story-image wp-story-crop-wide" src="https://videos.files.wordpress.com/Ua5EgvAv/wp-1603841857378_hd.original.jpg?resize=580%2C1031" data-recalc-dims="1" width="580" height="1031">
```

Note: You can also inspect the site's video library from Calypso (like the steps in https://github.com/Automattic/jetpack/pull/18384) and verify the images continue to display. Note though that the URLs are incorrectly wrapped in Photon arguments (i0.wp.com/...) which is broken for videos on private sites. That's an issue in Calypso which I'll open a PR there to fix.

#### Proposed changelog entry for your changes:
I'm not sure whether this is significant enough to be worth including, but in case it is maybe:
* Fixed responsiveness for VideoPress poster images
