### PR TITLE
Masterbar: Update link destination setting

### DIFF
--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1781,6 +1781,7 @@ class Jetpack {
 	 * Is a given user (or the current user if none is specified) linked to a WordPress.com user?
 	 */
 	public static function is_user_connected( $user_id = false ) {
+		_deprecated_function( __METHOD__, 'jetpack-9.5', 'Automattic\Jetpack\Connection\Manager\is_user_connected' );
 		return self::connection()->is_user_connected( $user_id );
 	}
 
@@ -1788,6 +1789,7 @@ class Jetpack {
 	 * Get the wpcom user data of the current|specified connected user.
 	 */
 	public static function get_connected_user_data( $user_id = null ) {
+		_deprecated_function( __METHOD__, 'jetpack-9.5', 'Automattic\Jetpack\Connection\Manager\get_connected_user_data' );
 		return self::connection()->get_connected_user_data( $user_id );
 	}
 
@@ -5486,7 +5488,7 @@ endif;
 	}
 
 	/**
-	 * Authenticates XML-RPC and other requests from the Jetpack Server.
+	 * Authenticates Xget_connected_user_dataML-RPC and other requests from the Jetpack Server.
 	 *
 	 * @deprecated since 7.7.0
 	 * @see Automattic\Jetpack\Connection\Manager::authenticate_jetpack()

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1788,30 +1788,7 @@ class Jetpack {
 	 * Get the wpcom user data of the current|specified connected user.
 	 */
 	public static function get_connected_user_data( $user_id = null ) {
-		// TODO: remove in favor of Connection_Manager->get_connected_user_data
-		if ( ! $user_id ) {
-			$user_id = get_current_user_id();
-		}
-
-		$transient_key = "jetpack_connected_user_data_$user_id";
-
-		if ( $cached_user_data = get_transient( $transient_key ) ) {
-			return $cached_user_data;
-		}
-
-		$xml = new Jetpack_IXR_Client(
-			array(
-				'user_id' => $user_id,
-			)
-		);
-		$xml->query( 'wpcom.getUser' );
-		if ( ! $xml->isError() ) {
-			$user_data = $xml->getResponse();
-			set_transient( $transient_key, $xml->getResponse(), DAY_IN_SECONDS );
-			return $user_data;
-		}
-
-		return false;
+		return self::connection()->get_connected_user_data( $user_id );
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1781,7 +1781,7 @@ class Jetpack {
 	 * Is a given user (or the current user if none is specified) linked to a WordPress.com user?
 	 */
 	public static function is_user_connected( $user_id = false ) {
-		_deprecated_function( __METHOD__, 'jetpack-9.5', 'Automattic\Jetpack\Connection\Manager\is_user_connected' );
+		_deprecated_function( __METHOD__, 'jetpack-9.5', 'Automattic\\Jetpack\\Connection\\Manager\\is_user_connected' );
 		return self::connection()->is_user_connected( $user_id );
 	}
 
@@ -1789,7 +1789,7 @@ class Jetpack {
 	 * Get the wpcom user data of the current|specified connected user.
 	 */
 	public static function get_connected_user_data( $user_id = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-9.5', 'Automattic\Jetpack\Connection\Manager\get_connected_user_data' );
+		_deprecated_function( __METHOD__, 'jetpack-9.5', 'Automattic\\Jetpack\\Connection\\Manager\\get_connected_user_data' );
 		return self::connection()->get_connected_user_data( $user_id );
 	}
 
@@ -5488,7 +5488,7 @@ endif;
 	}
 
 	/**
-	 * Authenticates Xget_connected_user_dataML-RPC and other requests from the Jetpack Server.
+	 * Authenticates XML-RPC and other requests from the Jetpack Server.
 	 *
 	 * @deprecated since 7.7.0
 	 * @see Automattic\Jetpack\Connection\Manager::authenticate_jetpack()

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Scan\Admin_Bar_Notice;
@@ -91,13 +92,14 @@ class Masterbar {
 	 * Constructor
 	 */
 	public function __construct() {
-		$this->user_id = get_current_user_id();
+		$this->user_id      = get_current_user_id();
+		$connection_manager = new Connection_Manager( 'jetpack' );
 
-		if ( ! Jetpack::is_user_connected( $this->user_id ) ) {
+		if ( ! $connection_manager->is_user_connected( $this->user_id ) ) {
 			return;
 		}
 
-		$this->user_data       = Jetpack::get_connected_user_data( $this->user_id );
+		$this->user_data       = $connection_manager->get_connected_user_data( $this->user_id );
 		$this->user_login      = $this->user_data['login'];
 		$this->user_email      = $this->user_data['email'];
 		$this->display_name    = $this->user_data['display_name'];

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Scan\Admin_Bar_Notice;
@@ -19,7 +18,6 @@ use Jetpack;
 use Jetpack_AMP_Support;
 use Jetpack_Plan;
 use WP_Admin_Bar;
-use WP_User;
 
 /**
  * Provides custom admin bar instead of the default WordPress admin bar.
@@ -93,23 +91,39 @@ class Masterbar {
 	 * Constructor
 	 */
 	public function __construct() {
+		$this->user_id = get_current_user_id();
+
+		if ( ! Jetpack::is_user_connected( $this->user_id ) ) {
+			return;
+		}
+
+		$this->user_data       = Jetpack::get_connected_user_data( $this->user_id );
+		$this->user_login      = $this->user_data['login'];
+		$this->user_email      = $this->user_data['email'];
+		$this->display_name    = $this->user_data['display_name'];
+		$this->user_site_count = $this->user_data['site_count'];
+
+		// Store part of the connected user data as user options so it can be used
+		// by other files of the masterbar module without making another XMLRPC
+		// request. Although `get_connected_user_data` tries to save the data for
+		// future uses on a transient, the data is not guaranteed to be cached.
+		if ( isset( $this->user_data['use_wp_admin_links'] ) ) {
+			update_user_option( get_current_user_id(), 'jetpack_admin_menu_link_destination', $this->user_data['use_wp_admin_links'] );
+		}
+
 		add_action( 'admin_bar_init', array( $this, 'init' ) );
 
-		// Post logout on the site, also log the user out of WordPress.com.
-		add_filter( 'logout_redirect', array( $this, 'maybe_logout_user_from_wpcom' ), 10, 3 );
+		if ( ! empty( $this->user_data['ID'] ) ) {
+			// Post logout on the site, also log the user out of WordPress.com.
+			add_filter( 'logout_redirect', array( $this, 'maybe_logout_user_from_wpcom' ) );
+		}
 	}
 
 	/**
 	 * Initialize our masterbar.
 	 */
 	public function init() {
-		$this->locale  = $this->get_locale();
-		$this->user_id = get_current_user_id();
-
-		// Limit the masterbar to be shown only to connected Jetpack users.
-		if ( ! Jetpack::is_user_connected( $this->user_id ) ) {
-			return;
-		}
+		$this->locale = $this->get_locale();
 
 		// Don't show the masterbar on WordPress mobile apps.
 		if ( User_Agent_Info::is_mobile_app() ) {
@@ -146,12 +160,6 @@ class Masterbar {
 			add_filter( 'show_admin_bar', '__return_true' );
 		}
 
-		$this->user_data       = Jetpack::get_connected_user_data( $this->user_id );
-		$this->user_login      = $this->user_data['login'];
-		$this->user_email      = $this->user_data['email'];
-		$this->display_name    = $this->user_data['display_name'];
-		$this->user_site_count = $this->user_data['site_count'];
-
 		// Used to build menu links that point directly to Calypso.
 		$this->primary_site_slug = ( new Status() )->get_site_suffix();
 
@@ -180,11 +188,9 @@ class Masterbar {
 	/**
 	 * Log out from WordPress.com when logging out of the local site.
 	 *
-	 * @param string  $redirect_to           The redirect destination URL.
-	 * @param string  $requested_redirect_to The requested redirect destination URL passed as a parameter.
-	 * @param WP_User $user                  The WP_User object for the user that's logging out.
+	 * @param string $redirect_to The redirect destination URL.
 	 */
-	public function maybe_logout_user_from_wpcom( $redirect_to, $requested_redirect_to, $user ) {
+	public function maybe_logout_user_from_wpcom( $redirect_to ) {
 		/**
 		 * Whether we should sign out from wpcom too when signing out from the masterbar.
 		 *
@@ -199,26 +205,17 @@ class Masterbar {
 			&& 'masterbar' === $_GET['context'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			&& $masterbar_should_logout_from_wpcom
 		) {
-			/*
-			 * Get the associated WordPress.com User ID, if the user is connected.
+			/**
+			 * Hook into the log out event happening from the Masterbar.
+			 *
+			 * @since 5.1.0
+			 * @since 7.9.0 Added the $wpcom_user_id parameter to the action.
+			 *
+			 * @module masterbar
+			 *
+			 * @param int $wpcom_user_id WordPress.com User ID.
 			 */
-			$connection_manager = new Connection_Manager();
-			if ( $connection_manager->is_user_connected( $user->ID ) ) {
-				$wpcom_user_data = $connection_manager->get_connected_user_data( $user->ID );
-				if ( ! empty( $wpcom_user_data['ID'] ) ) {
-					/**
-					 * Hook into the log out event happening from the Masterbar.
-					 *
-					 * @since 5.1.0
-					 * @since 7.9.0 Added the $wpcom_user_id parameter to the action.
-					 *
-					 * @module masterbar
-					 *
-					 * @param int $wpcom_user_id WordPress.com User ID.
-					 */
-					do_action( 'wp_masterbar_logout', $wpcom_user_data['ID'] );
-				}
-			}
+			do_action( 'wp_masterbar_logout', $this->user_data['ID'] );
 		}
 
 		return $redirect_to;

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -329,6 +329,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 4.4.0
 	 */
 	public function test_admin_user_unlink_permission() {
+		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 
 		$this->load_rest_endpoints_direct();
 
@@ -672,6 +673,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 4.4.0
 	 */
 	public function test_unlink_user() {
+		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user();
@@ -714,6 +716,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 8.8.0
 	 */
 	public function test_unlink_user_cache_data_removal() {
+		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user();
@@ -966,6 +969,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 7.7.0 No longer need to be master user to update.
 	 */
 	public function test_change_owner() {
+		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user( 'administrator' );
@@ -1132,6 +1136,8 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 9.4
 	 */
 	public function test_get_user_connection_data_without_master_user() {
+		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
+		$this->setExpectedDeprecated( 'Jetpack::get_connected_user_data' );
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user( 'administrator' );
 		wp_set_current_user( $user->ID );

--- a/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
@@ -305,6 +305,7 @@ EXPECTED;
 	}
 
 	public function test_get_other_linked_admins_one_admin_returns_false() {
+		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 		delete_transient( 'jetpack_other_linked_admins' );
 		$other_admins = Jetpack::get_other_linked_admins();
 		$this->assertFalse( $other_admins );
@@ -312,6 +313,7 @@ EXPECTED;
 	}
 
 	public function test_get_other_linked_admins_more_than_one_not_false() {
+		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 		delete_transient( 'jetpack_other_linked_admins' );
 		$master_user = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		$connected_admin = $this->factory->user->create( array( 'role' => 'administrator' ) );


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/47043
Follows up https://github.com/Automattic/jetpack/pull/18238

#### Changes proposed in this Pull Request:
Read the value of the new link destination setting that has been exposed in the `wpcom.getUser` XMLRPC response in D56006-code, and store it as the user option used by the new admin menu.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- On an Atomic site, [install & activate the Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/). Switch to this branch.
- Go to wordpress.com and switch to that Atomic site.
- Make sure that the sidebar menu items link to Calypso.
- Go to `/me/account` and enable the toggle that says "Replace all pages with WP Admin equivalents".
- Go to My Sites.
- Check the sidebar menu and make sure that all pages with WP Admin equivalents link to WP Admin.
- Go again to /me/account.
- Disable the new setting and save the interface settings.
- Go to My Sites.
- Check the sidebar menu and make sure that all pages with WP Admin equivalents link to Calypso.

#### Proposed changelog entry for your changes:
N/A.
