### PR TITLE
Autoloader: reintroduce the $jetpack_autoloader_including_latest global

### DIFF
--- a/projects/packages/autoloader/src/class-latest-autoloader-guard.php
+++ b/projects/packages/autoloader/src/class-latest-autoloader-guard.php
@@ -54,6 +54,12 @@ class Latest_Autoloader_Guard {
 	public function should_stop_init( $current_plugin, $plugins, $was_included_by_autoloader ) {
 		global $jetpack_autoloader_latest_version;
 
+		/*
+		 * This is a legacy variable. It's not used in the current logic, but required
+		 * for compatibility with older versions of the autoloader.
+		 */
+		global $jetpack_autoloader_including_latest;
+
 		// We need to reset the autoloader when the plugins change because
 		// that means the autoloader was generated with a different list.
 		if ( $this->plugins_handler->have_plugins_changed( $plugins ) ) {
@@ -69,7 +75,9 @@ class Latest_Autoloader_Guard {
 
 		$latest_plugin = $this->autoloader_locator->find_latest_autoloader( $plugins, $jetpack_autoloader_latest_version );
 		if ( isset( $latest_plugin ) && $latest_plugin !== $current_plugin ) {
+			$jetpack_autoloader_including_latest = true;
 			require $this->autoloader_locator->get_autoloader_path( $latest_plugin );
+			$jetpack_autoloader_including_latest = false;
 			return true;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When development versions of Jetpack that use the latest version of the autoloader are active alongside plugins that use older versions of the autoloader, fatals can occur. The fatals occur when the `JETPACK_AUTOLOAD_DEV` constant is not set to true, so the autoloader prefers stable versions over dev versions.

The fatals occur because the dev version of the autoloader selects the older version of the autoloader and attempts to load it. The dev version does not set the `$jetpack_autoloader_including_latest` global variable. However, the
older version of the autoloader uses that variable to determine whether it should initialize.

To fix this, set the value of the `$jetpack_autoloader_including_latest` in `Latest_Autoloader_Guard::should_stop_init`.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Reproduce the bug.
1. Make sure that the `JETPACK_AUTOLOAD_DEV` constant is not set to true.
2. Install and activate the Jetpack Beta plugin. Jetpack's stable version should be selected.
3. Install and activate WooCommerce.
4. In the Jetpack Beta plugin, activate the Bleeding Edge version. A fatal should occur.

##### Test this branch.
1. In the Jetpack Beta plugins, activate this branch. The fatal should not occur.

#### Proposed changelog entry for your changes:
* n/a.
