### PR TITLE
Instant Search: Sync with WPCOM codebase

### DIFF
--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -58,6 +58,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 	/**
 	 * Loads assets according to parameters provided.
+	 *
+	 * @param string $path_prefix - Prefix for assets' relative paths.
+	 * @param string $plugin_base_path - Base path for use in plugins_url.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
 		$polyfill_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle.js';
@@ -156,9 +159,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$excluded_post_types = array();
 		}
 
-		$polyfill_relative_path = '_inc/build/instant-search/jp-search-ie11-polyfill-payload.bundle.js';
-		$polyfill_path          = plugins_url( $polyfill_relative_path, JETPACK__PLUGIN_FILE );
-
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
@@ -212,6 +212,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 	/**
 	 * Passes options to the polyfill loader script.
+	 *
+	 * @param string $polyfill_payload_path - Absolute path to the IE11 polyfill payload.
 	 */
 	protected function inject_polyfill_js_options( $polyfill_payload_path ) {
 		wp_add_inline_script( 'jetpack-instant-search-ie11', 'var JetpackInstantSearchIe11PolyfillPath=decodeURIComponent("' . rawurlencode( $polyfill_payload_path ) . '");', 'before' );

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -53,9 +53,17 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * Loads assets for Jetpack Instant Search Prototype featuring Search As You Type experience.
 	 */
 	public function load_assets() {
-		$polyfill_relative_path = '_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle.js';
-		$script_relative_path   = '_inc/build/instant-search/jp-search-main.bundle.js';
-		$style_relative_path    = '_inc/build/instant-search/jp-search-main.bundle.css';
+		$this->load_assets_with_parameters( '', JETPACK__PLUGIN_FILE );
+	}
+
+	/**
+	 * Loads assets according to parameters provided.
+	 */
+	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
+		$polyfill_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle.js';
+		$script_relative_path   = $path_prefix . '_inc/build/instant-search/jp-search-main.bundle.js';
+		$style_relative_path    = $path_prefix . '_inc/build/instant-search/jp-search-main.bundle.css';
+
 		if (
 			! file_exists( JETPACK__PLUGIN_DIR . $polyfill_relative_path ) ||
 			! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ||
@@ -65,18 +73,23 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		}
 
 		$polyfill_version = Jetpack_Search_Helpers::get_asset_version( $polyfill_relative_path );
-		$polyfill_path    = plugins_url( $polyfill_relative_path, JETPACK__PLUGIN_FILE );
+		$polyfill_path    = plugins_url( $polyfill_relative_path, $plugin_base_path );
 		wp_enqueue_script( 'jetpack-instant-search-ie11', $polyfill_path, array(), $polyfill_version, true );
+		$polyfill_payload_path = plugins_url(
+			$path_prefix . '_inc/build/instant-search/jp-search-ie11-polyfill-payload.bundle.js',
+			$plugin_base_path
+		);
+		$this->inject_polyfill_js_options( $polyfill_payload_path );
 
 		$script_version = Jetpack_Search_Helpers::get_asset_version( $script_relative_path );
-		$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
+		$script_path    = plugins_url( $script_relative_path, $plugin_base_path );
 		wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
 		wp_set_script_translations( 'jetpack-instant-search', 'jetpack' );
 		$this->load_and_initialize_tracks();
 		$this->inject_javascript_options();
 
 		$style_version = Jetpack_Search_Helpers::get_asset_version( $style_relative_path );
-		$style_path    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
+		$style_path    = plugins_url( $style_relative_path, $plugin_base_path );
 		wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
 	}
 
@@ -195,7 +208,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
 		wp_add_inline_script( 'jetpack-instant-search', 'var JetpackInstantSearchOptions=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $options ) ) . '"));', 'before' );
-		wp_add_inline_script( 'jetpack-instant-search-ie11', 'var JetpackInstantSearchIe11PolyfillPath=decodeURIComponent("' . rawurlencode( $polyfill_path ) . '");', 'before' );
+	}
+
+	/**
+	 * Passes options to the polyfill loader script.
+	 */
+	protected function inject_polyfill_js_options( $polyfill_payload_path ) {
+		wp_add_inline_script( 'jetpack-instant-search-ie11', 'var JetpackInstantSearchIe11PolyfillPath=decodeURIComponent("' . rawurlencode( $polyfill_payload_path ) . '");', 'before' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/search/instant-search/babel.config.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/babel.config.js
@@ -9,7 +9,7 @@ module.exports = () => ( {
 		[
 			require.resolve( '@babel/preset-env' ),
 			{
-				corejs: 3.6,
+				corejs: '3.8.3',
 				ignoreBrowserslistConfig: true,
 				modules: false,
 				targets,

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -97,6 +97,7 @@
 		"component-uid": "0.0.2",
 		"cookie": "0.4.1",
 		"copy-webpack-plugin": "5.1.2",
+		"core-js": "3.8.3",
 		"create-react-class": "15.6.3",
 		"debug": "4.3.1",
 		"email-validator": "2.0.4",

--- a/projects/plugins/jetpack/yarn.lock
+++ b/projects/plugins/jetpack/yarn.lock
@@ -6614,6 +6614,11 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
   integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
+core-js@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.3.tgz#c21906e1f14f3689f93abcc6e26883550dd92dd0"
+  integrity sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add core-js@3.8.3 as an explicit dependency. Without this, the IE11 polyfill payload from #18506 does not work as intended.
* Update `class-jetpack-instant-search.php` to use the `load_assets` and `load_assets_with_parameters` functions pattern.

These changes have already shipped with D55894-code.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Ensure that all assets load as expected on a Jetpack Search enabled site.
  * `jp-search-ie11-polyfill-loader.bundle.js`
  * `jp-search-ie11-polyfill-payload.bundle.js` (if necessary).
  * `jp-search-main.bundle.js`
  * `jp-search-main.bundle.css`


#### Proposed changelog entry for your changes:
* None.
