### PR TITLE
Re-register Edit CSS sub page menu item

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -424,8 +424,8 @@ class Admin_Menu {
 			add_submenu_page( $themes_slug, esc_attr__( 'Menus', 'jetpack' ), __( 'Menus', 'jetpack' ), 'customize', esc_url( $customize_menu_url ), null, 20 );
 		}
 
-		// Register menu for the Custom CSS Jetpack module
-		add_submenu_page( $themes_slug, esc_attr__( 'Edit CSS', 'jetpack' ), __( 'Edit CSS', 'jetpack' ), 'edit_theme_options', 'editcss', array( 'Jetpack_Custom_CSS', 'admin' ));
+		// Register menu for the Custom CSS Jetpack module, but don't add it as a menu item.
+		$GLOBALS['_registered_pages'][ 'admin_page_editcss'] = true;
 
 		$this->migrate_submenus( 'themes.php', $themes_slug );
 		add_filter(

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -424,6 +424,9 @@ class Admin_Menu {
 			add_submenu_page( $themes_slug, esc_attr__( 'Menus', 'jetpack' ), __( 'Menus', 'jetpack' ), 'customize', esc_url( $customize_menu_url ), null, 20 );
 		}
 
+		// Register menu for the Custom CSS Jetpack module
+		add_submenu_page( $themes_slug, esc_attr__( 'Edit CSS', 'jetpack' ), __( 'Edit CSS', 'jetpack' ), 'edit_theme_options', 'editcss', array( 'Jetpack_Custom_CSS', 'admin' ));
+
 		$this->migrate_submenus( 'themes.php', $themes_slug );
 		add_filter(
 			'parent_file',

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -425,7 +425,7 @@ class Admin_Menu {
 		}
 
 		// Register menu for the Custom CSS Jetpack module, but don't add it as a menu item.
-		$GLOBALS['_registered_pages'][ 'admin_page_editcss'] = true;
+		$GLOBALS['_registered_pages']['admin_page_editcss'] = true;
 
 		$this->migrate_submenus( 'themes.php', $themes_slug );
 		add_filter(

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -425,7 +425,7 @@ class Admin_Menu {
 		}
 
 		// Register menu for the Custom CSS Jetpack module, but don't add it as a menu item.
-		$GLOBALS['_registered_pages']['admin_page_editcss'] = true;
+		$GLOBALS['_registered_pages']['admin_page_editcss'] = true; // phpcs:ignore
 
 		$this->migrate_submenus( 'themes.php', $themes_slug );
 		add_filter(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/49292

#### Changes proposed in this Pull Request:
Register again the `editcss` submenu page in the new Admin menu so it is available when the Nav Unification is enabled.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Apply D56069-code to your WP.com sandbox.
- Sandbox a Premium site.
- Go to Appearance > Customizer.
- Open "Additional CSS" panel. _If this is your first time adding CSS here you will need to add some, save and refresh to enable the "CSS Revisions"._
- Click "CSS Revisions" above the CSS editor.
- Make sure the "CSS Stylesheet Editor" from WP Admin is opened.

#### Proposed changelog entry for your changes:
N/A.
