### PR TITLE
Jetpack: Set composer autoloader-suffix

### DIFF
--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -75,7 +75,8 @@
 		"sort-packages": true,
 		"platform": {
 			"ext-intl": "0.0.0"
-		}
+		},
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3cjetpack"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-production",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
By default composer generates a new random suffix for its autoloader
classes if there isn't already a vendor/autoload.php file to read one
from.

This causes every commit to our Automattic/jetpack-production mirror
repo to change these files with a new suffix, cluttering the git
history.

We can avoid that by configuring a static suffix in composer.json. We
still use a long arbitrary string that it's unlikely anyone else will
choose by accident. The main risk is that someone might copy our
composer.json for their own plugin and not change it (despite the fact
that it contains the word "jetpack").

The "f11009ded9fc4592b6a05b61ce272b3c" isn't entirely arbitrary. It's
the MD5 hash of "Automattic/jetpack".

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `composer install` locally in project/plugins/jetpack/, and see that vendor/autoload.php uses the configured suffix.
* Look in the built artifact, see that Jetpack's vendor/autoload.php and other files use the configured suffix.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Probably none needed.
