### PR TITLE
Add error message for when episode is not available

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -98,15 +98,16 @@ class Jetpack_Podcast_Helper {
 	/**
 	 * Gets a specific track from the supplied feed URL.
 	 *
-	 * @param string $guid        The GUID of the track.
+	 * @param string $guid          The GUID of the track.
 	 * @param bool   $force_refresh Whether to force a refresh.
-	 * @return array|WP_Error     The track object or an error object.
+	 * @return array|WP_Error       The track object or an error object.
 	 */
 	public function get_track_data( $guid, $force_refresh = false ) {
 		// Try loading track data from the cache.
 		$transient_key = 'jetpack_podcast_' . md5( "$this->feed::$guid" );
 		$track_data    = get_transient( $transient_key );
 
+		// Clear the cache if force_refresh param is set.
 		if ( true === $force_refresh ) {
 			delete_transient( $track_data );
 		}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -247,6 +247,9 @@ class Jetpack_Podcast_Helper {
 	/**
 	 * Action handler to reset the SimplePie cache for the podcast feed.
 	 *
+	 * Note this only resets the cache for the specified url. If the feed locator finds the podcast feed
+	 * within the markup of the that url, that feed itself may still be cached.
+	 *
 	 * @param SimplePie $feed The SimplePie object, passed by reference.
 	 * @return void
 	 */

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -138,7 +138,10 @@ class Jetpack_Podcast_Helper {
 			set_transient( $transient_key, $track_data, HOUR_IN_SECONDS );
 		}
 
-		remove_action( 'wp_feed_options', array( __CLASS__, 'reset_simplepie_cache' ) );
+		if ( true === $force_refresh ) {
+			remove_action( 'wp_feed_options', array( __CLASS__, 'reset_simplepie_cache' ) );
+		}
+
 		return $track_data;
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -256,7 +256,7 @@ class Jetpack_Podcast_Helper {
 	public static function reset_simplepie_cache( &$feed ) {
 		// Retrieve the cache object for a feed url. Based on:
 		// https://github.com/WordPress/WordPress/blob/fd1c2cb4011845ceb7244a062b09b2506082b1c9/wp-includes/class-simplepie.php#L1412.
-		$cache = $feed->registry->call( 'Cache', 'get_handler', array( $feed->cache_location, call_user_func( $feed->cache_name_function, $feed->url ), 'spc' ) );
+		$cache = $feed->registry->call( 'Cache', 'get_handler', array( $feed->cache_location, call_user_func( $feed->cache_name_function, $feed->feed_url ), 'spc' ) );
 
 		if ( method_exists( $cache, 'unlink' ) ) {
 			$cache->unlink();

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -144,16 +144,16 @@ function process_anchor_params() {
 				} else {
 					$retry_url         = add_query_arg(
 						array(
-							'anchor_podcast' => $podcast_id,
 							'anchor_episode' => $episode_id,
-							'spotify_url'    => $valid_spotify_url ? $spotify_url : false,
+							'anchor_podcast' => $podcast_id,
+							'spotify_url'    => $valid_spotify_url ? rawurlencode( $spotify_url ) : false,
 						),
 						admin_url( 'post-new.php' )
 					);
 					$data['actions'][] = array(
 						'create-episode-error-notice',
 						array(
-							'retry_url' => $retry_url,
+							'retry_url' => esc_url_raw( $retry_url ),
 						),
 					);
 				}

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -146,7 +146,7 @@ function process_anchor_params() {
 						array(
 							'anchor_podcast' => $podcast_id,
 							'anchor_episode' => $episode_id,
-							'spotify_url'    => $spotify_url,
+							'spotify_url'    => $valid_spotify_url ? $spotify_url : false,
 						),
 						admin_url( 'post-new.php' )
 					);

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -141,6 +141,15 @@ function process_anchor_params() {
 							),
 						);
 					}
+				} else {
+					$data['actions'][] = array(
+						'create-error-notice',
+						array(
+							'podcast_id'  => $podcast_id,
+							'episode_id'  => $episode_id,
+							'spotify_url' => $spotify_url,
+						),
+					);
 				}
 			}
 		}

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -114,7 +114,7 @@ function process_anchor_params() {
 			}
 
 			if ( ! empty( $episode_id ) ) {
-				$track = $podcast_helper->get_track_data( $episode_id );
+				$track = $podcast_helper->get_track_data( $episode_id, true );
 				if ( ! \is_wp_error( $track ) ) {
 					update_post_meta( $post->ID, 'jetpack_anchor_episode', $track['guid'] );
 

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -142,12 +142,18 @@ function process_anchor_params() {
 						);
 					}
 				} else {
-					$data['actions'][] = array(
-						'create-error-notice',
+					$retry_url         = add_query_arg(
 						array(
-							'podcast_id'  => $podcast_id,
-							'episode_id'  => $episode_id,
-							'spotify_url' => $spotify_url,
+							'anchor_podcast' => $podcast_id,
+							'anchor_episode' => $episode_id,
+							'spotify_url'    => $spotify_url,
+						),
+						admin_url( 'post-new.php' )
+					);
+					$data['actions'][] = array(
+						'create-episode-error-notice',
+						array(
+							'retry_url' => $retry_url,
 						),
 					);
 				}

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -94,9 +94,15 @@ function createEpisodeErrorNotice( params ) {
 			'jetpack'
 		),
 		{
+			id: 'episode-error-notice',
 			actions: [
 				{
-					url: params.retry_url,
+					onClick() {
+						window.location.href = params.retry_url;
+					},
+					onKeyDown() {
+						window.location.href = params.retry_url;
+					},
 					label: __( 'Retry', 'jetpack' ),
 				},
 			],

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -86,7 +86,7 @@ function showPostPublishOutboundLink() {
 	} );
 }
 
-function createEpisodeErrorNotice() {
+function createEpisodeErrorNotice( params ) {
 	dispatch( 'core/notices' ).createNotice(
 		'error',
 		__(
@@ -96,9 +96,7 @@ function createEpisodeErrorNotice() {
 		{
 			actions: [
 				{
-					onClick() {
-						// TODO: force a podcast refresh
-					},
+					url: params.retry_url,
 					label: __( 'Retry', 'jetpack' ),
 				},
 			],
@@ -127,8 +125,8 @@ function initAnchor() {
 			case 'set-episode-title':
 				setEpisodeTitle( actionParams );
 				break;
-			case 'create-error-notice':
-				createEpisodeErrorNotice();
+			case 'create-episode-error-notice':
+				createEpisodeErrorNotice( actionParams );
 				break;
 		}
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -12,6 +12,7 @@ import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { external, Icon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
+import '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -85,6 +86,26 @@ function showPostPublishOutboundLink() {
 	} );
 }
 
+function createEpisodeErrorNotice() {
+	dispatch( 'core/notices' ).createNotice(
+		'error',
+		__(
+			"We couldn't find that episode in your feed. If you just published the episode, please try creating the post again in a few minutes.",
+			'jetpack'
+		),
+		{
+			actions: [
+				{
+					onClick() {
+						// TODO: force a podcast refresh
+					},
+					label: __( 'Retry', 'jetpack' ),
+				},
+			],
+		}
+	);
+}
+
 function initAnchor() {
 	const data = window.Jetpack_AnchorFm;
 	if ( typeof data !== 'object' ) {
@@ -105,6 +126,9 @@ function initAnchor() {
 				break;
 			case 'set-episode-title':
 				setEpisodeTitle( actionParams );
+				break;
+			case 'create-error-notice':
+				createEpisodeErrorNotice();
 				break;
 		}
 	} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18541

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds editor notice for when Anchor episode is not available
* Adds `force_refresh` param to to helper `get_track_data` method to clear the podcast helper and SimplePie caches when needed

<img width="1584" alt="Screen Shot 2021-01-27 at 5 08 49 PM" src="https://user-images.githubusercontent.com/1689238/106060689-57ecf100-60c2-11eb-8d49-a58384697231.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/18541

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

_Caching_
* Create a podcast on Anchor.fm, add an episode, and copy the RSS feed URL from the distribution settings.
* Add a podcast player block to a post with the RSS feed URL.
* Publish a new podcast episode.
* Go to the RSS feed URL and copy the GUID of the new episode (might take a couple of minutes to show up because of Anchor.fm caching).
* Go to 'wp-admin/post-new.php?anchor_podcast={podcast-id}&anchor_episode={episode-id}' and verify that no error message appears and the episode info populates the post as expected.

_Error Message_
* Go to 'wp-admin/post-new.php?anchor_podcast=22b6608&anchor_episode=asdflk&spotify_url=https%3A%2F%2Fopen.spotify.com%2Fepisode%2F2ehWhMLPR923YhlLMSR4et%3Fsi%3DJ5C7ofZ2S9KU3Iv1tqIagQ'
* Verify that an error message displays and you can click / tab to "Retry" to try to create the post again.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* No changelog needed since this is an update to the Anchor.fm block.

