### PR TITLE
Instant Search: Improve browser compatibility + UX for input handling

### DIFF
--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -159,11 +159,24 @@ class SearchApp extends Component {
 
 	handleInput = debounce( event => {
 		// Reference: https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes
-		if ( event.inputType.includes( 'format' ) || event.target.value === '' ) {
+		// NOTE: inputType is not compatible with IE11, so we use optional chaining here. https://caniuse.com/mdn-api_inputevent_inputtype
+		if ( event.inputType?.includes( 'format' ) ) {
 			return;
 		}
-		this.props.setSearchQuery( event.target.value );
 
+		// If user presses enter, propagate the query value and immediately show the results.
+		if ( event.key === 'Enter' ) {
+			this.props.setSearchQuery( event.target.value );
+			this.showResults();
+			return;
+		}
+
+		// Don't spawn the results overlay if the new inputted value is an empty string.
+		if ( event.target.value === '' ) {
+			return;
+		}
+
+		this.props.setSearchQuery( event.target.value );
 		if ( this.state.overlayOptions.overlayTrigger === 'immediate' ) {
 			this.showResults();
 		}

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -91,6 +91,7 @@ class SearchApp extends Component {
 		// Add listeners for input and submit
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.addEventListener( 'submit', this.handleSubmit );
+			input.addEventListener( 'keydown', this.handleKeydown );
 			input.addEventListener( 'input', this.handleInput );
 		} );
 
@@ -108,6 +109,7 @@ class SearchApp extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.removeEventListener( 'submit', this.handleSubmit );
+			input.removeEventListener( 'keydown', this.handleKeydown );
 			input.removeEventListener( 'input', this.handleInput );
 		} );
 
@@ -157,22 +159,18 @@ class SearchApp extends Component {
 		this.handleInput.flush();
 	};
 
-	handleInput = debounce( event => {
-		// Reference: https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes
-		// NOTE: inputType is not compatible with IE11, so we use optional chaining here. https://caniuse.com/mdn-api_inputevent_inputtype
-		if ( event.inputType?.includes( 'format' ) ) {
-			return;
-		}
-
+	handleKeydown = event => {
 		// If user presses enter, propagate the query value and immediately show the results.
 		if ( event.key === 'Enter' ) {
 			this.props.setSearchQuery( event.target.value );
 			this.showResults();
-			return;
 		}
+	};
 
-		// Don't spawn the results overlay if the new inputted value is an empty string.
-		if ( event.target.value === '' ) {
+	handleInput = debounce( event => {
+		// Reference: https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes
+		// NOTE: inputType is not compatible with IE11, so we use optional chaining here. https://caniuse.com/mdn-api_inputevent_inputtype
+		if ( event.inputType?.includes( 'format' ) || event.target.value === '' ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #18553.

#### Changes proposed in this Pull Request:
* Ignore `event.inputType` in the event handler if not supported by browser.
* Immediately search and spawn the overlay when a user presses Enter on a search input.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with Jetpack Search enabled.
* Ensure that your `node_modules` are up-to-date -- use `yarn disclean` if necessary.
* Try searching your site in IE11 by typing into a search input. Ensure that the overlay appears as expected.

#### Proposed changelog entry for your changes:
* None.
