### PR TITLE
Dialogue: support participants edition

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/components/participants-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/components/participants-controls.js
@@ -37,6 +37,7 @@ function ParticipantsLabelControl( { className, participants, onChange, onDelete
 					/>
 
 					<Button
+						disabled={ participants.length < 2 }
 						className={ `${ className }__remove-participant` }
 						label={ __( 'Remove participant', 'jetpack' ) }
 						onClick={ () => onDelete( participantSlug ) }

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -54,49 +54,65 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		[ setAttributes, participants ]
 	);
 
-	const setBlockAttributes = useCallback( setAttributes, [] );
-
-	// Context bridge.
-	const contextProvision = useMemo( () => ( {
-		setAttributes: setBlockAttributes,
-		updateParticipants,
-		getParticipantIndex: slug => participants.map( part => part.participantSlug ).indexOf( slug ),
-		getNextParticipantIndex: ( slug, offset = 0 ) =>
-			( contextProvision.getParticipantIndex( slug ) + 1 + offset ) % participants.length,
-		getNextParticipantSlug: ( slug, offset = 0 ) =>
-			participants[ contextProvision.getNextParticipantIndex( slug, offset ) ]?.participantSlug,
-
-		attributes: {
-			showTimestamps,
-		},
-	} ), [ participants, setBlockAttributes, showTimestamps, updateParticipants ] );
-
-	function deleteParticipant( deletedParticipantSlug ) {
+	const deleteParticipant = useCallback( function ( deletedParticipantSlug ) {
 		setAttributes( {
 			participants: participants.filter(
 				( { participantSlug } ) => participantSlug !== deletedParticipantSlug
 			),
 		} );
-	}
+	}, [ participants, setAttributes ] );
 
-	function addNewParticipant( newSpakerValue ) {
+	const addNewParticipant = useCallback( function( newSpakerValue ) {
 		const newParticipantSlug = participants.length
 			? participants[ participants.length - 1 ].participantSlug.replace(
 					/(\d+)/,
 					n => Number( n ) + 1
 			  )
 			: 'speaker-0';
+
+		const newParticipant = {
+			participant: newSpakerValue,
+			participantSlug: newParticipantSlug,
+			hasBoldStyle: true,
+		};
+
 		setAttributes( {
 			participants: [
 				...participants,
-				{
-					participant: newSpakerValue,
-					participantSlug: newParticipantSlug,
-					hasBoldStyle: true,
-				},
+				newParticipant,
 			],
 		} );
-	}
+
+		return newParticipant;
+	}, [ participants, setAttributes ] );
+
+	const setBlockAttributes = useCallback( setAttributes, [] );
+
+	// Context bridge.
+	const contextProvision = useMemo( () => ( {
+		setAttributes: setBlockAttributes,
+		addNewParticipant,
+		updateParticipants,
+		deleteParticipant,
+		getParticipantIndex: slug => participants.map( part => part.participantSlug ).indexOf( slug ),
+		getNextParticipantIndex: ( slug, offset = 0 ) =>
+			( contextProvision.getParticipantIndex( slug ) + 1 + offset ) % participants.length,
+		getNextParticipantSlug: ( slug, offset = 0 ) =>
+			participants[ contextProvision.getNextParticipantIndex( slug, offset ) ]?.participantSlug,
+		getPrevParticipantSlug: ( slug, offset = -2 ) =>
+			participants[ contextProvision.getNextParticipantIndex( slug, offset ) ]?.participantSlug,
+
+		attributes: {
+			showTimestamps,
+		},
+	} ), [
+		deleteParticipant,
+		participants,
+		setBlockAttributes,
+		showTimestamps,
+		updateParticipants,
+		addNewParticipant,
+	] );
 
 	const baseClassName = 'wp-block-jetpack-conversation';
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -11,13 +11,17 @@ import {
 	MenuItem,
 } from '@wordpress/components';
 import { check, people } from '@wordpress/icons';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 
 import { __ } from '@wordpress/i18n';
 
 function ParticipantEditItem( { value, onChange, onSelect, onDelete, disabled } ) {
 	const [ participant, setParticipant ] = useState( value );
+
+	useEffect( () => {
+		setParticipant( value );
+	}, [ value ] );
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -72,7 +72,7 @@ function ParticipantAddItem( { value, onAdd, className } ) {
 	);
 }
 
-function ParticipantsMenu( {
+export function ParticipantsMenu( {
 	participants,
 	className,
 	participantSlug,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -159,9 +159,9 @@ export function ParticipantsEditDropdown( props ) {
 	const {
 		label,
 		position = 'bottom',
-		labelClassName,
 		editMode = true,
-		onFocus,
+		icon = people,
+		toggleProps = <span>{ label }</span>
 	} = props;
 
 	return (
@@ -169,20 +169,8 @@ export function ParticipantsEditDropdown( props ) {
 			popoverProps={ {
 				position,
 			} }
-			toggleProps={ label
-				? {
-					className: labelClassName,
-					children: editMode
-						? <span>{ label }</span>
-						: <Button
-							className={ labelClassName }
-							onClick={ onFocus }
-							onFocus={ onFocus }
-						>{ label }</Button>,
-				}
-				: false
-			}
-			icon={ label ? null : people }
+			toggleProps={ toggleProps }
+			icon={ icon }
 		>
 			{ editMode
 				? ( { onClose } ) => <ParticipantsEditMenu { ...props } onClose={ onClose } />
@@ -193,7 +181,27 @@ export function ParticipantsEditDropdown( props ) {
 }
 
 export function ParticipantsDropdown( props ) {
+	const { labelClassName, onFocus, label } = props;
+	const className = label?.length
+		? labelClassName
+		: 'wp-block-jetpack-dialogue__participant is-undefined';
+
 	return (
-		<ParticipantsEditDropdown { ...props } editMode={ false } />
+		<ParticipantsEditDropdown
+			{ ...props }
+			editMode={ false }
+			icon={ null }
+			toggleProps={ {
+				className,
+				children:
+					<Button
+						className={ className }
+						onClick={ onFocus }
+						onFocus={ onFocus }
+					>
+						{ label || __( 'Not defined', 'jetpack' ) }
+					</Button>
+			} }
+		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -13,10 +13,18 @@ import {
 import { check, people } from '@wordpress/icons';
 import { useState, useEffect } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
-
 import { __ } from '@wordpress/i18n';
 
-function ParticipantEditItem( { value, onChange, onSelect, onDelete, onClose, disabled } ) {
+const participantNotDefinedLabel = __( 'Not defined', 'jetpack' );
+
+function ParticipantEditItem( {
+	value,
+	onChange,
+	onSelect,
+	onDelete,
+	onClose = () => {},
+	disabled,
+} ) {
 	const [ participant, setParticipant ] = useState( value );
 	useEffect( () => setParticipant( value ), [ value ] );
 
@@ -35,6 +43,7 @@ function ParticipantEditItem( { value, onChange, onSelect, onDelete, onClose, di
 						onClose();
 					}
 				} }
+				placeholder={ participantNotDefinedLabel }
 			/>
 
 			<Button
@@ -63,6 +72,7 @@ function ParticipantAddItem( { onAdd, className } ) {
 						onAdd( participant );
 					}
 				} }
+				placeholder={ __( 'New participant', 'jetpack' ) }
 			/>
 
 			<Button
@@ -88,7 +98,7 @@ export function ParticipantsEditMenu( {
 	onParticipantAdd,
 	onParticipantChange,
 	onParticipantDelete,
-	onClose,
+	onClose = () => {},
 } ) {
 	return (
 		<MenuGroup className={ `${ className }__participants` }>
@@ -145,7 +155,7 @@ export function ParticipantsMenu( { participants, className, onSelect, participa
 					isSelected={ participantSlug === slug }
 					icon={ participantSlug === slug ? check : null }
 				>
-					{ participant }
+					{ participant || participantNotDefinedLabel }
 				</MenuItem>
 			) ) }
 		</MenuGroup>
@@ -186,6 +196,31 @@ function ParticipantsEditDropdown( props ) {
 	);
 }
 
+function dropdownToggleProps( { label, className, onFocus } ) {
+	if ( label === false ) {
+		return {};
+	}
+
+	if ( label ) {
+		return {
+			className,
+			children:
+				<Button
+					className={ className }
+					onClick={ onFocus }
+					onFocus={ onFocus }
+				>
+					{ label }
+				</Button>
+		};
+	}
+
+	return {
+		className,
+		children: <span>{ participantNotDefinedLabel }</span>,
+	};
+}
+
 export function ParticipantsDropdown( props ) {
 	const { labelClassName, onFocus, label } = props;
 	const className = label?.length
@@ -195,20 +230,7 @@ export function ParticipantsDropdown( props ) {
 	return (
 		<ParticipantsEditDropdown
 			{ ...props }
-			toggleProps={ label
-				? {
-					className,
-					children:
-						<Button
-							className={ className }
-							onClick={ onFocus }
-							onFocus={ onFocus }
-						>
-							{ label || __( 'Not defined', 'jetpack' ) }
-						</Button>
-				}
-				: {}
-			}
+			toggleProps={ dropdownToggleProps( { label, className, onFocus } ) }
 		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -16,7 +16,7 @@ import { ENTER } from '@wordpress/keycodes';
 
 import { __ } from '@wordpress/i18n';
 
-function ParticipantEditItem( { value, onChange, onSelect, onDelete, disabled } ) {
+function ParticipantEditItem( { value, onChange, onSelect, onDelete, onClose, disabled } ) {
 	const [ participant, setParticipant ] = useState( value );
 	useEffect( () => setParticipant( value ), [ value ] );
 
@@ -28,10 +28,11 @@ function ParticipantEditItem( { value, onChange, onSelect, onDelete, disabled } 
 					setParticipant( newValue );
 					onChange( newValue );
 				} }
-				onClick={ ev => ev.stopPropagation() }
-				onKeyDown={ ( { keyCode } ) => {
-					if ( keyCode === ENTER ) {
+				onKeyDown={ ( ev ) => {
+					if ( ev.keyCode === ENTER ) {
+						ev.preventDefault();
 						onSelect();
+						onClose();
 					}
 				} }
 			/>
@@ -87,6 +88,7 @@ export function ParticipantsEditMenu( {
 	onParticipantAdd,
 	onParticipantChange,
 	onParticipantDelete,
+	onClose,
 } ) {
 	return (
 		<MenuGroup className={ `${ className }__participants` }>
@@ -96,7 +98,10 @@ export function ParticipantsEditMenu( {
 					value: slug,
 				} ) ) }
 				selected={ participantSlug }
-				onChange={ ( slug ) => onParticipantSelect( { participantSlug: slug } ) }
+				onChange={ ( slug ) => {
+					onParticipantSelect( { participantSlug: slug } );
+					onClose();
+				} }
 			/>
 
 			<div className={ `${ className }__participants-selector__container` }>
@@ -114,6 +119,7 @@ export function ParticipantsEditMenu( {
 							} ) }
 							onSelect={ () => onParticipantSelect( { participantSlug: slug } ) }
 							onDelete={ () => onParticipantDelete( slug ) }
+							onClose={ onClose }
 						/>
 					</div>
 				) ) }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -2,30 +2,119 @@
  * WordPress dependencies
  */
 import {
+	Button,
 	DropdownMenu,
 	MenuGroup,
-	MenuItem,
 	SelectControl,
+	TextControl,
+	RadioControl,
 } from '@wordpress/components';
-import { check } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
+import { ENTER } from '@wordpress/keycodes';
+
 import { __ } from '@wordpress/i18n';
 
-function ParticipantsMenu( { participants, className, onSelect, participantSlug, onClose } ) {
+function ParticipantEditItem( { value, onChange, onSelect, onDelete, disabled } ) {
+	const [ participant, setParticipant ] = useState( value );
+
 	return (
-		<MenuGroup className={ `${ className }__participants-selector` }>
-			{ participants.map( ( { participant, participantSlug: slug } ) => (
-				<MenuItem
-					key={ slug }
-					onClick={ () => {
-						onSelect( { participantSlug: slug } );
-						onClose();
-					} }
-					isSelected={ participantSlug === slug }
-					icon={ participantSlug === slug ? check : null }
-				>
-					{ participant }
-				</MenuItem>
-			) ) }
+		<>
+			<TextControl
+				value={ participant }
+				onChange={ ( newValue ) => {
+					setParticipant( newValue );
+					onChange( newValue );
+				} }
+				onClick={ ev => ev.stopPropagation() }
+				onKeyDown={ ( { keyCode } ) => {
+					if ( keyCode === ENTER ) {
+						onSelect();
+					}
+				} }
+			/>
+
+			<Button
+				disabled={ disabled }
+				icon="trash"
+				onClick={ () => onDelete() }
+			/>
+		</>
+	);
+}
+
+function ParticipantAddItem( { value, onAdd, className } ) {
+	const [ participant, setParticipant ] = useState( value );
+
+	return (
+		<div className={ className }>
+			<TextControl
+				value={ participant }
+				onChange={ ( newValue ) => {
+					setParticipant( newValue );
+				} }
+				onClick={ ev => ev.stopPropagation() }
+				onKeyDown={ ( { keyCode } ) => {
+					if ( keyCode === ENTER ) {
+						setParticipant( '' );
+						onAdd( participant );
+					}
+				} }
+			/>
+
+			<Button
+				icon="plus"
+				onClick={ () => {
+					setParticipant( '' );
+					onAdd( participant );
+				} }
+			/>
+		</div>
+	);
+}
+
+function ParticipantsMenu( {
+	participants,
+	className,
+	participantSlug,
+	onParticipantSelect,
+	onParticipantAdd,
+	onParticipantChange,
+	onParticipantDelete,
+} ) {
+	return (
+		<MenuGroup className={ `${ className }__participants` }>
+			<RadioControl
+				className={ `${ className }__participants-selector` }
+				options={ participants.map( ( { participantSlug: slug } ) => ( {
+					value: slug,
+				} ) ) }
+				selected={ participantSlug }
+				onChange={ ( slug ) => onParticipantSelect( { participantSlug: slug } ) }
+			/>
+
+			<div className={ `${ className }__participants-selector__container` }>
+				{ participants.map( ( { participant, participantSlug: slug } ) => (
+					<div
+						className={ `${ className }__participants-selector__participant` }
+						key={ slug }
+					>
+						<ParticipantEditItem
+							disabled={ participants.length < 2 }
+							value={ participant }
+							onChange={ ( value ) => onParticipantChange( {
+								participantSlug: slug,
+								participant: value,
+							} ) }
+							onSelect={ () => onParticipantSelect( { participantSlug: slug } ) }
+							onDelete={ () => onParticipantDelete( slug ) }
+						/>
+					</div>
+				) ) }
+				<ParticipantAddItem
+					className={ `${ className }__participants-selector__participant` }
+					onAdd={ onParticipantAdd }
+				/>
+			</div>
 		</MenuGroup>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -8,7 +8,9 @@ import {
 	SelectControl,
 	TextControl,
 	RadioControl,
+	MenuItem,
 } from '@wordpress/components';
+import { check } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 
@@ -119,6 +121,26 @@ export function ParticipantsEditMenu( {
 	);
 }
 
+export function ParticipantsMenu( { participants, className, onSelect, participantSlug, onClose } ) {
+	return (
+		<MenuGroup className={ `${ className }__participants-selector` }>
+			{ participants.map( ( { participant, participantSlug: slug } ) => (
+				<MenuItem
+					key={ slug }
+					onClick={ () => {
+						onSelect( { participantSlug: slug } );
+						onClose();
+					} }
+					isSelected={ participantSlug === slug }
+					icon={ participantSlug === slug ? check : null }
+				>
+					{ participant }
+				</MenuItem>
+			) ) }
+		</MenuGroup>
+	);
+}
+
 export function ParticipantsControl( { participants, participantSlug: slug, onSelect } ) {
 	return (
 		<SelectControl
@@ -134,7 +156,14 @@ export function ParticipantsControl( { participants, participantSlug: slug, onSe
 }
 
 export function ParticipantsEditDropdown( props ) {
-	const { label, position = 'bottom', labelClassName, icon = null } = props;
+	const {
+		label,
+		position = 'bottom',
+		labelClassName,
+		icon = null,
+		editMode = true,
+		onFocus,
+	} = props;
 
 	return (
 		<DropdownMenu
@@ -143,11 +172,26 @@ export function ParticipantsEditDropdown( props ) {
 			} }
 			toggleProps={ {
 				className: labelClassName,
-				children: <span>{ label }</span>,
+				children: editMode
+					? <span>{ label }</span>
+					: <Button
+						className={ labelClassName }
+						onClick={ onFocus }
+						onFocus={ onFocus }
+					>{ label }</Button>,
 			} }
 			icon={ icon }
 		>
-			{ ( { onClose } ) => <ParticipantsEditMenu { ...props } onClose={ onClose } /> }
+			{ editMode
+				? ( { onClose } ) => <ParticipantsEditMenu { ...props } onClose={ onClose } />
+				: ( { onClose } ) => <ParticipantsMenu { ...props } onClose={ onClose } />
+			}
 		</DropdownMenu>
+	);
+}
+
+export function ParticipantsDropdown( props ) {
+	return (
+		<ParticipantsEditDropdown { ...props } editMode={ false } />
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -156,20 +156,15 @@ export function ParticipantsControl( { participants, participantSlug: slug, onSe
 	);
 }
 
-export function ParticipantsEditDropdown( props ) {
+function ParticipantsEditDropdown( props ) {
 	const {
-		label,
-		position = 'bottom',
 		editMode = true,
 		icon = people,
-		toggleProps = <span>{ label }</span>
+		toggleProps = {},
 	} = props;
 
 	return (
 		<DropdownMenu
-			popoverProps={ {
-				position,
-			} }
 			toggleProps={ toggleProps }
 			icon={ icon }
 		>
@@ -190,19 +185,20 @@ export function ParticipantsDropdown( props ) {
 	return (
 		<ParticipantsEditDropdown
 			{ ...props }
-			editMode={ false }
-			icon={ null }
-			toggleProps={ {
-				className,
-				children:
-					<Button
-						className={ className }
-						onClick={ onFocus }
-						onFocus={ onFocus }
-					>
-						{ label || __( 'Not defined', 'jetpack' ) }
-					</Button>
-			} }
+			toggleProps={ label
+				? {
+					className,
+					children:
+						<Button
+							className={ className }
+							onClick={ onFocus }
+							onFocus={ onFocus }
+						>
+							{ label || __( 'Not defined', 'jetpack' ) }
+						</Button>
+				}
+				: {}
+			}
 		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -18,10 +18,7 @@ import { __ } from '@wordpress/i18n';
 
 function ParticipantEditItem( { value, onChange, onSelect, onDelete, disabled } ) {
 	const [ participant, setParticipant ] = useState( value );
-
-	useEffect( () => {
-		setParticipant( value );
-	}, [ value ] );
+	useEffect( () => setParticipant( value ), [ value ] );
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -72,7 +72,7 @@ function ParticipantAddItem( { value, onAdd, className } ) {
 	);
 }
 
-export function ParticipantsMenu( {
+export function ParticipantsEditMenu( {
 	participants,
 	className,
 	participantSlug,
@@ -133,7 +133,7 @@ export function ParticipantsControl( { participants, participantSlug: slug, onSe
 	);
 }
 
-export default function ParticipantsDropdown( props ) {
+export function ParticipantsEditDropdown( props ) {
 	const { label, position = 'bottom', labelClassName, icon = null } = props;
 
 	return (
@@ -147,7 +147,7 @@ export default function ParticipantsDropdown( props ) {
 			} }
 			icon={ icon }
 		>
-			{ ( { onClose } ) => <ParticipantsMenu { ...props } onClose={ onClose } /> }
+			{ ( { onClose } ) => <ParticipantsEditMenu { ...props } onClose={ onClose } /> }
 		</DropdownMenu>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -45,8 +45,8 @@ function ParticipantEditItem( { value, onChange, onSelect, onDelete, disabled } 
 	);
 }
 
-function ParticipantAddItem( { value, onAdd, className } ) {
-	const [ participant, setParticipant ] = useState( value );
+function ParticipantAddItem( { onAdd, className } ) {
+	const [ participant, setParticipant ] = useState( '' );
 
 	return (
 		<div className={ className }>
@@ -66,7 +66,11 @@ function ParticipantAddItem( { value, onAdd, className } ) {
 
 			<Button
 				icon="plus"
+				disabled={ ! participant?.length }
 				onClick={ () => {
+					if ( ! participant?.length ) {
+						return;
+					}
 					setParticipant( '' );
 					onAdd( participant );
 				} }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -10,7 +10,7 @@ import {
 	RadioControl,
 	MenuItem,
 } from '@wordpress/components';
-import { check } from '@wordpress/icons';
+import { check, people } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 
@@ -160,7 +160,6 @@ export function ParticipantsEditDropdown( props ) {
 		label,
 		position = 'bottom',
 		labelClassName,
-		icon = null,
 		editMode = true,
 		onFocus,
 	} = props;
@@ -170,17 +169,20 @@ export function ParticipantsEditDropdown( props ) {
 			popoverProps={ {
 				position,
 			} }
-			toggleProps={ {
-				className: labelClassName,
-				children: editMode
-					? <span>{ label }</span>
-					: <Button
-						className={ labelClassName }
-						onClick={ onFocus }
-						onFocus={ onFocus }
-					>{ label }</Button>,
-			} }
-			icon={ icon }
+			toggleProps={ label
+				? {
+					className: labelClassName,
+					children: editMode
+						? <span>{ label }</span>
+						: <Button
+							className={ labelClassName }
+							onClick={ onFocus }
+							onFocus={ onFocus }
+						>{ label }</Button>,
+				}
+				: false
+			}
+			icon={ label ? null : people }
 		>
 			{ editMode
 				? ( { onClose } ) => <ParticipantsEditMenu { ...props } onClose={ onClose } />

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -26,8 +26,9 @@ import { useSelect, dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import './editor.scss';
-import ParticipantsDropdown, {
-	ParticipantsMenu,
+import {
+	ParticipantsEditDropdown,
+	ParticipantsEditMenu,
 } from './components/participants-control';
 import { TimestampControl, TimestampDropdown } from './components/timestamp-control';
 import ConversationContext from '../conversation/components/context';
@@ -166,7 +167,7 @@ export default function DialogueEdit( {
 		<div className={ className }>
 			<BlockControls>
 				<ToolbarGroup>
-					<ParticipantsDropdown
+					<ParticipantsEditDropdown
 						id={ `dialogue-${ instanceId }-participants-dropdown` }
 						className={ baseClassName }
 						participants={ participants }
@@ -218,7 +219,7 @@ export default function DialogueEdit( {
 			<InspectorControls>
 				<Panel>
 					<PanelBody title={ __( 'Participant', 'jetpack' ) }>
-						<ParticipantsMenu
+						<ParticipantsEditMenu
 							id={ `dialogue-${ instanceId }-participants-dropdown` }
 							className={ baseClassName }
 							participants={ participants }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -29,6 +29,7 @@ import './editor.scss';
 import {
 	ParticipantsEditDropdown,
 	ParticipantsEditMenu,
+	ParticipantsDropdown,
 } from './components/participants-control';
 import { TimestampControl, TimestampDropdown } from './components/timestamp-control';
 import ConversationContext from '../conversation/components/context';
@@ -264,13 +265,14 @@ export default function DialogueEdit( {
 			</InspectorControls>
 
 			<div className={ `${ baseClassName }__meta` }>
-				<Button
+				<ParticipantsDropdown
+					labelClassName={ getParticipantLabelClass() }
+					participants={ participants }
+					label={ participantLabel }
+					participantSlug={ participantSlug }
+					onSelect={ setAttributes }
 					onFocus={ () => setIsFocusedOnParticipantLabel( true ) }
-					onClick={ () => setIsFocusedOnParticipantLabel( true ) }
-					className={ getParticipantLabelClass() }
-				>
-					{ participantLabel }
-				</Button>
+				/>
 
 				{ showTimestamp && (
 					<TimestampDropdown

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -172,7 +172,17 @@ export default function DialogueEdit( {
 						participants={ participants }
 						label={ __( 'Participant', 'jetpack' ) }
 						participantSlug={ participantSlug }
-						onSelect={ setAttributes }
+						onParticipantSelect={ setAttributes }
+						onParticipantAdd={ ( value ) => {
+							const { participantSlug: slug } = conversationBridge.addNewParticipant( value );
+							setTimeout( () => setAttributes( { participantSlug: slug } ), 100 );
+						} }
+						onParticipantChange={ conversationBridge.updateParticipants }
+						onParticipantDelete={ ( value ) => {
+							const prevParticipantSlug = conversationBridge.getPrevParticipantSlug( participantSlug );
+							setAttributes( { participantSlug: prevParticipantSlug } );
+							conversationBridge.deleteParticipant( value );
+						} }
 					/>
 				</ToolbarGroup>
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -172,7 +172,6 @@ export default function DialogueEdit( {
 						id={ `dialogue-${ instanceId }-participants-dropdown` }
 						className={ baseClassName }
 						participants={ participants }
-						label={ __( 'Participant', 'jetpack' ) }
 						participantSlug={ participantSlug }
 						onParticipantSelect={ setAttributes }
 						onParticipantAdd={ ( value ) => {
@@ -221,10 +220,8 @@ export default function DialogueEdit( {
 				<Panel>
 					<PanelBody title={ __( 'Participant', 'jetpack' ) }>
 						<ParticipantsEditMenu
-							id={ `dialogue-${ instanceId }-participants-dropdown` }
 							className={ baseClassName }
 							participants={ participants }
-							label={ __( 'Participant', 'jetpack' ) }
 							participantSlug={ participantSlug }
 							onParticipantSelect={ setAttributes }
 							onParticipantAdd={ ( value ) => {

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -172,7 +172,7 @@ export default function DialogueEdit( {
 						className={ baseClassName }
 						labelClassName={ getParticipantLabelClass() }
 						participants={ participants }
-						label={ null }
+						label={ false }
 						participantSlug={ participantSlug }
 						onSelect={ setAttributes }
 						editMode={ false }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -17,7 +17,6 @@ import {
 	ToggleControl,
 	ToolbarGroup,
 	ToolbarButton,
-	Button,
 } from '@wordpress/components';
 import { useContext, useState, useEffect, useRef } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -163,6 +163,17 @@ export default function DialogueEdit( {
 		setAttributes( { timestamp: time } );
 	}
 
+	function addConversationParticipant( value ) {
+		const { participantSlug: slug } = conversationBridge.addNewParticipant( value );
+		setTimeout( () => setAttributes( { participantSlug: slug } ), 100 );
+	}
+
+	function deleteConversationParticipant( value ) {
+		const prevParticipantSlug = conversationBridge.getPrevParticipantSlug( participantSlug );
+		setAttributes( { participantSlug: prevParticipantSlug } );
+		conversationBridge.deleteParticipant( value );
+	}
+
 	return (
 		<div className={ className }>
 			<BlockControls>
@@ -173,16 +184,9 @@ export default function DialogueEdit( {
 						participants={ participants }
 						participantSlug={ participantSlug }
 						onParticipantSelect={ setAttributes }
-						onParticipantAdd={ ( value ) => {
-							const { participantSlug: slug } = conversationBridge.addNewParticipant( value );
-							setTimeout( () => setAttributes( { participantSlug: slug } ), 100 );
-						} }
+						onParticipantAdd={ addConversationParticipant }
 						onParticipantChange={ conversationBridge.updateParticipants }
-						onParticipantDelete={ ( value ) => {
-							const prevParticipantSlug = conversationBridge.getPrevParticipantSlug( participantSlug );
-							setAttributes( { participantSlug: prevParticipantSlug } );
-							conversationBridge.deleteParticipant( value );
-						} }
+						onParticipantDelete={ deleteConversationParticipant }
 					/>
 				</ToolbarGroup>
 
@@ -223,16 +227,9 @@ export default function DialogueEdit( {
 							participants={ participants }
 							participantSlug={ participantSlug }
 							onParticipantSelect={ setAttributes }
-							onParticipantAdd={ ( value ) => {
-								const { participantSlug: slug } = conversationBridge.addNewParticipant( value );
-								setTimeout( () => setAttributes( { participantSlug: slug } ), 100 );
-							} }
+							onParticipantAdd={ addConversationParticipant }
 							onParticipantChange={ conversationBridge.updateParticipants }
-							onParticipantDelete={ ( value ) => {
-								const prevParticipantSlug = conversationBridge.getPrevParticipantSlug( participantSlug );
-								setAttributes( { participantSlug: prevParticipantSlug } );
-								conversationBridge.deleteParticipant( value );
-							} }
+							onParticipantDelete={ deleteConversationParticipant }
 						/>
 					</PanelBody>
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -177,6 +177,12 @@ export default function DialogueEdit( {
 	return (
 		<div className={ className }>
 			<BlockControls>
+				{ mediaSource && (
+					<MediaPlayerToolbarControl
+						onTimeChange={ ( time ) => setTimestamp( convertSecondsToTimeCode( time ) ) }
+					/>
+				) }
+
 				<ToolbarGroup>
 					<ParticipantsEditDropdown
 						id={ `dialogue-${ instanceId }-participants-dropdown` }
@@ -189,12 +195,6 @@ export default function DialogueEdit( {
 						onParticipantDelete={ deleteConversationParticipant }
 					/>
 				</ToolbarGroup>
-
-				{ mediaSource && (
-					<MediaPlayerToolbarControl
-						onTimeChange={ ( time ) => setTimestamp( convertSecondsToTimeCode( time ) ) }
-					/>
-				) }
 
 				{ currentParticipant && isFocusedOnParticipantLabel && (
 					<ToolbarGroup>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -163,17 +163,6 @@ export default function DialogueEdit( {
 		setAttributes( { timestamp: time } );
 	}
 
-	function addConversationParticipant( value ) {
-		const { participantSlug: slug } = conversationBridge.addNewParticipant( value );
-		setTimeout( () => setAttributes( { participantSlug: slug } ), 100 );
-	}
-
-	function deleteConversationParticipant( value ) {
-		const prevParticipantSlug = conversationBridge.getPrevParticipantSlug( participantSlug );
-		setAttributes( { participantSlug: prevParticipantSlug } );
-		conversationBridge.deleteParticipant( value );
-	}
-
 	return (
 		<div className={ className }>
 			<BlockControls>
@@ -190,9 +179,9 @@ export default function DialogueEdit( {
 						participants={ participants }
 						participantSlug={ participantSlug }
 						onParticipantSelect={ setAttributes }
-						onParticipantAdd={ addConversationParticipant }
+						onParticipantAdd={ conversationBridge.addNewParticipant }
 						onParticipantChange={ conversationBridge.updateParticipants }
-						onParticipantDelete={ deleteConversationParticipant }
+						onParticipantDelete={ conversationBridge.deleteParticipant }
 					/>
 				</ToolbarGroup>
 
@@ -227,9 +216,9 @@ export default function DialogueEdit( {
 							participants={ participants }
 							participantSlug={ participantSlug }
 							onParticipantSelect={ setAttributes }
-							onParticipantAdd={ addConversationParticipant }
+							onParticipantAdd={ conversationBridge.addNewParticipant }
 							onParticipantChange={ conversationBridge.updateParticipants }
-							onParticipantDelete={ deleteConversationParticipant }
+							onParticipantDelete={ conversationBridge.deleteParticipant }
 						/>
 					</PanelBody>
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -18,18 +18,14 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 } from '@wordpress/components';
-import { useContext, useState, useEffect, useRef } from '@wordpress/element';
+import { useContext, useState, useEffect } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
-import {
-	ParticipantsEditDropdown,
-	ParticipantsEditMenu,
-	ParticipantsDropdown,
-} from './components/participants-control';
+import { ParticipantsEditMenu, ParticipantsDropdown } from './components/participants-control';
 import { TimestampControl, TimestampDropdown } from './components/timestamp-control';
 import ConversationContext from '../conversation/components/context';
 import { list as defaultParticipants } from '../conversation/participants.json';
@@ -65,7 +61,6 @@ export default function DialogueEdit( {
 		placeholder,
 	} = attributes;
 	const [ isFocusedOnParticipantLabel, setIsFocusedOnParticipantLabel ] = useState( false );
-	const richTextRef = useRef();
 	const baseClassName = 'wp-block-jetpack-dialogue';
 
 	const { prevBlock, mediaSource } = useSelect( select => {
@@ -173,15 +168,14 @@ export default function DialogueEdit( {
 				) }
 
 				<ToolbarGroup>
-					<ParticipantsEditDropdown
-						id={ `dialogue-${ instanceId }-participants-dropdown` }
+					<ParticipantsDropdown
 						className={ baseClassName }
+						labelClassName={ getParticipantLabelClass() }
 						participants={ participants }
+						label={ null }
 						participantSlug={ participantSlug }
-						onParticipantSelect={ setAttributes }
-						onParticipantAdd={ conversationBridge.addNewParticipant }
-						onParticipantChange={ conversationBridge.updateParticipants }
-						onParticipantDelete={ conversationBridge.deleteParticipant }
+						onSelect={ setAttributes }
+						editMode={ false }
 					/>
 				</ToolbarGroup>
 
@@ -248,12 +242,18 @@ export default function DialogueEdit( {
 
 			<div className={ `${ baseClassName }__meta` }>
 				<ParticipantsDropdown
+					className={ baseClassName }
 					labelClassName={ getParticipantLabelClass() }
 					participants={ participants }
 					label={ participantLabel }
 					participantSlug={ participantSlug }
-					onSelect={ setAttributes }
+					onParticipantSelect={ setAttributes }
+					onParticipantAdd={ conversationBridge.addNewParticipant }
+					onParticipantChange={ conversationBridge.updateParticipants }
+					onParticipantDelete={ conversationBridge.deleteParticipant }
 					onFocus={ () => setIsFocusedOnParticipantLabel( true ) }
+					editMode={ true }
+					icon={ null }
 				/>
 
 				{ showTimestamp && (
@@ -267,7 +267,6 @@ export default function DialogueEdit( {
 			</div>
 
 			<RichText
-				ref={ richTextRef }
 				identifier="content"
 				tagName="p"
 				className={ `${ baseClassName }__content` }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -27,7 +27,7 @@ import { useSelect, dispatch } from '@wordpress/data';
  */
 import './editor.scss';
 import ParticipantsDropdown, {
-	ParticipantsControl,
+	ParticipantsMenu,
 } from './components/participants-control';
 import { TimestampControl, TimestampDropdown } from './components/timestamp-control';
 import ConversationContext from '../conversation/components/context';
@@ -218,11 +218,23 @@ export default function DialogueEdit( {
 			<InspectorControls>
 				<Panel>
 					<PanelBody title={ __( 'Participant', 'jetpack' ) }>
-						<ParticipantsControl
+						<ParticipantsMenu
+							id={ `dialogue-${ instanceId }-participants-dropdown` }
 							className={ baseClassName }
 							participants={ participants }
-							participantSlug={ participantSlug || '' }
-							onSelect={ setAttributes }
+							label={ __( 'Participant', 'jetpack' ) }
+							participantSlug={ participantSlug }
+							onParticipantSelect={ setAttributes }
+							onParticipantAdd={ ( value ) => {
+								const { participantSlug: slug } = conversationBridge.addNewParticipant( value );
+								setTimeout( () => setAttributes( { participantSlug: slug } ), 100 );
+							} }
+							onParticipantChange={ conversationBridge.updateParticipants }
+							onParticipantDelete={ ( value ) => {
+								const prevParticipantSlug = conversationBridge.getPrevParticipantSlug( participantSlug );
+								setAttributes( { participantSlug: prevParticipantSlug } );
+								conversationBridge.deleteParticipant( value );
+							} }
 						/>
 					</PanelBody>
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -50,6 +50,7 @@
 		align-items: center;
 		height: 40px;
 
+		.components-base-control,
 		.components-base-control__field {
 			margin-bottom: 0;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -25,3 +25,37 @@
 .wp-block-jetpack-dialogue__timestamp-dropdown {
 	min-width: 90px;
 }
+
+.wp-block-jetpack-dialogue__participants {
+	display: flex;
+
+	> div {
+		display: flex;
+	}
+
+	.wp-block-jetpack-dialogue__participants-selector {
+		display: inline-flex;
+
+		.components-radio-control__option {
+			height: 40px;
+			width: 26px;
+			display: flex;
+			align-items: center;
+			margin-bottom: 0;
+		}
+	}
+
+	.wp-block-jetpack-dialogue__participants-selector__participant {
+		display: inline-flex;
+		align-items: center;
+		height: 40px;
+
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
+
+		.components-button {
+			margin-left: 8px;
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -1,3 +1,5 @@
+@import '../../shared/styles/gutenberg-base-styles.scss';
+
 .wp-block-jetpack-dialogue {
 	.wp-block-jetpack-dialogue__meta {
 		display: flex;
@@ -39,6 +41,10 @@
 
 	&.has-uppercase-style {
 		text-transform: uppercase;
+	}
+
+	&.is-undefined {
+		color: $gray-600;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR implements a way to edit the conversation participants list straight from the Dialogue block. Also, it replaces the participant button with a participant dropdown, rendered in the editor canvas.

The main reason why we are suggesting these changes is to facilitate the participants edition. Currently and depending on how many Dialogue blocks the transcription has, to open the participants dropdown to edit can get tedious.

We've created three components, rendered in different locations of the app. With this, to edit a participant, the user just need to open the dropdoen from the toolbar or using the block settings sidebar.

## ParticipantsEditDropdown

This component is rendered in the block toolbar.

<img src="https://user-images.githubusercontent.com/77539/106078172-b54c6680-60f1-11eb-9430-e1d9c15abed8.png" width="400px" />

## ParticipantsEditMenu

It's the same component by adapted for the block settings sidebar

<img src="https://user-images.githubusercontent.com/77539/106087503-eaad8000-6102-11eb-8834-cb3484d205d5.png" width="400px" />

## ParticipantsDropdown

This component only allows selecting a participant option. It renders in the editor canvas:

<img src="https://user-images.githubusercontent.com/77539/106087577-0e70c600-6103-11eb-8e56-8d4bb0b4e411.png" width="400px" />

It's possible to add/edit and remove conversation participants from there.

Fixes https://github.com/Automattic/jetpack/issues/18566

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create/edit a conversation block
* Test all actions provided by the new components


https://user-images.githubusercontent.com/77539/106088679-29443a00-6105-11eb-90a6-fb541365cb40.mov


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
