### PR TITLE
Admin Color Schemes: add border to Contrast color scheme

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_overrides.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_overrides.scss
@@ -129,3 +129,8 @@
 	}
 
 }
+
+// Ensure sidebar is visually separate from the content in the Contrast color scheme
+.admin-color-contrast #adminmenuback {
+	outline: 1px solid $nav-unification-sidebar-border;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a border between the sidebar and the content in the Contrast color scheme

This PR is related to a similar change in Calypso https://github.com/Automattic/wp-calypso/pull/49408

The related issue is https://github.com/Automattic/wp-calypso/issues/48009

|Before|After|
|-|-|
|<img width="404" alt="Screenshot 2021-01-28 at 15 08 05" src="https://user-images.githubusercontent.com/1562646/106149539-abbb1100-617a-11eb-8d4e-a845a72c4efc.png">|<img width="414" alt="Screenshot 2021-01-28 at 15 07 34" src="https://user-images.githubusercontent.com/1562646/106149545-ad84d480-617a-11eb-9a60-8195b48becfb.png">|

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


- activate WPCOM toolbar in Settings>Writing
- select the Contrast color scheme in profile.php
- confirm there is now a visual divider between the sidebar and the content

