### PR TITLE
Build: Use Node 12 instead of Node latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"clean-jetpack": "cd projects/plugins/jetpack && yarn clean",
 		"distclean": "rm -rf node_modules && yarn clean-composer && yarn distclean-jetpack",
 		"distclean-jetpack": "cd projects/plugins/jetpack && yarn distclean",
-		"docker:build": "docker run -it --rm  -v ${PWD}:/usr/src/app -w /usr/src/app node:$(cat .nvmrc) yarn build",
+		"docker:build": "docker run -it --rm -v \"${PWD}:/usr/src/app\" -w /usr/src/app \"node:$(cat .nvmrc)\" yarn build",
 		"docker:build-image": "docker build -t automattic/jetpack-wordpress-dev tools/docker",
 		"docker:clean": "yarn docker:compose down --rmi all -v && rm -rf tools/docker/wordpress/* tools/docker/wordpress/.htaccess tools/docker/wordpress-develop/* tools/docker/logs/* tools/docker/data/mysql/*",
 		"docker:compose": "yarn docker:env && yarn docker:compose-volumes && yarn docker:compose-extras && docker-compose -f tools/docker/docker-compose.yml -f tools/docker/compose-volumes.built.yml -f tools/docker/compose-extras.yml",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"clean-jetpack": "cd projects/plugins/jetpack && yarn clean",
 		"distclean": "rm -rf node_modules && yarn clean-composer && yarn distclean-jetpack",
 		"distclean-jetpack": "cd projects/plugins/jetpack && yarn distclean",
-		"docker:build": "docker run -it --rm  -v ${PWD}:/usr/src/app -w /usr/src/app node:12 yarn build",
+		"docker:build": "docker run -it --rm  -v ${PWD}:/usr/src/app -w /usr/src/app node:$(cat .nvmrc) yarn build",
 		"docker:build-image": "docker build -t automattic/jetpack-wordpress-dev tools/docker",
 		"docker:clean": "yarn docker:compose down --rmi all -v && rm -rf tools/docker/wordpress/* tools/docker/wordpress/.htaccess tools/docker/wordpress-develop/* tools/docker/logs/* tools/docker/data/mysql/*",
 		"docker:compose": "yarn docker:env && yarn docker:compose-volumes && yarn docker:compose-extras && docker-compose -f tools/docker/docker-compose.yml -f tools/docker/compose-volumes.built.yml -f tools/docker/compose-extras.yml",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"clean-jetpack": "cd projects/plugins/jetpack && yarn clean",
 		"distclean": "rm -rf node_modules && yarn clean-composer && yarn distclean-jetpack",
 		"distclean-jetpack": "cd projects/plugins/jetpack && yarn distclean",
-		"docker:build": "docker run -it --rm  -v ${PWD}:/usr/src/app -w /usr/src/app node yarn build",
+		"docker:build": "docker run -it --rm  -v ${PWD}:/usr/src/app -w /usr/src/app node:12 yarn build",
 		"docker:build-image": "docker build -t automattic/jetpack-wordpress-dev tools/docker",
 		"docker:clean": "yarn docker:compose down --rmi all -v && rm -rf tools/docker/wordpress/* tools/docker/wordpress/.htaccess tools/docker/wordpress-develop/* tools/docker/logs/* tools/docker/data/mysql/*",
 		"docker:compose": "yarn docker:env && yarn docker:compose-volumes && yarn docker:compose-extras && docker-compose -f tools/docker/docker-compose.yml -f tools/docker/compose-volumes.built.yml -f tools/docker/compose-extras.yml",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes p1611862320013700-slack-CDLH4C1UZ

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* For the `yarn docker:build` command, use the node version from `.nvmrc` instead of `node:latest`.


#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Run `yarn docker:build` before after this patch.

#### Proposed changelog entry for your changes:
* n/a