### PR TITLE
Jetpack Recommendations: Add loading indicator for summary main content

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/style.scss
@@ -19,6 +19,13 @@
 
 .jp-recommendations-summary__content {
 	background: $white;
+
+	&.isLoading {
+		min-height: 730px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
 }
 
 .jp-recommendations-summary__configuration {
@@ -39,6 +46,13 @@
 
 	@include breakpoint( '<660px' ) {
 		padding: 0;
+	}
+
+	&.isLoading {
+		min-height: 430px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
@@ -60,6 +60,14 @@ export function isFetchingPluginsData( state ) {
 }
 
 /**
+ * Returns the site plugins data
+ * @param {Object} state Global state tree
+ */
+export function getPluginsData( state ) {
+	return state.jetpack.pluginsData.items;
+}
+
+/**
  * Returns whether the plugin is active or not.
  * @param  {Object}  state  Global state tree
  * @param  {String}  plugin Slug of plugin to check.

--- a/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
@@ -62,6 +62,7 @@ export function isFetchingPluginsData( state ) {
 /**
  * Returns the site plugins data
  * @param {Object} state Global state tree
+ * @return {Boolean} The plugins data
  */
 export function getPluginsData( state ) {
 	return state.jetpack.pluginsData.items;

--- a/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
@@ -52,8 +52,9 @@ export const reducer = combineReducers( {
  * Returns true if currently requesting plugin data. Otherwise false.
  * otherwise.
  *
- * @param  {Object}  state Global state tree
- * @return {Boolean}       Whether plugin data is being requested
+ * @param {object} state - Global state tree
+ *
+ * @returns {boolean} - Whether plugin data is being requested
  */
 export function isFetchingPluginsData( state ) {
 	return !! state.jetpack.pluginsData.requests.isFetchingPluginsData;
@@ -61,8 +62,10 @@ export function isFetchingPluginsData( state ) {
 
 /**
  * Returns the site plugins data
- * @param {Object} state Global state tree
- * @return {Boolean} The plugins data
+ *
+ * @param {object} state - Global state tree
+ *
+ * @returns {boolean} - The plugins data
  */
 export function getPluginsData( state ) {
 	return state.jetpack.pluginsData.items;
@@ -70,9 +73,11 @@ export function getPluginsData( state ) {
 
 /**
  * Returns whether the plugin is active or not.
- * @param  {Object}  state  Global state tree
- * @param  {String}  plugin Slug of plugin to check.
- * @return {Boolean} True if plugin is active, false otherwise.
+ *
+ * @param  {object}  state  - Global state tree
+ * @param  {string}  plugin - Slug of plugin to check.
+ *
+ * @returns {boolean} True if plugin is active, false otherwise.
  */
 export function isPluginActive( state, plugin ) {
 	return (
@@ -82,9 +87,11 @@ export function isPluginActive( state, plugin ) {
 
 /**
  * Returns whether the plugin is installed or not.
- * @param  {Object}  state  Global state tree
- * @param  {String}  plugin Slug of plugin to check.
- * @return {Boolean} True if plugin is installed, false otherwise.
+ *
+ * @param  {object}  state  - Global state tree
+ * @param  {string}  plugin - Slug of plugin to check.
+ *
+ * @returns {boolean} True if plugin is installed, false otherwise.
  */
 export function isPluginInstalled( state, plugin ) {
 	return !! state.jetpack.pluginsData.items[ plugin ];

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -104,7 +104,6 @@
 	"projects/plugins/jetpack/_inc/client/state/setup-wizard/reducer.js",
 	"projects/plugins/jetpack/_inc/client/state/site-products/reducer.js",
 	"projects/plugins/jetpack/_inc/client/state/site-verify/reducer.js",
-	"projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js",
 	"projects/plugins/jetpack/_inc/client/state/site/reducer.js",
 	"projects/plugins/jetpack/_inc/client/state/tracking/reducer.js",
 	"projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18588

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR adds a loading indicator to the main content of the summary to stabilize the visuals during loading.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p8oabR-BT-p2#comment-4914

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to `/wp-admin/admin.php?page=jetpack#/recommendations/summary`
2. Reload the page if you navigated there from within the React app.
3. Verify that the loading indicators display.
4. Repeat in mobile view.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*