### PR TITLE
Conversation/dialogue blocks: tweaks to styles and search terms

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/index.js
@@ -28,8 +28,9 @@ export const settings = {
 	icon,
 	category: 'layout',
 	keywords: [
-		_x( 'Conversation', 'block search term', 'jetpack' ),
-		__( 'transcription', 'jetpack' ),
+		_x( 'conversation', 'block search term', 'jetpack' ),
+		_x( 'transcription', 'block search term', 'jetpack' ),
+		_x( 'dialogue', 'block search term', 'jetpack' ),
 	],
 	supports: {
 		align: true,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -1,4 +1,9 @@
+@import '../../shared/styles/gutenberg-base-styles.scss';
+
 .wp-block-jetpack-dialogue {
+	margin-top: 20px;
+	margin-bottom: 20px;
+
 	.wp-block-jetpack-dialogue__meta {
 		display: flex;
 		flex-direction: row;
@@ -48,25 +53,27 @@
 }
 
 // Conversation styles.
-.wp-block-jetpack-conversation.is-style-column {
-	.wp-block-jetpack-dialogue {
-		display: flex;
+@include break-small {
+	.wp-block-jetpack-conversation.is-style-column {
+		.wp-block-jetpack-dialogue {
+			display: flex;
 
-		.wp-block-jetpack-dialogue__meta {
-			display: block;
-			align-items: initial;
-			flex: 0 0 20%;
-		}
+			.wp-block-jetpack-dialogue__meta {
+				display: block;
+				align-items: initial;
+				flex: 0 0 25%;
+			}
 
-		.wp-block-jetpack-dialogue__participant {
-			text-align: right;
-			margin-right: 12px;
-		}
+			.wp-block-jetpack-dialogue__participant {
+				text-align: right;
+				margin-right: 12px;
+			}
 
-		.components-dropdown,
-		.wp-block-jetpack-dialogue__timestamp-dropdown {
-			text-align: right;
-			display: block;
+			.components-dropdown,
+			.wp-block-jetpack-dialogue__timestamp-dropdown {
+				text-align: right;
+				display: block;
+			}
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -60,18 +60,16 @@
 
 			.wp-block-jetpack-dialogue__meta {
 				display: block;
-				align-items: initial;
 				flex: 0 0 25%;
+				text-align: right;
 			}
 
 			.wp-block-jetpack-dialogue__participant {
-				text-align: right;
 				margin-right: 12px;
 			}
 
 			.components-dropdown,
 			.wp-block-jetpack-dialogue__timestamp-dropdown {
-				text-align: right;
 				display: block;
 			}
 		}


### PR DESCRIPTION
Fixes #18567 and #18569

#### Changes proposed in this Pull Request:

- Stacks column style conversations on smaller screens
- Ensures participant names are right aligned for column style in the editor
- Add top/bottom margin to dialogue entries on the front-end
- Adds `dialogue` search term to conversation block, since the conversation block is what's available in the inserter

| **Before** | **After** |
| --- | --- |
| <img width="300" alt="image" src="https://user-images.githubusercontent.com/1699996/106225046-f6a04d00-61a9-11eb-9bec-218caea4bf8b.png"> | <img width="300" alt="image" src="https://user-images.githubusercontent.com/1699996/106225188-4121c980-61aa-11eb-9252-1101171594ce.png"> |
| <img width="300" alt="image" src="https://user-images.githubusercontent.com/1699996/106225053-fa33d400-61a9-11eb-84ca-b3fd6c77c74f.png"> | <img width="300" alt="image" src="https://user-images.githubusercontent.com/1699996/106225070-00c24b80-61aa-11eb-8024-490d6f99d0a5.png"> |
| <img width="626" alt="image" src="https://user-images.githubusercontent.com/1699996/106225587-17b56d80-61ab-11eb-9835-548c1bcada40.png"> | <img width="651" alt="image" src="https://user-images.githubusercontent.com/1699996/106225596-1d12b800-61ab-11eb-8eb7-27ab7874b290.png"> |



#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Use the quick inserter to test that you can insert a conversation block using the dialogue keyword (e.g. type `/dialogue`)
* Insert a conversation block and add dialogue entries
* Select the conversation block (parent of dialogue blocks) and choose the column style
* Ensure the participant names correctly align
* Save the post and view on a smaller screen--see that the columns stack for smaller screens

#### Proposed changelog entry for your changes:

* Conversation/dialogue blocks: improved dialogue spacing and alignment
