### PR TITLE
Story block: Fix srcset tag values on WP.com

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -48,7 +48,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 			}
 			$attachment_id = $media_file['id'];
 			if ( 'image' === $media_file['type'] ) {
-				$image = wp_get_attachment_image_src( $attachment_id, EMBED_SIZE, false );
+				$image = wp_get_attachment_image_src( $attachment_id, 'full', false );
 				if ( ! $image ) {
 					return $media_file;
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This fixes an issue with Story playback on WP.com, where images would sometimes be pixelated or blurry (Jetpack sites were not affected).

The reason this was happening was that the base image size [supplied to `wp_calculate_image_srcset`](https://github.com/Automattic/jetpack/blob/6cc6ec6b0243bb92767efd30a1214cf55e0cc2cb/projects/plugins/jetpack/extensions/blocks/story/story.php#L66) was small, and WP.com has added filtering that removes the full size image from the srcset sources if it's more than twice the base size of the image (see `filter_image_srcset()` in `wpcom-media.php`). This resulted in a too-small image being upscaled to fit the display and looking blurry.

Here's an example of the issue (Jetpack on the right is correctly loading the full-size image):

![srcset-diff](https://user-images.githubusercontent.com/9613966/106230146-314dc800-6232-11eb-977d-a167a13ccf4e.png)

This PR changes the behavior to default to the full size image instead. This makes sure the full size of the image is included in the srcset options on WP.com, so it can be used on large enough screens.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

This PR should be tested on Jetpack and on WP.com.

##### Jetpack

On a Jetpack site, this PR shouldn't affect any behavior - essentially just confirming nothing is broken):

In a post containing a story block on Jetpack, inspect network requests and verify that the images are loaded with appropriate size parameters, e.g.:

`https://i0.wp.com/siteurl/wp-content/uploads/2021/01/5287423744-1.jpg?w=1125&ssl=1`

Use responsive mode to test the same screen on a smaller handset. Observe that the maximum image requested is smaller:

`https://i0.wp.com/siteurl/wp-content/uploads/2021/01/5287423744-1.jpg?resize=768%2C1663&ssl=1`

(Depends on the full size of the image - happy to provide example images/posts if pinged!)

##### WordPress.com

Do the same as above on a WordPress.com site. Observe that media are now downloaded at large size when played back on a web browser:

`https://site.files.wordpress.com/2021/01/5287423744.jpg`

And that they're sized down in responsive move:

`https://site.files.wordpress.com/2021/01/5287423744.jpg?w=768&h=1663`

#### Proposed changelog entry for your changes:
None needed.