### PR TITLE
Changes the customize_slug depending on simple / atomic.

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -35,6 +35,13 @@ class Admin_Menu {
 	protected $domain;
 
 	/**
+	 * The customizer default link.
+	 *
+	 * @var string
+	 */
+	protected $customize_slug;
+
+	/**
 	 * Admin_Menu constructor.
 	 */
 	protected function __construct() {
@@ -44,7 +51,8 @@ class Admin_Menu {
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 		add_action( 'rest_request_before_callbacks', array( $this, 'rest_api_init' ), 11 );
 
-		$this->domain = ( new Status() )->get_site_suffix();
+		$this->domain          = ( new Status() )->get_site_suffix();
+		$this->$customize_slug = 'customize.php';
 	}
 
 	/**
@@ -99,7 +107,7 @@ class Admin_Menu {
 		$this->add_testimonials_menu( $wp_admin );
 		$this->add_portfolio_menu( $wp_admin );
 		$this->add_comments_menu( $wp_admin );
-		$this->add_appearance_menu( 'customize.php', $wp_admin );
+		$this->add_appearance_menu( $wp_admin );
 		$this->add_plugins_menu();
 		$this->add_users_menu( $wp_admin );
 		$this->add_tools_menu( $wp_admin );
@@ -364,10 +372,9 @@ class Admin_Menu {
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @param String $customize_slug Whether customizer links should point to Calypso or wp-admin.
 	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $customize_slug, $wp_admin = false ) {
+	public function add_appearance_menu( $wp_admin = false ) {
 		$user_can_customize = current_user_can( 'customize' );
 		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
 		$themes_slug        = $wp_admin ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
@@ -381,7 +388,7 @@ class Admin_Menu {
 
 		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), $appearance_cap, $themes_slug, null, 'dashicons-admin-appearance', 60 );
 		add_submenu_page( $themes_slug, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', $themes_slug, null, 5 );
-		add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $customize_slug, null, 10 );
+		add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $this->$customize_slug, null, 10 );
 
 		// Maintain id as JS selector.
 		$GLOBALS['menu'][60][5] = 'menu-appearance'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -394,7 +401,7 @@ class Admin_Menu {
 			$customize_header_url = admin_url( 'themes.php?page=custom-header' );
 			remove_submenu_page( 'themes.php', esc_url( $customize_header_url ) );
 
-			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_slug );
+			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $this->$customize_slug );
 			add_submenu_page( $themes_slug, __( 'Header', 'jetpack' ), __( 'Header', 'jetpack' ), 'customize', esc_url( $customize_header_url ), null, 15 );
 		}
 
@@ -406,21 +413,21 @@ class Admin_Menu {
 			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), admin_url( 'customize.php' ) );
 			remove_submenu_page( 'themes.php', esc_url( $customize_background_url ) );
 
-			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), $customize_slug );
+			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), $this->$customize_slug );
 			add_submenu_page( $themes_slug, esc_attr__( 'Background', 'jetpack' ), __( 'Background', 'jetpack' ), 'customize', esc_url( $customize_background_url ), null, 20 );
 		}
 
 		if ( current_theme_supports( 'widgets' ) ) {
 			remove_submenu_page( 'themes.php', 'widgets.php' );
 
-			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $customize_slug );
+			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $this->$customize_slug );
 			add_submenu_page( $themes_slug, esc_attr__( 'Widgets', 'jetpack' ), __( 'Widgets', 'jetpack' ), 'customize', esc_url( $customize_menu_url ), null, 20 );
 		}
 
 		if ( current_theme_supports( 'menus' ) || current_theme_supports( 'widgets' ) ) {
 			remove_submenu_page( 'themes.php', 'nav-menus.php' );
 
-			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $customize_slug );
+			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $this->$customize_slug );
 			add_submenu_page( $themes_slug, esc_attr__( 'Menus', 'jetpack' ), __( 'Menus', 'jetpack' ), 'customize', esc_url( $customize_menu_url ), null, 20 );
 		}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -365,7 +365,7 @@ class Admin_Menu {
 	 * Adds Appearance menu.
 	 *
 	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param String $customize_slug. Whether customizer links should point to Calypso or wp-admin.
+	 * @param String $customize_slug Whether customizer links should point to Calypso or wp-admin.
 	 */
 	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$user_can_customize = current_user_can( 'customize' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -364,8 +364,8 @@ class Admin_Menu {
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param string $customize_slug. Whether customizer links should point to Calypso or wp-admin.
+	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param String $customize_slug. Whether customizer links should point to Calypso or wp-admin.
 	 */
 	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$user_can_customize = current_user_can( 'customize' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -51,7 +51,7 @@ class Admin_Menu {
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 		add_action( 'rest_request_before_callbacks', array( $this, 'rest_api_init' ), 11 );
 
-		$this->domain          = ( new Status() )->get_site_suffix();
+		$this->domain = ( new Status() )->get_site_suffix();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -99,7 +99,7 @@ class Admin_Menu {
 		$this->add_testimonials_menu( $wp_admin );
 		$this->add_portfolio_menu( $wp_admin );
 		$this->add_comments_menu( $wp_admin );
-		$this->add_appearance_menu( $wp_admin, '' );
+		$this->add_appearance_menu( '', $wp_admin );
 		$this->add_plugins_menu();
 		$this->add_users_menu( $wp_admin );
 		$this->add_tools_menu( $wp_admin );
@@ -364,10 +364,10 @@ class Admin_Menu {
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 * @param String $customize_slug Whether customizer links should point to Calypso or wp-admin.
+	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
+	public function add_appearance_menu( $customize_slug, $wp_admin = false ) {
 		$user_can_customize = current_user_can( 'customize' );
 		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
 		$themes_slug        = $wp_admin ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -99,7 +99,7 @@ class Admin_Menu {
 		$this->add_testimonials_menu( $wp_admin );
 		$this->add_portfolio_menu( $wp_admin );
 		$this->add_comments_menu( $wp_admin );
-		$this->add_appearance_menu( $wp_admin );
+		$this->add_appearance_menu( $wp_admin, '' );
 		$this->add_plugins_menu();
 		$this->add_users_menu( $wp_admin );
 		$this->add_tools_menu( $wp_admin );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -99,7 +99,7 @@ class Admin_Menu {
 		$this->add_testimonials_menu( $wp_admin );
 		$this->add_portfolio_menu( $wp_admin );
 		$this->add_comments_menu( $wp_admin );
-		$this->add_appearance_menu( '', $wp_admin );
+		$this->add_appearance_menu( 'customize.php', $wp_admin );
 		$this->add_plugins_menu();
 		$this->add_users_menu( $wp_admin );
 		$this->add_tools_menu( $wp_admin );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -365,6 +365,7 @@ class Admin_Menu {
 	 * Adds Appearance menu.
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param string $customize_slug. Whether customizer links should point to Calypso or wp-admin.
 	 */
 	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$user_can_customize = current_user_can( 'customize' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -366,10 +366,9 @@ class Admin_Menu {
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $wp_admin = false ) {
+	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$user_can_customize = current_user_can( 'customize' );
 		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
-		$customize_slug     = $wp_admin ? 'customize.php' : 'https://wordpress.com/customize/' . $this->domain;
 		$themes_slug        = $wp_admin ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
 		$customize_url      = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' ); // phpcs:ignore
 		remove_menu_page( 'themes.php' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -39,7 +39,7 @@ class Admin_Menu {
 	 *
 	 * @var string
 	 */
-	protected $customize_slug;
+	protected $customize_slug = 'customize.php';
 
 	/**
 	 * Admin_Menu constructor.
@@ -52,7 +52,6 @@ class Admin_Menu {
 		add_action( 'rest_request_before_callbacks', array( $this, 'rest_api_init' ), 11 );
 
 		$this->domain          = ( new Status() )->get_site_suffix();
-		$this->$customize_slug = 'customize.php';
 	}
 
 	/**
@@ -372,7 +371,7 @@ class Admin_Menu {
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_appearance_menu( $wp_admin = false ) {
 		$user_can_customize = current_user_can( 'customize' );
@@ -388,7 +387,7 @@ class Admin_Menu {
 
 		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), $appearance_cap, $themes_slug, null, 'dashicons-admin-appearance', 60 );
 		add_submenu_page( $themes_slug, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', $themes_slug, null, 5 );
-		add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $this->$customize_slug, null, 10 );
+		add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $this->customize_slug, null, 10 );
 
 		// Maintain id as JS selector.
 		$GLOBALS['menu'][60][5] = 'menu-appearance'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -401,7 +400,7 @@ class Admin_Menu {
 			$customize_header_url = admin_url( 'themes.php?page=custom-header' );
 			remove_submenu_page( 'themes.php', esc_url( $customize_header_url ) );
 
-			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $this->$customize_slug );
+			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $this->customize_slug );
 			add_submenu_page( $themes_slug, __( 'Header', 'jetpack' ), __( 'Header', 'jetpack' ), 'customize', esc_url( $customize_header_url ), null, 15 );
 		}
 
@@ -413,21 +412,21 @@ class Admin_Menu {
 			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), admin_url( 'customize.php' ) );
 			remove_submenu_page( 'themes.php', esc_url( $customize_background_url ) );
 
-			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), $this->$customize_slug );
+			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), $this->customize_slug );
 			add_submenu_page( $themes_slug, esc_attr__( 'Background', 'jetpack' ), __( 'Background', 'jetpack' ), 'customize', esc_url( $customize_background_url ), null, 20 );
 		}
 
 		if ( current_theme_supports( 'widgets' ) ) {
 			remove_submenu_page( 'themes.php', 'widgets.php' );
 
-			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $this->$customize_slug );
+			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $this->customize_slug );
 			add_submenu_page( $themes_slug, esc_attr__( 'Widgets', 'jetpack' ), __( 'Widgets', 'jetpack' ), 'customize', esc_url( $customize_menu_url ), null, 20 );
 		}
 
 		if ( current_theme_supports( 'menus' ) || current_theme_supports( 'widgets' ) ) {
 			remove_submenu_page( 'themes.php', 'nav-menus.php' );
 
-			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $this->$customize_slug );
+			$customize_menu_url = add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $this->customize_slug );
 			add_submenu_page( $themes_slug, esc_attr__( 'Menus', 'jetpack' ), __( 'Menus', 'jetpack' ), 'customize', esc_url( $customize_menu_url ), null, 20 );
 		}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -229,4 +229,14 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		parent::add_options_menu( $wp_admin );
 	}
+
+	/**
+	 * Adds Appearance menu.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_appearance_menu( $wp_admin = false ) {
+		$customize_slug = 'customize.php';
+		parent::add_appearance_menu( $wp_admin, $customize_slug );
+	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -234,7 +234,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Appearance menu.
 	 *
 	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param String $customize_slug. Whether customizer links should point to Calypso or wp-admin.
+	 * @param String $customize_slug Whether customizer links should point to Calypso or wp-admin.
 	 */
 	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$customize_slug = 'customize.php';

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -235,7 +235,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $wp_admin = false ) {
+	public function add_appearance_menu( $wp_admin = false, $customize_slug = '' ) {
 		$customize_slug = 'customize.php';
 		parent::add_appearance_menu( $wp_admin, $customize_slug );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -229,15 +229,4 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		parent::add_options_menu( $wp_admin );
 	}
-
-	/**
-	 * Adds Appearance menu.
-	 *
-	 * @param String $customize_slug Whether customizer links should point to Calypso or wp-admin.
-	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
-	 */
-	public function add_appearance_menu( $customize_slug, $wp_admin = false ) {
-		$customize_slug = 'customize.php';
-		parent::add_appearance_menu( $customize_slug, $wp_admin );
-	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -233,11 +233,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 * @param String $customize_slug Whether customizer links should point to Calypso or wp-admin.
+	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
+	public function add_appearance_menu( $customize_slug, $wp_admin = false ) {
 		$customize_slug = 'customize.php';
-		parent::add_appearance_menu( $wp_admin, $customize_slug );
+		parent::add_appearance_menu( $customize_slug, $wp_admin );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -234,8 +234,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Appearance menu.
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param string $customize_slug. Whether customizer links should point to Calypso or wp-admin.
 	 */
-	public function add_appearance_menu( $wp_admin = false, $customize_slug = '' ) {
+	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$customize_slug = 'customize.php';
 		parent::add_appearance_menu( $wp_admin, $customize_slug );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -233,8 +233,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param string $customize_slug. Whether customizer links should point to Calypso or wp-admin.
+	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param String $customize_slug. Whether customizer links should point to Calypso or wp-admin.
 	 */
 	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$customize_slug = 'customize.php';

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -30,7 +30,8 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::rest_api_init();
 
 		// Get domain for requested site.
-		$this->domain = ( new Status() )->get_site_suffix();
+		$this->domain          = ( new Status() )->get_site_suffix();
+		$this->$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -21,7 +21,8 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::rest_api_init();
 
 		// Get domain for requested site.
-		$this->domain = ( new Status() )->get_site_suffix();
+		$this->domain          = ( new Status() )->get_site_suffix();
+		$this->$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 	}
 
 	/**
@@ -355,16 +356,5 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		}
 
 		return $result;
-	}
-
-	/**
-	 * Adds Appearance menu.
-	 *
-	 * @param String $customize_slug Whether customizer links should point to Calypso or wp-admin.
-	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
-	 */
-	public function add_appearance_menu( $customize_slug, $wp_admin = false ) {
-		$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
-		parent::add_appearance_menu( $customize_slug, $wp_admin );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -20,7 +20,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	protected function __construct() {
 		parent::__construct();
 
-		$this->$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
+		$this->customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 	}
 
 	/**
@@ -31,7 +31,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		// Get domain for requested site.
 		$this->domain          = ( new Status() )->get_site_suffix();
-		$this->$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
+		$this->customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -15,6 +15,15 @@ use Automattic\Jetpack\Status;
 class WPcom_Admin_Menu extends Admin_Menu {
 
 	/**
+	 * WPcom_Admin_Menu constructor.
+	 */
+	protected function __construct() {
+		parent::__construct();
+
+		$this->$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
+	}
+
+	/**
 	 * Sets up class properties for REST API requests.
 	 */
 	public function rest_api_init() {
@@ -22,7 +31,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		// Get domain for requested site.
 		$this->domain          = ( new Status() )->get_site_suffix();
-		$this->$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -361,8 +361,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds Appearance menu.
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param string $customize_slug. Whether customizer links should point to Calypso or wp-admin.
 	 */
-	public function add_appearance_menu( $wp_admin = false, $customize_slug = '' ) {
+	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 		parent::add_appearance_menu( $wp_admin, $customize_slug );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -360,8 +360,8 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param string $customize_slug. Whether customizer links should point to Calypso or wp-admin.
+	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param String $customize_slug. Whether customizer links should point to Calypso or wp-admin.
 	 */
 	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$customize_slug = 'https://wordpress.com/customize/' . $this->domain;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -30,7 +30,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::rest_api_init();
 
 		// Get domain for requested site.
-		$this->domain          = ( new Status() )->get_site_suffix();
+		$this->domain         = ( new Status() )->get_site_suffix();
 		$this->customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -360,11 +360,11 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 * @param String $customize_slug Whether customizer links should point to Calypso or wp-admin.
+	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
+	public function add_appearance_menu( $customize_slug, $wp_admin = false ) {
 		$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
-		parent::add_appearance_menu( $wp_admin, $customize_slug );
+		parent::add_appearance_menu( $customize_slug, $wp_admin );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -30,7 +30,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::rest_api_init();
 
 		// Get domain for requested site.
-		$this->domain          = ( new Status() )->get_site_suffix();
+		$this->domain = ( new Status() )->get_site_suffix();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -356,4 +356,14 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		return $result;
 	}
+
+	/**
+	 * Adds Appearance menu.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_appearance_menu( $wp_admin = false ) {
+		$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
+		parent::add_appearance_menu( $wp_admin, $customize_slug );
+	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -361,7 +361,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds Appearance menu.
 	 *
 	 * @param Bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param String $customize_slug. Whether customizer links should point to Calypso or wp-admin.
+	 * @param String $customize_slug Whether customizer links should point to Calypso or wp-admin.
 	 */
 	public function add_appearance_menu( $wp_admin = false, $customize_slug ) {
 		$customize_slug = 'https://wordpress.com/customize/' . $this->domain;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -362,7 +362,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $wp_admin = false ) {
+	public function add_appearance_menu( $wp_admin = false, $customize_slug = '' ) {
 		$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 		parent::add_appearance_menu( $wp_admin, $customize_slug );
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -491,8 +491,8 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 */
 	public function test_add_appearance_menu() {
 		global $menu, $submenu;
-
-		static::$admin_menu->add_appearance_menu( false );
+		$customize_slug = 'customize.php';
+		static::$admin_menu->add_appearance_menu( false, $customize_slug );
 
 		$slug = 'https://wordpress.com/themes/' . static::$domain;
 
@@ -520,15 +520,16 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		$customize_submenu_item = array(
 			'Customize',
 			'customize',
-			'https://wordpress.com/customize/' . static::$domain,
+			$customize_slug,
 			'Customize',
 		);
+
 		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
 
 		$widgets_submenu_item = array(
 			'Widgets',
 			'customize',
-			'https://wordpress.com/customize/' . static::$domain . '?autofocus%5Bpanel%5D=widgets',
+			$customize_slug . '?autofocus%5Bpanel%5D=widgets',
 			'Widgets',
 		);
 		$this->assertContains( $widgets_submenu_item, $submenu[ $slug ] );
@@ -536,7 +537,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		$menus_submenu_item = array(
 			'Menus',
 			'customize',
-			'https://wordpress.com/customize/' . static::$domain . '?autofocus%5Bpanel%5D=nav_menus',
+			$customize_slug . '?autofocus%5Bpanel%5D=nav_menus',
 			'Menus',
 		);
 		$this->assertContains( $menus_submenu_item, $submenu[ $slug ] );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -40,13 +40,6 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public static $domain;
 
 	/**
-	 * The customizer default link.
-	 *
-	 * @var string
-	 */
-	public static $customize_slug;
-
-	/**
 	 * Admin menu instance.
 	 *
 	 * @var Admin_Menu

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -492,7 +492,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_appearance_menu() {
 		global $menu, $submenu;
 		$customize_slug = 'customize.php';
-		static::$admin_menu->add_appearance_menu( false, $customize_slug );
+		static::$admin_menu->add_appearance_menu( $customize_slug, false );
 
 		$slug = 'https://wordpress.com/themes/' . static::$domain;
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -66,10 +66,8 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory Fixture factory.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		static::$domain  = ( new Status() )->get_site_suffix();
-		static::$customize_slug = 'customize.php';
-		static::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
-
+		static::$domain       = ( new Status() )->get_site_suffix();
+		static::$user_id      = $factory->user->create( array( 'role' => 'administrator' ) );
 		static::$menu_data    = get_menu_fixture();
 		static::$submenu_data = get_submenu_fixture();
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -40,6 +40,13 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public static $domain;
 
 	/**
+	 * The customizer default link.
+	 *
+	 * @var string
+	 */
+	public static $customize_slug;
+
+	/**
 	 * Admin menu instance.
 	 *
 	 * @var Admin_Menu
@@ -60,6 +67,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		static::$domain  = ( new Status() )->get_site_suffix();
+		static::$customize_slug = 'customize.php';
 		static::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
 		static::$menu_data    = get_menu_fixture();
@@ -492,7 +500,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_appearance_menu() {
 		global $menu, $submenu;
 		$customize_slug = 'customize.php';
-		static::$admin_menu->add_appearance_menu( $customize_slug, false );
+		static::$admin_menu->add_appearance_menu( false );
 
 		$slug = 'https://wordpress.com/themes/' . static::$domain;
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -41,6 +41,13 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	public static $domain;
 
 	/**
+	 * The customizer default link.
+	 *
+	 * @var string
+	 */
+	public static $customize_slug;
+
+	/**
 	 * Whether this testsuite is run on WP.com.
 	 *
 	 * @var bool
@@ -68,6 +75,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		static::$domain  = ( new Status() )->get_site_suffix();
+		static::$customize_slug = 'customize.php';
 		static::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
 		static::$menu_data    = get_menu_fixture();

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -41,13 +41,6 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	public static $domain;
 
 	/**
-	 * The customizer default link.
-	 *
-	 * @var string
-	 */
-	public static $customize_slug;
-
-	/**
 	 * Whether this testsuite is run on WP.com.
 	 *
 	 * @var bool

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -74,10 +74,8 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory Fixture factory.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		static::$domain  = ( new Status() )->get_site_suffix();
-		static::$customize_slug = 'customize.php';
-		static::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
-
+		static::$domain       = ( new Status() )->get_site_suffix();
+		static::$user_id      = $factory->user->create( array( 'role' => 'administrator' ) );
 		static::$menu_data    = get_menu_fixture();
 		static::$submenu_data = get_submenu_fixture();
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -74,10 +74,8 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory Fixture factory.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		static::$domain         = ( new Status() )->get_site_suffix();
-		static::$customize_slug = 'https://wordpress.com/customize/' . static::$domain;
-		static::$user_id        = $factory->user->create( array( 'role' => 'administrator' ) );
-
+		static::$domain       = ( new Status() )->get_site_suffix();
+		static::$user_id      = $factory->user->create( array( 'role' => 'administrator' ) );
 		static::$menu_data    = get_menu_fixture();
 		static::$submenu_data = get_submenu_fixture();
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -41,6 +41,13 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	public static $domain;
 
 	/**
+	 * The customizer default link.
+	 *
+	 * @var string
+	 */
+	public static $customize_slug;
+
+	/**
 	 * Whether this testsuite is run on WP.com.
 	 *
 	 * @var bool
@@ -67,8 +74,9 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory Fixture factory.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		static::$domain  = ( new Status() )->get_site_suffix();
-		static::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		static::$domain         = ( new Status() )->get_site_suffix();
+		static::$customize_slug = 'https://wordpress.com/customize/' . static::$domain;
+		static::$user_id        = $factory->user->create( array( 'role' => 'administrator' ) );
 
 		static::$menu_data    = get_menu_fixture();
 		static::$submenu_data = get_submenu_fixture();

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -41,13 +41,6 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	public static $domain;
 
 	/**
-	 * The customizer default link.
-	 *
-	 * @var string
-	 */
-	public static $customize_slug;
-
-	/**
 	 * Whether this testsuite is run on WP.com.
 	 *
 	 * @var bool


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/18596

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Support changing the customizer link ($customize_slug) through a parameter in the `add_appearance_menu` so that simple / atomic class can set the correct link.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**On an atomic site**
* Load this branch with Jetpack Beta
* Check that customizer URLs point to WPAdmin links and work

**On a jetpack site**
* Load this branch
* Enable `nav-unification` by adding `add_filter( 'jetpack_load_admin_menu_class', '__return_true' );` in a mu-plugin

**On a simple site**
* apply D56179 patch
* Check that customizer URLs point to WordPress.com links and work

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Avoid redirects for customizer links