### PR TITLE
Build: Use the CLI for build step to avoid duplicating logic

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -70,7 +70,7 @@ for project in projects/packages/* projects/plugins/*; do
 	fi
 	# Need to remove the "projects/" from the string since the CLI only looks for {type}/{project-name}.
 	SLUG=$(echo "$project" | cut -c 10-)
-	if jetpack build "${SLUG}"; then
+	if jetpack build "${SLUG}" --production; then
 		FAIL=false
 	else
 		FAIL=true

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -69,7 +69,7 @@ for project in projects/packages/* projects/plugins/*; do
 		fi
 	fi
 	# Need to remove the "projects/" from the string since the CLI only looks for {type}/{project-name}.
-	SLUG=$(echo "$project" | cut -c 10-)
+	SLUG="${project#projects/}"
 	if jetpack build "${SLUG}" --production; then
 		FAIL=false
 	else

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -22,6 +22,7 @@ echo "::set-output name=build-base::$BUILD_BASE"
 # Install Yarn generally.
 echo "::group::Monorepo setup"
 yarn install
+yarn cli-link
 echo "::endgroup::"
 
 EXIT=0
@@ -51,42 +52,41 @@ for project in projects/packages/* projects/plugins/*; do
 	## clone, delete files in the clone, and copy (new) files over
 	# this handles file deletions, additions, and changes seamlessly
 
-	if jq -e '.scripts["build-production"]' composer.json &>/dev/null; then
-		echo "::group::Building ${GIT_SLUG}"
+	echo "::group::Building ${GIT_SLUG}"
 
-		# If composer.json contains a reference to the monorepo repo, add one pointing to our production clones just before it.
-		# That allows us to pick up the built version for plugins like Jetpack.
-		# Also save the old contents to restore post-build to help with local testing.
-		OLDJSON=$(<composer.json)
-		JSON=$(jq --arg path "$BUILD_BASE/*/*" '( .repositories // [] | map( .options.monorepo or false ) | index(true) ) as $i | if $i != null then .repositories[$i:$i] |= [{ type: "path", url: $path, options: { monorepo: true } }] else . end' composer.json | "$BASE/tools/prettier" --parser=json-stringify)
-		if [[ "$JSON" != "$OLDJSON" ]]; then
-			echo "$JSON" > composer.json
-			if [[ -e "composer.lock" ]]; then
-				OLDLOCK=$(<composer.lock)
-				composer update --root-reqs --no-install
-			else
-				OLDLOCK=
-			fi
-		fi
-
-		if composer run-script --timeout=0 build-production; then
-			FAIL=false
+	# If composer.json contains a reference to the monorepo repo, add one pointing to our production clones just before it.
+	# That allows us to pick up the built version for plugins like Jetpack.
+	# Also save the old contents to restore post-build to help with local testing.
+	OLDJSON=$(<composer.json)
+	JSON=$(jq --arg path "$BUILD_BASE/*/*" '( .repositories // [] | map( .options.monorepo or false ) | index(true) ) as $i | if $i != null then .repositories[$i:$i] |= [{ type: "path", url: $path, options: { monorepo: true } }] else . end' composer.json | "$BASE/tools/prettier" --parser=json-stringify)
+	if [[ "$JSON" != "$OLDJSON" ]]; then
+		echo "$JSON" > composer.json
+		if [[ -e "composer.lock" ]]; then
+			OLDLOCK=$(<composer.lock)
+			composer update --root-reqs --no-install
 		else
-			FAIL=true
+			OLDLOCK=
 		fi
+	fi
+	# Need to remove the "projects/" from the string since the CLI only looks for {type}/{project-name}.
+	SLUG=$(echo "$project" | cut -c 10-)
+	if jetpack build "${SLUG}"; then
+		FAIL=false
+	else
+		FAIL=true
+	fi
 
-		# Restore files to help with local testing.
-		if [[ "$JSON" != "$OLDJSON" ]]; then
-			echo "$OLDJSON" > composer.json
-			[[ -n "$OLDLOCK" ]] && echo "$OLDLOCK" > composer.lock || rm -f composer.lock
-		fi
+	# Restore files to help with local testing.
+	if [[ "$JSON" != "$OLDJSON" ]]; then
+		echo "$OLDJSON" > composer.json
+		[[ -n "$OLDLOCK" ]] && echo "$OLDLOCK" > composer.lock || rm -f composer.lock
+	fi
 
-		echo "::endgroup::"
-		if $FAIL; then
-			echo "::error::Build of ${GIT_SLUG} failed"
-			EXIT=1
-			continue
-		fi
+	echo "::endgroup::"
+	if $FAIL; then
+		echo "::error::Build of ${GIT_SLUG} failed"
+		EXIT=1
+		continue
 	fi
 
 	BUILD_DIR="${BUILD_BASE}/${GIT_SLUG}"

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -25,7 +25,7 @@ async function buildRouter( options ) {
 	};
 
 	if ( options.project ) {
-		const data = await readComposerJson( options.project );
+		const data = await readComposerJson( options.project, true );
 		data !== false ? await build( options.project, options.production, data ) : false;
 	} else {
 		console.error( chalk.red( 'You did not choose a project!' ) );
@@ -40,12 +40,18 @@ async function buildRouter( options ) {
  * @param {object} composerJson - The project's composer.json file, parsed.
  */
 export async function build( project, production, composerJson ) {
-	const buildDev = composerJson.scripts[ 'build-development' ]
-		? 'composer build-development'
-		: null;
-	const buildProd = composerJson.scripts[ 'build-production' ] ? 'composer build-production' : null;
-	// If production, prefer production script. If dev, prefer dev. Either case, fall back to the other if exists.
-	const command = production ? buildProd || buildDev : buildDev || buildProd;
+	let command = false;
+
+	if ( composerJson.scripts ) {
+		const buildDev = composerJson.scripts[ 'build-development' ]
+			? 'composer build-development'
+			: null;
+		const buildProd = composerJson.scripts[ 'build-production' ]
+			? 'composer build-production'
+			: null;
+		// If production, prefer production script. If dev, prefer dev. Either case, fall back to the other if exists.
+		command = production ? buildProd || buildDev : buildDev || buildProd;
+	}
 
 	if ( ! command ) {
 		// If neither build step is defined, abort.

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -25,7 +25,7 @@ async function buildRouter( options ) {
 	};
 
 	if ( options.project ) {
-		const data = await readComposerJson( options.project, true );
+		const data = await readComposerJson( options.project );
 		data !== false ? await build( options.project, options.production, data ) : false;
 	} else {
 		console.error( chalk.red( 'You did not choose a project!' ) );


### PR DESCRIPTION
Uses the `jetpack build` logic to determine to run production vs development build commands instead of assuming `build-production` will always be present.

Also, removes a check for the `build-production` script. We'd want to lock in the composer packages either way, no?

The jetpack cli intentionally exits with `0` if there is no composer.json or build steps are present. It'll return `1` if a build step actually fails.

I realized this when reviewing https://github.com/Automattic/jetpack/pull/18303 that `build-development` wouldn't have actually built the plugin.

#### Changes proposed in this Pull Request:
* See above.
 
#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Can try to run the commands locally.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
