### PR TITLE
Calypso: Check moderation option before comment notification

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/functions.wp-notify.php
+++ b/projects/plugins/jetpack/_inc/lib/functions.wp-notify.php
@@ -223,17 +223,28 @@ function jetpack_notify_postauthor( $emails, $comment_id ) {
  *
  * @since 5.8.0
  * @since 9.2.0 Switched from pluggable function to filter callback
+ * @since 9.5.0 Updated the passing condition to call get_option( 'moderation_notify' ); directly.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
- * @param string $notify_moderator The value of the moderation_notify option.
+ * @param string $notify_moderator The value of the moderation_notify option OR if the comment is awaiting moderation.
  * @param int    $comment_id Comment ID.
  * @return boolean Returns false to shortcircuit the execution of wp_notify_moderator
  */
 function jetpack_notify_moderator( $notify_moderator, $comment_id ) {
+	/*
+	 * $notify_moderator is a tricky one. This filter is called in two places in Core. One is just to pass if a comment
+	 * is being held for moderation. See https://core.trac.wordpress.org/browser/tags/5.6/src/wp-includes/comment.php#L2296
+	 *
+	 * So we can't just assume that a true value here is what we need. The second time the filter is called, it checks
+	 * the option -- which is what we expected here. See https://core.trac.wordpress.org/browser/tags/5.6/src/wp-includes/pluggable.php#L1737
+	 *
+	 * It's possible another plugin would be filtering this value to true despite the option setting; however, since we're running at priority 1,
+	 * they can still do that. They'll just get the Core flow instead of this one.
+	 */
 
 	// If Jetpack is not active, or if Notify moderators options is not set, let the default flow go on.
-	if ( ! $notify_moderator || ! Jetpack::is_active() ) {
+	if ( ! $notify_moderator || ! get_option( 'moderation_notify' ) || ! Jetpack::is_active() ) {
 		return $notify_moderator;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
This is a tricky one. This filter is called in two places in Core. One is just to pass if a comment is being held for moderation. See https://core.trac.wordpress.org/browser/tags/5.6/src/wp-includes/comment.php#L2296
 
So we can't just assume that a true value here is what we need. The second time the filter is called, it checks the option -- which is what we expected here. See https://core.trac.wordpress.org/browser/tags/5.6/src/wp-includes/pluggable.php#L1737

It's possible another plugin would be filtering this value to true despite the option setting; however, since we're running at priority 1, they can still do that. They'll just get the Core flow instead of this one.

Fixes p9F6qB-6q6-p2

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* More defensive check before sending comment notification.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With Jetpack activated, uncheck both "email me when" options under Settings->Discussion.
* Check "Comment must be manually approved" under "before a comment appears".
* Set the `edit_links_calypso_redirect` option (wp jetpack options set edit_links_calypso_redirect 1)
* Add a comment in a different browser session (so that it would be moderated).
* Expected: No e-mail.
* Actual: E-mail sent.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Comments: Improve respect for the Core moderation option in particular cases.