### PR TITLE
Docker: Add exposed port to mysql server

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -69,6 +69,7 @@ You can set the following variables on a per-command basis (`PORT_WORDPRESS=8000
 * `PORT_MAILDEV`: (default=`1080`) The port on your host machine connected to the MailDev container's MailDev HTTP server.
 * `PORT_SMTP`: (default=`25`) The port on your host machine connected to the MailDev container's SMTP server.
 * `PORT_SFTP`: (default=`1022`) The port on your host machine connected to the SFTP container's SFTP server.
+* `POST_DB`: (default=`3306`) The port on your host machine connected to the MySQL database container.
 
 ### Container Environments
 

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - ./logs/mysql:/var/log/mysql
       - ./config/mysql.conf:/etc/mysql/conf.d/docker.cnf
     restart: always
+    ports:
+      - "${PORT_DB:-3306}:3306"
     env_file:
       - default.env
       - .env


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16483

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Exposes a port to connect to the mysql db, 3306 by default and accepts setting it via the env.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `yarn docker:down` if it's running.
* `yarn docker:up`
* From your computer shell, `mysql -h 127.0.0.1 -P 3306 --user="wordpress" --password="wordpress"` (for macOS people without mysql installed, `brew install mysql` works).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
