### PR TITLE
Instant Search: improve overlay Escape key event handler (including fix for IE11)

### DIFF
--- a/projects/plugins/jetpack/modules/search/instant-search/components/overlay.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/overlay.jsx
@@ -12,17 +12,20 @@ import { useEffect } from 'preact/hooks';
  */
 import './overlay.scss';
 
-const closeOnEscapeKey = callback => event => {
-	event.key === 'Escape' && callback();
+const callOnEscapeKey = callback => event => {
+	// IE11 uses 'Esc'
+	( event.key === 'Escape' || event.key === 'Esc' ) && callback();
 };
 
 const Overlay = props => {
 	const { children, closeOverlay, colorTheme, hasOverlayWidgets, isVisible, opacity } = props;
+
+	const closeWithEscape = callOnEscapeKey( closeOverlay );
 	useEffect( () => {
-		window.addEventListener( 'keydown', closeOnEscapeKey( closeOverlay ) );
+		window.addEventListener( 'keydown', closeWithEscape );
 		return () => {
 			// Cleanup after event
-			window.removeEventListener( 'keydown', closeOnEscapeKey( closeOverlay ) );
+			window.removeEventListener( 'keydown', closeWithEscape );
 		};
 	}, [] );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/18580.

#### Changes proposed in this Pull Request:
* Update the event handler so that the listener is properly removed (props @rinatkhaziev)

Rinat reported: "because closeOnEscapeKey( closeOverlay ) are two different functions it’s not getting removed properly"

* Fix Escape key behaviour in IE11

"(KeyboardEvent.key in IE11 uses “Esc” rather than “Escape” because it was implemented before the specification was finalized)." https://devstephen.medium.com/keyboardevent-key-for-cross-browser-key-press-check-61dbad0a067a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On a site with Instant Search enabled, enter a new search query to open the overlay.
* Press 'Escape' on your keyboard. The overlay should close.

Repeat the test in IE11. Ensure that Escape still closes the overlay.

#### Proposed changelog entry for your changes:
* Instant Search: fix closing of the overlay using the Escape key in IE11.
