### PR TITLE
Dialogue: edit participant from canvas

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -153,14 +153,17 @@ function podcastConversationSection() {
 				{
 					slug: 'participant-0',
 					label: __( 'Speaker 1', 'jetpack' ),
+					hasBoldStyle: true,
 				},
 				{
 					slug: 'participant-1',
 					label: __( 'Speaker 2', 'jetpack' ),
+					hasBoldStyle: true,
 				},
 				{
 					slug: 'participant-2',
 					label: __( 'Speaker 3', 'jetpack' ),
+					hasBoldStyle: true,
 				},
 			],
 		},
@@ -177,21 +180,21 @@ function podcastConversationSection() {
 				'jetpack/dialogue',
 				{
 					placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
-					participantSlug: 'participant-0',
+					slug: 'participant-0',
 				},
 			],
 			[
 				'jetpack/dialogue',
 				{
 					placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
-					participantSlug: 'participant-1',
+					slug: 'participant-1',
 				},
 			],
 			[
 				'jetpack/dialogue',
 				{
 					placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
-					participantSlug: 'participant-2',
+					slug: 'participant-2',
 				},
 			],
 		],

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -153,17 +153,14 @@ function podcastConversationSection() {
 				{
 					slug: 'participant-0',
 					label: __( 'Speaker 1', 'jetpack' ),
-					hasBoldStyle: true,
 				},
 				{
 					slug: 'participant-1',
 					label: __( 'Speaker 2', 'jetpack' ),
-					hasBoldStyle: true,
 				},
 				{
 					slug: 'participant-2',
 					label: __( 'Speaker 3', 'jetpack' ),
-					hasBoldStyle: true,
 				},
 			],
 		},

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -86,7 +86,6 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 			const newParticipant = {
 				slug: newParticipantSlug,
 				label: sanitizedSpeakerLabel,
-				hasBoldStyle: true,
 			};
 >>>>>>> 5b937f7... dialogue: janitorual - tidying
 

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -43,6 +43,11 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 	);
 
 	const addNewParticipant = useCallback( function( newSpeakerValue ) {
+		// Do not add speakers with empty names.
+		if ( ! newSpeakerValue?.length ) {
+			return;
+		}
+
 		// Check if the speaker label has been already added.
 		const existingParticipant = getParticipantByValue( participants, newSpeakerValue );
 		if ( existingParticipant ) {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -42,9 +42,9 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		[ setAttributes, participants ]
 	);
 
-	const addNewParticipant = useCallback( function( newSpakerValue ) {
+	const addNewParticipant = useCallback( function( newSpeakerValue ) {
 		// Check if the speaker label has been already added.
-		const existingParticipant = getParticipantByValue( participants, newSpakerValue );
+		const existingParticipant = getParticipantByValue( participants, newSpeakerValue );
 		if ( existingParticipant ) {
 			return existingParticipant;
 		}
@@ -55,8 +55,8 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 
 		const newParticipant = {
 			slug: newParticipantSlug,
-			label: getParticipantPlainText( newSpakerValue ),
-			value: newSpakerValue,
+			label: getParticipantPlainText( newSpeakerValue ),
+			value: newSpeakerValue,
 		};
 
 		setAttributes( {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -18,7 +18,7 @@ import {
 import './editor.scss';
 import ParticipantsDropdown, { ParticipantsSelector } from './components/participants-controls';
 import TranscriptionContext from './components/context';
-import { getParticipantPlainText, getParticipantByLabel } from './utils';
+import { getParticipantPlainText, getParticipantByValue } from './utils';
 
 const TRANSCRIPTION_TEMPLATE = [ [ 'jetpack/dialogue' ] ];
 
@@ -43,10 +43,8 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 	);
 
 	const addNewParticipant = useCallback( function( newSpakerValue ) {
-		const label = getParticipantPlainText( newSpakerValue );
-
 		// Check if the speaker label has been already added.
-		const existingParticipant = getParticipantByLabel( participants, label );
+		const existingParticipant = getParticipantByValue( participants, newSpakerValue );
 		if ( existingParticipant ) {
 			return existingParticipant;
 		}
@@ -57,7 +55,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 
 		const newParticipant = {
 			slug: newParticipantSlug,
-			label,
+			label: getParticipantPlainText( newSpakerValue ),
 			value: newSpakerValue,
 		};
 

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -18,7 +18,7 @@ import {
 import './editor.scss';
 import ParticipantsDropdown, { ParticipantsSelector } from './components/participants-controls';
 import TranscriptionContext from './components/context';
-import { getParticipantPlainText, getParticipantByValue } from './utils';
+import { getParticipantByLabel } from './utils';
 
 const TRANSCRIPTION_TEMPLATE = [ [ 'jetpack/dialogue' ] ];
 
@@ -42,15 +42,15 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		[ setAttributes, participants ]
 	);
 
-	const addNewParticipant = useCallback( function( newSpeakerValue ) {
-		const sanitizedSpeakerValue = newSpeakerValue.trim();
+	const addNewParticipant = useCallback( function( newSpeakerLabel ) {
+		const sanitizedSpeakerLabel = newSpeakerLabel.trim();
 		// Do not add speakers with empty names.
-		if ( ! sanitizedSpeakerValue?.length ) {
+		if ( ! sanitizedSpeakerLabel?.length ) {
 			return;
 		}
 
 		// Do not add a new participant with the same label.
-		const existingParticipant = getParticipantByValue( participants, sanitizedSpeakerValue );
+		const existingParticipant = getParticipantByLabel( participants, sanitizedSpeakerLabel );
 		if ( existingParticipant ) {
 			return existingParticipant;
 		}
@@ -61,8 +61,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 
 		const newParticipant = {
 			slug: newParticipantSlug,
-			label: getParticipantPlainText( sanitizedSpeakerValue ),
-			value: sanitizedSpeakerValue,
+			label: sanitizedSpeakerLabel,
 		};
 
 		setAttributes( {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { InnerBlocks, InspectorControls, BlockControls } from '@wordpress/block-editor';
 import {
 	Panel,
@@ -20,38 +20,14 @@ import ParticipantsDropdown, { ParticipantsSelector } from './components/partici
 import TranscriptionContext from './components/context';
 import { getParticipantPlainText } from './utils';
 
-import { list as defaultParticipants } from './participants.json';
-
 const TRANSCRIPTION_TEMPLATE = [
-	[ 'core/heading', { placeholder: __( 'Conversation title', 'jetpack' ) } ],
-	[ 'jetpack/dialogue', {
-		participantLabel: defaultParticipants[ 0 ].label,
-		participantValue: `<strong>${ defaultParticipants[ 0 ].label }</strong>`,
-		participantSlug: defaultParticipants[ 0 ].slug,
-	} ],
-	[ 'jetpack/dialogue', {
-		participantLabel: defaultParticipants[ 1 ].label,
-		participantValue: `<strong>${ defaultParticipants[ 1 ].label }</strong>`,
-		participantSlug: defaultParticipants[ 1 ].slug,
-	} ],
-	[ 'jetpack/dialogue', {
-		participantLabel: defaultParticipants[ 2 ].label,
-		participantValue: `<strong>${ defaultParticipants[ 2 ].label }</strong>`,
-		participantSlug: defaultParticipants[ 2 ].slug,
-	} ],
+	[ 'jetpack/dialogue' ],
+	[ 'jetpack/dialogue' ],
+	[ 'jetpack/dialogue' ],
 ];
 
 function ConversationEdit( { className, attributes, setAttributes } ) {
 	const { participants = [], showTimestamps } = attributes;
-
-	// Set initial conversation participants.
-	useEffect( () => {
-		if ( participants?.length ) {
-			return;
-		}
-
-		setAttributes( { participants: defaultParticipants } );
-	}, [ participants, setAttributes ] );
 
 	const updateParticipants = useCallback(
 		updatedParticipant => {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -43,13 +43,14 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 	);
 
 	const addNewParticipant = useCallback( function( newSpeakerValue ) {
+		const sanitizedSpeakerValue = newSpeakerValue.trim();
 		// Do not add speakers with empty names.
-		if ( ! newSpeakerValue?.length ) {
+		if ( ! sanitizedSpeakerValue?.length ) {
 			return;
 		}
 
-		// Check if the speaker label has been already added.
-		const existingParticipant = getParticipantByValue( participants, newSpeakerValue );
+		// Do not add a new participant with the same label.
+		const existingParticipant = getParticipantByValue( participants, sanitizedSpeakerValue );
 		if ( existingParticipant ) {
 			return existingParticipant;
 		}
@@ -60,8 +61,8 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 
 		const newParticipant = {
 			slug: newParticipantSlug,
-			label: getParticipantPlainText( newSpeakerValue ),
-			value: newSpeakerValue,
+			label: getParticipantPlainText( sanitizedSpeakerValue ),
+			value: sanitizedSpeakerValue,
 		};
 
 		setAttributes( {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -20,11 +20,7 @@ import ParticipantsDropdown, { ParticipantsSelector } from './components/partici
 import TranscriptionContext from './components/context';
 import { getParticipantPlainText } from './utils';
 
-const TRANSCRIPTION_TEMPLATE = [
-	[ 'jetpack/dialogue' ],
-	[ 'jetpack/dialogue' ],
-	[ 'jetpack/dialogue' ],
-];
+const TRANSCRIPTION_TEMPLATE = [ [ 'jetpack/dialogue' ] ];
 
 function ConversationEdit( { className, attributes, setAttributes } ) {
 	const { participants = [], showTimestamps } = attributes;

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -42,7 +42,6 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		[ setAttributes, participants ]
 	);
 
-<<<<<<< HEAD
 	const addNewParticipant = useCallback( function( newSpeakerLabel ) {
 		const sanitizedSpeakerLabel = newSpeakerLabel.trim();
 		// Do not add speakers with empty names.
@@ -64,30 +63,6 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 			slug: newParticipantSlug,
 			label: sanitizedSpeakerLabel,
 		};
-=======
-	const addNewParticipant = useCallback(
-		function ( newSpeakerLabel = '' ) {
-			const sanitizedSpeakerLabel = newSpeakerLabel.trim();
-			// Do not add speakers with empty names.
-			if ( ! sanitizedSpeakerLabel?.length ) {
-				return;
-			}
-
-			// Do not add a new participant with the same label.
-			const existingParticipant = getParticipantByLabel( participants, sanitizedSpeakerLabel );
-			if ( existingParticipant ) {
-				return existingParticipant;
-			}
-
-			const newParticipantSlug = participants.length
-				? participants[ participants.length - 1 ].slug.replace( /(\d+)/, n => Number( n ) + 1 )
-				: 'speaker-0';
-
-			const newParticipant = {
-				slug: newParticipantSlug,
-				label: sanitizedSpeakerLabel,
-			};
->>>>>>> 5b937f7... dialogue: janitorual - tidying
 
 		setAttributes( {
 			participants: [

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -42,6 +42,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		[ setAttributes, participants ]
 	);
 
+<<<<<<< HEAD
 	const addNewParticipant = useCallback( function( newSpeakerLabel ) {
 		const sanitizedSpeakerLabel = newSpeakerLabel.trim();
 		// Do not add speakers with empty names.
@@ -63,6 +64,31 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 			slug: newParticipantSlug,
 			label: sanitizedSpeakerLabel,
 		};
+=======
+	const addNewParticipant = useCallback(
+		function ( newSpeakerLabel = '' ) {
+			const sanitizedSpeakerLabel = newSpeakerLabel.trim();
+			// Do not add speakers with empty names.
+			if ( ! sanitizedSpeakerLabel?.length ) {
+				return;
+			}
+
+			// Do not add a new participant with the same label.
+			const existingParticipant = getParticipantByLabel( participants, sanitizedSpeakerLabel );
+			if ( existingParticipant ) {
+				return existingParticipant;
+			}
+
+			const newParticipantSlug = participants.length
+				? participants[ participants.length - 1 ].slug.replace( /(\d+)/, n => Number( n ) + 1 )
+				: 'speaker-0';
+
+			const newParticipant = {
+				slug: newParticipantSlug,
+				label: sanitizedSpeakerLabel,
+				hasBoldStyle: true,
+			};
+>>>>>>> 5b937f7... dialogue: janitorual - tidying
 
 		setAttributes( {
 			participants: [

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -18,7 +18,7 @@ import {
 import './editor.scss';
 import ParticipantsDropdown, { ParticipantsSelector } from './components/participants-controls';
 import TranscriptionContext from './components/context';
-import { getParticipantPlainText, getParticipantByValue } from './utils';
+import { getParticipantPlainText, getParticipantByLabel } from './utils';
 
 const TRANSCRIPTION_TEMPLATE = [ [ 'jetpack/dialogue' ] ];
 
@@ -46,7 +46,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		const label = getParticipantPlainText( newSpakerValue );
 
 		// Check if the speaker label has been already added.
-		const existingParticipant = getParticipantByValue( participants, label );
+		const existingParticipant = getParticipantByLabel( participants, label );
 		if ( existingParticipant ) {
 			return existingParticipant;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -18,7 +18,7 @@ import {
 import './editor.scss';
 import ParticipantsDropdown, { ParticipantsSelector } from './components/participants-controls';
 import TranscriptionContext from './components/context';
-import { getParticipantPlainText } from './utils';
+import { getParticipantPlainText, getParticipantByValue } from './utils';
 
 const TRANSCRIPTION_TEMPLATE = [ [ 'jetpack/dialogue' ] ];
 
@@ -43,14 +43,22 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 	);
 
 	const addNewParticipant = useCallback( function( newSpakerValue ) {
+		const label = getParticipantPlainText( newSpakerValue );
+
+		// Check if the speaker label has been already added.
+		const existingParticipant = getParticipantByValue( participants, label );
+		if ( existingParticipant ) {
+			return existingParticipant;
+		}
+
 		const newParticipantSlug = participants.length
 			? participants[ participants.length - 1 ].slug.replace( /(\d+)/, n => Number( n ) + 1 )
 			: 'speaker-0';
 
 		const newParticipant = {
-			label: getParticipantPlainText( newSpakerValue ),
 			slug: newParticipantSlug,
-			value: newSpakerValue
+			label,
+			value: newSpakerValue,
 		};
 
 		setAttributes( {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -43,6 +43,10 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 	);
 
 	const addNewParticipant = useCallback( function( newSpeakerLabel ) {
+		if ( ! newSpeakerLabel ) {
+			return;
+		}
+
 		const sanitizedSpeakerLabel = newSpeakerLabel.trim();
 		// Do not add speakers with empty names.
 		if ( ! sanitizedSpeakerLabel?.length ) {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/example.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/example.js
@@ -6,12 +6,16 @@ import { __ } from '@wordpress/i18n';
 
 const participants = [
 	{
-		participantSlug: 'participant-0',
-		participantLabel: 'Rosalind',
+		slug: 'participant-0',
+		label: 'Rosalind',
+		hasBoldStyle: true,
+		hasUppercaseStyle: true,
 	},
 	{
-		participantSlug: 'participant-1',
-		participantLabel: 'Orlando',
+		slug: 'participant-1',
+		label: 'Orlando',
+		hasBoldStyle: true,
+		hasUppercaseStyle: true,
 	},
 ];
 

--- a/projects/plugins/jetpack/extensions/blocks/conversation/example.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/example.js
@@ -8,14 +8,10 @@ const participants = [
 	{
 		slug: 'participant-0',
 		label: 'Rosalind',
-		hasBoldStyle: true,
-		hasUppercaseStyle: true,
 	},
 	{
 		slug: 'participant-1',
 		label: 'Orlando',
-		hasBoldStyle: true,
-		hasUppercaseStyle: true,
 	},
 ];
 

--- a/projects/plugins/jetpack/extensions/blocks/conversation/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/index.js
@@ -6,7 +6,7 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { ConversationIcon as icon } from '../../shared/icons';
+import { TranscriptIcon as icon } from '../../shared/icons';
 
 /**
  * Local dependencies

--- a/projects/plugins/jetpack/extensions/blocks/conversation/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/index.js
@@ -31,6 +31,7 @@ export const settings = {
 		_x( 'conversation', 'block search term', 'jetpack' ),
 		_x( 'transcription', 'block search term', 'jetpack' ),
 		_x( 'dialogue', 'block search term', 'jetpack' ),
+		_x( 'speaker', 'block search term', 'jetpack' ),
 	],
 	supports: {
 		align: true,

--- a/projects/plugins/jetpack/extensions/blocks/conversation/participants.json
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/participants.json
@@ -4,17 +4,17 @@
 		{
 			"slug": "participant-0",
 			"label": "Speaker 1",
-			"value": "<strong>Speaker 1</strong>"
+			"hasBoldStyle": true
 		},
 		{
 			"slug": "participant-1",
 			"label": "Speaker 2",
-			"value": "<strong>Speaker 2</strong>"
+			"hasBoldStyle": true
 		},
 		{
 			"slug": "participant-2",
 			"label": "Speaker 3",
-			"value": "<strong>Speaker 3</strong>"
+			"hasBoldStyle": true
 		}
 	]
 }

--- a/projects/plugins/jetpack/extensions/blocks/conversation/participants.json
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/participants.json
@@ -3,18 +3,15 @@
 	"list": [
 		{
 			"slug": "participant-0",
-			"label": "Speaker 1",
-			"hasBoldStyle": true
+			"label": "Speaker 1"
 		},
 		{
 			"slug": "participant-1",
-			"label": "Speaker 2",
-			"hasBoldStyle": true
+			"label": "Speaker 2"
 		},
 		{
 			"slug": "participant-2",
-			"label": "Speaker 3",
-			"hasBoldStyle": true
+			"label": "Speaker 3"
 		}
 	]
 }

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -21,7 +21,7 @@ export function getParticipantBySlug( participants, participantSlug ) {
 	return part?.length ? part[ 0 ] : null;
 }
 
-export function getParticipantByValue ( participants, participantLabel ) {
+export function getParticipantByLabel ( participants, participantLabel ) {
 	const part = participants.filter( ( { label } ) => ( label.toLowerCase() === participantLabel.toLowerCase() ) );
 	return part?.length ? part[ 0 ] : null;
 }

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -1,22 +1,10 @@
 
-export function getParticipantIndex ( slug, participants ) {
-	return participants.map( part => part.slug ).indexOf( slug );
-}
-
-export function getNextParticipantIndex ( slug, participants, offset = 0 ) {
-	return ( getParticipantIndex( slug, participants ) + 1 + offset ) % participants.length;
-}
-
-export function getNextParticipant ( slug, participants, offset = 0 ) {
-	return participants[ getNextParticipantIndex( slug, participants, offset ) ];
-}
-
 export function getParticipantBySlug( participants, participantSlug ) {
 	const part = participants.filter( ( { slug } ) => ( slug === participantSlug ) );
 	return part?.length ? part[ 0 ] : null;
 }
 
 export function getParticipantByLabel ( participants, participantLabel ) {
-	const part = participants.filter( ( { label } ) => ( label.toLowerCase() === participantLabel.toLowerCase() ) );
+	const part = participants.filter( ( { label } ) => ( label?.toLowerCase() === participantLabel?.toLowerCase() ) );
 	return part?.length ? part[ 0 ] : null;
 }

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -1,9 +1,4 @@
 
-/**
- * WordPress dependencies
- */
-import { create, getTextContent } from '@wordpress/rich-text';
-
 export function getParticipantIndex ( slug, participants ) {
 	return participants.map( part => part.slug ).indexOf( slug );
 }
@@ -24,14 +19,4 @@ export function getParticipantBySlug( participants, participantSlug ) {
 export function getParticipantByLabel ( participants, participantLabel ) {
 	const part = participants.filter( ( { label } ) => ( label.toLowerCase() === participantLabel.toLowerCase() ) );
 	return part?.length ? part[ 0 ] : null;
-}
-
-export function getParticipantByValue ( participants, value ) {
-	const participantLabel = getParticipantPlainText( value );
-	const part = participants.filter( ( { label } ) => ( label.toLowerCase() === participantLabel.toLowerCase() ) );
-	return part?.length ? part[ 0 ] : null;
-}
-
-export function getParticipantPlainText( html ) {
-	return getTextContent( create( { html } ) );
 }

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -26,6 +26,12 @@ export function getParticipantByLabel ( participants, participantLabel ) {
 	return part?.length ? part[ 0 ] : null;
 }
 
+export function getParticipantByValue ( participants, value ) {
+	const participantLabel = getParticipantPlainText( value );
+	const part = participants.filter( ( { label } ) => ( label.toLowerCase() === participantLabel.toLowerCase() ) );
+	return part?.length ? part[ 0 ] : null;
+}
+
 export function getParticipantPlainText( html ) {
 	return getTextContent( create( { html } ) );
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
@@ -1,8 +1,8 @@
 export default {
-	participantLabel: {
+	label: {
 		type: 'string',
 	},
-	participantSlug: {
+	slug: {
 		type: 'string',
 	},
 	timestamp: {

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
@@ -2,9 +2,6 @@ export default {
 	participantLabel: {
 		type: 'string',
 	},
-	participantValue: {
-		type: 'html',
-	},
 	participantSlug: {
 		type: 'string',
 	},

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -5,7 +5,7 @@ import { DropdownMenu, MenuGroup, MenuItem, SelectControl } from '@wordpress/com
 import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo, useState, Fragment } from '@wordpress/element';
 import {
 	__experimentalUseFocusOutside as useFocusOutside,
 } from '@wordpress/compose';
@@ -14,6 +14,11 @@ import {
  * Internal dependencies
  */
 import { getParticipantByValue, getParticipantPlainText } from '../../conversation/utils';
+
+// Fallback for `useFocusOutside` hook.
+const useFocusOutsideWithFallback = typeof useFocusOutside !== 'undefined'
+	? useFocusOutside
+	: () => {};
 
 function ParticipantsMenu( { participants, className, onSelect, participantSlug, onClose } ) {
 	return (
@@ -152,7 +157,7 @@ export function ParticipantsRichControl( {
 		addOrAddParticipant();
 	}
 
-	const focusOutsideProps = useFocusOutside( onFocusOutsideHandler );
+	const focusOutsideProps = useFocusOutsideWithFallback( onFocusOutsideHandler );
 
 	/**
 	 * Funcion handler when user types participant value.
@@ -195,7 +200,7 @@ export function ParticipantsRichControl( {
 	}, [ participants ] );
 
 	return (
-		<div { ...focusOutsideProps }>
+		<Fragment { ...focusOutsideProps }>
 			<RichText
 				tagName="div"
 				value={ value }
@@ -221,6 +226,6 @@ export function ParticipantsRichControl( {
 				} }
 				autocompleters={ addAutocomplete ? autocompleter : [] }
 			/>
-		</div>
+		</Fragment>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -276,12 +276,7 @@ export function SpeakerEditControl( {
 
 					const currentParticipantExists = getParticipantByLabel( participants, label );
 
-					// Update speaker label.
 					if ( participant && participant.label !== label ) {
-						if ( currentParticipantExists ) {
-							return onSelect( currentParticipantExists, true );
-						}
-
 						setEditingMode( EDIT_MODE_EDITING );
 						return onActionHandler( {
 							...participant,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -224,7 +224,8 @@ export function ParticipantsRichControl( {
 				key={ reRenderingKey }
 				tagName="div"
 				value={ value }
-				formattingControls={ [ 'bold', 'italic', 'text-color' ] }
+				formattingControls={ [] }
+				withoutInteractiveFormatting={ false }
 				onChange={ onChangeHandler }
 				placeholder={ __( 'Speaker', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -179,9 +179,6 @@ export function ParticipantsRichControl( {
 		// Always update the participant value (block attribute).
 		onParticipantChange( newValue );
 
-		// Force hiding autocompleter when more than word.
-		setAddAutocomplete( newValue.split( ' ' ).length === 1 );
-
 		// Update when adding a new participant while typing.
 		setIsAddingNewParticipant( ! newValue?.length || ! getParticipantByValue( participants, newValue ) );
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -208,7 +208,10 @@ export function ParticipantsRichControl( {
 		return [ refreshAutocompleter( participants ) ];
 	}, [ participants ] );
 
-	useEffect( () => setIsAddingNewParticipant( ! participant ), [ participant ] );
+	useEffect( () => {
+		setIsAddingNewParticipant( ! participant );
+		setAddAutocomplete( ! participant );
+	}, [ participant ] );
 
 	return (
 		<div

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -143,10 +143,10 @@ export function ParticipantsRichControl( {
 	const [ showAutocomplete, setAddAutocomplete ] = useState( true );
 	const [ editingMode, setEditingMode ] = useState( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
 
-	function onActionHandler() {
+	function onActionHandler( forceFocus ) {
 		switch ( editingMode ) {
 			case EDIT_MODE_ADDING: {
-				return onAdd( value, ! useFocusOutsideIsAvailable );
+				return onAdd( value, ! useFocusOutsideIsAvailable || forceFocus );
 			}
 
 			case EDIT_MODE_EDITING: {
@@ -154,7 +154,7 @@ export function ParticipantsRichControl( {
 					slug: participant.slug,
 					label: getParticipantPlainText( value ), // <- store plain participant value.
 					value,
-				}, ! useFocusOutsideIsAvailable );
+				}, ! useFocusOutsideIsAvailable || forceFocus );
 			}
 		}
 
@@ -182,9 +182,18 @@ export function ParticipantsRichControl( {
 	 * dependeing on the previous values.
 	 *
 	 * @param {string} newValue - New participant value.
-	 * @returns {null} Null.
+	 * @returns {null} Null
 	 */
 	function onChangeHandler( newValue ) {
+		// If the new value is empty,
+		// activate autocomplete, and emit onClean(),
+		// to clean the current participant.
+		if ( ! newValue?.length ) {
+			setEditingMode( EDIT_MODE_ADDING );
+			setAddAutocomplete( true );
+			return onClean();
+		}
+
 		// Always update the participant value (block attribute).
 		onParticipantChange( newValue );
 
@@ -194,7 +203,7 @@ export function ParticipantsRichControl( {
 		// and current conversation participant
 		// tied to this Dialogue block.
 		if ( participant ) {
-			if ( participantByNewValue ) {
+			if ( participant.value === newValue ) {
 				setEditingMode( EDIT_MODE_SELECTING );
 			} else {
 				setEditingMode( EDIT_MODE_EDITING );
@@ -203,15 +212,6 @@ export function ParticipantsRichControl( {
 			setEditingMode( EDIT_MODE_SELECTING );
 		} else {
 			setEditingMode( EDIT_MODE_ADDING );
-		}
-
-		// If the new value is empty,
-		// activate autocomplete, and emit onClean(),
-		// to clean the current participant.
-		if ( ! newValue?.length ) {
-			setEditingMode( EDIT_MODE_ADDING );
-			setAddAutocomplete( true );
-			return onClean();
 		}
 	}
 
@@ -256,7 +256,7 @@ export function ParticipantsRichControl( {
 						onParticipantChange( newValue );
 						setAddAutocomplete( false );
 						setEditingMode( EDIT_MODE_SELECTING );
-						return onSelect( replacedParticipant, true );
+						return onSelect( replacedParticipant );
 					}
 
 					if ( ! value?.length ) {
@@ -266,10 +266,15 @@ export function ParticipantsRichControl( {
 					// Handling participant selection,
 					// by typing `ENTER` KEY.
 					const participantExists = getParticipantByValue( participants, value );
+					const hasFormatChanges = participant?.value !== value;
 					if ( participantExists ) {
+						if ( hasFormatChanges ) {
+							setEditingMode( EDIT_MODE_EDITING );
+							return onActionHandler();
+						}
+
 						// Here, it adds or selects participant.
 						setEditingMode( EDIT_MODE_SELECTING );
-						onParticipantChange( participantExists );
 						return onSelect( participantExists, true );
 					}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -279,8 +279,14 @@ export function SpeakerEditControl( {
 						return;
 					}
 
+					const currentParticipantExists = getParticipantByLabel( participants, label );
+
 					// Update speaker label.
 					if ( participant && participant.label !== label ) {
+						if ( currentParticipantExists ) {
+							return onSelect( currentParticipantExists, true );
+						}
+
 						setEditingMode( EDIT_MODE_EDITING );
 						transcriptRef?.current?.focus();
 						return onActionHandler( {
@@ -290,12 +296,11 @@ export function SpeakerEditControl( {
 					}
 
 					// Select the speaker but from the current label value.
-					const participantExists = getParticipantByLabel( participants, label );
-						if ( participantExists ) {
-							setEditingMode( EDIT_MODE_SELECTING );
-							transcriptRef?.current?.focus();
-							return onSelect( participantExists, true );
-						}
+					if ( currentParticipantExists ) {
+						setEditingMode( EDIT_MODE_SELECTING );
+						transcriptRef?.current?.focus();
+						return onSelect( currentParticipantExists, true );
+					}
 
 					// Add a new speaker.
 					onActionHandler( true );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -126,16 +126,7 @@ export function ParticipantsRichControl( {
 } ) {
 	const [ addAutocomplete, setAddAutocomplete ] = useState( true );
 
-	/*
-	 * Handle when on focus out.
-	 * Add or Select a participant.
-	 */
-	function onFocusOutsideHandler() {
-		// Clean current participant when content is empty.
-		if ( ! value?.length ) {
-			return;
-		}
-
+	function addOrAddParticipant() {
 		// Before to update the participant,
 		// Let's check the participant doesn't exist.
 		const participantLabel = getParticipantPlainText( value );
@@ -146,6 +137,19 @@ export function ParticipantsRichControl( {
 		}
 
 		onAdd( value );
+	}
+
+	/*
+	 * Handle when on focus out.
+	 * Add or Select a participant.
+	 */
+	function onFocusOutsideHandler() {
+		// Clean current participant when content is empty.
+		if ( ! value?.length ) {
+			return;
+		}
+
+		addOrAddParticipant();
 	}
 
 	const focusOutsideProps = useFocusOutside( onFocusOutsideHandler );
@@ -198,13 +202,15 @@ export function ParticipantsRichControl( {
 				keepPlaceholderOnFocus={ true }
 				onSplit={ () => {} }
 				onReplace={ ( replaceValue ) => {
-					// It handleds replacing the block content
-					// by selecting a participant from the autocomplete.
 					const replacedParticipant = replaceValue?.[ 0 ];
 					if ( ! replacedParticipant ) {
+						// Here, it adds or selects participant.
+						addOrAddParticipant( value );
 						return;
 					}
 
+					// It handleds replacing the block content
+					// by selecting a participant from the autocomplete.
 					const { value: newValue } = replacedParticipant;
 					onParticipantChange( newValue );
 					setAddAutocomplete( false );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -144,8 +144,9 @@ function refreshAutocompleter( participants ) {
  * @param {object}   prop                     - ParticipantRichControl component.
  * @param {string}   prop.className           - Component CSS class.
  * @param {string}   prop.label               - Dialogue participant value. Local level.
- * @param {Array}    prop.participants        - Participants list. Global level (Conversation block).
  * @param {object}   prop.participant         - Participant object. Gloanl level.
+ * @param {Array}    prop.participants        - Participants list. Global level (Conversation block).
+ * @param {object}   prop.transcriptRef       - Reference to the transcript DOM element (DialogueEdit content).
  * @param {Function} prop.onParticipantChange - Use this callback to update participant label, locally.
  * @param {Function} prop.onUpdate            - Use this callback to update the participant, but globaly.
  * @param {Function} prop.onSelect            - Callback triggered when a particpant is selectd from the list.
@@ -157,8 +158,9 @@ function refreshAutocompleter( participants ) {
 export function SpeakerEditControl( {
 	className,
 	label,
-	participants,
 	participant,
+	participants,
+	transcriptRef,
 	onParticipantChange,
 	onUpdate = () => {},
 	onSelect,
@@ -269,6 +271,7 @@ export function SpeakerEditControl( {
 						const { label: newLabel } = replacedParticipant;
 						onParticipantChange( newLabel );
 						setEditingMode( EDIT_MODE_SELECTING );
+						transcriptRef?.current?.focus();
 						return onSelect( replacedParticipant );
 					}
 
@@ -279,21 +282,25 @@ export function SpeakerEditControl( {
 					// Update speaker label.
 					if ( participant && participant.label !== label ) {
 						setEditingMode( EDIT_MODE_EDITING );
+						transcriptRef?.current?.focus();
 						return onActionHandler( {
 							...participant,
 							label,
 						} );
 					}
 
+					// Select the speaker but from the current label value.
 					const participantExists = getParticipantByLabel( participants, label );
 						if ( participantExists ) {
 							setEditingMode( EDIT_MODE_SELECTING );
+							transcriptRef?.current?.focus();
 							return onSelect( participantExists, true );
 						}
 
-					// From here, it will add a new participant.
-					setEditingMode( EDIT_MODE_ADDING );
-					return onActionHandler( true );
+					// Add a new speaker.
+					onActionHandler( true );
+					setTimeout( () => transcriptRef?.current?.focus(), 100 );
+					return setEditingMode( EDIT_MODE_ADDING );
 				} }
 				autocompleters={ autocompleter }
 				onFocus={ onFocus }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -140,7 +140,6 @@ export function ParticipantsRichControl( {
 	onAdd,
 	onClean,
 } ) {
-	const [ showAutocomplete, setAddAutocomplete ] = useState( true );
 	const [ editingMode, setEditingMode ] = useState( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
 
 	function onActionHandler( forceFocus ) {
@@ -157,24 +156,9 @@ export function ParticipantsRichControl( {
 				}, ! useFocusOutsideIsAvailable || forceFocus );
 			}
 		}
-
-		setAddAutocomplete( false );
 	}
 
-	/*
-	 * Handle when on focus out.
-	 * Add or Select a participant.
-	 */
-	function onFocusOutsideHandler() {
-		// Clean current participant when content is empty.
-		if ( ! value?.length ) {
-			return setAddAutocomplete( false );
-		}
-
-		onActionHandler();
-	}
-
-	const focusOutsideProps = useFocusOutsideWithFallback( onFocusOutsideHandler );
+	const focusOutsideProps = useFocusOutsideWithFallback( onActionHandler );
 
 	/**
 	 * Funcion handler when user types participant value.
@@ -190,7 +174,6 @@ export function ParticipantsRichControl( {
 		// to clean the current participant.
 		if ( ! newValue?.length ) {
 			setEditingMode( EDIT_MODE_ADDING );
-			setAddAutocomplete( true );
 			return onClean();
 		}
 
@@ -217,16 +200,15 @@ export function ParticipantsRichControl( {
 
 	// Keep autocomplete options udated.
 	const autocompleter = useMemo( () => {
-		if ( ! showAutocomplete ) {
+		if ( editingMode !== EDIT_MODE_ADDING ) {
 			return [];
 		}
 
 		return [ refreshAutocompleter( participants ) ];
-	}, [ participants, showAutocomplete ] );
+	}, [ participants, editingMode ] );
 
 	useEffect( () => {
 		setEditingMode( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
-		setAddAutocomplete( ! participant );
 	}, [ participant ] );
 
 	return (
@@ -254,7 +236,6 @@ export function ParticipantsRichControl( {
 					if ( replacedParticipant ) {
 						const { value: newValue } = replacedParticipant;
 						onParticipantChange( newValue );
-						setAddAutocomplete( false );
 						setEditingMode( EDIT_MODE_SELECTING );
 						return onSelect( replacedParticipant );
 					}
@@ -266,16 +247,17 @@ export function ParticipantsRichControl( {
 					// Handling participant selection,
 					// by typing `ENTER` KEY.
 					const participantExists = getParticipantByValue( participants, value );
-					const hasFormatChanges = participant?.value !== value;
 					if ( participantExists ) {
-						if ( hasFormatChanges ) {
+						if ( ! participant ) {
+							setEditingMode( EDIT_MODE_SELECTING );
+							return onSelect( participantExists, true );
+						}
+
+						// Update participant format.
+						if ( participant?.value !== value ) {
 							setEditingMode( EDIT_MODE_EDITING );
 							return onActionHandler();
 						}
-
-						// Here, it adds or selects participant.
-						setEditingMode( EDIT_MODE_SELECTING );
-						return onSelect( participantExists, true );
 					}
 
 					// From here, it will add a new participant.

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -24,7 +24,6 @@ import {
 	Component,
 	useReducer,
 } from '@wordpress/element';
-import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -34,9 +33,6 @@ import { getParticipantByLabel } from '../../conversation/utils';
 const EDIT_MODE_ADDING = 'is-adding';
 const EDIT_MODE_SELECTING = 'is-selecting';
 const EDIT_MODE_EDITING = 'is-editing';
-
-// Fallback for `useFocusOutside` hook.
-const useFocusOutsideIsAvailable = typeof useFocusOutside !== 'undefined';
 
 function ParticipantsMenu( { participants, className, onSelect, slug, onClose } ) {
 	return (
@@ -174,18 +170,18 @@ export function SpeakerEditControl( {
 	// or when we need to hide it.
 	const [ reRenderingKey, triggerRefreshAutocomplete ] = useReducer( speakersControlReducer, 0 );
 
-	function onActionHandler( forceFocus ) {
+	function onActionHandler() {
 		switch ( editingMode ) {
 			case EDIT_MODE_ADDING: {
 				triggerRefreshAutocomplete();
-				return onAdd( label, ! useFocusOutsideIsAvailable || forceFocus );
+				return onAdd( label );
 			}
 
 			case EDIT_MODE_EDITING: {
 				return onUpdate( {
 					...participant,
 					label,
-				}, ! useFocusOutsideIsAvailable || forceFocus );
+				} );
 			}
 		}
 	}

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -6,12 +6,18 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { DropdownMenu, MenuGroup, MenuItem, SelectControl } from '@wordpress/components';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	SelectControl,
+	withFocusOutside,
+} from '@wordpress/components';
 import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
-import { useMemo, useState, useEffect } from '@wordpress/element';
+import { useMemo, useState, useEffect, Component } from '@wordpress/element';
 import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
 
 /**
@@ -25,7 +31,6 @@ const EDIT_MODE_EDITING = 'is-editing';
 
 // Fallback for `useFocusOutside` hook.
 const useFocusOutsideIsAvailable = typeof useFocusOutside !== 'undefined';
-const useFocusOutsideWithFallback = useFocusOutsideIsAvailable ? useFocusOutside : () => {};
 
 function ParticipantsMenu( { participants, className, onSelect, slug, onClose } ) {
 	return (
@@ -79,6 +84,18 @@ export default function ParticipantsDropdown( props ) {
 		</DropdownMenu>
 	);
 }
+
+const DetectOutside = withFocusOutside(
+	class extends Component {
+		handleFocusOutside( event ) {
+			this.props.onFocusOutside( event );
+		}
+
+		render() {
+			return this.props.children;
+		}
+	}
+);
 
 /**
  * Participants Autocompleter.
@@ -156,8 +173,6 @@ export function SpeakerEditControl( {
 		}
 	}
 
-	const focusOutsideProps = useFocusOutsideWithFallback( onActionHandler );
-
 	/**
 	 * Funcion handler when user types participant label.
 	 * It can edit a new participant, or add a new one,
@@ -210,14 +225,14 @@ export function SpeakerEditControl( {
 	}, [ participant ] );
 
 	return (
-		<div
+		<DetectOutside
 			className={ classNames( className, {
 				'has-bold-style': true,
 				'is-adding-participant': editingMode === EDIT_MODE_ADDING,
 				'is-editing-participant': editingMode === EDIT_MODE_EDITING,
 				'is-selecting-participant': editingMode === EDIT_MODE_SELECTING,
 			} ) }
-			{ ...focusOutsideProps }
+			onFocusOutside={ onActionHandler }
 		>
 			<RichText
 				key={ reRenderingKey }
@@ -271,6 +286,6 @@ export function SpeakerEditControl( {
 				autocompleters={ autocompleter }
 				onFocus={ onFocus }
 			/>
-		</div>
+		</DetectOutside>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -261,9 +261,14 @@ export function SpeakerEditControl( {
 						return;
 					}
 
-					const currentParticipantExists = getParticipantByLabel( participants, label );
+					const participantExists = getParticipantByLabel( participants, label );
 
 					if ( participant && participant.label !== label ) {
+						// Check if the participant label exists, but it isn't the current one.
+						if ( participantExists && participantExists.slug !== participant.slug ) {
+							return onSelect( participantExists );
+						}
+
 						setEditingMode( EDIT_MODE_EDITING );
 						return onActionHandler( {
 							...participant,
@@ -272,9 +277,9 @@ export function SpeakerEditControl( {
 					}
 
 					// Select the speaker but from the current label value.
-					if ( currentParticipantExists ) {
+					if ( participantExists ) {
 						setEditingMode( EDIT_MODE_SELECTING );
-						return onSelect( currentParticipantExists, true );
+						return onSelect( participantExists );
 					}
 
 					// Add a new speaker.

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -16,7 +16,7 @@ import {
 import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
-
+import { create, getTextContent } from '@wordpress/rich-text';
 import {
 	useMemo,
 	useState,
@@ -174,7 +174,7 @@ export function SpeakerEditControl( {
 		switch ( editingMode ) {
 			case EDIT_MODE_ADDING: {
 				triggerRefreshAutocomplete();
-				return onAdd( label );
+				return onAdd( getTextContent( create( { html: label } ) ) );
 			}
 
 			case EDIT_MODE_EDITING: {
@@ -252,7 +252,7 @@ export function SpeakerEditControl( {
 				tagName="div"
 				value={ label }
 				formattingControls={ [] }
-				withoutInteractiveFormatting={ false }
+				withoutInteractiveFormatting={ true }
 				onChange={ onChangeHandler }
 				placeholder={ __( 'Speaker', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -5,7 +5,7 @@ import { DropdownMenu, MenuGroup, MenuItem, SelectControl } from '@wordpress/com
 import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
-import { useMemo, useState, Fragment } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import {
 	__experimentalUseFocusOutside as useFocusOutside,
 } from '@wordpress/compose';
@@ -200,7 +200,7 @@ export function ParticipantsRichControl( {
 	}, [ participants ] );
 
 	return (
-		<Fragment { ...focusOutsideProps }>
+		<div { ...focusOutsideProps }>
 			<RichText
 				tagName="div"
 				value={ value }
@@ -226,6 +226,6 @@ export function ParticipantsRichControl( {
 				} }
 				autocompleters={ addAutocomplete ? autocompleter : [] }
 			/>
-		</Fragment>
+		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -13,7 +13,7 @@ import {
 /**
  * Internal dependencies
  */
-import { getParticipantByValue, getParticipantPlainText } from '../../conversation/utils';
+import { getParticipantByLabel, getParticipantPlainText } from '../../conversation/utils';
 
 // Fallback for `useFocusOutside` hook.
 const useFocusOutsideWithFallback = typeof useFocusOutside !== 'undefined'
@@ -135,7 +135,7 @@ export function ParticipantsRichControl( {
 		// Before to update the participant,
 		// Let's check the participant doesn't exist.
 		const participantLabel = getParticipantPlainText( value );
-		const existingParticipant = getParticipantByValue( participants, participantLabel );
+		const existingParticipant = getParticipantByLabel( participants, participantLabel );
 		if ( existingParticipant ) {
 			setAddAutocomplete( false );
 			return onSelect( existingParticipant );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -1,11 +1,16 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { DropdownMenu, MenuGroup, MenuItem, SelectControl } from '@wordpress/components';
 import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo, useState, useEffect } from '@wordpress/element';
 import {
 	__experimentalUseFocusOutside as useFocusOutside,
 } from '@wordpress/compose';
@@ -109,6 +114,7 @@ function refreshAutocompleter( participants ) {
  * Control to edit Dialogue participant globally.
  *
  * @param {object}   prop                     - ParticipantRichControl component.
+ * @param {string}   prop.className           - Component CSS class.
  * @param {string}   prop.value               - Dialogue participant value. Usually HTML. Local level.
  * @param {Array}    prop.participants        - Participants list. Global level (Conversation block).
  * @param {object}   prop.participant         - Participant object. Gloanl level.
@@ -120,6 +126,7 @@ function refreshAutocompleter( participants ) {
  * @returns {Function} React component function.
  */
 export function ParticipantsRichControl( {
+	className,
 	value,
 	participants,
 	participant,
@@ -130,6 +137,7 @@ export function ParticipantsRichControl( {
 	onClean,
 } ) {
 	const [ addAutocomplete, setAddAutocomplete ] = useState( true );
+	const [ isAddingNewParticipant, setIsAddingNewParticipant ] = useState( false );
 
 	function addOrSelectParticipant() {
 		// Before to update the participant,
@@ -173,6 +181,8 @@ export function ParticipantsRichControl( {
 		// Force hiding autocompleter when more than word.
 		setAddAutocomplete( newValue.split( ' ' ).length === 1 );
 
+		setIsAddingNewParticipant( ! newValue?.length || ! getParticipantByValue( participants, newValue ) );
+
 		// If the new value is empty,
 		// activate autocomplete, and emit on-clean
 		// to clean the current participant.
@@ -198,8 +208,15 @@ export function ParticipantsRichControl( {
 		return [ refreshAutocompleter( participants ) ];
 	}, [ participants ] );
 
+	useEffect( () => setIsAddingNewParticipant( ! participant ), [ participant ] );
+
 	return (
-		<div { ...focusOutsideProps }>
+		<div
+			className={ classNames( className, {
+				'is-adding-new-participant': isAddingNewParticipant,
+			} ) }
+			{ ...focusOutsideProps }
+		>
 			<RichText
 				tagName="div"
 				value={ value }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -13,7 +13,7 @@ import {
 /**
  * Internal dependencies
  */
-import { getParticipantByLabel, getParticipantPlainText } from '../../conversation/utils';
+import { getParticipantByValue, getParticipantPlainText } from '../../conversation/utils';
 
 // Fallback for `useFocusOutside` hook.
 const useFocusOutsideWithFallback = typeof useFocusOutside !== 'undefined'
@@ -134,8 +134,7 @@ export function ParticipantsRichControl( {
 	function addOrSelectParticipant() {
 		// Before to update the participant,
 		// Let's check the participant doesn't exist.
-		const participantLabel = getParticipantPlainText( value );
-		const existingParticipant = getParticipantByLabel( participants, participantLabel );
+		const existingParticipant = getParticipantByValue( participants, value );
 		if ( existingParticipant ) {
 			setAddAutocomplete( false );
 			return onSelect( existingParticipant );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -19,10 +19,13 @@ import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/com
  */
 import { getParticipantByValue, getParticipantPlainText } from '../../conversation/utils';
 
+const EDIT_MODE_ADDING = 'is-adding';
+const EDIT_MODE_SELECTING = 'is-selecting';
+const EDIT_MODE_EDITING = 'is-editing';
+
 // Fallback for `useFocusOutside` hook.
-const useFocusOutsideWithFallback = typeof useFocusOutside !== 'undefined'
-	? useFocusOutside
-	: () => {};
+const useFocusOutsideIsAvailable = typeof useFocusOutside !== 'undefined';
+const useFocusOutsideWithFallback = useFocusOutsideIsAvailable ? useFocusOutside : () => {};
 
 function ParticipantsMenu( { participants, className, onSelect, participantSlug, onClose } ) {
 	return (
@@ -138,23 +141,24 @@ export function ParticipantsRichControl( {
 	onClean,
 } ) {
 	const [ showAutocomplete, setAddAutocomplete ] = useState( true );
-	const [ isAddingNewParticipant, setIsAddingNewParticipant ] = useState( false );
+	const [ editingMode, setEditingMode ] = useState( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
 
-	function addOrSelectParticipant() {
-		if ( ! value?.length ) {
-			return;
+	function onActionHandler() {
+		switch ( editingMode ) {
+			case EDIT_MODE_ADDING: {
+				return onAdd( value, ! useFocusOutsideIsAvailable );
+			}
+
+			case EDIT_MODE_EDITING: {
+				return onUpdate( {
+					slug: participant.slug,
+					label: getParticipantPlainText( value ), // <- store plain participant value.
+					value,
+				}, ! useFocusOutsideIsAvailable );
+			}
 		}
 
 		setAddAutocomplete( false );
-
-		// Before to update the participant,
-		// Let's check the participant doesn't exist.
-		const existingParticipant = getParticipantByValue( participants, value );
-		if ( existingParticipant ) {
-			return onSelect( existingParticipant );
-		}
-
-		onAdd( value );
 	}
 
 	/*
@@ -167,7 +171,7 @@ export function ParticipantsRichControl( {
 			return setAddAutocomplete( false );
 		}
 
-		addOrSelectParticipant();
+		onActionHandler();
 	}
 
 	const focusOutsideProps = useFocusOutsideWithFallback( onFocusOutsideHandler );
@@ -184,30 +188,34 @@ export function ParticipantsRichControl( {
 		// Always update the participant value (block attribute).
 		onParticipantChange( newValue );
 
-		// Update when adding a new participant while typing.
-		setIsAddingNewParticipant( ! newValue?.length || ! getParticipantByValue( participants, newValue ) );
+		const participantByNewValue = getParticipantByValue( participants, newValue );
+
+		// Set editing mode depending on participant value,
+		// and current conversation participant
+		// tied to this Dialogue block.
+		if ( participant ) {
+			if ( participantByNewValue ) {
+				setEditingMode( EDIT_MODE_SELECTING );
+			} else {
+				setEditingMode( EDIT_MODE_EDITING );
+			}
+		} else if ( participantByNewValue ) {
+			setEditingMode( EDIT_MODE_SELECTING );
+		} else {
+			setEditingMode( EDIT_MODE_ADDING );
+		}
 
 		// If the new value is empty,
-		// activate autocomplete, and emit on-clean
+		// activate autocomplete, and emit onClean(),
 		// to clean the current participant.
 		if ( ! newValue?.length ) {
+			setEditingMode( EDIT_MODE_ADDING );
 			setAddAutocomplete( true );
 			return onClean();
 		}
-
-		// if there is not a current participant,
-		// there is not nothing to update.
-		if ( ! participant ) {
-			return;
-		}
-
-		onUpdate( {
-			slug: participant.slug,
-			label: getParticipantPlainText( newValue ), // <- store plain participant value.
-			value: newValue,
-		} );
 	}
 
+	// Keep autocomplete options udated.
 	const autocompleter = useMemo( () => {
 		if ( ! showAutocomplete ) {
 			return [];
@@ -217,14 +225,16 @@ export function ParticipantsRichControl( {
 	}, [ participants, showAutocomplete ] );
 
 	useEffect( () => {
-		setIsAddingNewParticipant( ! participant );
+		setEditingMode( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
 		setAddAutocomplete( ! participant );
 	}, [ participant ] );
 
 	return (
 		<div
 			className={ classNames( className, {
-				'is-adding-new-participant': isAddingNewParticipant,
+				'is-adding-participant': editingMode === EDIT_MODE_ADDING,
+				'is-editing-participant': editingMode === EDIT_MODE_EDITING,
+				'is-selecting-participant': editingMode === EDIT_MODE_SELECTING,
 			} ) }
 			{ ...focusOutsideProps }
 		>
@@ -238,24 +248,34 @@ export function ParticipantsRichControl( {
 				keepPlaceholderOnFocus={ true }
 				onSplit={ () => {} }
 				onReplace={ ( replaceValue ) => {
+					const replacedParticipant = replaceValue?.[ 0 ];
+					// Handling participant selection,
+					// by picking them from the autocomplete options.
+					if ( replacedParticipant ) {
+						const { value: newValue } = replacedParticipant;
+						onParticipantChange( newValue );
+						setAddAutocomplete( false );
+						setEditingMode( EDIT_MODE_SELECTING );
+						return onSelect( replacedParticipant, true );
+					}
+
 					if ( ! value?.length ) {
 						return;
 					}
 
-					const replacedParticipant = replaceValue?.[ 0 ];
-
-					if ( ! replacedParticipant ) {
+					// Handling participant selection,
+					// by typing `ENTER` KEY.
+					const participantExists = getParticipantByValue( participants, value );
+					if ( participantExists ) {
 						// Here, it adds or selects participant.
-						addOrSelectParticipant( value );
-						return;
+						setEditingMode( EDIT_MODE_SELECTING );
+						onParticipantChange( participantExists );
+						return onSelect( participantExists, true );
 					}
 
-					// It handleds replacing the block content
-					// by selecting a participant from the autocomplete.
-					const { value: newValue } = replacedParticipant;
-					onParticipantChange( newValue );
-					setAddAutocomplete( false );
-					onSelect( replacedParticipant );
+					// From here, it will add a new participant.
+					setEditingMode( EDIT_MODE_ADDING );
+					onActionHandler();
 				} }
 				autocompleters={ autocompleter }
 			/>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -92,7 +92,11 @@ const DetectOutside = withFocusOutside(
 		}
 
 		render() {
-			return this.props.children;
+			return (
+				<div className={ this.props.className }>
+					{ this.props.children }
+				</div>
+			);
 		}
 	}
 );
@@ -227,7 +231,7 @@ export function SpeakerEditControl( {
 	return (
 		<DetectOutside
 			className={ classNames( className, {
-				'has-bold-style': true,
+				'has-bold-style': label?.length,
 				'is-adding-participant': editingMode === EDIT_MODE_ADDING,
 				'is-editing-participant': editingMode === EDIT_MODE_EDITING,
 				'is-selecting-participant': editingMode === EDIT_MODE_SELECTING,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -210,6 +210,7 @@ export function SpeakerEditControl( {
 	return (
 		<div
 			className={ classNames( className, {
+				'has-bold-style': true,
 				'is-adding-participant': editingMode === EDIT_MODE_ADDING,
 				'is-editing-participant': editingMode === EDIT_MODE_EDITING,
 				'is-selecting-participant': editingMode === EDIT_MODE_SELECTING,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -131,7 +131,7 @@ export function ParticipantsRichControl( {
 } ) {
 	const [ addAutocomplete, setAddAutocomplete ] = useState( true );
 
-	function addOrAddParticipant() {
+	function addOrSelectParticipant() {
 		// Before to update the participant,
 		// Let's check the participant doesn't exist.
 		const participantLabel = getParticipantPlainText( value );
@@ -154,7 +154,7 @@ export function ParticipantsRichControl( {
 			return;
 		}
 
-		addOrAddParticipant();
+		addOrSelectParticipant();
 	}
 
 	const focusOutsideProps = useFocusOutsideWithFallback( onFocusOutsideHandler );
@@ -213,7 +213,7 @@ export function ParticipantsRichControl( {
 					const replacedParticipant = replaceValue?.[ 0 ];
 					if ( ! replacedParticipant ) {
 						// Here, it adds or selects participant.
-						addOrAddParticipant( value );
+						addOrSelectParticipant( value );
 						return;
 					}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -123,6 +123,7 @@ function refreshAutocompleter( participants ) {
  * @param {Function} prop.onSelect            - Callback triggered when a particpant is selectd from the list.
  * @param {Function} prop.onAdd               - Callback used to add a new participant.
  * @param {Function} prop.onClean             - Use this callback to disassociate the Dialogue with a participant.
+ * @param {Function} prop.onFocus             - onFocus callback RichText callback.
  * @returns {Function} React component function.
  */
 export function SpeakerEditControl( {
@@ -136,6 +137,7 @@ export function SpeakerEditControl( {
 	onSelect,
 	onAdd,
 	onClean,
+	onFocus,
 } ) {
 	const [ editingMode, setEditingMode ] = useState( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
 
@@ -267,6 +269,7 @@ export function SpeakerEditControl( {
 					onActionHandler( true );
 				} }
 				autocompleters={ autocompleter }
+				onFocus={ onFocus }
 			/>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -166,6 +166,9 @@ export function ParticipantsRichControl( {
 		// Always update the participant value (block attribute).
 		onParticipantChange( newValue );
 
+		// Force hiding autocompleter when more than word.
+		setAddAutocomplete( newValue.split( ' ' ).length === 1 );
+
 		// If the new value is empty,
 		// activate autocomplete, and emit on-clean
 		// to clean the current participant.

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -28,7 +28,7 @@ import {
 /**
  * Internal dependencies
  */
-import { getParticipantByLabel } from '../../conversation/utils';
+import { getParticipantByLabel, getParticipantBySlug } from '../../conversation/utils';
 
 const EDIT_MODE_ADDING = 'is-adding';
 const EDIT_MODE_SELECTING = 'is-selecting';
@@ -69,7 +69,10 @@ export function ParticipantsControl( { participants, slug, onSelect } ) {
 				label,
 				value,
 			} ) ) }
-			onChange={ participantSlug => onSelect( { slug: participantSlug } ) }
+			onChange={ participantSlug => onSelect( getParticipantBySlug(
+				participants,
+				participantSlug
+			) ) }
 		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -152,7 +152,6 @@ function refreshAutocompleter( participants ) {
  * @param {Function} prop.onSelect            - Callback triggered when a particpant is selectd from the list.
  * @param {Function} prop.onAdd               - Callback used to add a new participant.
  * @param {Function} prop.onClean             - Use this callback to disassociate the Dialogue with a participant.
- * @param {Function} prop.onFocus             - onFocus callback RichText callback.
  * @returns {Function} React component function.
  */
 export function SpeakerEditControl( {
@@ -166,7 +165,6 @@ export function SpeakerEditControl( {
 	onSelect,
 	onAdd,
 	onClean,
-	onFocus,
 } ) {
 	const [ editingMode, setEditingMode ] = useState( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
 
@@ -306,7 +304,6 @@ export function SpeakerEditControl( {
 					return setEditingMode( EDIT_MODE_ADDING );
 				} }
 				autocompleters={ autocompleter }
-				onFocus={ onFocus }
 			/>
 		</DetectOutside>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -280,7 +280,7 @@ export function ParticipantsRichControl( {
 
 					// From here, it will add a new participant.
 					setEditingMode( EDIT_MODE_ADDING );
-					onActionHandler();
+					onActionHandler( true );
 				} }
 				autocompleters={ autocompleter }
 			/>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -264,6 +264,8 @@ export function SpeakerEditControl( {
 				keepPlaceholderOnFocus={ true }
 				onSplit={ () => {} }
 				onReplace={ ( replaceValue ) => {
+					setTimeout( () => transcriptRef?.current?.focus(), 10 );
+
 					const replacedParticipant = replaceValue?.[ 0 ];
 					// Handling participant selection,
 					// by picking them from the autocomplete options.
@@ -271,7 +273,6 @@ export function SpeakerEditControl( {
 						const { label: newLabel } = replacedParticipant;
 						onParticipantChange( newLabel );
 						setEditingMode( EDIT_MODE_SELECTING );
-						transcriptRef?.current?.focus();
 						return onSelect( replacedParticipant );
 					}
 
@@ -288,7 +289,6 @@ export function SpeakerEditControl( {
 						}
 
 						setEditingMode( EDIT_MODE_EDITING );
-						transcriptRef?.current?.focus();
 						return onActionHandler( {
 							...participant,
 							label,
@@ -298,13 +298,11 @@ export function SpeakerEditControl( {
 					// Select the speaker but from the current label value.
 					if ( currentParticipantExists ) {
 						setEditingMode( EDIT_MODE_SELECTING );
-						transcriptRef?.current?.focus();
 						return onSelect( currentParticipantExists, true );
 					}
 
 					// Add a new speaker.
 					onActionHandler( true );
-					setTimeout( () => transcriptRef?.current?.focus(), 100 );
 					return setEditingMode( EDIT_MODE_ADDING );
 				} }
 				autocompleters={ autocompleter }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -240,7 +240,12 @@ export function ParticipantsRichControl( {
 				keepPlaceholderOnFocus={ true }
 				onSplit={ () => {} }
 				onReplace={ ( replaceValue ) => {
+					if ( ! value?.length ) {
+						return;
+					}
+
 					const replacedParticipant = replaceValue?.[ 0 ];
+
 					if ( ! replacedParticipant ) {
 						// Here, it adds or selects participant.
 						addOrSelectParticipant( value );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -10,10 +10,9 @@ import { DropdownMenu, MenuGroup, MenuItem, SelectControl } from '@wordpress/com
 import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
-import { useMemo, useState, useEffect, useReducer } from '@wordpress/element';
-import {
-	__experimentalUseFocusOutside as useFocusOutside,
-} from '@wordpress/compose';
+
+import { useMemo, useState, useEffect } from '@wordpress/element';
+import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -110,8 +109,6 @@ function refreshAutocompleter( participants ) {
 	};
 }
 
-const counterReducer = ( state ) => state + 1;
-
 /**
  * Control to edit Dialogue participant globally.
  *
@@ -119,6 +116,7 @@ const counterReducer = ( state ) => state + 1;
  * @param {string}   prop.className           - Component CSS class.
  * @param {string}   prop.value               - Dialogue participant value. Usually HTML. Local level.
  * @param {Array}    prop.participants        - Participants list. Global level (Conversation block).
+ * @param {string}   prop.reRenderingKey      - Custom property to for a re-render in the rich text component.
  * @param {object}   prop.participant         - Participant object. Gloanl level.
  * @param {Function} prop.onParticipantChange - Use this callback to update participant, value locally.
  * @param {Function} prop.onUpdate            - Use this value to update the participant but globaly.
@@ -132,6 +130,7 @@ export function ParticipantsRichControl( {
 	value,
 	participants,
 	participant,
+	reRenderingKey,
 	onParticipantChange,
 	onUpdate = () => {},
 	onSelect,
@@ -140,10 +139,6 @@ export function ParticipantsRichControl( {
 } ) {
 	const [ showAutocomplete, setAddAutocomplete ] = useState( true );
 	const [ isAddingNewParticipant, setIsAddingNewParticipant ] = useState( false );
-	const [ reRenderingKey, triggerRefreshAutocomplete ] = useReducer(
-		counterReducer,
-		0
-	);
 
 	function addOrSelectParticipant() {
 		if ( ! value?.length ) {
@@ -151,7 +146,6 @@ export function ParticipantsRichControl( {
 		}
 
 		setAddAutocomplete( false );
-		triggerRefreshAutocomplete();
 
 		// Before to update the participant,
 		// Let's check the participant doesn't exist.

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -16,7 +16,7 @@ import {
 import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
-import { useMemo, useState, useEffect, Component, useRef } from '@wordpress/element';
+import { useMemo, useState, useEffect, Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -157,7 +157,6 @@ export function SpeakerEditControl( {
 	onClean,
 } ) {
 	const [ editingMode, setEditingMode ] = useState( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
-	const elementRef = useRef();
 
 	function editSpeakerHandler() {
 		if ( ! label ) {
@@ -254,7 +253,6 @@ export function SpeakerEditControl( {
 			onFocusOutside={ editSpeakerHandler }
 		>
 			<RichText
-				ref={ elementRef }
 				tagName="div"
 				value={ label }
 				formattingControls={ [] }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -17,13 +17,7 @@ import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 import { create, getTextContent } from '@wordpress/rich-text';
-import {
-	useMemo,
-	useState,
-	useEffect,
-	Component,
-	useReducer,
-} from '@wordpress/element';
+import { useMemo, useState, useEffect, Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -89,8 +83,6 @@ export default function ParticipantsDropdown( props ) {
 		</DropdownMenu>
 	);
 }
-
-const speakersControlReducer = state => state + 1;
 
 const DetectOutside = withFocusOutside(
 	class extends Component {
@@ -167,16 +159,9 @@ export function SpeakerEditControl( {
 } ) {
 	const [ editingMode, setEditingMode ] = useState( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
 
-	// we use a reducer to force re-rendering the SpeakerEditControl,
-	// passing the `reRenderingKey` as property of the component.
-	// It's required when we want to update the options in the autocomplete,
-	// or when we need to hide it.
-	const [ reRenderingKey, triggerRefreshAutocomplete ] = useReducer( speakersControlReducer, 0 );
-
 	function onActionHandler() {
 		switch ( editingMode ) {
 			case EDIT_MODE_ADDING: {
-				triggerRefreshAutocomplete();
 				return onAdd( getTextContent( create( { html: label } ) ) );
 			}
 
@@ -251,7 +236,6 @@ export function SpeakerEditControl( {
 			onFocusOutside={ onActionHandler }
 		>
 			<RichText
-				key={ `re-render-key${ reRenderingKey }` }
 				tagName="div"
 				value={ label }
 				formattingControls={ [] }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -146,6 +146,10 @@ export function ParticipantsRichControl( {
 	);
 
 	function addOrSelectParticipant() {
+		if ( ! value?.length ) {
+			return;
+		}
+
 		setAddAutocomplete( false );
 		triggerRefreshAutocomplete();
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -137,8 +137,8 @@ function refreshAutocompleter( participants ) {
  * @param {string}   prop.className           - Component CSS class.
  * @param {string}   prop.label               - Dialogue participant value. Local level.
  * @param {Array}    prop.participants        - Participants list. Global level (Conversation block).
- * @param {string}   prop.reRenderingKey      - Custom property to for a re-render in the rich text component.
  * @param {object}   prop.participant         - Participant object. Gloanl level.
+ * @param {string}   prop.reRenderingKey      - Custom property to for a re-render in the rich text component.
  * @param {Function} prop.onParticipantChange - Use this callback to update participant label, locally.
  * @param {Function} prop.onUpdate            - Use this callback to update the participant, but globaly.
  * @param {Function} prop.onSelect            - Callback triggered when a particpant is selectd from the list.
@@ -170,7 +170,7 @@ export function SpeakerEditControl( {
 
 			case EDIT_MODE_EDITING: {
 				return onUpdate( {
-					slug: participant.slug,
+					...participant,
 					label,
 				}, ! useFocusOutsideIsAvailable || forceFocus );
 			}
@@ -254,7 +254,6 @@ export function SpeakerEditControl( {
 					// by picking them from the autocomplete options.
 					if ( replacedParticipant ) {
 						const { label: newLabel } = replacedParticipant;
-
 						onParticipantChange( newLabel );
 						setEditingMode( EDIT_MODE_SELECTING );
 						return onSelect( replacedParticipant );
@@ -264,28 +263,24 @@ export function SpeakerEditControl( {
 						return;
 					}
 
-					// Handling participant selection,
-					// by typing `ENTER` KEY.
+					// Update speaker label.
+					if ( participant && participant.label !== label ) {
+						setEditingMode( EDIT_MODE_EDITING );
+						return onActionHandler( {
+							...participant,
+							label,
+						} );
+					}
+
 					const participantExists = getParticipantByLabel( participants, label );
-					if ( participantExists ) {
-						if (
-							! participant ||
-							participant.label === label
-						) {
+						if ( participantExists ) {
 							setEditingMode( EDIT_MODE_SELECTING );
 							return onSelect( participantExists, true );
 						}
 
-						// Update participant format.
-						if ( participant?.label !== label ) {
-							setEditingMode( EDIT_MODE_EDITING );
-							return onActionHandler();
-						}
-					}
-
 					// From here, it will add a new participant.
 					setEditingMode( EDIT_MODE_ADDING );
-					onActionHandler( true );
+					return onActionHandler( true );
 				} }
 				autocompleters={ autocompleter }
 				onFocus={ onFocus }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -140,11 +140,12 @@ export function ParticipantsRichControl( {
 	const [ isAddingNewParticipant, setIsAddingNewParticipant ] = useState( false );
 
 	function addOrSelectParticipant() {
+		setAddAutocomplete( false );
+
 		// Before to update the participant,
 		// Let's check the participant doesn't exist.
 		const existingParticipant = getParticipantByValue( participants, value );
 		if ( existingParticipant ) {
-			setAddAutocomplete( false );
 			return onSelect( existingParticipant );
 		}
 
@@ -158,7 +159,7 @@ export function ParticipantsRichControl( {
 	function onFocusOutsideHandler() {
 		// Clean current participant when content is empty.
 		if ( ! value?.length ) {
-			return;
+			return setAddAutocomplete( false );
 		}
 
 		addOrSelectParticipant();
@@ -181,6 +182,7 @@ export function ParticipantsRichControl( {
 		// Force hiding autocompleter when more than word.
 		setAddAutocomplete( newValue.split( ' ' ).length === 1 );
 
+		// Update when adding a new participant while typing.
 		setIsAddingNewParticipant( ! newValue?.length || ! getParticipantByValue( participants, newValue ) );
 
 		// If the new value is empty,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -38,6 +38,7 @@ export default function DialogueEdit( {
 	context,
 	onReplace,
 	mergeBlocks,
+	isSelected,
 } ) {
 	const {
 		content,
@@ -68,7 +69,7 @@ export default function DialogueEdit( {
 	// Conversation context. A bridge between dialogue and conversation blocks.
 	const conversationBridge = useContext( ConversationContext );
 
-	const debounceSetDialoguesAttrs = useDebounce( setAttributes, 200 );
+	const debounceSetDialoguesAttrs = useDebounce( setAttributes, 100 );
 
 	// Update dialogue participant with conversation participant changes.
 	useEffect( () => {
@@ -80,11 +81,16 @@ export default function DialogueEdit( {
 			return;
 		}
 
+		// Do not update current Dialogue block.
+		if ( isSelected ) {
+			return;
+		}
+
 		debounceSetDialoguesAttrs( {
 			participantLabel: conversationParticipant.label,
 			participantValue: conversationParticipant.value,
 		} );
-	}, [ conversationParticipant, debounceSetDialoguesAttrs, participantSlug ] );
+	}, [ conversationParticipant, debounceSetDialoguesAttrs, isSelected, participantSlug ] );
 
 	// Update dialogue timestamp setting from parent conversation.
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -170,6 +170,9 @@ export default function DialogueEdit( {
 							participantValue: value,
 							participantSlug: slug,
 						} );
+
+						// Focus on block content.
+						richTextRef?.current?.focus();
 					} }
 
 					onClean = { () => {
@@ -184,6 +187,9 @@ export default function DialogueEdit( {
 						if ( ! newParticipant ) {
 							return;
 						}
+
+						// Focus on block content.
+						richTextRef?.current?.focus();
 
 						setAttributes( {
 							participantValue: newParticipant.value,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls, RichText, BlockControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Panel, PanelBody, ToggleControl } from '@wordpress/components';
-import { useContext, useEffect, useRef, useReducer, useState } from '@wordpress/element';
+import { useContext, useEffect, useRef, useState } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
 
@@ -24,8 +24,6 @@ import { getParticipantBySlug } from '../conversation/utils';
 
 const blockName = 'jetpack/dialogue';
 const blockNameFallback = 'core/paragraph';
-
-const speakersControlReducer = state => state + 1;
 
 export default function DialogueEdit( {
 	className,
@@ -50,12 +48,6 @@ export default function DialogueEdit( {
 		select => select( MEDIA_SOURCE_STORE_ID ).getDefaultMediaSource(),
 		[]
 	);
-
-	// we use a reducer to force re-rendering the SpeakerEditControl,
-	// passing the `reRenderingKey` as property of the component.
-	// It's required when we want to update the options in the autocomplete,
-	// or when we need to hide it.
-	const [ reRenderingKey, triggerRefreshAutocomplete ] = useReducer( speakersControlReducer, 0 );
 
 	const contentRef = useRef();
 
@@ -159,7 +151,6 @@ export default function DialogueEdit( {
 					label={ label }
 					participant={ conversationParticipant }
 					participants={ participants }
-					reRenderingKey={ `re-render-key${ reRenderingKey }` }
 					onParticipantChange={ ( updatedParticipant ) => {
 						setAttributes( { label: updatedParticipant } );
 					} }
@@ -170,10 +161,7 @@ export default function DialogueEdit( {
 					} }
 
 					onAdd={ ( newLabel ) => {
-						triggerRefreshAutocomplete();
-
 						const newParticipant = conversationBridge.addNewParticipant( newLabel );
-
 						setAttributes( newParticipant );
 					} }
 					onUpdate={ ( participant ) => {
@@ -242,7 +230,7 @@ export default function DialogueEdit( {
 				keepPlaceholderOnFocus={ true }
 				isSelected={ isContentIsSelected }
 				onFocus={ () => setIsContentSelected( true ) }
-			/>
+				/>
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -4,12 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, RichText, BlockControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import {
-	Panel,
-	PanelBody,
-	ToggleControl,
-} from '@wordpress/components';
-import { useContext, useEffect } from '@wordpress/element';
+import { Panel, PanelBody, ToggleControl } from '@wordpress/components';
+import { useContext, useEffect, useRef } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
 
@@ -52,6 +48,8 @@ export default function DialogueEdit( {
 	const mediaSource = useSelect( select => (
 		select( MEDIA_SOURCE_STORE_ID ).getDefaultMediaSource()
 	), [] );
+
+	const contentRef = useRef();
 
 	// Block context integration.
 	const participantsFromContext = context[ 'jetpack/conversation-participants' ];
@@ -161,6 +159,9 @@ export default function DialogueEdit( {
 					} }
 
 					onSelect={ ( { slug, label, value } ) => {
+						// let's focus to content when it's possible.
+						contentRef?.current?.focus();
+
 						setAttributes( {
 							participantLabel: label,
 							participantValue: value,
@@ -173,9 +174,13 @@ export default function DialogueEdit( {
 					} }
 
 					onAdd={ ( newValue ) => {
+						// let's focus to content when it's possible.
+						contentRef?.current?.focus();
+
 						if ( ! newValue?.length ) {
 							return;
 						}
+
 						const newParticipant = conversationBridge.addNewParticipant( newValue );
 						if ( ! newParticipant ) {
 							return;
@@ -202,6 +207,7 @@ export default function DialogueEdit( {
 			</div>
 
 			<RichText
+				ref={ contentRef }
 				identifier="content"
 				tagName="p"
 				className={ `${ BASE_CLASS_NAME }__content` }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -254,7 +254,12 @@ export default function DialogueEdit( {
 					// onFocusOutside is not supported by some Gutenberg versions.
 					// Take a look at <ParticipantsRichControl /> to get more info.
 					// addNewParticipant will take over to add, or not, the participant.
-					conversationBridge.addNewParticipant( participantValue );
+					const { value, label, slug } = conversationBridge.addNewParticipant( participantValue );
+					setAttributes( {
+						participantValue: value,
+						participantLabel: label,
+						participantSlug: slug,
+					} );
 				} }
 			/>
 		</div>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -20,7 +20,7 @@ import ConversationContext from '../conversation/components/context';
 import { STORE_ID as MEDIA_SOURCE_STORE_ID } from '../../store/media-source/constants';
 import { MediaPlayerToolbarControl } from '../../shared/components/media-player-control';
 import { convertSecondsToTimeCode } from '../../shared/components/media-player-control/utils';
-import { getParticipantBySlug, getParticipantByLabel } from '../conversation/utils';
+import { getParticipantBySlug } from '../conversation/utils';
 
 const blockName = 'jetpack/dialogue';
 const blockNameFallback = 'core/paragraph';
@@ -241,37 +241,7 @@ export default function DialogueEdit( {
 				placeholder={ placeholder || __( 'Write dialogue…', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
 				isSelected={ isContentIsSelected }
-				onFocus={ ( event ) => {
-					setIsContentSelected( true );
-
-					if ( ! label ) {
-						triggerRefreshAutocomplete();
-						return;
-					}
-
-					event.preventDefault();
-
-					// Provably, we should add a new participant from here.
-					// onFocusOutside is not supported by some Gutenberg versions.
-					// Take a look at <SpeakerEditControl /> to get more info.
-					const participantExists = getParticipantByLabel( participants, label );
-
-					// If participant exists let's update it.
-					if ( participantExists ) {
-						setAttributes( participantExists );
-					} else {
-						// Otherwise, let's create a new one...
-						const newParticipant = conversationBridge.addNewParticipant( label );
-						if ( ! newParticipant ) {
-							return;
-						}
-
-						// ... and update the dialogue with these new values.
-						setAttributes( newParticipant );
-					}
-
-					triggerRefreshAutocomplete();
-				} }
+				onFocus={ () => setIsContentSelected( true ) }
 			/>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -151,6 +151,7 @@ export default function DialogueEdit( {
 
 			<div className={ `${ BASE_CLASS_NAME }__meta` }>
 				<ParticipantsRichControl
+					className={ `${ BASE_CLASS_NAME }__participant` }
 					label={ participantLabel }
 					value={ participantValue }
 					participant={ conversationParticipant }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -21,7 +21,7 @@ import { list as defaultParticipants } from '../conversation/participants.json';
 import { STORE_ID as MEDIA_SOURCE_STORE_ID } from '../../store/media-source/constants';
 import { MediaPlayerToolbarControl } from '../../shared/components/media-player-control';
 import { convertSecondsToTimeCode } from '../../shared/components/media-player-control/utils';
-import { getParticipantBySlug } from '../conversation/utils';
+import { getParticipantBySlug, getParticipantByValue } from '../conversation/utils';
 
 const blockName = 'jetpack/dialogue';
 const blockNameFallback = 'core/paragraph';
@@ -299,12 +299,20 @@ export default function DialogueEdit( {
 					// onFocusOutside is not supported by some Gutenberg versions.
 					// Take a look at <ParticipantsRichControl /> to get more info.
 					// addNewParticipant will take over to add, or not, the participant.
-					const participantAdded = conversationBridge.addNewParticipant( participantValue );
-					if ( participantAdded ) {
+					const participantExists = getParticipantByValue( participants, participantValue );
+					const hasFormatChanges = conversationParticipant?.value !== participantValue;
+					if ( participantExists ) {
+						if ( hasFormatChanges ) {
+							return conversationBridge.updateParticipants( {
+								...conversationParticipant,
+								value: participantValue,
+							} );
+						}
+
 						setAttributes( {
-							participantValue: participantAdded.value,
-							participantLabel: participantAdded.label,
-							participantSlug: participantAdded.slug,
+							participantValue: participantExists.value,
+							participantLabel: participantExists.label,
+							participantSlug: participantExists.slug,
 						} );
 					}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -151,6 +151,7 @@ export default function DialogueEdit( {
 					label={ label }
 					participant={ conversationParticipant }
 					participants={ participants }
+					transcriptRef={ contentRef }
 					onParticipantChange={ ( updatedParticipant ) => {
 						setAttributes( { label: updatedParticipant } );
 					} }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls, RichText, BlockControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Panel, PanelBody, ToggleControl } from '@wordpress/components';
-import { useContext, useEffect, useRef, useReducer } from '@wordpress/element';
+import { useContext, useEffect, useRef, useReducer, useState } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
 
@@ -45,10 +45,12 @@ export default function DialogueEdit( {
 		showTimestamp,
 		timestamp,
 	} = attributes;
+	const [ isContentIsSelected, setIsContentSelected ] = useState( false );
 
-	const mediaSource = useSelect( select => (
-		select( MEDIA_SOURCE_STORE_ID ).getDefaultMediaSource()
-	), [] );
+	const mediaSource = useSelect(
+		select => select( MEDIA_SOURCE_STORE_ID ).getDefaultMediaSource(),
+		[]
+	);
 
 	// we use a reducer to force re-rendering the SpeakerEditControl,
 	// passing the `reRenderingKey` as property of the component.
@@ -120,7 +122,6 @@ export default function DialogueEdit( {
 			return;
 		}
 
-		// contentRef?.current?.focus();
 		setTimeout( () => contentRef?.current?.focus(), 100 );
 	}
 
@@ -204,6 +205,7 @@ export default function DialogueEdit( {
 						conversationBridge.updateParticipants( participant );
 						focusOnContent( forceFucus );
 					} }
+					onFocus={ () => setIsContentSelected( false ) }
 				/>
 
 				{ showTimestamp && (
@@ -264,7 +266,10 @@ export default function DialogueEdit( {
 				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 				placeholder={ placeholder || __( 'Write dialogue…', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
+				isSelected={ isContentIsSelected }
 				onFocus={ ( event ) => {
+					setIsContentSelected( true );
+
 					if ( ! label ) {
 						triggerRefreshAutocomplete();
 						return;

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -17,7 +17,6 @@ import { ParticipantsControl, SpeakerEditControl } from './components/participan
 import { TimestampControl, TimestampDropdown } from './components/timestamp-control';
 import { BASE_CLASS_NAME } from './utils';
 import ConversationContext from '../conversation/components/context';
-import { list as defaultParticipants } from '../conversation/participants.json';
 import { STORE_ID as MEDIA_SOURCE_STORE_ID } from '../../store/media-source/constants';
 import { MediaPlayerToolbarControl } from '../../shared/components/media-player-control';
 import { convertSecondsToTimeCode } from '../../shared/components/media-player-control/utils';
@@ -67,7 +66,7 @@ export default function DialogueEdit( {
 	// Participants list.
 	const participants = participantsFromContext?.length
 		? participantsFromContext
-		: defaultParticipants;
+		: [];
 
 	const conversationParticipant = getParticipantBySlug( participants, slug );
 
@@ -174,6 +173,7 @@ export default function DialogueEdit( {
 						triggerRefreshAutocomplete();
 
 						const newParticipant = conversationBridge.addNewParticipant( newLabel );
+
 						setAttributes( newParticipant );
 					} }
 					onUpdate={ ( participant ) => {

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -249,6 +249,13 @@ export default function DialogueEdit( {
 				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 				placeholder={ placeholder || __( 'Write dialogue…', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
+				onFocus={ () => {
+					// Provably, we should add a new participant from here.
+					// onFocusOutside is not supported by some Gutenberg versions.
+					// Take a look at <ParticipantsRichControl /> to get more info.
+					// addNewParticipant will take over to add, or not, the participant.
+					conversationBridge.addNewParticipant( participantValue );
+				} }
 			/>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -109,22 +109,6 @@ export default function DialogueEdit( {
 		setAttributes( { timestamp: time } );
 	}
 
-	/**
-	 * Make focus in the content component.
-	 * It also deals with a race condition
-	 * when setting the slug attribute
-	 * and onFocus() callback.
-	 *
-	 * @param {boolean} force - Defines if effectively make the focus in the content.
-	 */
-	function focusOnContent( force ) {
-		if ( ! force ) {
-			return;
-		}
-
-		setTimeout( () => contentRef?.current?.focus(), 100 );
-	}
-
 	return (
 		<div className={ className }>
 			<BlockControls>
@@ -180,30 +164,20 @@ export default function DialogueEdit( {
 					onParticipantChange={ ( updatedParticipant ) => {
 						setAttributes( { label: updatedParticipant } );
 					} }
-					onSelect={ ( selectedParticipant, forceFucus ) => {
-						setAttributes( selectedParticipant );
-						focusOnContent( forceFucus );
-					} }
+					onSelect={ setAttributes }
 
 					onClean={ () => {
 						setAttributes( { slug: null, label: '' } );
 					} }
 
-					onAdd={ ( newLabel, forceFucus ) => {
+					onAdd={ ( newLabel ) => {
 						triggerRefreshAutocomplete();
 
 						const newParticipant = conversationBridge.addNewParticipant( newLabel );
-						if ( ! newParticipant ) {
-							focusOnContent( forceFucus );
-							return;
-						}
-
 						setAttributes( newParticipant );
-						focusOnContent( forceFucus );
 					} }
-					onUpdate={ ( participant, forceFucus ) => {
+					onUpdate={ ( participant ) => {
 						conversationBridge.updateParticipants( participant );
-						focusOnContent( forceFucus );
 					} }
 					onFocus={ () => setIsContentSelected( false ) }
 				/>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -13,7 +13,7 @@ import { useDebounce } from '@wordpress/compose';
  * Internal dependencies
  */
 import './editor.scss';
-import { ParticipantsControl, ParticipantsRichControl } from './components/participants-control';
+import { ParticipantsControl, SpeakerEditControl } from './components/participants-control';
 import { TimestampControl, TimestampDropdown } from './components/timestamp-control';
 import { BASE_CLASS_NAME } from './utils';
 import ConversationContext from '../conversation/components/context';
@@ -39,8 +39,8 @@ export default function DialogueEdit( {
 } ) {
 	const {
 		content,
-		participantLabel,
-		participantSlug,
+		label,
+		slug,
 		placeholder,
 		showTimestamp,
 		timestamp,
@@ -50,7 +50,7 @@ export default function DialogueEdit( {
 		select( MEDIA_SOURCE_STORE_ID ).getDefaultMediaSource()
 	), [] );
 
-	// we use a reducer to force re-rendering the ParticipantsRichControl,
+	// we use a reducer to force re-rendering the SpeakerEditControl,
 	// passing the `reRenderingKey` as property of the component.
 	// It's required when we want to update the options in the autocomplete,
 	// or when we need to hide it.
@@ -67,7 +67,7 @@ export default function DialogueEdit( {
 		? participantsFromContext
 		: defaultParticipants;
 
-	const conversationParticipant = getParticipantBySlug( participants, participantSlug );
+	const conversationParticipant = getParticipantBySlug( participants, slug );
 
 	// Conversation context. A bridge between dialogue and conversation blocks.
 	const conversationBridge = useContext( ConversationContext );
@@ -80,7 +80,7 @@ export default function DialogueEdit( {
 			return;
 		}
 
-		if ( conversationParticipant.slug !== participantSlug ) {
+		if ( conversationParticipant.slug !== slug ) {
 			return;
 		}
 
@@ -90,9 +90,9 @@ export default function DialogueEdit( {
 		}
 
 		debounceSetDialoguesAttrs( {
-			participantLabel: conversationParticipant.label,
+			label: conversationParticipant.label,
 		} );
-	}, [ conversationParticipant, debounceSetDialoguesAttrs, isSelected, participantSlug ] );
+	}, [ conversationParticipant, debounceSetDialoguesAttrs, isSelected, slug ] );
 
 	// Update dialogue timestamp setting from parent conversation.
 	useEffect( () => {
@@ -110,7 +110,7 @@ export default function DialogueEdit( {
 	/**
 	 * Make focus in the content component.
 	 * It also deals with a race condition
-	 * when setting the participantSlug attribute
+	 * when setting the slug attribute
 	 * and onFocus() callback.
 	 *
 	 * @param {boolean} force - Defines if effectively make the focus in the content.
@@ -140,7 +140,7 @@ export default function DialogueEdit( {
 						<ParticipantsControl
 							className={ BASE_CLASS_NAME }
 							participants={ participants }
-							participantSlug={ participantSlug || '' }
+							slug={ slug || '' }
 							onSelect={ setAttributes }
 						/>
 					</PanelBody>
@@ -170,29 +170,22 @@ export default function DialogueEdit( {
 			</InspectorControls>
 
 			<div className={ `${ BASE_CLASS_NAME }__meta` }>
-				<ParticipantsRichControl
+				<SpeakerEditControl
 					className={ `${ BASE_CLASS_NAME }__participant` }
-					label={ participantLabel }
+					label={ label }
 					participant={ conversationParticipant }
 					participants={ participants }
 					reRenderingKey={ `re-render-key${ reRenderingKey }` }
 					onParticipantChange={ ( updatedParticipant ) => {
-						setAttributes( { participantLabel: updatedParticipant } );
+						setAttributes( { label: updatedParticipant } );
 					} }
-					onSelect={ ( { slug, label }, forceFucus ) => {
-						setAttributes( {
-							participantLabel: label,
-							participantSlug: slug,
-						} );
-
+					onSelect={ ( selectedParticipant, forceFucus ) => {
+						setAttributes( selectedParticipant );
 						focusOnContent( forceFucus );
 					} }
 
 					onClean={ () => {
-						setAttributes( {
-							participantSlug: null,
-							participantLabel: '',
-						} );
+						setAttributes( { slug: null, label: '' } );
 					} }
 
 					onAdd={ ( newLabel, forceFucus ) => {
@@ -204,10 +197,7 @@ export default function DialogueEdit( {
 							return;
 						}
 
-						setAttributes( {
-							participantLabel: newParticipant.label,
-							participantSlug: newParticipant.slug,
-						} );
+						setAttributes( newParticipant );
 						focusOnContent( forceFucus );
 					} }
 					onUpdate={ ( participant, forceFucus ) => {
@@ -275,7 +265,7 @@ export default function DialogueEdit( {
 				placeholder={ placeholder || __( 'Write dialogue…', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
 				onFocus={ ( event ) => {
-					if ( ! participantLabel ) {
+					if ( ! label ) {
 						triggerRefreshAutocomplete();
 						return;
 					}
@@ -284,27 +274,21 @@ export default function DialogueEdit( {
 
 					// Provably, we should add a new participant from here.
 					// onFocusOutside is not supported by some Gutenberg versions.
-					// Take a look at <ParticipantsRichControl /> to get more info.
-					const participantExists = getParticipantByLabel( participants, participantLabel );
+					// Take a look at <SpeakerEditControl /> to get more info.
+					const participantExists = getParticipantByLabel( participants, label );
 
 					// If participant exists let's update it.
 					if ( participantExists ) {
-						setAttributes( {
-							participantLabel: participantExists.label,
-							participantSlug: participantExists.slug,
-						} );
+						setAttributes( participantExists );
 					} else {
 						// Otherwise, let's create a new one...
-						const newParticipant = conversationBridge.addNewParticipant( participantLabel );
+						const newParticipant = conversationBridge.addNewParticipant( label );
 						if ( ! newParticipant ) {
 							return;
 						}
 
 						// ... and update the dialogue with these new values.
-						setAttributes( {
-							participantLabel: newParticipant.label,
-							participantSlug: newParticipant.slug,
-						} );
+						setAttributes( newParticipant );
 					}
 
 					triggerRefreshAutocomplete();

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/components';
 import { useContext, useEffect, useRef } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
+import { useDebounce } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -67,6 +68,8 @@ export default function DialogueEdit( {
 	// Conversation context. A bridge between dialogue and conversation blocks.
 	const conversationBridge = useContext( ConversationContext );
 
+	const debounceSetDialoguesAttrs = useDebounce( setAttributes, 200 );
+
 	// Update dialogue participant with conversation participant changes.
 	useEffect( () => {
 		if ( ! conversationParticipant ) {
@@ -77,11 +80,11 @@ export default function DialogueEdit( {
 			return;
 		}
 
-		setAttributes( {
+		debounceSetDialoguesAttrs( {
 			participantLabel: conversationParticipant.label,
 			participantValue: conversationParticipant.value,
 		} );
-	}, [ conversationParticipant, participantSlug, setAttributes ] );
+	}, [ conversationParticipant, debounceSetDialoguesAttrs, participantSlug ] );
 
 	// Update dialogue timestamp setting from parent conversation.
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -166,9 +166,6 @@ export default function DialogueEdit( {
 							participantValue: value,
 							participantSlug: slug,
 						} );
-
-						// Focus on block content.
-						richTextRef?.current?.focus();
 					} }
 
 					onClean = { () => {
@@ -183,9 +180,6 @@ export default function DialogueEdit( {
 						if ( ! newParticipant ) {
 							return;
 						}
-
-						// Focus on block content.
-						richTextRef?.current?.focus();
 
 						setAttributes( {
 							participantValue: newParticipant.value,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -64,7 +64,7 @@ export default function DialogueEdit( {
 	// Conversation context. A bridge between dialogue and conversation blocks.
 	const conversationBridge = useContext( ConversationContext );
 
-	const debounceSetDialoguesAttrs = useDebounce( setAttributes, 100 );
+	const debounceSetDialoguesAttrs = useDebounce( setAttributes, 250 );
 
 	// Update dialogue participant with conversation participant changes.
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -9,7 +9,7 @@ import {
 	PanelBody,
 	ToggleControl,
 } from '@wordpress/components';
-import { useContext, useEffect, useRef } from '@wordpress/element';
+import { useContext, useEffect } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
 
@@ -48,7 +48,6 @@ export default function DialogueEdit( {
 		showTimestamp,
 		timestamp,
 	} = attributes;
-	const richTextRef = useRef();
 
 	const mediaSource = useSelect( select => (
 		select( MEDIA_SOURCE_STORE_ID ).getDefaultMediaSource()
@@ -203,7 +202,6 @@ export default function DialogueEdit( {
 			</div>
 
 			<RichText
-				ref={ richTextRef }
 				identifier="content"
 				tagName="p"
 				className={ `${ BASE_CLASS_NAME }__content` }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -194,8 +194,12 @@ export default function DialogueEdit( {
 						focusOnContent( forceFucus );
 					} }
 
-					onClean = { () => {
-						setAttributes( { participantSlug: null } );
+					onClean={ () => {
+						setAttributes( {
+							participantSlug: null,
+							participantLabel: '',
+							participantValue: '',
+						} );
 					} }
 
 					onAdd={ ( newValue, forceFucus ) => {
@@ -283,22 +287,26 @@ export default function DialogueEdit( {
 				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 				placeholder={ placeholder || __( 'Write dialogue…', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
-				onFocus={ () => {
+				onFocus={ ( event ) => {
 					if ( ! participantValue ) {
 						triggerRefreshAutocomplete();
 						return;
 					}
 
+					event.preventDefault();
+
 					// Provably, we should add a new participant from here.
 					// onFocusOutside is not supported by some Gutenberg versions.
 					// Take a look at <ParticipantsRichControl /> to get more info.
 					// addNewParticipant will take over to add, or not, the participant.
-					const { value, label, slug } = conversationBridge.addNewParticipant( participantValue );
-					setAttributes( {
-						participantValue: value,
-						participantLabel: label,
-						participantSlug: slug,
-					} );
+					const participantAdded = conversationBridge.addNewParticipant( participantValue );
+					if ( participantAdded ) {
+						setAttributes( {
+							participantValue: participantAdded.value,
+							participantLabel: participantAdded.label,
+							participantSlug: participantAdded.slug,
+						} );
+					}
 
 					triggerRefreshAutocomplete();
 				} }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -8,7 +8,6 @@ import {
 	Panel,
 	PanelBody,
 	ToggleControl,
-	ToolbarGroup,
 } from '@wordpress/components';
 import { useContext, useEffect, useRef } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
@@ -18,7 +17,7 @@ import { useDebounce } from '@wordpress/compose';
  * Internal dependencies
  */
 import './editor.scss';
-import ParticipantsDropdown, { ParticipantsControl, ParticipantsRichControl } from './components/participants-control';
+import { ParticipantsControl, ParticipantsRichControl } from './components/participants-control';
 import { TimestampControl, TimestampDropdown } from './components/timestamp-control';
 import { BASE_CLASS_NAME } from './utils';
 import ConversationContext from '../conversation/components/context';
@@ -108,15 +107,6 @@ export default function DialogueEdit( {
 	return (
 		<div className={ className }>
 			<BlockControls>
-				<ToolbarGroup>
-					<ParticipantsDropdown
-						className={ BASE_CLASS_NAME }
-						participants={ participants }
-						participantSlug={ participantSlug }
-						onSelect={ setAttributes }
-					/>
-				</ToolbarGroup>
-
 				{ mediaSource && (
 					<MediaPlayerToolbarControl
 						onTimeChange={ time => setTimestamp( convertSecondsToTimeCode( time ) ) }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls, RichText, BlockControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Panel, PanelBody, ToggleControl } from '@wordpress/components';
-import { useContext, useEffect, useRef, useState } from '@wordpress/element';
+import { useContext, useEffect, useRef } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
 
@@ -42,7 +42,6 @@ export default function DialogueEdit( {
 		showTimestamp,
 		timestamp,
 	} = attributes;
-	const [ isContentIsSelected, setIsContentSelected ] = useState( false );
 
 	const mediaSource = useSelect(
 		select => select( MEDIA_SOURCE_STORE_ID ).getDefaultMediaSource(),
@@ -168,7 +167,6 @@ export default function DialogueEdit( {
 					onUpdate={ ( participant ) => {
 						conversationBridge.updateParticipants( participant );
 					} }
-					onFocus={ () => setIsContentSelected( false ) }
 				/>
 
 				{ showTimestamp && (
@@ -229,9 +227,7 @@ export default function DialogueEdit( {
 				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 				placeholder={ placeholder || __( 'Write dialogue…', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
-				isSelected={ isContentIsSelected }
-				onFocus={ () => setIsContentSelected( true ) }
-				/>
+			/>
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -184,7 +184,6 @@ export default function DialogueEdit( {
 					} }
 
 					onSelect={ ( { slug, label, value }, forceFucus ) => {
-						// let's focus to content when it's possible.
 						setAttributes( {
 							participantLabel: label,
 							participantValue: value,
@@ -203,7 +202,6 @@ export default function DialogueEdit( {
 					} }
 
 					onAdd={ ( newValue, forceFucus ) => {
-						// let's focus to content when it's possible.
 						triggerRefreshAutocomplete();
 
 						if ( ! newValue?.length ) {
@@ -298,21 +296,38 @@ export default function DialogueEdit( {
 					// Provably, we should add a new participant from here.
 					// onFocusOutside is not supported by some Gutenberg versions.
 					// Take a look at <ParticipantsRichControl /> to get more info.
-					// addNewParticipant will take over to add, or not, the participant.
 					const participantExists = getParticipantByValue( participants, participantValue );
 					const hasFormatChanges = conversationParticipant?.value !== participantValue;
+
+					// If participant exists ...
 					if ( participantExists ) {
+						// and there are formats differences...
 						if ( hasFormatChanges ) {
+							// updates the participant,
 							return conversationBridge.updateParticipants( {
 								...conversationParticipant,
 								value: participantValue,
 							} );
 						}
 
+						// Otherwise, simply update the dialogue participant.
 						setAttributes( {
 							participantValue: participantExists.value,
 							participantLabel: participantExists.label,
 							participantSlug: participantExists.slug,
+						} );
+					} else {
+						// But, if it doens't exist let's create a new one...
+						const newParticipant = conversationBridge.addNewParticipant( participantValue );
+						if ( ! newParticipant ) {
+							return;
+						}
+
+						// ... and update the dialogue with these new values.
+						setAttributes( {
+							participantValue: newParticipant.value,
+							participantLabel: newParticipant.label,
+							participantSlug: newParticipant.slug,
 						} );
 					}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -25,3 +25,7 @@
 .wp-block-jetpack-dialogue__timestamp-dropdown {
 	min-width: 90px;
 }
+
+.wp-block-jetpack-dialogue__participant.is-adding-new-participant {
+	opacity: 0.7;
+}

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -26,22 +26,10 @@
 	min-width: 90px;
 }
 
-.wp-block-jetpack-dialogue__participant.is-editing-participant,
-.wp-block-jetpack-dialogue__participant.is-selecting-participant,
 .wp-block-jetpack-dialogue__participant.is-adding-participant {
-	border-width: 1px;
-	border-style: solid;
-}
-
-.wp-block-jetpack-dialogue__participant.is-adding-participant {
-	border-color: #0A0;
+	opacity: 0.7;
 }
 
 .wp-block-jetpack-dialogue__participant.is-editing-participant {
-	border-color: #A00;
+	opacity: 0.7;
 }
-
-.wp-block-jetpack-dialogue__participant.is-selecting-participant {
-	border-color: #04A;
-}
-

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -26,6 +26,22 @@
 	min-width: 90px;
 }
 
-.wp-block-jetpack-dialogue__participant.is-adding-new-participant {
-	opacity: 0.7;
+.wp-block-jetpack-dialogue__participant.is-editing-participant,
+.wp-block-jetpack-dialogue__participant.is-selecting-participant,
+.wp-block-jetpack-dialogue__participant.is-adding-participant {
+	border-width: 1px;
+	border-style: solid;
 }
+
+.wp-block-jetpack-dialogue__participant.is-adding-participant {
+	border-color: #0A0;
+}
+
+.wp-block-jetpack-dialogue__participant.is-editing-participant {
+	border-color: #A00;
+}
+
+.wp-block-jetpack-dialogue__participant.is-selecting-participant {
+	border-color: #04A;
+}
+

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -32,6 +32,12 @@ export const settings = {
 	save,
 	attributes,
 	usesContext: [ 'jetpack/conversation-participants', 'jetpack/conversation-showTimestamps' ],
+	keywords: [
+		_x( 'Dialogue', 'block search term', 'jetpack' ),
+		__( 'dialog', 'jetpack' ),
+		__( 'speaker', 'jetpack' ),
+		__( 'participant', 'jetpack' ),
+	],
 	transforms: {
 		from: [
 			{

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/index.js
@@ -33,10 +33,10 @@ export const settings = {
 	attributes,
 	usesContext: [ 'jetpack/conversation-participants', 'jetpack/conversation-showTimestamps' ],
 	keywords: [
-		_x( 'Dialogue', 'block search term', 'jetpack' ),
-		__( 'dialog', 'jetpack' ),
-		__( 'speaker', 'jetpack' ),
-		__( 'participant', 'jetpack' ),
+		_x( 'dialogue', 'block search term', 'jetpack' ),
+		_x( 'participant', 'block search term', 'jetpack' ),
+		_x( 'transcription', 'block search term', 'jetpack' ),
+		_x( 'speaker', 'block search term', 'jetpack' ),
 	],
 	transforms: {
 		from: [

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/index.js
@@ -10,7 +10,7 @@ import { createBlock } from '@wordpress/blocks';
 import attributes from './attributes';
 import edit from './edit';
 import save from './save';
-import { DialogueIcon as icon } from '../../shared/icons';
+import { TranscriptSpeakerIcon as icon } from '../../shared/icons';
 import { list as defaultParticipants } from '../conversation/participants.json';
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
@@ -10,13 +10,13 @@ import { BASE_CLASS_NAME } from './utils';
 import { convertTimeCodeToSeconds } from '../../shared/components/media-player-control/utils';
 
 export default function save( { attributes } ) {
-	const { content, participantLabel, showTimestamp, timestamp } = attributes;
+	const { content, label, showTimestamp, timestamp } = attributes;
 
 	return (
 		<div>
 			<div className={ `${ BASE_CLASS_NAME }__meta` }>
 				<div className={ `${ BASE_CLASS_NAME }__participant` }>
-					{ participantLabel }
+					{ label }
 				</div>
 				{ showTimestamp && (
 					<div className={ `${ BASE_CLASS_NAME }__timestamp` }>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
@@ -15,7 +15,7 @@ export default function save( { attributes } ) {
 	return (
 		<div>
 			<div className={ `${ BASE_CLASS_NAME }__meta` }>
-				<div className={ `${ BASE_CLASS_NAME }__participant` }>
+				<div className={ `${ BASE_CLASS_NAME }__participant has-bold-style` }>
 					{ label }
 				</div>
 				{ showTimestamp && (

--- a/projects/plugins/jetpack/extensions/shared/icons.js
+++ b/projects/plugins/jetpack/extensions/shared/icons.js
@@ -198,9 +198,13 @@ export const TranscriptIcon = {
 		<SVG viewBox="0 0 24 24">
 			<Rect x="0" fill="none" width="24" height="24" />
 			<G>
-				<Path d="M11.1114 8H20.0002M11.1113 15H20.0002" stroke="#00101C" stroke-width="1.5" />
-				<Path d="M4 10V6L8 8L4 10Z" fill="#1E1E1E" />
-				<Path d="M4 17V13L8 15L4 17Z" fill="#1E1E1E" />
+				<Path
+					d="M11.1114 8H20.0002M11.1113 15H20.0002"
+					stroke={ getIconColor() }
+					stroke-width="1.5"
+				/>
+				<Path d="M4 10V6L8 8L4 10Z" fill={ getIconColor() } />
+				<Path d="M4 17V13L8 15L4 17Z" fill={ getIconColor() } />
 			</G>
 		</SVG>
 	),
@@ -212,9 +216,9 @@ export const TranscriptSpeakerIcon = {
 		<SVG viewBox="0 0 24 24">
 			<Rect x="0" fill="none" width="24" height="24" />
 			<G>
-				<Path d="M4 12V4L11 8L4 12Z" fill="#1E1E1E" />
-				<Path d="M4 14.5H20V16H4V14.5Z" fill="#1E1E1E" />
-				<Path d="M4 18.5H13V20H4V18.5Z" fill="#1E1E1E" />
+				<Path d="M4 12V4L11 8L4 12Z" />
+				<Path d="M4 14.5H20V16H4V14.5Z" />
+				<Path d="M4 18.5H13V20H4V18.5Z" />
 			</G>
 		</SVG>
 	),

--- a/projects/plugins/jetpack/extensions/shared/icons.js
+++ b/projects/plugins/jetpack/extensions/shared/icons.js
@@ -192,6 +192,34 @@ export const DialogueIcon = {
 	),
 };
 
+export const TranscriptIcon = {
+	foreground: getIconColor(),
+	src: (
+		<SVG viewBox="0 0 24 24">
+			<Rect x="0" fill="none" width="24" height="24" />
+			<G>
+				<Path d="M11.1114 8H20.0002M11.1113 15H20.0002" stroke="#00101C" stroke-width="1.5" />
+				<Path d="M4 10V6L8 8L4 10Z" fill="#1E1E1E" />
+				<Path d="M4 17V13L8 15L4 17Z" fill="#1E1E1E" />
+			</G>
+		</SVG>
+	),
+};
+
+export const TranscriptSpeakerIcon = {
+	foreground: getIconColor(),
+	src: (
+		<SVG viewBox="0 0 24 24">
+			<Rect x="0" fill="none" width="24" height="24" />
+			<G>
+				<Path d="M4 12V4L11 8L4 12Z" fill="#1E1E1E" />
+				<Path d="M4 14.5H20V16H4V14.5Z" fill="#1E1E1E" />
+				<Path d="M4 18.5H13V20H4V18.5Z" fill="#1E1E1E" />
+			</G>
+		</SVG>
+	),
+};
+
 export const formatUppercase = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M2.5 7.5V4.5H15.5V7.5H10.5V19.5H7.5V7.5H2.5ZM12.5 9.5H21.5V12.5H18.5V19.5H15.5V12.5H12.5V9.5Z" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR implements a new component used to edit the participants in a conversation structure.

https://user-images.githubusercontent.com/77539/106919456-ec6dd980-66e8-11eb-96a3-92f5f520cc12.mov


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: edit participant from canvas

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new conversation block. Check you can get it by `conversation`, `transcription`, `dialogue`, `dialog`, and `speaker` keywords.
* When you start a new component from scratch, there is not any participant defined in the conversation context, thus you need to start to type the participant name in some of the dialogue blocks.
* The new participant will be added once press `ENTER` key or when on focus outside
* When editing a new Dialogue participant, you should get the participant suggestions.
* To add a new participant, you need to clean the participant content before starting to type. Otherwise, it will edit the current participant and all sibling Dialogue blocks with the same participant.

D56506-code

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
