### PR TITLE
Use rest_request_before_callbacks as a filter.

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -71,8 +71,10 @@ class Admin_Menu {
 
 	/**
 	 * Sets up class properties for REST API requests.
+	 *
+	 * @param WP_REST_Response $response Response from the endpoint.
 	 */
-	public function rest_api_init( $response, $handler, $request ) {
+	public function rest_api_init( $response ) {
 		$this->is_api_request = true;
 
 		return $response;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -49,7 +49,7 @@ class Admin_Menu {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
-		add_action( 'rest_request_before_callbacks', array( $this, 'rest_api_init' ), 11 );
+		add_filter( 'rest_request_before_callbacks', array( $this, 'rest_api_init' ), 11, 3 );
 
 		$this->domain = ( new Status() )->get_site_suffix();
 	}
@@ -72,8 +72,10 @@ class Admin_Menu {
 	/**
 	 * Sets up class properties for REST API requests.
 	 */
-	public function rest_api_init() {
+	public function rest_api_init( $response, $handler, $request ) {
 		$this->is_api_request = true;
+
+		return $response;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -49,7 +49,7 @@ class Admin_Menu {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
-		add_filter( 'rest_request_before_callbacks', array( $this, 'rest_api_init' ), 11, 3 );
+		add_filter( 'rest_request_before_callbacks', array( $this, 'rest_api_init' ), 11 );
 
 		$this->domain = ( new Status() )->get_site_suffix();
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -25,9 +25,11 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 	/**
 	 * Sets up class properties for REST API requests.
+	 *
+	 * @param WP_REST_Response $response Response from the endpoint.
 	 */
-	public function rest_api_init( $response, $handler, $request ) {
-		parent::rest_api_init( $response, $handler, $request );
+	public function rest_api_init( $response  ) {
+		parent::rest_api_init( $response );
 
 		// Get domain for requested site.
 		$this->domain         = ( new Status() )->get_site_suffix();

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -26,12 +26,14 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	/**
 	 * Sets up class properties for REST API requests.
 	 */
-	public function rest_api_init() {
-		parent::rest_api_init();
+	public function rest_api_init( $response, $handler, $request ) {
+		parent::rest_api_init( $response, $handler, $request );
 
 		// Get domain for requested site.
 		$this->domain         = ( new Status() )->get_site_suffix();
 		$this->customize_slug = 'https://wordpress.com/customize/' . $this->domain;
+
+		return $response;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -28,7 +28,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 *
 	 * @param WP_REST_Response $response Response from the endpoint.
 	 */
-	public function rest_api_init( $response  ) {
+	public function rest_api_init( $response ) {
 		parent::rest_api_init( $response );
 
 		// Get domain for requested site.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes p1YhhO-Md-p2

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Uses `rest_request_before_callbacks` as a filter rather than an action. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**On Simple**
- apply the patch to your sandbox
- visit `http://wordpress.com/` and select your sandboxed site
- make sure that you don't get duplicate menu items like 
![](https://cln.sh/wAmkVe+)

**On Atomic**
- Use Jetpack Beta and switch to this branch
- visit `http://wordpress.com/` and select your atomic site
- make sure that you don't get duplicate menu items like 
![](https://cln.sh/wAmkVe+)

Please also follow p1YhhO-Md-p2#comment-6349 for the jetpack-licensing issue

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fixes jetpack-licensing endpoint