### PR TITLE
Docker: Add wp-control as a default debugging plugin

### DIFF
--- a/tools/docker/bin/install.sh
+++ b/tools/docker/bin/install.sh
@@ -25,6 +25,10 @@ wp --allow-root option update blog_public 0
 # https://wordpress.org/plugins/query-monitor/
 wp --allow-root plugin install query-monitor --activate
 
+# Install WP-Control
+# https://wordpress.org/plugins/wp-crontrol/
+wp --allow-root plugin install wp-crontrol --activate
+
 # Activate Jetpack
 wp --allow-root plugin activate jetpack
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

wp-crontrol is an extremely handy plugin for debugging cron issues on sites and is my first install anytime cron comes up.

To aid others in faster access and discoverability of this debugging tool, let's add it to our default docker install.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add wp-crontrol as a default debugging plugin.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `yarn docker:install`
* Confirm wp-crontrol was installed (should be in the CLI output 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
