### PR TITLE
Audio Player: Fix the error thrown from MediaElement of parentNode being undefined

### DIFF
--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
@@ -53,7 +53,6 @@ function AudioPlayer( {
 	preload = 'metadata',
 } ) {
 	const audioRef = useRef();
-	const containerRef = useRef();
 
 	/**
 	 * Play current audio.
@@ -91,21 +90,16 @@ function AudioPlayer( {
 	}, [] );
 
 	useEffect( () => {
-		const container = containerRef.current;
-		const audioEl = document.createElement( 'audio' );
-		audioEl.src = trackSource;
+		const audio = audioRef.current;
 
 		// Pre load audio meta data.
-		audioEl.preload = preload;
+		audio.preload = preload;
 
 		// Insert player into the DOM.
-		container.appendChild( audioEl );
-		const mediaElement = new MediaElementPlayer( audioEl, {
+		const mediaElement = new MediaElementPlayer( audio, {
 			...meJsSettings,
 			success: () => loadWhenReady && audio?.load()
 		} );
-		audioRef.current = mediaElement.domNode;
-		const audio = audioRef.current;
 
 		// Add the skip and jump buttons if needed
 		if ( onJumpBack || onSkipForward ) {
@@ -134,11 +128,11 @@ function AudioPlayer( {
 
 		return () => {
 			// Cleanup.
+			mediaElement.remove();
 			onPlay && audio.removeEventListener( 'play', onPlay );
 			onPause && audio.removeEventListener( 'pause', onPause );
 			onError && audio.removeEventListener( 'error', onError );
 			onMetadataLoaded && audio.removeEventListener( 'loadedmetadata', onMetadataLoaded );
-			mediaElement.remove();
 		};
 	}, [
 		onPlay,
@@ -149,7 +143,6 @@ function AudioPlayer( {
 		onMetadataLoaded,
 		loadWhenReady,
 		preload,
-		trackSource,
 	] );
 
 	// If we get lots of events from clicking on the progress bar in the MediaElement
@@ -207,7 +200,12 @@ function AudioPlayer( {
 		}
 	}, [ audioRef, currentTime ] );
 
-	return <div className="jetpack-audio-player" ref={ containerRef } />;
+	return (
+		<div className="jetpack-audio-player">
+			{ /* eslint-disable-next-line jsx-a11y/media-has-caption */ }
+			<audio src={ trackSource } ref={ audioRef }></audio>
+		</div>
+	);
 }
 
 export default AudioPlayer;


### PR DESCRIPTION
When the AudioPlayer component was used there were occasions when both the mount and unmount parts of the `useEffect` hook would run in a single render. `MediaElement` has a responsive mode that uses `setTimeout( ..., 0)` to wait for the audio player to be rendered before checking and updating its size. The problem here is that the audio element was being cleaned up as part of the `useEffect` before the sizing function had a chance to run. It would then run and assuming the audio element was still part of the DOM, would attempt to read properties about its `parentNode`. This would cause an error as `parentNode` was undefined.

#### Changes proposed in this Pull Request:
This should probably be patched in MediaElement itself, but it is an edge case, and I think something specific to do with how this operates with `useEffect`. But until then, this change patches the `setResponsiveMode` of MediaElement. It firsts check that the `parentNode` property is defined. If it is, then it simply calls the original method.

Additionally, this makes some minor tweaks to the order we add and remove event listeners, as well as creating the audio element each time.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This is a bug fix.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
* Insert a podcast block into a post.
* Set the feed to a podcast.
* Click the replace button and change the feed to a different podcast
* Once loaded, check the developer tools console and you should see an error about `parentNode` being undefined.
* With this change, that error shouldn't appear

#### Proposed changelog entry for your changes:
* Fixed a bug that caused an error when changing the podcast's block's RSS feed.
