### PR TITLE
Fix JS errors for eu-widget in block widget editor

### DIFF
--- a/projects/plugins/jetpack/modules/widgets/eu-cookie-law/eu-cookie-law-admin.js
+++ b/projects/plugins/jetpack/modules/widgets/eu-cookie-law/eu-cookie-law-admin.js
@@ -23,7 +23,7 @@
 		);
 		$document.on( 'widget-updated widget-added', function ( e, widget ) {
 			var widgetId = $( widget ).attr( 'id' );
-			if ( widgetId.indexOf( 'eu_cookie_law_widget' ) !== -1 ) {
+			if ( widgetId && widgetId.indexOf( 'eu_cookie_law_widget' ) !== -1 ) {
 				maybeShowNotice( null, $( '#' + widgetId + ' .eu-cookie-law-widget-policy-url' ) );
 			}
 		} );

--- a/projects/plugins/jetpack/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/projects/plugins/jetpack/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -10,6 +10,10 @@
 		initialScrollPosition,
 		scrollFunction;
 
+	if ( null === widget || null === overlay ) {
+		return;
+	}
+
 	/**
 	 * Gets the amount that the window is scrolled.
 	 *


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Gutenberg 8.9.0 introduced a block-based widget editing screen, and
these changes fix two JS errors that were occuring due to:

1. `eu-cookie-law-admin.js` referencing an id value which when editing
the widget from the block-based screen is no longer present - there is
a legacy widget block wrapper.
2. `eu-cookie-law.js` may not always find the right DOM elements from
the block-based widget screen as the block is rendered or rerendered.

A separate issue has been opened for the `Preview` option not working as expected: #18664

#### Jetpack product discussion

Fixes #18565

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Refer to reproduction steps outlined in #18565
* After pulling/building proposed changes, test that you are able to add & edit a `Jetpack Cookies & Consents Banner` widget from the Gutenberg block-based widgets screen. Refresh the page and make sure no JS errors are thrown.
* Deactivate Gutenberg and make sure the normal WP Admin widget editing screen, and the Widgets item in Customizer work as expected.

#### Proposed changelog entry for your changes:

* Cookie Widget: Fix JS error when editing widget from block-based widget editor
