### PR TITLE
Podcast Player: Add an episode selection UI

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -39,10 +39,11 @@ class Jetpack_Podcast_Helper {
 	 * @return array|WP_Error  The player data or a error object.
 	 */
 	public function get_player_data( $args = array() ) {
-		$guids = isset( $args['guids'] ) && $args['guids'] ? $args['guids'] : array();
+		$guids           = isset( $args['guids'] ) && $args['guids'] ? $args['guids'] : array();
+		$episode_options = isset( $args['episode-options'] ) && $args['episode-options'];
 
 		// Try loading data from the cache.
-		$transient_key = 'jetpack_podcast_' . md5( $this->feed . implode( ',', $guids ) );
+		$transient_key = 'jetpack_podcast_' . md5( $this->feed . implode( ',', $guids ) . "-$episode_options" );
 		$player_data   = get_transient( $transient_key );
 
 		// Fetch data if we don't have any cached.
@@ -87,6 +88,16 @@ class Jetpack_Podcast_Helper {
 				'cover'  => $cover,
 				'tracks' => $tracks,
 			);
+
+			if ( $episode_options ) {
+				$player_data['options'] = array();
+				foreach ( $rss->get_items() as $episode ) {
+					$player_data['options'][] = array(
+						'label' => $this->get_plain_text( $episode->get_title() ),
+						'value' => $episode->get_id(),
+					);
+				}
+			}
 
 			// Cache for 1 hour.
 			set_transient( $transient_key, $player_data, HOUR_IN_SECONDS );
@@ -337,21 +348,22 @@ class Jetpack_Podcast_Helper {
 			'title'      => 'jetpack-podcast-player-data',
 			'type'       => 'object',
 			'properties' => array(
-				'title'  => array(
+				'title'   => array(
 					'description' => __( 'The title of the podcast.', 'jetpack' ),
 					'type'        => 'string',
 				),
-				'link'   => array(
+				'link'    => array(
 					'description' => __( 'The URL of the podcast website.', 'jetpack' ),
 					'type'        => 'string',
 					'format'      => 'uri',
 				),
-				'cover'  => array(
+				'cover'   => array(
 					'description' => __( 'The URL of the podcast cover image.', 'jetpack' ),
 					'type'        => 'string',
 					'format'      => 'uri',
 				),
-				'tracks' => self::get_tracks_schema(),
+				'tracks'  => self::get_tracks_schema(),
+				'options' => self::get_options_schema(),
 			),
 		);
 	}
@@ -398,6 +410,33 @@ class Jetpack_Podcast_Helper {
 					),
 					'title'            => array(
 						'description' => __( 'The episode title.', 'jetpack' ),
+						'type'        => 'string',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Gets the episode options schema.
+	 *
+	 * Useful for json schema in REST API endpoints.
+	 *
+	 * @return array Tracks json schema.
+	 */
+	public static function get_options_schema() {
+		return array(
+			'description' => __( 'The options that will be displayed in the episode selection UI', 'jetpack' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'label' => array(
+						'description' => __( 'The display label of the option, the episode title.', 'jetpack' ),
+						'type'        => 'string',
+					),
+					'value' => array(
+						'description' => __( 'The value used for that option, the episode GUID', 'jetpack' ),
 						'type'        => 'string',
 					),
 				),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
@@ -42,7 +42,7 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 						return current_user_can( 'edit_posts' );
 					},
 					'args'                => array(
-						'url'   => array(
+						'url'             => array(
 							'description'       => __( 'The Podcast RSS feed URL.', 'jetpack' ),
 							'type'              => 'string',
 							'required'          => 'true',
@@ -50,7 +50,7 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 								return wp_http_validate_url( $param );
 							},
 						),
-						'guids' => array(
+						'guids'           => array(
 							'description'       => __( 'A list of unique identifiers for fetching specific podcast episodes.', 'jetpack' ),
 							'type'              => 'array',
 							'required'          => 'false',
@@ -60,6 +60,11 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 							'sanitize_callback' => function ( $guids ) {
 									return array_map( 'sanitize_text_field', $guids );
 							},
+						),
+						'episode-options' => array(
+							'description' => __( 'Whether we should return the episodes list for use in the selection UI', 'jetpack' ),
+							'type'        => 'boolean',
+							'required'    => 'false',
 						),
 					),
 					'schema'              => array( $this, 'get_public_item_schema' ),
@@ -77,11 +82,17 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 	public function get_player_data( $request ) {
 		$helper = new Jetpack_Podcast_Helper( $request['url'] );
 
+		$args = array();
+
 		if ( isset( $request['guids'] ) ) {
-			$player_data = $helper->get_player_data( array( 'guids' => $request['guids'] ) );
-		} else {
-			$player_data = $helper->get_player_data();
+			$args['guids'] = $request['guids'];
 		}
+
+		if ( isset( $request['episode-options'] ) && $request['episode-options'] ) {
+			$args['episode-options'] = true;
+		}
+
+		$player_data = $helper->get_player_data( $args );
 
 		if ( is_wp_error( $player_data ) ) {
 			return rest_ensure_response( $player_data );

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
@@ -9,12 +9,16 @@ import { PODCAST_FEED, EMBED_BLOCK } from './constants';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
-export const fetchPodcastFeed = async ( { url, guids = [] } ) => {
+export const fetchPodcastFeed = async ( { url, guids = [], fetchEpisodeOptions = false } ) => {
 	// First try calling our endpoint for Podcast parsing.
 	let feedData, feedError;
 	try {
 		feedData = await apiFetch( {
-			path: addQueryArgs( '/wpcom/v2/podcast-player', { url, guids } ),
+			path: addQueryArgs( '/wpcom/v2/podcast-player', {
+				url,
+				guids,
+				[ 'episode-options' ]: fetchEpisodeOptions,
+			} ),
 		} );
 	} catch ( err ) {
 		// We are not rethrowing the error just yet so we can try the embed too.

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/editor.scss
@@ -54,5 +54,8 @@
 	.embed-actions {
 		display: flex;
 		flex-direction: row;
+		@media screen and (max-width: 360px) {
+			flex-direction: column-reverse;
+		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/editor.scss
@@ -23,10 +23,14 @@
 
 // Placeholder styles
 .jetpack-podcast-player__placeholder {
+	.components-placeholder__fieldset form {
+		flex-direction: column;
+	}
 	.components-base-control,
 	.components-base-control__field {
 		display: flex;
 		flex-grow: 1;
+		flex-direction: column;
 	}
 
 	.components-base-control__field {
@@ -35,5 +39,20 @@
 
 	.components-placeholder__learn-more {
 		margin-top: 1em;
+		flex-grow: 1;
+	}
+
+	.components-form-token-field__suggestions-list {
+		margin: 0;
+		padding: 0;
+	}
+
+	.components-combobox-control {
+		margin-top: 5px;
+	}
+
+	.embed-actions {
+		display: flex;
+		flex-direction: row;
 	}
 }


### PR DESCRIPTION
Now that we have changed the podcast block so that it can be set to display a particular episode, we need to add the user interface to select the episode.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18008

#### Changes proposed in this Pull Request:
This change does 2 things:

* It modifies the API endpoint to return data that can be used to populate a combobox
* It adds that combobox to the edit screen of the block so that it can be used to select a single episode
for the block to display, rather than a list of the most recent episodes.

#### Jetpack product discussion
This is an enhancement that has been developed as part of the Anchor.FM project.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Using this branch:

* Add a podcast block.
* Set the feed URL to a podcast feed.
* You may have to wait a few moments, but the combobox should be populated with a list of episodes.
* Select an episode and click on embed.
* The block should be fixed to that episode.
* Click replace in the toolbar and try selecting a different episode, clearing the episode selection, and swapping to a different feed.

#### Known issues
There is currently no indication that we are loading the list episodes for a feed. This ideally would be part of the combobox control, but until that's the case we can add something in a follow-up PR.

The error messages returned from the API are displayed in a notification in the block. These aren't always very intuitive, so it would be good to update those, or simply display a single more generic error when something goes wrong. It's nearly always related to not being able to read the feed, so something prompting to try again or refer to a support doc, might be all we need.

Large feeds can cause an out of memory error when reading them. An example is, https://feeds.megaphone.fm/sidehustleschool However, this can be read ok on WPCOM as the memory limit is higher, but in my local dev environment, it's set to 64MB, which is too little to read this feed of over 1200 episodes. We might be able to do something using a streaming parser, but that would be a large change, that is best as a separate PR. 

#### Proposed changelog entry for your changes:
* Podcast player block can now be set to a specific podcast episode.
