### PR TITLE
Autoloader: avoid warnings when no absolute paths are found

### DIFF
--- a/projects/packages/autoloader/src/class-plugin-locator.php
+++ b/projects/packages/autoloader/src/class-plugin-locator.php
@@ -124,15 +124,17 @@ class Plugin_Locator {
 		$path_constants = array( WP_PLUGIN_DIR, WPMU_PLUGIN_DIR );
 
 		$plugin_paths = array();
-		foreach ( $plugins as $key => $value ) {
-			$path = $this->path_processor->find_directory_with_autoloader( $key, $path_constants );
-			if ( $path ) {
-				$plugin_paths[] = $path;
-			}
+		if ( is_array( $plugins ) && ! empty( $plugins ) ) {
+			foreach ( $plugins as $key => $value ) {
+				$path = $this->path_processor->find_directory_with_autoloader( $key, $path_constants );
+				if ( $path ) {
+					$plugin_paths[] = $path;
+				}
 
-			$path = $this->path_processor->find_directory_with_autoloader( $value, $path_constants );
-			if ( $path ) {
-				$plugin_paths[] = $path;
+				$path = $this->path_processor->find_directory_with_autoloader( $value, $path_constants );
+				if ( $path ) {
+					$plugin_paths[] = $path;
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* In some situations, no absolute paths are returned in options. In those scenarios, avoid such PHP warnings:

```
Warning: Invalid argument supplied for foreach() in /wp-content/mu-plugins/jetpack-plugin/vendor/jetpack-autoloader/class-plugin-locator.php on line 137
```

#### Jetpack product discussion

* p1612277404030200-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* See discussion in p1612277404030200-slack-CBG1CP4EN

#### Proposed changelog entry for your changes:

* N/A