### PR TITLE
Conversation: re-organize timestamp and participants controls

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/components/participants-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/components/participants-controls.js
@@ -1,43 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { TextControl, Button } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 
-function AddParticipantButton( { className, onAdd, participants = [] } ) {
-	return (
-		<div className={ `${ className }__participant` }>
-			<Button
-				className={ `${ className }__add-button` }
-				label={ __( 'Add Participant', 'jetpack' ) }
-				onClick={ () => onAdd( `Participant ${ participants.length + 1 }` ) }
-				isSecondary
-				isSmall
-			>
-				{ __( 'Add participant', 'jetpack' ) }
-			</Button>
-		</div>
-	);
-}
-
-function ParticipantsLabelControl( { className, participants, onChange, onDelete } ) {
+function ParticipantsLabelControl( { className, participants, onDelete } ) {
 	return (
 		<div className={ `${ className }__participant-control` }>
 			{ participants.map( ( { label, slug } ) => (
 				<div key={ `${ slug }-key` } className={ `${ className }__participant` }>
-					<TextControl
-						value={ label }
-						onChange={ value =>
-							onChange( {
-								slug,
-								label: value,
-							} )
-						}
-					/>
+					<div className={ `${ className }__participant-label` }>
+						{ label }
+					</div>
 
 					<Button
-						disabled={ participants.length < 2 }
 						className={ `${ className }__remove-participant` }
 						label={ __( 'Remove participant', 'jetpack' ) }
 						onClick={ () => onDelete( slug ) }
@@ -52,17 +28,13 @@ function ParticipantsLabelControl( { className, participants, onChange, onDelete
 	);
 }
 
-export function ParticipantsSelector( { participants, className, onChange, onDelete, onAdd } ) {
+export function ParticipantsSelector( { participants, className, onChange, onDelete } ) {
 	return (
-		<Fragment>
-			<ParticipantsLabelControl
-				className={ className }
-				participants={ participants }
-				onChange={ onChange }
-				onDelete={ onDelete }
-			/>
-
-			<AddParticipantButton className={ className } onAdd={ onAdd } participants={ participants } />
-		</Fragment>
+		<ParticipantsLabelControl
+			className={ className }
+			participants={ participants }
+			onChange={ onChange }
+			onDelete={ onDelete }
+		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/conversation/components/participants-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/components/participants-controls.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { DropdownMenu, TextControl, Button } from '@wordpress/components';
+import { TextControl, Button } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 
@@ -64,19 +64,5 @@ export function ParticipantsSelector( { participants, className, onChange, onDel
 
 			<AddParticipantButton className={ className } onAdd={ onAdd } participants={ participants } />
 		</Fragment>
-	);
-}
-
-export default function ParticipantsDropdown( props ) {
-	return (
-		<DropdownMenu
-			popoverProps={ { position: 'bottom' } }
-			toggleProps={ {
-				children: <span>{ props.label }</span>,
-			} }
-			icon={ null }
-		>
-			{ () => <ParticipantsSelector { ...props } /> }
-		</DropdownMenu>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -116,9 +116,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 							<ParticipantsSelector
 								className={ baseClassName }
 								participants={ participants }
-								onChange={ updateParticipants }
 								onDelete={ deleteParticipant }
-								onAdd={ addNewParticipant }
 							/>
 						</PanelBody>
 

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -3,20 +3,18 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
-import { InnerBlocks, InspectorControls, BlockControls } from '@wordpress/block-editor';
+import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
 import {
 	Panel,
 	PanelBody,
 	ToggleControl,
-	ToolbarButton,
-	ToolbarGroup,
 } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
-import ParticipantsDropdown, { ParticipantsSelector } from './components/participants-controls';
+import { ParticipantsSelector } from './components/participants-controls';
 import TranscriptionContext from './components/context';
 import { getParticipantByLabel } from './utils';
 
@@ -109,28 +107,6 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 	return (
 		<TranscriptionContext.Provider value={ contextProvision }>
 			<div className={ className }>
-				<BlockControls>
-					<ToolbarGroup>
-						<ParticipantsDropdown
-							className={ baseClassName }
-							participants={ participants }
-							label={ __( 'Participants', 'jetpack' ) }
-							onChange={ updateParticipants }
-							onDelete={ deleteParticipant }
-							onAdd={ addNewParticipant }
-						/>
-					</ToolbarGroup>
-
-					<ToolbarGroup>
-						<ToolbarButton
-							isActive={ showTimestamps }
-							onClick={ () => setAttributes( { showTimestamps: ! showTimestamps } ) }
-						>
-							{ __( 'Timestamps', 'jetpack' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
-
 				<InspectorControls>
 					<Panel>
 						<PanelBody

--- a/projects/plugins/jetpack/extensions/blocks/conversation/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/editor.scss
@@ -1,43 +1,12 @@
 // Settings sidebar.
 $participant-height: 30px;
 
-.components-panel__body.wp-block-jetpack-conversation__participants {
-	.components-base-control {
-		margin-bottom: 0;
-	}
-}
-
 .wp-block-jetpack-conversation__participant {
 	display: flex;
-
-	.components-base-control {
-		margin-bottom: 5px;
-		flex-grow: 2;
-	}
-
-	.components-button {
-		height: $participant-height;
-		line-height: $participant-height;
-	}
-}
-
-.wp-block-jetpack-conversation__participant-control {
-	margin-bottom: 0;
-}
-
-.wp-block-jetpack-conversation__remove-participant {
-	margin-left: 8px;
+	height: $participant-height;
+	line-height: $participant-height;
 }
 
 .wp-block-jetpack-conversation__participant-label {
-	height: 2em;
-	line-height: 2em;
-	font-size: 16px;
-}
-
-.wp-block-jetpack-conversation__participant-formats {
-	display: flex;
-	.components-button {
-		margin-right: 5px;
-	}
+	flex-grow: 2;
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -8,6 +8,7 @@
 		display: flex;
 		flex-direction: row;
 		align-items: center;
+		min-height: 38px;
 	}
 
 	.wp-block-jetpack-dialogue__participant {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

**IMPORTANT**: PR branched off from update/dialogue-participant-canvas-edition

This PR cleans and updates the `timestamp` and `participants` controls from the toolbar and the block settings (sidebar).
Issue tasks:

* Remove timestamp and speaker management from the Conversation block,
* and place those controls in the child blocks. 
* Toggling on timestamps in a child block will still affect other child blocks, 
* and will remove the need to move between the parent and child block to make updates.

Fixes https://github.com/Automattic/jetpack/issues/18671

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation: re-organize timestamp and participants controls

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new Conversation/Dialogue block
* Add some participants there.
* Confirm either participants and timestamps controls have been removed from the toolbar

before | after
------|------
![image](https://user-images.githubusercontent.com/77539/106625278-489ff480-6555-11eb-9c4b-a02f281b8bd9.png) | ![image](https://user-images.githubusercontent.com/77539/106625110-1d1d0a00-6555-11eb-8ae8-3dd469f9c5d5.png)

* Check the block sidebar:

before | after
-----|-----
![image](https://user-images.githubusercontent.com/77539/106625317-505f9900-6555-11eb-8e79-f418284feb5a.png) | ![image](https://user-images.githubusercontent.com/77539/106625189-345bf780-6555-11eb-8a51-f78e641c6e60.png)

* confirm it's still possible to remove a participant from the block settings (sidebar).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
