### PR TITLE
E2E Tests: use JS to force connect variation

### DIFF
--- a/projects/plugins/jetpack/.wp-env.json
+++ b/projects/plugins/jetpack/.wp-env.json
@@ -4,11 +4,11 @@
 		"WP_DEBUG": true,
 		"WP_DEBUG_LOG": true,
 		"WP_DEBUG_DISPLAY": false,
-		"JETPACK_BETA_BLOCKS": true,
-		"JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME": true
+		"JETPACK_BETA_BLOCKS": true
 	},
 	"mappings": {
 		"wp-content/plugins/jetpack-dev": ".",
-		"wp-content/plugins/e2e-plugin-updater.php": "./tests/e2e/plugins/e2e-plugin-updater.php"
+		"wp-content/plugins/e2e-plugin-updater.php": "./tests/e2e/plugins/e2e-plugin-updater.php",
+		"wp-content/packages": "../../packages/"
 	}
 }

--- a/projects/plugins/jetpack/tests/e2e/.eslintrc.js
+++ b/projects/plugins/jetpack/tests/e2e/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
 		jestPuppeteer: true,
 		reporter: true,
 		jasmine: true,
+		jpConnect: true,
 	},
 	settings: {
 		jest: {

--- a/projects/plugins/jetpack/tests/e2e/lib/flows/jetpack-connect.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/flows/jetpack-connect.js
@@ -30,17 +30,13 @@ const cookie = config.get( 'storeSandboxCookieValue' );
 const cardCredentials = config.get( 'testCardCredentials' );
 
 /**
- * Connects your site to WPCOM as `wpcomUser`, buys a Professional plan via sandbox cookie
+ * Goes through connection flow via classic (calypso) flow
  *
- * @param {Object} o Optional object with params such as `wpcomUser` and expected Jetpack plan
- * @param {string} o.wpcomUser
+ * @param {Object} o Optional object with params such as `plan` and `mockPlanData`
  * @param {string} o.plan
  * @param {boolean} o.mockPlanData
  */
-export async function connectThroughWPAdminIfNeeded( {
-	plan = 'complete',
-	mockPlanData = false,
-} = {} ) {
+export async function connectThroughWPAdmin( { plan = 'complete', mockPlanData = false } = {} ) {
 	if ( await isBlogTokenSet() ) {
 		return 'already_connected';
 	}
@@ -62,6 +58,7 @@ export async function connectThroughWPAdminIfNeeded( {
 
 async function doClassicConnection( mockPlanData ) {
 	const jetpackPage = await JetpackPage.init( page );
+	await jetpackPage.forceVariation( 'original' );
 	await jetpackPage.connect();
 	// Go through Jetpack connect flow
 	await ( await AuthorizePage.init( page ) ).approve();
@@ -76,6 +73,7 @@ async function doClassicConnection( mockPlanData ) {
 
 export async function doInPlaceConnection() {
 	const jetpackPage = await JetpackPage.init( page );
+	await jetpackPage.forceVariation( 'in_place' );
 	await jetpackPage.connect();
 
 	await ( await InPlaceAuthorizeFrame.init( page ) ).approve();

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
@@ -70,7 +70,7 @@ export default class BlockEditorPage extends Page {
 	}
 
 	async focus() {
-		await this.page.focus( this.expectedSelector );
+		await this.page.focus( '.editor-post-title__input' );
 		await waitAndClick( this.page, '.editor-post-title__input' );
 	}
 

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/jetpack.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/jetpack.js
@@ -40,6 +40,13 @@ export default class JetpackPage extends Page {
 		return await isEventuallyVisible( this.page, connectionInfo, 5000 );
 	}
 
+	async forceVariation( variation = 'original' ) {
+		return await this.page.evaluate(
+			forceVariation => ( jpConnect.forceVariation = forceVariation ),
+			variation
+		);
+	}
+
 	async isPlan( plan ) {
 		switch ( plan ) {
 			case 'free':

--- a/projects/plugins/jetpack/tests/e2e/lib/setup-env.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/setup-env.js
@@ -13,7 +13,7 @@ import { logHTML, logDebugLog } from './page-helper';
 import logger from './logger';
 import { execWpCommand } from './utils-helper';
 import {
-	connectThroughWPAdminIfNeeded,
+	connectThroughWPAdmin,
 	loginToWpcomIfNeeded,
 	loginToWpSite,
 } from './flows/jetpack-connect';
@@ -157,7 +157,7 @@ async function maybePreConnect() {
 		return;
 	}
 
-	const status = await connectThroughWPAdminIfNeeded( { wpcomUser, mockPlanData, plan } );
+	const status = await connectThroughWPAdmin( { mockPlanData, plan } );
 
 	if ( status !== 'already_connected' ) {
 		const result = await execWpCommand( 'wp option get jetpack_private_options --format=json' );

--- a/projects/plugins/jetpack/tests/e2e/specs/connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/connection.test.js
@@ -16,8 +16,8 @@ describe( 'Connection', () => {
 			'wp option delete e2e_jetpack_plan_data',
 			'wp option delete jetpack_active_plan',
 			'wp option delete jetpack_private_options',
-			'wp option delete jetpack_sync_error_idc',
-			'wp config set --raw JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME false'
+			'wp option delete jetpack_sync_error_idc'
+			// 'wp config set --raw JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME false'
 		);
 		await page.reload();
 		await page.reload();
@@ -27,7 +27,7 @@ describe( 'Connection', () => {
 		await execWpCommand(
 			'wp option update jetpack_private_options --format=json < jetpack_private_options.txt'
 		);
-		await execWpCommand( 'wp config set --raw JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME true' );
+		// await execWpCommand( 'wp config set --raw JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME true' );
 	} );
 
 	it( 'In-place', async () => {

--- a/projects/plugins/jetpack/tests/e2e/specs/connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/connection.test.js
@@ -17,7 +17,6 @@ describe( 'Connection', () => {
 			'wp option delete jetpack_active_plan',
 			'wp option delete jetpack_private_options',
 			'wp option delete jetpack_sync_error_idc'
-			// 'wp config set --raw JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME false'
 		);
 		await page.reload();
 		await page.reload();
@@ -27,7 +26,6 @@ describe( 'Connection', () => {
 		await execWpCommand(
 			'wp option update jetpack_private_options --format=json < jetpack_private_options.txt'
 		);
-		// await execWpCommand( 'wp config set --raw JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME true' );
 	} );
 
 	it( 'In-place', async () => {

--- a/projects/plugins/jetpack/tests/e2e/specs/plugin-updater.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/plugin-updater.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { catchBeforeAll, step } from '../lib/setup-env';
-import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
+import { connectThroughWPAdmin } from '../lib/flows/jetpack-connect';
 import {
 	execWpCommand,
 	prepareUpdaterTest,
@@ -51,7 +51,7 @@ describe( 'Jetpack updater', () => {
 		} );
 
 		await step( 'Can connect Jetpack', async () => {
-			await connectThroughWPAdminIfNeeded( { mockPlanData: true, plan: 'free' } );
+			await connectThroughWPAdmin( { mockPlanData: true, plan: 'free' } );
 		} );
 	} );
 } );

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -234,7 +234,6 @@
 	"projects/plugins/jetpack/modules/widgets/milestone/admin.js",
 	"projects/plugins/jetpack/modules/widgets/simple-payments/customizer.js",
 	"projects/plugins/jetpack/modules/wpgroho.js",
-	"projects/plugins/jetpack/tests/e2e/lib/flows/jetpack-connect.js",
 	"projects/plugins/jetpack/tests/e2e/lib/setup-env.js",
 	"projects/plugins/jetpack/tests/e2e/specs/free-blocks.test.js",
 	"projects/plugins/jetpack/tools/builder/react.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* fixes a bug related to missed packages folder in wp-env environment
* switches the connection variation switch from PHP constant for a JS approach
* rename `connectThroughWPAdminIfNeeded` to reflect actual implementation
* Attempt to address flakiness related to unexpected "Saved" state in block editor

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure tests are green in CI
* Re-run it few times, to make sure there no intermittent failures
* Run `./tests/e2e/bin/env.sh start`. Make sure script can activate `jetpack-dev` plugin

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
