### PR TITLE
Tools: Update eslint-changed to match phpcs-changed

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -358,7 +358,7 @@ jobs:
       - run: yarn lint-required
 
   ### Runs eslint-changed on JS files listed in eslint-excludelist.json.
-  # Local equivalent: `yarn lint-changed --git-branch=<base>`
+  # Local equivalent: `yarn lint-changed --git-base=<base>`
   # `<base>` is the branch this PR is to be merged into, probably `origin/master`.
   #
   # Pre-commit, you might also `git add` the relevant files and run `yarn lint-changed`
@@ -394,7 +394,7 @@ jobs:
       - name: Run eslint-changed
         env:
           FILES: ${{ needs.changed_files.outputs.js_excluded_files }}
-        run: yarn lint-changed --git-branch=${{ github.event.pull_request.base.sha }} $(jq -rn --argjson files "$FILES" '$files[]')
+        run: yarn lint-changed --git-base=${{ github.event.pull_request.base.sha }} $(jq -rn --argjson files "$FILES" '$files[]')
 
   ### Checks that copied files (e.g. readme, license) are in sync
   # Local equivalent: `./tools/check-copied-files.sh`

--- a/tools/eslint-changed.js
+++ b/tools/eslint-changed.js
@@ -35,7 +35,10 @@ program
 	)
 	.option( '--git-staged', 'Compare the staged version to the HEAD version (this is the default).' )
 	.option( '--git-unstaged', 'Compare the working copy version to the staged (or HEAD) version.' )
-	.option( '--git-branch <ref>', 'Compare the HEAD version to the HEAD of a different branch.' )
+	.option(
+		'--git-base <ref>',
+		'Compare the HEAD version to the HEAD of a different base (e.g. branch).'
+	)
 
 	.option( '--debug', 'Enable debug output.' )
 	.option(
@@ -62,7 +65,7 @@ if ( argv.diff !== undefined && argv.git ) {
 	[ 'eslint-new', 'diff' ],
 	[ 'git-staged', 'git' ],
 	[ 'git-unstaged', 'git' ],
-	[ 'git-branch', 'git' ],
+	[ 'git-base', 'git' ],
 ].forEach( x => {
 	const [ arg1, arg2 ] = x;
 	const prop1 = arg1.replace( /-[a-z]/g, v => v[ 1 ].toUpperCase() );
@@ -147,10 +150,10 @@ async function main() {
 		diffBase = doCmd( git, args ).trim();
 
 		args = [ 'diff' ];
-		if ( argv.gitBranch !== undefined ) {
-			origRef = argv.gitBranch;
+		if ( argv.gitBase !== undefined ) {
+			origRef = argv.gitBase;
 			newRef = 'HEAD';
-			args.push( `${ argv.gitBranch }...HEAD` );
+			args.push( `${ argv.gitBase }...HEAD` );
 		} else if ( argv.gitUnstaged ) {
 			origRef = ':0';
 			newRef = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

In #18627, we updated to the latest version of phpcs-changed which updated from `--git-branch` to `--git-base`.

To mirror them, let's update the arg the same. The same happy accident with phpcs-changed where it worked with any base, not just branches, already, should be the same for us as well.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* eslint-changed now uses `--git-base` instead of `--git-branch`

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make changes in JS and run `yarn lint-changed --git-base [base]` with a different branch.
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
