### PR TITLE
Autoloader: stricter type-checking on WP functions

### DIFF
--- a/projects/packages/autoloader/src/class-plugin-locator.php
+++ b/projects/packages/autoloader/src/class-plugin-locator.php
@@ -51,8 +51,8 @@ class Plugin_Locator {
 	 * @return array $plugin_paths The list of absolute paths we've found.
 	 */
 	public function find_using_option( $option_name, $site_option = false ) {
-		$raw = $site_option ? get_site_option( $option_name, array() ) : get_option( $option_name, array() );
-		if ( empty( $raw ) ) {
+		$raw = $site_option ? get_site_option( $option_name ) : get_option( $option_name );
+		if ( false === $raw ) {
 			return array();
 		}
 
@@ -120,6 +120,10 @@ class Plugin_Locator {
 	 * @return string[]
 	 */
 	private function convert_plugins_to_paths( $plugins ) {
+		if ( ! is_array( $plugins ) || empty( $plugins ) ) {
+			return array();
+		}
+
 		// We're going to look for plugins in the standard directories.
 		$path_constants = array( WP_PLUGIN_DIR, WPMU_PLUGIN_DIR );
 

--- a/projects/packages/autoloader/src/class-plugins-handler.php
+++ b/projects/packages/autoloader/src/class-plugins-handler.php
@@ -114,7 +114,7 @@ class Plugins_Handler {
 	 */
 	public function get_cached_plugins() {
 		$cached = get_transient( self::TRANSIENT_KEY );
-		if ( false === $cached ) {
+		if ( ! is_array( $cached ) || empty( $cached ) ) {
 			return array();
 		}
 

--- a/projects/packages/autoloader/tests/php/tests/unit/test-plugin-locator.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/test-plugin-locator.php
@@ -177,6 +177,23 @@ class Test_Plugin_Locator extends TestCase {
 	}
 
 	/**
+	 * Tests that it does not give errors or warnings when the option contains unexpected data.
+	 */
+	public function test_using_option_handles_invalid_data() {
+		add_test_option(
+			'test_plugin_paths',
+			'invalid'
+		);
+
+		$this->path_processor->expects( $this->never() )->method( 'find_directory_with_autoloader' );
+
+		$plugin_paths = $this->locator->find_using_option( 'test_plugin_paths' );
+
+		$this->assertTrue( is_array( $plugin_paths ) );
+		$this->assertEmpty( $plugin_paths );
+	}
+
+	/**
 	 * Tests that plugins in request parameters are not discovered if a nonce is not set.
 	 */
 	public function test_using_request_action_returns_nothing_without_nonce() {

--- a/projects/packages/autoloader/tests/php/tests/unit/test-plugins-handler.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/test-plugins-handler.php
@@ -265,6 +265,20 @@ class Test_Plugins_Handler extends TestCase {
 	}
 
 	/**
+	 * Tests that an empty array is returned when the cache contains invalid data.
+	 */
+	public function test_gets_cached_plugins_handles_invalid_data() {
+		set_transient( Plugins_Handler::TRANSIENT_KEY, 'invalid' );
+
+		$this->path_processor->expects( $this->never() )->method( 'untokenize_path_constants' );
+
+		$plugin_paths = $this->plugins_handler->get_cached_plugins();
+
+		$this->assertTrue( is_array( $plugin_paths ) );
+		$this->assertEmpty( $plugin_paths );
+	}
+
+	/**
 	 * Tests that the plugins are updated when they have changed.
 	 */
 	public function test_updates_cache_writes_plugins() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

As an alternative to #18673 this PR adds stricter type checking around WordPress functions. It's possible that filters may cause these to return unexpected data and we should add resiliency to avoid fatals in those cases.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

The circumstances where this can be tested on a live site are difficult but I've included tests that verify the bug is fixed.

#### Proposed changelog entry for your changes:
* Autoloader: stricter type-checking on WP functions
