### PR TITLE
Tests: Suppress errors for imagesize

### DIFF
--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -15,6 +15,7 @@
  *	}
  */
 define( 'TESTING_IN_JETPACK', true );
+define( 'WP_RUN_CORE_TESTS', true );
 
 // Support for:
 // 1. `WP_DEVELOP_DIR` environment variable

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -15,7 +15,6 @@
  *	}
  */
 define( 'TESTING_IN_JETPACK', true );
-define( 'WP_RUN_CORE_TESTS', true );
 
 // Support for:
 // 1. `WP_DEVELOP_DIR` environment variable

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.recipe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.recipe.php
@@ -165,14 +165,7 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_recipe_image_valid_attachment() {
 		// Create a mock attachment.
-		$attachment_id = $this->_make_attachment(
-			array(
-				'file'  => 'example.jpg',
-				'url'   => 'http://example.com/wp-content/uploads/example.jpg',
-				'type'  => 'image/jpeg',
-				'error' => false,
-			)
-		);
+		$attachment_id = $this->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
 
 		// Get shortcode with new attachment.
 		$content = '[recipe image="' . $attachment_id . '"]';
@@ -334,14 +327,7 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_recipe_image_shortcode_attachment() {
 		// Create a mock attachment.
-		$attachment_id = $this->_make_attachment(
-			array(
-				'file'  => 'example.jpg',
-				'url'   => 'http://example.com/wp-content/uploads/example.jpg',
-				'type'  => 'image/jpeg',
-				'error' => false,
-			)
-		);
+		$attachment_id = $this->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
 
 		// Get shortcode with new attachment.
 		$content = '[recipe-image ' . $attachment_id . ']';
@@ -357,14 +343,7 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_recipe_image_shortcode_attachment_attr() {
 		// Create a mock attachment.
-		$attachment_id = $this->_make_attachment(
-			array(
-				'file'  => 'example.jpg',
-				'url'   => 'http://example.com/wp-content/uploads/example.jpg',
-				'type'  => 'image/jpeg',
-				'error' => false,
-			)
-		);
+		$attachment_id = $this->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
 
 		// Get shortcode with new attachment.
 		$content = '[recipe-image image="' . $attachment_id . '"]';

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.recipe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.recipe.php
@@ -165,7 +165,8 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_recipe_image_valid_attachment() {
 		// Create a mock attachment.
-		$attachment_id = $this->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
+		$url           = wp_get_attachment_url( $attachment_id );
 
 		// Get shortcode with new attachment.
 		$content = '[recipe image="' . $attachment_id . '"]';
@@ -178,12 +179,12 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 			&& wp_lazy_loading_enabled( 'img', 'wp_get_attachment_image' )
 		) {
 			$this->assertContains(
-				'<img src="http://example.org/wp-content/uploads/example.jpg" class="jetpack-recipe-image u-photo photo" alt="" loading="lazy" itemprop="image" />',
+				'src="' . $url . '" class="jetpack-recipe-image u-photo photo" alt="" loading="lazy" itemprop="image" />',
 				$shortcode_content
 			);
 		} else {
 			$this->assertContains(
-				'<img src="http://example.org/wp-content/uploads/example.jpg" class="jetpack-recipe-image u-photo photo" alt="" itemprop="image" />',
+				'src="' . $url . '" class="jetpack-recipe-image u-photo photo" alt="" itemprop="image" />',
 				$shortcode_content
 			);
 		}
@@ -328,12 +329,13 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	public function test_shortcodes_recipe_image_shortcode_attachment() {
 		// Create a mock attachment.
 		$attachment_id = $this->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
+		$url           = wp_get_attachment_url( $attachment_id );
 
 		// Get shortcode with new attachment.
 		$content = '[recipe-image ' . $attachment_id . ']';
 
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<img src="http://example.org/wp-content/uploads/example.jpg" class="jetpack-recipe-image u-photo photo"', $shortcode_content );
+		$this->assertContains( 'src="' . $url . '" class="jetpack-recipe-image u-photo photo"', $shortcode_content );
 	}
 
 	/**
@@ -344,12 +346,13 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	public function test_shortcodes_recipe_image_shortcode_attachment_attr() {
 		// Create a mock attachment.
 		$attachment_id = $this->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
+		$url           = wp_get_attachment_url( $attachment_id );
 
 		// Get shortcode with new attachment.
 		$content = '[recipe-image image="' . $attachment_id . '"]';
 
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<img src="http://example.org/wp-content/uploads/example.jpg" class="jetpack-recipe-image u-photo photo"', $shortcode_content );
+		$this->assertContains( 'src="' . $url . '" class="jetpack-recipe-image u-photo photo"', $shortcode_content );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.recipe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.recipe.php
@@ -328,7 +328,7 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_recipe_image_shortcode_attachment() {
 		// Create a mock attachment.
-		$attachment_id = $this->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
 		$url           = wp_get_attachment_url( $attachment_id );
 
 		// Get shortcode with new attachment.
@@ -345,7 +345,7 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_recipe_image_shortcode_attachment_attr() {
 		// Create a mock attachment.
-		$attachment_id = $this->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/../../files/jetpack.jpg' );
 		$url           = wp_get_attachment_url( $attachment_id );
 
 		// Get shortcode with new attachment.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* https://core.trac.wordpress.org/changeset/50146 stopped suppressing errors for `getimagesize`, which we had used to our advantage when mocking an attachment.

This PR changes those tests to create an upload object and handle it primarily, instead of a bad mock.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Does the PHP unit tests pass?
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
