### PR TITLE
WPCOM API / Media: handle WordPress.com file operation differences

### DIFF
--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1338,6 +1338,16 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$file_info = pathinfo( $file );
 		$ext       = isset( $file_info['extension'] ) ? $file_info['extension'] : null;
 
+		// File operations are handled differently on WordPress.com.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$attachment_metadata = wp_get_attachment_metadata( $media_item->ID );
+			$filesize            = ! empty( $attachment_metadata['filesize'] )
+				? $attachment_metadata['filesize']
+				: 0;
+		} else {
+			$filesize = filesize( $attachment_file );
+		}
+
 		$response = array(
 			'ID'          => $media_item->ID,
 			'URL'         => wp_get_attachment_url( $media_item->ID ),
@@ -1353,7 +1363,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			'description' => $media_item->post_content,
 			'alt'         => get_post_meta( $media_item->ID, '_wp_attachment_image_alt', true ),
 			'icon'        => wp_mime_type_icon( $media_item->ID ),
-			'size'        => size_format( filesize( $attachment_file ), 2 ),
+			'size'        => size_format( (int) $filesize, 2 ),
 			'thumbnails'  => array(),
 		);
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This is a follow-up from #18637.

On WordPress.com, file operations are handled a bit differently and calling filesize() can consequently cause warnings.
We now avoid calling it on WordPress.com, and instead rely on the filesize metadata field when it is available (it is not for all images).

#### Jetpack product discussion

* See D56399-code

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to https://developer.wordpress.com/docs/api/console/
* Query the media endpoint for a site where you've applied this patch.
* You should see the media size in the response

![image](https://user-images.githubusercontent.com/426388/106742602-8700e680-661d-11eb-9576-67a0f84538ed.png)


#### Proposed changelog entry for your changes:

* N/A
