### PR TITLE
Remove Sync's usage of wp_startswith

### DIFF
--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -332,7 +332,7 @@ class Posts extends Module {
 	 */
 	public function is_whitelisted_post_meta( $meta_key ) {
 		// The _wpas_skip_ meta key is used by Publicize.
-		return in_array( $meta_key, Settings::get_setting( 'post_meta_whitelist' ), true ) || wp_startswith( $meta_key, '_wpas_skip_' );
+		return in_array( $meta_key, Settings::get_setting( 'post_meta_whitelist' ), true ) || ( 0 === strpos( $meta_key, '_wpas_skip_' ) );
 	}
 
 	/**


### PR DESCRIPTION
To make Sync a standalone package we need to remove references to Jetpack functions and constants. This update replaces the usage of `wp_startswith` with `0 === strpos` to check the meta_key.

#### Changes proposed in this Pull Request:
* Removal of dependency functions.

#### Does this pull request change what data or activity we track or use?
NO

#### Testing instructions:

* This update is covered under existing unit tests "test_syncs_wpas_skip_meta"
* To manually test you can add the _wpas_meta_ meta value to a post and verify it is synced to the Cache DB.
* add_post_meta( POST_ID, '_wpas_skip_1234', '1' );

#### Proposed changelog entry for your changes:
* Sync - Packaging : removal of Jetpack dependent functions.
