### PR TITLE
Update plugin modify endpoint to use should_update

### DIFF
--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -327,6 +327,12 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				continue;
 			}
 
+			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated.
+			$wp_automatic_updater = new WP_Automatic_Updater();
+			if ( ! $wp_automatic_updater->should_update( 'plugin', $plugin, WP_PLUGIN_DIR ) ) {
+				continue;
+			}
+
 			/**
 			 * Pre-upgrade action
 			 *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -328,8 +328,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 
 			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated.
-			$wp_automatic_updater = new WP_Automatic_Updater();
-			if ( ! $wp_automatic_updater->should_update( 'plugin', $plugin, WP_PLUGIN_DIR ) ) {
+			if ( ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $plugin, WP_PLUGIN_DIR ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Rely on core's `WP_Automatic_Updater` class to check if any of the `update_plugins` items `should_update()`.

#### Jetpack product discussion

See #18562

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* With this change pulled down, connect Jetpack to WordPress.com
* Install a plugin for testing such as Hello Dolly, and `Enable auto-updates` for the plugin from WP Admin
* Add `define( 'AUTOMATIC_UPDATER_DISABLED', true );` to your site's `wp-config.php` file
* Rollback the version of the plugin you enabled auto-updates for using something like the WP Rollback plugin. Refresh WP Admin to make sure you see that a new version is available for that plugin.
* Visit `https://wordpress.com/plugins/manage/__YOUR_SITE__` where you should see some toast messages telling you the plugin is being updated.
* If you refresh WP Admin however, you should see that the plugin was _not_ updated, and that a newer version is still available.
* Remaining issues regarding WPcom Calypso reporting the plugin(s) as updating are being tracked in #18562

#### Proposed changelog entry for your changes:

* Auto-updates: plugin modify API endpoint respects auto-update constant/filters
