### PR TITLE
Deprecate jetpack_json_wrap

### DIFF
--- a/projects/packages/sync/src/class-functions.php
+++ b/projects/packages/sync/src/class-functions.php
@@ -635,4 +635,45 @@ class Functions {
 
 		return $theme_support;
 	}
+
+	/**
+	 * Wraps data in a way so that we can distinguish between objects and array and also prevent object recursion.
+	 *
+	 * @since 9.5.0
+	 *
+	 * @param array|obj $any        Source data to be cleaned up.
+	 * @param array     $seen_nodes Built array of nodes.
+	 *
+	 * @return array
+	 */
+	public static function json_wrap( &$any, $seen_nodes = array() ) {
+		if ( is_object( $any ) ) {
+			$input        = get_object_vars( $any );
+			$input['__o'] = 1;
+		} else {
+			$input = &$any;
+		}
+
+		if ( is_array( $input ) ) {
+			$seen_nodes[] = &$any;
+
+			$return = array();
+
+			foreach ( $input as $k => &$v ) {
+				if ( ( is_array( $v ) || is_object( $v ) ) ) {
+					if ( in_array( $v, $seen_nodes, true ) ) {
+						continue;
+					}
+					$return[ $k ] = self::json_wrap( $v, $seen_nodes );
+				} else {
+					$return[ $k ] = $v;
+				}
+			}
+
+			return $return;
+		}
+
+		return $any;
+
+	}
 }

--- a/projects/packages/sync/src/class-json-deflate-array-codec.php
+++ b/projects/packages/sync/src/class-json-deflate-array-codec.php
@@ -54,7 +54,6 @@ class JSON_Deflate_Array_Codec implements Codec_Interface {
 	 * @return false|string
 	 */
 	protected function json_serialize( $any ) {
-		// This prevents fatal error when updating pre 6.0 via the cli command.
 		return wp_json_encode( Functions::json_wrap( $any ) );
 	}
 

--- a/projects/packages/sync/src/class-json-deflate-array-codec.php
+++ b/projects/packages/sync/src/class-json-deflate-array-codec.php
@@ -54,11 +54,8 @@ class JSON_Deflate_Array_Codec implements Codec_Interface {
 	 * @return false|string
 	 */
 	protected function json_serialize( $any ) {
-		if ( function_exists( 'jetpack_json_wrap' ) ) {
-			return wp_json_encode( jetpack_json_wrap( $any ) );
-		}
 		// This prevents fatal error when updating pre 6.0 via the cli command.
-		return wp_json_encode( $this->json_wrap( $any ) );
+		return wp_json_encode( Functions::json_wrap( $any ) );
 	}
 
 	/**
@@ -69,43 +66,6 @@ class JSON_Deflate_Array_Codec implements Codec_Interface {
 	 */
 	protected function json_unserialize( $str ) {
 		return $this->json_unwrap( json_decode( $str, true ) );
-	}
-
-	/**
-	 * Wraps JSON
-	 *
-	 * @param object|array $any Wrapping value.
-	 * @param array        $seen_nodes Seen nodes.
-	 * @return array
-	 */
-	private function json_wrap( &$any, $seen_nodes = array() ) {
-		if ( is_object( $any ) ) {
-			$input        = get_object_vars( $any );
-			$input['__o'] = 1;
-		} else {
-			$input = &$any;
-		}
-
-		if ( is_array( $input ) ) {
-			$seen_nodes[] = &$any;
-
-			$return = array();
-
-			foreach ( $input as $k => &$v ) {
-				if ( ( is_array( $v ) || is_object( $v ) ) ) {
-					if ( in_array( $v, $seen_nodes, true ) ) {
-						continue;
-					}
-					$return[ $k ] = $this->json_wrap( $v, $seen_nodes );
-				} else {
-					$return[ $k ] = $v;
-				}
-			}
-
-			return $return;
-		}
-
-		return $any;
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
@@ -187,7 +188,7 @@ abstract class Module {
 		if ( $sort && is_array( $values ) ) {
 			$this->recursive_ksort( $values );
 		}
-		return crc32( wp_json_encode( jetpack_json_wrap( $values ) ) );
+		return crc32( wp_json_encode( Functions::json_wrap( $values ) ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -326,7 +326,7 @@ add_filter( 'upgrader_pre_download', 'jetpack_upgrader_pre_download' );
 function jetpack_json_wrap( &$any, $seen_nodes = array() ) {
 	_deprecated_function( __METHOD__, 'jetpack-9.5', 'Automattic\Jetpack\Sync\Functions' );
 
-	return Functions::json_wrap( $$any, $seen_nodes );
+	return Functions::json_wrap( $any, $seen_nodes );
 }
 
 /**

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -13,6 +13,7 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Device_Detection;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Sync\Functions;
 
 /**
  * Disable direct access.
@@ -314,6 +315,8 @@ add_filter( 'upgrader_pre_download', 'jetpack_upgrader_pre_download' );
  * Wraps data in a way so that we can distinguish between objects and array and also prevent object recursion.
  *
  * @since 6.1.0
+
+ * @deprecated Automattic\Jetpack\Sync\Functions::json_wrap
  *
  * @param array|obj $any        Source data to be cleaned up.
  * @param array     $seen_nodes Built array of nodes.
@@ -321,33 +324,9 @@ add_filter( 'upgrader_pre_download', 'jetpack_upgrader_pre_download' );
  * @return array
  */
 function jetpack_json_wrap( &$any, $seen_nodes = array() ) {
-	if ( is_object( $any ) ) {
-		$input        = get_object_vars( $any );
-		$input['__o'] = 1;
-	} else {
-		$input = &$any;
-	}
+	_deprecated_function( __METHOD__, 'jetpack-9.5', 'Automattic\Jetpack\Sync\Functions' );
 
-	if ( is_array( $input ) ) {
-		$seen_nodes[] = &$any;
-
-		$return = array();
-
-		foreach ( $input as $k => &$v ) {
-			if ( ( is_array( $v ) || is_object( $v ) ) ) {
-				if ( in_array( $v, $seen_nodes, true ) ) {
-					continue;
-				}
-				$return[ $k ] = jetpack_json_wrap( $v, $seen_nodes );
-			} else {
-				$return[ $k ] = $v;
-			}
-		}
-
-		return $return;
-	}
-
-	return $any;
+	return Functions::json_wrap( $$any, $seen_nodes );
 }
 
 /**


### PR DESCRIPTION
jetpack_json_wrap is used for encoding sync events to ensure we can consistently decode them. This function is only being used by the Sync Package as such we are migrating it into the Sync/Functions class as a static method json_wrap.

#### Changes proposed in this Pull Request:
* Migration of jetpack_json_wrap function to Sync/Functions::json_wrap

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Verify all Sync Unit Tests pass. This action is called in sending of data so an error will cause the full test suite to fail.
* On a Jetpack connected site perform edit actions and verify they are sent to WP.com. I suggest using Instant Search, Publicize or similar feature and confirm the post publicizes or is available in search results.

#### Proposed changelog entry for your changes:
* Sync :: deprecation of jetpack_json_wrap with replacement by Sync/Functions::json_wrap
