### PR TITLE
Revert "Update plugin modify endpoint to use should_update"

### DIFF
--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -327,11 +327,6 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				continue;
 			}
 
-			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated.
-			if ( ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $plugin, WP_PLUGIN_DIR ) ) {
-				continue;
-			}
-
 			/**
 			 * Pre-upgrade action
 			 *


### PR DESCRIPTION
Reverts Automattic/jetpack#18697

`should_update` expects an object for the $plugin item update offer, this change was throwing some PHP notices and I'd like to test it a bit more.