### PR TITLE
Update plugin API endpoints to use should_update

### DIFF
--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -144,7 +144,8 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			$plugin['action_links'] = $action_link;
 		}
 
-		$autoupdate           = in_array( $plugin_file, (array) get_site_option( 'auto_update_plugins', array() ), true );
+		$plugin['plugin']     = $plugin_file;
+		$autoupdate           = ( new WP_Automatic_Updater() )->should_update( 'plugin', (object) $plugin, WP_PLUGIN_DIR );
 		$plugin['autoupdate'] = $autoupdate;
 
 		$autoupdate_translation = in_array( $plugin_file, Jetpack_Options::get_option( 'autoupdate_plugins_translations', array() ) );

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -181,8 +181,9 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			$plugin['action_links'] = $action_link;
 		}
 
-		$autoupdate = $this->plugin_has_autoupdates_enabled( $plugin_file );
-		$plugin['autoupdate']      = $autoupdate;
+		$plugin['plugin']     = $plugin_file;
+		$autoupdate           = ( new WP_Automatic_Updater() )->should_update( 'plugin', (object) $plugin, WP_PLUGIN_DIR );
+		$plugin['autoupdate'] = $autoupdate;
 
 		$autoupdate_translation = $this->plugin_has_translations_autoupdates_enabled( $plugin_file );
 		$plugin['autoupdate_translation'] = $autoupdate || $autoupdate_translation || Jetpack_Options::get_option( 'autoupdate_translations', false );

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -200,14 +200,9 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		return $plugin;
 	}
 
-	protected function plugin_has_autoupdates_enabled( $plugin_file ) {
-		return (bool) in_array( $plugin_file, (array) get_site_option( 'auto_update_plugins', array() ), true );
-	}
-
 	protected function plugin_has_translations_autoupdates_enabled( $plugin_file ) {
 		return (bool) in_array( $plugin_file, Jetpack_Options::get_option( 'autoupdate_plugins_translations', array() ) );
 	}
-
 
 	protected function get_file_mod_capabilities() {
 		$reasons_can_not_autoupdate = array();

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -145,6 +145,9 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		}
 
 		$plugin['plugin']     = $plugin_file;
+		if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
 		$autoupdate           = ( new WP_Automatic_Updater() )->should_update( 'plugin', (object) $plugin, WP_PLUGIN_DIR );
 		$plugin['autoupdate'] = $autoupdate;
 
@@ -182,6 +185,9 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		}
 
 		$plugin['plugin']     = $plugin_file;
+		if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
 		$autoupdate           = ( new WP_Automatic_Updater() )->should_update( 'plugin', (object) $plugin, WP_PLUGIN_DIR );
 		$plugin['autoupdate'] = $autoupdate;
 

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -144,7 +144,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			$plugin['action_links'] = $action_link;
 		}
 
-		$plugin['plugin']     = $plugin_file;
+		$plugin['plugin'] = $plugin_file;
 		if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 		}
@@ -184,7 +184,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			$plugin['action_links'] = $action_link;
 		}
 
-		$plugin['plugin']     = $plugin_file;
+		$plugin['plugin'] = $plugin_file;
 		if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 		}

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -327,6 +327,11 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				continue;
 			}
 
+			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated.
+			if ( ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $update_plugins->response[ $plugin ], WP_PLUGIN_DIR ) ) {
+				continue;
+			}
+
 			/**
 			 * Pre-upgrade action
 			 *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -328,6 +328,10 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 
 			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated.
+			if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+			}
+
 			if ( ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $update_plugins->response[ $plugin ], WP_PLUGIN_DIR ) ) {
 				continue;
 			}

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -328,10 +328,6 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 
 			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated.
-			if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-			}
-
 			if ( ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $update_plugins->response[ $plugin ], WP_PLUGIN_DIR ) ) {
 				continue;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Rely on core's `WP_Automatic_Updater` class to check if any of the `update_plugins` items `should_update()`.
* Rely on core's `WP_Automatic_Updater` class to pass on an accurate `autoupdate` value for plugin items, as that value is currently [used](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/plugins/installed/actions.js#L520) in Calypso plugin management screens to fire update requests.

#### Jetpack product discussion

See #18562

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* With this change pulled down, connect Jetpack to WordPress.com
* Install a plugin for testing such as Hello Dolly, and `Enable auto-updates` for the plugin from WP Admin
* Add `add_filter( 'auto_update_plugin', '__return_false' );` to a mu-plugin for testing.
* Rollback the version of the plugin you enabled auto-updates for using something like the WP Rollback plugin. Refresh WP Admin to make sure you see that a new version is available for that plugin.
* Visit `https://wordpress.com/plugins/manage/__YOUR_SITE__` and observe that no plugins are being automatically updated. Inspecting the GET request for the plugins will show that each plugin item in the response has `autoupdate` set to `false` matching up with the filter we previously set.

#### Proposed changelog entry for your changes:

* Auto-updates: plugin API endpoints respect auto-update constant/filters
