### PR TITLE
Sync: Trigger initial sync on jetpack_site_registered

### DIFF
--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -248,8 +248,8 @@ class Actions {
 		}
 
 		$connection = new Jetpack_Connection();
-		if ( ! $connection->is_active() ) {
-			if ( ! doing_action( 'jetpack_user_authorized' ) ) {
+		if ( ! $connection->is_connected() ) {
+			if ( ! doing_action( 'jetpack_site_registered' ) ) {
 				return false;
 			}
 		}
@@ -285,7 +285,7 @@ class Actions {
 				$debug['debug_details']['is_staging_site'] = true;
 			}
 			$connection = new Jetpack_Connection();
-			if ( ! $connection->is_active() ) {
+			if ( ! $connection->is_connected() ) {
 				$debug['debug_details']['active_connection'] = false;
 			}
 		}

--- a/projects/packages/sync/src/class-main.php
+++ b/projects/packages/sync/src/class-main.php
@@ -25,7 +25,7 @@ class Main {
 			add_action( 'plugins_loaded', array( __CLASS__, 'on_plugins_loaded_late' ), 90 );
 		}
 		// Any hooks below are special cases that need to be declared even if Sync is not allowed.
-		add_action( 'jetpack_user_authorized', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );
+		add_action( 'jetpack_site_registered', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );
 	}
 
 	/**

--- a/projects/packages/sync/src/class-users.php
+++ b/projects/packages/sync/src/class-users.php
@@ -36,7 +36,7 @@ class Users {
 	 */
 	public static function init() {
 		$connection = new Jetpack_Connection();
-		if ( $connection->is_active() ) {
+		if ( $connection->has_connected_user() ) {
 			// Kick off synchronization of user role when it changes.
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}

--- a/projects/packages/sync/src/class-users.php
+++ b/projects/packages/sync/src/class-users.php
@@ -35,6 +35,7 @@ class Users {
 	 * @todo Eventually, connection needs to be instantiated at the top level in the sync package.
 	 */
 	public static function init() {
+		add_action( 'jetpack_user_authorized', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );
 		$connection = new Jetpack_Connection();
 		if ( $connection->has_connected_user() ) {
 			// Kick off synchronization of user role when it changes.

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -897,7 +897,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				break;
 			case 'start':
 				if ( ! Actions::sync_allowed() ) {
-					if ( ! Settings::get_setting( 'disable' ) ) {
+					if ( Settings::get_setting( 'disable' ) ) {
 						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. It is currently disabled. Run `wp jetpack sync enable` to enable it.', 'jetpack' ) );
 						return;
 					}

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -901,9 +901,12 @@ class Jetpack_CLI extends WP_CLI_Command {
 						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. It is currently disabled. Run `wp jetpack sync enable` to enable it.', 'jetpack' ) );
 						return;
 					}
-					if ( doing_action( 'jetpack_user_authorized' ) || Jetpack::is_active() ) {
-						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. Jetpack is not connected.', 'jetpack' ) );
-						return;
+					$connection = new Connection_Manager();
+					if ( ! $connection->is_connected() ) {
+						if ( ! doing_action( 'jetpack_site_registered' ) ) {
+							WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. Jetpack is not connected.', 'jetpack' ) );
+							return;
+						}
 					}
 
 					$status = new Status();

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -70,8 +70,8 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
-	function test_starts_full_sync_on_user_authorized() {
-		do_action( 'jetpack_user_authorized', 'abcd1234' );
+	function test_starts_full_sync_on_site_registered() {
+		do_action( 'jetpack_site_registered', 'abcd1234' );
 		$this->assertTrue( Modules::get_module( 'full-sync' )->is_started() );
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -70,8 +70,19 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
-	function test_starts_full_sync_on_site_registered() {
+	/**
+	 * Test 'jetpack_site_registered' triggers initial sync.
+	 */
+	public function test_starts_initial_sync_on_site_registered() {
 		do_action( 'jetpack_site_registered', 'abcd1234' );
+		$this->assertTrue( Modules::get_module( 'full-sync' )->is_started() );
+	}
+
+	/**
+	 * Test 'jetpack_user_authorized' triggers initial sync.
+	 */
+	public function test_starts_initial_sync_on_user_authorized() {
+		do_action( 'jetpack_user_authorized', 'abcd1234' );
 		$this->assertTrue( Modules::get_module( 'full-sync' )->is_started() );
 	}
 


### PR DESCRIPTION
This PR updates the Sync logic that triggers an initial sync on `jetpack_user_authorized`, to do so on `jetpack_site_registered ` instead.

The main reason is that on user-less Jetpack connections, aka when no user has connected their WP.com account, the initial sync would never get triggered.

Besides from that, given that Sync now relies only on the site connection (blog token), there's nothing preventing us to trigger the initial sync when the site is connected.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the hook that triggers the initial sync on `Sync\Main` class's `configure` method from `jetpack_user_authorized` to `jetpack_site_registered`
* Replaces the `is_active` check in `Sync\Actions` class's `get_debug_details` method, with `is_connected`. `is_active` looks for an existing user connection, while `is_connected` looks for an existing site connection. Given Sync only relies in the site connection, from Sync's perspective, `is_connected` makes more sense to be used when debugging.
* Replaces the the `is_active` check in `Sync\Actions` class's `sync_allowed` method, with `is_connected` and a corresponding check whether `jetpack_site_registered` action is running. This ensures consistency with the aforementioned hook replacement.
* Replaces the the `is_active` check in `Sync\Users` class's `init ` method, with `has_connected_user`. The logic here is that we only want to trigger user related sync only when at least a connected user exists. Using `has_connected_user` seems more explicit in this case.
* Updates the jetpack cli `sync start` command to respect the above changes.
* Updates the corresponding unit tests.

Bonus:
* Fixes a bug in Jetpack CLI command to start sync ( `wp jetpack sync start` ). Seems we were displaying an error that sync was disabled when it was enabled. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-aJm-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Before:**
* Create a new JN site and make sure user-less mode is enabled ( Settings -> Jetpack Constants -> `JETPACK_NO_USER_TEST_MODE`)
* Connect your Jetpack Site, skipping user authorization
* Go to the Jetpack Debugger and verify a full sync was never triggered

**After:**
* Create a new JN site using the current branch and repeat the above process.
* Go to the Jetpack Debugger and verify a full sync has been triggered
* Connect your admin user
* Go to the Jetpack Debugger and verify another full sync has been triggered

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* N/A: Hardening of Jetpack Sync with focus on User-less connections