### PR TITLE
Dialogue: new approach to edit timestamp

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -3,12 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
+
 import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
-import {
-	Panel,
-	PanelBody,
-	ToggleControl,
-} from '@wordpress/components';
+import { Panel, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -117,17 +114,6 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 								className={ baseClassName }
 								participants={ participants }
 								onDelete={ deleteParticipant }
-							/>
-						</PanelBody>
-
-						<PanelBody
-							title={ __( 'Timestamps', 'jetpack' ) }
-							className={ `${ baseClassName }__timestamps` }
-						>
-							<ToggleControl
-								label={ __( 'Show timestamps', 'jetpack' ) }
-								checked={ showTimestamps }
-								onChange={ value => setAttributes( { showTimestamps: value } ) }
 							/>
 						</PanelBody>
 					</Panel>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
@@ -129,9 +129,9 @@ export function TimestampControl( {
 				className={ `${ className }__timestamp-range-control` }
 				min={ 0 }
 				max={ duration }
-				onChange={ ( timeInSecons ) => {
-					setRangeValue( timeInSecons );
-					debouncedSetAttributes( timeInSecons, onChange );
+				onChange={ ( timeInSeconds ) => {
+					setRangeValue( timeInSeconds );
+					debouncedSetAttributes( timeInSeconds, onChange );
 				} }
 				withInputField={ false }
 				renderTooltipContent={ ( time ) => convertSecondsToTimeCode( time ) }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
@@ -27,10 +27,6 @@ const timestampMap = [ 'hour', 'min', 'sec' ];
  * @returns {string} HH:MM:SS format.
  */
 function setTimestampValue( typeValue, smh ) {
-	if ( smh.length <= 2 ) {
-		smh.unshift( '00' );
-	}
-
 	const type = Object.keys( typeValue )?.[ 0 ];
 	if ( ! type ) {
 		return smh.join( ':' );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
@@ -122,7 +122,7 @@ export function TimestampControl( {
 				min={ 0 }
 				max={ duration }
 				onChange={ ( time ) => onChange( convertSecondsToTimeCode( time ) ) }
-				withInputField={ false }
+				withInputField={ true }
 				renderTooltipContent={ ( time ) => convertSecondsToTimeCode( time ) }
 			/>
 		</>
@@ -160,12 +160,17 @@ export function TimestampEditControl( {
 
 	onChange,
 	onToggle,
+	onPlayback,
 } ) {
-	function TimestampLabel() {
+	function TimestampButton() {
 		return (
-			<div className={ `${ className }__timestamp-label` }>
+			<Button
+				className={ `${ className }__timestamp-label` }
+				isTertiary
+				onClick={ () => onPlayback( convertTimeCodeToSeconds( value ) ) }
+			>
 				{ value }
-			</div>
+			</Button>
 		);
 	}
 
@@ -174,7 +179,7 @@ export function TimestampEditControl( {
 			return null;
 		}
 
-		return <TimestampLabel />;
+		return <TimestampButton />;
 	}
 
 	function ToggleButton( { label } ) {
@@ -201,7 +206,7 @@ export function TimestampEditControl( {
 
 	return (
 		<>
-			<TimestampLabel />
+			<TimestampButton />
 			<ToggleButton label={ __( 'Remove', 'jetpack' ) } />
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
@@ -61,7 +61,6 @@ export function TimestampControl( {
 	onChange,
 	shortLabel = false,
 	isDisabled = false,
-	mediaSource,
 	duration,
 } ) {
 	const smh = value.split( ':' );
@@ -116,18 +115,16 @@ export function TimestampControl( {
 				/>
 			</div>
 
-			{ mediaSource && (
-				<RangeControl
-					disabled={ typeof duration === 'undefined' }
-					value={ convertTimeCodeToSeconds( value ) }
-					className={ `${ className }__timestamp-range-control` }
-					min={ 0 }
-					max={ duration }
-					onChange={ ( time ) => onChange( convertSecondsToTimeCode( time ) ) }
-					withInputField={ false }
-					renderTooltipContent={ ( time ) => convertSecondsToTimeCode( time ) }
-				/>
-			) }
+			<RangeControl
+				disabled={ typeof duration === 'undefined' }
+				value={ convertTimeCodeToSeconds( value ) }
+				className={ `${ className }__timestamp-range-control` }
+				min={ 0 }
+				max={ duration }
+				onChange={ ( time ) => onChange( convertSecondsToTimeCode( time ) ) }
+				withInputField={ false }
+				renderTooltipContent={ ( time ) => convertSecondsToTimeCode( time ) }
+			/>
 		</>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
@@ -135,3 +135,52 @@ export function TimestampDropdown( props ) {
 		/>
 	);
 }
+
+export function TimestampEditControl( {
+	className,
+	isSelected,
+	show,
+	value,
+
+	onToggle,
+} ) {
+	function TimestampLabel() {
+		return (
+			<div className={ `${ className }__timestamp-label` }>
+				{ value }
+			</div>
+		);
+	}
+
+	if ( ! isSelected ) {
+		if ( ! show ) {
+			return null;
+		}
+
+		return <TimestampLabel />;
+	}
+
+	function ToggleButton( { label } ) {
+		return (
+			<Button
+				className={ `${ className }__timestamp-button` }
+				isSmall
+				isSecondary
+				onClick={ () => onToggle( ! show ) }
+			>
+				{ label }
+			</Button>
+		);
+	}
+
+	if ( ! show ) {
+		return <ToggleButton label={ __( 'Add timestamp', 'jetpack' ) } />;
+	}
+
+	return (
+		<>
+			<TimestampLabel />
+			<ToggleButton label={ __( 'Remove', 'jetpack' ) } />
+		</>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
@@ -122,7 +122,7 @@ export function TimestampControl( {
 				min={ 0 }
 				max={ duration }
 				onChange={ ( time ) => onChange( convertSecondsToTimeCode( time ) ) }
-				withInputField={ true }
+				withInputField={ false }
 				renderTooltipContent={ ( time ) => convertSecondsToTimeCode( time ) }
 			/>
 		</>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { Dropdown, Button } from '@wordpress/components';
+import { Dropdown, Button, RangeControl } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import NumberControl from '../../../shared/components/number-control';
-import { convertSecondsToTimeCode } from '../../../shared/components/media-player-control/utils';
+import { convertSecondsToTimeCode, convertTimeCodeToSeconds } from '../../../shared/components/media-player-control/utils';
 
 function validateValue( val, max ) {
 	return Math.max( 0, Math.min( val, max ) );
@@ -61,6 +61,8 @@ export function TimestampControl( {
 	onChange,
 	shortLabel = false,
 	isDisabled = false,
+	mediaSource,
+	duration,
 } ) {
 	const smh = value.split( ':' );
 	if ( smh.length <= 2 ) {
@@ -68,50 +70,65 @@ export function TimestampControl( {
 	}
 
 	return (
-		<div className={ `${ className }__timestamp-controls` }>
-			<NumberControl
-				className={ `${ className }__timestamp-control__hour` }
-				label={	shortLabel
-					? _x( 'Hour', 'hour (short form)', 'jetpack' )
-					: _x( 'Hour', 'hour (long form)', 'jetpack' )
-				}
-				value={ smh[ 0 ] }
-				min={ 0 }
-				max={ 23 }
-				onChange={ hour => (
-					! isDisabled && onChange( setTimestampValue( { hour }, smh ) )
-				) }
-				disabled={ isDisabled }
-			/>
+		<>
+			<div className={ `${ className }__timestamp-controls` }>
+				<NumberControl
+					className={ `${ className }__timestamp-control__hour` }
+					label={	shortLabel
+						? _x( 'Hour', 'hour (short form)', 'jetpack' )
+						: _x( 'Hour', 'hour (long form)', 'jetpack' )
+					}
+					value={ smh[ 0 ] }
+					min={ 0 }
+					max={ 23 }
+					onChange={ hour => (
+						! isDisabled && onChange( setTimestampValue( { hour }, smh ) )
+					) }
+					disabled={ isDisabled }
+				/>
 
-			<NumberControl
-				className={ `${ className }__timestamp-control__minute` }
-				label={
-					shortLabel ? _x( 'Min', 'Short for Minute', 'jetpack' ) : __( 'Minute', 'jetpack' )
-				}
-				value={ smh[ 1 ] }
-				min={ 0 }
-				max={ 59 }
-				onChange={ min => (
-					! isDisabled && onChange( setTimestampValue( { min }, smh ) )
-				) }
-				disabled={ isDisabled }
-			/>
+				<NumberControl
+					className={ `${ className }__timestamp-control__minute` }
+					label={
+						shortLabel ? _x( 'Min', 'Short for Minute', 'jetpack' ) : __( 'Minute', 'jetpack' )
+					}
+					value={ smh[ 1 ] }
+					min={ 0 }
+					max={ 59 }
+					onChange={ min => (
+						! isDisabled && onChange( setTimestampValue( { min }, smh ) )
+					) }
+					disabled={ isDisabled }
+				/>
 
-			<NumberControl
-				className={ `${ className }__timestamp-control__second` }
-				label={
-					shortLabel ? _x( 'Sec', 'Short for Second', 'jetpack' ) : __( 'Second', 'jetpack' )
-				}
-				value={ smh[ 2 ] }
-				min={ 0 }
-				max={ 59 }
-				onChange={ sec => (
-					! isDisabled && onChange( setTimestampValue( { sec }, smh ) )
-				) }
-				disabled={ isDisabled }
-			/>
-		</div>
+				<NumberControl
+					className={ `${ className }__timestamp-control__second` }
+					label={
+						shortLabel ? _x( 'Sec', 'Short for Second', 'jetpack' ) : __( 'Second', 'jetpack' )
+					}
+					value={ smh[ 2 ] }
+					min={ 0 }
+					max={ 59 }
+					onChange={ sec => (
+						! isDisabled && onChange( setTimestampValue( { sec }, smh ) )
+					) }
+					disabled={ isDisabled }
+				/>
+			</div>
+
+			{ mediaSource && (
+				<RangeControl
+					disabled={ typeof duration === 'undefined' }
+					value={ convertTimeCodeToSeconds( value ) }
+					className={ `${ className }__timestamp-range-control` }
+					min={ 0 }
+					max={ duration }
+					onChange={ ( time ) => onChange( convertSecondsToTimeCode( time ) ) }
+					withInputField={ false }
+					renderTooltipContent={ ( time ) => convertSecondsToTimeCode( time ) }
+				/>
+			) }
+		</>
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
@@ -182,7 +182,7 @@ export function TimestampEditControl( {
 			<Button
 				className={ `${ className }__timestamp-button` }
 				isSmall
-				isSecondary
+				isTertiary
 				onClick={ () => {
 					onToggle( ! show );
 					if ( ! show ) {

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/timestamp-control.js
@@ -8,6 +8,7 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import NumberControl from '../../../shared/components/number-control';
+import { convertSecondsToTimeCode } from '../../../shared/components/media-player-control/utils';
 
 function validateValue( val, max ) {
 	return Math.max( 0, Math.min( val, max ) );
@@ -141,7 +142,9 @@ export function TimestampEditControl( {
 	isSelected,
 	show,
 	value,
+	mediaCurrentTime = 0,
 
+	onChange,
 	onToggle,
 } ) {
 	function TimestampLabel() {
@@ -166,7 +169,12 @@ export function TimestampEditControl( {
 				className={ `${ className }__timestamp-button` }
 				isSmall
 				isSecondary
-				onClick={ () => onToggle( ! show ) }
+				onClick={ () => {
+					onToggle( ! show );
+					if ( ! show ) {
+						onChange( convertSecondsToTimeCode( mediaCurrentTime ) );
+					}
+				} }
 			>
 				{ label }
 			</Button>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -43,10 +43,17 @@ export default function DialogueEdit( {
 		timestamp,
 	} = attributes;
 
-	const mediaSource = useSelect(
-		select => select( MEDIA_SOURCE_STORE_ID ).getDefaultMediaSource(),
-		[]
-	);
+	const { mediaSource, mediaCurrentTime } = useSelect( select => {
+		const {
+			getDefaultMediaSource,
+			getMediaSourceCurrentTime,
+		} = select( MEDIA_SOURCE_STORE_ID );
+
+		return {
+			mediaSource: getDefaultMediaSource(),
+			mediaCurrentTime: getMediaSourceCurrentTime(),
+		};
+	}, [] );
 
 	const contentRef = useRef();
 
@@ -164,6 +171,7 @@ export default function DialogueEdit( {
 					show={ showTimestamp }
 					isSelected={ isSelected }
 					value={ timestamp }
+					mediaCurrentTime={ mediaCurrentTime }
 					onChange={ setTimestamp }
 					onToggle={ ( show ) => setAttributes( { showTimestamp: show } ) }
 				/>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -4,9 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, RichText, BlockControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { Panel, PanelBody, ToggleControl } from '@wordpress/components';
 import { useContext, useEffect, useRef } from '@wordpress/element';
-import { useSelect, dispatch } from '@wordpress/data';
+import { dispatch, useSelect, useDispatch } from '@wordpress/data';
+import { Panel, PanelBody } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 
 /**
@@ -43,20 +43,23 @@ export default function DialogueEdit( {
 		timestamp,
 	} = attributes;
 
-	const { mediaSource, mediaCurrentTime, mediaDuration } = useSelect( select => {
+	const { mediaSource, mediaCurrentTime, mediaDuration, mediaDomReference } = useSelect( select => {
 		const {
 			getDefaultMediaSource,
 			getMediaSourceCurrentTime,
 			getMediaSourceDuration,
+			getMediaSourceDomReference,
 		} = select( MEDIA_SOURCE_STORE_ID );
 
 		return {
 			mediaSource: getDefaultMediaSource(),
 			mediaCurrentTime: getMediaSourceCurrentTime(),
 			mediaDuration: getMediaSourceDuration(),
+			mediaDomReference: getMediaSourceDomReference(),
 		};
 	}, [] );
 
+	const { playMediaSource, setMediaSourceCurrentTime } = useDispatch( MEDIA_SOURCE_STORE_ID );
 	const contentRef = useRef();
 
 	// Block context integration.
@@ -96,6 +99,14 @@ export default function DialogueEdit( {
 
 	function setTimestamp( time ) {
 		setAttributes( { timestamp: time } );
+	}
+
+	function audioPlayback( time ) {
+		if ( mediaDomReference ) {
+			mediaDomReference.currentTime = time;
+		}
+		setMediaSourceCurrentTime( time );
+		playMediaSource();
 	}
 
 	return (
@@ -173,6 +184,7 @@ export default function DialogueEdit( {
 						mediaCurrentTime={ mediaCurrentTime }
 						onChange={ setTimestamp }
 						onToggle={ ( show ) => setAttributes( { showTimestamp: show } ) }
+						onPlayback={ audioPlayback }
 					/>
 				) }
 			</div>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -43,15 +43,17 @@ export default function DialogueEdit( {
 		timestamp,
 	} = attributes;
 
-	const { mediaSource, mediaCurrentTime } = useSelect( select => {
+	const { mediaSource, mediaCurrentTime, mediaDuration } = useSelect( select => {
 		const {
 			getDefaultMediaSource,
 			getMediaSourceCurrentTime,
+			getMediaSourceDuration,
 		} = select( MEDIA_SOURCE_STORE_ID );
 
 		return {
 			mediaSource: getDefaultMediaSource(),
 			mediaCurrentTime: getMediaSourceCurrentTime(),
+			mediaDuration: getMediaSourceDuration(),
 		};
 	}, [] );
 
@@ -135,6 +137,8 @@ export default function DialogueEdit( {
 								className={ BASE_CLASS_NAME }
 								value={ timestamp }
 								onChange={ setTimestamp }
+								mediaSource={ mediaSource }
+								duration={ mediaDuration }
 							/>
 						) }
 					</PanelBody>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -52,7 +52,6 @@ export default function DialogueEdit( {
 
 	// Block context integration.
 	const participantsFromContext = context[ 'jetpack/conversation-participants' ];
-	const showConversationTimestamps = context[ 'jetpack/conversation-showTimestamps' ];
 
 	// Participants list.
 	const participants = participantsFromContext?.length
@@ -85,11 +84,6 @@ export default function DialogueEdit( {
 			label: conversationParticipant.label,
 		} );
 	}, [ conversationParticipant, debounceSetDialoguesAttrs, isSelected, slug ] );
-
-	// Update dialogue timestamp setting from parent conversation.
-	useEffect( () => {
-		setAttributes( { showTimestamp: showConversationTimestamps } );
-	}, [ showConversationTimestamps, setAttributes ] );
 
 	function setTimestamp( time ) {
 		setAttributes( { timestamp: time } );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -125,23 +125,15 @@ export default function DialogueEdit( {
 						</PanelBody>
 					) }
 
-					{ mediaSource && (
+					{ mediaSource && showTimestamp && (
 						<PanelBody title={ __( 'Timestamp', 'jetpack' ) }>
-							<ToggleControl
-								label={ __( 'Show conversation timestamps', 'jetpack' ) }
-								checked={ showTimestamp }
-								onChange={ ( show ) => setAttributes( { showTimestamp: show } ) }
+							<TimestampControl
+								className={ BASE_CLASS_NAME }
+								value={ timestamp }
+								onChange={ setTimestamp }
+								mediaSource={ mediaSource }
+								duration={ mediaDuration }
 							/>
-
-							{ showTimestamp && (
-								<TimestampControl
-									className={ BASE_CLASS_NAME }
-									value={ timestamp }
-									onChange={ setTimestamp }
-									mediaSource={ mediaSource }
-									duration={ mediaDuration }
-								/>
-							) }
 						</PanelBody>
 					) }
 				</Panel>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -91,10 +91,6 @@ export default function DialogueEdit( {
 		setAttributes( { showTimestamp: showConversationTimestamps } );
 	}, [ showConversationTimestamps, setAttributes ] );
 
-	function setShowConversationTimestamps( value ) {
-		conversationBridge.setAttributes( { showTimestamps: value } );
-	}
-
 	function setTimestamp( time ) {
 		setAttributes( { timestamp: time } );
 	}
@@ -130,7 +126,7 @@ export default function DialogueEdit( {
 						<ToggleControl
 							label={ __( 'Show conversation timestamps', 'jetpack' ) }
 							checked={ showTimestamp }
-							onChange={ setShowConversationTimestamps }
+							onChange={ ( show ) => setAttributes( { showTimestamp: show } ) }
 						/>
 
 						{ showTimestamp && (

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -14,7 +14,7 @@ import { useDebounce } from '@wordpress/compose';
  */
 import './editor.scss';
 import { ParticipantsControl, SpeakerEditControl } from './components/participants-control';
-import { TimestampControl, TimestampDropdown } from './components/timestamp-control';
+import { TimestampControl, TimestampEditControl } from './components/timestamp-control';
 import { BASE_CLASS_NAME } from './utils';
 import ConversationContext from '../conversation/components/context';
 import { STORE_ID as MEDIA_SOURCE_STORE_ID } from '../../store/media-source/constants';
@@ -169,14 +169,14 @@ export default function DialogueEdit( {
 					} }
 				/>
 
-				{ showTimestamp && (
-					<TimestampDropdown
-						className={ BASE_CLASS_NAME }
-						value={ timestamp }
-						onChange={ setTimestamp }
-						shortLabel={ true }
-					/>
-				) }
+				<TimestampEditControl
+					className={ BASE_CLASS_NAME }
+					show={ showTimestamp }
+					isSelected={ isSelected }
+					value={ timestamp }
+					onChange={ setTimestamp }
+					onToggle={ ( show ) => setAttributes( { showTimestamp: show } ) }
+				/>
 			</div>
 
 			<RichText

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -125,23 +125,25 @@ export default function DialogueEdit( {
 						</PanelBody>
 					) }
 
-					<PanelBody title={ __( 'Timestamp', 'jetpack' ) }>
-						<ToggleControl
-							label={ __( 'Show conversation timestamps', 'jetpack' ) }
-							checked={ showTimestamp }
-							onChange={ ( show ) => setAttributes( { showTimestamp: show } ) }
-						/>
-
-						{ showTimestamp && (
-							<TimestampControl
-								className={ BASE_CLASS_NAME }
-								value={ timestamp }
-								onChange={ setTimestamp }
-								mediaSource={ mediaSource }
-								duration={ mediaDuration }
+					{ mediaSource && (
+						<PanelBody title={ __( 'Timestamp', 'jetpack' ) }>
+							<ToggleControl
+								label={ __( 'Show conversation timestamps', 'jetpack' ) }
+								checked={ showTimestamp }
+								onChange={ ( show ) => setAttributes( { showTimestamp: show } ) }
 							/>
-						) }
-					</PanelBody>
+
+							{ showTimestamp && (
+								<TimestampControl
+									className={ BASE_CLASS_NAME }
+									value={ timestamp }
+									onChange={ setTimestamp }
+									mediaSource={ mediaSource }
+									duration={ mediaDuration }
+								/>
+							) }
+						</PanelBody>
+					) }
 				</Panel>
 			</InspectorControls>
 
@@ -170,15 +172,17 @@ export default function DialogueEdit( {
 					} }
 				/>
 
-				<TimestampEditControl
-					className={ BASE_CLASS_NAME }
-					show={ showTimestamp }
-					isSelected={ isSelected }
-					value={ timestamp }
-					mediaCurrentTime={ mediaCurrentTime }
-					onChange={ setTimestamp }
-					onToggle={ ( show ) => setAttributes( { showTimestamp: show } ) }
-				/>
+				{ mediaSource && (
+					<TimestampEditControl
+						className={ BASE_CLASS_NAME }
+						show={ showTimestamp }
+						isSelected={ isSelected }
+						value={ timestamp }
+						mediaCurrentTime={ mediaCurrentTime }
+						onChange={ setTimestamp }
+						onToggle={ ( show ) => setAttributes( { showTimestamp: show } ) }
+					/>
+				) }
 			</div>
 
 			<RichText

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -26,6 +26,11 @@
 	min-width: 290px;
 }
 
+.wp-block-jetpack-dialogue__timestamp-range-control {
+	margin-top: 8px;
+	margin-right: 16px;
+}
+
 .wp-block-jetpack-dialogue__timestamp-dropdown {
 	min-width: 90px;
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -7,6 +7,10 @@
 	}
 }
 
+.wp-block-jetpack-dialogue__timestamp-button {
+	margin-left: 6px;
+}
+
 .wp-block-jetpack-dialogue__timestamp-control__hour,
 .wp-block-jetpack-dialogue__timestamp-control__minute {
 	margin-right: 5px;

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
@@ -19,7 +19,7 @@ export default function save( { attributes } ) {
 					{ label }
 				</div>
 				{ showTimestamp && (
-					<div className={ `${ BASE_CLASS_NAME }__timestamp` }>
+					<div className={ `${ BASE_CLASS_NAME }__timestamp-label` }>
 						<a
 							className={ `${ BASE_CLASS_NAME }__timestamp_link` }
 							href={ `#${ convertTimeCodeToSeconds( timestamp ) }` }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -27,6 +27,7 @@
 		font-size: 16px;
 		white-space: nowrap;
 		color: inherit;
+		margin-left: 5px;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -20,7 +20,7 @@
 		color: inherit;
 	}
 
-	.wp-block-jetpack-dialogue__timestamp {
+	.wp-block-jetpack-dialogue__timestamp-label {
 		margin-right: 0;
 		padding: 6px 12px;
 		text-align: right;

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -77,3 +77,10 @@
 		}
 	}
 }
+
+// Hide timestams by CSS when no media source.
+body.no-media-source {
+	.wp-block-jetpack-dialogue__timestamp-label {
+		display: none;
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/view.js
@@ -11,7 +11,14 @@ import './style.scss';
 const STORE_ID = 'jetpack/media-source';
 
 domReady( function () {
-	// Play podcast by cliking on the timestamp label
+	// Show/hide timestamp labels according to media source availability.
+	const mediaSource = select( STORE_ID )?.getDefaultMediaSource();
+
+	if ( ! mediaSource ) {
+		document?.body.classList.add( 'no-media-source' );
+	}
+
+	// Playback podcast by cliking on the timestamp label.
 	document.body.addEventListener( 'click', event => {
 		if ( ! event?.target?.classList?.contains( 'wp-block-jetpack-dialogue__timestamp_link' ) ) {
 			return;
@@ -22,7 +29,6 @@ domReady( function () {
 			return;
 		}
 
-		const mediaSource = select( STORE_ID )?.getDefaultMediaSource();
 		if ( ! mediaSource ) {
 			return;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/18675

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: new approach to edit timestamp

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create/edit a post
* Add a podcast block with a valid RSS feed. You can use this one: `https://distributed.blog/2020/07/24/lara-hogan-management-secrets/`
* Add a Conversation/Dialogue blocks composition
* you should be able to see the media player control in the Dialogue toolbar, as well as the `Add timestamp` link in the Dialogue block.
* 
<img width="406" alt="Screen Shot 2021-02-10 at 3 39 39 PM" src="https://user-images.githubusercontent.com/77539/107555727-47567380-6bb6-11eb-8ca1-cb2d061209ac.png">

* From here, you can add and remove the timestamp
* Confirm it gets the timestamp value from the current time in the player. If the player is in the `10:00` position, the timestamp should get this value by clicking on the `Add timestamp` link.
* Open the block settings.
* You should see the Range control. Confirm you can change the timestamp using it.
* Confirm that when clicking on the timestamp button, it playback the player to its value. In the following screenshot, the player should playback at `14:16`.
*
![image](https://user-images.githubusercontent.com/77539/107556016-a87e4700-6bb6-11eb-9ef7-c13a725f1e8a.png)



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
