### PR TITLE
Carousel: Improve handling of touch device events

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -242,7 +242,7 @@ div.jp-carousel-buttons a:hover {
 	padding:0.35em 0 0;
 	position: absolute;
 	text-align: right;
-	width: 90%;
+	width: calc( 100vw - 25px );
 }
 
 .jp-carousel-transitions .jp-carousel-close-hint {
@@ -1129,7 +1129,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	 	font-weight: 800 !important;
 		font-size: 26px !important;
 		position: fixed !important;
-		top: -10px;
+		top: 0;
 	}
 
 	.jp-carousel-slide img {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -252,7 +252,7 @@ jQuery( document ).ready( function ( $ ) {
 				right: 0,
 			} );
 
-			close_hint = $( '<div class="jp-carousel-close-hint"><span>&times;</span></div>' ).css( {
+			close_hint = $( '<div class="jp-carousel-close-hint"><span>&#10006;</span></div>' ).css( {
 				position: 'fixed',
 			} );
 
@@ -297,7 +297,11 @@ jQuery( document ).ready( function ( $ ) {
 					data = data || [];
 
 					if ( target.is( gallery ) || target.parents().add( target ).is( close_hint ) ) {
-						container.jp_carousel( 'close' );
+						if ( ! window.matchMedia( '(max-device-width: 760px)' ).matches ) {
+							container.jp_carousel( 'close' );
+						} else if ( target.parents().add( target ).is( close_hint ) ) {
+							container.jp_carousel( 'close' );
+						}
 					} else if ( target.hasClass( 'jp-carousel-commentlink' ) ) {
 						e.preventDefault();
 						e.stopPropagation();
@@ -447,7 +451,16 @@ jQuery( document ).ready( function ( $ ) {
 							} );
 						}
 					} else if ( ! target.parents( '.jp-carousel-info' ).length ) {
-						container.jp_carousel( 'next' );
+						if ( window.matchMedia( '(max-device-width: 760px)' ).matches ) {
+							if ( e.pageX <= 70 ) {
+								container.jp_carousel( 'previous' );
+							}
+							if ( $( window ).width() - e.pageX <= 70 ) {
+								container.jp_carousel( 'next' );
+							}
+						} else {
+							container.jp_carousel( 'next' );
+						}
 					}
 				} )
 				.bind( 'jp_carousel.afterOpen', function () {
@@ -1757,15 +1770,16 @@ jQuery( document ).ready( function ( $ ) {
 ( function ( $ ) {
 	$.fn.touchwipe = function ( settings ) {
 		var config = {
-			min_move_x: 20,
-			min_move_y: 20,
+			threshold: 150, // Required min distance traveled to be considered swipe.
+			restraint: 100, // Maximum distance allowed at the same time in perpendicular direction.
+			allowedTime: 300, // Maximum time allowed to travel that distance.
 			wipeLeft: function (/*e*/) {},
 			wipeRight: function (/*e*/) {},
 			wipeUp: function (/*e*/) {},
 			wipeDown: function (/*e*/) {},
 			preventDefaultEvents: true,
 		};
-
+		var startTime, elapsedTime;
 		if ( settings ) {
 			$.extend( config, settings );
 		}
@@ -1790,19 +1804,22 @@ jQuery( document ).ready( function ( $ ) {
 					var y = e.touches[ 0 ].pageY;
 					var dx = startX - x;
 					var dy = startY - y;
-					if ( Math.abs( dx ) >= config.min_move_x ) {
-						cancelTouch();
-						if ( dx > 0 ) {
-							config.wipeLeft( e );
-						} else {
-							config.wipeRight( e );
-						}
-					} else if ( Math.abs( dy ) >= config.min_move_y ) {
-						cancelTouch();
-						if ( dy > 0 ) {
-							config.wipeDown( e );
-						} else {
-							config.wipeUp( e );
+					elapsedTime = new Date().getTime() - startTime;
+					if ( elapsedTime <= config.allowedTime ) {
+						if ( Math.abs( dx ) >= config.threshold && Math.abs( dy ) <= config.restraint ) {
+							cancelTouch();
+							if ( dx > 0 ) {
+								config.wipeLeft( e );
+							} else {
+								config.wipeRight( e );
+							}
+						} else if ( Math.abs( dy ) >= config.threshold && Math.abs( dx ) <= config.restraint ) {
+							cancelTouch();
+							if ( dy > 0 ) {
+								config.wipeDown( e );
+							} else {
+								config.wipeUp( e );
+							}
 						}
 					}
 				}
@@ -1810,6 +1827,7 @@ jQuery( document ).ready( function ( $ ) {
 
 			function onTouchStart( e ) {
 				if ( e.touches.length === 1 ) {
+					startTime = new Date().getTime();
 					startX = e.touches[ 0 ].pageX;
 					startY = e.touches[ 0 ].pageY;
 					isMoving = true;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -299,8 +299,17 @@ jQuery( document ).ready( function ( $ ) {
 					if ( target.is( gallery ) || target.parents().add( target ).is( close_hint ) ) {
 						if ( ! window.matchMedia( '(max-device-width: 760px)' ).matches ) {
 							container.jp_carousel( 'close' );
-						} else if ( target.parents().add( target ).is( close_hint ) ) {
-							container.jp_carousel( 'close' );
+						} else {
+							if ( target.parents().add( target ).is( close_hint ) ) {
+								container.jp_carousel( 'close' );
+							}
+
+							if ( e.pageX <= 70 ) {
+								container.jp_carousel( 'previous' );
+							}
+							if ( $( window ).width() - e.pageX <= 70 ) {
+								container.jp_carousel( 'next' );
+							}
 						}
 					} else if ( target.hasClass( 'jp-carousel-commentlink' ) ) {
 						e.preventDefault();

--- a/projects/plugins/jetpack/modules/carousel/rtl/jetpack-carousel-rtl.css
+++ b/projects/plugins/jetpack/modules/carousel/rtl/jetpack-carousel-rtl.css
@@ -244,7 +244,7 @@ div.jp-carousel-buttons a:hover {
 	padding:0.35em 0 0;
 	position: absolute;
 	text-align: right;
-	width: 90%;
+	width: calc( 100vw - 25px );
 }
 
 .jp-carousel-transitions .jp-carousel-close-hint {
@@ -1094,7 +1094,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	 	font-weight: 800 !important;
 		font-size: 26px !important;
 		position: fixed !important;
-		top: -10px;
+		top: 0;
 	}
 
 	.jp-carousel-slide img {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Modifies the touch events to be more accurate on left and right swipe
* Removes click event from centre image on small devices to allow pinch zooming, etc. without moving to next image
* Add next and previous click events if screen tapped close to edge on small devices

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Check out this PR to local test env
* Make sure carousel works as normal on desktop browser
* Using ngrok or jurrasic tube set up external url and test carousel on touch device, checking that you can ping zoom central image and move left and right with swipe or tap on edge of screen

#### Proposed changelog entry for your changes:

* Improved handling of carousel touch events on small devices to allow better pinch zoom, etc. of central image.
