### PR TITLE
Jetpack Recommendations: Fix popover tracks event

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/checkbox-answer/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/checkbox-answer/index.jsx
@@ -30,7 +30,7 @@ const CheckboxAnswerComponent = ( { answerKey, checked, info, title, updateCheck
 
 	const onPopoverClick = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_recommendations_site_type_popover_click', {
-			type: answerKey.replace( '-', '_' ),
+			type: answerKey.replace( /-/g, '_' ),
 		} );
 	}, [ answerKey ] );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR fixes the Tracks events for the popovers in the site type prompt of the recommendations. They were being sent with `-` in their properties, which causes them to be rejected. Now they are sent only with `_`

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/recommendations/site-type`.
* Click one of the info popovers on the response questions.
* In the network tab look for a call to `t.gif`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
