### PR TITLE
Connection: Prevent pointless calls to the test API

### DIFF
--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -204,6 +204,11 @@ class Client {
 	 * @return array|WP_Error WP HTTP response on success
 	 */
 	public static function _wp_remote_request( $url, $args, $set_fallback = false ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+		$fallback = \Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' );
+		if ( false === $fallback ) {
+			\Jetpack_Options::update_option( 'fallback_no_verify_ssl_certs', 0 );
+		}
+
 		/**
 		 * SSL verification (`sslverify`) for the JetpackClient remote request
 		 * defaults to off, use this filter to force it on.
@@ -217,11 +222,6 @@ class Client {
 		 */
 		if ( apply_filters( 'jetpack_client_verify_ssl_certs', false ) ) {
 			return wp_remote_request( $url, $args );
-		}
-
-		$fallback = \Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' );
-		if ( false === $fallback ) {
-			\Jetpack_Options::update_option( 'fallback_no_verify_ssl_certs', 0 );
 		}
 
 		if ( (int) $fallback ) {

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3553,7 +3553,8 @@ p {
 		$is_offline_mode = ( new Status() )->is_offline_mode();
 		if ( ! self::is_active() && ! $is_offline_mode ) {
 			Jetpack_Connection_Banner::init();
-		} elseif ( false === Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' ) ) {
+			/** Already documented in automattic/jetpack-connection::src/class-client.php */
+		} elseif ( ( false === Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' ) ) && ! apply_filters( 'jetpack_client_verify_ssl_certs', false ) ) {
 			// Upgrade: 1.1 -> 1.1.1
 			// Check and see if host can verify the Jetpack servers' SSL certificate
 			$args = array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes p9dueE-2l1-p2

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Prevents needless calls to the WP.com Test API endpoint.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
p9dueE-2l1-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `add_filter( 'jetpack_client_verify_ssl_certs', '__return_true' )`;
* `wp jetpack options update fallback_no_verify_ssl_certs false`
* Monitor outbound traffic from your server. See that on every wp-admin request, a call is made to the test api endpoint.
* Apply patch, add the filter and reset the option, then confirm no requests or at least no more than one. :)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Admin: fix issue of excessive test API calls.