### PR TITLE
WhatsApp: Adjust menu size and remove some settings from block menu

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/edit.js
@@ -129,46 +129,51 @@ export default function WhatsAppButtonEdit( { attributes, setAttributes, classNa
 		);
 	};
 
+	const renderPhoneSettings = () => {
+		return (
+			<BaseControl
+				label={ __( 'Phone Number', 'jetpack' ) }
+				help={ __(
+					'Enter the phone number you use for WhatsApp and would like to be contacted on.',
+					'jetpack'
+				) }
+				className="jetpack-whatsapp-button__phonenumber"
+			>
+				<SelectControl
+					value={ countryCode }
+					onChange={ value => setAttributes( { countryCode: value } ) }
+					options={ countryCodes }
+				/>
+
+				<TextControl
+					placeholder={ __( 'Your phone number…', 'jetpack' ) }
+					onChange={ newPhoneNumber => {
+						setAttributes( { phoneNumber: newPhoneNumber } );
+
+						if ( newPhoneNumber.length === 0 ) {
+							setIsValidPhoneNumber( true );
+						}
+
+						if ( newPhoneNumber.length > 2 ) {
+							setIsValidPhoneNumber( validatePhoneNumber( newPhoneNumber ) );
+						}
+					} }
+					value={ phoneNumber }
+				/>
+
+				{ ! isValidPhoneNumber && (
+					<HelpMessage isError className="jetpack-whatsapp-error">
+						{ __( 'Please enter a valid phone number.', 'jetpack' ) }
+					</HelpMessage>
+				) }
+			</BaseControl>
+		);
+	};
+
 	const renderSettings = () => {
 		return (
 			<>
-				<BaseControl
-					label={ __( 'Phone Number', 'jetpack' ) }
-					help={ __(
-						'Enter the phone number you use for WhatsApp and would like to be contacted on.',
-						'jetpack'
-					) }
-					className="jetpack-whatsapp-button__phonenumber"
-				>
-					<SelectControl
-						value={ countryCode }
-						onChange={ value => setAttributes( { countryCode: value } ) }
-						options={ countryCodes }
-					/>
-
-					<TextControl
-						placeholder={ __( 'Your phone number…', 'jetpack' ) }
-						onChange={ newPhoneNumber => {
-							setAttributes( { phoneNumber: newPhoneNumber } );
-
-							if ( newPhoneNumber.length === 0 ) {
-								setIsValidPhoneNumber( true );
-							}
-
-							if ( newPhoneNumber.length > 2 ) {
-								setIsValidPhoneNumber( validatePhoneNumber( newPhoneNumber ) );
-							}
-						} }
-						value={ phoneNumber }
-					/>
-
-					{ ! isValidPhoneNumber && (
-						<HelpMessage isError className="jetpack-whatsapp-error">
-							{ __( 'Please enter a valid phone number.', 'jetpack' ) }
-						</HelpMessage>
-					) }
-				</BaseControl>
-
+				{ renderPhoneSettings() }
 				<TextareaControl
 					label={ __( 'Default First Message', 'jetpack' ) }
 					help={ __(
@@ -206,7 +211,7 @@ export default function WhatsAppButtonEdit( { attributes, setAttributes, classNa
 							className="jetpack-whatsapp-button-settings-selector"
 							contentClassName="jetpack-whatsapp-button__popover"
 							renderToggle={ ( { isOpen, onToggle } ) => renderSettingsToggle( isOpen, onToggle ) }
-							renderContent={ () => renderSettings() }
+							renderContent={ () => renderPhoneSettings() }
 						/>
 					</ToolbarGroup>
 				</BlockControls>

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/editor.scss
@@ -41,6 +41,7 @@
 .jetpack-whatsapp-button__popover {
 	.components-popover__content {
 		padding: 12px;
+		min-width: 260px;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 212-gh-Automattic/view-design
Fixes #18645 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Restores min-width for the block toolbar menu on the Whatsapp block
* Removes the `Default First Message` and `Open In New Tab` settings from the block toolbar menu; they are kept in the Inspector Controls.

Before:
<img width="789" alt="Screen Shot 2021-02-05 at 2 56 44 PM" src="https://user-images.githubusercontent.com/63313398/107097704-6756f300-67c2-11eb-87ab-17a80af2f934.png">

After:
<img width="792" alt="Screen Shot 2021-02-05 at 2 58 57 PM" src="https://user-images.githubusercontent.com/63313398/107097816-b13fd900-67c2-11eb-8598-8f294bc23f21.png">


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a WhatsApp block to a new post
* Open the WhatsApp button settings from the block toolbar and verify that it only contains the Phone Number setting, and that the menu is the correct size
* Open the Inspector Controls for the WhatsApp block and verify that the Default First Message and Open In New Tab settings are still present
* 
#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*