### PR TITLE
Anchor: Remove image next to podcast player block

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -27,49 +27,24 @@ function spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) {
 	];
 }
 
-function podcastSection( { episodeTrack, feedUrl, coverImage } ) {
-	const { image, guid } = episodeTrack;
+function podcastSection( { episodeTrack, feedUrl } ) {
+	const { guid } = episodeTrack;
 
 	return [
-		'core/columns',
-		{
-			align: 'wide',
-		},
+		'core/group',
+		{},
 		[
 			[
-				'core/column',
+				'jetpack/podcast-player',
 				{
-					width: '30%',
+					customPrimaryColor: getIconColor(),
+					hexPrimaryColor: getIconColor(),
+					url: feedUrl,
+					selectedEpisodes: guid ? [ { guid } ] : [],
+					showCoverArt: false,
+					showEpisodeTitle: false,
+					showEpisodeDescription: false,
 				},
-				[
-					[
-						'core/image',
-						{
-							url: image ? image : coverImage,
-						},
-					],
-				],
-			],
-			[
-				'core/column',
-				{
-					width: '70%',
-					verticalAlignment: 'center',
-				},
-				[
-					[
-						'jetpack/podcast-player',
-						{
-							customPrimaryColor: getIconColor(),
-							hexPrimaryColor: getIconColor(),
-							url: feedUrl,
-							selectedEpisodes: guid ? [ { guid } ] : [],
-							showCoverArt: false,
-							showEpisodeTitle: false,
-							showEpisodeDescription: false,
-						},
-					],
-				],
 			],
 		],
 	];
@@ -201,14 +176,8 @@ function podcastConversationSection() {
 /*
  * Template parts
  */
-function episodeBasicTemplate( {
-	spotifyShowUrl,
-	spotifyImageUrl,
-	episodeTrack = {},
-	feedUrl,
-	coverImage,
-} ) {
-	const tpl = [ podcastSection( { episodeTrack, feedUrl, coverImage } ) ];
+function episodeBasicTemplate( { spotifyShowUrl, spotifyImageUrl, episodeTrack = {}, feedUrl } ) {
+	const tpl = [ podcastSection( { episodeTrack, feedUrl } ) ];
 
 	if ( spotifyShowUrl && spotifyImageUrl ) {
 		tpl.push( spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) );

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -31,22 +31,16 @@ function podcastSection( { episodeTrack, feedUrl } ) {
 	const { guid } = episodeTrack;
 
 	return [
-		'core/group',
-		{},
-		[
-			[
-				'jetpack/podcast-player',
-				{
-					customPrimaryColor: getIconColor(),
-					hexPrimaryColor: getIconColor(),
-					url: feedUrl,
-					selectedEpisodes: guid ? [ { guid } ] : [],
-					showCoverArt: false,
-					showEpisodeTitle: false,
-					showEpisodeDescription: false,
-				},
-			],
-		],
+		'jetpack/podcast-player',
+		{
+			customPrimaryColor: getIconColor(),
+			hexPrimaryColor: getIconColor(),
+			url: feedUrl,
+			selectedEpisodes: guid ? [ { guid } ] : [],
+			showCoverArt: false,
+			showEpisodeTitle: false,
+			showEpisodeDescription: false,
+		},
 	];
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the image next to the podcast player block in the Anchor block, and centers the podcast player

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1612562996197700-slack-C01FD4FGD7X

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to 'wp-admin/post-new.php?anchor_podcast=22b6608&anchor_episode=547d02ae-abde-462d-92af-3de55ed5bcd2&spotify_url=https://open.spotify.com/show/6HTZdaDHjqXKDE4acYffoD?si=EVfDYETjQCu7pasVG5D73Q'
* Check that the player is centered and there is no cover image next to it.
<img width="643" alt="Screen Shot 2021-02-05 at 6 46 09 PM" src="https://user-images.githubusercontent.com/1689238/107100465-72218000-67e2-11eb-97e5-7718113edb95.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
N/A