### PR TITLE
Custom Content Types: add support for Newspack's Blog Posts block

### DIFF
--- a/projects/plugins/jetpack/modules/custom-post-types/portfolios.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/portfolios.php
@@ -289,6 +289,7 @@ class Jetpack_Portfolio {
 				'revisions',
 				'excerpt',
 				'custom-fields',
+				'newspack_blocks',
 			),
 			'rewrite' => array(
 				'slug'       => 'portfolio',

--- a/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
@@ -315,6 +315,7 @@ class Jetpack_Testimonial {
 				'page-attributes',
 				'revisions',
 				'excerpt',
+				'newspack_blocks',
 			),
 			'rewrite' => array(
 				'slug'       => 'testimonial',


### PR DESCRIPTION
Fixes #18741

#### Changes proposed in this Pull Request:

- Allow Newspack's Blog Posts block to display Testimonial and Portfolio posts.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On an Atomic site, go to Jetpack > Settings > Writing
* Enable both Custom Content Types
* Create posts for both content types, and publish them.
* Go to Posts > Add New
* Add a new Blog Posts Block: https://wordpress.com/support/wordpress-editor/blocks/blog-posts-block/
* You should be able to pull the Custom Posts you've just created in the "Post Types" sidbar panel.

![image](https://user-images.githubusercontent.com/426388/107202479-89d35100-69fa-11eb-9a0b-d8f30846f662.png)


#### Proposed changelog entry for your changes:

* Custom Content Types: allow Newspack's Blog Posts block to display Testimonial and Portfolio posts.

