### PR TITLE
Connection: Migrate deprecations

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,5 +1,6 @@
 <?php
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Partner;
@@ -489,7 +490,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 function jetpack_current_user_data() {
 	$current_user   = wp_get_current_user();
 	$is_master_user = $current_user->ID == Jetpack_Options::get_option( 'master_user' );
-	$dotcom_data    = Jetpack::get_connected_user_data();
+	$dotcom_data    = ( new Connection_Manager( 'jetpack' ) )->get_connected_user_data();
 
 	// Add connected user gravatar to the returned dotcom_data.
 	$dotcom_data['avatar'] = ( ! empty( $dotcom_data['email'] ) ?
@@ -503,7 +504,7 @@ function jetpack_current_user_data() {
 		: false );
 
 	$current_user_data = array(
-		'isConnected' => Jetpack::is_user_connected( $current_user->ID ),
+		'isConnected' => ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $current_user->ID ),
 		'isMaster'    => $is_master_user,
 		'username'    => $current_user->user_login,
 		'id'          => $current_user->ID,

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -1227,8 +1227,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @uses Jetpack::is_user_connected();
-	 *
 	 * @return bool|WP_Error True if user is able to unlink.
 	 */
 	public static function get_user_connection_data_permission_callback() {
@@ -1260,12 +1258,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @uses Jetpack::is_user_connected();
+	 * @uses Automattic\Jetpack\Connection\Manager::is_user_connected();)
 	 *
 	 * @return bool|WP_Error True if user is able to unlink.
 	 */
 	public static function unlink_user_permission_callback() {
-		if ( current_user_can( 'jetpack_connect_user' ) && Jetpack::is_user_connected( get_current_user_id() ) ) {
+		if ( current_user_can( 'jetpack_connect_user' ) && ( new Connection_Manager( 'jetpack' ) )->is_user_connected( get_current_user_id() ) ) {
 			return true;
 		}
 
@@ -1808,7 +1806,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			);
 		}
 
-		if ( ! Jetpack::is_user_connected( $new_owner_id ) ) {
+		if ( ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $new_owner_id ) ) {
 			return new WP_Error(
 				'new_owner_not_connected',
 				esc_html__( 'New owner is not connected', 'jetpack' ),
@@ -1885,7 +1883,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return WP_REST_Response|WP_Error Response, else error.
 	 */
 	public static function get_user_tracking_settings( $request ) {
-		if ( ! Jetpack::is_user_connected() ) {
+		if ( ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
 			$response = array(
 				'tracks_opt_out' => true, // Default to opt-out if not connected to wp.com.
 			);
@@ -1918,7 +1916,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return WP_REST_Response|WP_Error Response, else error.
 	 */
 	public static function update_user_tracking_settings( $request ) {
-		if ( ! Jetpack::is_user_connected() ) {
+		if ( ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
 			$response = array(
 				'tracks_opt_out' => true, // Default to opt-out if not connected to wp.com.
 			);

--- a/projects/plugins/jetpack/_inc/lib/functions.wp-notify.php
+++ b/projects/plugins/jetpack/_inc/lib/functions.wp-notify.php
@@ -10,6 +10,7 @@
  * to check for Jetpack::is_active() too early in the load flow.
  */
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
 
 // phpcs:disable WordPress.WP.I18n.MissingArgDomain --reason: WP Core string.
@@ -407,5 +408,5 @@ function jetpack_notify_moderator( $notify_moderator, $comment_id ) {
  */
 function jetpack_notify_is_user_connected_by_email( $email ) {
 	$user = get_user_by( 'email', $email );
-	return Jetpack::is_user_connected( $user->ID );
+	return ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user->ID );
 }

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
 
@@ -716,7 +717,7 @@ class Jetpack_Gutenberg {
 		} else {
 			$user_data                 = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
 			$blog_id                   = Jetpack_Options::get_option( 'id', 0 );
-			$is_current_user_connected = Jetpack::is_user_connected();
+			$is_current_user_connected = ( new Connection_Manager( 'jetpack' ) )->is_user_connected();
 		}
 
 		wp_localize_script(

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1421,7 +1421,7 @@ class Jetpack {
 			if ( count( $admins ) > 1 ) {
 				$available = array();
 				foreach ( $admins as $admin ) {
-					if ( self::is_user_connected( $admin->ID ) ) {
+					if ( self::connection()->is_user_connected( $admin->ID ) ) {
 						$available[] = $admin->ID;
 					}
 				}
@@ -4151,7 +4151,7 @@ p {
 			// @todo: Add validation against a known allowed list.
 			$from = ! empty( $_GET['from'] ) ? $_GET['from'] : 'iframe';
 			// User clicked in the iframe to link their accounts
-			if ( ! self::is_user_connected() ) {
+			if ( ! self::connection()->is_user_connected() ) {
 				$redirect = ! empty( $_GET['redirect_after_auth'] ) ? $_GET['redirect_after_auth'] : false;
 
 				add_filter( 'allowed_redirect_hosts', array( &$this, 'allow_wpcom_environments' ) );
@@ -7085,7 +7085,7 @@ endif;
 	 * Show Jetpack icon if the user is linked.
 	 */
 	function jetpack_show_user_connected_icon( $val, $col, $user_id ) {
-		if ( 'user_jetpack' == $col && self::is_user_connected( $user_id ) ) {
+		if ( 'user_jetpack' === $col && self::connection()->is_user_connected( $user_id ) ) {
 			$jetpack_logo = new Jetpack_Logo();
 			$emblem_html  = sprintf(
 				'<a title="%1$s" class="jp-emblem-user-admin">%2$s</a>',

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-user-connect-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-user-connect-endpoint.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 
 class Jetpack_JSON_API_User_Connect_Endpoint extends Jetpack_JSON_API_Endpoint {
@@ -11,7 +12,7 @@ class Jetpack_JSON_API_User_Connect_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	function result() {
 		Connection_Utils::update_user_token( $this->user_id, sprintf( '%s.%d', $this->user_token, $this->user_id ), false );
-		return array( 'success' => Jetpack::is_user_connected( $this->user_id ) );
+		return array( 'success' => ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $this->user_id ) );
 	}
 
 	function validate_input( $user_id ) {
@@ -20,7 +21,7 @@ class Jetpack_JSON_API_User_Connect_Endpoint extends Jetpack_JSON_API_Endpoint {
 			return new WP_Error( 'input_error', __( 'user_id is required', 'jetpack' ) );
 		}
 		$this->user_id = $user_id;
-		if ( Jetpack::is_user_connected( $this->user_id ) ) {
+		if ( ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $this->user_id ) ) {
 			return new WP_Error( 'user_already_connected', __( 'The user is already connected', 'jetpack' ) );
 		}
 		if ( ! isset( $input['user_token'] ) ) {

--- a/projects/plugins/jetpack/modules/monitor.php
+++ b/projects/plugins/jetpack/modules/monitor.php
@@ -12,6 +12,11 @@
  * Additional Search Queries: monitor, uptime, downtime, monitoring, maintenance, maintenance mode, offline, site is down, site down, down, repair, error
  */
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
+/**
+ * Class Jetpack_Monitor
+ */
 class Jetpack_Monitor {
 
 	public $module = 'monitor';
@@ -22,7 +27,7 @@ class Jetpack_Monitor {
 	}
 
 	public function activate_module() {
-		if ( Jetpack::is_user_connected() ) {
+		if ( ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
 			self::update_option_receive_jetpack_monitor_notification( true );
 		}
 	}

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -11,6 +11,8 @@
  * Additional Search Queries: notification, notifications, toolbar, adminbar, push, comments
  */
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 if ( !defined( 'JETPACK_NOTES__CACHE_BUSTER' ) ) define( 'JETPACK_NOTES__CACHE_BUSTER', JETPACK__VERSION . '-' . gmdate( 'oW' ) );
 
 class Jetpack_Notifications {
@@ -202,7 +204,7 @@ class Jetpack_Notifications {
 	}
 
 	function print_js() {
-		$link_accounts_url = is_user_logged_in() && !Jetpack::is_user_connected() ? Jetpack::admin_url() : false;
+		$link_accounts_url = is_user_logged_in() && ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ? Jetpack::admin_url() : false;
 ?>
 <script data-ampdevmode type="text/javascript">
 /* <![CDATA[ */

--- a/projects/plugins/jetpack/modules/sharedaddy.php
+++ b/projects/plugins/jetpack/modules/sharedaddy.php
@@ -15,6 +15,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
@@ -39,7 +40,7 @@ function sharedaddy_loaded() {
  */
 function jetpack_sharedaddy_configuration_url() {
 	$status = new Status();
-	if ( $status->is_offline_mode() || $status->is_staging_site() || ! Jetpack::is_user_connected() ) {
+	if ( $status->is_offline_mode() || $status->is_staging_site() || ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
 		return admin_url( 'options-general.php?page=sharing' );
 	}
 

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -1,9 +1,10 @@
 <?php
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\Redirect;
 
 require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' );
 require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-notices.php' );
@@ -810,7 +811,7 @@ class Jetpack_SSO {
 			$json_api_auth_environment = Jetpack_SSO_Helpers::get_json_api_auth_environment();
 
 			$is_json_api_auth  = ! empty( $json_api_auth_environment );
-			$is_user_connected = Jetpack::is_user_connected( $user->ID );
+			$is_user_connected = ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user->ID );
 			$roles             = new Roles();
 			$tracking->record_user_event( 'sso_user_logged_in', array(
 				'user_found_with'  => $user_found_with,
@@ -1079,7 +1080,7 @@ class Jetpack_SSO {
 	 * stored when the user logs out, and then deleted when the user logs in.
 	 */
 	function store_wpcom_profile_cookies_on_logout() {
-		if ( ! Jetpack::is_user_connected( get_current_user_id() ) ) {
+		if ( ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( get_current_user_id() ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -16,6 +16,7 @@
 
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\XMLRPC_Async_Call;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
@@ -1608,7 +1609,7 @@ function jetpack_stats_load_admin_css() {
  * @return mixed
  */
 function jetpack_stats_post_table( $columns ) { // Adds a stats link on the edit posts page
-	if ( ! current_user_can( 'view_stats' ) || ! Jetpack::is_user_connected() ) {
+	if ( ! current_user_can( 'view_stats' ) || ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
 		return $columns;
 	}
 	// Array-Fu to add before comments

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -329,7 +329,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 4.4.0
 	 */
 	public function test_admin_user_unlink_permission() {
-		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 
 		$this->load_rest_endpoints_direct();
 
@@ -673,7 +672,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 4.4.0
 	 */
 	public function test_unlink_user() {
-		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user();
@@ -716,7 +714,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 8.8.0
 	 */
 	public function test_unlink_user_cache_data_removal() {
-		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user();
@@ -969,7 +966,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 7.7.0 No longer need to be master user to update.
 	 */
 	public function test_change_owner() {
-		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user( 'administrator' );
@@ -1136,8 +1132,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @since 9.4
 	 */
 	public function test_get_user_connection_data_without_master_user() {
-		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
-		$this->setExpectedDeprecated( 'Jetpack::get_connected_user_data' );
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user( 'administrator' );
 		wp_set_current_user( $user->ID );

--- a/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
@@ -305,7 +305,6 @@ EXPECTED;
 	}
 
 	public function test_get_other_linked_admins_one_admin_returns_false() {
-		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 		delete_transient( 'jetpack_other_linked_admins' );
 		$other_admins = Jetpack::get_other_linked_admins();
 		$this->assertFalse( $other_admins );
@@ -313,7 +312,6 @@ EXPECTED;
 	}
 
 	public function test_get_other_linked_admins_more_than_one_not_false() {
-		$this->setExpectedDeprecated( 'Jetpack::is_user_connected' );
 		delete_transient( 'jetpack_other_linked_admins' );
 		$master_user = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		$connected_admin = $this->factory->user->create( array( 'role' => 'administrator' ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/18727

#### Changes proposed in this Pull Request:
In #18548 we deprecated `Jetpack::is_user_connected` and `Jetpack::get_connected_user_data`. This PR migrate all the deprecations so the functions from the connection manager package are used instead.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Many files have changed. Unit tests should cover us. Alternatively check the modified files and manually test the relevant UI. 

#### Proposed changelog entry for your changes:
No.
