### PR TITLE
Dialogue: support speaker colors

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -27,7 +27,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		updatedParticipant => {
 			setAttributes( {
 				participants: participants.map( participant => {
-					if ( participant.slug !== updatedParticipant.slug ) {
+					if ( ! updatedParticipant || participant.slug !== updatedParticipant.slug ) {
 						return participant;
 					}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
@@ -11,6 +11,10 @@ export default {
 		type: 'string',
 		validator: colorValidator,
 	},
+	customLabelTextColor: {
+		type: 'string',
+		validator: colorValidator,
+	},
 	slug: {
 		type: 'string',
 	},

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
@@ -15,6 +15,14 @@ export default {
 		type: 'string',
 		validator: colorValidator,
 	},
+	labelBackgroundColor: {
+		type: 'string',
+		validator: colorValidator,
+	},
+	customLabelBackgroundColor: {
+		type: 'string',
+		validator: colorValidator,
+	},
 	slug: {
 		type: 'string',
 	},

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
@@ -1,6 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import colorValidator from '../../shared/colorValidator';
+
 export default {
 	label: {
 		type: 'string',
+	},
+	labelTextColor: {
+		type: 'string',
+		validator: colorValidator,
 	},
 	slug: {
 		type: 'string',

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -134,6 +134,7 @@ function refreshAutocompleter( participants ) {
  * @param {object}   prop                     - ParticipantRichControl component.
  * @param {string}   prop.className           - Component CSS class.
  * @param {string}   prop.label               - Dialogue participant value. Local level.
+ * @param {object}   prop.color               - Label color object.
  * @param {object}   prop.participant         - Participant object. Gloanl level.
  * @param {Array}    prop.participants        - Participants list. Global level (Conversation block).
  * @param {object}   prop.transcriptRef       - Reference to the transcript DOM element (DialogueEdit content).
@@ -147,6 +148,7 @@ function refreshAutocompleter( participants ) {
 export function SpeakerEditControl( {
 	className,
 	label,
+	color,
 	participant,
 	participants,
 	transcriptRef,
@@ -242,6 +244,10 @@ export function SpeakerEditControl( {
 		setEditingMode( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
 	}, [ participant ] );
 
+	const inlineStyles = {
+		color: color.color,
+	};
+
 	return (
 		<DetectOutside
 			className={ classNames( className, {
@@ -260,6 +266,7 @@ export function SpeakerEditControl( {
 				onChange={ onChangeHandler }
 				placeholder={ __( 'Speaker', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
+				style={ inlineStyles }
 				onSplit={ () => {} }
 				onReplace={ ( replaceValue ) => {
 					setTimeout( () => transcriptRef?.current?.focus(), 10 );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -91,7 +91,10 @@ const DetectOutside = withFocusOutside(
 
 		render() {
 			return (
-				<div className={ this.props.className }>
+				<div
+					className={ this.props.className }
+					style={ this.props.style }
+				>
 					{ this.props.children }
 				</div>
 			);
@@ -135,6 +138,7 @@ function refreshAutocompleter( participants ) {
  * @param {string}   prop.className           - Component CSS class.
  * @param {string}   prop.label               - Dialogue participant value. Local level.
  * @param {object}   prop.color               - Label color object.
+ * @param {object}   prop.backgroundColor     - Label background color object.
  * @param {object}   prop.participant         - Participant object. Gloanl level.
  * @param {Array}    prop.participants        - Participants list. Global level (Conversation block).
  * @param {object}   prop.transcriptRef       - Reference to the transcript DOM element (DialogueEdit content).
@@ -149,6 +153,7 @@ export function SpeakerEditControl( {
 	className,
 	label,
 	color,
+	backgroundColor,
 	participant,
 	participants,
 	transcriptRef,
@@ -246,6 +251,7 @@ export function SpeakerEditControl( {
 
 	const inlineStyles = {
 		color: color.color,
+		backgroundColor: backgroundColor.color,
 	};
 
 	return (
@@ -256,7 +262,9 @@ export function SpeakerEditControl( {
 				'is-editing-participant': editingMode === EDIT_MODE_EDITING,
 				'is-selecting-participant': editingMode === EDIT_MODE_SELECTING,
 			} ) }
+
 			onFocusOutside={ editSpeakerHandler }
+			style={ inlineStyles }
 		>
 			<RichText
 				tagName="div"
@@ -266,7 +274,6 @@ export function SpeakerEditControl( {
 				onChange={ onChangeHandler }
 				placeholder={ __( 'Speaker', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
-				style={ inlineStyles }
 				onSplit={ () => {} }
 				onReplace={ ( replaceValue ) => {
 					setTimeout( () => transcriptRef?.current?.focus(), 10 );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -8,12 +8,18 @@ import { useMemoOne } from 'use-memo-one';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, RichText, BlockControls } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	RichText,
+	BlockControls,
+	withColors,
+	PanelColorSettings,
+ } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Panel, PanelBody, ToggleControl } from '@wordpress/components';
 import { useContext, useEffect, useRef } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
-import { useDebounce } from '@wordpress/compose';
+import { useDebounce, compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -39,7 +45,7 @@ const useDebounceWithFallback = useDebounce
 		return debounced;
 	};
 
-export default function DialogueEdit( {
+function DialogueEdit( {
 	className,
 	attributes,
 	setAttributes,
@@ -47,6 +53,9 @@ export default function DialogueEdit( {
 	onReplace,
 	mergeBlocks,
 	isSelected,
+
+	labelTextColor,
+	setLabelTextColor,
 } ) {
 	const {
 		content,
@@ -139,6 +148,17 @@ export default function DialogueEdit( {
 							<p>{ mediaSource.title }</p>
 						</PanelBody>
 					) }
+
+					<PanelColorSettings
+						title={ __( 'Color Settings', 'jetpack' ) }
+						colorSettings={ [
+							{
+								value: labelTextColor.color,
+								onChange: setLabelTextColor,
+								label: __( 'Label Color', 'jetpack' ),
+							},
+						] }
+					/>
 
 					<PanelBody title={ __( 'Timestamp', 'jetpack' ) }>
 						<ToggleControl
@@ -245,3 +265,9 @@ export default function DialogueEdit( {
 		</div>
 	);
 }
+
+export default compose( [
+	withColors(
+		{ labelTextColor: 'color' },
+	),
+] )( DialogueEdit );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -233,7 +233,17 @@ function DialogueEdit( {
 					onParticipantChange={ ( updatedParticipant ) => {
 						setAttributes( { label: updatedParticipant } );
 					} }
-					onSelect={ setAttributes }
+					onSelect={ ( selectedParticipant ) => {
+						setAttributes( selectedParticipant );
+
+						if ( selectedParticipant?.color ) {
+							setLabelTextColor( selectedParticipant.color );
+						}
+
+						if ( selectedParticipant?.backgroundColor ) {
+							setLabelBackgroundColor( selectedParticipant.backgroundColor );
+						}
+					} }
 
 					onClean={ () => {
 						setAttributes( { slug: null, label: '' } );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -184,13 +184,8 @@ function DialogueEdit( {
 						/>
 					</PanelBody>
 
-					{ !! mediaSource?.title && (
-						<PanelBody title={ __( 'Podcast episode', 'jetpack' ) }>
-							<p>{ mediaSource.title }</p>
-						</PanelBody>
-					) }
-
 					<PanelColorSettings
+						initialOpen={ false }
 						title={ __( 'Color Settings', 'jetpack' ) }
 						colorSettings={ [
 							{
@@ -206,6 +201,12 @@ function DialogueEdit( {
 							},
 						] }
 					/>
+
+					{ !! mediaSource?.title && (
+						<PanelBody title={ __( 'Podcast episode', 'jetpack' ) }>
+							<p>{ mediaSource.title }</p>
+						</PanelBody>
+					) }
 
 					<PanelBody title={ __( 'Timestamp', 'jetpack' ) }>
 						<ToggleControl

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -56,6 +56,8 @@ function DialogueEdit( {
 
 	labelTextColor,
 	setLabelTextColor,
+	labelBackgroundColor,
+	setLabelBackgroundColor,
 } ) {
 	const {
 		content,
@@ -88,10 +90,14 @@ function DialogueEdit( {
 	const conversationBridge = useContext( ConversationContext );
 
 	// Debounced function to keep all sibling Dialogue blocks in-sync.
-	const syncSpeakersGlobally = useDebounceWithFallback( ( newAttributes, color ) => {
+	const syncSpeakersGlobally = useDebounceWithFallback( ( newAttributes, colors ) => {
 		setAttributes( newAttributes );
-		if ( color ) {
-			setLabelTextColor( color );
+		if ( colors?.color ) {
+			setLabelTextColor( colors.color );
+		}
+
+		if ( colors?.backgroundColor ) {
+			setLabelBackgroundColor( colors.backgroundColor );
 		}
 	}, 250 );
 
@@ -114,7 +120,10 @@ function DialogueEdit( {
 			{
 				label: conversationParticipant.label,
 			},
-			conversationParticipant?.color,
+			{
+				color: conversationParticipant?.color,
+				backgroundColor: conversationParticipant?.backgroundColor,
+			}
 		);
 	}, [ conversationParticipant, syncSpeakersGlobally, isSelected, slug ] );
 
@@ -131,12 +140,23 @@ function DialogueEdit( {
 		setAttributes( { timestamp: time } );
 	}
 
-	function setLabelTextColorHandler( color ) {
-		setLabelTextColor( color );
-		conversationBridge.updateParticipants( {
-			...conversationParticipant,
-			color,
-		} );
+	function setLabelColorHandler( type ) {
+		return function( color ) {
+			if ( type === 'labelTextColor' ) {
+				setLabelTextColor( color );
+				return conversationBridge.updateParticipants( {
+					...conversationParticipant,
+					color,
+				} );
+			}
+
+			setLabelBackgroundColor( color );
+
+			conversationBridge.updateParticipants( {
+				...conversationParticipant,
+				backgroundColor: color,
+			} );
+		};
 	}
 
 	return (
@@ -171,8 +191,14 @@ function DialogueEdit( {
 						colorSettings={ [
 							{
 								value: labelTextColor.color,
-								onChange: setLabelTextColorHandler,
-								label: __( 'Label Color', 'jetpack' ),
+								onChange: setLabelColorHandler( 'labelTextColor' ),
+								label: __( 'Label color', 'jetpack' ),
+							},
+
+							{
+								value: labelBackgroundColor.color,
+								onChange: setLabelColorHandler( 'labelBackgroundColor' ),
+								label: __( 'Label Background color', 'jetpack' ),
 							},
 						] }
 					/>
@@ -203,6 +229,7 @@ function DialogueEdit( {
 					participants={ participants }
 					transcriptRef={ contentRef }
 					color={ labelTextColor }
+					backgroundColor={ labelBackgroundColor }
 					onParticipantChange={ ( updatedParticipant ) => {
 						setAttributes( { label: updatedParticipant } );
 					} }
@@ -286,6 +313,6 @@ function DialogueEdit( {
 
 export default compose( [
 	withColors(
-		{ labelTextColor: 'color' },
+		{ labelTextColor: 'color', labelBackgroundColor: 'background-color' },
 	),
 ] )( DialogueEdit );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -91,12 +91,16 @@ function DialogueEdit( {
 
 	// Debounced function to keep all sibling Dialogue blocks in-sync.
 	const syncSpeakersGlobally = useDebounceWithFallback( ( newAttributes, colors ) => {
-		setAttributes( newAttributes );
-		if ( colors?.color ) {
+		// Check whether it needs to update the block label.
+		if ( newAttributes?.label && newAttributes.label !== label ) {
+			setAttributes( newAttributes );
+		}
+
+		if ( colors?.color && colors.color !== labelTextColor.color ) {
 			setLabelTextColor( colors.color );
 		}
 
-		if ( colors?.backgroundColor ) {
+		if ( colors?.backgroundColor && colors.backgroundColor !== labelBackgroundColor.color ) {
 			setLabelBackgroundColor( colors.backgroundColor );
 		}
 	}, 250 );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -185,6 +185,7 @@ function DialogueEdit( {
 					participant={ conversationParticipant }
 					participants={ participants }
 					transcriptRef={ contentRef }
+					color={ labelTextColor }
 					onParticipantChange={ ( updatedParticipant ) => {
 						setAttributes( { label: updatedParticipant } );
 					} }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
@@ -20,28 +20,39 @@ export default function save( { attributes, blockName } ) {
 		label,
 		labelTextColor,
 		customLabelTextColor,
+		labelBackgroundColor,
+		customLabelBackgroundColor,
 		showTimestamp,
 		timestamp,
 	} = attributes;
 
 	const labelTextColorCSSClass = getColorClassName( 'color', labelTextColor );
 
+	const labelBackgroundcolorCSSClass = getColorClassName( 'background-color', labelBackgroundColor );
+
 	const speakerCSSClasses = classnames( `${ BASE_CLASS_NAME }__participant`, 'has-bold-style', {
 		[ `wp-block-jetpack-${ blockName }` ]: blockName,
 		'has-text-color': labelTextColor || customLabelTextColor,
 		[ labelTextColorCSSClass ]: labelTextColorCSSClass,
+		'has-background-color': labelBackgroundColor || customLabelBackgroundColor,
+		[ labelBackgroundcolorCSSClass ]: labelBackgroundcolorCSSClass,
 	} );
 
-	const labelTextColorInlineStyle = {
-		color: labelTextColorCSSClass ? undefined : customLabelTextColor,
-	};
+	const labelInlineStyle = {};
+	if ( labelTextColorCSSClass ) {
+		labelInlineStyle.color = customLabelTextColor;
+	}
+
+	if ( labelBackgroundcolorCSSClass ) {
+		labelInlineStyle.backgroundColor = customLabelBackgroundColor;
+	}
 
 	return (
 		<div>
 			<div className={ `${ BASE_CLASS_NAME }__meta` }>
 				<div
 					className={ speakerCSSClasses }
-					style={ labelTextColorInlineStyle }
+					style={ labelInlineStyle }
 				>
 					{ label }
 				</div>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
@@ -25,9 +25,7 @@ export default function save( { attributes, blockName } ) {
 		showTimestamp,
 		timestamp,
 	} = attributes;
-
 	const labelTextColorCSSClass = getColorClassName( 'color', labelTextColor );
-
 	const labelBackgroundcolorCSSClass = getColorClassName( 'background-color', labelBackgroundColor );
 
 	const speakerCSSClasses = classnames( `${ BASE_CLASS_NAME }__participant`, 'has-bold-style', {
@@ -39,11 +37,11 @@ export default function save( { attributes, blockName } ) {
 	} );
 
 	const labelInlineStyle = {};
-	if ( labelTextColorCSSClass ) {
+	if ( ! labelTextColorCSSClass ) {
 		labelInlineStyle.color = customLabelTextColor;
 	}
 
-	if ( labelBackgroundcolorCSSClass ) {
+	if ( ! labelBackgroundcolorCSSClass ) {
 		labelInlineStyle.backgroundColor = customLabelBackgroundColor;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RichText, getColorClassName } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -9,13 +14,35 @@ import { RichText } from '@wordpress/block-editor';
 import { BASE_CLASS_NAME } from './utils';
 import { convertTimeCodeToSeconds } from '../../shared/components/media-player-control/utils';
 
-export default function save( { attributes } ) {
-	const { content, label, showTimestamp, timestamp } = attributes;
+export default function save( { attributes, blockName } ) {
+	const {
+		content,
+		label,
+		labelTextColor,
+		customLabelTextColor,
+		showTimestamp,
+		timestamp,
+	} = attributes;
+
+	const labelTextColorCSSClass = getColorClassName( 'color', labelTextColor );
+
+	const speakerCSSClasses = classnames( `${ BASE_CLASS_NAME }__participant`, 'has-bold-style', {
+		[ `wp-block-jetpack-${ blockName }` ]: blockName,
+		'has-text-color': labelTextColor || customLabelTextColor,
+		[ labelTextColorCSSClass ]: labelTextColorCSSClass,
+	} );
+
+	const labelTextColorInlineStyle = {
+		color: labelTextColorCSSClass ? undefined : customLabelTextColor,
+	};
 
 	return (
 		<div>
 			<div className={ `${ BASE_CLASS_NAME }__meta` }>
-				<div className={ `${ BASE_CLASS_NAME }__participant has-bold-style` }>
+				<div
+					className={ speakerCSSClasses }
+					style={ labelTextColorInlineStyle }
+				>
 					{ label }
 				</div>
 				{ showTimestamp && (

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -12,12 +12,12 @@
 	}
 
 	.wp-block-jetpack-dialogue__participant {
-		font-size: inherit;
-		padding: 0;
+		padding: 0 5px;
+		height: auto;
 		line-height: 17px;
 		line-height: var( --global--line-height-body );
 		overflow-wrap: anywhere;
-		color: inherit;
+		border-radius: 5px
 	}
 
 	.wp-block-jetpack-dialogue__timestamp {
@@ -31,10 +31,6 @@
 }
 
 .wp-block-jetpack-dialogue__participant {
-	padding: 3px 0;
-	height: auto;
-	line-height: 1.2;
-
 	&.has-bold-style {
 		font-weight: bold;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR adds text color and background color for each Dialogue blocks.

![image](https://user-images.githubusercontent.com/77539/107428463-6f37cf80-6b01-11eb-81df-8e40b5a2ba09.png)

https://user-images.githubusercontent.com/77539/107428381-4e6f7a00-6b01-11eb-98e3-76d8d54b401a.mov

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: support speaker colors

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a conversation with dialogue blocks composition
* Defines the conversation speakers
* Set the speaker colors, using the blocks setting sidebar
* Confirm the speaker colors are propagated to all sibling dialogue blocks.
* Confirm colors are properly applied in the front-end. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
