### PR TITLE
Admin Menu: Sanitize URLs in endpoint response

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -297,7 +297,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		// External URLS.
 		if ( preg_match( '/^https?:\/\//', $url ) ) {
 			// Allow URLs pointing to WordPress.com.
-			if ( 0 === strpos( $url, 'https://wordpress.com' ) ) {
+			if ( 0 === strpos( $url, 'https://wordpress.com/' ) ) {
 				// Calypso needs the domain removed so they're not interpreted as external links.
 				$url = str_replace( 'https://wordpress.com', '', $url );
 				return esc_url_raw( $url );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -303,11 +303,6 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				return esc_url_raw( $url );
 			}
 
-			// Allow URLs pointing to Jetpack.com.
-			if ( 0 === strpos( $url, 'https://jetpack.com' ) ) {
-				return esc_url_raw( $url );
-			}
-
 			// Disallow other external URLs.
 			return '';
 		}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -294,41 +294,50 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function prepare_menu_item_url( $url, $parent_slug = '' ) {
-		// For security reasons, do not allow external URLs (unless they point to Calypso).
+		// External URLS.
 		if ( preg_match( '/^https?:\/\//', $url ) ) {
+			// Allow URLs pointing to WordPress.com.
 			if ( 0 === strpos( $url, 'https://wordpress.com' ) ) {
-				// Calypso URLs need the base removed so they're not interpreted as external links.
+				// Calypso needs the domain removed so they're not interpreted as external links.
 				$url = str_replace( 'https://wordpress.com', '', $url );
-			} else {
-				$url = '';
+				return esc_url_raw( $url );
 			}
-		} else {
-			$menu_hook   = get_plugin_page_hook( $url, $parent_slug );
-			$menu_file   = wp_parse_url( $url, PHP_URL_PATH ); // Removes query args to get a file name.
-			$parent_file = wp_parse_url( $parent_slug, PHP_URL_PATH );
 
-			if (
-				! empty( $menu_hook ) ||
-				(
-					'index.php' !== $url &&
-					file_exists( WP_PLUGIN_DIR . "/$menu_file" ) &&
-					! file_exists( ABSPATH . "/wp-admin/$menu_file" )
-				)
-			) {
-				if (
-					( 'admin.php' !== $parent_file && file_exists( WP_PLUGIN_DIR . "/$parent_file" ) && ! is_dir( WP_PLUGIN_DIR . "/$parent_file" ) ) ||
-					( file_exists( ABSPATH . "/wp-admin/$parent_file" ) && ! is_dir( ABSPATH . "/wp-admin/$parent_file" ) )
-				) {
-					$url = add_query_arg( array( 'page' => $url ), admin_url( $parent_slug ) );
-				} else {
-					$url = add_query_arg( array( 'page' => $url ), admin_url( 'admin.php' ) );
-				}
-			} elseif ( file_exists( ABSPATH . "/wp-admin/$menu_file" ) ) {
-				$url = admin_url( $url );
+			// Allow URLs pointing to Jetpack.com.
+			if ( 0 === strpos( $url, 'https://jetpack.com' ) ) {
+				return esc_url_raw( $url );
 			}
+
+			// Disallow other external URLs.
+			return '';
 		}
 
-		return esc_url( $url );
+		// Internal URLs.
+		$menu_hook   = get_plugin_page_hook( $url, $parent_slug );
+		$menu_file   = wp_parse_url( $url, PHP_URL_PATH ); // Removes query args to get a file name.
+		$parent_file = wp_parse_url( $parent_slug, PHP_URL_PATH );
+
+		if (
+			! empty( $menu_hook ) ||
+			(
+				'index.php' !== $url &&
+				file_exists( WP_PLUGIN_DIR . "/$menu_file" ) &&
+				! file_exists( ABSPATH . "/wp-admin/$menu_file" )
+			)
+		) {
+			if (
+				( 'admin.php' !== $parent_file && file_exists( WP_PLUGIN_DIR . "/$parent_file" ) && ! is_dir( WP_PLUGIN_DIR . "/$parent_file" ) ) ||
+				( file_exists( ABSPATH . "/wp-admin/$parent_file" ) && ! is_dir( ABSPATH . "/wp-admin/$parent_file" ) )
+			) {
+				$url = add_query_arg( array( 'page' => $url ), admin_url( $parent_slug ) );
+			} else {
+				$url = add_query_arg( array( 'page' => $url ), admin_url( 'admin.php' ) );
+			}
+		} elseif ( file_exists( ABSPATH . "/wp-admin/$menu_file" ) ) {
+			$url = admin_url( $url );
+		}
+
+		return esc_url_raw( $url );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -294,9 +294,14 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function prepare_menu_item_url( $url, $parent_slug = '' ) {
-		// Calypso URLs need the base removed so they're not interpreted as external links.
-		if ( 0 === strpos( $url, 'https://wordpress.com' ) ) {
-			$url = str_replace( 'https://wordpress.com', '', $url );
+		// For security reasons, do not allow external URLs (unless they point to Calypso).
+		if ( preg_match( '/^https?:\/\//', $url ) ) {
+			if ( 0 === strpos( $url, 'https://wordpress.com' ) ) {
+				// Calypso URLs need the base removed so they're not interpreted as external links.
+				$url = str_replace( 'https://wordpress.com', '', $url );
+			} else {
+				$url = '';
+			}
 		} else {
 			$menu_hook   = get_plugin_page_hook( $url, $parent_slug );
 			$menu_file   = wp_parse_url( $url, PHP_URL_PATH ); // Removes query args to get a file name.
@@ -323,7 +328,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 		}
 
-		return $url;
+		return esc_url( $url );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -381,13 +381,6 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				'__return_true',
 				admin_url( 'admin.php?page=custom_settings' ),
 			),
-			// Jetpack.
-			array(
-				'https://jetpack.com/redirect/?source=calypso-backups&#038;site=example.org',
-				'jetpack',
-				null,
-				'https://jetpack.com/redirect/?source=calypso-backups&#038;site=example.org',
-			),
 			// WooCommerce URLs.
 			array(
 				'product_attributes',

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -407,6 +407,19 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				'__return_true',
 				admin_url( 'admin.php?page=wc-admin&amp;path=customers' ),
 			),
+			// Disallowed URLs.
+			array(
+				'javascript:alert("Hello")',
+				'',
+				null,
+				'',
+			),
+			array(
+				'http://example.com',
+				'',
+				null,
+				'',
+			),
 		);
 	}
 

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -420,6 +420,12 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				null,
 				'',
 			),
+			array(
+				'https://wordpress.commerce.malicious-site.com',
+				'',
+				null,
+				'',
+			),
 		);
 	}
 


### PR DESCRIPTION
Counterpart of https://github.com/Automattic/wp-calypso/pull/49718
Needed by 577-gh-Automattic/wpcomsh
Further reading: p9o2xV-1fe-p2

#### Changes proposed in this Pull Request:

Sanitize the URLs returned in the `admin-menu` endpoint response to ensure that only internal links are used.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Spin up a Jetpack site running this branch.
* Add a mu-plugin with the code below:
```php
add_action( 'admin_menu', function() {
	global $menu, $submenu;
	$menu[0] = [ 'Click here', 'read', 'javascript:alert("hello")' ];
	$submenu['javascript:alert("hello")'] = [ [ 'Or here', 'read', 'http://example.com' ] ];
} );
```
* Go the [WP.com API console](https://developer.wordpress.com/docs/api/console/).
* Select "WP REST API" and "wpcom/v2".
* Make a `GET` request to `/sites/:site/admin-menu`.
* Make sure the first item of the response and its child contain an empty URL. <img width="803" alt="Screen Shot 2021-02-09 at 11 15 32" src="https://user-images.githubusercontent.com/1233880/107349949-1d735300-6ac9-11eb-8659-590eb78eec39.png">
* Make sure the URLs of the rest of items are unaffected.


#### Proposed changelog entry for your changes:
Not needed.