### PR TITLE
Audio Player: add `loadWhenReady` and `preload` properties

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.js
@@ -304,6 +304,7 @@ export class PodcastPlayer extends Component {
 						onError={ this.handleError }
 						playStatus={ playerState }
 						currentTime={ currentTime }
+						loadWhenReay={ true }
 						onTimeChange={ this.handleTimeChange }
 						onMetadataLoaded={ this.updateMediaData }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.js
@@ -304,7 +304,6 @@ export class PodcastPlayer extends Component {
 						onError={ this.handleError }
 						playStatus={ playerState }
 						currentTime={ currentTime }
-						loadWhenReady={ true }
 						onTimeChange={ this.handleTimeChange }
 						onMetadataLoaded={ this.updateMediaData }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.js
@@ -304,7 +304,7 @@ export class PodcastPlayer extends Component {
 						onError={ this.handleError }
 						playStatus={ playerState }
 						currentTime={ currentTime }
-						loadWhenReay={ true }
+						loadWhenReady={ true }
 						onTimeChange={ this.handleTimeChange }
 						onMetadataLoaded={ this.updateMediaData }
 					/>

--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/README.md
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/README.md
@@ -26,6 +26,21 @@ The URL of the audio file to play. In the case of the podcast player, this is al
 
 Used in conjunction with `onTimeChange` this tracks the current position in the audio file, and can be set to a value in order to jump back and forth.
 
+#### `loadWhenReady`
+
+Loads the audio file when it's ready. `False` as default.
+
+#### `preload`
+
+This props will be propagated to the <audio> element.
+
+> This enumerated attribute is intended to provide a hint to the browser about what the author thinks will lead to the best user experience. 
+
+https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#attr-preload
+
+`metadata` as default.
+
+
 #### `onTimeChange`
 
 While the file is playing, this callback will be triggered every second to update the controlling component that the time position has changed. This value is then expected to be passed back in using the `currentTime` prop.

--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
@@ -49,6 +49,7 @@ function AudioPlayer( {
 	currentTime,
 	playStatus = STATE_PAUSED,
 	onMetadataLoaded,
+	loadWhenReay = false,
 } ) {
 	const audioRef = useRef();
 
@@ -74,7 +75,14 @@ function AudioPlayer( {
 
 	useEffect( () => {
 		const audio = audioRef.current;
-		const mediaElement = new MediaElementPlayer( audio, meJsSettings );
+		const mediaElement = new MediaElementPlayer( audio, {
+			...meJsSettings,
+			success: function() {
+				if ( loadWhenReay && audio?.load ) {
+					audio.load();
+				}
+			}
+		} );
 
 		// Add the skip and jump buttons if needed
 		if ( onJumpBack || onSkipForward ) {

--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
@@ -127,6 +127,7 @@ function AudioPlayer( {
 		onSkipForward,
 		onMetadataLoaded,
 		loadWhenReady,
+		preload,
 	] );
 
 	// If we get lots of events from clicking on the progress bar in the MediaElement

--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
@@ -113,7 +113,16 @@ function AudioPlayer( {
 			onError && audio.removeEventListener( 'error', onError );
 			onMetadataLoaded && audio.removeEventListener( 'loadedmetadata', onMetadataLoaded );
 		};
-	}, [ audioRef, onPlay, onPause, onError, onJumpBack, onSkipForward, onMetadataLoaded ] );
+	}, [
+		audioRef,
+		onPlay,
+		onPause,
+		onError,
+		onJumpBack,
+		onSkipForward,
+		onMetadataLoaded,
+		loadWhenReady,
+	] );
 
 	// If we get lots of events from clicking on the progress bar in the MediaElement
 	// then we can get stuck in a loop. We can so by debouncing here we wait until the

--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
@@ -77,11 +77,7 @@ function AudioPlayer( {
 		const audio = audioRef.current;
 		const mediaElement = new MediaElementPlayer( audio, {
 			...meJsSettings,
-			success: function() {
-				if ( loadWhenReay && audio?.load ) {
-					audio.load();
-				}
-			}
+			success: () => loadWhenReady && audio?.load()
 		} );
 
 		// Add the skip and jump buttons if needed

--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
@@ -49,7 +49,7 @@ function AudioPlayer( {
 	currentTime,
 	playStatus = STATE_PAUSED,
 	onMetadataLoaded,
-	loadWhenReay = false,
+	loadWhenReady = false,
 } ) {
 	const audioRef = useRef();
 

--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/index.jsx
@@ -50,6 +50,7 @@ function AudioPlayer( {
 	playStatus = STATE_PAUSED,
 	onMetadataLoaded,
 	loadWhenReady = false,
+	preload = 'metadata',
 } ) {
 	const audioRef = useRef();
 
@@ -75,6 +76,10 @@ function AudioPlayer( {
 
 	useEffect( () => {
 		const audio = audioRef.current;
+
+		// Pre load audio meta data.
+		audio.preload = preload;
+
 		const mediaElement = new MediaElementPlayer( audio, {
 			...meJsSettings,
 			success: () => loadWhenReady && audio?.load()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Audio Player: support load file when ready feature

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1612872457005400?thread_ts=1612868861.488300&cid=CKZHG0QCR-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

With these changes, the media file will be initially loaded when a podcast block is added, so
* Create/edit a post
* Open the redux tool
* Add a podcast block
* set a valid RSS feed
* check that the duration is already populated in the media source

<img width="1792" alt="Screen Shot 2021-02-09 at 9 14 24 AM" src="https://user-images.githubusercontent.com/77539/107362242-44288e00-6ab7-11eb-8ea7-bd238a08f640.png">

* Confirm that changing the episode, the duration also updated to the new file.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
