### PR TITLE
Dialogue: add fallback for useDebounce

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+import { useMemoOne } from 'use-memo-one';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -24,6 +30,14 @@ import { getParticipantBySlug } from '../conversation/utils';
 
 const blockName = 'jetpack/dialogue';
 const blockNameFallback = 'core/paragraph';
+
+const useDebounceWithFallback = useDebounce
+	? useDebounce
+	: function useDebounceFallback( ...args ) {
+		const debounced = useMemoOne( () => debounce( ...args ), args );
+		useEffect( () => () => debounced.cancel(), [ debounced ] );
+		return debounced;
+	};
 
 export default function DialogueEdit( {
 	className,
@@ -64,7 +78,7 @@ export default function DialogueEdit( {
 	// Conversation context. A bridge between dialogue and conversation blocks.
 	const conversationBridge = useContext( ConversationContext );
 
-	const debounceSetDialoguesAttrs = useDebounce( setAttributes, 250 );
+	const debounceSetDialoguesAttrs = useDebounceWithFallback( setAttributes, 250 );
 
 	// Update dialogue participant with conversation participant changes.
 	useEffect( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR adds a fallback for the `useDebounce` hook. It isn't available in WordPress version 5.5. This hook was introduced in this PR https://github.com/Automattic/jetpack/pull/18646


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: add fallback for useDebounce()

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1612871290001800?thread_ts=1612868861.488300&cid=CKZHG0QCR-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Switch to WordPress core 5.5
If you use Jetpack env dev, you can run `yarn docker:wp core update --version=5.5 --force`
* Confirm that, without the changes suggested by this PR, the editor app breaks when a new Dialogue/Conversation block is created
* Confirm that, with these changes, the app works as expected.
* Try to create a conversation with many Dialogue blocks
* Set the same speaker for some of them.
* Edit a speaker label, and confirm the label is propagated to all sibling dialogue blocks.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
