### PR TITLE
eslint-changed: Use merge-base to fetch old file versions

### DIFF
--- a/tools/eslint-changed.js
+++ b/tools/eslint-changed.js
@@ -151,9 +151,12 @@ async function main() {
 
 		args = [ 'diff' ];
 		if ( argv.gitBase !== undefined ) {
-			origRef = argv.gitBase;
+			const args2 = [ 'merge-base', argv.gitBase, 'HEAD' ];
+			debug( 'Running git merge-base command:', git, args2.join( ' ' ) );
+			origRef = doCmd( git, args2 ).trim();
+			debug( 'Merge base is:', origRef );
 			newRef = 'HEAD';
-			args.push( `${ argv.gitBase }...HEAD` );
+			args.push( `${ origRef }...HEAD` );
 		} else if ( argv.gitUnstaged ) {
 			origRef = ':0';
 			newRef = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We're using `git diff gitBase...HEAD` to get a diff for line number
correction, which uses the merge-base of gitBase and HEAD as the left
side of the diff rather than gitBase itself.

But when we run eslint, we run it against the file versions from gitBase
itself rather than from the merge-base commit.

This can break the line number correction and result in unchanged issues
being reported as changed.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1612859631270800-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a branch A.
* Make a branch B from A that touches a file with eslint warnings, preferably without actually adding or removing any lines or affecting any of the warnings.
* Add a commit to A inserting or removing lines early in the file. Do not merge this into B.
* On branch B, execute `tools/eslint-changed.js --git --git-base=A the-file.js`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.