### PR TITLE
Instagram: use arguments provided by shortcode attributes

### DIFF
--- a/projects/plugins/jetpack/modules/shortcodes/instagram.php
+++ b/projects/plugins/jetpack/modules/shortcodes/instagram.php
@@ -57,7 +57,7 @@ function jetpack_instagram_enable_embeds() {
 	/**
 	 * Add auth token required by Instagram's oEmbed REST API, or proxy through WP.com.
 	 */
-	add_filter( 'oembed_fetch_url', 'jetpack_instagram_oembed_fetch_url', 10, 2 );
+	add_filter( 'oembed_fetch_url', 'jetpack_instagram_oembed_fetch_url', 10, 3 );
 
 	/**
 	 * Add JP auth headers if we're proxying through WP.com.
@@ -214,16 +214,17 @@ function jetpack_instagram_get_allowed_parameters( $url, $atts = array() ) {
  *
  * @param string $provider URL of the oEmbed provider.
  * @param string $url      URL of the content to be embedded.
+ * @param array  $args      Additional arguments for retrieving embed HTML.
  *
  * @return string
  */
-function jetpack_instagram_oembed_fetch_url( $provider, $url ) {
+function jetpack_instagram_oembed_fetch_url( $provider, $url, $args ) {
 	if ( ! wp_startswith( $provider, 'https://graph.facebook.com/v5.0/instagram_oembed/' ) ) {
 		return $provider;
 	}
 
 	// Get a set of URL and parameters supported by Facebook.
-	$clean_parameters = jetpack_instagram_get_allowed_parameters( $url );
+	$clean_parameters = jetpack_instagram_get_allowed_parameters( $url, $args );
 
 	// Replace existing URL by our clean version.
 	if ( ! empty( $clean_parameters['url'] ) ) {

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.instagram.php
@@ -179,13 +179,18 @@ BODY;
 	}
 
 	/**
+	 * Test different oEmbed URLs and their output.
+	 *
 	 * @covers ::jetpack_instagram_oembed_fetch_url
+	 * @dataProvider get_instagram_urls
+	 *
+	 * @param string $original Instagram URL provided by user.
+	 * @param string $expected Instagram URL embedded in the final post content.
 	 */
-	public function test_instagram_replace_image_url_with_embed() {
+	public function test_instagram_oembed_fetch_url( $original, $expected ) {
 		global $post;
 
-		$instagram_url = 'https://www.instagram.com/p/BnMO9vRleEx/';
-		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_url ) );
+		$post = $this->factory->post->create_and_get( array( 'post_content' => $original ) );
 
 		setup_postdata( $post );
 		ob_start();
@@ -194,100 +199,36 @@ BODY;
 		wp_reset_postdata();
 
 		$this->assertContains(
-			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url,
+			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $expected,
 			$actual
 		);
 	}
 
 	/**
-	 * @covers ::jetpack_instagram_oembed_fetch_url
+	 * List of variation of Instagram embed URLs.
 	 */
-	public function test_instagram_replace_image_url_with_embed_and_remove_query_args() {
-		global $post;
-
-		$instagram_url                 = 'https://www.instagram.com/p/BnMO9vRleEx/';
-		$instagram_url_with_query_args = $instagram_url . '?utm_source=ig_web_copy_link';
-
-		$post = $this->factory->post->create_and_get( array( 'post_content' => $instagram_url_with_query_args ) );
-
-		setup_postdata( $post );
-		ob_start();
-		the_content();
-		$actual = ob_get_clean();
-		wp_reset_postdata();
-
-		$this->assertContains(
-			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url . '"',
-			$actual
-		);
-	}
-
-	/**
-	 * @covers ::jetpack_instagram_oembed_fetch_url
-	 */
-	public function test_instagram_replace_video_url_with_embed() {
-		global $post;
-
-		$instagram_url = 'https://www.instagram.com/tv/BkQjCfsBIzi/';
-		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_url ) );
-
-		setup_postdata( $post );
-		ob_start();
-		the_content();
-		$actual = ob_get_clean();
-		wp_reset_postdata();
-
-		$this->assertContains(
-			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_url,
-			$actual
-		);
-	}
-
-	/**
-	 * @covers ::jetpack_instagram_oembed_fetch_url
-	 */
-	public function test_instagram_replace_profile_image_url_with_embed() {
-		global $post;
-
-		$instagram_username      = 'jeherve';
-		$instagram_id            = 'BnMO9vRleEx';
-		$instagram_original_url  = 'https://www.instagram.com/' . $instagram_username . '/p/' . $instagram_id . '/';
-		$instagram_canonical_url = 'https://www.instagram.com/p/' . $instagram_id . '/';
-		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_original_url ) );
-
-		setup_postdata( $post );
-		ob_start();
-		the_content();
-		$actual = ob_get_clean();
-		wp_reset_postdata();
-
-		$this->assertContains(
-			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_canonical_url,
-			$actual
-		);
-	}
-
-	/**
-	 * @covers ::jetpack_instagram_oembed_fetch_url
-	 */
-	public function test_instagram_replace_profile_video_url_with_embed() {
-		global $post;
-
-		$instagram_username      = 'instagram';
-		$instagram_id            = 'BkQjCfsBIzi';
-		$instagram_original_url  = 'https://www.instagram.com/' . $instagram_username . '/tv/' . $instagram_id . '/';
-		$instagram_canonical_url = 'https://www.instagram.com/tv/' . $instagram_id . '/';
-		$post          = $this->factory->post->create_and_get( array( 'post_content' => $instagram_original_url ) );
-
-		setup_postdata( $post );
-		ob_start();
-		the_content();
-		$actual = ob_get_clean();
-		wp_reset_postdata();
-
-		$this->assertContains(
-			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="' . $instagram_canonical_url,
-			$actual
+	public function get_instagram_urls() {
+		return array(
+			'simple_image_embed'            => array(
+				'https://www.instagram.com/p/BnMO9vRleEx/',
+				'https://www.instagram.com/p/BnMO9vRleEx/',
+			),
+			'instagram_url_with_query_args' => array(
+				'https://www.instagram.com/p/BnMO9vRleEx/?utm_source=ig_web_copy_link',
+				'https://www.instagram.com/p/BnMO9vRleEx/',
+			),
+			'video_embed'                   => array(
+				'https://www.instagram.com/tv/BkQjCfsBIzi/',
+				'https://www.instagram.com/tv/BkQjCfsBIzi/',
+			),
+			'image_embed_with_username'     => array(
+				'https://www.instagram.com/jeherve/p/BnMO9vRleEx/',
+				'https://www.instagram.com/p/BnMO9vRleEx/',
+			),
+			'video_embed_with_username'     => array(
+				'https://www.instagram.com/instagram/tv/BkQjCfsBIzi/',
+				'https://www.instagram.com/tv/BkQjCfsBIzi/',
+			),
 		);
 	}
 


### PR DESCRIPTION
Fixes #18389

#### Changes proposed in this Pull Request:

When one uses the Instagram shortcode to embed an Instagram post, one can provide additional shortcode attributes such as hidecaption. Those attributes are the same options you can add as query strings of the instagram URL when you simply paste an Instagram URL on its own line in the editor and let oEmbed do the work.

Until now, however, although we did pass those shortcode attributes to `WP_Embed::shortcode()`, we did not actually use them when we built the final oEmbed fetch URL.

**Note**: I originally thought to add tests for this, but we already had tests for `jetpack_instagram_oembed_fetch_url`; I just made them a bit easier to parse. 

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:

Shortcodes: use arguments provided by shortcode attributes for the Instagram embeds.
