### PR TITLE
Anchor.fm / Widget Visibility: avoid fatal errors when using PHP 8

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -69,7 +69,11 @@ function process_anchor_params() {
 
 	$current_screen = \get_current_screen();
 	// TODO: Replace `$current_screen->is_block_editor()` with `wp_should_load_block_editor_scripts_and_styles()` that is introduced in WP 5.6.
-	if ( method_exists( $current_screen, 'is_block_editor' ) && ! $current_screen->is_block_editor() ) {
+	if (
+		is_object( $current_screen )
+		&& method_exists( $current_screen, 'is_block_editor' )
+		&& ! $current_screen->is_block_editor()
+	) {
 		// Return early if we are not in the block editor.
 		return;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/anchor-fm.php
@@ -70,8 +70,7 @@ function process_anchor_params() {
 	$current_screen = \get_current_screen();
 	// TODO: Replace `$current_screen->is_block_editor()` with `wp_should_load_block_editor_scripts_and_styles()` that is introduced in WP 5.6.
 	if (
-		is_object( $current_screen )
-		&& method_exists( $current_screen, 'is_block_editor' )
+		$current_screen instanceof \WP_Screen
 		&& ! $current_screen->is_block_editor()
 	) {
 		// Return early if we are not in the block editor.

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -25,8 +25,7 @@ class Jetpack_Widget_Conditions {
 		$current_screen = get_current_screen();
 		// TODO: Replace `$current_screen->is_block_editor()` with `wp_should_load_block_editor_scripts_and_styles()` that is introduced in WP 5.6.
 		if (
-			is_object( $current_screen )
-			&& method_exists( $current_screen, 'is_block_editor' )
+			$current_screen instanceof \WP_Screen
 			&& $current_screen->is_block_editor()
 		) {
 			return;

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -23,8 +23,12 @@ class Jetpack_Widget_Conditions {
 
 	public static function widget_admin_setup() {
 		$current_screen = get_current_screen();
-		// TODO: Replace `$current_screen->is_block_editor()` with `wp_should_load_block_editor_scripts_and_styles()` that is introduced in WP 5.6
-		if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+		// TODO: Replace `$current_screen->is_block_editor()` with `wp_should_load_block_editor_scripts_and_styles()` that is introduced in WP 5.6.
+		if (
+			is_object( $current_screen )
+			&& method_exists( $current_screen, 'is_block_editor' )
+			&& $current_screen->is_block_editor()
+		) {
 			return;
 		}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Starting in PHP 8, method_exists() now throws a TypeError when not using an object or a string. Let's avoid any fatals by checking for a valid object first.


#### Jetpack product discussion
Primary issue: #17166
#### Does this pull request change what data or activity we track or use?
No
#### Testing instructions:

* Start on a site running PHP 8.
* Enable the Widget visibility module.
* Go to Appearance > Widgets
* Add a new widget, and add some visibility settings.
* As you attempt to save those settings, you'll notice the Fatal error in your logs.
* Apply the patch.
* You should now be able to save your visibility settings with no errors.

#### Proposed changelog entry for your changes:

* Anchor.fm / Widget Visibility: avoid fatal errors when using PHP 8