### PR TITLE
Update Checksums to support blacklisted taxonomies.

### DIFF
--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -300,6 +300,23 @@ class Settings {
 	}
 
 	/**
+	 * Returns structured SQL clause for blacklisted taxonomies.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return array taxonomies filter values
+	 */
+	public static function get_blacklisted_taxonomies_structured() {
+		return array(
+			'taxonomy' => array(
+				'operator' => 'NOT IN',
+				'values'   => array_map( 'esc_sql', self::get_setting( 'taxonomies_blacklist' ) ),
+			),
+		);
+	}
+
+	/**
 	 * Returns escaped SQL for blacklisted comment meta.
 	 * Can be injected directly into a WHERE clause.
 	 *

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -95,6 +95,20 @@ class Table_Checksum {
 	private $parent_table = null;
 
 	/**
+	 * What field to use for the parent table join, if it has a "parent" table.
+	 *
+	 * @var mixed|null
+	 */
+	private $parent_join_field = null;
+
+	/**
+	 * What field to use for the table join, if it has a "parent" table.
+	 *
+	 * @var mixed|null
+	 */
+	private $table_join_field = null;
+
+	/**
 	 * Table_Checksum constructor.
 	 *
 	 * @param string $table The table to calculate checksums for.
@@ -144,12 +158,14 @@ class Table_Checksum {
 				'filter_values'   => Sync\Settings::get_disallowed_post_types_structured(),
 			),
 			'postmeta'           => array(
-				'table'           => $wpdb->postmeta,
-				'range_field'     => 'post_id',
-				'key_fields'      => array( 'post_id', 'meta_key' ),
-				'checksum_fields' => array( 'meta_key', 'meta_value' ),
-				'filter_values'   => Sync\Settings::get_allowed_post_meta_structured(),
-				'parent_table'    => 'posts',
+				'table'             => $wpdb->postmeta,
+				'range_field'       => 'post_id',
+				'key_fields'        => array( 'post_id', 'meta_key' ),
+				'checksum_fields'   => array( 'meta_key', 'meta_value' ),
+				'filter_values'     => Sync\Settings::get_allowed_post_meta_structured(),
+				'parent_table'      => 'posts',
+				'parent_join_field' => 'ID',
+				'table_join_field'  => 'post_id',
 			),
 			'comments'           => array(
 				'table'           => $wpdb->comments,
@@ -157,48 +173,58 @@ class Table_Checksum {
 				'key_fields'      => array( 'comment_ID' ),
 				'checksum_fields' => array( 'comment_content' ),
 				'filter_values'   => array(
-					'comment_type' => array(
+					'comment_type'     => array(
 						'operator' => 'IN',
 						'values'   => apply_filters(
 							'jetpack_sync_whitelisted_comment_types',
 							array( '', 'comment', 'trackback', 'pingback', 'review' )
 						),
 					),
+					'comment_approved' => array(
+						'operator' => '<>',
+						'values'   => array( 'spam' ),
+					),
 				),
-				'filter_sql'      => Sync\Settings::get_comments_filter_sql(),
 			),
 			'commentmeta'        => array(
-				'table'           => $wpdb->commentmeta,
-				'range_field'     => 'comment_id',
-				'key_fields'      => array( 'comment_id', 'meta_key' ),
-				'checksum_fields' => array( 'meta_key', 'meta_value' ),
-				'filter_values'   => Sync\Settings::get_allowed_comment_meta_structured(),
-				'parent_table'    => 'comments',
+				'table'             => $wpdb->commentmeta,
+				'range_field'       => 'comment_id',
+				'key_fields'        => array( 'comment_id', 'meta_key' ),
+				'checksum_fields'   => array( 'meta_key', 'meta_value' ),
+				'filter_values'     => Sync\Settings::get_allowed_comment_meta_structured(),
+				'parent_table'      => 'comments',
+				'parent_join_field' => 'comment_ID',
+				'table_join_field'  => 'comment_id',
 			),
 			'terms'              => array(
 				'table'           => $wpdb->terms,
 				'range_field'     => 'term_id',
 				'key_fields'      => array( 'term_id' ),
 				'checksum_fields' => array( 'term_id', 'name', 'slug' ),
+				'parent_table'    => 'term_taxonomy',
 			),
 			'termmeta'           => array(
 				'table'           => $wpdb->termmeta,
 				'range_field'     => 'term_id',
 				'key_fields'      => array( 'term_id', 'meta_key' ),
 				'checksum_fields' => array( 'meta_key', 'meta_value' ),
-				'parent_table'    => 'terms',
+				'parent_table'    => 'term_taxonomy',
 			),
 			'term_relationships' => array(
-				'table'           => $wpdb->term_relationships,
-				'range_field'     => 'object_id',
-				'key_fields'      => array( 'object_id' ),
-				'checksum_fields' => array( 'object_id', 'term_taxonomy_id' ),
+				'table'             => $wpdb->term_relationships,
+				'range_field'       => 'object_id',
+				'key_fields'        => array( 'object_id' ),
+				'checksum_fields'   => array( 'object_id', 'term_taxonomy_id' ),
+				'parent_table'      => 'term_taxonomy',
+				'parent_join_field' => 'term_taxonomy_id',
+				'table_join_field'  => 'term_taxonomy_id',
 			),
 			'term_taxonomy'      => array(
 				'table'           => $wpdb->term_taxonomy,
 				'range_field'     => 'term_taxonomy_id',
 				'key_fields'      => array( 'term_taxonomy_id' ),
 				'checksum_fields' => array( 'term_taxonomy_id', 'term_id', 'taxonomy', 'description', 'parent' ),
+				'filter_values'   => Sync\Settings::get_blacklisted_taxonomies_structured(),
 			),
 			'links'              => $wpdb->links, // TODO describe in the array format or add exceptions.
 			'options'            => $wpdb->options, // TODO describe in the array format or add exceptions.
@@ -217,6 +243,8 @@ class Table_Checksum {
 		$this->filter_values         = isset( $table_configuration['filter_values'] ) ? $table_configuration['filter_values'] : null;
 		$this->additional_filter_sql = ! empty( $table_configuration['filter_sql'] ) ? $table_configuration['filter_sql'] : '';
 		$this->parent_table          = isset( $table_configuration['parent_table'] ) ? $table_configuration['parent_table'] : null;
+		$this->parent_join_field     = isset( $table_configuration['parent_join_field'] ) ? $table_configuration['parent_join_field'] : $table_configuration['range_field'];
+		$this->table_join_field      = isset( $table_configuration['table_join_field'] ) ? $table_configuration['table_join_field'] : $table_configuration['range_field'];
 	}
 
 	/**
@@ -323,6 +351,7 @@ class Table_Checksum {
 			switch ( $filter['operator'] ) {
 				case 'IN':
 				case 'NOT IN':
+				case '<>':
 					$values_placeholders = implode( ',', array_fill( 0, count( $filter['values'] ), '%s' ) );
 					$statement           = "{$key} {$filter['operator']} ( $values_placeholders )";
 
@@ -345,10 +374,11 @@ class Table_Checksum {
 	 * @param int|null   $range_to      End of the range.
 	 * @param array|null $filter_values Additional filter values. Not used at the moment.
 	 * @param string     $table_prefix  Table name to be prefixed to the columns. Used in sub-queries where columns can clash.
+	 * @param bool       $exclude_range Flag to exclude addition of range filter for parent tables.
 	 *
 	 * @return string
 	 */
-	public function build_filter_statement( $range_from = null, $range_to = null, $filter_values = null, $table_prefix = '' ) {
+	public function build_filter_statement( $range_from = null, $range_to = null, $filter_values = null, $table_prefix = '', $exclude_range = false ) {
 		global $wpdb;
 
 		// If there is a field prefix that we want to use with table aliases.
@@ -359,13 +389,15 @@ class Table_Checksum {
 		 */
 
 		$filter_array = array( '1 = 1' );
-		if ( null !== $range_from ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$filter_array[] = $wpdb->prepare( "{$parent_prefix}{$this->range_field} >= %d", array( intval( $range_from ) ) );
-		}
-		if ( null !== $range_to ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$filter_array[] = $wpdb->prepare( "{$parent_prefix}{$this->range_field} <= %d", array( intval( $range_to ) ) );
+		if ( ! $exclude_range ) {
+			if ( null !== $range_from ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$filter_array[] = $wpdb->prepare( "{$parent_prefix}{$this->range_field} >= %d", array( intval( $range_from ) ) );
+			}
+			if ( null !== $range_to ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$filter_array[] = $wpdb->prepare( "{$parent_prefix}{$this->range_field} <= %d", array( intval( $range_to ) ) );
+			}
 		}
 
 		/**
@@ -435,7 +467,12 @@ class Table_Checksum {
 		$key_fields = implode( ',', $key_fields );
 
 		// Prepare the checksum fields.
-		$checksum_fields_string = implode( ',', array_merge( $this->checksum_fields, array( $salt ) ) );
+		$checksum_fields = array();
+		// Prefix the fields with the table name, to avoid clashes in queries with sub-queries (e.g. meta tables).
+		foreach ( $this->checksum_fields as $field ) {
+			$checksum_fields[] = $this->table . '.' . $field;
+		}
+		$checksum_fields_string = implode( ',', array_merge( $checksum_fields, array( $salt ) ) );
 
 		$additional_fields = '';
 		if ( $granular_result ) {
@@ -451,10 +488,10 @@ class Table_Checksum {
 		$join_statement = '';
 		if ( $this->parent_table ) {
 			$parent_table_obj    = new Table_Checksum( $this->parent_table );
-			$parent_filter_query = $parent_table_obj->build_filter_statement( $range_from, $range_to, null, 'parent_table' );
+			$parent_filter_query = $parent_table_obj->build_filter_statement( $range_from, $range_to, null, 'parent_table', true );
 
 			$join_statement = "
-				INNER JOIN {$parent_table_obj->table} as parent_table ON ({$this->table}.{$this->range_field} = parent_table.{$parent_table_obj->range_field} AND {$parent_filter_query})
+				INNER JOIN {$parent_table_obj->table} as parent_table ON ({$this->table}.{$this->table_join_field} = parent_table.{$this->parent_join_field} AND {$parent_filter_query})
 			";
 		}
 

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -181,7 +181,7 @@ class Table_Checksum {
 						),
 					),
 					'comment_approved' => array(
-						'operator' => '<>',
+						'operator' => 'NOT IN',
 						'values'   => array( 'spam' ),
 					),
 				),
@@ -351,7 +351,6 @@ class Table_Checksum {
 			switch ( $filter['operator'] ) {
 				case 'IN':
 				case 'NOT IN':
-				case '<>':
 					$values_placeholders = implode( ',', array_fill( 0, count( $filter['values'] ), '%s' ) );
 					$statement           = "{$key} {$filter['operator']} ( $values_placeholders )";
 
@@ -360,7 +359,6 @@ class Table_Checksum {
 
 					$result[] = $prepared_statement;
 					break;
-				// TODO implement other operators if needed.
 			}
 		}
 

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -372,11 +372,10 @@ class Table_Checksum {
 	 * @param int|null   $range_to      End of the range.
 	 * @param array|null $filter_values Additional filter values. Not used at the moment.
 	 * @param string     $table_prefix  Table name to be prefixed to the columns. Used in sub-queries where columns can clash.
-	 * @param bool       $exclude_range Flag to exclude addition of range filter for parent tables.
 	 *
 	 * @return string
 	 */
-	public function build_filter_statement( $range_from = null, $range_to = null, $filter_values = null, $table_prefix = '', $exclude_range = false ) {
+	public function build_filter_statement( $range_from = null, $range_to = null, $filter_values = null, $table_prefix = '' ) {
 		global $wpdb;
 
 		// If there is a field prefix that we want to use with table aliases.
@@ -387,15 +386,13 @@ class Table_Checksum {
 		 */
 
 		$filter_array = array( '1 = 1' );
-		if ( ! $exclude_range ) {
-			if ( null !== $range_from ) {
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				$filter_array[] = $wpdb->prepare( "{$parent_prefix}{$this->range_field} >= %d", array( intval( $range_from ) ) );
-			}
-			if ( null !== $range_to ) {
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				$filter_array[] = $wpdb->prepare( "{$parent_prefix}{$this->range_field} <= %d", array( intval( $range_to ) ) );
-			}
+		if ( null !== $range_from ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$filter_array[] = $wpdb->prepare( "{$parent_prefix}{$this->range_field} >= %d", array( intval( $range_from ) ) );
+		}
+		if ( null !== $range_to ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$filter_array[] = $wpdb->prepare( "{$parent_prefix}{$this->range_field} <= %d", array( intval( $range_to ) ) );
 		}
 
 		/**
@@ -486,7 +483,7 @@ class Table_Checksum {
 		$join_statement = '';
 		if ( $this->parent_table ) {
 			$parent_table_obj    = new Table_Checksum( $this->parent_table );
-			$parent_filter_query = $parent_table_obj->build_filter_statement( $range_from, $range_to, null, 'parent_table', true );
+			$parent_filter_query = $parent_table_obj->build_filter_statement( null, null, null, 'parent_table' );
 
 			$join_statement = "
 				INNER JOIN {$parent_table_obj->table} as parent_table ON ({$this->table}.{$this->table_join_field} = parent_table.{$this->parent_join_field} AND {$parent_filter_query})


### PR DESCRIPTION
The Checksum process rolled out in Jetpack 9.3 did not limit taxonomies based on existing blacklists. This update overhauls the table configuration and supporting functionality so that we don't identify content as missing that is not supposed to be Synced to the cache site.


#### Changes proposed in this Pull Request:
* Updates taxonomy checksums to exclude blacklisted taxonomies.

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* Perform a checksum of all tables.
```$rs = new Automattic\Jetpack\Sync\Replicastore();```
* Verify that no errors are returned and we have a checksum for all 7 tables 
* Note the checksum values for terms, term_taxonomy and term_relationships
* Add a new taxonomy of "ancestors", "comments_number", "the_categories" and "usermeta"
* Add terms to each of the new categories
* Add terms to existing posts
* Perform a new checksum of all tables.
* Verify that the checksum values for terms, term_taxonomy and term_relationships have not changed from before terms/taxonomies were added.

#### Proposed changelog entry for your changes:
* Jetpack Sync - Update checksum process to exclude blacklisted taxonomies.
