### PR TITLE
Adds a WordPress.org theme install menu item.

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -396,8 +396,8 @@ class Admin_Menu {
 		remove_submenu_page( 'themes.php', 'custom-background' );
 
 		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), $appearance_cap, $themes_slug, null, 'dashicons-admin-appearance', 60 );
-		add_submenu_page( $themes_slug, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', $themes_slug, null, 5 );
-		add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $this->customize_slug, null, 10 );
+		add_submenu_page( $themes_slug, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', $themes_slug, null, 0 );
+		add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $this->customize_slug, null, 1 );
 
 		// Maintain id as JS selector.
 		$GLOBALS['menu'][60][5] = 'menu-appearance'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -38,6 +38,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$wp_admin = $this->should_link_to_wp_admin();
 
 		$this->add_my_home_menu( $wp_admin );
+		$this->add_theme_install_menu( $wp_admin );
 
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request ) {
@@ -202,5 +203,16 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
 		parent::add_options_menu( $wp_admin );
+	}
+
+	/**
+	 * Adds a WordPress.org theme install menu item.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_theme_install_menu( $wp_admin = false ) {
+		$parent_menu_slug = $wp_admin ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
+
+		add_submenu_page( $parent_menu_slug, esc_attr__( 'WordPress.org Themes', 'jetpack' ), __( 'WordPress.org Themes', 'jetpack' ), 'switch_themes', 'theme-install.php', null, 1 );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -213,6 +213,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_theme_install_menu( $wp_admin = false ) {
 		$parent_menu_slug = $wp_admin ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
 
-		add_submenu_page( $parent_menu_slug, esc_attr__( 'WordPress.org Themes', 'jetpack' ), __( 'WordPress.org Themes', 'jetpack' ), 'switch_themes', 'theme-install.php', null, 1 );
+		add_submenu_page( $parent_menu_slug, esc_attr__( 'Add New Theme', 'jetpack' ), __( 'Add New Theme', 'jetpack' ), 'install_themes', 'theme-install.php', null, 1 );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -345,8 +345,16 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 			'theme-install.php',
 			'Add New Theme',
 		);
+		static::$admin_menu->add_appearance_menu( false );
 		static::$admin_menu->add_theme_install_menu( false );
 
-		$this->assertContains( $submenu_item, $submenu[ $slug ] );
+		// Multisite users don't have the `install_themes` capability by default,
+		// so we have to make a dynamic check based on whether the current user can
+		// install themes.
+		if ( current_user_can( 'install_themes' ) ) {
+			$this->assertContains( $submenu_item, $submenu[ $slug ] );
+		} else {
+			$this->assertNotContains( $submenu_item, $submenu[ $slug ] );
+		}
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -329,4 +329,24 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		// Check Plugins menu always links to WP Admin.
 		$this->assertContains( 'plugins.php', $menu[65] );
 	}
+
+	/**
+	 * Tests add_theme_install_menu
+	 *
+	 * @covers ::add_theme_install_menu
+	 */
+	public function test_add_theme_install_menu() {
+		global $submenu;
+
+		$slug         = 'https://wordpress.com/themes/' . static::$domain;
+		$submenu_item = array(
+			'WordPress.org Themes',
+			'switch_themes',
+			'theme-install.php',
+			'WordPress.org Themes',
+		);
+		static::$admin_menu->add_theme_install_menu( false );
+
+		$this->assertContains( $submenu_item, $submenu[ $slug ] );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -340,10 +340,10 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 
 		$slug         = 'https://wordpress.com/themes/' . static::$domain;
 		$submenu_item = array(
-			'WordPress.org Themes',
-			'switch_themes',
+			'Add New Theme',
+			'install_themes',
 			'theme-install.php',
-			'WordPress.org Themes',
+			'Add New Theme',
 		);
 		static::$admin_menu->add_theme_install_menu( false );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/49238

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds a WordPress.org theme install menu item for WoA sites only so users have the chance to install a theme from the WordPress.org repository

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Select this branch in Jetpack Beta
* Make sure that a Appearance -> WordPress.org Themes exists under Themes 
* The above menu redirects to `/wp-admin/theme-install.php`
* Run `yarn docker:phpunit --filter Test_Atomic_Admin_Menu` and confirm there are no failures

Before | After
-------|------
![](https://cln.sh/FJKR4p+) | ![](https://cln.sh/RFR3DB+)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Adds a WordPress.org theme install menu item for Atomic sites.
