### PR TITLE
API Endpoints: filter the switchBlogOwner http response before the request.

### DIFF
--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -114,16 +114,18 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 	/**
 	 * Used to simulate a successful response to any XML-RPC request.
-	 * Should be hooked on the `http_response` filter.
+	 * Should be hooked on the `pre_http_resquest` filter.
 	 *
-	 * @param array|obj $response HTTP Response.
-	 * @param array     $args     HTTP request arguments.
-	 * @param string    $url      The request URL.
+	 * @param false  $preempt A preemptive return value of an HTTP request.
+	 * @param array  $args    HTTP request arguments.
+	 * @param string $url     The request URL.
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function mock_xmlrpc_success( $response, $args, $url ) {
+	public function mock_xmlrpc_success( $preempt, $args, $url ) {
 		if ( strpos( $url, 'https://jetpack.wordpress.com/xmlrpc.php' ) !== false ) {
+			$response = array();
+
 			$response['body'] = '
 				<methodResponse>
 					<params>
@@ -135,9 +137,10 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 			';
 
 			$response['response']['code'] = 200;
+			return $response;
 		}
 
-		return $response;
+		return $preempt;
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -133,6 +133,8 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 					</params>
 				</methodResponse>
 			';
+
+			$response['response']['code'] = 200;
 		}
 
 		return $response;
@@ -1003,11 +1005,11 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		) );
 
 		// Change owner to valid user
-		add_filter( 'http_response', array( $this, 'mock_xmlrpc_success' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10, 3 );
 		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => $new_owner->ID ), 'POST' );
 		$this->assertResponseStatus( 200, $response );
 		$this->assertEquals( $new_owner->ID, Jetpack_Options::get_option( 'master_user' ), 'Master user not changed' );
-		remove_filter( 'http_response', array( $this, 'mock_xmlrpc_success' ), 10 );
+		remove_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10 );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The `WP_Test_Jetpack_REST_API_endpoints::test_change_owner` test started failing today with the message "Failed asserting that 500 matches expected 200".

It looks like the [jetpack.switchBlogOwner request](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php#L1824) is returning an error. We haven’t identified the root cause of the failure, but manual testing has not revealed any issues with changing the blog owner.

To fix the test failure, we can intercept the http request and provide the mocked http response using the `pre_http_request` filter in the `WP_Test_Jetpack_REST_API_endpoints::test_change_owner` method. 

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Verify that the tests pass.

#### Proposed changelog entry for your changes:
* n/a
