### PR TITLE
Dialogue: set Dialogue timestamp from the toolbar button

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -128,7 +128,10 @@ export default function DialogueEdit( {
 			<BlockControls>
 				{ mediaSource && (
 					<MediaPlayerToolbarControl
-						onTimestampClick={ time => setTimestamp( convertSecondsToTimeCode( time ) ) }
+						onTimestampClick={ time => {
+							setAttributes( { showTimestamp: true } );
+							setTimestamp( convertSecondsToTimeCode( time ) );
+						} }
 					/>
 				) }
 			</BlockControls>

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -128,7 +128,7 @@ export default function DialogueEdit( {
 			<BlockControls>
 				{ mediaSource && (
 					<MediaPlayerToolbarControl
-						onTimeChange={ time => setTimestamp( convertSecondsToTimeCode( time ) ) }
+						onTimestampClick={ time => setTimestamp( convertSecondsToTimeCode( time ) ) }
 					/>
 				) }
 			</BlockControls>

--- a/projects/plugins/jetpack/extensions/shared/components/media-player-control/index.js
+++ b/projects/plugins/jetpack/extensions/shared/components/media-player-control/index.js
@@ -28,6 +28,7 @@ export function MediaPlayerControl( {
 	jumpBackIcon = ControlBackFiveIcon,
 	skipForwardIcon = ControlForwardFiveIcon,
 	currenTimeDisplay = true,
+	onTimestampClick,
 } ) {
 	const {
 		playerState,
@@ -106,15 +107,17 @@ export function MediaPlayerControl( {
 			) }
 
 			{ currenTimeDisplay && (
-				<div
+				<ToolbarButton
 					className={ classnames(
 						'media-player-control__current-time', {
 							'is-disabled': isDisabled,
 						}
 					) }
+					label={ __( 'Set timestamp', 'jetpack' ) }
+					onClick={ () => onTimestampClick( mediaCurrentTime ) }
 				>
 					{ timeInFormat }
-				</div>
+				</ToolbarButton>
 			) }
 		</>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR renders the timestamp in the block toolbar with a Button component, which provides a way to set the Dialogue timestamp by clicking on it.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: set Dialogue timestamp from the toolbar button

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1612991089094400-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create/edit a post
* Add a podcast block with a valid RSS feed. You can use this one: https://distributed.blog/2020/07/24/lara-hogan-management-secrets/
* Add a Conversation/Dialogue blocks composition
* Confirm that is possible to set the Dialogue timestamp value by clicking on the timestamp button, rendered in the block toolbar.
<img width="433" alt="Screen Shot 2021-02-10 at 7 02 20 PM" src="https://user-images.githubusercontent.com/77539/107578515-98746080-6bd2-11eb-9dcc-93501bcb2e5c.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
