### PR TITLE
Conversation/Dialogue: render render speaker label properly

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/components/participants-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/components/participants-controls.js
@@ -4,13 +4,18 @@
 import { Button } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { getPlainText } from '../utils';
+
 function ParticipantsLabelControl( { className, participants, onDelete } ) {
 	return (
 		<div className={ `${ className }__participant-control` }>
 			{ participants.map( ( { label, slug } ) => (
 				<div key={ `${ slug }-key` } className={ `${ className }__participant` }>
 					<div className={ `${ className }__participant-label` }>
-						{ label }
+						{ getPlainText( label ) }
 					</div>
 
 					<Button

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -13,7 +13,7 @@ import { Panel, PanelBody } from '@wordpress/components';
 import './editor.scss';
 import { ParticipantsSelector } from './components/participants-controls';
 import TranscriptionContext from './components/context';
-import { getParticipantByLabel, cleanFormatStyle } from './utils';
+import { getParticipantByLabel } from './utils';
 
 const TRANSCRIPTION_TEMPLATE = [ [ 'jetpack/dialogue' ] ];
 
@@ -27,8 +27,6 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 					if ( participant.slug !== updatedParticipant.slug ) {
 						return participant;
 					}
-
-					updatedParticipant.label = cleanFormatStyle( updatedParticipant.label );
 
 					return {
 						...participant,
@@ -45,7 +43,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 			return;
 		}
 
-		const sanitizedSpeakerLabel = cleanFormatStyle( newSpeakerLabel );
+		const sanitizedSpeakerLabel = newSpeakerLabel.trim();
 		// Do not add speakers with empty names.
 		if ( ! sanitizedSpeakerLabel?.length ) {
 			return;

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -14,6 +14,6 @@ export function getParticipantByLabel ( participants, participantLabel ) {
 	return part?.length ? part[ 0 ] : null;
 }
 
-export function cleanFormatStyle( html ) {
+export function getPlainText( html ) {
 	return getTextContent( create( { html } ) )?.trim();
 }

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -3,6 +3,7 @@
  * WordPress dependencies
  */
 import { create, getTextContent } from '@wordpress/rich-text';
+import { escapeHTML } from '@wordpress/escape-html';
 
 export function getParticipantBySlug( participants, participantSlug ) {
 	const part = participants.filter( ( { slug } ) => ( slug === participantSlug ) );
@@ -14,6 +15,11 @@ export function getParticipantByLabel ( participants, participantLabel ) {
 	return part?.length ? part[ 0 ] : null;
 }
 
-export function getPlainText( html ) {
-	return getTextContent( create( { html } ) )?.trim();
+export function getPlainText( html, escape = false ) {
+	const text = getTextContent( create( { html } ) )?.trim();
+	if ( ! escape ) {
+		return text;
+	}
+
+	return escapeHTML( text );
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -22,7 +22,7 @@ import { escapeHTML } from '@wordpress/escape-html';
 /**
  * Internal dependencies
  */
-import { getParticipantByLabel, getParticipantBySlug, cleanFormatStyle } from '../../conversation/utils';
+import { getParticipantByLabel, getParticipantBySlug, getPlainText } from '../../conversation/utils';
 
 const EDIT_MODE_ADDING = 'is-adding';
 const EDIT_MODE_SELECTING = 'is-selecting';
@@ -175,7 +175,7 @@ export function SpeakerEditControl( {
 			setEditingMode( EDIT_MODE_EDITING );
 			return onUpdate( {
 				...participant,
-				label: escapeHTML( cleanFormatStyle( label ) ),
+				label: escapeHTML( getPlainText( label ) ),
 			} );
 		}
 
@@ -186,7 +186,7 @@ export function SpeakerEditControl( {
 		}
 
 		// Add a new speaker.
-		onAdd( escapeHTML( cleanFormatStyle( label ) ) );
+		onAdd( escapeHTML( getPlainText( label ) ) );
 		return setEditingMode( EDIT_MODE_ADDING );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -17,11 +17,12 @@ import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 import { useMemo, useState, useEffect, Component } from '@wordpress/element';
+import { escapeHTML } from '@wordpress/escape-html';
 
 /**
  * Internal dependencies
  */
-import { getParticipantByLabel, getParticipantBySlug } from '../../conversation/utils';
+import { getParticipantByLabel, getParticipantBySlug, cleanFormatStyle } from '../../conversation/utils';
 
 const EDIT_MODE_ADDING = 'is-adding';
 const EDIT_MODE_SELECTING = 'is-selecting';
@@ -174,7 +175,7 @@ export function SpeakerEditControl( {
 			setEditingMode( EDIT_MODE_EDITING );
 			return onUpdate( {
 				...participant,
-				label,
+				label: escapeHTML( cleanFormatStyle( label ) ),
 			} );
 		}
 
@@ -185,7 +186,7 @@ export function SpeakerEditControl( {
 		}
 
 		// Add a new speaker.
-		onAdd( label );
+		onAdd( escapeHTML( cleanFormatStyle( label ) ) );
 		return setEditingMode( EDIT_MODE_ADDING );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -60,7 +60,7 @@ export function ParticipantsControl( { participants, slug, onSelect } ) {
 			label={ __( 'Participant name', 'jetpack' ) }
 			value={ slug }
 			options={ participants.map( ( { slug: value, label } ) => ( {
-				label,
+				label: getPlainText( label ),
 				value,
 			} ) ) }
 			onChange={ participantSlug => onSelect( getParticipantBySlug(

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -17,7 +17,6 @@ import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 import { useMemo, useState, useEffect, Component } from '@wordpress/element';
-import { escapeHTML } from '@wordpress/escape-html';
 
 /**
  * Internal dependencies
@@ -175,7 +174,7 @@ export function SpeakerEditControl( {
 			setEditingMode( EDIT_MODE_EDITING );
 			return onUpdate( {
 				...participant,
-				label: escapeHTML( getPlainText( label ) ),
+				label: getPlainText( label, true ),
 			} );
 		}
 
@@ -186,7 +185,7 @@ export function SpeakerEditControl( {
 		}
 
 		// Add a new speaker.
-		onAdd( escapeHTML( getPlainText( label ) ) );
+		onAdd( getPlainText( label, true ) );
 		return setEditingMode( EDIT_MODE_ADDING );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -113,7 +113,7 @@ function refreshAutocompleter( participants ) {
 		options: participants,
 
 		getOptionLabel: ( { label } ) => (
-			<span>{ label }</span>
+			<span>{ getPlainText( label ) }</span>
 		),
 
 		getOptionKeywords: ( { label } ) => [ label ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR handles setting the speaker label in order to prevent adding format styles, and also allowing special characters.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation/Dialogue: render render speaker label properly.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1612970062065000-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

It's preferable testing in SImple sites  (D56853-code)

* Create a new conversation block.
* Paste the speaker name copying text with format styles: **Joey**, _Kerry_.
* Confirm that, although initially, the component shows the label with styles (like the screenshot below), once the speaker is added the styles are removed from there.

before to add | once added
-----|-------
![image](https://user-images.githubusercontent.com/77539/107585605-57357e00-6bdd-11eb-9223-0518bffd9f70.png) | ![image](https://user-images.githubusercontent.com/77539/107585684-716f5c00-6bdd-11eb-81b1-86fd99546533.png)

* Confirm that the speaker label is properly printed in the block settings (sidebar)

Dialogue sidebar |  Conversation sidebar
--------|--------
![image](https://user-images.githubusercontent.com/77539/107585773-92d04800-6bdd-11eb-8a69-22e5a18db19a.png) | ![image](https://user-images.githubusercontent.com/77539/107585798-9c59b000-6bdd-11eb-9231-3d36f44bf7dc.png)

* Save the post
* hard refresh
* Confirm it doesn't get block validation issues.
* Set a speaker name using special characters, for instance `<retro>`
* Confirm it's added properly:

Canvas | Dialogue sidebar | Conversation canvas | Autocomplete
----|-----|-----|------
![image](https://user-images.githubusercontent.com/77539/107586014-ee9ad100-6bdd-11eb-8a74-c5308baad8c4.png) | ![image](https://user-images.githubusercontent.com/77539/107586018-f2c6ee80-6bdd-11eb-9677-cd17bcd647bf.png) | ![image](https://user-images.githubusercontent.com/77539/107586028-f8243900-6bdd-11eb-9f31-dd1a07cd2c30.png) | ![image](https://user-images.githubusercontent.com/77539/107586602-032b9900-6bdf-11eb-8544-9bd80a3e583c.png)

* save - hard refresh - no block validation issues

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
