### PR TITLE
Instant Search: Fix live integration with the Customizer

### DIFF
--- a/projects/plugins/jetpack/modules/search/instant-search/lib/customize.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/customize.js
@@ -15,13 +15,7 @@ const SETTINGS_TO_STATE_MAP = new Map( [
 ] );
 
 export function isInCustomizer() {
-	return Boolean(
-		'undefined' !== typeof window.wp &&
-			window.wp.customize &&
-			window.wp.customize.settings &&
-			window.wp.customize.settings.url &&
-			window.wp.customize.settings.url.self
-	);
+	return typeof window?.wp?.customize === 'function';
 }
 
 export function bindCustomizerChanges( callback ) {


### PR DESCRIPTION
Fixes #18248.

#### Changes proposed in this Pull Request:
* Simplifies our check for the Customizer environment. Due to an overly aggressive conditional, we were failing to integrate with the Customizer's JS API when it was appropriate to do so.

#### Does this pull request change what data or activity we track or use?
None.

#### Testing instructions:
* Apply this change to your Jetpack site.
* Navigate to your site's Customizer.
* Once the Customizer has finished loading, try modifying any of the Jetpack Search configuration options. Most changes should take effect without an iframe reload.

#### Proposed changelog entry for your changes:
* Fixes a bug that prevented Jetpack Search setting changes from being shown in the Customizer.