### PR TITLE
Instant Search: Fix bugs related to modal invocation

### DIFF
--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -163,7 +163,7 @@ class SearchApp extends Component {
 		if ( ! this.state.showResults ) {
 			const value = event.target.querySelector( this.props.themeOptions.searchInputSelector )
 				?.value;
-			value && this.props.setSearchQuery( value );
+			this.props.setSearchQuery( value ); // empty string is an allowed value. Don't do a falsy check.
 			this.showResults();
 		}
 	};

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -152,6 +152,7 @@ class SearchApp extends Component {
 		this.props.initializeQueryValues( {
 			defaultSort: this.props.defaultSort,
 		} );
+		this.showResults();
 	};
 
 	handleSubmit = event => {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -158,6 +158,14 @@ class SearchApp extends Component {
 	handleSubmit = event => {
 		event.preventDefault();
 		this.handleInput.flush();
+
+		// handleInput didn't respawn the overlay. Do it manually -- form submission must spawn an overlay.
+		if ( ! this.state.showResults ) {
+			const value = event.target.querySelector( this.props.themeOptions.searchInputSelector )
+				?.value;
+			value && this.props.setSearchQuery( value );
+			this.showResults();
+		}
 	};
 
 	handleKeydown = event => {


### PR DESCRIPTION
Fixes #18555 and #18701.

#### Changes proposed in this Pull Request:
* Pressing the browser's "back" button will now properly respawn the search interface.
* Pressing a "submit" button on a search input form will now properly spawn the search interface.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Apply this change to your Jetpack Search site with the 2021 theme.
2. Start at `/` and enter a query into the search input at the footer. Ensure that the search interface spawns.
3. Click `X` at the top right to dismiss the search interface. Ensure that the query you entered in (2) remains in the search input and that the address bar has been updated to `/`.
4. Click on the "Search" button adjacent to the search input. Ensure that the overlay spawns and that the address bar has been updated to `/?q=whatever-your-query-was`.
5. Dismiss the search interface via `X` and then press "back" in your browser. Ensure that the interface respawns with the correct location in the address bar.

#### Proposed changelog entry for your changes:
* Fixes a Jetpack Search bug related to browser history navigation (back and forward).