### PR TITLE
Override masterbar to show quick links on Atomic sites

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -294,7 +294,7 @@
 	}
 
 	#wpadminbar #wp-admin-bar-ab-new-post > .ab-item {
-		box-sizing: inherit;
+		box-sizing: inherit !important;
 	}
 
 	#wpadminbar #wp-admin-bar-my-account > .ab-item {
@@ -309,5 +309,17 @@
 		position: static;
 		margin-top: 3px;
 		top: 13px;
+	}
+}
+
+@media screen and  (max-width: 480px) {
+	#wpadminbar #wp-toolbar.quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
+		width: auto;
+		margin-top: 12px;
+	}
+
+	/* Hide debug bar on mobile devices. */
+	#wpadminbar #wp-toolbar.quicklinks li#wp-admin-bar-debug-bar {
+		display: none;
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -274,7 +274,7 @@
 	color: #ffffff;
 }
 
-#wpadminbar ul#wp-admin-bar-root-default {
+#wpadminbar .quicklinks ul#wp-admin-bar-root-default {
 	padding-left: 0 !important;
 }
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -310,6 +310,11 @@
 		margin-top: 3px;
 		top: 13px;
 	}
+
+	/* Hide debug bar. */
+	#wpadminbar #wp-toolbar.quicklinks li#wp-admin-bar-debug-bar {
+		display: none;
+	}
 }
 
 @media screen and  (max-width: 480px) {
@@ -319,10 +324,5 @@
 
 	#wpadminbar #wp-toolbar.quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
 		margin-top: 12px;
-	}
-
-	/* Hide debug bar on mobile devices. */
-	#wpadminbar #wp-toolbar.quicklinks li#wp-admin-bar-debug-bar {
-		display: none;
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -236,6 +236,7 @@
 	.auto-fold #adminmenuback,
 	.auto-fold #adminmenuwrap {
 		width: 100%;
+		z-index: 171;
 	}
 
 	ul#adminmenu a.wp-has-current-submenu:after,

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -313,8 +313,11 @@
 }
 
 @media screen and  (max-width: 480px) {
-	#wpadminbar #wp-toolbar.quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
+	#wpadminbar #wp-toolbar.quicklinks li#wp-admin-bar-my-account.with-avatar > a {
 		width: auto;
+	}
+
+	#wpadminbar #wp-toolbar.quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
 		margin-top: 12px;
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -283,7 +283,7 @@
 }
 
 @media screen and (max-width: 782px) {
-	#wp-toolbar > ul > li {
+	#wpadminbar #wp-toolbar > ul > li {
 		display: block;
 	}
 
@@ -301,11 +301,12 @@
 		width: auto;
 	}
 
-	#wpadminbar .quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
+	#wpadminbar #wp-toolbar.quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
 		display: block;
 		right: auto;
 		left: auto;
 		position: static;
 		margin-top: 3px;
+		top: 13px;
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/overrides.css
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/overrides.css
@@ -107,10 +107,6 @@
 	.wp-admin.jetpack-masterbar.post-new-php.block-editor-page .wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle {
 		left: 0;
 	}
-
-	.jetpack-masterbar #wpadminbar #wp-toolbar li img.avatar {
-		top: -1px;
-	}
 }
 
 @media screen and (max-width: 782px) {
@@ -142,13 +138,5 @@
 	#wpadminbar #wp-admin-bar-jetpack-scan-notice,
 	.jetpack-masterbar #wpadminbar #wp-admin-bar-recovery-mode {
 		display: none;
-	}
-
-	.jetpack-masterbar #wpadminbar #wp-toolbar li:not(#wp-admin-bar-debug-bar) {
-		display: block;
-	}
-
-	.jetpack-masterbar #wpadminbar #wp-toolbar li img.avatar {
-		top: 13px;
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/overrides.css
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/overrides.css
@@ -107,6 +107,10 @@
 	.wp-admin.jetpack-masterbar.post-new-php.block-editor-page .wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle {
 		left: 0;
 	}
+
+	.jetpack-masterbar #wpadminbar #wp-toolbar li img.avatar {
+		top: -1px;
+	}
 }
 
 @media screen and (max-width: 782px) {
@@ -134,8 +138,17 @@
 	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar li#wp-admin-bar-newdash {
 		order: 3;
 	}
+
 	#wpadminbar #wp-admin-bar-jetpack-scan-notice,
 	.jetpack-masterbar #wpadminbar #wp-admin-bar-recovery-mode {
 		display: none;
+	}
+
+	.jetpack-masterbar #wpadminbar #wp-toolbar li:not(#wp-admin-bar-debug-bar) {
+		display: block;
+	}
+
+	.jetpack-masterbar #wpadminbar #wp-toolbar li img.avatar {
+		top: 13px;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/49793

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add specificity to admin menu CSS so that they get applied on Atomic sites.
* Additional specificity will display masterbar icons on mobile

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an Atomic site on your A8C account so that nav unification is enabled.
* Install Jetpack Beta
* Checkout this branch via Jetpack Beta plugin
* Reduce viewport to mobile view and observe changes below

Repeat steps on a non-A8C account to ensure this works as expected for non-nav unified users.

<table>
<tr>
	<td>Before</td>
	<td>After</td>
</tr>
<tr>
	<td><img src="https://user-images.githubusercontent.com/8639742/107649323-446e8800-6c75-11eb-9884-677ad8088e62.png" /></td>
	<td><img src="https://user-images.githubusercontent.com/8639742/107649373-4f291d00-6c75-11eb-8ec5-6812384a2e5e.png" /></td>
</tr>
</table>

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
