### PR TITLE
Required Review Action: update so Approvers are the default group

### DIFF
--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -1,22 +1,22 @@
-# Crew needs to review changes to the monorepo itself.
+# Jetpack Approvers need to review changes to the monorepo itself.
 - name: Monorepo itself
   paths:
    - '!projects/**'
   teams:
-   - jetpack-crew
+   - jetpack-approvers
 
-# Crew reviews the Jetpack plugin and all packages.
+# Jetpack Approvers review the Jetpack plugin and all packages.
 - name: Jetpack and packages
   paths:
    - 'projects/packages/**'
    - 'projects/plugins/jetpack/**'
   teams:
-   - jetpack-crew
+   - jetpack-approvers
 
-# Crew reviews everything that hasn't been specifically assigned above.
+# Jetpack Approvers review everything that hasn't been specifically assigned above.
 # This needs to be last.
-- name: Default to Crew
+- name: Default to Jetpack Approvers
   paths: unmatched
   teams:
-   - jetpack-crew
+   - jetpack-approvers
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

We want Jetpack Approvers to be able to approve any PR in the repo.

#### Jetpack product discussion

* See p1613000059385100-slack-CBG1CP4EN


#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Default to the Jetpack Approvers team for folks who can approve all PRs in the repo.

#### Proposed changelog entry for your changes:

* N/A