### PR TITLE
Dialogue: handling line breaks in content

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -15,6 +15,7 @@ export function getParticipantByLabel ( participants, participantLabel ) {
 	return part?.length ? part[ 0 ] : null;
 }
 
+<<<<<<< HEAD
 export function getPlainText( html, escape = false ) {
 	const text = getTextContent( create( { html } ) )?.trim();
 	if ( ! escape ) {
@@ -22,4 +23,12 @@ export function getPlainText( html, escape = false ) {
 	}
 
 	return escapeHTML( text );
+=======
+export function cleanFormatStyle( html ) {
+	if ( ! html ) {
+		return '';
+	}
+
+	return getTextContent( create( { html } ) )?.trim();
+>>>>>>> 98810ec... dialogue: re-implement replace with pargrapah
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { BASE_CLASS_NAME } from './utils';
+
 export default {
 	label: {
 		type: 'string',
@@ -19,6 +24,8 @@ export default {
 	content: {
 		type: 'string',
 		source: 'html',
-		selector: '.wp-block-jetpack-dialogue__content',
+		selector: `.${ BASE_CLASS_NAME }__content-wrapper`,
+		multiline: 'p',
+		default: '',
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -253,6 +253,7 @@ export function SpeakerEditControl( {
 			onFocusOutside={ editSpeakerHandler }
 		>
 			<RichText
+				identifier="speaker"
 				tagName="div"
 				value={ label }
 				formattingControls={ [] }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -26,7 +26,7 @@ import ConversationContext from '../conversation/components/context';
 import { STORE_ID as MEDIA_SOURCE_STORE_ID } from '../../store/media-source/constants';
 import { MediaPlayerToolbarControl } from '../../shared/components/media-player-control';
 import { convertSecondsToTimeCode } from '../../shared/components/media-player-control/utils';
-import { getParticipantBySlug } from '../conversation/utils';
+import { getParticipantBySlug, getPlainText } from '../conversation/utils';
 
 const blockName = 'jetpack/dialogue';
 const blockNameFallback = 'core/paragraph';
@@ -227,16 +227,15 @@ export default function DialogueEdit( {
 					}
 
 					// Detect if the block content is empty.
-					// If so, keep only one paragraph block,
-					// in order to avoid duplicated blocks.
+					// If so, create and render only one paragraph block.
 					if (
-						blocks[ 0 ]?.name === blockNameFallback &&
-						blocks[ 1 ]?.name === blockNameFallback &&
-						! blocks[ 0 ]?.attributes.content &&
-						! blocks[ 1 ]?.attributes.content
+						blocks[ 0 ]?.name === blockName &&
+						blocks[ 1 ]?.name === blockName &&
+						! getPlainText( blocks[ 0 ]?.attributes.content ) &&
+						! getPlainText( blocks[ 1 ]?.attributes.content )
 					) {
 						dispatch( 'core/block-editor' ).selectBlock( blocks[ 0 ].clientId );
-						return onReplace( [ blocks[ 0 ] ], ...args );
+						return onReplace( [ createBlock( blockNameFallback ) ], ...args );
 					}
 
 					// Update new block attributes.

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -210,8 +210,6 @@ export default function DialogueEdit( {
 				ref={ contentRef }
 				identifier="content"
 				multiline
-				tagName="p"
-				className={ `${ BASE_CLASS_NAME }__content` }
 				value={ content }
 				onChange={ value => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -209,16 +209,13 @@ export default function DialogueEdit( {
 			<RichText
 				ref={ contentRef }
 				identifier="content"
+				multiline
 				tagName="p"
 				className={ `${ BASE_CLASS_NAME }__content` }
 				value={ content }
 				onChange={ value => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
-				onSplit={ value => {
-					if ( ! content?.length ) {
-						return createBlock( blockNameFallback );
-					}
-
+				onSplit={ ( value ) => {
 					return createBlock( blockName, {
 						...attributes,
 						content: value,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
@@ -29,11 +29,12 @@ export default function save( { attributes } ) {
 					</div>
 				) }
 			</div>
-			<RichText.Content
-				className={ `${ BASE_CLASS_NAME }__content` }
-				tagName="p"
-				value={ content }
-			/>
+			<div className={ `${ BASE_CLASS_NAME }__content-wrapper entry-content` }>
+				<RichText.Content
+					multiline
+					value={ content }
+				/>
+			</div>
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/style.scss
@@ -50,8 +50,8 @@
 }
 
 // dialogue content.
-.block-editor-block-list__block .wp-block-jetpack-dialogue__content {
-	margin: 0 0 1em 0;
+.wp-block-jetpack-dialogue__content-wrapper {
+	margin: 0;
 }
 
 // Conversation styles.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR improves the way to create line breaks of the `Dialogue` block content, allowing creating paragraphs on in without combining with the SHIFT key.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: handling line breaks in content

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


Step | Screenshot
-----|-----
**(1)** Start from scratch creating a new Conversation/Dialogue block | ![image](https://user-images.githubusercontent.com/77539/107669969-0d967300-6c71-11eb-993c-5db3e892b890.png)
**(2)** Add a new speaker (optional), pressing enter to focus the dialogue content | ![image](https://user-images.githubusercontent.com/77539/107670271-53ebd200-6c71-11eb-9459-272d24f82e08.png)
**(3)** Start to type the first paragraph | ![image](https://user-images.githubusercontent.com/77539/107670350-69f99280-6c71-11eb-8280-4b52c4435531.png)
**(4)** press `ENTER` to create a new paragraph, but checking that it's still in the same `Dialogue` block | ![image](https://user-images.githubusercontent.com/77539/107670479-8a295180-6c71-11eb-882d-e83461f8cdf5.png)
**(5)** You can confirm that using the `Outline` tool | ![image](https://user-images.githubusercontent.com/77539/107670607-a6c58980-6c71-11eb-9106-84288e79b70a.png)
**(6)** Type the second paragraph | ![image](https://user-images.githubusercontent.com/77539/107670699-c361c180-6c71-11eb-8654-13254a6b8aba.png)
**(7)** Type `ENTER` again. Confirm you still are in the same `Dialogue` Block | ![image](https://user-images.githubusercontent.com/77539/107670823-e7bd9e00-6c71-11eb-8178-df9025d583bd.png)
**(8) Typing `ENTER` again should create a new `Dialogue` block, since the new line was empty.  | ![image](https://user-images.githubusercontent.com/77539/107670990-15a2e280-6c72-11eb-8bf8-ea7dd569d555.png)
**(9)** Typing `Enter` in the empty-content of a `Dialogue` block should replace it with a `Paragraph` block. | ![image](https://user-images.githubusercontent.com/77539/107671129-4551ea80-6c72-11eb-9dd0-89db091d9d29.png)
**(10)** Take a look to teh front-end too. | ![image](https://user-images.githubusercontent.com/77539/107671825-0708fb00-6c73-11eb-8133-6c28b65eaba7.png)










#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
