### PR TITLE
Refactor Jetpack callables into the plugin

### DIFF
--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -283,8 +283,6 @@ class Defaults {
 		'main_network_site_wpcom_id'       => array( 'Automattic\\Jetpack\\Sync\\Functions', 'main_network_site_wpcom_id' ),
 		'site_url'                         => array( 'Automattic\\Jetpack\\Sync\\Functions', 'site_url' ),
 		'home_url'                         => array( 'Automattic\\Jetpack\\Sync\\Functions', 'home_url' ),
-		'single_user_site'                 => array( 'Jetpack', 'is_single_user_site' ),
-		'updates'                          => array( 'Jetpack', 'get_updates' ),
 		'has_file_system_write_access'     => array( 'Automattic\\Jetpack\\Sync\\Functions', 'file_system_write_access' ),
 		'is_version_controlled'            => array( 'Automattic\\Jetpack\\Sync\\Functions', 'is_version_controlled' ),
 		'taxonomies'                       => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_taxonomies' ),
@@ -296,13 +294,11 @@ class Defaults {
 		'wp_version'                       => array( 'Automattic\\Jetpack\\Sync\\Functions', 'wp_version' ),
 		'get_plugins'                      => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_plugins' ),
 		'get_plugins_action_links'         => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_plugins_action_links' ),
-		'active_modules'                   => array( 'Jetpack', 'get_active_modules' ),
 		'hosting_provider'                 => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_hosting_provider' ),
 		'locale'                           => 'get_locale',
 		'site_icon_url'                    => array( 'Automattic\\Jetpack\\Sync\\Functions', 'site_icon_url' ),
 		'roles'                            => array( 'Automattic\\Jetpack\\Sync\\Functions', 'roles' ),
 		'timezone'                         => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_timezone' ),
-		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_availability' ), // Includes both Gutenberg blocks *and* plugins.
 		'paused_themes'                    => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_paused_themes' ),
 		'paused_plugins'                   => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_paused_plugins' ),
 		'theme_support'                    => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_theme_support' ),
@@ -352,19 +348,6 @@ class Defaults {
 	 * @return array Whitelist of callables allowed to be managed via the JSON API.
 	 */
 	public static function get_callable_whitelist() {
-		$default = self::$default_callable_whitelist;
-
-		if ( defined( 'JETPACK__PLUGIN_DIR' ) && include_once JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' ) {
-			$sso_helpers = array(
-				'sso_is_two_step_required'      => array( 'Jetpack_SSO_Helpers', 'is_two_step_required' ),
-				'sso_should_hide_login_form'    => array( 'Jetpack_SSO_Helpers', 'should_hide_login_form' ),
-				'sso_match_by_email'            => array( 'Jetpack_SSO_Helpers', 'match_by_email' ),
-				'sso_new_user_override'         => array( 'Jetpack_SSO_Helpers', 'new_user_override' ),
-				'sso_bypass_default_login_form' => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
-			);
-			$default     = array_merge( $default, $sso_helpers );
-		}
-
 		/**
 		 * Filter the list of callables that are manageable via the JSON API.
 		 *
@@ -374,7 +357,7 @@ class Defaults {
 		 *
 		 * @param array The default list of callables.
 		 */
-		return apply_filters( 'jetpack_sync_callable_whitelist', $default );
+		return apply_filters( 'jetpack_sync_callable_whitelist', self::$default_callable_whitelist );
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -795,6 +795,9 @@ class Jetpack {
 		// Actions for licensing.
 		Licensing::instance()->initialize();
 
+		// Filters for Sync Callables.
+		add_filter( 'jetpack_sync_callable_whitelist', array( $this, 'filter_sync_callable_whitelist' ), 10, 1 );
+
 		// Make resources use static domain when possible.
 		add_filter( 'jetpack_static_url', array( 'Automattic\\Jetpack\\Assets', 'staticize_subdomain' ) );
 	}
@@ -1024,6 +1027,39 @@ class Jetpack {
 			)
 		);
 
+	}
+
+	/**
+	 * Extend callables with Jetpack Plugin functions.
+	 *
+	 * @param array $callables list of callables.
+	 *
+	 * @return array list of callables.
+	 */
+	public function filter_sync_callable_whitelist( $callables ) {
+
+		// Jetpack Functions.
+		$jetpack_callables = array(
+			'single_user_site'         => array( 'Jetpack', 'is_single_user_site' ),
+			'updates'                  => array( 'Jetpack', 'get_updates' ),
+			'active_modules'           => array( 'Jetpack', 'get_active_modules' ),
+			'available_jetpack_blocks' => array( 'Jetpack_Gutenberg', 'get_availability' ), // Includes both Gutenberg blocks *and* plugins.
+		);
+		$callables         = array_merge( $callables, $jetpack_callables );
+
+		// Jetpack_SSO_Helpers.
+		if ( include_once JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' ) {
+			$sso_helpers = array(
+				'sso_is_two_step_required'      => array( 'Jetpack_SSO_Helpers', 'is_two_step_required' ),
+				'sso_should_hide_login_form'    => array( 'Jetpack_SSO_Helpers', 'should_hide_login_form' ),
+				'sso_match_by_email'            => array( 'Jetpack_SSO_Helpers', 'match_by_email' ),
+				'sso_new_user_override'         => array( 'Jetpack_SSO_Helpers', 'new_user_override' ),
+				'sso_bypass_default_login_form' => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
+			);
+			$callables   = array_merge( $callables, $sso_helpers );
+		}
+
+		return $callables;
 	}
 
 	function jetpack_track_last_sync_callback( $params ) {


### PR DESCRIPTION
jetpack_sync_callable_whitelist filter exists to allow extending of Sync callables. To ensure the Sync Package is isolated this PR removes Jetpack functions from the default definitions and adds them using the filter during Jetpack initialization.

#### Changes proposed in this Pull Request:
* No functional changes, simply shifting addition of Jetpack callables into Jetpack.

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

These changes are covered under the existing test test_sync_callable_whitelist

Manual Test
* $cm = Automattic\Jetpack\Sync\Modules::get_module( 'functions' );
* $cm->get_all_callables();
* verify that the callable list includes:
  single_user_site
  updates
  active_modules
  available_jetpack_blocks
  sso_is_two_step_required
  sso_should_hide_login_form
  sso_match_by_email
  sso_new_user_override
  sso_bypass_default_login_form

#### Proposed changelog entry for your changes:
* N/A - no functional changes simply shifting code :)
