### PR TITLE
Dialogue block: use HTML for label attribute

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/attributes.js
@@ -1,6 +1,8 @@
 export default {
 	label: {
 		type: 'string',
+		source: 'html',
+		selector: '.wp-block-jetpack-dialogue__participant',
 	},
 	slug: {
 		type: 'string',

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/save.js
@@ -15,9 +15,11 @@ export default function save( { attributes } ) {
 	return (
 		<div>
 			<div className={ `${ BASE_CLASS_NAME }__meta` }>
-				<div className={ `${ BASE_CLASS_NAME }__participant has-bold-style` }>
-					{ label }
-				</div>
+				<RichText.Content
+					className={ `${ BASE_CLASS_NAME }__participant has-bold-style` }
+					tagName="div"
+					value={ label }
+				/>
 				{ showTimestamp && (
 					<div className={ `${ BASE_CLASS_NAME }__timestamp-label` }>
 						<a


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Uses an `html` source for the label attribute, so it doesn't need to be duplicated in the html comment and the block markup
* Uses `<RIchText.Content>` in the save function for the label, now that it's generated using the RichText component.

| **Before** | **After** |
| - | - |
| <img width="821" alt="Screen Shot 2021-02-11 at 14 43 15" src="https://user-images.githubusercontent.com/1699996/107696821-09ba1f00-6c78-11eb-8c19-1734b6eb3144.png"> | <img width="829" alt="Screen Shot 2021-02-11 at 14 43 52" src="https://user-images.githubusercontent.com/1699996/107696855-13dc1d80-6c78-11eb-8753-4877399090de.png"> |

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

1. Insert a conversation block and add speaker entries
1. Use the code editor to verify the label attribute is no longer duplicated in the HTML comment
1. Load an existing conversation block from a post, there should not be any errors and you should see the same block attribute change.

#### Proposed changelog entry for your changes:

N/a, as I think we can wrap this into all the other block improvements for the upcoming release.
