### PR TITLE
SSO: Disregard filters to use in-place connection when redirecting after SSO

### DIFF
--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -1067,7 +1067,11 @@ class Jetpack_SSO {
 
 		/**
 		 * Return the raw connect URL with our redirect and attribute connection to SSO.
+		 * We remove any other filters that may be turning on the in-place connection
+		 * since we will be redirecting the user as opposed to iFraming.
 		 */
+		remove_all_filters( 'jetpack_use_iframe_authorization_flow' );
+		add_filter( 'jetpack_use_iframe_authorization_flow', '__return_false' );
 		$connect_url = Jetpack::init()->build_connect_url( true, $redirect_after_auth, 'sso' );
 
 		add_filter( 'allowed_redirect_hosts', array( 'Jetpack_SSO_Helpers', 'allowed_redirect_hosts' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When a site has set the `jetpack_use_iframe_authorization_flow` filter to return true, it's possible for a user to be redirected to the in-place connection after approving an SSO connection, when that user is not already connected to the site. This is an issue since the in-place connection is designed in such a way to be embedded in an iframe. Instead, we always want the user to be redirected to the legacy connection flow.

To handle that behavior, this PR removes any previous filters on `jetpack_use_iframe_authorization_flow` and then adds a new filter to return true, to be extra defensive in case we default to passing the filter `true` in the future.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up JN site
- Connect site
- Enable SSO
- Ensure that setting to allow finding users by email address is on
- Add a filter for `jetpack_use_iframe_authorization_flow` and set to `true`
- Create new editor user on site that has the same email address as a WP.com user that is not currently connected to your site
- Open incognito tab, or browser that is not logged into your site currently
- Login to WordPress.com
- Go to $site.com/wp-admin
- Click "Login with WordPress.com" button
- Ensure that you end up on Calypso as the connection is setup

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fixes a UX issue in the connection flow after users login with SSO
