### PR TITLE
Admin Menu: Add "Advanced Users Management" menu on WoA sites

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -506,10 +506,10 @@ class Admin_Menu {
 			remove_submenu_page( 'users.php', 'grofiles-user-settings' );
 
 			add_menu_page( esc_attr__( 'Users', 'jetpack' ), __( 'Users', 'jetpack' ), 'list_users', $users_slug, null, 'dashicons-admin-users', 70 );
-			add_submenu_page( $users_slug, esc_attr__( 'All People', 'jetpack' ), __( 'All People', 'jetpack' ), 'list_users', $users_slug, null, 5 );
-			add_submenu_page( $users_slug, esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', $add_new_slug, null, 10 );
-			add_submenu_page( $users_slug, esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', $profile_slug, null, 15 );
-			add_submenu_page( $users_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account', null, 20 );
+			add_submenu_page( $users_slug, esc_attr__( 'All People', 'jetpack' ), __( 'All People', 'jetpack' ), 'list_users', $users_slug );
+			add_submenu_page( $users_slug, esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', $add_new_slug );
+			add_submenu_page( $users_slug, esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', $profile_slug );
+			add_submenu_page( $users_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
 
 			$this->migrate_submenus( 'users.php', $users_slug );
 			add_filter(

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -494,8 +494,9 @@ class Admin_Menu {
 	 */
 	public function add_users_menu( $wp_admin = false ) {
 		$users_slug   = $wp_admin ? 'users.php' : 'https://wordpress.com/people/team/' . $this->domain;
-		$add_new_slug = 'https://wordpress.com/people/new/' . $this->domain;
+		$add_new_slug = $wp_admin ? 'user-new.php' : 'https://wordpress.com/people/new/' . $this->domain;
 		$profile_slug = $wp_admin ? 'profile.php' : 'https://wordpress.com/me';
+		$account_slug = 'https://wordpress.com/me/account';
 
 		if ( current_user_can( 'list_users' ) ) {
 			remove_menu_page( 'users.php' );
@@ -509,13 +510,28 @@ class Admin_Menu {
 			add_submenu_page( $users_slug, esc_attr__( 'All People', 'jetpack' ), __( 'All People', 'jetpack' ), 'list_users', $users_slug );
 			add_submenu_page( $users_slug, esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', $add_new_slug );
 			add_submenu_page( $users_slug, esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', $profile_slug );
-			add_submenu_page( $users_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
+			add_submenu_page( $users_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', $account_slug );
 
 			$this->migrate_submenus( 'users.php', $users_slug );
 			add_filter(
 				'parent_file',
 				function ( $parent_file ) use ( $users_slug ) {
 					return 'users.php' === $parent_file ? $users_slug : $parent_file;
+				}
+			);
+		} else {
+			remove_menu_page( 'profile.php' );
+			remove_submenu_page( 'profile.php', 'grofiles-editor' );
+			remove_submenu_page( 'profile.php', 'grofiles-user-settings' );
+
+			add_menu_page( esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', $profile_slug, null, 'dashicons-admin-users', 70 );
+			add_submenu_page( $profile_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', $account_slug, null, 5 );
+
+			$this->migrate_submenus( 'profile.php', $profile_slug );
+			add_filter(
+				'parent_file',
+				function ( $parent_file ) use ( $profile_slug ) {
+					return 'profile.php' === $parent_file ? $profile_slug : $parent_file;
 				}
 			);
 		}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -233,4 +233,22 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Customize on Atomic sites is always done on WP Admin.
 		parent::add_appearance_menu( $wp_admin_themes, true );
 	}
+
+	/**
+	 * Adds Users menu.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_users_menu( $wp_admin = false ) {
+		parent::add_users_menu( $wp_admin );
+
+		// No need to add a menu linking to WP Admin if there is already one.
+		if ( $wp_admin ) {
+			return;
+		}
+
+		$parent_menu_slug = 'https://wordpress.com/people/team/' . $this->domain;
+
+		add_submenu_page( $parent_menu_slug, esc_attr__( 'Advanced Users Management', 'jetpack' ), __( 'Advanced Users Management', 'jetpack' ), 'list_users', 'users.php', null, 2 );
+	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -205,49 +205,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_users_menu( $wp_admin = false ) {
-		$users_slug   = $wp_admin ? 'users.php' : 'https://wordpress.com/people/team/' . $this->domain;
-		$add_new_slug = 'https://wordpress.com/people/new/' . $this->domain;
-		$profile_slug = $wp_admin ? 'grofiles-editor' : 'https://wordpress.com/me';
-		$account_slug = $wp_admin ? 'grofiles-user-settings' : 'https://wordpress.com/me/account';
-
-		if ( current_user_can( 'list_users' ) ) {
-			remove_menu_page( 'users.php' );
-			remove_submenu_page( 'users.php', 'users.php' );
-			remove_submenu_page( 'users.php', 'user-new.php' );
-			remove_submenu_page( 'users.php', 'profile.php' );
-			remove_submenu_page( 'users.php', 'grofiles-editor' );
-			remove_submenu_page( 'users.php', 'grofiles-user-settings' );
-
-			add_menu_page( esc_attr__( 'Users', 'jetpack' ), __( 'Users', 'jetpack' ), 'list_users', $users_slug, null, 'dashicons-admin-users', 70 );
-			add_submenu_page( $users_slug, esc_attr__( 'All People', 'jetpack' ), __( 'All People', 'jetpack' ), 'list_users', $users_slug, null, 5 );
-			add_submenu_page( $users_slug, esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', $add_new_slug, null, 10 );
-			add_submenu_page( $users_slug, esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', $profile_slug, null, 15 );
-			add_submenu_page( $users_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', $account_slug, null, 20 );
-
-			$this->migrate_submenus( 'users.php', $users_slug );
-			add_filter(
-				'parent_file',
-				function ( $parent_file ) use ( $users_slug ) {
-					return 'users.php' === $parent_file ? $users_slug : $parent_file;
-				}
-			);
-		} elseif ( ! $wp_admin ) {
-			remove_menu_page( 'profile.php' );
-			remove_submenu_page( 'profile.php', 'grofiles-editor' );
-			remove_submenu_page( 'profile.php', 'grofiles-user-settings' );
-
-			add_menu_page( esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', $profile_slug, null, 'dashicons-admin-users', 70 );
-			add_submenu_page( $profile_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', $account_slug, null, 5 );
-
-			$this->migrate_submenus( 'profile.php', $profile_slug );
-			add_filter(
-				'parent_file',
-				function ( $parent_file ) use ( $profile_slug ) {
-					return 'profile.php' === $parent_file ? $profile_slug : $parent_file;
-				}
-			);
-		}
+	public function add_users_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Users on Simple sites are always managed on Calypso.
+		parent::add_users_menu( false );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -602,7 +602,25 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_users_menu( false );
 
-		$this->assertEmpty( $menu );
+		$profile_menu_item = array(
+			'My Profile',
+			'read',
+			'https://wordpress.com/me',
+			'My Profile',
+			'menu-top toplevel_page_https://wordpress.com/me',
+			'toplevel_page_https://wordpress.com/me',
+			'dashicons-admin-users',
+		);
+		$this->assertSame( $menu[70], $profile_menu_item );
+
+		$account_submenu_item = array(
+			'Account Settings',
+			'read',
+			'https://wordpress.com/me/account',
+			'Account Settings',
+		);
+		$this->assertContains( $account_submenu_item, $submenu['https://wordpress.com/me'] );
+		$this->assertArrayNotHasKey( 'profile.php', $submenu );
 
 		// Reset.
 		wp_set_current_user( static::$user_id );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -398,4 +398,26 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		);
 		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
 	}
+
+	/**
+	 * Tests add_users_menu
+	 *
+	 * @covers ::add_users_menu
+	 */
+	public function test_add_users_menu() {
+		global $submenu;
+
+		$submenu_item = array(
+			'Advanced Users Management',
+			'list_users',
+			'users.php',
+			'Advanced Users Management',
+		);
+
+		static::$admin_menu->add_users_menu( true );
+		$this->assertNotContains( $submenu_item, $submenu['users.php'] );
+
+		static::$admin_menu->add_users_menu( false );
+		$this->assertContains( $submenu_item, $submenu[ 'https://wordpress.com/people/team/' . static::$domain ] );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -266,85 +266,12 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_users_menu
 	 */
 	public function test_add_users_menu() {
-		global $menu, $submenu;
+		global $menu;
 
-		// Current user can't list users.
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'editor' ) ) );
-		$menu = array();
+		static::$admin_menu->add_users_menu( true );
 
-		static::$admin_menu->add_users_menu( false );
-
-		$profile_menu_item = array(
-			'My Profile',
-			'read',
-			'https://wordpress.com/me',
-			'My Profile',
-			'menu-top toplevel_page_https://wordpress.com/me',
-			'toplevel_page_https://wordpress.com/me',
-			'dashicons-admin-users',
-		);
-		$this->assertSame( $menu[70], $profile_menu_item );
-
-		$account_submenu_item = array(
-			'Account Settings',
-			'read',
-			'https://wordpress.com/me/account',
-			'Account Settings',
-		);
-		$this->assertContains( $account_submenu_item, $submenu['https://wordpress.com/me'] );
-		$this->assertArrayNotHasKey( 'profile.php', $submenu );
-
-		// Reset.
-		wp_set_current_user( static::$user_id );
-		$menu = static::$menu_data;
-
-		static::$admin_menu->add_users_menu( false );
-
-		$slug = 'https://wordpress.com/people/team/' . static::$domain;
-
-		$users_menu_item = array(
-			'Users',
-			'list_users',
-			$slug,
-			'Users',
-			'menu-top toplevel_page_' . $slug,
-			'toplevel_page_' . $slug,
-			'dashicons-admin-users',
-		);
-		$this->assertSame( $menu[70], $users_menu_item );
-		$this->assertEmpty( $submenu['users.php'] );
-
-		$all_people_submenu_item = array(
-			'All People',
-			'list_users',
-			$slug,
-			'All People',
-		);
-		$this->assertContains( $all_people_submenu_item, $submenu[ $slug ] );
-
-		$add_new_submenu_item = array(
-			'Add New',
-			'promote_users',
-			'https://wordpress.com/people/new/' . static::$domain,
-			'Add New',
-		);
-		$this->assertContains( $add_new_submenu_item, $submenu[ $slug ] );
-
-		$profile_submenu_item = array(
-			'My Profile',
-			'read',
-			'https://wordpress.com/me',
-			'My Profile',
-		);
-		$this->assertContains( $profile_submenu_item, $submenu[ $slug ] );
-
-		$account_submenu_item = array(
-			'Account Settings',
-			'read',
-			'https://wordpress.com/me/account',
-			'Account Settings',
-		);
-		$this->assertContains( $account_submenu_item, $submenu[ $slug ] );
+		// Check that menu always links to Calypso.
+		$this->assertSame( $menu[70][2], 'https://wordpress.com/people/team/' . static::$domain );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/49211

#### Changes proposed in this Pull Request:
Add a new menu item to the new unified menu on WoA sites that links to the WP Admin user lists screen, so users can continue editing users from there as they have been doing with the old menu (currently enabled in production to all non-a8c users). This is especially useful for WooCommerce sites with the Product Vendor extension installed.

<img width="449" alt="Screen Shot 2021-02-12 at 15 17 12" src="https://user-images.githubusercontent.com/1233880/107780484-06419900-6d47-11eb-883d-55c24d228faa.png">

This PR also includes a small refactoring of the `add_users_menu` function, to make the code a bit more maintainable.

#### Jetpack product discussion
paYJgx-1lp-p2#comment-1661

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Install Jetpack Beta on a WoA site and activate the branch of this PR.
- Go to https://wordpress.com and switch to that WoA site.
- Make sure there is a new "Users > Advanced Users Management" menu entry that links to `/wp-admin/users.php`.
- Go to https://wordpress.com/me/account and turn on the "Dashboard appearance" toggle for replacing all menu links with WP Admin when possible.
- Go back to https://wordpress.com and switch to the WoA site again.
- Make sure there isn't a "Users > Advanced Users Management" menu entry (since "All People" already links to `/wp-admin/users.php`). This may need a few reloads, since the cached dashboard appearance setting is cleared asynchronously).

#### Proposed changelog entry for your changes:
Admin Menu: Add "Advanced Users Management" menu on WoA sites