### PR TITLE
Conversation: handling removed/restored speakers

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -38,12 +38,12 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		[ setAttributes, participants ]
 	);
 
-	const addNewParticipant = useCallback( function( newSpeakerLabel ) {
-		if ( ! newSpeakerLabel ) {
+	const addNewParticipant = useCallback( function( { label, slug } ) {
+		if ( ! label ) {
 			return;
 		}
 
-		const sanitizedSpeakerLabel = newSpeakerLabel.trim();
+		const sanitizedSpeakerLabel = label.trim();
 		// Do not add speakers with empty names.
 		if ( ! sanitizedSpeakerLabel?.length ) {
 			return;
@@ -56,7 +56,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		}
 
 		// Creates the participant slug.
-		const newParticipantSlug = `speaker-${ +( new Date() ) }`;
+		const newParticipantSlug = slug || `speaker-${ +( new Date() ) }`;
 
 		const newParticipant = {
 			slug: newParticipantSlug,

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -56,9 +56,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		}
 
 		// Creates the participant slug.
-		const newParticipantSlug = participants.length
-			? participants[ participants.length - 1 ].slug.replace( /(\d+)/, n => Number( n ) + 1 )
-			: 'speaker-0';
+		const newParticipantSlug = `speaker-${ +( new Date() ) }`;
 
 		const newParticipant = {
 			slug: newParticipantSlug,

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -10,7 +10,7 @@ import { useMemoOne } from 'use-memo-one';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, RichText, BlockControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
+import { useContext, useEffect, useRef } from '@wordpress/element';
 import { dispatch, useSelect, useDispatch } from '@wordpress/data';
 import { Panel, PanelBody } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
@@ -26,7 +26,7 @@ import ConversationContext from '../conversation/components/context';
 import { STORE_ID as MEDIA_SOURCE_STORE_ID } from '../../store/media-source/constants';
 import { MediaPlayerToolbarControl } from '../../shared/components/media-player-control';
 import { convertSecondsToTimeCode } from '../../shared/components/media-player-control/utils';
-import { getParticipantByLabel, getParticipantBySlug } from '../conversation/utils';
+import { getParticipantBySlug } from '../conversation/utils';
 
 const blockName = 'jetpack/dialogue';
 const blockNameFallback = 'core/paragraph';
@@ -91,8 +91,6 @@ export default function DialogueEdit( {
 
 	const debounceSetDialoguesAttrs = useDebounceWithFallback( setAttributes, 250 );
 
-	const participantExist = useMemo( () => getParticipantByLabel( participants, label ), [ label, participants ] );
-
 	// Update dialogue participant with conversation participant changes.
 	useEffect( () => {
 		// Do not update current Dialogue block.
@@ -100,15 +98,12 @@ export default function DialogueEdit( {
 			return;
 		}
 
+		// When no context, nothing to do.
 		if ( ! conversationParticipant ) {
-			if ( participantExist ) {
-				debounceSetDialoguesAttrs( participantExist );
-				return;
-			}
-
 			return;
 		}
 
+		// Only take care of Dialogue with same speaker.
 		if ( conversationParticipant.slug !== slug ) {
 			return;
 		}
@@ -116,7 +111,7 @@ export default function DialogueEdit( {
 		debounceSetDialoguesAttrs( {
 			label: conversationParticipant.label,
 		} );
-	}, [ conversationParticipant, debounceSetDialoguesAttrs, isSelected, participantExist, slug ] );
+	}, [ conversationParticipant, debounceSetDialoguesAttrs, isSelected, slug ] );
 
 	function setTimestamp( time ) {
 		setAttributes( { timestamp: time } );
@@ -191,7 +186,7 @@ export default function DialogueEdit( {
 					} }
 
 					onAdd={ ( newLabel ) => {
-						const newParticipant = conversationBridge.addNewParticipant( newLabel );
+						const newParticipant = conversationBridge.addNewParticipant( { label: newLabel, slug } );
 						setAttributes( newParticipant );
 					} }
 					onUpdate={ ( participant ) => {

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -102,17 +102,20 @@ export default function DialogueEdit( {
 
 		if ( ! conversationParticipant ) {
 			if ( participantExist ) {
-				return debounceSetDialoguesAttrs( participantExist );
+				debounceSetDialoguesAttrs( participantExist );
+				return;
 			}
 
 			return;
 		}
 
-		if ( conversationParticipant.slug === slug ) {
-			return debounceSetDialoguesAttrs( {
-				label: conversationParticipant.label,
-			} );
+		if ( conversationParticipant.slug !== slug ) {
+			return;
 		}
+
+		debounceSetDialoguesAttrs( {
+			label: conversationParticipant.label,
+		} );
 	}, [ conversationParticipant, debounceSetDialoguesAttrs, isSelected, participantExist, slug ] );
 
 	function setTimestamp( time ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR fixes some issues when removing speakers from the Conversation block, as well as how they can be restored.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation: handling removed/restored speakers

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1613141900276100-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start testing with a new post
* Create a new Conversation/Dialogue blocks composition.
* Create two speakers, and add some Dialogue blocks there:

Description | Screenshot
-------|---------
Like this blocks composition | ![image](https://user-images.githubusercontent.com/77539/107808413-4c4b2c80-6d48-11eb-8840-c412a778d507.png)
From the outline | ![image](https://user-images.githubusercontent.com/77539/107808546-8ddbd780-6d48-11eb-932b-c9bae71b85bb.png)
Two speakers, from the Conversation block | ![image](https://user-images.githubusercontent.com/77539/107808583-9b915d00-6d48-11eb-881c-d632ee9294dd.png)
Remove both of them. No speakers in the sidebar. Speakers with gray color in the canvas  |  <img width="1025" alt="Screen Shot 2021-02-12 at 3 40 35 PM" src="https://user-images.githubusercontent.com/77539/107808699-c24f9380-6d48-11eb-9833-b0be3a7946da.png">
Restore the speaker, simply focusing the input and pressing `ENTER` or `TAB`, or making a focus outside event. Speaker should be there again | ![image](https://user-images.githubusercontent.com/77539/107809020-3d18ae80-6d49-11eb-9fe7-f37f5c7edb8b.png)
Remove it again, and restore it but editing the name BEFORE. You should see the name propagated for all Dialogue blocks |  ![image](https://user-images.githubusercontent.com/77539/107809140-65a0a880-6d49-11eb-921d-211cd0048192.png)


https://user-images.githubusercontent.com/77539/107809349-b2847f00-6d49-11eb-9a97-47357736927a.mov



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
