### PR TITLE
In-Place Connection: Reload for paid plans.

### DIFF
--- a/projects/plugins/jetpack/_inc/connect-button.js
+++ b/projects/plugins/jetpack/_inc/connect-button.js
@@ -163,7 +163,9 @@ jQuery( document ).ready( function ( $ ) {
 				var parser = document.createElement( 'a' );
 				parser.href = jpConnect.dashboardUrl;
 				var reload =
-					window.location.pathname === parser.pathname && window.location.hash !== parser.hash;
+					window.location.pathname === parser.pathname &&
+					window.location.hash.length &&
+					parser.hash.length;
 
 				window.location.assign( jpConnect.dashboardUrl );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
If in-place connection is initiated from Jetpack Dashboard URL (`/wp-admin/admin.php?page=jetpack#/dashboard`), the Dashboard does not get reload for customers with paid plans.

Those customers end up watching the endless spin of the loader with the "Finishing up" text until they finally reload the page and see Jetpack fully connected.

This PR fixes the bug.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Confirm the issue is present before checking out the PR:
1. Connect Jetpack, purchase a plan (e.g. Security Daily).
2. Go to Jetpack Dashboard, disconnect Jetpack.
3. Go to the page `/wp-admin/admin.php?page=jetpack#/dashboard` (you will likely be there already though).
4. Connect Jetpack using in-place flow.
5. After connecting, you should get stuck on the "Finishing up" stage.
6. Reload the page, Jetpack should be connected already.

Now checkout the PR, rebuild JS if needed, and confirm that the issue is fixed:
1. Disconnect Jetpack, go to the same page: `/wp-admin/admin.php?page=jetpack#/dashboard`
2. Connect Jetpack using in-place flow.
3. The page should get reloaded, Jetpack Dashboard should show up.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Connection flow: ensuring Jetpack Dashboard successfully loads after reconnect.
