### PR TITLE
Avoid unnecessary converting of booleans to strings in the WordAds module

### DIFF
--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-api.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-api.php
@@ -94,7 +94,7 @@ class WordAds_API {
 			self::get_wordads_status();
 		}
 
-		return self::$wordads_status['approved'];
+		return (bool) self::$wordads_status['approved'];
 	}
 
 	/**
@@ -109,7 +109,7 @@ class WordAds_API {
 			self::get_wordads_status();
 		}
 
-		return self::$wordads_status['active'];
+		return (bool) self::$wordads_status['active'];
 	}
 
 	/**
@@ -124,7 +124,7 @@ class WordAds_API {
 			self::get_wordads_status();
 		}
 
-		return self::$wordads_status['house'];
+		return (bool) self::$wordads_status['house'];
 	}
 
 	/**
@@ -139,7 +139,7 @@ class WordAds_API {
 			self::get_wordads_status();
 		}
 
-		return self::$wordads_status['unsafe'];
+		return (bool) self::$wordads_status['unsafe'];
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-api.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-api.php
@@ -94,7 +94,7 @@ class WordAds_API {
 			self::get_wordads_status();
 		}
 
-		return self::$wordads_status['approved'] ? '1' : '0';
+		return self::$wordads_status['approved'];
 	}
 
 	/**
@@ -109,7 +109,7 @@ class WordAds_API {
 			self::get_wordads_status();
 		}
 
-		return self::$wordads_status['active'] ? '1' : '0';
+		return self::$wordads_status['active'];
 	}
 
 	/**
@@ -124,7 +124,7 @@ class WordAds_API {
 			self::get_wordads_status();
 		}
 
-		return self::$wordads_status['house'] ? '1' : '0';
+		return self::$wordads_status['house'];
 	}
 
 	/**
@@ -139,7 +139,7 @@ class WordAds_API {
 			self::get_wordads_status();
 		}
 
-		return self::$wordads_status['unsafe'] ? '1' : '0';
+		return self::$wordads_status['unsafe'];
 	}
 
 	/**


### PR DESCRIPTION
This is a possible solution for https://github.com/Automattic/jetpack/issues/10063

The wordads module has code in it that converts settings from booleans to a string representation of a boolean prior to saving them via update_option(). True to '1'. False to '0'. The phpdocs for the functions specifically state that booleans should be returned.

There are 4 option values affected. All of them are directly related to the wordads module. wordads_approved, wordads_active, wordads_house, and wordads_unsafe

This conversion from true booleans to a string representation does not appear to be harmful but it is unnecessary. It can also make the function documentation appear to be wrong and undermining trust in the docs appears unwise. "The docs say it returns a boolean but it clearly returns a string."

Note: if you coerce the strings '0' and '1' to a boolean they will be evaluated correctly so the function docs are not exactly wrong, they just appear to be wrong. Some examples of coercing these strings to booleans:
var_dump( (bool) '0'); // evaluates to false
if ('1') { //'1' evaluates to true

If you call update_option() with a boolean then call get_option() you will in fact get back '0' or '1'. update_option() is essentially performing that conversion internally and the wordads code doesn't need to do it first. The class WordAds_Params bulk loads the wordads options and already contains code to convert these strings back to true booleans.

Fixes #10063

#### Changes proposed in this Pull Request:
* No functional changes
* Remove the unnecessary boolean to string conversion from the option updating code.

#### Jetpack product discussion
I am not an Automattician

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Using a site that already has wordads available on the site, do the ads continue to function when you switch to this code?
* No functional changes are expected.

#### Proposed changelog entry for your changes:
* No changelog entry necessary
