### PR TITLE
Admin Menu: Remove "Backups & Scan" menu

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -300,6 +300,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				return esc_url_raw( $url );
 			}
 
+			// Allow URLs pointing to Jetpack.com.
+			if ( 0 === strpos( $url, 'https://jetpack.com/' ) ) {
+				return esc_url_raw( $url );
+			}
+
 			// Disallow other external URLs.
 			return '';
 		}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
 /**
@@ -628,13 +629,15 @@ class Admin_Menu {
 
 		remove_menu_page( 'jetpack' );
 		remove_submenu_page( 'jetpack', 'stats' );
+		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
+		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
 
 		$this->migrate_submenus( 'jetpack', $jetpack_slug );
 
-		add_submenu_page( $jetpack_slug, esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', $jetpack_slug, null, 0 );
-		add_submenu_page( $jetpack_slug, esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 1 );
+		add_submenu_page( $jetpack_slug, esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', $jetpack_slug, null, 2 );
+		add_submenu_page( $jetpack_slug, esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 3 );
 		/* translators: Jetpack sidebar menu item. */
-		add_submenu_page( $jetpack_slug, esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'read', 'https://wordpress.com/jetpack-search/' . $this->domain, null, 2 );
+		add_submenu_page( $jetpack_slug, esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'read', 'https://wordpress.com/jetpack-search/' . $this->domain, null, 4 );
 
 		add_filter(
 			'parent_file',

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -31,7 +31,18 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	public function add_jetpack_menu() {
 		parent::add_jetpack_menu();
 
-		add_submenu_page( 'https://wordpress.com/activity-log/' . $this->domain, esc_attr__( 'Scan', 'jetpack' ), __( 'Scan', 'jetpack' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, 2 );
+		$parent_slug = 'https://wordpress.com/activity-log/' . $this->domain;
+
+		// Place "Scan" submenu after Backup.
+		$position = 0;
+		global $submenu;
+		foreach ( $submenu[ $parent_slug ] as $submenu_item ) {
+			$position++;
+			if ( __( 'Backup', 'jetpack' ) === $submenu_item[3] ) {
+				break;
+			}
+		}
+		add_submenu_page( $parent_slug, esc_attr__( 'Scan', 'jetpack' ), __( 'Scan', 'jetpack' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $position );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -381,6 +381,13 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				'__return_true',
 				admin_url( 'admin.php?page=custom_settings' ),
 			),
+			// Jetpack.
+			array(
+				'https://jetpack.com/redirect/?source=calypso-backups&#038;site=example.org',
+				'jetpack',
+				null,
+				'https://jetpack.com/redirect/?source=calypso-backups&#038;site=example.org',
+			),
 			// WooCommerce URLs.
 			array(
 				'product_attributes',

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Dashboard_Customizations\Admin_Menu;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
 require_jetpack_file( 'modules/masterbar/admin-menu/class-admin-menu.php' );
@@ -823,6 +824,13 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			'stats',
 		);
 		$this->assertNotContains( $stats_submenu_item, $submenu[ $slug ] );
+
+		$backups_submenu_item = array(
+			'Backup &amp; Scan',
+			'manage_options',
+			esc_url( Redirect::get_url( 'calypso-backups' ) ),
+		);
+		$this->assertNotContains( $backups_submenu_item, $submenu[ $slug ] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/50039
Fixes https://github.com/Automattic/wp-calypso/issues/49978

#### Changes proposed in this Pull Request:
Since 577-gh-Automattic/wpcomsh, menu items registered by third-party plugin show up in the Calypso/WP Admin menu when the nav unification is enabled.

"Jetpack > Backups & Scan" is one of these menu items, which is registered by Jetpack. However, it is redundant, since we already include separate links for the "Backup" and "Scan" pages, so this PR removes the redundant "Backups & Scan" menu entry.

Also noted that the "Backups & Scan" menu links to a `jetpack.com` URL which was no longer an allowed URL since https://github.com/Automattic/jetpack/pull/18759. Although I've not found any other menu that links to a `jetpack.com` URL, this PR also adds the `jetpack.com` URL just in case I missed anything or for future usages.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
_Jetpack_
- Spin up a Jetpack site running this branch.
- With Nav Unification disabled (`add_filter( 'jetpack_load_admin_menu_class', '__return_true' )`) check that:
  - Calypso: Nothing changes, the Jetpack menu still contains the same items: Activity Log, Backup, Scan, Search.
  - WP Admin: Nothing changes, the Jetpack menu still contains the same items: Dashboard, Settings, Backups & Scan, etc.

_Atomic_
- Install Jetpack Beta and activate the branch of this PR.
- Check in both Calypso/WP Admin that the Jetpack menu no longer contains the "Backups & Scan" submenu.

_Simple_
- Apply D57066-code to your WP.com sandbox.
- Sandbox the API and a Simple site.
- Check in both Calypso/WP Admin that nothing changes, the Jetpack menu still contains the same items: Activity Log, Backup, Search.

#### Proposed changelog entry for your changes:
Admin Menu: Remove "Backups & Scan" menu