### PR TITLE
Markdown: Fix db error missing options table when WP site is being installed.

### DIFF
--- a/projects/plugins/jetpack/modules/markdown/easy-markdown.php
+++ b/projects/plugins/jetpack/modules/markdown/easy-markdown.php
@@ -92,6 +92,12 @@ class WPCom_Markdown {
 	 * @return null
 	 */
 	public function maybe_load_actions_and_filters( $new_blog_id = null, $old_blog_id = null ) {
+
+		// When WP sites are being installed, the options table is not available yet.
+		if ( function_exists( 'wp_installing' ) && wp_installing() ) {
+			return;
+		}
+
 		// If this is a switch_to_blog call, and the blog isn't changing, we'll already be loaded
 		if ( $new_blog_id && $new_blog_id === $old_blog_id ) {
 			return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR fixes the error on WPCOM.

```
WordPress database error Table 'wpmu_6cb.wp_1234567_options' doesn't exist for query INSERT INTO `wp_1234567_options` (`option_name`, `option_value`, `autoload`) VALUES ('wpcom_publish_comments_with_markdown', '', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`) made by add_option from <wp server address here> public-api.wordpress.com/rest/v1.1/sites/new?http_envelope=1
```

The markdown plugin listens to the `switch_blog` action and executes `maybe_load_actions_and_filters()`.

However, the `switch_blog` action is also called when a new site is created (site entry exists) but not yet initialized (site db tables not exists).

The fix is to prevent `maybe_load_actions_and_filters()` from executing when site is still being installed.

This causes the error as seen above.

#### Jetpack product discussion

A test phab patch was tested here D56697-code.

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

A test phab patch was tested here D56697-code.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fix markdown filters loading too early during new site creation causing db error `options table does not exist`.