### PR TITLE
Conversation/dialogue blocks: use "Speaker" for participant label

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -38,40 +38,40 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 		[ setAttributes, participants ]
 	);
 
-	const addNewParticipant = useCallback( function( { label, slug } ) {
-		if ( ! label ) {
-			return;
-		}
+	const addNewParticipant = useCallback(
+		function ( { label, slug } ) {
+			if ( ! label ) {
+				return;
+			}
 
-		const sanitizedSpeakerLabel = label.trim();
-		// Do not add speakers with empty names.
-		if ( ! sanitizedSpeakerLabel?.length ) {
-			return;
-		}
+			const sanitizedSpeakerLabel = label.trim();
+			// Do not add speakers with empty names.
+			if ( ! sanitizedSpeakerLabel?.length ) {
+				return;
+			}
 
-		// Do not add a new participant with the same label.
-		const existingParticipant = getParticipantByLabel( participants, sanitizedSpeakerLabel );
-		if ( existingParticipant ) {
-			return existingParticipant;
-		}
+			// Do not add a new participant with the same label.
+			const existingParticipant = getParticipantByLabel( participants, sanitizedSpeakerLabel );
+			if ( existingParticipant ) {
+				return existingParticipant;
+			}
 
-		// Creates the participant slug.
-		const newParticipantSlug = slug || `speaker-${ +( new Date() ) }`;
+			// Creates the participant slug.
+			const newParticipantSlug = slug || `speaker-${ +new Date() }`;
 
-		const newParticipant = {
-			slug: newParticipantSlug,
-			label: sanitizedSpeakerLabel,
-		};
+			const newParticipant = {
+				slug: newParticipantSlug,
+				label: sanitizedSpeakerLabel,
+			};
 
-		setAttributes( {
-			participants: [
-				...participants,
-				newParticipant,
-			],
-		} );
+			setAttributes( {
+				participants: [ ...participants, newParticipant ],
+			} );
 
-		return newParticipant;
-	}, [ participants, setAttributes ] );
+			return newParticipant;
+		},
+		[ participants, setAttributes ]
+	);
 
 	const setBlockAttributes = useCallback( setAttributes, [] );
 
@@ -85,12 +85,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 				showTimestamps,
 			},
 		} ),
-		[
-			addNewParticipant,
-			setBlockAttributes,
-			showTimestamps,
-			updateParticipants,
-		]
+		[ addNewParticipant, setBlockAttributes, showTimestamps, updateParticipants ]
 	);
 
 	function deleteParticipant( deletedParticipantSlug ) {
@@ -107,7 +102,7 @@ function ConversationEdit( { className, attributes, setAttributes } ) {
 				<InspectorControls>
 					<Panel>
 						<PanelBody
-							title={ __( 'Participants', 'jetpack' ) }
+							title={ __( 'Speakers', 'jetpack' ) }
 							className={ `${ baseClassName }__participants` }
 						>
 							<ParticipantsSelector

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -21,7 +21,11 @@ import { useMemo, useState, useEffect, Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { getParticipantByLabel, getParticipantBySlug, getPlainText } from '../../conversation/utils';
+import {
+	getParticipantByLabel,
+	getParticipantBySlug,
+	getPlainText,
+} from '../../conversation/utils';
 
 const EDIT_MODE_ADDING = 'is-adding';
 const EDIT_MODE_SELECTING = 'is-selecting';
@@ -31,9 +35,7 @@ function ParticipantsMenu( { participants, className, onSelect, slug, onClose } 
 	return (
 		<MenuGroup className={ `${ className }__participants-selector` }>
 			{ participants.map( ( { label, slug: speakerSlug } ) => {
-				const optionLabel = (
-					<span>{ label }</span>
-				);
+				const optionLabel = <span>{ label }</span>;
 
 				return (
 					<MenuItem
@@ -56,16 +58,15 @@ function ParticipantsMenu( { participants, className, onSelect, slug, onClose } 
 export function ParticipantsControl( { participants, slug, onSelect } ) {
 	return (
 		<SelectControl
-			label={ __( 'Participant name', 'jetpack' ) }
+			label={ __( 'Speaker name', 'jetpack' ) }
 			value={ slug }
 			options={ participants.map( ( { slug: value, label } ) => ( {
 				label: getPlainText( label ),
 				value,
 			} ) ) }
-			onChange={ participantSlug => onSelect( getParticipantBySlug(
-				participants,
-				participantSlug
-			) ) }
+			onChange={ participantSlug =>
+				onSelect( getParticipantBySlug( participants, participantSlug ) )
+			}
 		/>
 	);
 }
@@ -90,11 +91,7 @@ const DetectOutside = withFocusOutside(
 		}
 
 		render() {
-			return (
-				<div className={ this.props.className }>
-					{ this.props.children }
-				</div>
-			);
+			return <div className={ this.props.className }>{ this.props.children }</div>;
 		}
 	}
 );
@@ -111,13 +108,11 @@ function refreshAutocompleter( participants ) {
 		triggerPrefix: '',
 		options: participants,
 
-		getOptionLabel: ( { label } ) => (
-			<span>{ getPlainText( label ) }</span>
-		),
+		getOptionLabel: ( { label } ) => <span>{ getPlainText( label ) }</span>,
 
 		getOptionKeywords: ( { label } ) => [ label ],
 
-		getOptionCompletion: ( option ) => ( {
+		getOptionCompletion: option => ( {
 			action: 'replace',
 			value: option,
 		} ),
@@ -156,7 +151,9 @@ export function SpeakerEditControl( {
 	onAdd,
 	onClean,
 } ) {
-	const [ editingMode, setEditingMode ] = useState( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
+	const [ editingMode, setEditingMode ] = useState(
+		participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING
+	);
 
 	function editSpeakerHandler() {
 		if ( ! label ) {
@@ -261,7 +258,7 @@ export function SpeakerEditControl( {
 				placeholder={ __( 'Speaker', 'jetpack' ) }
 				keepPlaceholderOnFocus={ true }
 				onSplit={ () => {} }
-				onReplace={ ( replaceValue ) => {
+				onReplace={ replaceValue => {
 					setTimeout( () => transcriptRef?.current?.focus(), 10 );
 
 					const replacedParticipant = replaceValue?.[ 0 ];

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -34,10 +34,10 @@ const blockNameFallback = 'core/paragraph';
 const useDebounceWithFallback = useDebounce
 	? useDebounce
 	: function useDebounceFallback( ...args ) {
-		const debounced = useMemoOne( () => debounce( ...args ), args );
-		useEffect( () => () => debounced.cancel(), [ debounced ] );
-		return debounced;
-	};
+			const debounced = useMemoOne( () => debounce( ...args ), args );
+			useEffect( () => () => debounced.cancel(), [ debounced ] );
+			return debounced;
+	  };
 
 export default function DialogueEdit( {
 	className,
@@ -48,14 +48,7 @@ export default function DialogueEdit( {
 	mergeBlocks,
 	isSelected,
 } ) {
-	const {
-		content,
-		label,
-		slug,
-		placeholder,
-		showTimestamp,
-		timestamp,
-	} = attributes;
+	const { content, label, slug, placeholder, showTimestamp, timestamp } = attributes;
 
 	const { mediaSource, mediaCurrentTime, mediaDuration, mediaDomReference } = useSelect( select => {
 		const {
@@ -80,9 +73,7 @@ export default function DialogueEdit( {
 	const participantsFromContext = context[ 'jetpack/conversation-participants' ];
 
 	// Participants list.
-	const participants = participantsFromContext?.length
-		? participantsFromContext
-		: [];
+	const participants = participantsFromContext?.length ? participantsFromContext : [];
 
 	const conversationParticipant = getParticipantBySlug( participants, slug );
 
@@ -140,7 +131,7 @@ export default function DialogueEdit( {
 
 			<InspectorControls>
 				<Panel>
-					<PanelBody title={ __( 'Participant', 'jetpack' ) }>
+					<PanelBody title={ __( 'Speaker', 'jetpack' ) }>
 						<ParticipantsControl
 							className={ BASE_CLASS_NAME }
 							participants={ participants }
@@ -176,20 +167,21 @@ export default function DialogueEdit( {
 					participant={ conversationParticipant }
 					participants={ participants }
 					transcriptRef={ contentRef }
-					onParticipantChange={ ( updatedParticipant ) => {
+					onParticipantChange={ updatedParticipant => {
 						setAttributes( { label: updatedParticipant } );
 					} }
 					onSelect={ setAttributes }
-
 					onClean={ () => {
 						setAttributes( { slug: null, label: '' } );
 					} }
-
-					onAdd={ ( newLabel ) => {
-						const newParticipant = conversationBridge.addNewParticipant( { label: newLabel, slug } );
+					onAdd={ newLabel => {
+						const newParticipant = conversationBridge.addNewParticipant( {
+							label: newLabel,
+							slug,
+						} );
 						setAttributes( newParticipant );
 					} }
-					onUpdate={ ( participant ) => {
+					onUpdate={ participant => {
 						conversationBridge.updateParticipants( participant );
 					} }
 				/>
@@ -202,7 +194,7 @@ export default function DialogueEdit( {
 						value={ timestamp }
 						mediaCurrentTime={ mediaCurrentTime }
 						onChange={ setTimestamp }
-						onToggle={ ( show ) => setAttributes( { showTimestamp: show } ) }
+						onToggle={ show => setAttributes( { showTimestamp: show } ) }
 						onPlayback={ audioPlayback }
 					/>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates the "Participant" labels in the sidebar to "Speaker" to be consistent with the DIalogue block placeholder.

| Conversation sidebar | Dialogue sidebar | Dialogue placeholder |
| - | - | - |
| <img width="274" alt="Screen Shot 2021-02-15 at 12 15 49" src="https://user-images.githubusercontent.com/1699996/107984710-257e3780-6f8e-11eb-8d45-f675d51e3fb0.png"> | <img width="273" alt="Screen Shot 2021-02-15 at 12 16 08" src="https://user-images.githubusercontent.com/1699996/107984712-2616ce00-6f8e-11eb-8be9-2cc4076b7ba4.png"> | <img width="381" alt="Screen Shot 2021-02-15 at 12 19 28" src="https://user-images.githubusercontent.com/1699996/107984713-2616ce00-6f8e-11eb-9799-e3c0469c2c13.png">


#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Insert a conversation block
* See that "Speaker" is used in the sidebar of both the Conversation and Dialogue blocks

Most of the changes in this PR are Prettier pre-commit formatting. The actual label changes are these:

- [Conversation block sidebar](https://github.com/Automattic/jetpack/pull/18829/files#diff-04a08080b68bc48aa381ec4de36541e54ae76ca3f8f2231fdb71ef506b3041d4R105)
- [Dialogue block sidebar](https://github.com/Automattic/jetpack/pull/18829/files#diff-c77c717cb9d1e917e90b90e3dee5194d902a0999ad5acf3309726cd6b836e0dcR134)
- [Dialogue block dropdown](https://github.com/Automattic/jetpack/pull/18829/files#diff-304429f01a58379889bd99ce8beab22128391ab8a922c2de610cb82b743ad04cR61)

#### Proposed changelog entry for your changes:

n/a, as I think we already have changelog entries for these blocks
