### PR TITLE
Recurring Payments: fix import errors when adding payment plan

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -27,9 +27,13 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies
  */
 import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
-import { minimumTransactionAmountForCurrency } from '../../shared/currencies';
+import {
+	CURRENCY_OPTIONS,
+	isPriceValid,
+	minimumTransactionAmountForCurrency,
+} from '../../shared/currencies';
 import getSiteFragment from '../../shared/get-site-fragment';
-import { icon, isPriceValid, removeInvalidProducts, CURRENCY_OPTIONS } from '.';
+import { icon, removeInvalidProducts } from '.';
 import { flashIcon } from '../../shared/icons';
 
 const API_STATE_LOADING = 0;

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
@@ -49,10 +49,6 @@
 			margin-right: 4px;
 		}
 
-		&__field-currency {
-			width: 30%;
-		}
-
 		&__field-error .components-text-control__input {
 			border: 1px solid;
 			border-color: var( --color-error );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/50091

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* A few utility functions and constants were moved as part of the Premium Content move to Jetpack, and imported incorrectly from within the Recurring Payments block. This caused issues when trying to add a new Payment plan from the block, and also caused the Currency input to not appear. This PR fixes the imports.
* When I added the Currency input back in I noticed it was being collapsed very small, so that you couldn't read the text of the label. This PR includes a CSS fix for that.

Currency input before:
<img width="248" alt="Screen Shot 2021-02-15 at 11 33 27 AM" src="https://user-images.githubusercontent.com/63313398/107986793-a420a800-6f81-11eb-8253-4882de0f0664.png">

Currency input after:
<img width="237" alt="Screen Shot 2021-02-15 at 11 33 05 AM" src="https://user-images.githubusercontent.com/63313398/107986811-abe04c80-6f81-11eb-85b3-c62fb13d4f65.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test for wpcom and jetpack. You will need a Premium plan and a Stripe connection in order to test.
* Create a new post and add a Payments block
* From the Payments menu above the block (pictured below), click `Add a new Payment plan`
* Enter a new amount in the `Price` input
* Verify that the `Currency` input renders correctly (correct width) and can be edited as well
* Add the new plan
* Publish the post
* View it from an incognito window and click the button. You should see a confirmation window asking you to pay the price you entered earlier.

**NOTE: There are a couple of pre-existing CSS issues with the `Add New Payment Plan` box, including the text being partially cut off by padding in the Currency input in certain themes. Separate issues have been filed for those**

Screenshots:


<img width="662" alt="Screen Shot 2021-02-15 at 11 03 30 AM" src="https://user-images.githubusercontent.com/63313398/107984910-d92afb80-6f7d-11eb-925d-e14a1179e940.png">

<img width="636" alt="Screen Shot 2021-02-15 at 11 31 02 AM" src="https://user-images.githubusercontent.com/63313398/107986829-b7cc0e80-6f81-11eb-9a3c-03768d559edf.png">

When the button is clicked on the frontend from an Incognito window, after adding a custom $0.55 plan:
<img width="723" alt="Screen Shot 2021-02-15 at 11 05 57 AM" src="https://user-images.githubusercontent.com/63313398/107984911-db8d5580-6f7d-11eb-9437-05eb6b032bd5.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
