### PR TITLE
Dialogue: Tweak speaker input size

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -3,6 +3,7 @@
  */
 import { debounce } from 'lodash';
 import { useMemoOne } from 'use-memo-one';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -169,7 +170,9 @@ export default function DialogueEdit( {
 				</Panel>
 			</InspectorControls>
 
-			<div className={ `${ BASE_CLASS_NAME }__meta` }>
+			<div className={ classnames( `${ BASE_CLASS_NAME }__meta`, {
+				'has-not-media-source': ! mediaSource,
+			} ) }>
 				<SpeakerEditControl
 					className={ `${ BASE_CLASS_NAME }__participant` }
 					label={ label }

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -42,7 +42,6 @@
 	opacity: 0.7;
 }
 
-
 .wp-block-jetpack-conversation:not(.is-style-column) {
 	.wp-block-jetpack-dialogue__meta {
 		// The div below is added by the withFocusOutside HoC.

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -46,7 +46,7 @@
 	.wp-block-jetpack-dialogue__meta {
 		// The div below is added by the withFocusOutside HoC.
 		// We need to stretch it out to deal with speaker width.
-		&.has-not-media-source > div:not([class]) {
+		&.has-not-media-source > div {
 			width: 100%;
 		}	
 	

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -16,7 +16,6 @@
 	margin-right: 5px;
 }
 
-
 .wp-block-jetpack-dialogue__timestamp-control__play-button {
 	align-self: flex-end;
 	margin-left: 10px;
@@ -41,4 +40,19 @@
 
 .wp-block-jetpack-dialogue__participant.is-editing-participant {
 	opacity: 0.7;
+}
+
+
+.wp-block-jetpack-conversation:not(.is-style-column) {
+	.wp-block-jetpack-dialogue__meta {
+		// The div below is added by the withFocusOutside HoC.
+		// We need to stretch it out to deal with speaker width.
+		&.has-not-media-source > div:not([class]) {
+			width: 100%;
+		}	
+	
+		.wp-block-jetpack-dialogue__participant {
+			min-width: 50px;
+		}
+	}
 }

--- a/projects/plugins/jetpack/extensions/shared/components/media-player-control/index.js
+++ b/projects/plugins/jetpack/extensions/shared/components/media-player-control/index.js
@@ -125,7 +125,7 @@ export function MediaPlayerControl( {
 
 export function MediaPlayerToolbarControl( props ) {
 	return (
-		<ToolbarGroup>
+		<ToolbarGroup className="media-player-control__toolbar">
 			<MediaPlayerControl { ...props } />
 		</ToolbarGroup>
 	);

--- a/projects/plugins/jetpack/extensions/shared/components/media-player-control/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/media-player-control/style.scss
@@ -23,3 +23,9 @@
 		padding: 0;
 	}
 }
+
+.media-player-control__toolbar .components-toolbar-button {
+	.dashicons {
+		margin: 0;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR tweaks the speaker input size to try to improve the UX when selecting and in general interacting with the editor.
Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: Tweak speaker input size

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p7DVsv-atS-p2#comment-34465

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit/create an empty post

Step | Screenshot
-----|------
Add a Conversation Block | ![image](https://user-images.githubusercontent.com/77539/107993814-2200a580-6fba-11eb-973e-79c7ee872b07.png)
Confirm the speaker input stretches to the whole width. It allows start to edit the speaker by clicking on any place of the input. | ![image](https://user-images.githubusercontent.com/77539/107993876-4197ce00-6fba-11eb-8d99-f2c7a8c5d416.png)
Confirm it's still easily selectable when the speaker has only one character, for instance, a dot `.`. | ![image](https://user-images.githubusercontent.com/77539/107994275-182b7200-6fbb-11eb-9447-538a57a22600.png)
Add a podcast player block. | ![image](https://user-images.githubusercontent.com/77539/107994106-b23eea80-6fba-11eb-8814-19bfa7b7240f.png)
Now, when clicking on the speaker area, it also shows the `Add timestamp` button. | ![image](https://user-images.githubusercontent.com/77539/107994318-32655000-6fbb-11eb-8caf-fd885fb1b51a.png)
Confirm the speaker input has a min-width that allows to select it easily too. | ![image](https://user-images.githubusercontent.com/77539/107994389-4ad56a80-6fbb-11eb-8338-4df5c9ecab77.png)
Confirm these changes don't affect the `Column` style. | ![image](https://user-images.githubusercontent.com/77539/107994538-95ef7d80-6fbb-11eb-9c04-1e1ba2511c9e.png)


This PR also fixes an issue in the `<MediaPlayerControl />` component, removing the extra margin in the play/pause icons (dashicons). It happens in the current master version of core, or also in Simple sites:

before | after
-----|-------
<img width="350" alt="Screen Shot 2021-02-15 at 6 31 56 PM" src="https://user-images.githubusercontent.com/77539/107994807-20d07800-6fbc-11eb-884a-484eddb36de6.png"> | <img width="394" alt="Screen Shot 2021-02-15 at 6 30 52 PM" src="https://user-images.githubusercontent.com/77539/107994810-229a3b80-6fbc-11eb-9624-00f734dc97c0.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*