### PR TITLE
Conversation: Handle closely speaker-name changes propagation

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -102,7 +102,7 @@ const DetectOutside = withFocusOutside(
  * @param {Array} participants - Conversation participants list.
  * @returns {object} Participants autocompleter.
  */
-function refreshAutocompleter( participants ) {
+function freshAutocompleter( participants ) {
 	return {
 		name: 'jetpack/conversation-participants',
 		triggerPrefix: '',
@@ -232,7 +232,7 @@ export function SpeakerEditControl( {
 			return [];
 		}
 
-		return [ refreshAutocompleter( participants ) ];
+		return [ freshAutocompleter( participants ) ];
 	}, [ participants, editingMode ] );
 
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -40,7 +40,7 @@ export default function DialogueEdit( {
 } ) {
 	const { content, label, slug, placeholder, showTimestamp, timestamp } = attributes;
 
-	const { mediaSource, mediaCurrentTime, mediaDuration, mediaDomReference } = useSelect( select => {
+	const { mediaSource, mediaCurrentTime, mediaDuration, mediaDomReference, isMultipleSelection } = useSelect( select => {
 		const {
 			getDefaultMediaSource,
 			getMediaSourceCurrentTime,
@@ -53,6 +53,7 @@ export default function DialogueEdit( {
 			mediaCurrentTime: getMediaSourceCurrentTime(),
 			mediaDuration: getMediaSourceDuration(),
 			mediaDomReference: getMediaSourceDomReference(),
+			isMultipleSelection: select( 'core/block-editor' ).getMultiSelectedBlocks().length,
 		};
 	}, [] );
 
@@ -77,6 +78,10 @@ export default function DialogueEdit( {
 			return;
 		}
 
+		if ( isMultipleSelection ) {
+			return;
+		}
+
 		// When no context, nothing to do.
 		if ( ! conversationParticipant ) {
 			return;
@@ -90,7 +95,7 @@ export default function DialogueEdit( {
 		setAttributes( {
 			label: conversationParticipant.label,
 		} );
-	}, [ conversationParticipant, isSelected, setAttributes, slug ] );
+	}, [ conversationParticipant, isMultipleSelection, isSelected, setAttributes, slug ] );
 
 	function setTimestamp( time ) {
 		setAttributes( { timestamp: time } );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
-import { useMemoOne } from 'use-memo-one';
 import classnames from 'classnames';
 
 /**
@@ -14,7 +12,6 @@ import { createBlock } from '@wordpress/blocks';
 import { useContext, useEffect, useRef } from '@wordpress/element';
 import { dispatch, useSelect, useDispatch } from '@wordpress/data';
 import { Panel, PanelBody } from '@wordpress/components';
-import { useDebounce } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -31,14 +28,6 @@ import { getParticipantBySlug } from '../conversation/utils';
 
 const blockName = 'jetpack/dialogue';
 const blockNameFallback = 'core/paragraph';
-
-const useDebounceWithFallback = useDebounce
-	? useDebounce
-	: function useDebounceFallback( ...args ) {
-			const debounced = useMemoOne( () => debounce( ...args ), args );
-			useEffect( () => () => debounced.cancel(), [ debounced ] );
-			return debounced;
-	  };
 
 export default function DialogueEdit( {
 	className,
@@ -81,8 +70,6 @@ export default function DialogueEdit( {
 	// Conversation context. A bridge between dialogue and conversation blocks.
 	const conversationBridge = useContext( ConversationContext );
 
-	const debounceSetDialoguesAttrs = useDebounceWithFallback( setAttributes, 250 );
-
 	// Update dialogue participant with conversation participant changes.
 	useEffect( () => {
 		// Do not update current Dialogue block.
@@ -100,10 +87,10 @@ export default function DialogueEdit( {
 			return;
 		}
 
-		debounceSetDialoguesAttrs( {
+		setAttributes( {
 			label: conversationParticipant.label,
 		} );
-	}, [ conversationParticipant, debounceSetDialoguesAttrs, isSelected, slug ] );
+	}, [ conversationParticipant, isSelected, setAttributes, slug ] );
 
 	function setTimestamp( time ) {
 		setAttributes( { timestamp: time } );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -73,12 +73,13 @@ export default function DialogueEdit( {
 
 	// Update dialogue participant with conversation participant changes.
 	useEffect( () => {
-		// Do not update current Dialogue block.
-		if ( isSelected ) {
+		// Do not update when multi blocks selected.
+		if ( isMultipleSelection ) {
 			return;
 		}
 
-		if ( isMultipleSelection ) {
+		// Do not update current Dialogue block.
+		if ( isSelected ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -73,30 +73,42 @@ export default function DialogueEdit( {
 
 	// Update dialogue participant with conversation participant changes.
 	useEffect( () => {
-		// Do not update when multi blocks selected.
+		// Do not update when multi-blocks selected.
 		if ( isMultipleSelection ) {
 			return;
 		}
 
-		// Do not update current Dialogue block.
+		// Do not update current block.
 		if ( isSelected ) {
 			return;
 		}
 
-		// When no context, nothing to do.
+		// Bail early when bridge is not ready.
 		if ( ! conversationParticipant ) {
 			return;
 		}
 
-		// Only take care of Dialogue with same speaker.
+		// Only take care of blocks with same speaker slug.
 		if ( conversationParticipant.slug !== slug ) {
+			return;
+		}
+
+		// Only update if the label has changed.
+		if ( conversationParticipant.label === label ) {
 			return;
 		}
 
 		setAttributes( {
 			label: conversationParticipant.label,
 		} );
-	}, [ conversationParticipant, isMultipleSelection, isSelected, setAttributes, slug ] );
+	}, [
+		conversationParticipant,
+		label,
+		slug,
+		isMultipleSelection,
+		isSelected,
+		setAttributes,
+	] );
 
 	function setTimestamp( time ) {
 		setAttributes( { timestamp: time } );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -53,7 +53,7 @@ export default function DialogueEdit( {
 			mediaCurrentTime: getMediaSourceCurrentTime(),
 			mediaDuration: getMediaSourceDuration(),
 			mediaDomReference: getMediaSourceDomReference(),
-			isMultipleSelection: select( 'core/block-editor' ).getMultiSelectedBlocks().length,
+			isMultipleSelection: select( 'core/block-editor' ).getMultiSelectedBlocks().length > 0,
 		};
 	}, [] );
 
@@ -178,7 +178,13 @@ export default function DialogueEdit( {
 					onParticipantChange={ updatedParticipant => {
 						setAttributes( { label: updatedParticipant } );
 					} }
-					onSelect={ setAttributes }
+					onSelect={ ( selectedParticipant ) => {
+						if ( isMultipleSelection ) {
+							return;
+						}
+
+						setAttributes( selectedParticipant );
+					} }
 					onClean={ () => {
 						setAttributes( { slug: null, label: '' } );
 					} }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

~This PR fixes a bug when the user selects multiple blocks. It changes the speakers of some Dialogue blocks because the app detects that the block is selected, and consequently updates the speaker.~

This PR handles the propagation of the speaker-name changes among all Dialogue sibling blocks closely.
It checks if whether the participant label and the current block label are different before applying the changes, also checks if there is a multi-blocks-selection, and finally it removes the debouncing when setting attributes.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation: Handle closely speaker-name changes propagation

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p7DVsv-atS-p2#comment-34479

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create Conversation/Dialogue composition
* Defines some speakers for them

**before**
In the following video, the speaker changes from `James` to `Jimmy` just because of the multi-selection.

https://user-images.githubusercontent.com/77539/108001635-b9222900-6fcb-11eb-83be-346ec966a130.mov



**after**
It's possible to select all blocks, move them and also apply a multiple speaker edition 

https://user-images.githubusercontent.com/77539/108001540-7a8c6e80-6fcb-11eb-9ccc-d228d7d20869.mov

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*