### PR TITLE
Podcast Helper: Allow filtering the number of tracks returned by get_track_list.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -170,9 +170,18 @@ class Jetpack_Podcast_Helper {
 			return $rss;
 		}
 
-		// Get first ten items by default and format them.
+		/**
+		 * Allow requesting a specific number of tracks from SimplePie's `get_items` call.
+		 * The default number of tracks is ten.
+		 *
+		 * @since 9.5.0
+		 *
+		 * @param object $rss The SimplePie object built from core's `fetch_feed` call.
+		 */
 		$tracks_quantity = apply_filters( 'jetpack_podcast_helper_list_quantity', 10, $rss );
-		$track_list      = array_map( array( __CLASS__, 'setup_tracks_callback' ), $rss->get_items( 0, $tracks_quantity ) );
+
+		// Process the requested number of items from our feed.
+		$track_list = array_map( array( __CLASS__, 'setup_tracks_callback' ), $rss->get_items( 0, $tracks_quantity ) );
 
 		// Filter out any tracks that are empty.
 		// Reset the array indicies.

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -170,8 +170,9 @@ class Jetpack_Podcast_Helper {
 			return $rss;
 		}
 
-		// Get first ten items and format them.
-		$track_list = array_map( array( __CLASS__, 'setup_tracks_callback' ), $rss->get_items( 0, 10 ) );
+		// Get first ten items by default and format them.
+		$tracks_quantity = apply_filters( 'jetpack_podcast_helper_list_quantity', 10, $rss );
+		$track_list      = array_map( array( __CLASS__, 'setup_tracks_callback' ), $rss->get_items( 0, $tracks_quantity ) );
 
 		// Filter out any tracks that are empty.
 		// Reset the array indicies.

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -176,7 +176,8 @@ class Jetpack_Podcast_Helper {
 		 *
 		 * @since 9.5.0
 		 *
-		 * @param object $rss The SimplePie object built from core's `fetch_feed` call.
+		 * @param int    $number Number of tracks fetched. Default is 10.
+		 * @param object $rss    The SimplePie object built from core's `fetch_feed` call.
 		 */
 		$tracks_quantity = apply_filters( 'jetpack_podcast_helper_list_quantity', 10, $rss );
 


### PR DESCRIPTION
This PR adds a filter to allow a variable number of tracks to be returned when getting a track list. The default remains at ten.

See: 474-gh-Automattic/dotcom-manage

#### Jetpack product discussion
pbAPfg-PF-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* TBD

#### Proposed changelog entry for your changes:
* A filter is now available to modify the number of tracks returned by a Podcast Helper track list.