### PR TITLE
Dialogue: handling attributes for split blocks

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -216,8 +216,14 @@ export default function DialogueEdit( {
 						return createBlock( blockNameFallback );
 					}
 
+					// Copy attrs for the new block
+					// only if content is not empty.
+					const newAttributes = value?.length
+						? attributes
+						: {};
+
 					return createBlock( blockName, {
-						...attributes,
+						...newAttributes,
 						content: value,
 					} );
 				} }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR handles properly the block attributes for the block when they are created by splitting its content.
Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: handling attributes for split blocks.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1613477977476200-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create / Edit a new Conversation/Dialogue blocks composition. Set an speaker value and fill the content.
<img src="https://user-images.githubusercontent.com/77539/108064052-e35eff80-703a-11eb-801d-c0414f01cb01.png" width="500px" />

* Split the content by pressing the ENTER key in the start, middle, and end of the Dialogue content.


**BEFORE**
It doesn't matter how the content was split, the speaker is always propagated to the new block


**AFTER**
The speaker is propagated as long as the new block gets content.

**before** | **after**
------|------
![image](https://user-images.githubusercontent.com/77539/108064216-1bfed900-703b-11eb-96f6-c8b237b1f3d8.png) | ![image](https://user-images.githubusercontent.com/77539/108064585-a9dac400-703b-11eb-85b1-f7ca9e1a299d.png)
![image](https://user-images.githubusercontent.com/77539/108064478-831c8d80-703b-11eb-9e8f-9222619c19cb.png) | ![image](https://user-images.githubusercontent.com/77539/108064646-bfe88480-703b-11eb-95a7-f97452c56d77.png)
![image](https://user-images.githubusercontent.com/77539/108064501-8d3e8c00-703b-11eb-9472-043e81193b99.png) | ![image](https://user-images.githubusercontent.com/77539/108064689-cb3bb000-703b-11eb-8479-b1cf25315cbc.png)




#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
