### PR TITLE
E2E tests: Add record video option

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -90,7 +90,7 @@ jobs:
       continue-on-error: true
       uses: actions/upload-artifact@v2
       with:
-        name: test-output
+        name: test-output-${{ matrix.gutenberg }}
         path: projects/plugins/jetpack/tests/e2e/output
 
     # Disable Allure reports until we'll need it

--- a/projects/plugins/jetpack/tests/e2e/jest-playwright.config.js
+++ b/projects/plugins/jetpack/tests/e2e/jest-playwright.config.js
@@ -22,5 +22,9 @@ module.exports = {
 			width: 1280,
 			height: 1024,
 		},
+		recordVideo: {
+			dir: 'output/videos/',
+			size: { width: 800, height: 600 },
+		},
 	},
 };

--- a/projects/plugins/jetpack/tests/e2e/jest-playwright.config.js
+++ b/projects/plugins/jetpack/tests/e2e/jest-playwright.config.js
@@ -24,6 +24,7 @@ module.exports = {
 		},
 		recordVideo: {
 			dir: 'output/videos/',
+			//todo revisit video resolution with Playwright 1.9.0
 			size: { width: 800, height: 600 },
 		},
 	},

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -17,8 +17,8 @@
 	"distclean": "rm -rf node_modules && yarn clean",
 	"install-if-deps-outdated": "yarn install --check-files --production=false --frozen-lockfile",
 	"test-e2e-env": "./bin/env.sh start",
-	"test-decrypt-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./config/encrypted.enc -out ./config/local-test.js",
 	"test-e2e": "NODE_CONFIG_DIR='./config' jest --config jest.config.js --runInBand --verbose",
+	"test-decrypt-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./config/encrypted.enc -out ./config/local-test.js",
 	"test-encrypt-config": "openssl enc -md sha1 -aes-256-cbc -pass env:CONFIG_KEY -in ./config/local-test.js -out ./config/encrypted.enc"
   },
   "devDependencies": {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

##### Add video recording capability for E2E tests

* Used Playwright's video recording capability. Currently there is no option to specify a video file naming pattern. If needed we can address this in the future and find a way to somehow rename the files.
* 800x600 resolution is currently needed to workaround a Playwright issue that is scheduled to be fixed in version 1.9.0

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* E2E tests should pass and video recordings should be saved in `output/videos`

#### Proposed changelog entry for your changes:
n/a
