### PR TITLE
Dialogue: improve speakers autocomplete handling

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -16,7 +16,7 @@ import {
 import { check, people } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
-import { useMemo, useState, useEffect, Component } from '@wordpress/element';
+import { useMemo, useState, Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -151,9 +151,7 @@ export function SpeakerEditControl( {
 	onAdd,
 	onClean,
 } ) {
-	const [ editingMode, setEditingMode ] = useState(
-		participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING
-	);
+	const [ editingMode, setEditingMode ] = useState();
 
 	function editSpeakerHandler() {
 		if ( ! label ) {
@@ -228,16 +226,17 @@ export function SpeakerEditControl( {
 
 	// Keep autocomplete options udated.
 	const autocompleter = useMemo( () => {
+		// No autocomplete when no edit mode defined.
+		if ( ! editingMode ) {
+			return [];
+		}
+
 		if ( editingMode === EDIT_MODE_EDITING ) {
 			return [];
 		}
 
 		return [ refreshAutocompleter( participants ) ];
 	}, [ participants, editingMode ] );
-
-	useEffect( () => {
-		setEditingMode( participant ? EDIT_MODE_SELECTING : EDIT_MODE_ADDING );
-	}, [ participant ] );
 
 	return (
 		<DetectOutside

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -27,9 +27,13 @@ import {
 	getPlainText,
 } from '../../conversation/utils';
 
-const EDIT_MODE_ADDING = 'is-adding';
-const EDIT_MODE_SELECTING = 'is-selecting';
-const EDIT_MODE_EDITING = 'is-editing';
+const EDIT_MODE_READY = 'is-participant-ready';
+const EDIT_MODE_ADDING = 'is-participant-adding';
+const EDIT_MODE_ADDED = 'was-participant-added';
+const EDIT_MODE_SELECTING = 'is-participant-selecting';
+const EDIT_MODE_SELECTED = 'was-participant-selected';
+const EDIT_MODE_EDITING = 'is-participant-editing';
+const EDIT_MODE_EDITED = 'was-participant-edited';
 
 function ParticipantsMenu( { participants, className, onSelect, slug, onClose } ) {
 	return (
@@ -151,7 +155,7 @@ export function SpeakerEditControl( {
 	onAdd,
 	onClean,
 } ) {
-	const [ editingMode, setEditingMode ] = useState();
+	const [ editingMode, setEditingMode ] = useState( EDIT_MODE_READY );
 
 	function editSpeakerHandler() {
 		if ( ! label ) {
@@ -163,10 +167,11 @@ export function SpeakerEditControl( {
 		if ( participant && participant.label !== label ) {
 			// Check if the participant label exists, but it isn't the current one.
 			if ( participantExists && participantExists.slug !== participant.slug ) {
+				setEditingMode( EDIT_MODE_SELECTED );
 				return onSelect( participantExists );
 			}
 
-			setEditingMode( EDIT_MODE_EDITING );
+			setEditingMode( EDIT_MODE_EDITED );
 			return onUpdate( {
 				...participant,
 				label: getPlainText( label, true ),
@@ -175,13 +180,13 @@ export function SpeakerEditControl( {
 
 		// Select the speaker but from the current label value.
 		if ( participantExists ) {
-			setEditingMode( EDIT_MODE_SELECTING );
+			setEditingMode( EDIT_MODE_SELECTED );
 			return onSelect( participantExists );
 		}
 
 		// Add a new speaker.
 		onAdd( getPlainText( label, true ) );
-		return setEditingMode( EDIT_MODE_ADDING );
+		return setEditingMode( EDIT_MODE_ADDED );
 	}
 
 	/**
@@ -231,7 +236,12 @@ export function SpeakerEditControl( {
 			return [];
 		}
 
-		if ( editingMode === EDIT_MODE_EDITING ) {
+		// SHow Autocomplete only when
+		// adding a selecting a/the participant.
+		if (
+			editingMode !== EDIT_MODE_ADDING &&
+			editingMode !== EDIT_MODE_SELECTING
+		) {
 			return [];
 		}
 
@@ -242,9 +252,7 @@ export function SpeakerEditControl( {
 		<DetectOutside
 			className={ classNames( className, {
 				'has-bold-style': label?.length,
-				'is-adding-participant': editingMode === EDIT_MODE_ADDING,
-				'is-editing-participant': editingMode === EDIT_MODE_EDITING,
-				'is-selecting-participant': editingMode === EDIT_MODE_SELECTING,
+				[ editingMode ]: editingMode,
 			} ) }
 			onFocusOutside={ editSpeakerHandler }
 		>
@@ -266,7 +274,7 @@ export function SpeakerEditControl( {
 					if ( replacedParticipant ) {
 						const { label: newLabel } = replacedParticipant;
 						onParticipantChange( newLabel );
-						setEditingMode( EDIT_MODE_SELECTING );
+						setEditingMode( EDIT_MODE_SELECTED );
 						return onSelect( replacedParticipant );
 					}
 

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/editor.scss
@@ -34,11 +34,8 @@
 	min-width: 90px;
 }
 
-.wp-block-jetpack-dialogue__participant.is-adding-participant {
-	opacity: 0.7;
-}
-
-.wp-block-jetpack-dialogue__participant.is-editing-participant {
+.wp-block-jetpack-dialogue__participant.is-participant-adding,
+.wp-block-jetpack-dialogue__participant.is-participant-editing {
 	opacity: 0.7;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR improves the way of handling the speaker's autocompleter.


Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dialogue: improve speakers autocomplete handling

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

> When the suggestion text is the same as the label I’ve already entered, and there’s just one suggestion, I wouldn’t expect to see suggestions at all:
> <img src="https://user-images.githubusercontent.com/77539/108090614-93436580-7059-11eb-9e54-5a57729e1f87.png" width="300px" />

p7DVsv-atS-p2#comment-34461


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test the whole implementation gets a little bit tricky. The best way to do it is by paying attention to the CSS class defined in the participant element:

State | Canvas | Element Inspector
-----|------|-----
Create a new block ( **ready** - initial state) | ![image](https://user-images.githubusercontent.com/77539/108091128-254b6e00-705a-11eb-8084-cc6eff1cfc8a.png) | ![image](https://user-images.githubusercontent.com/77539/108091165-31373000-705a-11eb-91fe-59b77f35e33a.png)
Start to type to add anew participant (**adding**) | ![image](https://user-images.githubusercontent.com/77539/108091250-490eb400-705a-11eb-86f7-d90304fb2646.png) | ![image](https://user-images.githubusercontent.com/77539/108091273-4e6bfe80-705a-11eb-8f29-25b3f592812c.png)
Add the new participant (**added**) | ![image](https://user-images.githubusercontent.com/77539/108091342-62affb80-705a-11eb-9db8-6473aaabcd9c.png) | ![image](https://user-images.githubusercontent.com/77539/108091427-765b6200-705a-11eb-9807-344ab00931f9.png)
Start to edit (**editing**) | ![image](https://user-images.githubusercontent.com/77539/108091504-8a9f5f00-705a-11eb-99f6-e54a2c7b0941.png) | ![image](https://user-images.githubusercontent.com/77539/108091524-8ecb7c80-705a-11eb-9de5-8467dad18722.png)
Edit the participant (**edited**) | ![image](https://user-images.githubusercontent.com/77539/108091598-a0ad1f80-705a-11eb-90b9-a7f30db3cad6.png) | ![image](https://user-images.githubusercontent.com/77539/108091615-a571d380-705a-11eb-99dd-f7e8b69f7c27.png)
When editing the label matches with a participant already added, it changes to **selecting** | ![image](https://user-images.githubusercontent.com/77539/108091779-c9cdb000-705a-11eb-80d7-e2f20b075a1a.png) | ![image](https://user-images.githubusercontent.com/77539/108091809-d520db80-705a-11eb-9205-f61a3a191bf7.png)
Once **selected** | ![image](https://user-images.githubusercontent.com/77539/108091984-000b2f80-705b-11eb-8bdd-2d4687c591a7.png) | ![image](https://user-images.githubusercontent.com/77539/108092016-06011080-705b-11eb-915c-36192afc9ea7.png)

In short, confirm that the Autocompleter is only shown when adding a new speaker, or by selecting while typing a new one and it matches with a label already added.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*