### PR TITLE
Conversation Block: Correct the strokeWidth attribute in the icon

### DIFF
--- a/projects/plugins/jetpack/extensions/shared/icons.js
+++ b/projects/plugins/jetpack/extensions/shared/icons.js
@@ -201,7 +201,7 @@ export const TranscriptIcon = {
 				<Path
 					d="M11.1114 8H20.0002M11.1113 15H20.0002"
 					stroke={ getIconColor() }
-					stroke-width="1.5"
+					strokeWidth="1.5"
 				/>
 				<Path d="M4 10V6L8 8L4 10Z" fill={ getIconColor() } />
 				<Path d="M4 17V13L8 15L4 17Z" fill={ getIconColor() } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The `TranscriptIcon` was using an attribute of `stroke-width` which is invalid JSX. This causes an error to be thrown as the icon is used by the inserter, selecting the block etc.

This change makes the attribute `strokeWidth` which fixes the issue.

#### Jetpack product discussion
This is a bug fix to an existing feature.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Open the developer console. 
* Open the block inserter with `/` or in some other way cause a conversation block to render its icon.
* Without this PR you should see an error saying `Warning: Invalid DOM property `stroke-width`. Did you mean 'strokeWidth'?`
* With this PR, there shouldn't be any error.

#### Proposed changelog entry for your changes:
N/A This is a minor bug fix
