### PR TITLE
Recommendations: Hide JITMs when banner is displaying

### DIFF
--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -80,7 +80,8 @@ class JITM {
 	 * @param \WP_Screen $screen WP Core's screen object.
 	 */
 	public function prepare_jitms( $screen ) {
-		if ( ! in_array(
+		// Disable all JITMs on these pages
+		if ( in_array(
 			$screen->id,
 			array(
 				'jetpack_page_akismet-key-config',
@@ -88,10 +89,21 @@ class JITM {
 			),
 			true
 		) ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
-			add_action( 'admin_notices', array( $this, 'ajax_message' ) );
-			add_action( 'edit_form_top', array( $this, 'ajax_message' ) );
+			return;
 		}
+
+		// Disable all JITMs on pages where the recommendations banner is displaying
+		if ( in_array( $screen->id, array(
+				'dashboard',
+				'plugins',
+				'jetpack_page_stats'
+			), true ) && \Jetpack_Recommendations_Banner::can_be_displayed() ) {
+			return;
+		}
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
+		add_action( 'admin_notices', array( $this, 'ajax_message' ) );
+		add_action( 'edit_form_top', array( $this, 'ajax_message' ) );
 	}
 
 	/**

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -80,7 +80,14 @@ class JITM {
 	 * @param \WP_Screen $screen WP Core's screen object.
 	 */
 	public function prepare_jitms( $screen ) {
-		// Show JITMs only if they aren't disabled on the current screen via this filter.
+		/**
+		 * Filter to hide JITMs on certain screens.
+		 *
+		 * @since 9.5.0
+		 *
+		 * @param bool true Whether to show just in time messages.
+		 * @param string $string->id The ID of the current screen.
+		 */
 		if ( apply_filters( 'jetpack_display_jitms_on_screen', true, $screen->id ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'admin_notices', array( $this, 'ajax_message' ) );

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -89,7 +89,7 @@ class JITM {
 					'admin_page_jetpack_modules',
 				),
 				true
-		) ) {
+			) ) {
 			return;
 		}
 
@@ -101,8 +101,10 @@ class JITM {
 					'dashboard',
 					'plugins',
 					'jetpack_page_stats',
-			), true ) &&
-			\Jetpack_Recommendations_Banner::can_be_displayed()
+				),
+				true
+			)
+			&& \Jetpack_Recommendations_Banner::can_be_displayed()
 		) {
 			return;
 		}

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -80,38 +80,11 @@ class JITM {
 	 * @param \WP_Screen $screen WP Core's screen object.
 	 */
 	public function prepare_jitms( $screen ) {
-		// Disable all JITMs on these pages.
-		if (
-			in_array(
-				$screen->id,
-				array(
-					'jetpack_page_akismet-key-config',
-					'admin_page_jetpack_modules',
-				),
-				true
-			) ) {
-			return;
+		if ( apply_filters( 'jetpack_display_jitms', true, $screen->id ) ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
+			add_action( 'admin_notices', array( $this, 'ajax_message' ) );
+			add_action( 'edit_form_top', array( $this, 'ajax_message' ) );
 		}
-
-		// Disable all JITMs on pages where the recommendations banner is displaying.
-		if (
-			in_array(
-				$screen->id,
-				array(
-					'dashboard',
-					'plugins',
-					'jetpack_page_stats',
-				),
-				true
-			)
-			&& \Jetpack_Recommendations_Banner::can_be_displayed()
-		) {
-			return;
-		}
-
-		add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
-		add_action( 'admin_notices', array( $this, 'ajax_message' ) );
-		add_action( 'edit_form_top', array( $this, 'ajax_message' ) );
 	}
 
 	/**

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -83,12 +83,12 @@ class JITM {
 		// Disable all JITMs on these pages.
 		if (
 			in_array(
-			$screen->id,
-			array(
-				'jetpack_page_akismet-key-config',
-				'admin_page_jetpack_modules',
-			),
-			true
+				$screen->id,
+				array(
+					'jetpack_page_akismet-key-config',
+					'admin_page_jetpack_modules',
+				),
+				true
 		) ) {
 			return;
 		}
@@ -101,7 +101,9 @@ class JITM {
 					'dashboard',
 					'plugins',
 					'jetpack_page_stats',
-				), true ) && \Jetpack_Recommendations_Banner::can_be_displayed() ) {
+			), true ) &&
+			\Jetpack_Recommendations_Banner::can_be_displayed()
+		) {
 			return;
 		}
 

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -80,7 +80,7 @@ class JITM {
 	 * @param \WP_Screen $screen WP Core's screen object.
 	 */
 	public function prepare_jitms( $screen ) {
-		if ( apply_filters( 'jetpack_display_jitms', true, $screen->id ) ) {
+		if ( apply_filters( 'jetpack_display_jitms_on_screen', true, $screen->id ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'admin_notices', array( $this, 'ajax_message' ) );
 			add_action( 'edit_form_top', array( $this, 'ajax_message' ) );

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -80,6 +80,7 @@ class JITM {
 	 * @param \WP_Screen $screen WP Core's screen object.
 	 */
 	public function prepare_jitms( $screen ) {
+		// Show JITMs only if they aren't disabled on the current screen via this filter.
 		if ( apply_filters( 'jetpack_display_jitms_on_screen', true, $screen->id ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'admin_notices', array( $this, 'ajax_message' ) );

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -80,8 +80,9 @@ class JITM {
 	 * @param \WP_Screen $screen WP Core's screen object.
 	 */
 	public function prepare_jitms( $screen ) {
-		// Disable all JITMs on these pages
-		if ( in_array(
+		// Disable all JITMs on these pages.
+		if (
+			in_array(
 			$screen->id,
 			array(
 				'jetpack_page_akismet-key-config',
@@ -92,12 +93,15 @@ class JITM {
 			return;
 		}
 
-		// Disable all JITMs on pages where the recommendations banner is displaying
-		if ( in_array( $screen->id, array(
-				'dashboard',
-				'plugins',
-				'jetpack_page_stats'
-			), true ) && \Jetpack_Recommendations_Banner::can_be_displayed() ) {
+		// Disable all JITMs on pages where the recommendations banner is displaying.
+		if (
+			in_array(
+				$screen->id,
+				array(
+					'dashboard',
+					'plugins',
+					'jetpack_page_stats',
+				), true ) && \Jetpack_Recommendations_Banner::can_be_displayed() ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
+++ b/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
@@ -54,7 +54,7 @@ class Jetpack_Recommendations_Banner {
 	/**
 	 * Determines if the banner can be displayed
 	 */
-	private function can_be_displayed() {
+	public static function can_be_displayed() {
 		if ( ! Jetpack_Recommendations::is_banner_enabled() ) {
 			return false;
 		}

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -332,7 +332,13 @@ class Jetpack_Admin {
 		Jetpack_Debugger::jetpack_debug_display_handler();
 	}
 
-	function should_display_jitms( $value, $screen_id ) {
+	/**
+	 * @param $value The default value of the filter.
+	 * @param $screen_id The ID of the screen being tested for JITM display.
+	 *
+	 * @return bool True if JITMs should display, false otherwise.
+	 */
+	public function should_display_jitms( $value, $screen_id ) {
 		// Disable all JITMs on these pages.
 		if (
 		in_array(

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -335,7 +335,7 @@ class Jetpack_Admin {
 	/**
 	 * Determines if JITMs should display on a particular screen.
 	 *
-	 * @param bool $value The default value of the filter.
+	 * @param bool   $value The default value of the filter.
 	 * @param string $screen_id The ID of the screen being tested for JITM display.
 	 *
 	 * @return bool True if JITMs should display, false otherwise.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -78,7 +78,7 @@ class Jetpack_Admin {
 			}
 		}
 
-		add_filter( 'jetpack_display_jitms', array( $this, 'should_display_jitms' ), 10, 2 );
+		add_filter( 'jetpack_display_jitms_on_screen', array( $this, 'should_display_jitms_on_screen' ), 10, 2 );
 	}
 
 	/**
@@ -340,7 +340,7 @@ class Jetpack_Admin {
 	 *
 	 * @return bool True if JITMs should display, false otherwise.
 	 */
-	public function should_display_jitms( $value, $screen_id ) {
+	public function should_display_jitms_on_screen( $value, $screen_id ) {
 		// Disable all JITMs on these pages.
 		if (
 		in_array(

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -77,6 +77,8 @@ class Jetpack_Admin {
 				add_action( 'admin_enqueue_scripts', array( $this, 'akismet_logo_replacement_styles' ) );
 			}
 		}
+
+		add_filter( 'jetpack_display_jitms', array( $this, 'should_display_jitms' ), 10, 2 );
 	}
 
 	/**
@@ -328,6 +330,39 @@ class Jetpack_Admin {
 	function debugger_page() {
 		jetpack_require_lib( 'debugger' );
 		Jetpack_Debugger::jetpack_debug_display_handler();
+	}
+
+	function should_display_jitms( $value, $screen_id ) {
+		// Disable all JITMs on these pages.
+		if (
+		in_array(
+			$screen_id,
+			array(
+				'jetpack_page_akismet-key-config',
+				'admin_page_jetpack_modules',
+			),
+			true
+		) ) {
+			return false;
+		}
+
+		// Disable all JITMs on pages where the recommendations banner is displaying.
+		if (
+			in_array(
+				$screen_id,
+				array(
+					'dashboard',
+					'plugins',
+					'jetpack_page_stats',
+				),
+				true
+			)
+			&& \Jetpack_Recommendations_Banner::can_be_displayed()
+		) {
+			return false;
+		}
+
+		return $value;
 	}
 }
 Jetpack_Admin::init();

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -333,8 +333,10 @@ class Jetpack_Admin {
 	}
 
 	/**
-	 * @param $value The default value of the filter.
-	 * @param $screen_id The ID of the screen being tested for JITM display.
+	 * Determines if JITMs should display on a particular screen.
+	 *
+	 * @param bool $value The default value of the filter.
+	 * @param string $screen_id The ID of the screen being tested for JITM display.
 	 *
 	 * @return bool True if JITMs should display, false otherwise.
 	 */

--- a/projects/plugins/jetpack/scss/jetpack-recommendations-banner.scss
+++ b/projects/plugins/jetpack/scss/jetpack-recommendations-banner.scss
@@ -176,7 +176,3 @@
 	width: 75%;
 	margin: 10%;
 }
-
-.jitm-banner {
-	display: none !important;
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/pull/18359#pullrequestreview-590433047

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR updates the JITMs so that they do not display together with the recommendations banner.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Start with a new site.
2. Visit the wp-admin home page and verify that the recommendations banner displays and no JITMs display.
3. Visit the plugins page and verify that the recommendations banner displays and no JITMs display.
4. Dismiss the banner and reload the page. Verify that the recommendations banner does not display and a JITM does display.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
None needed
