### PR TITLE
Podcast API Endpoint: Add the publish date to the track information.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -461,7 +461,7 @@ class Jetpack_Podcast_Helper {
 						'type'        => 'string',
 					),
 					'publish_date'     => array(
-						'description' => __( 'The UTC publish date of the episode', 'jetpack' ),
+						'description' => __( 'The UTC publish date and time of the episode', 'jetpack' ),
 						'type'        => 'string',
 					),
 				),

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -314,7 +314,7 @@ class Jetpack_Podcast_Helper {
 			return array();
 		}
 
-		$publish_date = $episode->get_gmdate( 'Y-m-d H:i:s' );
+		$publish_date = $episode->get_gmdate( DATE_ATOM );
 		// Build track data.
 		$track = array(
 			'id'               => wp_unique_id( 'podcast-track-' ),

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -463,6 +463,7 @@ class Jetpack_Podcast_Helper {
 					'publish_date'     => array(
 						'description' => __( 'The UTC publish date and time of the episode', 'jetpack' ),
 						'type'        => 'string',
+						'format'      => 'date-time',
 					),
 				),
 			),

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -314,6 +314,7 @@ class Jetpack_Podcast_Helper {
 			return array();
 		}
 
+		$publish_date = $episode->get_gmdate( 'Y-m-d H:i:s' );
 		// Build track data.
 		$track = array(
 			'id'               => wp_unique_id( 'podcast-track-' ),
@@ -325,7 +326,7 @@ class Jetpack_Podcast_Helper {
 			'title'            => $this->get_plain_text( $episode->get_title() ),
 			'image'            => esc_url( $this->get_episode_image_url( $episode ) ),
 			'guid'             => $this->get_plain_text( $episode->get_id() ),
-			'publish_date'     => $episode->get_gmdate( 'Y-m-d H:i:s' ),
+			'publish_date'     => $publish_date ? $publish_date : null,
 		);
 
 		if ( empty( $track['title'] ) ) {
@@ -460,7 +461,7 @@ class Jetpack_Podcast_Helper {
 						'type'        => 'string',
 					),
 					'publish_date'     => array(
-						'description' => __( 'The publish date of the episode', 'jetpack' ),
+						'description' => __( 'The UTC publish date of the episode', 'jetpack' ),
 						'type'        => 'string',
 					),
 				),

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -325,6 +325,7 @@ class Jetpack_Podcast_Helper {
 			'title'            => $this->get_plain_text( $episode->get_title() ),
 			'image'            => esc_url( $this->get_episode_image_url( $episode ) ),
 			'guid'             => $this->get_plain_text( $episode->get_id() ),
+			'publish_date'     => $episode->get_gmdate( 'Y-m-d H:i:s' ),
 		);
 
 		if ( empty( $track['title'] ) ) {
@@ -456,6 +457,10 @@ class Jetpack_Podcast_Helper {
 					),
 					'title'            => array(
 						'description' => __( 'The episode title.', 'jetpack' ),
+						'type'        => 'string',
+					),
+					'publish_date'     => array(
+						'description' => __( 'The publish date of the episode', 'jetpack' ),
 						'type'        => 'string',
 					),
 				),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
As part of the Anchor.FM integration we'd like to set the publish date of the generated posts to the publish date of the podcast episode. This information could also be of use in other contexts.

This change adds the UTC publish date to the track information, formatted for use as the post's `post_date_gmt`.

#### Jetpack product discussion
N/A this is an enhancement to an existing feature.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Insert a podcast block
* Open the developer console and select the network requests tab
* Set a valid podcast feed - e.g. https://www.spreaker.com/show/3314543/episodes/feed
* Check the next requests for the `podcast-player` request. 
* You should see the `publish_date` included for each of the episodes in the response

#### Proposed changelog entry for your changes:
Added the publish date to the track details of the podcast player API endpoint.
