### PR TITLE
VideoPress: avoid warning when no rating is set

### DIFF
--- a/projects/plugins/jetpack/modules/videopress/utility-functions.php
+++ b/projects/plugins/jetpack/modules/videopress/utility-functions.php
@@ -529,6 +529,7 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	$video_info->blog_id         = $blog_id;
 	$video_info->guid            = null;
 	$video_info->finish_date_gmt = '0000-00-00 00:00:00';
+	$video_info->rating          = null;
 
 	if ( is_wp_error( $post ) ) {
 		return $video_info;


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

In some scenarios, the following notice happens:

```
PHP Notice:  Undefined property: stdClass::$rating in /home/holden/apps/jeherve_com/w/wp-content/plugins/jetpack-dev/_inc/lib/core-api/wpcom-fields/class-wpcom-rest-api-v2-attachment-videopress-data.php on line 97
```

Let's make sure we always have at least a default rating.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

Testing instructions are similar to the ones in #17659. 

* Start with a site with a paid plan, and where you've activated VideoPress under Jetpack > Settings > Performance.
* In a post, add a /video block and upload a new video
* Once the video has uploaded, change the value for Rating in the sidebar. It will save automatically.
Open the Media Library, find your video and open it
* The rating in the media library should match the rating you selected on the block
* Update the rating here to a new value. It will save automatically.
* Go back to your post and select the video block (if you left the previous window/tab open you may need to refresh the page)
* The rating should match the rating you selected from the media library
* View the public page for the post. If you selected a Rating other than G, then you should be shown the "Age Gate" before being allowed to play the video.

**Editing existing video blocks**

* Select an existing video block and Click the Pencil icon in the toolbar
* Upload or choose a new video that has a different rating than the current video
* Observe the Rating in the sidebar, ensure that rating changes to the rating for the new video and that the video preview changes to the new video.

#### Proposed changelog entry for your changes:

* Video Block: avoid potential PHP notice when working with Jetpack Videos.
