### PR TITLE
First batch of improvements to Carousel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-improvement-batch-1
+++ b/projects/plugins/jetpack/changelog/update-carousel-improvement-batch-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: major
+
+Carousel: under-the-hood code improvements.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -7,7 +7,20 @@
 }
 
 .jp-carousel-overlay {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 	background: #000;
+}
+
+.jp-carousel {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 15vh;
 }
 
 div.jp-carousel-fadeaway {
@@ -54,13 +67,32 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 .jp-carousel-wrap {
 	font-family: "Helvetica Neue", sans-serif !important;
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	z-index: 2147483647;
+	overflow: hidden auto;
+	direction: ltr;
 }
 
 .jp-carousel-info {
+	display: flex;
+	flex-direction: column;
 	position: absolute;
+	top: 86vh; /* Fallback, if calc is not supported */
+	top: calc( 85vh + 5px );
 	bottom: 0;
 	text-align: left !important;
 	-webkit-font-smoothing: subpixel-antialiased !important;
+}
+
+.jp-carousel-info-columns {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: flex-start;
 }
 
 .jp-carousel-info ::selection {
@@ -77,6 +109,14 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	position: relative;
 	left: 25%;
 	width: 50%;
+}
+
+.jp-carousel-left-column-wrapper {
+	flex-grow: 1;
+}
+
+.jp-carousel-left-column-wrapper > .jp-carousel-photo-info {
+	display: none;
 }
 
 .jp-carousel-transitions .jp-carousel-photo-info {
@@ -102,11 +142,23 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	-webkit-font-smoothing: subpixel-antialiased;
 }
 
+.jp-carousel-next-button {
+	right: 15px;
+}
+
+.jp-carousel-previous-button {
+	left: 0;
+}
+
 .jp-carousel-next-button,
 .jp-carousel-previous-button {
 	text-indent: -9999px;
 	overflow: hidden;
 	cursor: pointer;
+	position: fixed;
+	top: 40px;
+	bottom: 15vh;
+	width: 110px;
 }
 
 .jp-carousel-next-button span,
@@ -177,10 +229,11 @@ div.jp-carousel-buttons a:hover {
 
 .jp-carousel-slide, .jp-carousel-slide img, .jp-carousel-next-button,
 .jp-carousel-previous-button {
-	-webkit-transform:translate3d(0, 0, 0);
-	-moz-transform:translate3d(0, 0, 0);
-	-o-transform:translate3d(0, 0, 0);
-	-ms-transform:translate3d(0, 0, 0);
+	-webkit-transform: translate3d(0, 0, 0);
+	-moz-transform: translate3d(0, 0, 0);
+	-o-transform: translate3d(0, 0, 0);
+	-ms-transform: translate3d(0, 0, 0);
+	transform: translate3d(0, 0, 0);
 }
 
 .jp-carousel-slide {
@@ -239,8 +292,8 @@ div.jp-carousel-buttons a:hover {
 	color: #999;
 	cursor: default;
 	letter-spacing: 0 !important;
-	padding:0.35em 0 0;
-	position: absolute;
+	padding: 0.35em 0 0;
+	position: fixed;
 	text-align: right;
 	width: calc( 100vw - 25px );
 }
@@ -464,8 +517,10 @@ div#carousel-reblog-box {
 	color: #999;
 	font-size: 15px;
 	padding-top: 24px;
+	margin-top: 20px;
 	margin-bottom: 20px;
-	font-weight:400;
+	font-weight: 400;
+	width: 100%;
 }
 .jp-carousel-titleanddesc-title {
 	font: 300 1.5em/1.1 "Helvetica Neue", sans-serif !important;
@@ -532,6 +587,8 @@ div#carousel-reblog-box {
 	overflow: hidden;
 	padding: 18px 20px;
 	width: 209px !important;
+	margin-top: 20px;
+	margin-left: 40px;
 }
 
 .jp-carousel-image-meta li,
@@ -602,45 +659,14 @@ a.jp-carousel-image-download:hover {
 
 /** Meta Box End **/
 
-/** GPS Map Start **/
-.jp-carousel-image-map {
-	position: relative;
-	margin: -20px -20px 20px;
-	border-bottom: 1px solid rgba( 255, 255, 255, 0.17 );
-	height: 154px;
-}
-
-.jp-carousel-image-map img.gmap-main {
-	-moz-border-radius-topleft: 6px;
-	border-top-left-radius: 6px;
-	border-right: 1px solid rgba( 255, 255, 255, 0.17 );
-}
-.jp-carousel-image-map div.gmap-topright {
-	width: 94px;
-	height: 154px;
-	position: absolute;
-	top: 0;
-	right: 0;
-}
-.jp-carousel-image-map div.imgclip {
-	overflow: hidden;
-	-moz-border-radius-topright: 6px;
-	border-top-right-radius: 6px;
-}
-.jp-carousel-image-map div.gmap-topright img {
-	margin-left: -40px;
-}
-.jp-carousel-image-map img.gmap-bottomright {
-	position: absolute;
-	top: 96px;
-	right: 0;
-}
-
 /** Comments Start **/
 .jp-carousel-comments {
 	font: 15px/1.7 "Helvetica Neue", sans-serif !important;
 	font-weight: 400;
-	background:none transparent;
+	background: none transparent;
+	width: 100%;
+	bottom: 10px;
+	margin-top: 20px;
 }
 
 .jp-carousel-comments p a:hover, .jp-carousel-comments p a:focus, .jp-carousel-comments p a:active {
@@ -648,12 +674,15 @@ a.jp-carousel-image-download:hover {
 }
 
 .jp-carousel-comment {
-	background:none transparent;
+	background: none transparent;
 	color: #999;
-	margin-bottom: 20px;
-	clear:left;
+	clear: left;
 	overflow: auto;
-	width: 100%
+	width: 100%;
+}
+
+.jp-carousel-comment + .jp-carousel-comment {
+	margin-top: 20px;
 }
 
 .jp-carousel-comment p {
@@ -796,9 +825,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	width: 100%
 }
 
-#jp-carousel-comment-form-commenting-as {
-}
-
 #jp-carousel-comment-form-commenting-as input {
 	background: rgba(34,34,34,0.9);
 	border: 1px solid #3a3a3a;
@@ -848,16 +874,12 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	float:right;
 }
 
-#js-carousel-comment-form-container {
-	margin-bottom:15px;
-	overflow: auto;
-	width: 100%;
-}
-
 #jp-carousel-comment-form-container {
-	margin-bottom:15px;
+	margin-bottom: 15px;
 	overflow: auto;
 	width: 100%;
+	margin-top: 20px;
+	color: #999;
 }
 
 #jp-carousel-comment-post-results {
@@ -886,10 +908,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	color:#DF4926;
 }
 
-.jp-carousel-comment-post-success {
-	/*color:#21759B;*/
-}
-
 #jp-carousel-comments-closed {
 	display: none;
 	color: #999;
@@ -901,6 +919,9 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	color: #999;
 	text-align: left;
 	margin-bottom: 20px;
+	width: 100;
+	bottom: 10px;
+	margin-top: 20px;
 }
 
 
@@ -1109,6 +1130,10 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		margin: 0 10px !important;
 	}
 
+	.jp-carousel-info-columns {
+		flex-direction: column;
+	}
+
 	.jp-carousel-next-button, .jp-carousel-previous-button {
 		display: none !important;
 	}
@@ -1120,9 +1145,10 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	.jp-carousel-image-meta {
 		float: none !important;
 		width: 100% !important;
-		-moz-box-sizing:border-box;
-		-webkit-box-sizing:border-box;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
 		box-sizing: border-box;
+		margin-left: 0;
 	}
 
 	.jp-carousel-close-hint {
@@ -1165,5 +1191,17 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	.jp-carousel-photo-info {
 		left: 0 !important;
 		width: 100% !important;
+	}
+
+	.jp-carousel-info > .jp-carousel-photo-info {
+		display: none;
+	}
+
+	.jp-carousel-left-column-wrapper > .jp-carousel-photo-info {
+		display: block;
+	}
+
+	.jp-carousel-caption {
+		overflow: visible !important;
 	}
 }

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -73,7 +73,8 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	bottom: 0;
 	left: 0;
 	z-index: 2147483647;
-	overflow: hidden auto;
+	overflow-x: hidden;
+	overflow-y: auto;
 	direction: ltr;
 }
 
@@ -683,6 +684,10 @@ a.jp-carousel-image-download:hover {
 
 .jp-carousel-comment + .jp-carousel-comment {
 	margin-top: 20px;
+}
+
+.jp-carousel-comment:last-of-type {
+	margin-bottom: 20px;
 }
 
 .jp-carousel-comment p {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -106,14 +106,18 @@ jQuery( document ).ready( function ( $ ) {
 						data = wrap.data( 'carousel-extra' ),
 						slide = wrap.find( 'div.selected' ),
 						attachment_id = slide.data( 'attachment-id' );
-					var close_hint = container.find( '.jp-carousel-close-hint' );
 					data = data || [];
 
-					if ( target.is( gallery ) || target.parents().add( target ).is( close_hint ) ) {
+					if (
+						target.is( gallery ) ||
+						target.parents().add( target ).is( container.find( '.jp-carousel-close-hint' ) )
+					) {
 						if ( ! window.matchMedia( '(max-device-width: 760px)' ).matches ) {
 							container.jp_carousel( 'close' );
 						} else {
-							if ( target.parents().add( target ).is( close_hint ) ) {
+							if (
+								target.parents().add( target ).is( container.find( '.jp-carousel-close-hint' ) )
+							) {
 								container.jp_carousel( 'close' );
 							}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -3,20 +3,16 @@
 jQuery( document ).ready( function ( $ ) {
 	// gallery faded layer and container elements
 	var overlay,
-		comments,
 		gallery,
 		container,
-		nextButton,
-		previousButton,
 		info,
 		transitionBegin,
 		caption,
 		resizeTimeout,
 		photo_info,
-		close_hint,
 		commentInterval,
 		lastSelectedSlide,
-		screenPadding = 110,
+		screenPadding,
 		originalOverflow = $( 'body' ).css( 'overflow' ),
 		originalHOverflow = $( 'html' ).css( 'overflow' ),
 		proportion = 85,
@@ -24,26 +20,7 @@ jQuery( document ).ready( function ( $ ) {
 		imageMeta,
 		titleAndDescription,
 		commentForm,
-		leftColWrapper,
 		scrollPos;
-
-	if ( window.innerWidth <= 760 ) {
-		screenPadding = Math.round( ( window.innerWidth / 760 ) * 110 );
-
-		if (
-			screenPadding < 40 &&
-			( 'ontouchstart' in window || ( window.DocumentTouch && document instanceof DocumentTouch ) )
-		) {
-			screenPadding = 0;
-		}
-	}
-
-	// Adding a polyfill for browsers that do not have Date.now
-	if ( 'undefined' === typeof Date.now ) {
-		Date.now = function now() {
-			return new Date().getTime();
-		};
-	}
 
 	var keyListener = function ( e ) {
 		switch ( e.which ) {
@@ -74,226 +51,62 @@ jQuery( document ).ready( function ( $ ) {
 		}
 	};
 
+	var calculatePadding = function () {
+		var baseScreenPadding = 110;
+		screenPadding = baseScreenPadding;
+
+		if ( window.innerWidth <= 760 ) {
+			screenPadding = Math.round( ( window.innerWidth / 760 ) * baseScreenPadding );
+			var isTouch =
+				'ontouchstart' in window || ( window.DocumentTouch && document instanceof DocumentTouch );
+
+			if ( screenPadding < 40 && isTouch ) {
+				screenPadding = 0;
+			}
+		}
+	};
+
 	var resizeListener = function (/*e*/) {
+		// Don't animate if user prefers reduced motion.
+		var shouldAnimate =
+			window.matchMedia && ! window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
 		clearTimeout( resizeTimeout );
 		resizeTimeout = setTimeout( function () {
-			gallery.jp_carousel( 'slides' ).jp_carousel( 'fitSlide', true );
-			gallery.jp_carousel( 'updateSlidePositions', true );
-			gallery.jp_carousel( 'fitMeta', true );
+			calculatePadding();
+			gallery.jp_carousel( 'slides' ).jp_carousel( 'fitSlide', shouldAnimate );
+			gallery.jp_carousel( 'updateSlidePositions', shouldAnimate );
+			gallery.jp_carousel( 'fitMeta', shouldAnimate );
 		}, 200 );
 	};
 
 	var prepareGallery = function (/*dataCarouselExtra*/) {
 		if ( ! overlay ) {
-			overlay = $( '<div></div>' ).addClass( 'jp-carousel-overlay' ).css( {
-				position: 'fixed',
-				top: 0,
-				right: 0,
-				bottom: 0,
-				left: 0,
-			} );
+			container = $( '.jp-carousel-wrap' );
+			overlay = container.find( '.jp-carousel-overlay' );
 
-			var displayComments = 1 === +jetpackCarouselStrings.display_comments;
-			var buttons = displayComments
-				? '<a class="jp-carousel-commentlink" href="#">' + jetpackCarouselStrings.comment + '</a>'
-				: '';
-			if ( 1 === Number( jetpackCarouselStrings.is_logged_in ) ) {
-			}
+			gallery = container.find( '.jp-carousel' );
+			caption = container.find( '.jp-carousel-caption' );
+			photo_info = container.find( '.jp-carousel-photo-info' );
+			info = container.find( '.jp-carousel-info' );
+			commentForm = container.find( '.jp-carousel-comment-form-container' );
+			imageMeta = container.find( '.jp-carousel-image-meta' );
+			titleAndDescription = container.find( '.jp-carousel-titleanddesc' );
 
-			buttons = $( '<div class="jp-carousel-buttons">' + buttons + '</div>' );
+			var nextButton = container.find( '.jp-carousel-next-button' );
+			var previousButton = container.find( '.jp-carousel-previous-button' );
 
-			caption = $( '<h2 itemprop="caption description"></h2>' );
-			photo_info = $( '<div class="jp-carousel-photo-info"></div>' ).append( caption );
-
-			imageMeta = $( '<div></div>' ).addClass( 'jp-carousel-image-meta' ).css( {
-				float: 'right',
-				'margin-top': '20px',
-				width: '250px',
-			} );
-
-			if ( 0 < buttons.children().length ) {
-				imageMeta.append( buttons );
-			}
-
-			imageMeta
-				.append( "<ul class='jp-carousel-image-exif' style='display:none;'></ul>" )
-				.append( "<a class='jp-carousel-image-download' style='display:none;'></a>" )
-				.append( "<div class='jp-carousel-image-map' style='display:none;'></div>" );
-
-			titleAndDescription = $( '<div></div>' )
-				.addClass( 'jp-carousel-titleanddesc' )
-				.css( {
-					width: '100%',
-					'margin-top': imageMeta.css( 'margin-top' ),
-				} );
-
-			var leftWidth = $( window ).width() - screenPadding * 2 - ( imageMeta.width() + 40 );
-			leftWidth += 'px';
-
-			leftColWrapper = $( '<div></div>' )
-				.addClass( 'jp-carousel-left-column-wrapper' )
-				.css( {
-					width: Math.floor( leftWidth ),
-				} )
-				.append( titleAndDescription );
-
-			if ( displayComments ) {
-				var commentFormMarkup = '<div id="jp-carousel-comment-form-container">';
-
-				if (
-					jetpackCarouselStrings.local_comments_commenting_as &&
-					jetpackCarouselStrings.local_comments_commenting_as.length
-				) {
-					// Comments not enabled, fallback to local comments
-
-					if (
-						1 !== Number( jetpackCarouselStrings.is_logged_in ) &&
-						1 === Number( jetpackCarouselStrings.comment_registration )
-					) {
-						commentFormMarkup +=
-							'<div id="jp-carousel-comment-form-commenting-as">' +
-							jetpackCarouselStrings.local_comments_commenting_as +
-							'</div>';
-					} else {
-						commentFormMarkup += '<form id="jp-carousel-comment-form">';
-						commentFormMarkup +=
-							'<textarea name="comment" class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea" id="jp-carousel-comment-form-comment-field" placeholder="' +
-							jetpackCarouselStrings.write_comment +
-							'"></textarea>';
-						commentFormMarkup += '<div id="jp-carousel-comment-form-submit-and-info-wrapper">';
-						commentFormMarkup +=
-							'<div id="jp-carousel-comment-form-commenting-as">' +
-							jetpackCarouselStrings.local_comments_commenting_as +
-							'</div>';
-						commentFormMarkup +=
-							'<input type="submit" name="submit" class="jp-carousel-comment-form-button" id="jp-carousel-comment-form-button-submit" value="' +
-							jetpackCarouselStrings.post_comment +
-							'" />';
-						commentFormMarkup += '<span id="jp-carousel-comment-form-spinner">&nbsp;</span>';
-						commentFormMarkup += '<div id="jp-carousel-comment-post-results"></div>';
-						commentFormMarkup += '</div>';
-						commentFormMarkup += '</form>';
-					}
-				}
-				commentFormMarkup += '</div>';
-
-				commentForm = $( commentFormMarkup ).css( {
-					width: '100%',
-					'margin-top': '20px',
-					color: '#999',
-				} );
-
-				comments = $( '<div></div>' ).addClass( 'jp-carousel-comments' ).css( {
-					width: '100%',
-					bottom: '10px',
-					'margin-top': '20px',
-				} );
-
-				var commentsLoading = $(
-					'<div id="jp-carousel-comments-loading"><span>' +
-						jetpackCarouselStrings.loading_comments +
-						'</span></div>'
-				).css( {
-					width: '100%',
-					bottom: '10px',
-					'margin-top': '20px',
-				} );
-
-				leftColWrapper.append( commentForm ).append( comments ).append( commentsLoading );
-			}
-
-			var fadeaway = $( '<div></div>' ).addClass( 'jp-carousel-fadeaway' );
-
-			info = $( '<div></div>' )
-				.addClass( 'jp-carousel-info' )
-				.css( {
-					top: Math.floor( ( $( window ).height() / 100 ) * proportion ),
-					left: screenPadding,
-					right: screenPadding,
-				} )
-				.append( photo_info )
-				.append( imageMeta );
-
-			if ( window.innerWidth <= 760 ) {
-				photo_info.remove().insertAfter( titleAndDescription );
-				info.prepend( leftColWrapper );
-			} else {
-				info.append( leftColWrapper );
-			}
-
-			var targetBottomPos = $( window ).height() - parseInt( info.css( 'top' ), 10 ) + 'px';
-
-			nextButton = $( '<div><span></span></div>' )
-				.addClass( 'jp-carousel-next-button' )
-				.css( {
-					right: '15px',
-				} )
-				.hide();
-
-			previousButton = $( '<div><span></span></div>' )
-				.addClass( 'jp-carousel-previous-button' )
-				.css( {
-					left: 0,
-				} )
-				.hide();
-
-			nextButton.add( previousButton ).css( {
-				position: 'fixed',
-				top: '40px',
-				bottom: targetBottomPos,
-				width: screenPadding,
-			} );
-
-			gallery = $( '<div></div>' ).addClass( 'jp-carousel' ).css( {
-				position: 'absolute',
-				top: 0,
-				bottom: targetBottomPos,
-				left: 0,
-				right: 0,
-			} );
-
-			close_hint = $( '<div class="jp-carousel-close-hint"><span>&#10006;</span></div>' ).css( {
-				position: 'fixed',
-			} );
-
-			container = $( '<div></div>' )
-				.addClass( 'jp-carousel-wrap' )
-				.addClass( 'jp-carousel-transitions' );
-			if ( 'white' === jetpackCarouselStrings.background_color ) {
-				container.addClass( 'jp-carousel-light' );
-			}
-
-			container.attr( 'itemscope', '' );
-
-			container.attr( 'itemtype', 'https://schema.org/ImageGallery' );
+			calculatePadding();
+			gallery.jp_carousel( 'fitMeta', false );
 
 			container
-				.css( {
-					position: 'fixed',
-					top: 0,
-					right: 0,
-					bottom: 0,
-					left: 0,
-					'z-index': 2147483647,
-					'overflow-x': 'hidden',
-					'overflow-y': 'auto',
-					direction: 'ltr',
-				} )
-				.hide()
-				.append( overlay )
-				.append( gallery )
-				.append( fadeaway )
-				.append( info )
-				.append( nextButton )
-				.append( previousButton )
-				.append( close_hint )
-				.appendTo( $( 'body' ) )
 				.click( function ( e ) {
 					var target = $( e.target ),
 						wrap = target.parents( 'div.jp-carousel-wrap' ),
 						data = wrap.data( 'carousel-extra' ),
 						slide = wrap.find( 'div.selected' ),
 						attachment_id = slide.data( 'attachment-id' );
+					var close_hint = container.find( '.jp-carousel-close-hint' );
 					data = data || [];
 
 					if ( target.is( gallery ) || target.parents().add( target ).is( close_hint ) ) {
@@ -514,7 +327,7 @@ jQuery( document ).ready( function ( $ ) {
 					}
 				} );
 
-			$( '.jp-carousel-wrap' ).touchwipe( {
+			container.touchwipe( {
 				wipeLeft: function ( e ) {
 					e.preventDefault();
 					gallery.jp_carousel( 'next' );
@@ -830,7 +643,6 @@ jQuery( document ).ready( function ( $ ) {
 			var imageMeta = current.data( 'image-meta' );
 			gallery.jp_carousel( 'updateExif', imageMeta );
 			gallery.jp_carousel( 'updateFullSizeLink', current );
-			gallery.jp_carousel( 'updateMap', imageMeta );
 
 			if ( 1 === +jetpackCarouselStrings.display_comments ) {
 				gallery.jp_carousel( 'testCommentsOpened', current.data( 'comments-opened' ) );
@@ -937,8 +749,8 @@ jQuery( document ).ready( function ( $ ) {
 		},
 
 		fitInfo: function (/*animated*/) {
-			var current = this.jp_carousel( 'selectedSlide' ),
-				size = current.jp_carousel( 'bestFit' );
+			var current = this.jp_carousel( 'selectedSlide' );
+			var size = current.jp_carousel( 'bestFit' );
 
 			photo_info.css( {
 				left: Math.floor( ( info.width() - size.width ) * 0.5 ),
@@ -949,17 +761,15 @@ jQuery( document ).ready( function ( $ ) {
 		},
 
 		fitMeta: function ( animated ) {
-			var newInfoTop = {
-				top: Math.floor( ( $( window ).height() / 100 ) * proportion + 5 ) + 'px',
+			var newInfoPos = {
+				left: screenPadding + 'px',
+				right: screenPadding + 'px',
 			};
-			var newLeftWidth = { width: info.width() - ( imageMeta.width() + 80 ) + 'px' };
 
 			if ( animated ) {
-				info.animate( newInfoTop );
-				leftColWrapper.animate( newLeftWidth );
+				info.animate( newInfoPos );
 			} else {
-				info.animate( newInfoTop );
-				leftColWrapper.css( newLeftWidth );
+				info.css( newInfoPos );
 			}
 		},
 
@@ -1367,62 +1177,6 @@ jQuery( document ).ready( function ( $ ) {
 			$( 'div.jp-carousel-image-meta a.jp-carousel-image-download' ).replaceWith( permalink );
 		},
 
-		updateMap: function ( meta ) {
-			if (
-				! meta.latitude ||
-				! meta.longitude ||
-				1 !== Number( jetpackCarouselStrings.display_geo )
-			) {
-				return;
-			}
-
-			var latitude = meta.latitude,
-				longitude = meta.longitude,
-				$metabox = $( 'div.jp-carousel-image-meta', 'div.jp-carousel-wrap' ),
-				$mapbox = $( '<div></div>' ),
-				style =
-					'&scale=2&style=feature:all|element:all|invert_lightness:true|hue:0x0077FF|saturation:-50|lightness:-5|gamma:0.91';
-
-			$mapbox
-				.addClass( 'jp-carousel-image-map' )
-				.html(
-					'<img width="154" height="154" src="https://maps.googleapis.com/maps/api/staticmap?\
-							center=' +
-						latitude +
-						',' +
-						longitude +
-						'&\
-							zoom=8&\
-							size=154x154&\
-							sensor=false&\
-							markers=size:medium%7Ccolor:blue%7C' +
-						latitude +
-						',' +
-						longitude +
-						style +
-						'" class="gmap-main" />\
-							\
-						<div class="gmap-topright"><div class="imgclip"><img width="175" height="154" src="https://maps.googleapis.com/maps/api/staticmap?\
-							center=' +
-						latitude +
-						',' +
-						longitude +
-						'&\
-							zoom=3&\
-							size=175x154&\
-							sensor=false&\
-							markers=size:small%7Ccolor:blue%7C' +
-						latitude +
-						',' +
-						longitude +
-						style +
-						'"c /></div></div>\
-							\
-						'
-				)
-				.prependTo( $metabox );
-		},
-
 		testCommentsOpened: function ( opened ) {
 			if ( 1 === parseInt( opened, 10 ) ) {
 				$( '.jp-carousel-buttons' ).fadeIn( 'fast' );
@@ -1511,7 +1265,7 @@ jQuery( document ).ready( function ( $ ) {
 					// attachment id might no longer match the current attachment id by the time we get the data back or a now
 					// registered infiniscroll event kicks in, so we don't ever display comments for the wrong image by mistake.
 					var current = $( '.jp-carousel div.selected' );
-					if ( current && current.data && current.data( 'attachment-id' ) != args.attachment_id ) {
+					if ( current && current.data && current.data( 'attachment-id' ) !== args.attachment_id ) {
 						comments.fadeOut( 'fast' );
 						comments.empty();
 						return;
@@ -1529,9 +1283,8 @@ jQuery( document ).ready( function ( $ ) {
 					comments.show();
 					commentsLoading.hide();
 				},
-				error: function ( xhr, status, error ) {
+				error: function () {
 					// TODO: proper error handling
-					console.log( 'Comment get fail...', xhr, status, error );
 					comments.fadeIn( 'fast' );
 					commentsLoading.fadeOut( 'fast' );
 				},
@@ -1554,7 +1307,6 @@ jQuery( document ).ready( function ( $ ) {
 				.slideUp( 'fast' )
 				.html( '<span class="jp-carousel-comment-post-error">' + args.error + '</span>' )
 				.slideDown( 'fast' );
-
 			$( '#jp-carousel-comment-form-spinner' ).hide();
 		},
 
@@ -1651,7 +1403,6 @@ jQuery( document ).ready( function ( $ ) {
 			if ( ! $( this ).jp_carousel( 'testForData', e.currentTarget ) ) {
 				return;
 			}
-
 			// If Gallery is made up of individual Image blocks check for custom link before
 			// loading carousel.
 			if ( $( e.target ).parents().eq( 1 ).hasClass( 'wp-block-image' ) ) {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -454,7 +454,7 @@ class Jetpack_Carousel {
 							<?php if ( $localize_strings['display_comments'] ) : ?>
 							<a class="jp-carousel-commentlink" href="#"><?php echo esc_html( $localize_strings['comment'] ); ?></a>
 							<?php endif ?>
-							<?php if ( is_user_logged_in() && $localize_strings['reblog_enabled'] ) : ?>
+							<?php if ( is_user_logged_in() && in_array( 'reblog_enabled', $localize_strings, true ) && $localize_strings['reblog_enabled'] ) : ?>
 								<a class="jp-carousel-reblog" href="#"><?php echo esc_html( $localize_strings['reblog'] ); ?></a>
 							<?php endif ?>
 						</div>

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -294,7 +294,7 @@ class Jetpack_Carousel {
 			 *
 			 * @param bool Enable Jetpack Carousel stat collection. Default false.
 			 */
-			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules(), true ) && ! ( new Status() )->is_development_mode() ) {
+			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules(), true ) && ! ( new Status() )->is_offline_mode() ) {
 				$localize_strings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . wp_parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
 
 				// Set the stats as empty if user is logged in but logged-in users shouldn't be tracked.
@@ -382,8 +382,17 @@ class Jetpack_Carousel {
 									<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
 										<div id="jp-carousel-comment-form-commenting-as">
 											<p id="jp-carousel-commenting-as">
-												<?php // phpcs:ignore Standard.Category.SniffName.ErrorCode,WordPress.Security.EscapeOutput.UnsafePrintingFunction ?>
-												<?php _e( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ); ?>
+												<?php
+													echo wp_kses(
+														__( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ),
+														array(
+															'a' => array(
+																'href'  => array(),
+																'class' => array(),
+															),
+														)
+													);
+												?>
 											</p>
 										</div>
 									<?php else : ?>
@@ -392,22 +401,27 @@ class Jetpack_Carousel {
 												name="comment"
 												class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"
 												id="jp-carousel-comment-form-comment-field"
-												placeholder="<?php echo( esc_attr( $localize_strings['write_comment'] ) ); ?>"
+												placeholder="<?php echo esc_attr( $localize_strings['write_comment'] ); ?>"
 											></textarea>
 											<div id="jp-carousel-comment-form-submit-and-info-wrapper">
 												<div id="jp-carousel-comment-form-commenting-as">
 													<?php if ( $localize_strings['is_logged_in'] ) : ?>
 														<p id="jp-carousel-commenting-as">
-															<?php /* translators: %s is replaced with the user's display name */ ?>
-															<?php echo( esc_html( sprintf( __( 'Commenting as %s', 'jetpack' ), $current_user->data->display_name ) ) ); ?>
+															<?php
+																printf(
+																	/* translators: %s is replaced with the user's display name */
+																	esc_html__( 'Commenting as %s', 'jetpack' ),
+																	esc_html( $current_user->data->display_name )
+																);
+															?>
 														</p>
 													<?php else : ?>
 														<fieldset>
-															<label for="email"><?php echo( esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ) ); ?></label>
+															<label for="email"><?php echo esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ); ?></label>
 															<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
 														</fieldset>
 														<fieldset>
-															<label for="author"><?php echo( esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ) ); ?></label>
+															<label for="author"><?php echo esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ); ?></label>
 															<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
 														</fieldset>
 														<fieldset>
@@ -421,7 +435,7 @@ class Jetpack_Carousel {
 													name="submit"
 													class="jp-carousel-comment-form-button"
 													id="jp-carousel-comment-form-button-submit"
-													value="<?php echo( esc_attr( $localize_strings['post_comment'] ) ); ?>" />
+													value="<?php echo esc_attr( $localize_strings['post_comment'] ); ?>" />
 												<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
 												<div id="jp-carousel-comment-post-results"></div>
 											</div>
@@ -431,17 +445,17 @@ class Jetpack_Carousel {
 							</div>
 							<div class="jp-carousel-comments"></div>
 							<div id="jp-carousel-comments-loading">
-								<span><?php echo( esc_html( $localize_strings['loading_comments'] ) ); ?></span>
+								<span><?php echo esc_html( $localize_strings['loading_comments'] ); ?></span>
 							</div>
 						<?php endif ?>
 					</div>
 					<div class="jp-carousel-image-meta">
 						<div class="jp-carousel-buttons">
 							<?php if ( $localize_strings['display_comments'] ) : ?>
-							<a class="jp-carousel-commentlink" href="#"><?php echo( esc_html( $localize_strings['comment'] ) ); ?></a>
+							<a class="jp-carousel-commentlink" href="#"><?php echo esc_html( $localize_strings['comment'] ); ?></a>
 							<?php endif ?>
 							<?php if ( is_user_logged_in() && $localize_strings['is_public'] && $localize_strings['reblog_enabled'] ) : ?>
-								<a class="jp-carousel-reblog" href="#"><?php echo( esc_html( $localize_strings['reblog'] ) ); ?></a>
+								<a class="jp-carousel-reblog" href="#"><?php echo esc_html( $localize_strings['reblog'] ); ?></a>
 							<?php endif ?>
 						</div>
 						<ul class="jp-carousel-image-exif" style="display: none;"></ul>

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -454,7 +454,7 @@ class Jetpack_Carousel {
 							<?php if ( $localize_strings['display_comments'] ) : ?>
 							<a class="jp-carousel-commentlink" href="#"><?php echo esc_html( $localize_strings['comment'] ); ?></a>
 							<?php endif ?>
-							<?php if ( is_user_logged_in() && $localize_strings['is_public'] && $localize_strings['reblog_enabled'] ) : ?>
+							<?php if ( is_user_logged_in() && $localize_strings['reblog_enabled'] ) : ?>
 								<a class="jp-carousel-reblog" href="#"><?php echo esc_html( $localize_strings['reblog'] ); ?></a>
 							<?php endif ?>
 						</div>

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -242,7 +242,6 @@ class Jetpack_Carousel {
 			// Note: using  home_url() instead of admin_url() for ajaxurl to be sure  to get same domain on wpcom when using mapped domains (also works on self-hosted)
 			// Also: not hardcoding path since there is no guarantee site is running on site root in self-hosted context.
 			$is_logged_in         = is_user_logged_in();
-			$current_user         = wp_get_current_user();
 			$comment_registration = (int) get_option( 'comment_registration' );
 			$require_name_email   = (int) get_option( 'require_name_email' );
 			$localize_strings     = array(
@@ -281,27 +280,6 @@ class Jetpack_Carousel {
 				'meta_data'                       => array( 'camera', 'aperture', 'shutter_speed', 'focal_length', 'copyright' ),
 			);
 
-			if ( ! isset( $localize_strings['jetpack_comments_iframe_src'] ) || empty( $localize_strings['jetpack_comments_iframe_src'] ) ) {
-				// We're not using Comments after all, so fallback to standard local comments.
-
-				if ( $is_logged_in ) {
-					$localize_strings['local_comments_commenting_as'] = '<p id="jp-carousel-commenting-as">' . sprintf( __( 'Commenting as %s', 'jetpack' ), $current_user->data->display_name ) . '</p>';
-				} else {
-					if ( $comment_registration ) {
-						$localize_strings['local_comments_commenting_as'] = '<p id="jp-carousel-commenting-as">' . __( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ) . '</p>';
-					} else {
-						$required = ( $require_name_email ) ? __( '%s (Required)', 'jetpack' ) : '%s';
-						$localize_strings['local_comments_commenting_as'] = ''
-							. '<fieldset><label for="email">' . sprintf( $required, __( 'Email', 'jetpack' ) ) . '</label> '
-							. '<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" /></fieldset>'
-							. '<fieldset><label for="author">' . sprintf( $required, __( 'Name', 'jetpack' ) ) . '</label> '
-							. '<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" /></fieldset>'
-							. '<fieldset><label for="url">' . __( 'Website', 'jetpack' ) . '</label> '
-							. '<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" /></fieldset>';
-					}
-				}
-			}
-
 			/**
 			 * Handle WP stats for images in full-screen.
 			 * Build string with tracking info.
@@ -316,7 +294,7 @@ class Jetpack_Carousel {
 			 *
 			 * @param bool Enable Jetpack Carousel stat collection. Default false.
 			 */
-			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules(), true ) && ! ( new Status() )->is_offline_mode() ) {
+			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules(), true ) && ! ( new Status() )->is_development_mode() ) {
 				$localize_strings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . wp_parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
 
 				// Set the stats as empty if user is logged in but logged-in users shouldn't be tracked.
@@ -357,8 +335,131 @@ class Jetpack_Carousel {
 			 */
 			do_action( 'jp_carousel_enqueue_assets', $this->first_run, $localize_strings );
 
+			// Add the carousel skeleton to the page.
+			$this->localize_strings = $localize_strings;
+			add_action( 'wp_footer', array( $this, 'add_carousel_skeleton' ) );
+
 			$this->first_run = false;
 		}
+	}
+
+	/**
+	 * Generate the HTML skeleton that will be picked up by the Carousel JS and used for showing the carousel.
+	 */
+	public function add_carousel_skeleton() {
+		$localize_strings = $this->localize_strings;
+		$is_light         = ( 'white' === $localize_strings['background_color'] );
+		// Determine whether to fall back to standard local comments.
+		$use_local_comments = ! isset( $localize_strings['jetpack_comments_iframe_src'] ) || empty( $localize_strings['jetpack_comments_iframe_src'] );
+		$current_user       = wp_get_current_user();
+		$require_name_email = (int) get_option( 'require_name_email' );
+		/* translators: %s is replaced with a field name in the form, e.g. "Email" */
+		$required = ( $require_name_email ) ? __( '%s (Required)', 'jetpack' ) : '%s';
+		?>
+
+		<div
+			class="jp-carousel-wrap jp-carousel-transitions<?php echo( $is_light ? ' jp-carousel-light' : '' ); ?>"
+			itemscope
+			itemtype="https://schema.org/ImageGallery"
+			style="display: none;">
+			<div class="jp-carousel-overlay"></div>
+			<div class="jp-carousel"></div>
+			<div class="jp-carousel-fadeaway"></div>
+			<div class="jp-carousel-info">
+				<div class="jp-carousel-photo-info">
+					<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
+				</div>
+				<div class="jp-carousel-info-columns">
+					<div class="jp-carousel-left-column-wrapper">
+						<div class="jp-carousel-titleanddesc"></div>
+						<!-- Intentional duplicate -->
+						<div class="jp-carousel-photo-info">
+							<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
+						</div>
+						<?php if ( $localize_strings['display_comments'] ) : ?>
+							<div id="jp-carousel-comment-form-container">
+								<?php if ( $use_local_comments ) : ?>
+									<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
+										<div id="jp-carousel-comment-form-commenting-as">
+											<p id="jp-carousel-commenting-as">
+												<?php // phpcs:ignore Standard.Category.SniffName.ErrorCode,WordPress.Security.EscapeOutput.UnsafePrintingFunction ?>
+												<?php _e( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ); ?>
+											</p>
+										</div>
+									<?php else : ?>
+										<form id="jp-carousel-comment-form">
+											<textarea
+												name="comment"
+												class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"
+												id="jp-carousel-comment-form-comment-field"
+												placeholder="<?php echo( esc_attr( $localize_strings['write_comment'] ) ); ?>"
+											></textarea>
+											<div id="jp-carousel-comment-form-submit-and-info-wrapper">
+												<div id="jp-carousel-comment-form-commenting-as">
+													<?php if ( $localize_strings['is_logged_in'] ) : ?>
+														<p id="jp-carousel-commenting-as">
+															<?php /* translators: %s is replaced with the user's display name */ ?>
+															<?php echo( esc_html( sprintf( __( 'Commenting as %s', 'jetpack' ), $current_user->data->display_name ) ) ); ?>
+														</p>
+													<?php else : ?>
+														<fieldset>
+															<label for="email"><?php echo( esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ) ); ?></label>
+															<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
+														</fieldset>
+														<fieldset>
+															<label for="author"><?php echo( esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ) ); ?></label>
+															<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
+														</fieldset>
+														<fieldset>
+															<label for="url"><?php esc_html_e( 'Website', 'jetpack' ); ?></label>
+															<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" />
+														</fieldset>
+													<?php endif ?>
+												</div>
+												<input
+													type="submit"
+													name="submit"
+													class="jp-carousel-comment-form-button"
+													id="jp-carousel-comment-form-button-submit"
+													value="<?php echo( esc_attr( $localize_strings['post_comment'] ) ); ?>" />
+												<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
+												<div id="jp-carousel-comment-post-results"></div>
+											</div>
+										</form>
+									<?php endif ?>
+								<?php endif ?>
+							</div>
+							<div class="jp-carousel-comments"></div>
+							<div id="jp-carousel-comments-loading">
+								<span><?php echo( esc_html( $localize_strings['loading_comments'] ) ); ?></span>
+							</div>
+						<?php endif ?>
+					</div>
+					<div class="jp-carousel-image-meta">
+						<div class="jp-carousel-buttons">
+							<?php if ( $localize_strings['display_comments'] ) : ?>
+							<a class="jp-carousel-commentlink" href="#"><?php echo( esc_html( $localize_strings['comment'] ) ); ?></a>
+							<?php endif ?>
+							<?php if ( is_user_logged_in() && $localize_strings['is_public'] && $localize_strings['reblog_enabled'] ) : ?>
+								<a class="jp-carousel-reblog" href="#"><?php echo( esc_html( $localize_strings['reblog'] ) ); ?></a>
+							<?php endif ?>
+						</div>
+						<ul class="jp-carousel-image-exif" style="display: none;"></ul>
+						<a class="jp-carousel-image-download" style="display: none;"></a>
+						<div class="jp-carousel-image-map" style="display: none;"></div>
+					</div>
+				</div>
+			</div>
+			<div class="jp-carousel-next-button" style="display: none;">
+				<span></span>
+			</div>
+			<div class="jp-carousel-previous-button" style="display: none;">
+				<span></span>
+			</div>
+			<div class="jp-carousel-close-hint"><span>&times;</span></div>
+		</div>
+
+		<?php
 	}
 
 	function set_in_gallery( $output ) {

--- a/projects/plugins/jetpack/modules/carousel/rtl/jetpack-carousel-rtl.css
+++ b/projects/plugins/jetpack/modules/carousel/rtl/jetpack-carousel-rtl.css
@@ -1,4 +1,4 @@
-/* This file was automatically generated on Jul 30 2015 22:37:09 */
+/* This file was automatically generated on Feb 17 2021 11:23:04 */
 
 [data-carousel-extra] {
 	cursor: pointer; /* adds a cursor when the carousel takes effect */
@@ -9,7 +9,20 @@
 }
 
 .jp-carousel-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
 	background: #000;
+}
+
+.jp-carousel {
+	position: absolute;
+	top: 0;
+	right: 0;
+	left: 0;
+	bottom: 15vh;
 }
 
 div.jp-carousel-fadeaway {
@@ -39,8 +52,8 @@ div.jp-carousel-fadeaway {
 	margin: 25px 2px 0 20px;
 	background-color: #fff;
 	border-right: 4px solid #ffba00;
-	-webkit-box-shadow: 0 0 1px 1px rgba(0,0,0,0.1);
-	box-shadow: 0 0 1px 1px rgba(0,0,0,0.1);
+	-webkit-box-shadow: 0 1px 1px 0 rgba(0,0,0,0.1);
+	box-shadow: 0 1px 1px 0 rgba(0,0,0,0.1);
 }
 
 @media
@@ -56,13 +69,32 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 .jp-carousel-wrap {
 	font-family: "Helvetica Neue", sans-serif !important;
+	position: fixed;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	z-index: 2147483647;
+	overflow: hidden auto;
+	direction: rtl;
 }
 
 .jp-carousel-info {
+	display: flex;
+	flex-direction: column;
 	position: absolute;
+	top: 86vh; /* Fallback, if calc is not supported */
+	top: calc( 85vh + 5px );
 	bottom: 0;
 	text-align: right !important;
 	-webkit-font-smoothing: subpixel-antialiased !important;
+}
+
+.jp-carousel-info-columns {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: flex-start;
 }
 
 .jp-carousel-info ::selection {
@@ -79,6 +111,14 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	position: relative;
 	right: 25%;
 	width: 50%;
+}
+
+.jp-carousel-left-column-wrapper {
+	flex-grow: 1;
+}
+
+.jp-carousel-left-column-wrapper > .jp-carousel-photo-info {
+	display: none;
 }
 
 .jp-carousel-transitions .jp-carousel-photo-info {
@@ -104,11 +144,23 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	-webkit-font-smoothing: subpixel-antialiased;
 }
 
+.jp-carousel-next-button {
+	left: 15px;
+}
+
+.jp-carousel-previous-button {
+	right: 0;
+}
+
 .jp-carousel-next-button,
 .jp-carousel-previous-button {
 	text-indent: -9999px;
 	overflow: hidden;
 	cursor: pointer;
+	position: fixed;
+	top: 40px;
+	bottom: 15vh;
+	width: 110px;
 }
 
 .jp-carousel-next-button span,
@@ -179,10 +231,11 @@ div.jp-carousel-buttons a:hover {
 
 .jp-carousel-slide, .jp-carousel-slide img, .jp-carousel-next-button,
 .jp-carousel-previous-button {
-	-webkit-transform:translate3d(0, 0, 0);
-	-moz-transform:translate3d(0, 0, 0);
-	-o-transform:translate3d(0, 0, 0);
-	-ms-transform:translate3d(0, 0, 0);
+	-webkit-transform: translate3d(0, 0, 0);
+	-moz-transform: translate3d(0, 0, 0);
+	-o-transform: translate3d(0, 0, 0);
+	-ms-transform: translate3d(0, 0, 0);
+	transform: translate3d(0, 0, 0);
 }
 
 .jp-carousel-slide {
@@ -241,10 +294,10 @@ div.jp-carousel-buttons a:hover {
 	color: #999;
 	cursor: default;
 	letter-spacing: 0 !important;
-	padding:0.35em 0 0;
-	position: absolute;
-	text-align: right;
-	width: calc( 100vw - 25px );
+	padding: 0.35em 0 0;
+	position: fixed;
+	text-align: left;
+	width: 90%;
 }
 
 .jp-carousel-transitions .jp-carousel-close-hint {
@@ -258,7 +311,7 @@ div.jp-carousel-buttons a:hover {
 	cursor: pointer;
 	background-color: black;
 	background-color: rgba(0,0,0,0.8);
-	display: block;
+	display: inline-block;
 	height: 22px;
 	font: 400 24px/1 "Helvetica Neue", sans-serif !important;
 	line-height: 22px;
@@ -376,8 +429,8 @@ div#carousel-reblog-box {
 	float: right;
 	margin: 6px 9px 0 9px;
 	border: 1px solid #666;
-	-webkit-box-shadow: inset 2px 2px 2px rgba(0,0,0,0.2);
-	box-shadow: inset 2px 2px 2px rgba(0,0,0,0.2);
+	-webkit-box-shadow: inset -2px 2px 2px rgba(0,0,0,0.2);
+	box-shadow: inset -2px 2px 2px rgba(0,0,0,0.2);
 	-moz-border-radius: 2px;
 	-webkit-border-radius: 2px;
 	border-radius: 2px;
@@ -466,8 +519,10 @@ div#carousel-reblog-box {
 	color: #999;
 	font-size: 15px;
 	padding-top: 24px;
+	margin-top: 20px;
 	margin-bottom: 20px;
-	font-weight:400;
+	font-weight: 400;
+	width: 100%;
 }
 .jp-carousel-titleanddesc-title {
 	font: 300 1.5em/1.1 "Helvetica Neue", sans-serif !important;
@@ -534,6 +589,8 @@ div#carousel-reblog-box {
 	overflow: hidden;
 	padding: 18px 20px;
 	width: 209px !important;
+	margin-top: 20px;
+	margin-right: 40px;
 }
 
 .jp-carousel-image-meta li,
@@ -558,7 +615,8 @@ div#carousel-reblog-box {
 
 .jp-carousel-image-meta li {
 	width: 48% !important;
-	float: right !important;
+	display: inline-block !important;
+	vertical-align: top !important;
 	margin: 0 0 15px 2% !important;
 	color: #fff !important;
 	font-size:13px !important;
@@ -581,7 +639,7 @@ a.jp-carousel-image-download {
 	font-weight: 400;
 	font-size: 13px;
 	text-decoration: none;
-	background-position: 0 -82px;
+	background-position: 100% -82px;
 }
 
 a.jp-carousel-image-download span.photo-size {
@@ -596,52 +654,21 @@ a.jp-carousel-image-download span.photo-size-times {
 }
 
 a.jp-carousel-image-download:hover {
-	background-position: 0 -122px;
+	background-position: 100% -122px;
 	color: #68c9e8;
 	border: none !important;
 }
 
 /** Meta Box End **/
 
-/** GPS Map Start **/
-.jp-carousel-image-map {
-	position: relative;
-	margin: -20px -20px 20px;
-	border-bottom: 1px solid rgba( 255, 255, 255, 0.17 );
-	height: 154px;
-}
-
-.jp-carousel-image-map img.gmap-main {
-	-moz-border-radius-topleft: 6px;
-	border-top-right-radius: 6px;
-	border-left: 1px solid rgba( 255, 255, 255, 0.17 );
-}
-.jp-carousel-image-map div.gmap-topright {
-	width: 94px;
-	height: 154px;
-	position: absolute;
-	top: 0;
-	left: 0;
-}
-.jp-carousel-image-map div.imgclip {
-	overflow: hidden;
-	-moz-border-radius-topright: 6px;
-	border-top-left-radius: 6px;
-}
-.jp-carousel-image-map div.gmap-topright img {
-	margin-right: -40px;
-}
-.jp-carousel-image-map img.gmap-bottomright {
-	position: absolute;
-	top: 96px;
-	left: 0;
-}
-
 /** Comments Start **/
 .jp-carousel-comments {
 	font: 15px/1.7 "Helvetica Neue", sans-serif !important;
 	font-weight: 400;
-	background:none transparent;
+	background: none transparent;
+	width: 100%;
+	bottom: 10px;
+	margin-top: 20px;
 }
 
 .jp-carousel-comments p a:hover, .jp-carousel-comments p a:focus, .jp-carousel-comments p a:active {
@@ -649,12 +676,15 @@ a.jp-carousel-image-download:hover {
 }
 
 .jp-carousel-comment {
-	background:none transparent;
+	background: none transparent;
 	color: #999;
-	margin-bottom: 20px;
-	clear:right;
+	clear: right;
 	overflow: auto;
-	width: 100%
+	width: 100%;
+}
+
+.jp-carousel-comment + .jp-carousel-comment {
+	margin-top: 20px;
 }
 
 .jp-carousel-comment p {
@@ -721,8 +751,8 @@ textarea#jp-carousel-comment-form-comment-field {
 	margin: 0;
 	float: none;
 	height: 147px;
-	-webkit-box-shadow: inset 2px 2px 2px rgba(0,0,0,0.2);
-	box-shadow: inset 2px 2px 2px rgba(0,0,0,0.2);
+	-webkit-box-shadow: inset -2px 2px 2px rgba(0,0,0,0.2);
+	box-shadow: inset -2px 2px 2px rgba(0,0,0,0.2);
 	-moz-border-radius: 3px;
 	-webkit-border-radius: 3px;
 	border-radius: 3px;
@@ -745,13 +775,49 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	color: #aaa;
 }
 
-#jp-carousel-comment-form-spinner {
-	color: #fff;
-	margin:22px 10px 0 0;
-	display: block;
+#jp-carousel-comment-form-spinner,
+#jp-carousel-comment-form-spinner:after {
+	border-radius: 50%;
 	width: 20px;
 	height: 20px;
+}
+#jp-carousel-comment-form-spinner {
+	display: none;
 	float: right;
+	margin: 22px 10px 0 0;
+	font-size: 10px;
+	position: relative;
+	text-indent: -9999em;
+	border-top: 4px solid rgba(255, 255, 255, 0.2);
+	border-left: 4px solid rgba(255, 255, 255, 0.2);
+	border-bottom: 4px solid rgba(255, 255, 255, 0.2);
+	border-right: 4px solid #ffffff;
+	-webkit-transform: translateZ(0);
+	-ms-transform: translateZ(0);
+	transform: translateZ(0);
+	-webkit-animation: load8 1.1s infinite linear;
+	animation: load8 1.1s infinite linear;
+}
+
+@-webkit-keyframes load8 {
+	0% {
+		-webkit-transform: rotate(0deg);
+		transform: rotate(0deg);
+	}
+	100% {
+		-webkit-transform: rotate(-360deg);
+		transform: rotate(-360deg);
+	}
+}
+@keyframes load8 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(-360deg);
+    transform: rotate(-360deg);
+  }
 }
 
 #jp-carousel-comment-form-submit-and-info-wrapper {
@@ -761,9 +827,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	width: 100%
 }
 
-#jp-carousel-comment-form-commenting-as {
-}
-
 #jp-carousel-comment-form-commenting-as input {
 	background: rgba(34,34,34,0.9);
 	border: 1px solid #3a3a3a;
@@ -771,8 +834,8 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	font: 13px/1.4 "Helvetica Neue", sans-serif !important;
 	padding: 3px 6px;
 	float: right;
-	-webkit-box-shadow: inset 2px 2px 2px rgba(0,0,0,0.2);
-	box-shadow: inset 2px 2px 2px rgba(0,0,0,0.2);
+	-webkit-box-shadow: inset -2px 2px 2px rgba(0,0,0,0.2);
+	box-shadow: inset -2px 2px 2px rgba(0,0,0,0.2);
 	-moz-border-radius: 2px;
 	-webkit-border-radius: 2px;
 	border-radius: 2px;
@@ -813,16 +876,12 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	float:left;
 }
 
-#js-carousel-comment-form-container {
-	margin-bottom:15px;
-	overflow: auto;
-	width: 100%;
-}
-
 #jp-carousel-comment-form-container {
-	margin-bottom:15px;
+	margin-bottom: 15px;
 	overflow: auto;
 	width: 100%;
+	margin-top: 20px;
+	color: #999;
 }
 
 #jp-carousel-comment-post-results {
@@ -843,16 +902,12 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	border-radius: 2px;
 	font: 13px/1.4 "Helvetica Neue", sans-serif !important;
 	border: 1px solid rgba( 255, 255, 255, 0.17 );
-	-webkit-box-shadow: inset 0px 5px 5px 0px rgba(0, 0, 0, 1);
-	        box-shadow: inset 0px 5px 5px 0px rgba(0, 0, 0, 1);
+	-webkit-box-shadow: inset 0px 0px 5px 5px rgba(0, 0, 0, 1);
+	        box-shadow: inset 0px 0px 5px 5px rgba(0, 0, 0, 1);
 }
 
 .jp-carousel-comment-post-error {
 	color:#DF4926;
-}
-
-.jp-carousel-comment-post-success {
-	/*color:#21759B;*/
 }
 
 #jp-carousel-comments-closed {
@@ -866,6 +921,9 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	color: #999;
 	text-align: right;
 	margin-bottom: 20px;
+	width: 100;
+	bottom: 10px;
+	margin-top: 20px;
 }
 
 
@@ -1018,11 +1076,11 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 }
 
 .jp-carousel-light a.jp-carousel-image-download {
-	background-position: 0 -122px;
+	background-position: 100% -122px;
 }
 
 .jp-carousel-light a.jp-carousel-image-download:hover {
-	background-position: 0 -122px;
+	background-position: 100% -122px;
 	color: #f1831e;
 }
 
@@ -1030,16 +1088,16 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	background: #fbfbfb;
 	color: #333;
 	border: 1px solid #dfdfdf;
-	-webkit-box-shadow: inset 2px 2px 2px rgba(0,0,0,0.1);
-	box-shadow: inset 2px 2px 2px rgba(0,0,0,0.1);
+	-webkit-box-shadow: inset -2px 2px 2px rgba(0,0,0,0.1);
+	box-shadow: inset -2px 2px 2px rgba(0,0,0,0.1);
 }
 
 .jp-carousel-light #jp-carousel-comment-form-commenting-as input {
 	background: #fbfbfb;
 	border: 1px solid #dfdfdf;
 	color: #333;
-	-webkit-box-shadow: inset 2px 2px 2px rgba(0,0,0,0.1);
-	box-shadow: inset 2px 2px 2px rgba(0,0,0,0.1);
+	-webkit-box-shadow: inset -2px 2px 2px rgba(0,0,0,0.1);
+	box-shadow: inset -2px 2px 2px rgba(0,0,0,0.1);
 }
 
 .jp-carousel-light #jp-carousel-comment-form-commenting-as input:focus {
@@ -1074,6 +1132,10 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		margin: 0 10px !important;
 	}
 
+	.jp-carousel-info-columns {
+		flex-direction: column;
+	}
+
 	.jp-carousel-next-button, .jp-carousel-previous-button {
 		display: none !important;
 	}
@@ -1085,9 +1147,10 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	.jp-carousel-image-meta {
 		float: none !important;
 		width: 100% !important;
-		-moz-box-sizing:border-box;
-		-webkit-box-sizing:border-box;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
 		box-sizing: border-box;
+		margin-right: 0;
 	}
 
 	.jp-carousel-close-hint {
@@ -1130,5 +1193,17 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	.jp-carousel-photo-info {
 		right: 0 !important;
 		width: 100% !important;
+	}
+
+	.jp-carousel-info > .jp-carousel-photo-info {
+		display: none;
+	}
+
+	.jp-carousel-left-column-wrapper > .jp-carousel-photo-info {
+		display: block;
+	}
+
+	.jp-carousel-caption {
+		overflow: visible !important;
 	}
 }

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -164,7 +164,6 @@
 	"projects/plugins/jetpack/extensions/shared/public-path.js",
 	"projects/plugins/jetpack/modules/.eslintrc.js",
 	"projects/plugins/jetpack/modules/calypsoify/mods-gutenberg.js",
-	"projects/plugins/jetpack/modules/carousel/jetpack-carousel.js",
 	"projects/plugins/jetpack/modules/contact-form/js/editor-view.js",
 	"projects/plugins/jetpack/modules/contact-form/js/grunion-admin.js",
 	"projects/plugins/jetpack/modules/contact-form/js/grunion.js",


### PR DESCRIPTION
This patch is the first of a series of changes that aim to improve the Carousel and ultimately remove its `jQuery` dependency, while keeping it IE11-compatible.

I'm trying to keep the changes relatively small and self-contained so that they can be incrementally tested (and debugged, if needed), instead of dropping a gigantic change that rewrites the world.

This PR syncs Jetpack to D56414-code, and applies some extra lint fixes, since the rules appear to be different. The change was started on wpcom instead of Jetpack due to legacy reasons. The next batch of improvements works on making that unnecessary.

This PR is a manual sync, since the automated tool appears to fail due to the mismatch in directory structure for the RTL CSS.

#### Changes proposed in this Pull Request:
* Move carousel skeleton HTML generation to the server. It only gets generated once, and it can be made to be device-independent, so there's no point doing it in JS. Note that populating the skeleton with data for a particular gallery is still done in JS, as is some of the resizing logic.
* Remove map generation code from JS.
* Modernise some of the layout to rely more on CSS and less on JS, by e.g. making use of flexbox.
* Rework padding calculations to be simpler and to work consistently across window resizes.
* Don't animate padding-related transitions if the user prefers reduced motion.
* Move some styles away from inlined style attributes, and into the CSS file.
* Remove Date.now polyfill, which is only applicable to ancient browsers.

#### Jetpack product discussion
See p1HpG7-bfN-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Smoke-test the carousel and ensure that it continues to work in the exact same way.

#### Proposed changelog entry for your changes:
* Carousel: under-the-hood code improvements.
