### PR TITLE
Keyring: Register Sharing page without menu

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.jetpack-keyring-service-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class.jetpack-keyring-service-helper.php
@@ -6,6 +6,13 @@ class Jetpack_Keyring_Service_Helper {
 	 **/
 	private static $instance = null;
 
+	/**
+	 * Whether the `sharing` page is registered.
+	 *
+	 * @var bool
+	 */
+	private static $is_sharing_page_registered = false;
+
 	static function init() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new Jetpack_Keyring_Service_Helper;
@@ -42,33 +49,32 @@ class Jetpack_Keyring_Service_Helper {
 	 * Constructor
 	 */
 	private function __construct() {
-		add_action( 'admin_menu', array( __CLASS__, 'add_sharing_menu' ), 21 );
+		add_action( 'admin_menu', array( __CLASS__, 'register_sharing_page' ) );
 
 		add_action( 'load-settings_page_sharing', array( __CLASS__, 'admin_page_load' ), 9 );
 	}
 
 	/**
-	 * We need a `sharing` submenu page to be able to connect and disconnect services.
+	 * We need a `sharing` page to be able to connect and disconnect services.
 	 */
-	public static function add_sharing_menu() {
-		global $submenu;
-
-		if (
-			! isset( $submenu['options-general.php'] )
-			|| ! is_array( $submenu['options-general.php'] )
-		) {
+	public static function register_sharing_page() {
+		if ( self::$is_sharing_page_registered ) {
 			return;
 		}
 
-		$general_settings_names = array_map(
-			function ( $menu ) {
-				return array_values( $menu )[0];
-			},
-			$submenu['options-general.php']
-		);
-		if ( ! in_array( 'Sharing', $general_settings_names, true ) ) {
-			add_submenu_page( 'options-general.php', '', '', 'manage_options', 'sharing', '__return_empty_string' );
+		self::$is_sharing_page_registered = true;
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
 		}
+
+		global $_registered_pages;
+
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		$hookname = get_plugin_page_hookname( 'sharing', 'options-general.php' );
+		add_action( $hookname, array( __CLASS__, 'admin_page_load' ) );
+		$_registered_pages[ $hookname ] = true; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	function get_services( $filter = 'all' ) {
@@ -118,34 +124,43 @@ class Jetpack_Keyring_Service_Helper {
 	}
 
 	static function connect_url( $service_name, $for ) {
-		return add_query_arg( array(
-			'action'   => 'request',
-			'service'  => $service_name,
-			'kr_nonce' => wp_create_nonce( 'keyring-request' ),
-			'nonce'    => wp_create_nonce( "keyring-request-$service_name" ),
-			'for'      => $for,
-		), menu_page_url( 'sharing', false ) );
+		return add_query_arg(
+			array(
+				'action'   => 'request',
+				'service'  => $service_name,
+				'kr_nonce' => wp_create_nonce( 'keyring-request' ),
+				'nonce'    => wp_create_nonce( "keyring-request-$service_name" ),
+				'for'      => $for,
+			),
+			admin_url( 'options-general.php?page=sharing' )
+		);
 	}
 
 	static function refresh_url( $service_name, $for ) {
-		return add_query_arg( array(
-			'action'   => 'request',
-			'service'  => $service_name,
-			'kr_nonce' => wp_create_nonce( 'keyring-request' ),
-			'refresh'  => 1,
-			'for'      => $for,
-			'nonce'    => wp_create_nonce( "keyring-request-$service_name" ),
-		), admin_url( 'options-general.php?page=sharing' ) );
+		return add_query_arg(
+			array(
+				'action'   => 'request',
+				'service'  => $service_name,
+				'kr_nonce' => wp_create_nonce( 'keyring-request' ),
+				'refresh'  => 1,
+				'for'      => $for,
+				'nonce'    => wp_create_nonce( "keyring-request-$service_name" ),
+			),
+			admin_url( 'options-general.php?page=sharing' )
+		);
 	}
 
 	static function disconnect_url( $service_name, $id ) {
-		return add_query_arg( array(
-			'action'   => 'delete',
-			'service'  => $service_name,
-			'id'       => $id,
-			'kr_nonce' => wp_create_nonce( 'keyring-request' ),
-			'nonce'    => wp_create_nonce( "keyring-request-$service_name" ),
-		), menu_page_url( 'sharing', false ) );
+		return add_query_arg(
+			array(
+				'action'   => 'delete',
+				'service'  => $service_name,
+				'id'       => $id,
+				'kr_nonce' => wp_create_nonce( 'keyring-request' ),
+				'nonce'    => wp_create_nonce( "keyring-request-$service_name" ),
+			),
+			admin_url( 'options-general.php?page=sharing' )
+		);
 	}
 
 	static function admin_page_load() {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
@@ -88,15 +88,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 		global $publicize;
 		/**
 		 * We need this because Publicize::get_available_service_data() uses `Jetpack_Keyring_Service_Helper`
-		 * and `Jetpack_Keyring_Service_Helper` relies on `menu_page_url()`.
-		 *
-		 * We also need add_submenu_page(), as the URLs for connecting each service
-		 * rely on the `sharing` menu subpage being present.
+		 * and `Jetpack_Keyring_Service_Helper` needs a `sharing` page to be registered.
 		 */
-		include_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-		// The `sharing` submenu page must exist for service connect URLs to be correct.
-		add_submenu_page( 'options-general.php', '', '', 'manage_options', 'sharing', '__return_empty_string' );
+		jetpack_require_lib( 'class.jetpack-keyring-service-helper' );
+		Jetpack_Keyring_Service_Helper::register_sharing_page();
 
 		$services_data = $publicize->get_available_service_data();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Alternative approach to #13799, so the Keyring services can use the Sharing page without the need of being explicitly registered as an empty menu item.

Before | After
--- | ---
<img width="436" alt="Screen Shot 2021-02-17 at 11 41 37" src="https://user-images.githubusercontent.com/1233880/108204376-03b6b900-7124-11eb-8a28-e3a61ef25aa1.png"> | <img width="329" alt="Screen Shot 2021-02-17 at 13 14 34" src="https://user-images.githubusercontent.com/1233880/108204385-074a4000-7124-11eb-8e1c-09ba22889998.png">

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- With this patch on, go to Jetpack > Settings > Sharing and disable all modules.
- Check the Settings menu, and make sure there isn't any empty submenu item linking to `options-general.php?page=sharing`.
- Go to Jetpack > Settings > Traffic
- Try to automatically verify your site with Google.
- The pop up that opens should lead you to Google.
- Go to Jetpack > Settings > Sharing and enable at least one module.
- Check the Settings menu, and make sure there is a Sharing submenu item linking to `options-general.php?page=sharing`.
- Go to Jetpack > Settings > Traffic
- Try to automatically verify your site with Google.
- The pop up that opens should lead you to Google.

#### Proposed changelog entry for your changes:
Not needed?
