### PR TITLE
Admin Menu: Fix link destination for Widgets and Menus

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -215,4 +215,15 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		add_submenu_page( $parent_menu_slug, esc_attr__( 'Add New Theme', 'jetpack' ), __( 'Add New Theme', 'jetpack' ), 'install_themes', 'theme-install.php', null, 1 );
 	}
+
+	/**
+	 * Adds Appearance menu.
+	 *
+	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Customize on Atomic sites is always done on WP Admin.
+		parent::add_appearance_menu( $wp_admin_themes, true );
+	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -76,4 +76,15 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 
 		add_menu_page( __( 'WP Admin', 'jetpack' ), __( 'WP Admin', 'jetpack' ), 'read', $menu_slug, null, 'dashicons-wordpress-alt', $position );
 	}
+
+	/**
+	 * Adds Appearance menu.
+	 *
+	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Customize on Atomic sites is always done on Jetpack sites.
+		parent::add_appearance_menu( $wp_admin_themes, true );
+	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -17,15 +17,6 @@ require_once __DIR__ . '/class-admin-menu.php';
 class WPcom_Admin_Menu extends Admin_Menu {
 
 	/**
-	 * WPcom_Admin_Menu constructor.
-	 */
-	protected function __construct() {
-		parent::__construct();
-
-		$this->customize_slug = 'https://wordpress.com/customize/' . $this->domain;
-	}
-
-	/**
 	 * Sets up class properties for REST API requests.
 	 *
 	 * @param WP_REST_Response $response Response from the endpoint.
@@ -34,8 +25,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::rest_api_init( $response );
 
 		// Get domain for requested site.
-		$this->domain         = ( new Status() )->get_site_suffix();
-		$this->customize_slug = 'https://wordpress.com/customize/' . $this->domain;
+		$this->domain = ( new Status() )->get_site_suffix();
 
 		return $response;
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -491,7 +491,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 */
 	public function test_add_appearance_menu() {
 		global $menu, $submenu;
-		$customize_slug = 'customize.php';
+		$customize_slug = 'https://wordpress.com/customize/' . static::$domain;
 		static::$admin_menu->add_appearance_menu( false );
 
 		$slug = 'https://wordpress.com/themes/' . static::$domain;

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -357,4 +357,25 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 			$this->assertNotContains( $submenu_item, $submenu[ $slug ] );
 		}
 	}
+
+	/**
+	 * Tests add_appearance_menu
+	 *
+	 * @covers ::add_appearance_menu
+	 */
+	public function test_add_appearance_menu() {
+		global $submenu;
+
+		$slug = 'https://wordpress.com/themes/' . static::$domain;
+		static::$admin_menu->add_appearance_menu( false, false );
+
+		// Check Customize menu always links to WP Admin.
+		$customize_submenu_item = array(
+			'Customize',
+			'customize',
+			'customize.php',
+			'Customize',
+		);
+		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -159,4 +159,25 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 		);
 		$this->assertSame( end( $menu ), $wp_admin_menu_item );
 	}
+
+	/**
+	 * Tests add_appearance_menu
+	 *
+	 * @covers ::add_appearance_menu
+	 */
+	public function test_add_appearance_menu() {
+		global $submenu;
+
+		$slug = 'https://wordpress.com/themes/' . static::$domain;
+		static::$admin_menu->add_appearance_menu( false, false );
+
+		// Check Customize menu always links to WP Admin.
+		$customize_submenu_item = array(
+			'Customize',
+			'customize',
+			'customize.php',
+			'Customize',
+		);
+		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -391,27 +391,6 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests add_appearance_menu
-	 *
-	 * @covers ::add_appearance_menu
-	 */
-	public function test_add_appearance_menu() {
-		global $submenu;
-
-		$slug = 'https://wordpress.com/themes/' . static::$domain;
-		static::$admin_menu->add_appearance_menu( false );
-
-		// Check Customize menu always links to WP.com.
-		$customize_submenu_item = array(
-			'Customize',
-			'customize',
-			'https://wordpress.com/customize/' . static::$domain,
-			'Customize',
-		);
-		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
-	}
-
-	/**
 	 * Tests add_gutenberg_menus
 	 *
 	 * @covers ::add_gutenberg_menus


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/49830

#### Changes proposed in this Pull Request:

We were previously always linking to the Customizer for managing widgets and menus since that's what the existing Calypso nav does. However there are better WP Admin screens for doing that when the user has the "Replace all dashboard pages with WP Admin equivalents when possible." setting enabled or when the WP Admin Customizer is forced on Jetpack/Atomic sites.

This PR adjusts the link destination of Customize, Widgets and Menus according to the table below:

Site | Customize | Widgets | Menus
--- | --- | --- | ---
Simple | `wordpress.com/customize` or `/wp-admin/customize.php`, depends on the link destination setting toggle. | `wordpress.com/customize` or `/wp-admin/widgets.php`, depends on the link destination setting toggle. | `wordpress.com/customize` or `/wp-admin/nav-menus.php`, depends on the link destination setting toggle.
Jetpack | `/wp-admin/customize.php` | `/wp-admin/widgets.php` | `/wp-admin/nav-menus.php`
Atomic | `/wp-admin/customize.php` | `/wp-admin/widgets.php` | `/wp-admin/nav-menus.php`

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
_Simple_
* Go to https://wordpress.com/me/account and disable the "Replace all dashboard pages with WP Admin equivalents when possible." setting.
* Apply D57198-code to your WP.com sandbox.
* Sandbox the API and a Simple site.
* Go to https://wordpress.com and switch to that site.
* Make sure that Appearance > Customize, Appearance > Widgets, and Appearance > Menus opens the Calypso Customizer.
* Enable now the "Replace all dashboard pages with WP Admin equivalents when possible." setting.
* Make sure that Appearance > Customize opens the WP Admin Customizer.
* Make sure that Appearance > Widgets opens the WP Admin Widgets screen.
* Make sure that Appearance > Menus opens the WP Admin Nav Menus screen.

_Jetpack_
* Go to https://wordpress.com/me/account and disable the "Replace all dashboard pages with WP Admin equivalents when possible." setting.
* Spin up a Jetpack site running the branch of this PR.
* Go to https://wordpress.com and switch to that site.
* Make sure that Appearance > Customize opens the WP Admin Customizer (the link destination setting is ignored).
* Make sure that Appearance > Widgets opens the WP Admin Widgets screen (the link destination setting is ignored).
* Make sure that Appearance > Menus opens the WP Admin Nav Menus screen (the link destination setting is ignored).
* Enable now the "Replace all dashboard pages with WP Admin equivalents when possible." setting
* Make sure that Appearance > Customize opens the WP Admin Customizer.
* Make sure that Appearance > Widgets opens the WP Admin Widgets screen.
* Make sure that Appearance > Menus opens the WP Admin Nav Menus screen.

_Atomic_
* Go to https://wordpress.com/me/account and disable the "Replace all dashboard pages with WP Admin equivalents when possible." setting.
* Install Jetpack Beta on a WoA site up and activate the branch of this PR.
* Go to https://wordpress.com and switch to that site.
* Make sure that Appearance > Customize opens the WP Admin Customizer (the link destination setting is ignored).
* Make sure that Appearance > Widgets opens the WP Admin Widgets screen (the link destination setting is ignored).
* Make sure that Appearance > Menus opens the WP Admin Nav Menus screen (the link destination setting is ignored).
* Enable now the "Replace all dashboard pages with WP Admin equivalents when possible." setting
* Make sure that Appearance > Customize opens the WP Admin Customizer.
* Make sure that Appearance > Widgets opens the WP Admin Widgets screen.
* Make sure that Appearance > Menus opens the WP Admin Nav Menus screen.

#### Proposed changelog entry for your changes:
N/A.
