### PR TITLE
E2E tests: Save browser storage and reuse the wpcom session

### DIFF
--- a/projects/plugins/jetpack/tests/e2e/.gitignore
+++ b/projects/plugins/jetpack/tests/e2e/.gitignore
@@ -5,3 +5,4 @@ plan-data.txt
 e2e_tunnels.txt
 jetpack-private-options.txt
 /allure-results
+storage.json

--- a/projects/plugins/jetpack/tests/e2e/lib/flows/jetpack-connect.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/flows/jetpack-connect.js
@@ -128,6 +128,8 @@ export async function loginToWpcomIfNeeded( wpcomUser, mockPlanData ) {
 	}
 	if ( ! ( await login.isLoggedIn() ) ) {
 		await login.login( wpcomUser );
+	} else {
+		logger.debug( 'Already logged into WPCOM' );
 	}
 }
 

--- a/projects/plugins/jetpack/tests/e2e/lib/logger.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/logger.js
@@ -100,6 +100,7 @@ if ( process.env.E2E_DEBUG || ! process.env.CI ) {
 	logger.add(
 		new transports.Console( {
 			format: stringFormat,
+			level: 'debug',
 		} )
 	);
 }

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wpcom/login.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wpcom/login.js
@@ -9,6 +9,7 @@ import getRedirectUrl from '../../../../../_inc/client/lib/jp-redirect';
 import Page from '../page';
 import { getAccountCredentials, isEventuallyVisible } from '../../page-helper';
 import logger from '../../logger';
+import fs from 'fs';
 
 export default class LoginPage extends Page {
 	constructor( page ) {
@@ -18,6 +19,7 @@ export default class LoginPage extends Page {
 	}
 
 	async login( wpcomUser, { retry = true } = {} ) {
+		logger.debug( 'Log in WPCOM' );
 		const [ username, password ] = getAccountCredentials( wpcomUser );
 
 		const usernameSelector = '#usernameOrEmail';
@@ -48,6 +50,10 @@ export default class LoginPage extends Page {
 			}
 			throw e;
 		}
+
+		// save storage state to reuse later to skip log in
+		const storage = await context.storageState();
+		fs.writeFileSync( 'config/storage.json', JSON.stringify( storage ) );
 	}
 
 	async isLoggedIn() {

--- a/projects/plugins/jetpack/tests/e2e/lib/setup-env.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/setup-env.js
@@ -83,9 +83,14 @@ async function setUserAgent() {
 	const userAgentSuffix = 'wp-e2e-tests';
 	const e2eUserAgent = `${ userAgent } ${ userAgentSuffix }`;
 
+	if ( ! fs.existsSync( 'config/storage.json' ) ) {
+		fs.writeFileSync( 'config/storage.json', '{}' );
+	}
+
 	// Reset context as a workaround to set a custom user agent
 	await jestPlaywright.resetContext( {
 		userAgent: e2eUserAgent,
+		storageState: 'config/storage.json',
 	} );
 
 	userAgent = await page.evaluate( () => navigator.userAgent );

--- a/projects/plugins/jetpack/tests/e2e/lib/setup-env.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/setup-env.js
@@ -83,14 +83,15 @@ async function setUserAgent() {
 	const userAgentSuffix = 'wp-e2e-tests';
 	const e2eUserAgent = `${ userAgent } ${ userAgentSuffix }`;
 
-	if ( ! fs.existsSync( 'config/storage.json' ) ) {
-		fs.writeFileSync( 'config/storage.json', '{}' );
+	const storageFilePath = 'config/storage.json';
+	if ( ! fs.existsSync( storageFilePath ) ) {
+		fs.writeFileSync( storageFilePath, '{}' );
 	}
 
 	// Reset context as a workaround to set a custom user agent
 	await jestPlaywright.resetContext( {
 		userAgent: e2eUserAgent,
-		storageState: 'config/storage.json',
+		storageState: storageFilePath,
 	} );
 
 	userAgent = await page.evaluate( () => navigator.userAgent );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
After WPCOM login save the browser storage in a file and pass it the next time the browser context is reset. This way we don't need to login on each test.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Login to WPcom is done only once at the beginning. For each subsequent test the user should be already logged in.
* All E2E tests should pass.

#### Proposed changelog entry for your changes:
n/a
