### PR TITLE
[WIP] Button Block: Add ability to set custom widths

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/button/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/attributes.js
@@ -50,4 +50,7 @@ export default {
 	borderRadius: {
 		type: 'number',
 	},
+	width: {
+		type: 'string',
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/button/button-width-panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/button-width-panel.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	BaseControl,
+	Button,
+	ButtonGroup,
+	PanelBody,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const widthUnits = [
+	{ value: 'px', label: 'px', default: 150 },
+	{ value: '%', label: '%', default: 100 },
+	{ value: 'em', label: 'em', default: 10 },
+];
+
+const alignedWidthUnits = [
+	{ value: 'px', label: 'px', default: 150 },
+	{ value: 'em', label: 'em', default: 10 },
+];
+
+const ButtonWidthPanel = props => {
+	const { align, predefinedWidths = [ '25%', '50%', '75%', '100%' ], setAttributes, width } = props;
+
+	// Left/right aligned blocks are floated so % widths don't work as expected.
+	const isAlignedLeftOrRight = align === 'left' || align === 'right';
+
+	const handleWidthChange = selectedWidth => {
+		// Handle toggling width selection off.
+		const newWidth = width === selectedWidth ? undefined : selectedWidth;
+		setAttributes( { width: newWidth } );
+	};
+
+	return (
+		<PanelBody title={ __( 'Width settings', 'jetpack' ) }>
+			<BaseControl label={ __( 'Button width', 'jetpack' ) }>
+				<div
+					className={ classnames( 'jetpack-button__width-settings', {
+						'is-aligned': isAlignedLeftOrRight,
+					} ) }
+				>
+					{ ! isAlignedLeftOrRight && (
+						<ButtonGroup aria-label={ __( 'Percentage width', 'jetpack' ) }>
+							{ predefinedWidths.map( predefinedWidth => {
+								return (
+									<Button
+										key={ predefinedWidth }
+										isSmall
+										isPrimary={ predefinedWidth === width }
+										onClick={ () => handleWidthChange( predefinedWidth ) }
+									>
+										{ predefinedWidth }
+									</Button>
+								);
+							} ) }
+						</ButtonGroup>
+					) }
+					<UnitControl
+						className="jetpack-button__custom-width"
+						isResetValueOnUnitChange
+						max={ width?.includes( '%' ) ? 100 : undefined }
+						min={ 0 }
+						onChange={ selectedWidth => setAttributes( { width: selectedWidth } ) }
+						size={ 'small' }
+						units={ isAlignedLeftOrRight ? alignedWidthUnits : widthUnits }
+						value={ width }
+					/>
+				</div>
+			</BaseControl>
+		</PanelBody>
+	);
+};
+
+export default ButtonWidthPanel;

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -148,6 +148,7 @@ function get_button_styles( $attributes ) {
 	$has_named_gradient          = array_key_exists( 'gradient', $attributes );
 	$has_custom_gradient         = array_key_exists( 'customGradient', $attributes );
 	$has_border_radius           = array_key_exists( 'borderRadius', $attributes );
+	$has_width                   = array_key_exists( 'width', $attributes );
 
 	if ( ! $has_named_text_color && $has_custom_text_color ) {
 		$styles[] = sprintf( 'color: %s;', $attributes['customTextColor'] );
@@ -169,6 +170,10 @@ function get_button_styles( $attributes ) {
 	// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 	if ( $has_border_radius && 0 != $attributes['borderRadius'] ) {
 		$styles[] = sprintf( 'border-radius: %spx;', $attributes['borderRadius'] );
+	}
+
+	if ( $has_width ) {
+		$styles[] = sprintf( 'width: %s', $attributes['width'] );
 	}
 
 	return implode( ' ', $styles );

--- a/projects/plugins/jetpack/extensions/blocks/button/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/edit.js
@@ -13,6 +13,7 @@ import {
 	withColors,
 } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -21,9 +22,20 @@ import { __ } from '@wordpress/i18n';
 import applyFallbackStyles from './apply-fallback-styles';
 import ButtonBorderPanel from './button-border-panel';
 import ButtonColorsPanel from './button-colors-panel';
+import ButtonWidthPanel from './button-width-panel';
 import { IS_GRADIENT_AVAILABLE } from './constants';
 import usePassthroughAttributes from './use-passthrough-attributes';
 import './editor.scss';
+
+const usePrevious = value => {
+	const ref = useRef();
+
+	useEffect( () => {
+		ref.current = value;
+	}, [ value ] );
+
+	return ref.current;
+};
 
 function ButtonEdit( {
 	attributes,
@@ -37,7 +49,8 @@ function ButtonEdit( {
 	setTextColor,
 	textColor,
 } ) {
-	const { borderRadius, element, placeholder, text } = attributes;
+	const { align, borderRadius, element, placeholder, text, width } = attributes;
+	const previousAlign = usePrevious( align );
 
 	usePassthroughAttributes( { attributes, clientId, setAttributes } );
 
@@ -46,6 +59,16 @@ function ButtonEdit( {
 		const newValue = 'input' === element ? value.replace( /<br>/gim, ' ' ) : value;
 		setAttributes( { text: newValue } );
 	};
+
+	useEffect( () => {
+		// Reset button width if switching to left or right alignment for first time.
+		const alignmentChanged = previousAlign !== align;
+		const isAlignedLeftRight = align === 'left' || align === 'right';
+
+		if ( alignmentChanged && isAlignedLeftRight && width?.includes( '%' ) ) {
+			setAttributes( { width: undefined } );
+		}
+	}, [ align, previousAlign, setAttributes, width ] );
 
 	/* eslint-disable react-hooks/rules-of-hooks */
 	const {
@@ -69,6 +92,7 @@ function ButtonEdit( {
 		[ textColor.class ]: textColor.class,
 		[ gradientClass ]: gradientClass,
 		'no-border-radius': 0 === borderRadius,
+		'has-custom-width': !! width,
 	} );
 
 	const buttonStyles = {
@@ -77,6 +101,7 @@ function ButtonEdit( {
 			: { backgroundColor: backgroundColor.color } ),
 		color: textColor.color,
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+		width,
 	};
 
 	return (
@@ -105,6 +130,7 @@ function ButtonEdit( {
 					} }
 				/>
 				<ButtonBorderPanel borderRadius={ borderRadius } setAttributes={ setAttributes } />
+				<ButtonWidthPanel align={ align } width={ width } setAttributes={ setAttributes } />
 			</InspectorControls>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -9,3 +9,36 @@
 		justify-content: center;
 	}
 }
+
+div[data-type="jetpack/button"]:not([data-align='left']):not([data-align='right']) {
+	width: 100%;
+}
+
+div[data-type="jetpack/button"][data-align] {
+	z-index: 1;
+
+	.wp-block > div {
+		max-width: 100%;
+	}
+}
+
+.jetpack-button__width-settings {
+	display: flex;
+	align-items: center;
+
+	.components-button-group {
+		display: flex;
+		margin-right: 1em;
+	}
+
+	&:not(.is-aligned) {
+		.components-unit-control-wrapper {
+			flex: 1;
+		}
+	}
+}
+
+.wp-block-button__link.has-custom-width {
+	// width: 100%;
+	max-width: 100%;
+}

--- a/projects/plugins/jetpack/extensions/blocks/button/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/save.js
@@ -30,6 +30,7 @@ export default function ButtonSave( { attributes, blockName, uniqueId } ) {
 		text,
 		textColor,
 		url,
+		width,
 	} = attributes;
 
 	if ( ! saveInPostContent ) {
@@ -51,6 +52,7 @@ export default function ButtonSave( { attributes, blockName, uniqueId } ) {
 		[ backgroundClass ]: backgroundClass,
 		[ gradientClass ]: gradientClass,
 		'no-border-radius': 0 === borderRadius,
+		'has-custom-width': !! width,
 	} );
 
 	const buttonStyle = {
@@ -59,6 +61,7 @@ export default function ButtonSave( { attributes, blockName, uniqueId } ) {
 			backgroundClass || customGradient || gradient ? undefined : customBackgroundColor,
 		color: textClass ? undefined : customTextColor,
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+		width,
 	};
 
 	return (


### PR DESCRIPTION
Fixes #18594

#### Description
This PR trials an alternate approach to applying custom Jetpack button widths than https://github.com/Automattic/jetpack/pull/18809. The aim was to see if there was a way to keep the floating alignment behaviour while still giving control over the button width.

This is still very much a WIP and primarily for discussion purposes at this stage. The blocks which add the Jetpack button block as an inner block might need a tweak or two to their CSS. This has only been trialed with the Payments block so far.

#### Changes proposed in this Pull Request:
* Adds the ability to set a custom width on Jetpack Button blocks
* Allows preset percentage widths to be selected via a simple button group
* Allows custom widths to use non-percentage units
* Removes any percentage based width when applying an alignment to the button
* Only px and em widths can be applied to aligned buttons

#### Known Issues
_**1. Current use of the `UnitControl` is broken. It enters and infinite loop and crashes the block at the moment. Ran out of time today but will fix ASAP.**_

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No change.

#### Testing instructions:

1. Checkout this branch
2. Build and sync Jetpack to sandbox or apply PR's diff
3. Create a new post, add a payments block, select a plan/product then add a few paragraphs of text after it.
4. Select the button block and change its width via the inspector controls 
    (**Known issue: just drag unit control up and down to adjust, it goes into infinite loop on key press**)
5. Try different alignments, switch units, save and confirm visually on frontend


#### Screenshot

![Alt-ButtonWidthApproach](https://user-images.githubusercontent.com/60436221/108335503-c4b95e00-721e-11eb-94ea-c0108e8f37c7.gif)


#### Proposed changelog entry for your changes:
* Jetpack Button: Allow specification of custom button widths.
