### PR TITLE
Remove jQuery from Related Posts

### DIFF
--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -5,7 +5,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Sync\Settings;
 
 class Jetpack_RelatedPosts {
-	const VERSION   = '20201207';
+	const VERSION   = '20210219';
 	const SHORTCODE = 'jetpack-related-posts';
 
 	private static $instance     = null;

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1655,7 +1655,7 @@ EOT;
 	 * @return null
 	 */
 	protected function _enqueue_assets( $script, $style ) {
-		$dependencies = is_customize_preview() ? array( 'customize-base' ) : array( 'jquery' );
+		$dependencies = is_customize_preview() ? array( 'customize-base' ) : array();
 		if ( $script ) {
 			wp_enqueue_script(
 				'jetpack_related-posts',

--- a/projects/plugins/jetpack/modules/related-posts/related-posts.js
+++ b/projects/plugins/jetpack/modules/related-posts/related-posts.js
@@ -3,7 +3,9 @@
 /**
  * Load related posts
  */
-( function ( $ ) {
+( function () {
+	'use strict';
+
 	var jprp = {
 		response: null,
 
@@ -36,8 +38,9 @@
 			}
 
 			var args = 'relatedposts=1';
-			if ( $( '#jp-relatedposts' ).data( 'exclude' ) ) {
-				args += '&relatedposts_exclude=' + $( '#jp-relatedposts' ).data( 'exclude' );
+			var relatedPosts = document.querySelector( '#jp-relatedposts' );
+			if ( relatedPosts.hasAttribute( 'data-exclude' ) ) {
+				args += '&relatedposts_exclude=' + relatedPosts.getAttribute( 'data-exclude' );
 			}
 
 			if ( is_customizer ) {
@@ -57,32 +60,30 @@
 		},
 
 		getAnchor: function ( post, classNames ) {
-			var anchor_title = post.title;
-			var anchor = $( '<a>' );
-
-			anchor.attr( {
-				class: classNames,
-				href: post.url,
-				title: anchor_title,
-				'data-origin': post.url_meta.origin,
-				'data-position': post.url_meta.position,
-			} );
+			var anchorTitle = post.title;
+			var anchor = document.createElement( 'a' );
+			anchor.setAttribute( 'class', classNames );
+			anchor.setAttribute( 'href', post.url );
+			anchor.setAttribute( 'title', anchorTitle );
+			anchor.setAttribute( 'data-origin', post.url_meta.origin );
+			anchor.setAttribute( 'data-position', post.url_meta.position );
 
 			if ( '' !== post.rel ) {
-				anchor.attr( {
-					rel: post.rel,
-				} );
+				anchor.setAttribute( 'rel', post.rel );
 			}
 
-			var anchor_html = $( '<div>' ).append( anchor ).html();
-			return [ anchor_html.substring( 0, anchor_html.length - 4 ), '</a>' ];
+			var div = document.createElement( 'div' );
+			div.appendChild( anchor );
+
+			var anchorHTML = div.innerHTML;
+			return [ anchorHTML.substring( 0, anchorHTML.length - 4 ), '</a>' ];
 		},
 
 		generateMinimalHtml: function ( posts, options ) {
 			var self = this;
 			var html = '';
 
-			$.each( posts, function ( index, post ) {
+			posts.forEach( function ( post, index ) {
 				var anchor = self.getAnchor( post, 'jp-relatedposts-post-a' );
 				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index;
 
@@ -130,7 +131,7 @@
 			var self = this;
 			var html = '';
 
-			$.each( posts, function ( index, post ) {
+			posts.forEach( function ( post, index ) {
 				var anchor = self.getAnchor( post, 'jp-relatedposts-post-a' );
 				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index;
 
@@ -143,6 +144,10 @@
 				} else {
 					classes += ' jp-relatedposts-post-thumbs';
 				}
+
+				var dummyContainer = document.createElement( 'p' );
+				dummyContainer.innerHTML = post.excerpt;
+				var excerpt = dummyContainer.textContent;
 
 				html +=
 					'<div class="' +
@@ -180,10 +185,7 @@
 					'</' +
 					related_posts_js_options.post_heading +
 					'>';
-				html +=
-					'<p class="jp-relatedposts-post-excerpt">' +
-					$( '<p>' ).text( post.excerpt ).html() +
-					'</p>';
+				html += '<p class="jp-relatedposts-post-excerpt">' + excerpt + '</p>';
 				if ( options.showDate ) {
 					html +=
 						'<time class="jp-relatedposts-post-date" datetime="' +
@@ -213,25 +215,29 @@
 		 * work.
 		 */
 		setVisualExcerptHeights: function () {
-			var elements = $(
+			var elements = document.querySelectorAll(
 				'#jp-relatedposts .jp-relatedposts-post-nothumbs .jp-relatedposts-post-excerpt'
 			);
 
-			if ( 0 >= elements.length ) {
+			if ( ! elements.length ) {
 				return;
 			}
 
-			var fontSize = parseInt( elements.first().css( 'font-size' ), 10 ),
-				lineHeight = parseInt( elements.first().css( 'line-height' ), 10 );
+			var firstElementStyles = getComputedStyle( elements[ 0 ] );
+
+			var fontSize = parseInt( firstElementStyles.fontSize, 10 );
+			var lineHeight = parseInt( firstElementStyles.lineHeight, 10 );
 
 			// Show 5 lines of text
-			elements.css( 'max-height', ( 5 * lineHeight ) / fontSize + 'em' );
+			for ( var i = 0; i < elements.length; i++ ) {
+				elements[ i ].style.maxHeight = ( 5 * lineHeight ) / fontSize + 'em';
+			}
 		},
 
 		getTrackedUrl: function ( anchor ) {
 			var args = 'relatedposts_hit=1';
-			args += '&relatedposts_origin=' + $( anchor ).data( 'origin' );
-			args += '&relatedposts_position=' + $( anchor ).data( 'position' );
+			args += '&relatedposts_origin=' + anchor.getAttribute( 'data-origin' );
+			args += '&relatedposts_position=' + anchor.getAttribute( 'data-position' );
 
 			var pathname = anchor.pathname;
 			if ( '/' !== pathname[ 0 ] ) {
@@ -265,8 +271,12 @@
 
 	function afterPostsHaveLoaded() {
 		jprp.setVisualExcerptHeights();
-		$( '#jp-relatedposts a.jp-relatedposts-post-a' ).click( function () {
-			this.href = jprp.getTrackedUrl( this );
+		var posts = document.querySelectorAll( '#jp-relatedposts a.jp-relatedposts-post-a' );
+
+		Array.prototype.forEach.call( posts, function ( post ) {
+			document.addEventListener( 'click', function () {
+				post.href = jprp.getTrackedUrl( post );
+			} );
 		} );
 	}
 
@@ -276,52 +286,75 @@
 	function startRelatedPosts() {
 		jprp.cleanupTrackedUrl();
 
-		var endpointURL = jprp.getEndpointURL(),
-			$relatedPosts = $( '#jp-relatedposts' );
+		var endpointURL = jprp.getEndpointURL();
+		var relatedPosts = document.querySelector( '#jp-relatedposts' );
 
-		if ( $( '#jp-relatedposts .jp-relatedposts-post' ).length ) {
+		if ( document.querySelectorAll( '#jp-relatedposts .jp-relatedposts-post' ).length ) {
 			afterPostsHaveLoaded();
 			return;
 		}
 
-		$.getJSON( endpointURL, function ( response ) {
-			if ( 0 === response.items.length || 0 === $relatedPosts.length ) {
-				return;
+		var request = new XMLHttpRequest();
+		request.open( 'GET', endpointURL, true );
+		request.setRequestHeader( 'x-requested-with', 'XMLHttpRequest' );
+
+		request.onreadystatechange = function () {
+			if ( this.readyState === XMLHttpRequest.DONE && this.status === 200 ) {
+				try {
+					var response = JSON.parse( request.responseText );
+
+					if ( 0 === response.items.length || 0 === relatedPosts.length ) {
+						return;
+					}
+
+					jprp.response = response;
+
+					var html,
+						showThumbnails,
+						options = {};
+
+					if ( 'undefined' !== typeof wp && wp.customize ) {
+						showThumbnails = wp.customize.instance( 'jetpack_relatedposts[show_thumbnails]' ).get();
+						options.showDate = wp.customize.instance( 'jetpack_relatedposts[show_date]' ).get();
+						options.showContext = wp.customize
+							.instance( 'jetpack_relatedposts[show_context]' )
+							.get();
+						options.layout = wp.customize.instance( 'jetpack_relatedposts[layout]' ).get();
+					} else {
+						showThumbnails = response.show_thumbnails;
+						options.showDate = response.show_date;
+						options.showContext = response.show_context;
+						options.layout = response.layout;
+					}
+
+					html = ! showThumbnails
+						? jprp.generateMinimalHtml( response.items, options )
+						: jprp.generateVisualHtml( response.items, options );
+
+					var div = document.createElement( 'div' );
+					relatedPosts.appendChild( div );
+					div.outerHTML = html;
+
+					if ( options.showDate ) {
+						var dates = relatedPosts.querySelectorAll( '.jp-relatedposts-post-date' );
+
+						Array.prototype.forEach.call( dates, function ( date ) {
+							date.style.display = 'block';
+						} );
+					}
+
+					relatedPosts.style.display = 'block';
+					afterPostsHaveLoaded();
+				} catch ( error ) {
+					// Do nothing
+				}
 			}
+		};
 
-			jprp.response = response;
-
-			var html,
-				showThumbnails,
-				options = {};
-
-			if ( 'undefined' !== typeof wp && wp.customize ) {
-				showThumbnails = wp.customize.instance( 'jetpack_relatedposts[show_thumbnails]' ).get();
-				options.showDate = wp.customize.instance( 'jetpack_relatedposts[show_date]' ).get();
-				options.showContext = wp.customize.instance( 'jetpack_relatedposts[show_context]' ).get();
-				options.layout = wp.customize.instance( 'jetpack_relatedposts[layout]' ).get();
-			} else {
-				showThumbnails = response.show_thumbnails;
-				options.showDate = response.show_date;
-				options.showContext = response.show_context;
-				options.layout = response.layout;
-			}
-
-			html = ! showThumbnails
-				? jprp.generateMinimalHtml( response.items, options )
-				: jprp.generateVisualHtml( response.items, options );
-
-			$relatedPosts.append( html );
-			if ( options.showDate ) {
-				$relatedPosts.find( '.jp-relatedposts-post-date' ).css( 'display', 'block' );
-			}
-
-			$relatedPosts.show();
-			afterPostsHaveLoaded();
-		} );
+		request.send();
 	}
 
-	$( function () {
+	function init() {
 		if ( 'undefined' !== typeof wp && wp.customize ) {
 			if ( wp.customize.selectiveRefresh ) {
 				wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function ( placement ) {
@@ -334,5 +367,11 @@
 		} else {
 			startRelatedPosts();
 		}
-	} );
-} )( jQuery );
+	}
+
+	if ( document.readyState !== 'loading' ) {
+		init();
+	} else {
+		document.addEventListener( 'DOMContentLoaded', init );
+	}
+} )();


### PR DESCRIPTION
This PR removes `jQuery` as a dependency to the Related Posts script, by reimplementing the latter in IE 11-compatible ES5.

#### Changes proposed in this Pull Request:
* Remove `jQuery` dependency from Related Posts

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* In your test blog, make sure you enable the Related Posts Jetpack feature.
* Create several classic content blog posts (not Gutenberg). In my testing, I created 4 posts using the same tag and with similar short content.
* Open one of the blog posts and ensure that Related Posts are shown. They should be loaded dynamically via JS, so you'll see them pop in shortly after the page is first rendered.
* Apply this PR.
* Ensure that Related Posts are still shown, in the exact same way.
* Ensure that the admin pages for the feature still work correctly.
* Ensure that the customizer for the feature still works correctly.

Note: I added all the reviewers that GitHub suggested; please feel free to remove yourself or ignore this PR if you're not the right person.

#### Proposed changelog entry for your changes:
* Related Posts: remove `jQuery` dependency.
