### PR TITLE
Connection: updating the deprecated `is_user_connected()` method

### DIFF
--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4238,7 +4238,7 @@ p {
 						exit;
 					}
 
-					if ( self::is_active() && self::is_user_connected() ) {
+					if ( static::is_active() && static::connection()->is_user_connected() ) {
 						// The user is either already connected, or finished the connection process.
 						wp_safe_redirect( $dest_url );
 						exit;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The method `Jetpack::is_user_connected()` is deprecated by PR #18548.
Replacing it with its counterpart from the `jetpack-connection` package.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Connect the Jetpack site.
2. Open the following URL: `https://your-site.local/wp-admin/admin.php?page=jetpack&action=authorize_redirect&dest_url=https://wordpress.com/something
3. You should get redirected to `https://wordpress.com/something` (it's 404, and it's ok).

#### Proposed changelog entry for your changes:
n/a