### PR TITLE
Autoloader: Fix coverage test

### DIFF
--- a/projects/packages/autoloader/phpunit.xml.dist
+++ b/projects/packages/autoloader/phpunit.xml.dist
@@ -12,12 +12,8 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">views</directory>
-			</exclude>
+			<!-- Do not add `.`, bootstrap.php sets up a loop from tests/php/tmp/wp-content/plugins/current/vendor/automattic/jetpack-autoloader → . which PHPUnit chokes on. -->
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The coverage test isn't actually running, PHPUnit complains

    Warning: Incorrect filter configuration, code coverage will not be processed

This turns out to be due to the attempt to exclude a "views" directory
that does not exist.

Fixing this reveals another bug: bootstrap.php sets up a symlink from
tests/php/tmp/wp-content/plugins/current/vendor/automattic/jetpack-autoloader
back to the root directory, and PHPUnit is apparently not smart enough
to handle that when trying to find the files to cover
(sebastianbergmann/php-code-coverage#849). Work around that by adding
`src` specifically instead of adding `.` then trying to exclude `tests`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the Code Coverage job generate coverage for automattic/jetpack-autoloader?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.
