### PR TITLE
Actions: do not add milestone info to comment when undefined

### DIFF
--- a/.github/actions/repo-gardening/src/tasks/check-description/index.js
+++ b/.github/actions/repo-gardening/src/tasks/check-description/index.js
@@ -248,7 +248,9 @@ Once you’ve done so, switch to the "[Status] Needs Review" label; someone from
 
 	// Gather info about the next release for that plugin.
 	const milestoneInfo = await buildMilestoneInfo( octokit, owner, repo, number );
-	comment += milestoneInfo;
+	if ( milestoneInfo ) {
+		comment += milestoneInfo;
+	}
 
 	// Look for an existing check-description task comment.
 	const existingComment = await getCheckComment( octokit, owner, repo, number );


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Follow-up from #18558.

When we do not have any plugin info, let's not try to add anything to the comment.

You can see the bug in action here:
https://github.com/Automattic/jetpack/pull/18877#issuecomment-781887430

![image](https://user-images.githubusercontent.com/426388/108473174-fa496000-728d-11eb-91ff-2ffb39a6bd0c.png)


#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Check the comment below.

#### Proposed changelog entry for your changes:

* N/A
