### PR TITLE
Actions: do not run label and comment automations on closed PRs

### DIFF
--- a/.github/actions/repo-gardening/src/if-not-closed.js
+++ b/.github/actions/repo-gardening/src/if-not-closed.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+const debug = require( './debug' );
+
+/* global WPAutomationTask */
+
+/**
+ * Higher-order function which executes and returns the result of the given
+ * handler only if the PR is not currently closed.
+ *
+ * @param {WPAutomationTask} handler - Original task.
+ *
+ * @returns {WPAutomationTask} Enhanced task.
+ */
+function ifNotClosed( handler ) {
+	const newHandler = ( payload, octokit ) => {
+		if ( payload.pull_request.state !== 'closed' ) {
+			return handler( payload, octokit );
+		}
+		debug( `main: Skipping ${ handler.name } because the PR is closed.` );
+	};
+	Object.defineProperty( newHandler, 'name', { value: handler.name } );
+	return newHandler;
+}
+
+module.exports = ifNotClosed;

--- a/.github/actions/repo-gardening/src/index.js
+++ b/.github/actions/repo-gardening/src/index.js
@@ -13,6 +13,7 @@ const addLabels = require( './tasks/add-labels' );
 const checkDescription = require( './tasks/check-description' );
 const debug = require( './debug' );
 const ifNotFork = require( './if-not-fork' );
+const ifNotClosed = require( './if-not-closed' );
 
 const automations = [
 	{
@@ -27,12 +28,12 @@ const automations = [
 	{
 		event: 'pull_request',
 		action: [ 'opened', 'reopened', 'synchronize', 'edited', 'labeled' ],
-		task: addLabels,
+		task: ifNotClosed( addLabels ),
 	},
 	{
 		event: 'pull_request',
 		action: [ 'opened', 'reopened', 'synchronize', 'edited', 'labeled' ],
-		task: checkDescription,
+		task: ifNotClosed( checkDescription ),
 	},
 ];
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Follow-up to #18558.

We do not have to keep editing labels or comments on PRs that are closed.

Here is an example: #18881 Since I removed status labels from that PR, the action ran, the comment was updated, and a label was added:

![image](https://user-images.githubusercontent.com/426388/108477339-624e7500-7293-11eb-881c-797687e9d743.png)

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* See that the comment was properly added below, and that no "needs author reply" was added back to that closed PR: #18883 

#### Proposed changelog entry for your changes:

* N/A
