### PR TITLE
Issues templates: update label name for Beta plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin_jetpack-beta.md
+++ b/.github/ISSUE_TEMPLATE/plugin_jetpack-beta.md
@@ -2,7 +2,7 @@
 name: Plugin - Jetpack Beta Tester
 about: Create an issue report focused on the Jetpack Beta Tester plugin
 title: 'Beta Plugin: ADD_YOUR_TITLE_HERE'
-labels: '[Plugin] Beta Plugin, [Type] Bug'
+labels: '[Plugin] Beta, [Type] Bug'
 assignees: ''
 
 ---


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* The Beta plugin label is now just "Beta".

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here; just look at the label name here ->

#### Proposed changelog entry for your changes:

* N/A
