### PR TITLE
Fix Publicize Services endpoint on WP.com

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-services.php
@@ -86,12 +86,15 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Services extends WP_REST_Control
 	 */
 	public function get_items( $request ) {
 		global $publicize;
-		/**
-		 * We need this because Publicize::get_available_service_data() uses `Jetpack_Keyring_Service_Helper`
-		 * and `Jetpack_Keyring_Service_Helper` needs a `sharing` page to be registered.
-		 */
-		jetpack_require_lib( 'class.jetpack-keyring-service-helper' );
-		Jetpack_Keyring_Service_Helper::register_sharing_page();
+
+		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+			/**
+			 * We need this because Publicize::get_available_service_data() uses `Jetpack_Keyring_Service_Helper`
+			 * and `Jetpack_Keyring_Service_Helper` needs a `sharing` page to be registered.
+			 */
+			jetpack_require_lib( 'class.jetpack-keyring-service-helper' );
+			Jetpack_Keyring_Service_Helper::register_sharing_page();
+		}
 
 		$services_data = $publicize->get_available_service_data();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes a regression introduced by https://github.com/Automattic/jetpack/pull/18861 since the `Jetpack_Keyring_Service_Helper` class is not available in WP.com.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply D57190-code to your WP.com sandbox.
* Sandbox the API.
* Go to the [WP.com API console](https://developer.wordpress.com/docs/api/console/).
* Make an `GET` request to `wpcom/v2/sites/:site/publicize/services` for a Simple site.
* Make sure it returns a 200 response.

#### Proposed changelog entry for your changes:
N/A.
