### PR TITLE
Skip master user tests when in userless mode

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -297,6 +297,14 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				)
 			);
 		}
+		if ( ! ( new Connection_Manager() )->get_connection_owner_id() && ( new Status() )->is_no_user_testing_mode() ) {
+			return self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'Jetpack is running in userless mode. No master user to check.', 'jetpack' ),
+				)
+			);
+		}
 		$local_user = $this->helper_retrieve_local_master_user();
 
 		if ( $local_user->exists() ) {
@@ -324,6 +332,14 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				array(
 					'name'              => $name,
 					'short_description' => __( 'Jetpack is not connected.', 'jetpack' ),
+				)
+			);
+		}
+		if ( ! ( new Connection_Manager() )->get_connection_owner_id() && ( new Status() )->is_no_user_testing_mode() ) {
+			return self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'Jetpack is running in userless mode. No master user to check.', 'jetpack' ),
 				)
 			);
 		}


### PR DESCRIPTION
Adapts the Connection healthy checks to skip Master User tests when running userless mode

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Skip some connection tests when in userlessmode

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a new not connected site
* Define the `JETPACK_NO_USER_TEST_MODE`
* Go to Tools > Site Health
* Go under passed tests and look for "Master User Exists On Site" and "Master User Can Manage Options" tests
* Confirm they were skipped with a message saying Jetpack is not connected 

<img width="814" alt="Captura de Tela 2021-02-19 às 14 17 36" src="https://user-images.githubusercontent.com/971483/108540269-bec78980-72bf-11eb-98ac-4997fe22d4a7.png">


* Connect Jetpack only at a site level
* Visit `/wp-admin/admin.php?page=jetpack-debugger` and make sure `Your Jetpack setup looks a-okay!`
* Go to Tools > Site Health
* Go under passed tests and look for "Master User Exists On Site" and "Master User Can Manage Options" tests
* Confirm they were skipped with a message saying Jetpack is in user-less mode

<img width="816" alt="Captura de Tela 2021-02-19 às 14 06 53" src="https://user-images.githubusercontent.com/971483/108540580-1bc33f80-72c0-11eb-8797-f3f4aa5e7d06.png">

* Connect Jetpack with a user
* Visit `/wp-admin/admin.php?page=jetpack-debugger` and make sure `Your Jetpack setup looks a-okay!`
* Go to Tools > Site Health
* Go under passed tests and look for "Master User Exists On Site" and "Master User Can Manage Options" tests
* Confirm they have passed

<img width="811" alt="Captura de Tela 2021-02-19 às 14 15 44" src="https://user-images.githubusercontent.com/971483/108540633-31d10000-72c0-11eb-946e-68bfa7cbe815.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* update connection health tests in user less mode
