### PR TITLE
Slideshow Block: Display full width and images as such

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -73,6 +73,12 @@
 		object-fit: contain;
 	}
 
+	&.alignfull .wp-block-jetpack-slideshow_image {
+		max-width: unset;
+		object-fit: cover;
+		width: 100vw;
+	}
+
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next,
 	.wp-block-jetpack-slideshow_button-pause,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #12178

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds CSS rule for full width slideshows to fill the width of the screen.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate a theme with support for full-width slideshows (Twenty Twenty-One)
* Create a page/post
* Add new Slideshow Block and add one or more large images
* Set display mode to full width
* Publish and view page/post

Before | After
----|----
<img width="1676" alt="Screen Shot 2021-02-19 at 12 55 33 PM" src="https://user-images.githubusercontent.com/1398304/108560665-f0d1ef00-72b1-11eb-9bb0-5d9a44195577.png"> | <img width="1675" alt="Screen Shot 2021-02-19 at 12 56 08 PM" src="https://user-images.githubusercontent.com/1398304/108560676-f596a300-72b1-11eb-81a5-89a9871e7e1b.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fixed a bug where full-width slideshow blocks didn't display images actually in full width.