### PR TITLE
Adds message to Instagram widget form for disconnected users

### DIFF
--- a/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
 
 /**
  * This is the actual Instagram widget along with other code that only applies to the widget.
@@ -380,6 +381,18 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 	 */
 	public function form( $instance ) {
 		$instance = wp_parse_args( $instance, $this->defaults );
+
+		if ( ! ( new Manager() )->is_user_connected() ) {
+			echo '<p>';
+			printf(
+				// translators: %1$1 and %2$s are the opening and closing a tags creating a link to the Jetpack dashboard.
+				esc_html__( 'In order to use this widget you need %1$scomplete your Jetpack connection%2$s by authorizing your user.', 'jetpack' ),
+				'<a href="' . esc_url( Jetpack::admin_url() ) . '">',
+				'</a>'
+			);
+			echo '</p>';
+			return;
+		}
 
 		// If coming back to the widgets page from an action, expand this widget.
 		if ( isset( $_GET['instagram_widget_id'] ) && (int) $_GET['instagram_widget_id'] === (int) $this->number ) {


### PR DESCRIPTION
The Instagram widget requires a User connected to Jetpack in order to work. 

With the upcoming User-less connection, it's nice that we display a proper message when a disconnected user attempts to use the widget, otherwise they would see a "Instagram is having connectivity issues" which is not true.

By the way, this is what happens today when secondary disconnected users try to use the widget, so this PR also fixes it.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a proper message in the Instagram widget form for disconnected users

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a Jetpack site and define the `JETPACK_NO_USER_TEST_MODE` constant.
* Connect the site only at a site level
* Go to Appearance > Widgets, and add the Instagram widget
* Confirm you see a message telling that you have to connect your user to Jetpack

<img width="442" alt="Captura de Tela 2021-02-19 às 18 06 22" src="https://user-images.githubusercontent.com/971483/108562833-3bb62b80-72df-11eb-9942-a7bcdbaebca4.png">

* Click the link and confirm you are taken to the Jetpack Dashboard
* Connect your user
* Go back to Widgets and confirm the widget works as usual
* Create a secondary user and log in with it
* Go to Widgets and confirm you see the same message telling to connect Jetpack

Finally, give feedback on the text of the message.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Adds a proper message in the Instagram widget form for disconnected users
