### PR TITLE
Ads: Fixes check for displaying the Ads module settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -260,7 +260,7 @@ export const SettingsCard = props => {
 
 			case FEATURE_WORDADS_JETPACK:
 				if (
-					! hasPremiumOrBetter ||
+					! hasPremiumOrBetter &&
 					-1 === props.activeFeatures.indexOf( FEATURE_WORDADS_JETPACK )
 				) {
 					return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Sites that are enrolled in WordAds should still be able to update their ads settings, even if the site no longer meets the plan eligibility. This PR fixes the check that was preventing site admins from accessing their Ads settings.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Setup a test site with an eligible plan enrolled in WordAds
* Remove the plan
* Verify the Ads settings at Jetpack > Settings > Traffic are displayed, and able to be modified

#### Proposed changelog entry for your changes:
* N/A
