### PR TITLE
Protect: introduce new wp_robots_no_robots when available

### DIFF
--- a/projects/plugins/jetpack/modules/protect/blocked-login-page.php
+++ b/projects/plugins/jetpack/modules/protect/blocked-login-page.php
@@ -370,7 +370,11 @@ class Jetpack_Protect_Blocked_Login_Page {
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 			<meta name="viewport" content="width=device-width">
 			<?php
-			if ( function_exists( 'wp_no_robots' ) ) {
+			// Remove wp_no_robots() when WordPress 5.7 is the minimum required version.
+			if ( function_exists( 'wp_robots' ) && function_exists( 'wp_robots_no_robots' ) && function_exists( 'add_filter' ) ) {
+				add_filter( 'wp_robots', 'wp_robots_no_robots' );
+				wp_robots();
+			} else {
 				wp_no_robots();
 			}
 			?>

--- a/projects/plugins/jetpack/modules/protect/blocked-login-page.php
+++ b/projects/plugins/jetpack/modules/protect/blocked-login-page.php
@@ -370,12 +370,10 @@ class Jetpack_Protect_Blocked_Login_Page {
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 			<meta name="viewport" content="width=device-width">
 			<?php
-			// Remove wp_no_robots() when WordPress 5.7 is the minimum required version.
-			if ( function_exists( 'wp_robots' ) && function_exists( 'wp_robots_no_robots' ) && function_exists( 'add_filter' ) ) {
-				add_filter( 'wp_robots', 'wp_robots_no_robots' );
-				wp_robots();
+			if ( get_option( 'blog_public' ) ) {
+				echo "<meta name='robots' content='noindex,follow' />\n";
 			} else {
-				wp_no_robots();
+				echo "<meta name='robots' content='noindex,nofollow' />\n";
 			}
 			?>
 			<title><?php echo $title ?></title>


### PR DESCRIPTION


#### Changes proposed in this Pull Request:

`wp_robots_no_robots()` replaces `wp_no_robots()` in WP 5.7:
https://core.trac.wordpress.org/ticket/51511#comment:13


#### Jetpack product discussion

Primary issue: #18842 

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Add the following constant to your site: `define( 'JETPACK_ALWAYS_PROTECT_LOGIN', true );`
* Connect your site to WordPress.com; Protect should be automatically enabled.
* Log out
* Try to log back in.
* See the new blocked login page.
* Whether you use WordPress 5.6 or WP 5.7 (via the WordPress Beta Tester plugin for example), you should see a `<meta name='robots' content` meta tag in the page's `head`.

#### Proposed changelog entry for your changes:

* Protect: use new Robots API introduced in WordPress 5.7 when displaying a blocked login page.
