### PR TITLE
Admin Menu: Exclude hidden items from API response

### DIFF
--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -173,6 +173,11 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 					'count' => 5,
 				),
 			),
+			// Hidden menu item.
+			array(
+				array( 'Hidden', 'read', 'hidden', '', 'hide-if-js' ),
+				array(),
+			),
 		);
 	}
 
@@ -237,6 +242,12 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 					'url'    => admin_url( 'upload.php' ),
 					'count'  => 15,
 				),
+			),
+			// Hidden submenu item.
+			array(
+				array( 'Hidden', 'read', 'hidden', 'Hidden', 'hide-if-js' ),
+				array( 'My Plugin', 'read', 'my-plugin', 'My Plugin', '', '', '' ),
+				array(),
 			),
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/50249

#### Changes proposed in this Pull Request:
[Some plugins like WooCommerce make use of WP CSS class `hide-if-js` to avoid showing menu items that shouldn't be there](https://github.com/woocommerce/woocommerce-admin/blob/07d26b12847647b273db2c285315b7dfa8f550ec/src/Features/Navigation/CoreMenu.php#L292-L299), but not remove them completely so their routes remain available.

To mimic that behavior, this PR excludes any menu and submenu item that contains the `hide-if-js` class from the `wpcom/v2/admin-menu` API response.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Try to replicate first the issue on a Jetpack site running the `master` branch by adding the code below to a mu-plugin:
```
add_filter( 'jetpack_load_admin_menu_class', '__return_true' );

add_action( 'admin_menu', function () {
	add_menu_page( 'My Plugin', 'My Plugin', 'read', 'my-plugin-1', '', '', 0 );
	add_submenu_page( 'my-plugin-1', 'Hidden', 'Hidden', 'read', 'my-hidden-submenu' );
	add_menu_page( 'Hidden', 'Hidden', 'read', 'my-plugin-2', '', '', 1 );

	global $menu, $submenu;
	$menu[1][4] .= ' hide-if-js';
	$submenu['my-plugin-1'][1][] .= ' hide-if-js';
} );
```
- Load WP Admin and note how only one item is visible: <img width="575" alt="Screen Shot 2021-02-22 at 12 15 34" src="https://user-images.githubusercontent.com/1233880/108703941-98962980-750b-11eb-87fc-e0eeb00ec8b7.png">
- Load Calypso and note how the hidden items are visible: <img width="454" alt="Screen Shot 2021-02-22 at 12 15 46" src="https://user-images.githubusercontent.com/1233880/108703989-a8ae0900-750b-11eb-9877-39c61a71c485.png">
- Switch to this branch and reload Calypso.
- Make sure the hidden items are no longer visible in the menu: <img width="465" alt="Screen Shot 2021-02-22 at 12 29 41" src="https://user-images.githubusercontent.com/1233880/108704045-bfecf680-750b-11eb-9917-2b006ddf058c.png">



#### Proposed changelog entry for your changes:
N/A.
