### PR TITLE
Avoid accessing undefined indexes in Instagram widget

### DIFF
--- a/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
@@ -587,11 +587,17 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 			$instance['token_id'] = $old_instance['token_id'];
 		}
 
-		$instance['title'] = wp_strip_all_tags( $new_instance['title'] );
+		if ( isset( $new_instance['title'] ) ) {
+			$instance['title'] = wp_strip_all_tags( $new_instance['title'] );
+		}
 
-		$instance['columns'] = max( 1, min( $this->valid_options['max_columns'], (int) $new_instance['columns'] ) );
+		if ( isset( $new_instance['columns'] ) ) {
+			$instance['columns'] = max( 1, min( $this->valid_options['max_columns'], (int) $new_instance['columns'] ) );
+		}
 
-		$instance['count'] = max( 1, min( $this->valid_options['max_count'], (int) $new_instance['count'] ) );
+		if ( isset( $new_instance['count'] ) ) {
+			$instance['count'] = max( 1, min( $this->valid_options['max_count'], (int) $new_instance['count'] ) );
+		}
 
 		return $instance;
 	}


### PR DESCRIPTION
This is a possible fix for https://github.com/Automattic/jetpack/issues/17801

When first dragging the instagram widget into a widget area some PHP errors occur (visible with Query Monitor). The errors are the result of accessing undefined array indexes.

Fixes #17801 

#### Changes proposed in this Pull Request:
I have added some simple isset() checks. $instance contains all the default values. It is updated with supplied values if the relevant array index is defined. 

No change in behaviour is expected (apart from not producing errors)

#### Jetpack product discussion
I am not an Automattician.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Enable extra sidebar widgets https://jetpack.com/support/extra-sidebar-widgets/
* Install and enable Query Monitor
* Go to /wp-admin/widgets.php and drag the "Instagram (Jetpack)" widget into a widget area. No php errors should result.

If the Instagram widget doesn't seem to be available after you have enabled extra sidebar widgets be aware that Jetpack::is_active() must evaluate to true for it to appear. In projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php see the check on line 609.

The errors only occurred when first dragging the widget into the sidebar. No errors occur on page reloads. To test repeatedly you need to delete then re-add the widget.

#### Proposed changelog entry for your changes:
No change log entry required
