### PR TITLE
Anchor.fm: Remove group block to prevent blank excerpt

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/templates/index.js
@@ -15,16 +15,18 @@ import createBlocksFromTemplate from '../../../shared/create-block-from-inner-bl
 
 function spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) {
 	return [
-		'core/image',
-		{
-			url: spotifyImageUrl,
-			linkDestination: 'none',
-			href: spotifyShowUrl,
-			align: 'center',
-			width: 165,
-			height: 40,
-			className: 'is-spotify-podcast-badge',
-		},
+		[
+			'core/image',
+			{
+				url: spotifyImageUrl,
+				linkDestination: 'none',
+				href: spotifyShowUrl,
+				align: 'center',
+				width: 165,
+				height: 40,
+				className: 'is-spotify-podcast-badge',
+			},
+		],
 	];
 }
 
@@ -32,16 +34,18 @@ function podcastSection( { episodeTrack, feedUrl } ) {
 	const { guid } = episodeTrack;
 
 	return [
-		'jetpack/podcast-player',
-		{
-			customPrimaryColor: getIconColor(),
-			hexPrimaryColor: getIconColor(),
-			url: feedUrl,
-			selectedEpisodes: guid ? [ { guid } ] : [],
-			showCoverArt: false,
-			showEpisodeTitle: false,
-			showEpisodeDescription: false,
-		},
+		[
+			'jetpack/podcast-player',
+			{
+				customPrimaryColor: getIconColor(),
+				hexPrimaryColor: getIconColor(),
+				url: feedUrl,
+				selectedEpisodes: guid ? [ { guid } ] : [],
+				showCoverArt: false,
+				showEpisodeTitle: false,
+				showEpisodeDescription: false,
+			},
+		],
 	];
 }
 
@@ -70,7 +74,7 @@ function podcastSummarySection( { episodeTrack } ) {
 		] );
 	}
 
-	return [ 'core/group', {}, sectionBlocks ];
+	return sectionBlocks;
 }
 
 function podcastConversationSection() {
@@ -83,8 +87,54 @@ function podcastConversationSection() {
 	if ( ! isConversationBlockAvailable ) {
 		// When it is not, return a fallback core-blocks composition.
 		return [
-			'core/group',
-			{},
+			[
+				'core/heading',
+				{
+					level: 3,
+					content: __( 'Transcription', 'jetpack' ),
+					placeholder: __( 'Podcast episode transcription', 'jetpack' ),
+				},
+			],
+			[
+				'core/paragraph',
+				{
+					placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+				},
+			],
+			[
+				'core/paragraph',
+				{
+					placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+				},
+			],
+			[
+				'core/paragraph',
+				{
+					placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+				},
+			],
+		];
+	}
+
+	return [
+		[
+			conversationBlockName,
+			{
+				participants: [
+					{
+						slug: 'participant-0',
+						label: __( 'Speaker 1', 'jetpack' ),
+					},
+					{
+						slug: 'participant-1',
+						label: __( 'Speaker 2', 'jetpack' ),
+					},
+					{
+						slug: 'participant-2',
+						label: __( 'Speaker 3', 'jetpack' ),
+					},
+				],
+			},
 			[
 				[
 					'core/heading',
@@ -95,74 +145,26 @@ function podcastConversationSection() {
 					},
 				],
 				[
-					'core/paragraph',
+					'jetpack/dialogue',
 					{
 						placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+						slug: 'participant-0',
 					},
 				],
 				[
-					'core/paragraph',
+					'jetpack/dialogue',
 					{
 						placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+						slug: 'participant-1',
 					},
 				],
 				[
-					'core/paragraph',
+					'jetpack/dialogue',
 					{
 						placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
+						slug: 'participant-2',
 					},
 				],
-			],
-		];
-	}
-
-	return [
-		conversationBlockName,
-		{
-			participants: [
-				{
-					slug: 'participant-0',
-					label: __( 'Speaker 1', 'jetpack' ),
-				},
-				{
-					slug: 'participant-1',
-					label: __( 'Speaker 2', 'jetpack' ),
-				},
-				{
-					slug: 'participant-2',
-					label: __( 'Speaker 3', 'jetpack' ),
-				},
-			],
-		},
-		[
-			[
-				'core/heading',
-				{
-					level: 3,
-					content: __( 'Transcription', 'jetpack' ),
-					placeholder: __( 'Podcast episode transcription', 'jetpack' ),
-				},
-			],
-			[
-				'jetpack/dialogue',
-				{
-					placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
-					slug: 'participant-0',
-				},
-			],
-			[
-				'jetpack/dialogue',
-				{
-					placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
-					slug: 'participant-1',
-				},
-			],
-			[
-				'jetpack/dialogue',
-				{
-					placeholder: __( 'Podcast episode dialogue', 'jetpack' ),
-					slug: 'participant-2',
-				},
 			],
 		],
 	];
@@ -172,14 +174,14 @@ function podcastConversationSection() {
  * Template parts
  */
 function episodeBasicTemplate( { spotifyShowUrl, spotifyImageUrl, episodeTrack = {}, feedUrl } ) {
-	const tpl = [ podcastSection( { episodeTrack, feedUrl } ) ];
+	const tpl = [ ...podcastSection( { episodeTrack, feedUrl } ) ];
 
 	if ( spotifyShowUrl && spotifyImageUrl ) {
-		tpl.push( spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) );
+		tpl.push( ...spotifyTemplate( { spotifyShowUrl, spotifyImageUrl } ) );
 	}
 
-	tpl.push( podcastSummarySection( { episodeTrack } ) );
-	tpl.push( podcastConversationSection() );
+	tpl.push( ...podcastSummarySection( { episodeTrack } ) );
+	tpl.push( ...podcastConversationSection() );
 
 	return tpl;
 }
@@ -193,5 +195,5 @@ export function spotifyBadgeTemplate( params ) {
 		return;
 	}
 
-	return createBlocksFromTemplate( [ spotifyTemplate( params ) ] );
+	return createBlocksFromTemplate( [ ...spotifyTemplate( params ) ] );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Removes the group block from the Anchor.fm podcast episode post template to work around an issue where content in the group block doesn't display in the post excerpt.

https://github.com/WordPress/gutenberg/issues/26706

| **Before** | **After** |
| - | - |
| <img width="622" alt="Screen Shot 2021-02-22 at 15 36 22" src="https://user-images.githubusercontent.com/1699996/108773342-cbe4b280-7523-11eb-8dfa-7f49d4119724.png"> | <img width="622" alt="Screen Shot 2021-02-22 at 15 35 34" src="https://user-images.githubusercontent.com/1699996/108773356-d4d58400-7523-11eb-8ffb-847863b7d148.png"> |

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

1. Visit a url that creates a podcast start post, with the necessary Anchor information in the query parameters, (e.g. `/wp-admin/post-new.php?anchor_episode=fb1dcaa4-bf8c-43dc-92e1-7b46b7a77a2b&anchor_podcast=22b6608&spotify_url=https://open.spotify.com/show/6HTZdaDHjqXKDE4acYffoD?si=EVfDYETjQCu7pasVG5D73Q&nd=1`)
2. Make sure the post is created with the podcast title, podcast player, summary/description, and a blank transcript
3. Make sure the group block is not used in the template
4. If you have the conversation block enabled, (e.g., comment out [the block registration hook](https://github.com/Automattic/jetpack/blob/98ad189d646e26a8b3b7047e865d676a15a797ad/projects/plugins/jetpack/extensions/blocks/conversation/conversation.php#L38)), and make sure the fallback content works, as well.

#### Proposed changelog entry for your changes:

* Anchor.fm block: remove group block from podcast episode post template
