### PR TITLE
Comments / Publicize: add missing Tokens imports

### DIFF
--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -1,7 +1,8 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 require dirname( __FILE__ ) . '/base.php';
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Tokens;
 
 /**
  * Main Comments class

--- a/projects/plugins/jetpack/modules/publicize/publicize-jetpack.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize-jetpack.php
@@ -1,5 +1,6 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Redirect;
 
 class Publicize extends Publicize_Base {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* This follows-up #18812, and should avoid fatals when trying to use one of the 2 features.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No
#### Testing instructions:

* Go to Jetpack > Settings and enable the Comments and Publicize modules
* You shouldn't get any fatal errors on your site. 

#### Proposed changelog entry for your changes:

* N/A
