### PR TITLE
Use phpcs-changed 2.7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-codesniffer": "@dev",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
 		"php-parallel-lint/php-parallel-lint": "1.2.0",
-		"sirbrillig/phpcs-changed": "2.7.0"
+		"sirbrillig/phpcs-changed": "2.7.1"
 	},
 	"scripts": {
 		"pre-update-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae37d53f8c27feb5a55bbaf55f69b2c6",
+    "content-hash": "8992d09276dafc91b21271a94a4da465",
     "packages": [],
     "packages-dev": [
         {
@@ -569,16 +569,16 @@
         },
         {
             "name": "sirbrillig/phpcs-changed",
-            "version": "v2.7.0",
+            "version": "v2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-changed.git",
-                "reference": "3a29de78291cf1ec71b23fd4553a968c13620519"
+                "reference": "c521b6a303fb1c721949c7e4bdc0f3bbd7e5125f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/3a29de78291cf1ec71b23fd4553a968c13620519",
-                "reference": "3a29de78291cf1ec71b23fd4553a968c13620519",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/c521b6a303fb1c721949c7e4bdc0f3bbd7e5125f",
+                "reference": "c521b6a303fb1c721949c7e4bdc0f3bbd7e5125f",
                 "shasum": ""
             },
             "require": {
@@ -620,9 +620,9 @@
             "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
-                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.7.0"
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.7.1"
             },
-            "time": "2021-01-29T17:25:46+00:00"
+            "time": "2021-02-16T15:50:18+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
That release fixes a bug that can cause files changed in both the
current branch and in the base branch since the branchpoint to show
warnings from unchanged lines.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1612859631270800-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `composer install` and see that phpcs-changed 2.7.1 is now used. You might also try to reproduce [the bug](https://github.com/sirbrillig/phpcs-changed/issues/42) that that release fixes if you want.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* None needed.