### PR TITLE
Admin Menu: Keep Plugins submenus when they link to WP Admin

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -461,9 +461,13 @@ class Admin_Menu {
 		$menu_slug = $wp_admin ? 'plugins.php' : 'https://wordpress.com/plugins/' . $this->domain;
 
 		remove_menu_page( 'plugins.php' );
-		remove_submenu_page( 'plugins.php', 'plugins.php' );
-		remove_submenu_page( 'plugins.php', 'plugin-install.php' );
-		remove_submenu_page( 'plugins.php', 'plugin-editor.php' );
+
+		// Keep submenus when links point to WP Admin.
+		if ( ! $wp_admin ) {
+			remove_submenu_page( 'plugins.php', 'plugins.php' );
+			remove_submenu_page( 'plugins.php', 'plugin-install.php' );
+			remove_submenu_page( 'plugins.php', 'plugin-editor.php' );
+		}
 
 		$count = '';
 		if ( ! is_multisite() && current_user_can( 'update_plugins' ) ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -87,4 +87,14 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		// Customize on Atomic sites is always done on Jetpack sites.
 		parent::add_appearance_menu( $wp_admin_themes, true );
 	}
+
+	/**
+	 * Adds Plugins menu.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_plugins_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Plugins on Jetpack sites are always managed on Calypso.
+		parent::add_plugins_menu( false );
+	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -285,4 +285,14 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		return $result;
 	}
+
+	/**
+	 * Adds Plugins menu.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_plugins_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Plugins on Simple sites are always managed on Calypso.
+		parent::add_plugins_menu( false );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -571,6 +571,14 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		$this->assertEquals( $plugins_menu_item, $menu[65] );
 		$this->assertEmpty( $submenu['plugins.php'] );
 		$this->assertArrayNotHasKey( $slug, $submenu );
+
+		// Reset.
+		$menu    = static::$menu_data;
+		$submenu = static::$submenu_data;
+
+		// Check submenu are kept when using WP Admin links.
+		static::$admin_menu->add_plugins_menu( true );
+		$this->assertNotEmpty( $submenu['plugins.php'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -180,4 +180,18 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 		);
 		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
 	}
+
+	/**
+	 * Tests add_plugins_menu
+	 *
+	 * @covers ::add_plugins_menu
+	 */
+	public function test_add_plugins_menu() {
+		global $menu;
+
+		static::$admin_menu->add_plugins_menu( true );
+
+		// Check Plugins menu always links to Calypso.
+		$this->assertContains( 'https://wordpress.com/plugins/' . static::$domain, $menu[65] );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -345,4 +345,18 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		);
 		$this->assertSame( $menu[61], $fse_menu );
 	}
+
+	/**
+	 * Tests add_plugins_menu
+	 *
+	 * @covers ::add_plugins_menu
+	 */
+	public function test_add_plugins_menu() {
+		global $menu;
+
+		static::$admin_menu->add_plugins_menu( true );
+
+		// Check Plugins menu always links to Calypso.
+		$this->assertContains( 'https://wordpress.com/plugins/' . static::$domain, $menu[65] );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/18831

#### Changes proposed in this Pull Request:
- Add back the submenus of the Plugins menu when they link to WP Admin (only Atomic sites).
- Force the Plugins menu to link to Calypso on Simple and Jetpack sites (to mimic the behavior of the existing/old navigation).

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
_Simple_
* Go to https://wordpress.com/me/account and disable the "Replace all dashboard pages with WP Admin equivalents when possible." setting.
* Apply D57572-code to your WP.com sandbox.
* Sandbox the API and a Simple site.
* Go to https://wordpress.com and switch to that site.
* Make sure that the Plugins menu links to Calypso.
* Enable now the "Replace all dashboard pages with WP Admin equivalents when possible." setting.
* Make sure that Plugins still links to Calypso.

_Jetpack_
* Go to https://wordpress.com/me/account and disable the "Replace all dashboard pages with WP Admin equivalents when possible." setting.
* Spin up a Jetpack site running the branch of this PR.
* Go to https://wordpress.com and switch to that site.
* Make sure that the Plugins menu links to Calypso.
* Enable now the "Replace all dashboard pages with WP Admin equivalents when possible." setting.
* Make sure that Plugins still links to Calypso.

_Atomic_
* Go to https://wordpress.com/me/account and disable the "Replace all dashboard pages with WP Admin equivalents when possible." setting.
* Install Jetpack Beta on a WoA site up and activate the branch of this PR.
* Go to https://wordpress.com and switch to that site.
* Make sure that the Plugins menu contains 3 submenus: Installed Plugins, Add New, and Plugin Editor.
* Make sure they all link to WP Admin.
* Enable now the "Replace all dashboard pages with WP Admin equivalents when possible." setting
* Make sure that the Plugins submenus still point to WP Admin.

#### Proposed changelog entry for your changes:
N/A.
