### PR TITLE
rest-api: update the new/update post endpoints to always return media errors as an array

### DIFF
--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -850,8 +850,14 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			$return['sticky'] = ( true === $sticky );
 		}
 
-		if ( ! empty( $media_results['errors'] ) )
-			$return['media_errors'] = $media_results['errors'];
+		if ( ! empty( $media_results['errors'] ) ) {
+			// Depending on whether the errors array keys are sequential or not
+			// json_encode would transform this into either an array or an object
+			// see https://www.php.net/manual/en/function.json-encode.php#example-3967
+
+			// We use array_values to always return an array
+			$return['media_errors'] = array_values( $media_results['errors'] );
+		}
 
 		if ( 'publish' !== $return['status'] && isset( $input['title'] )) {
 			$sal_site = $this->get_sal_post_by( 'ID', $post_id, $args['context'] );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -851,11 +851,12 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		}
 
 		if ( ! empty( $media_results['errors'] ) ) {
-			// Depending on whether the errors array keys are sequential or not
-			// json_encode would transform this into either an array or an object
-			// see https://www.php.net/manual/en/function.json-encode.php#example-3967
-
-			// We use array_values to always return an array
+			/*
+			 * Depending on whether the errors array keys are sequential or not
+			 * json_encode would transform this into either an array or an object
+			 * see https://www.php.net/manual/en/function.json-encode.php#example-3967
+			 * We use array_values to always return an array
+			 */
 			$return['media_errors'] = array_values( $media_results['errors'] );
 		}
 


### PR DESCRIPTION
WordPress.com merge.
- r221604-wpcom
- D57570-code

#### Changes proposed in this Pull Request:

The `media_errors` value in this endpoint response is inconcistent
It can sometimes be an array, and sometimes an object.

This happens because we set the errors array key to the uploaded media id.

And php’s `json_encode` just does this:
```
$> return json_encode( [ 0 => 'Element Zero', 1 => 'Element One' ], JSON_PRETTY_PRINT )
'[
    "Element Zero",
    "Element One"
]'
$> return json_encode( [ 0 => 'Element Zero', 2 => 'Element Two' ], JSON_PRETTY_PRINT )
'{
    "0": "Element Zero",
    "2": "Element Two"
}'
```

This is documented behavior - see https://www.php.net/manual/en/function.json-encode.php#example-3967

With this change, we will always return an array.

Note that the [endpoint documentation](P2gHKz-g-p2.2/post/sites/%24site/posts/new/) does not define the expected return format, and since returning an object seems less likely, we're treating it as an edge case which we're fixing.

See discussion in p1614149916022500-slack-C01A60HCGUA

#### Testing instructions:

Test manually using postman or the dev console.
An example request body could be 
```
{
    "title": "2 errors ",
    "content": "testing post. 2 media_urls would return an error ",
    "status": "draft",
    "media_urls": [
        "1.gif",
        "2.gif"
    ]
}
```

#### Does this pull request change what data or activity we track or use?
No

#### Proposed changelog entry for your changes:
No changelog is needed.
