### PR TITLE
Admin Menu: Use first submenu URL as parent menu URL

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -231,11 +231,13 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			);
 		}
 
-		$url = $menu_item[2];
+		$url         = $menu_item[2];
+		$parent_slug = '';
 
 		// If there are submenus, the parent menu should always link to the first submenu.
 		// @see https://core.trac.wordpress.org/browser/trunk/src/wp-admin/menu-header.php?rev=49193#L152.
 		if ( ! empty( $submenu[ $menu_item[2] ] ) ) {
+			$parent_slug        = $url;
 			$first_submenu_item = reset( $submenu[ $menu_item[2] ] );
 			$url                = $first_submenu_item[2];
 		}
@@ -245,7 +247,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			'slug'  => sanitize_title_with_dashes( $menu_item[2] ),
 			'title' => $menu_item[0],
 			'type'  => 'menu-item',
-			'url'   => $this->prepare_menu_item_url( $url ),
+			'url'   => $this->prepare_menu_item_url( $url, $parent_slug ),
 		);
 
 		$parsed_item = $this->parse_markup_data( $item['title'] );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -212,6 +212,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return array Prepared menu item.
 	 */
 	private function prepare_menu_item( array $menu_item ) {
+		global $submenu;
+
 		// Exclude unauthorized menu items.
 		if ( ! current_user_can( $menu_item[1] ) ) {
 			return array();
@@ -229,12 +231,21 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			);
 		}
 
+		$url = $menu_item[2];
+
+		// If there are submenus, the parent menu should always link to the first submenu.
+		// @see https://core.trac.wordpress.org/browser/trunk/src/wp-admin/menu-header.php?rev=49193#L152.
+		if ( ! empty( $submenu[ $menu_item[2] ] ) ) {
+			$first_submenu_item = reset( $submenu[ $menu_item[2] ] );
+			$url                = $first_submenu_item[2];
+		}
+
 		$item = array(
 			'icon'  => $this->prepare_menu_item_icon( $menu_item[6] ),
 			'slug'  => sanitize_title_with_dashes( $menu_item[2] ),
 			'title' => $menu_item[0],
 			'type'  => 'menu-item',
-			'url'   => $this->prepare_menu_item_url( $menu_item[2] ),
+			'url'   => $this->prepare_menu_item_url( $url ),
 		);
 
 		$parsed_item = $this->parse_markup_data( $item['title'] );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/50059

#### Changes proposed in this Pull Request:
This PR updates the `admin-menu` endpoint in order to mimic the behavior done by Core in which it always uses the URL of the first submenu in the parent menu, so they both link to the same page: https://core.trac.wordpress.org/browser/trunk/src/wp-admin/menu-header.php?rev=49193#L152

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Spin up a Jetpack site running the `master` branch.
* Add the code below to a mu-plugin.
```
add_action( 'admin_menu', function () {
	add_menu_page( 'My Plugin', 'My Plugin', 'read', 'index.php?page=my-plugin', '', '', 0 );
	add_submenu_page( 'index.php?page=my-plugin', '1st submenu', '1st submenu', 'read', 'index.php?page=my-plugin-1', null, 0 );
}, 100000 );
```
* In the WP.com API console, make a `GET` request to the `wpcom/v2/sites/:site/admin-menu` endpoint.
* Note how the URL of the first menu differs from the URL of its first submenu: <img width="697" alt="Screen Shot 2021-02-26 at 10 45 53" src="https://user-images.githubusercontent.com/1233880/109284452-292c7c80-7820-11eb-8632-5e5a3d960ec4.png">

* Switch to this branch and repeat the request.
* Make sure the URLs match now: <img width="760" alt="Screen Shot 2021-02-26 at 10 48 48" src="https://user-images.githubusercontent.com/1233880/109284608-56792a80-7820-11eb-99de-181703507c94.png">


#### Proposed changelog entry for your changes:
N/A.