### PR TITLE
Parses count and removes the counter markup from title of admin_menu api response.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -356,9 +356,9 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	}
 
 	/**
-	 * Parses the update count from a given menu item title and removes the associated markup.
+	 * Parses the a counter from a given menu item title and removes the associated markup.
 	 *
-	 * "Plugin" and "Updates" menu items have a count badge when there are updates available.
+	 * "Plugins", "Comments", "Updates" menu items have a count badge when there are updates available.
 	 * This method parses that information and adds it to the response.
 	 *
 	 * @param array $item containing title to parse.
@@ -368,28 +368,13 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		$title = $item['title'];
 
 		if ( false !== strpos( $title, 'count-' ) ) {
-			preg_match( '/class="(.+\s)?count-(\d*)/', $title, $matches );
+			preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches );
 
-			$count = absint( $matches[2] );
+			$count = absint( $matches[1] );
 			if ( $count > 0 ) {
 				$item['count'] = $count;
 			}
-		}
-
-		return $item;
-	}
-
-	/**
-	 * Removes unexpected markup from the title.
-	 *
-	 * @param array $item containing title to parse.
-	 * @return array
-	 */
-	private function sanitize_title( $item ) {
-		$title = $item['title'];
-
-		if ( wp_strip_all_tags( $title ) !== trim( $title ) ) {
-			$item['title'] = trim( substr( $title, 0, strpos( $title, '<' ) ) );
+			$item['title'] = trim( str_replace( $matches[0], '', $title ) );
 		}
 
 		return $item;
@@ -408,7 +393,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 
 		$item = $this->parse_count_data( $item );
 		// It's important we sanitize the title after parsing data to remove the markup.
-		$item = $this->sanitize_title( $item );
+		$item['title'] = ucfirst( wp_strip_all_tags( $item['title'] ) );
 
 		return $item;
 	}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -372,8 +372,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 
 			$count = absint( $matches[1] );
 			if ( $count > 0 ) {
+				// Keep the counter in the item array.
 				$item['count'] = $count;
 			}
+
+			// Finally remove the markup.
 			$item['title'] = trim( str_replace( $matches[0], '', $title ) );
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -356,7 +356,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	}
 
 	/**
-	 * Parses the a counter from a given menu item title and removes the associated markup.
+	 * Parses the counter from a given menu item title and removes the associated markup.
 	 *
 	 * "Plugins", "Comments", "Updates" menu items have a count badge when there are updates available.
 	 * This method parses that information and adds it to the response.
@@ -395,7 +395,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		);
 
 		$item = $this->parse_count_data( $item );
-		// It's important we sanitize the title after parsing data to remove the markup.
+		// It's important we sanitize the title after parsing data to remove any unexpected markup but keep the content.
 		$item['title'] = ucfirst( wp_strip_all_tags( $item['title'] ) );
 
 		return $item;

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -448,12 +448,12 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	 *
 	 * @throws \ReflectionException Noop.
 	 * @dataProvider menu_item_update_data
-	 * @covers ::parse_markup_data
+	 * @covers ::parse_menu_item
 	 */
-	public function test_parse_markup_data( $menu_item, $expected ) {
+	public function test_parse_menu_item( $menu_item, $expected ) {
 		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
 
-		$prepare_menu_item_url = $class->getMethod( 'parse_markup_data' );
+		$prepare_menu_item_url = $class->getMethod( 'parse_menu_item' );
 		$prepare_menu_item_url->setAccessible( true );
 
 		$this->assertSame(
@@ -490,43 +490,43 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 			array(
 				'Finally some updates <span class="update-plugins count-5"><span class="update-count">5</span></span>',
 				array(
-					'title' => 'Finally some updates',
 					'count' => 5,
+					'title' => 'Finally some updates',
 				),
 			),
 			array(
 				'<span class="update-plugins count-5"><span class="update-count">5</span></span> finally some updates',
 				array(
-					'title' => 'Finally some updates',
 					'count' => 5,
+					'title' => 'Finally some updates',
 				),
 			),
 			array(
 				'Plugin updates <span class="update-plugins count-5"><span class="plugin-count">5</span></span>',
 				array(
-					'title' => 'Plugin updates',
 					'count' => 5,
+					'title' => 'Plugin updates',
 				),
 			),
 			array(
 				'<span class="update-plugins count-5"><span class="plugin-count">5</span></span> plugin updates',
 				array(
-					'title' => 'Plugin updates',
 					'count' => 5,
+					'title' => 'Plugin updates',
 				),
 			),
 			array(
 				'Comments <span class="awaiting-mod count-2"><span class="pending-count" aria-hidden="true">2</span><span class="comments-in-moderation-text screen-reader-text">Comments in moderation</span></span>',
 				array(
-					'title' => 'Comments',
 					'count' => 2,
+					'title' => 'Comments',
 				),
 			),
 			array(
 				'<span class="awaiting-mod count-2"><span class="pending-count" aria-hidden="true">2</span><span class="comments-in-moderation-text screen-reader-text"> comments in moderation</span></span> Comments',
 				array(
-					'title' => 'Comments',
 					'count' => 2,
+					'title' => 'Comments',
 				),
 			),
 			array(

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -482,7 +482,20 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				),
 			),
 			array(
+				'<span class="update-plugins count-0"><span class="update-count">0</span></span> Zero updates',
+				array(
+					'title' => 'Zero updates',
+				),
+			),
+			array(
 				'Finally some updates <span class="update-plugins count-5"><span class="update-count">5</span></span>',
+				array(
+					'title' => 'Finally some updates',
+					'count' => 5,
+				),
+			),
+			array(
+				'<span class="update-plugins count-5"><span class="update-count">5</span></span> finally some updates',
 				array(
 					'title' => 'Finally some updates',
 					'count' => 5,
@@ -496,9 +509,30 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				),
 			),
 			array(
-				'Unexpected markup <span class="unexpected-classname">badge name</span>',
+				'<span class="update-plugins count-5"><span class="plugin-count">5</span></span> plugin updates',
 				array(
-					'title' => 'Unexpected markup',
+					'title' => 'Plugin updates',
+					'count' => 5,
+				),
+			),
+			array(
+				'Comments <span class="awaiting-mod count-2"><span class="pending-count" aria-hidden="true">2</span><span class="comments-in-moderation-text screen-reader-text">Comments in moderation</span></span>',
+				array(
+					'title' => 'Comments',
+					'count' => 2,
+				),
+			),
+			array(
+				'<span class="awaiting-mod count-2"><span class="pending-count" aria-hidden="true">2</span><span class="comments-in-moderation-text screen-reader-text"> comments in moderation</span></span> Comments',
+				array(
+					'title' => 'Comments',
+					'count' => 2,
+				),
+			),
+			array(
+				'<span class="unexpected-classname">badge name</span> Unexpected <font style="vertical-align: inherit;"><font style="vertical-align: inherit;">markup</font></font><span class="awaiting-mod"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;"></font></font></span> <span class="unexpected-classname">badge name</span>',
+				array(
+					'title' => 'Badge name Unexpected markup badge name',
 				),
 			),
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/50373

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes markup of counter while keeping the counter
* Removes unexpected markup while keeping the markup

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Counter cases:
- `<span class="update-plugins count-[NUMBER]"><span class="update-count">[NUMBER]</span></span>` for Updates
- `<span class="update-plugins count-[NUMBER]"><span class="plugin-count">[NUMBER]</span></span>` for Plugins
- `<span class="awaiting-mod count-[NUMBER]"><span class="pending-count" aria-hidden="true">[NUMBER]</span><span class="comments-in-moderation-text screen-reader-text">[NUMBER] Comments in moderation</span></span>` for Comments

Markup cases:
- `<font style="vertical-align: inherit;"><font style="vertical-align: inherit;">Site editor </font></font><span class="awaiting-mod"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">beta</font></font></span>`

* I have updated the tests so please run `yarn docker:phpunit --filter WPCOM_REST_API_V2_Endpoint_Admin_Menu`

To check manually
* add the following to an mu-plugin
```
add_action( 'admin_menu', function () {
	$count = '<span class="update-plugins count-2"><span class="plugin-count">2</span></span>';
	add_menu_page( 'My Plugin', sprintf( __( 'My Plugin', 'jetpack' ) . ' %s', $count ), 'read', 'my-plugin-1', '', '', 0 );

	$count = '<span class="update-plugins count-2"><span class="update-count">2</span></span>';
	add_submenu_page( 'my-plugin-1', 'Hidden', sprintf( __( 'Updates', 'jetpack' ) . ' %s', $count ), 'read', 'my-updates' );

	$count = '<span class="awaiting-mod count-2"><span class="pending-count" aria-hidden="true">2</span><span class="comments-in-moderation-text screen-reader-text">2 Comments in moderation</span></span>';
	add_submenu_page( 'my-plugin-1', 'Hidden', sprintf( __( 'Comments', 'jetpack' ) . ' %s', $count ), 'read', 'my-comments' );

	$markup = '<font style="vertical-align: inherit;"><font style="vertical-align: inherit;">Site editor </font></font><span class="awaiting-mod"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">beta</font></font></span>';
	add_submenu_page( 'my-plugin-1', 'Hidden', $markup, 'read', 'my-site-editor' );

	// With markup in the beginning
	$count = '<span class="update-plugins count-2"><span class="plugin-count">2</span></span>';
	add_submenu_page( 'my-plugin-1', 'My Plugin', sprintf( '%s ' . __( 'My Plugin', 'jetpack' ), $count ), 'read', 'my-plugin-1' );

	$count = '<span class="update-plugins count-2"><span class="update-count">2</span></span>';
	add_submenu_page( 'my-plugin-1', 'Hidden', sprintf(  '%s ' . __( 'Updates', 'jetpack' ), $count ), 'read', 'my-updates' );

	$count = '<span class="awaiting-mod count-2"><span class="pending-count" aria-hidden="true">2</span><span class="comments-in-moderation-text screen-reader-text">2 Comments in moderation</span></span>';
	add_submenu_page( 'my-plugin-1', 'Hidden', sprintf( '%s ' . __( 'Comments', 'jetpack' ) , $count ), 'read', 'my-comments' );
} );
```
* load the site in Calypso

Before | After
-------|------
![](https://cln.sh/V5DJU0+)| ![](https://cln.sh/mhyDz9+)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fixes unexpected markup in menu titles.
