### PR TITLE
Form: ensure that the form settings look good in WP 5.7+

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -281,6 +281,7 @@ input.components-text-control__input {
 // Make sure form settings dropdown looks good on older Gutenberg versions
 .jetpack-contact-form__popover .components-popover__content {
 	padding: 12px;
+	min-width: 260px;
 }
 
 .jetpack-contact-form__crm_text {


### PR DESCRIPTION
Fixes #18930

#### Changes proposed in this Pull Request:

This PR adds a minimum width to the form block settings so each field can be easily edited.


<table>
<tr>
	<td>Before</td>
	<td>After</td>
</tr>
<tr>
	<td><img src="https://user-images.githubusercontent.com/426388/109128030-5a894780-774f-11eb-9fc1-f692f7173745.png" /></td>
	<td><img src="https://user-images.githubusercontent.com/426388/109128079-6a089080-774f-11eb-9bd6-3a0ff506d27f.png" /></td>
</tr>
</table>

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

This is worth testing in different environments:
- On a site running WP 5.6
- On a site running WP 5.7
- On a site running WP 5.7 + the Gutenberg plugin

* On all sites, enable the contact form module (that's done for you when you connect a site to WordPress.com) and add a form block to a post. 
* After adding the form, select the main form block (not one of the children blocks) and click on the Edit button.

#### Proposed changelog entry for your changes:

Contact Form Block: ensure that the form settings are displayed properly on WordPress 5.7.
