### PR TITLE
Admin Menu: Add Theme Editor submenu on Atomic sites

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -232,6 +232,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// Customize on Atomic sites is always done on WP Admin.
 		parent::add_appearance_menu( $wp_admin_themes, true );
+
+		// Add back the Theme Editor submenu.
+		$parent_slug = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
+		add_submenu_page( $parent_slug, __( 'Theme Editor', 'jetpack' ), __( 'Theme Editor', 'jetpack' ), 'edit_themes', 'theme-editor.php' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -397,6 +397,15 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 			'Customize',
 		);
 		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
+
+		// Check Theme Editor is present.
+		$theme_editor_submenu_item = array(
+			'Theme Editor',
+			'edit_themes',
+			'theme-editor.php',
+			'Theme Editor',
+		);
+		$this->assertContains( $theme_editor_submenu_item, $submenu[ $slug ] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -405,7 +405,14 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 			'theme-editor.php',
 			'Theme Editor',
 		);
-		$this->assertContains( $theme_editor_submenu_item, $submenu[ $slug ] );
+		// Multisite users don't have the `edit_themes` capability by default,
+		// so we have to make a dynamic check based on whether the current user can
+		// install themes.
+		if ( current_user_can( 'install_themes' ) ) {
+			$this->assertContains( $theme_editor_submenu_item, $submenu[ $slug ] );
+		} else {
+			$this->assertNotContains( $theme_editor_submenu_item, $submenu[ $slug ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Adds back the Theme Editor submenu to the new unified menu on Atomic sites, so users don't lose access to this feature (which was already available in the existing navigation).

#### Jetpack product discussion
No.

#### Does this pull request change what data or activity we track or use?
N/A.

#### Testing instructions:
* Install Jetpack Beta on a WoA site and activate the branch of this PR.
* Make sure there is a "Theme Editor" submenu under "Appearance" that links to `/wp-admin/theme-editor.php`.

#### Proposed changelog entry for your changes:
N/A.
