### PR TITLE
Premium Content: update require for logged out view button

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
@@ -62,7 +62,7 @@ function render_loggedout_view_block( $attributes, $content, $block = null ) {
 
 	// Old versions of the block were rendering the subscribe/login button server-side, so we need to still support them.
 	if ( ! empty( $attributes['buttonClasses'] ) ) {
-		require_once __DIR__ . '/_inc/legacy-buttons.php';
+		require_once __DIR__ . '/../_inc/legacy-buttons.php';
 
 		$buttons = create_legacy_buttons_markup( $attributes, $content, $block );
 		return $content . $buttons;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
@@ -62,7 +62,7 @@ function render_loggedout_view_block( $attributes, $content, $block = null ) {
 
 	// Old versions of the block were rendering the subscribe/login button server-side, so we need to still support them.
 	if ( ! empty( $attributes['buttonClasses'] ) ) {
-		require_once '../_inc/legacy-buttons.php';
+		require_once dirname( __DIR__ ) . '/_inc/legacy-buttons.php';
 
 		$buttons = create_legacy_buttons_markup( $attributes, $content, $block );
 		return $content . $buttons;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
@@ -62,7 +62,7 @@ function render_loggedout_view_block( $attributes, $content, $block = null ) {
 
 	// Old versions of the block were rendering the subscribe/login button server-side, so we need to still support them.
 	if ( ! empty( $attributes['buttonClasses'] ) ) {
-		require_once dirname( __DIR__ ) . '/_inc/legacy-buttons.php';
+		require_once __DIR__ . '/_inc/legacy-buttons.php';
 
 		$buttons = create_legacy_buttons_markup( $attributes, $content, $block );
 		return $content . $buttons;


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
Relative path includes are not allowed on wpcom.

#### Jetpack product discussion
* N/A
#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* Start from a site with a Paid plan, and with the Beta blocks enabled.
* Create a new post with a Premium Content block, connected to Stripe, and with a paid plan.
* Add some content for logged out users.
* Publish post
* View the page while logged out, the "Log In" button should be displayed.

#### Proposed changelog entry for your changes:

* N/A
