### PR TITLE
Beautiful Math - Remove title attribute from module generated image

### DIFF
--- a/projects/plugins/jetpack/modules/latex.php
+++ b/projects/plugins/jetpack/modules/latex.php
@@ -110,7 +110,7 @@ function latex_render( $latex, $fg, $bg, $s = 0 ) {
 	$alt = str_replace( '\\', '&#92;', esc_attr( $latex ) );
 
 	return sprintf(
-		'<img src="%1$s" alt="%2$s" title="%2$s" class="latex" />',
+		'<img src="%1$s" alt="%2$s" class="latex" />',
 		esc_url( $url ),
 		$alt
 	);


### PR DESCRIPTION
Removing the title tag from the generated image.  

Fixes #18954

#### Changes proposed in this Pull Request:
* This is a change to remove the title tag from the image this module generates.  

#### Jetpack product discussion
This was first noted here 3777668-zen

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Add sample LaTex code to a page/post.  Look at the HTML of the generated image.  The title attribute should be removed. 

#### Proposed changelog entry for your changes:
Remove title attribute from Beautiful Math generated LaTex image. 

#### Other Info
This is my first pull request so please let me know how better I can test this out!
