### PR TITLE
Faux LiveChat Target existing window if available 

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
@@ -40,6 +40,8 @@ class Inline_Help {
 		add_action( 'admin_footer', array( $this, 'add_fab_icon' ) );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_fab_styles' ) );
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_fab_scripts' ) );
 	}
 
 	/**
@@ -108,5 +110,15 @@ class Inline_Help {
 	 */
 	public function add_fab_styles() {
 		wp_enqueue_style( 'a8c-faux-inline-help', plugins_url( 'inline-help.css', __FILE__ ), array(), JETPACK__VERSION );
+	}
+
+	public function add_fab_scripts() {
+		wp_enqueue_script(
+			'a8c-faux-inline-help',
+			plugins_url( 'inline-help.js', __FILE__ ),
+			array(),
+			JETPACK__VERSION,
+			true
+		);
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
@@ -112,6 +112,11 @@ class Inline_Help {
 		wp_enqueue_style( 'a8c-faux-inline-help', plugins_url( 'inline-help.css', __FILE__ ), array(), JETPACK__VERSION );
 	}
 
+	/**
+	 * Enqueues FAB JS scripts.
+	 *
+	 * @return void
+	 */
 	public function add_fab_scripts() {
 		wp_enqueue_script(
 			'a8c-faux-inline-help',

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help-template.php
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help-template.php
@@ -9,7 +9,7 @@
 ?>
 
 <div class="a8c-faux-inline-help">
-	<a class="a8c-faux-inline-help__button" href="<?php echo esc_url( $args['href'] ); ?>" target="_blank" rel="noopener noreferrer" title="<?php echo esc_attr__( 'Help', 'jetpack' ); ?>">
+	<a data-faux-inline-help class="a8c-faux-inline-help__button" href="<?php echo esc_url( $args['href'] ); ?>" target="WPComInlineHelp" rel="noopener noreferrer" title="<?php echo esc_attr__( 'Help', 'jetpack' ); ?>">
 		<?php echo wp_kses( $args['icon'], $args['svg_allowed'] ); ?>
 	</a>
 </div>

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
@@ -1,15 +1,17 @@
 ( function () {
 	var windowObjectReference = null;
 	function init() {
-		document.querySelector( '[data-faux-inline-help]' ).addEventListener( 'click', function ( e ) {
-			e.preventDefault();
+		var fauxInlineHelpButton = document.querySelector( '[data-faux-inline-help]' );
+		fauxInlineHelpButton &&
+			fauxInlineHelpButton.addEventListener( 'click', function ( e ) {
+				e.preventDefault();
 
-			if ( windowObjectReference === null || windowObjectReference.closed ) {
-				windowObjectReference = window.open( e.target.href, e.target.target );
-			} else {
-				windowObjectReference.focus();
-			}
-		} );
+				if ( windowObjectReference === null || windowObjectReference.closed ) {
+					windowObjectReference = window.open( e.target.href, e.target.target );
+				} else {
+					windowObjectReference.focus();
+				}
+			} );
 	}
 
 	if ( document.readyState === 'loading' ) {

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
@@ -1,7 +1,12 @@
 ( function () {
 	function init() {
 		var fauxInlineHelpButton = document.querySelector( '[data-faux-inline-help]' );
-		fauxInlineHelpButton &&
+		if ( fauxInlineHelpButton ) {
+			fauxInlineHelpButton.addEventListener( 'click', function ( e ) {
+				e.preventDefault();
+				window.open( e.target.href, e.target.target );
+			} );
+		}
 			fauxInlineHelpButton.addEventListener( 'click', function ( e ) {
 				e.preventDefault();
 				window.open( e.target.href, e.target.target );

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
@@ -1,16 +1,10 @@
 ( function () {
-	var windowObjectReference = null;
 	function init() {
 		var fauxInlineHelpButton = document.querySelector( '[data-faux-inline-help]' );
 		fauxInlineHelpButton &&
 			fauxInlineHelpButton.addEventListener( 'click', function ( e ) {
 				e.preventDefault();
-
-				if ( windowObjectReference === null || windowObjectReference.closed ) {
-					windowObjectReference = window.open( e.target.href, e.target.target );
-				} else {
-					windowObjectReference.focus();
-				}
+				window.open( e.target.href, e.target.target );
 			} );
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
@@ -5,7 +5,7 @@
 			if ( e.target.dataset.fauxInlineHelp !== undefined ) {
 				e.preventDefault();
 
-				if ( windowObjectReference == null || windowObjectReference.closed ) {
+				if ( windowObjectReference === null || windowObjectReference.closed ) {
 					windowObjectReference = window.open( e.target.href, e.target.target );
 				} else {
 					windowObjectReference.focus();

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
@@ -1,15 +1,13 @@
 ( function () {
 	var windowObjectReference = null;
 	function init() {
-		document.addEventListener( 'click', function ( e ) {
-			if ( e.target.dataset.fauxInlineHelp !== undefined ) {
-				e.preventDefault();
+		document.querySelector( '[data-faux-inline-help]' ).addEventListener( 'click', function ( e ) {
+			e.preventDefault();
 
-				if ( windowObjectReference === null || windowObjectReference.closed ) {
-					windowObjectReference = window.open( e.target.href, e.target.target );
-				} else {
-					windowObjectReference.focus();
-				}
+			if ( windowObjectReference === null || windowObjectReference.closed ) {
+				windowObjectReference = window.open( e.target.href, e.target.target );
+			} else {
+				windowObjectReference.focus();
 			}
 		} );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/inline-help.js
@@ -1,0 +1,22 @@
+( function () {
+	var windowObjectReference = null;
+	function init() {
+		document.addEventListener( 'click', function ( e ) {
+			if ( e.target.dataset.fauxInlineHelp !== undefined ) {
+				e.preventDefault();
+
+				if ( windowObjectReference == null || windowObjectReference.closed ) {
+					windowObjectReference = window.open( e.target.href, e.target.target );
+				} else {
+					windowObjectReference.focus();
+				}
+			}
+		} );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();


### PR DESCRIPTION
See paYJgx-1nM-p2#comment-1735

This allows the faux inline help to open in an existing window if it's available rather than a new tab each time. This is like how the `Preview` feature works in WordPress.org in that if you have an existing preview window open and you click `Preview` it will try to open in the existing window.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Attempt to open faux live chat link in existing window to avoid multiple duplicate tabs.

#### Jetpack product discussion
paYJgx-1nM-p2#comment-1735

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:

* In local JP env go to WPAdmin.
* Click the `?` icon (bottom right).
* See it open in new tab.
* Switch back to WPAdmin tab.
* Click the `?` icon _again_.
* It should open in the existing tab you create on the first click rather than _another_ duplicate tab.
* Check the Calypso page still tracks the event - `DevTools` -> `Network` -> search for `t.gif` and check request params.

Or to test on Simple simply check out the diff D57816-code and repeat steps above on your _sandboxed_ Simple site.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Opens faux live chat link in the existing tab/window to avoid multiple duplicate tabs.