### PR TITLE
Adds return url param for customizer link.

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -386,7 +386,12 @@ class Admin_Menu {
 		$user_can_customize = current_user_can( 'customize' );
 		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
 		$themes_slug        = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
-		$customize_slug     = $wp_admin_customize ? 'customize.php' : 'https://wordpress.com/customize/' . $this->domain; // phpcs:ignore
+		if ( ! $wp_admin_customize ) {
+			$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
+		} else {
+			// In case this is an api request we will have to add the 'return' querystring via JS.
+			$customize_slug = $this->is_api_request ? 'customize.php' : add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
+		}
 		remove_menu_page( 'themes.php' );
 		remove_submenu_page( 'themes.php', 'themes.php' );
 		remove_submenu_page( 'themes.php', 'theme-editor.php' );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -393,9 +393,10 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		$customize_submenu_item = array(
 			'Customize',
 			'customize',
-			'customize.php',
+			'customize.php?return',
 			'Customize',
 		);
+
 		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
 
 		// Check Theme Editor is present.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Relates to https://github.com/Automattic/wp-calypso/issues/49568

This is the WP Admin version of https://github.com/Automattic/wp-calypso/pull/50586/files

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- For simple sites that haven't selected "Replace all dashboard pages with WP Admin equivalents when possible." we always load customizer in `https://wordpress.com/customize/' . $this->domain`;
- In other cases where customizer will open in WP Admin, if the request is not coming from the API (calypso) we add as a `return` param the current url.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**In your sandbox simple site**
- Apply this patch
- Turn on "Replace all dashboard pages with WP Admin equivalents when possible."
- Go to WP Admin
- Go to Appearance -> Customizer
- Click exit
- You should return to your initial page

**API**
- Go to https://developer.wordpress.com/docs/api/console/
- Make a GET request to **WP REST API** - **wpcom/v2** - `/sites/[YOUR_SITE_ID]/admin-menu/`
- Make sure that customizer link is `[DOMAIN]/wp-admin/customize.php`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Clicking exit in customizer now properly returns to the previous page.
