### PR TITLE
Admin menu: Update "Dashboard" menu instead of removing/adding it

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -128,7 +128,7 @@ class Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_my_home_menu( $wp_admin = false ) {
-		global $menu;
+		global $menu, $submenu;
 
 		$dashboard_menu_item     = null;
 		$dashboard_menu_position = null;
@@ -145,9 +145,12 @@ class Admin_Menu {
 			return;
 		}
 
+		$menu_slug = $wp_admin ? 'index.php' : 'https://wordpress.com/home/' . $this->domain;
+		$cap       = $wp_admin ? 'read' : 'manage_options'; // Calypso's My Home is only available for admins.
+
 		$dashboard_menu_item[0] = __( 'My Home', 'jetpack' );
-		$dashboard_menu_item[1] = $wp_admin ? 'read' : 'manage_options'; // Calypso's My Home is only available for admins.
-		$dashboard_menu_item[2] = $wp_admin ? 'index.php' : 'https://wordpress.com/home/' . $this->domain;
+		$dashboard_menu_item[1] = $cap;
+		$dashboard_menu_item[2] = $menu_slug;
 		$dashboard_menu_item[3] = __( 'My Home', 'jetpack' );
 		$dashboard_menu_item[6] = 'dashicons-admin-home';
 
@@ -156,11 +159,16 @@ class Admin_Menu {
 
 		remove_submenu_page( 'index.php', 'index.php' );
 
+		// Only add submenu when there are other submenu items.
+		if ( ! empty( $submenu['index.php'] ) ) {
+			add_submenu_page( $menu_slug, __( 'My Home', 'jetpack' ), __( 'My Home', 'jetpack' ), $cap, $menu_slug, null, 0 );
+		}
+
 		$this->migrate_submenus( 'index.php', $dashboard_menu_item[2] );
 		add_filter(
 			'parent_file',
-			function ( $parent_file ) use ( $dashboard_menu_item ) {
-				return 'index.php' === $parent_file ? $dashboard_menu_item[2] : $parent_file;
+			function ( $parent_file ) use ( $menu_slug ) {
+				return 'index.php' === $parent_file ? $menu_slug : $parent_file;
 			}
 		);
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -154,6 +154,8 @@ class Admin_Menu {
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$menu[ $dashboard_menu_position ] = $dashboard_menu_item;
 
+		remove_submenu_page( 'index.php', 'index.php' );
+
 		$this->migrate_submenus( 'index.php', $dashboard_menu_item[2] );
 		add_filter(
 			'parent_file',

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -128,26 +128,37 @@ class Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_my_home_menu( $wp_admin = false ) {
-		global $submenu;
+		global $menu;
 
-		$menu_slug = $wp_admin ? 'index.php' : 'https://wordpress.com/home/' . $this->domain;
-		$cap       = $wp_admin ? 'read' : 'manage_options'; // Calypso's My Home is only available for admins.
+		$dashboard_menu_item     = null;
+		$dashboard_menu_position = null;
 
-		remove_menu_page( 'index.php' );
-		remove_submenu_page( 'index.php', 'index.php' );
-
-		add_menu_page( __( 'My Home', 'jetpack' ), __( 'My Home', 'jetpack' ), $cap, $menu_slug, null, 'dashicons-admin-home', 2 );
-
-		// Only add submenu when there are other submenu items.
-		if ( ! empty( $submenu['index.php'] ) ) {
-			add_submenu_page( $menu_slug, __( 'My Home', 'jetpack' ), __( 'My Home', 'jetpack' ), $cap, $menu_slug, null, 1 );
+		foreach ( $menu as $i => $item ) {
+			if ( 'index.php' === $item[2] ) {
+				$dashboard_menu_item     = $item;
+				$dashboard_menu_position = $i;
+				break;
+			}
 		}
 
-		$this->migrate_submenus( 'index.php', $menu_slug );
+		if ( ! $dashboard_menu_item ) {
+			return;
+		}
+
+		$dashboard_menu_item[0] = __( 'My Home', 'jetpack' );
+		$dashboard_menu_item[1] = $wp_admin ? 'read' : 'manage_options'; // Calypso's My Home is only available for admins.
+		$dashboard_menu_item[2] = $wp_admin ? 'index.php' : 'https://wordpress.com/home/' . $this->domain;
+		$dashboard_menu_item[3] = __( 'My Home', 'jetpack' );
+		$dashboard_menu_item[6] = 'dashicons-admin-home';
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$menu[ $dashboard_menu_position ] = $dashboard_menu_item;
+
+		$this->migrate_submenus( 'index.php', $dashboard_menu_item[2] );
 		add_filter(
 			'parent_file',
-			function ( $parent_file ) use ( $menu_slug ) {
-				return 'index.php' === $parent_file ? $menu_slug : $parent_file;
+			function ( $parent_file ) use ( $dashboard_menu_item ) {
+				return 'index.php' === $parent_file ? $dashboard_menu_item[2] : $parent_file;
 			}
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -166,7 +166,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_my_home_menu
 	 */
 	public function test_add_my_home_menu() {
-		global $menu;
+		global $menu, $submenu;
 
 		static::$admin_menu->add_my_home_menu( false );
 
@@ -182,6 +182,27 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			'dashicons-admin-home',
 		);
 		$this->assertSame( $menu[2], $my_home_menu_item );
+
+		// Has My Home submenu item when there are other submenu items.
+		$my_home_submenu_item = array(
+			'My Home',
+			'manage_options',
+			$slug,
+			'My Home',
+		);
+		$this->assertContains( $my_home_submenu_item, $submenu[ $slug ] );
+		// Reset data.
+		$menu    = static::$menu_data;
+		$submenu = static::$submenu_data;
+
+		// Has no ny Home submenu when there are no other submenus.
+		$submenu['index.php'] = array(
+			0 => array( 'Home', 'read', 'index.php' ),
+		);
+
+		static::$admin_menu->add_my_home_menu( false );
+
+		$this->assertArrayNotHasKey( 'https://wordpress.com/home/' . static::$domain, $submenu );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -166,7 +166,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_my_home_menu
 	 */
 	public function test_add_my_home_menu() {
-		global $menu, $submenu;
+		global $menu;
 
 		static::$admin_menu->add_my_home_menu( false );
 
@@ -177,32 +177,11 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			'manage_options',
 			$slug,
 			'My Home',
-			'menu-top toplevel_page_' . $slug,
-			'toplevel_page_' . $slug,
+			'menu-top menu-top-first menu-icon-dashboard',
+			'menu-dashboard',
 			'dashicons-admin-home',
 		);
 		$this->assertSame( $menu[2], $my_home_menu_item );
-
-		// Has My Home submenu item when there are other submenu items.
-		$my_home_submenu_item = array(
-			'My Home',
-			'manage_options',
-			$slug,
-			'My Home',
-		);
-		$this->assertContains( $my_home_submenu_item, $submenu[ $slug ] );
-		// Reset data.
-		$menu    = static::$menu_data;
-		$submenu = static::$submenu_data;
-
-		// Has no ny Home submenu when there are no other submenus.
-		$submenu['index.php'] = array(
-			0 => array( 'Home', 'read', 'index.php' ),
-		);
-
-		static::$admin_menu->add_my_home_menu( false );
-
-		$this->assertArrayNotHasKey( 'https://wordpress.com/home/' . static::$domain, $submenu );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/50498
Fixes https://github.com/Automattic/wp-calypso/issues/50501

#### Changes proposed in this Pull Request:

I'm not sure why, but it seems that unregistering the Dashboard menu and registering it again with the same slug causes some side effects to their submenus like the issue noted in https://github.com/Automattic/wp-calypso/issues/50498.

To work around that, this PR makes sure that the "Dashboard" > "My Home" replacement happens by directly updating the `$menu` global instead of unregistering/registering the menu.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
_Simple_

- Apply D57840-code to your WP.com sandbox.
- Sandbox a Simple site.
- Go to https://wordpress.com/me/account and enable the "Replace all dashboard pages with WP Admin equivalents when possible" setting.
- Go to `<SITE_DOMAIN>/wp-admin/index.php?page=my-blogs&show=hidden`.
- Make sure the page loads correctly.
- Make sure "My Home" does not have submenus.

_Atomic_
- Install Jetpack Beta and activate the branch of this PR.
- Click on the "My Home" parent menu.
- Make sure the WP Admin dashboard shows up.
- If there is an "Updates" submenu, make sure it does appear below the "My Home" submenu.

#### Proposed changelog entry for your changes:
N/A.
