### PR TITLE
Star Ratings: Add unit tests and fixtures to validate block content parsing

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/rating-star/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/edit.js
@@ -16,7 +16,7 @@ import {
 import { PanelBody, RangeControl } from '@wordpress/components';
 import { ENTER } from '@wordpress/keycodes';
 
-const Rating = ( { id, setRating, children } ) => {
+export const Rating = ( { id, setRating, children } ) => {
 	const setNewRating = newRating => () => setRating( newRating );
 	const maybeSetNewRating = newRating => ( { keyCode } ) =>
 		keyCode === ENTER ? setRating( newRating ) : null;

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/edit.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import { Rating } from '../edit';
+
+describe( 'Rating', () => {
+
+	const defaultProps = {
+		id: 1,
+		setRating: jest.fn(),
+		children: [ <p>Things are just fine!</p> ]
+	};
+	test( 'loads and displays children', () => {
+		render( <Rating { ...defaultProps } /> );
+		expect( screen.getByText( 'Things are just fine!' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/edit.js
@@ -6,6 +6,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/extend-expect';
 
 /**
@@ -14,14 +15,35 @@ import '@testing-library/jest-dom/extend-expect';
 import { Rating } from '../edit';
 
 describe( 'Rating', () => {
-
+	const setRatingMock = jest.fn();
 	const defaultProps = {
 		id: 1,
-		setRating: jest.fn(),
-		children: [ <p>Things are just fine!</p> ]
+		setRating: setRatingMock,
+		children: [ <p key="yo">Things are just fine!</p> ]
 	};
+
+	beforeEach( () => {
+		setRatingMock.mockClear();
+	} );
+
 	test( 'loads and displays children', () => {
 		render( <Rating { ...defaultProps } /> );
 		expect( screen.getByText( 'Things are just fine!' ) ).toBeInTheDocument();
+	} );
+
+	test( 'fires click event handler callbacks', () => {
+		render( <Rating { ...defaultProps } /> );
+		userEvent.click( screen.getByRole( 'button' ) );
+		expect( setRatingMock ).toBeCalledTimes(1 );
+		expect( setRatingMock ).toBeCalledWith( defaultProps.id );
+	} );
+
+	test( 'fires keydown event handler callbacks', () => {
+		render( <Rating { ...defaultProps } /> );
+		userEvent.type( screen.getByRole( 'button' ), '{enter}' );
+		// A focused keypress event fires both keydown and click so we expect two executions
+		expect( setRatingMock ).toBeCalledTimes(2 );
+		expect( setRatingMock.mock.calls[0][0] ).toBe( defaultProps.id );
+		expect( setRatingMock.mock.calls[1][0] ).toBe( defaultProps.id );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/fixtures/jetpack__rating-star.html
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/fixtures/jetpack__rating-star.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/rating-star {"rating":3,"maxRating":7,"color":"#39414D","className":"is-style-outlined"} -->
+<figure class="wp-block-jetpack-rating-star is-style-outlined" style="text-align:left"><span style="color:#39414D">★</span><span style="color:#39414D">★</span><span style="color:#39414D">★</span></figure>
+<!-- /wp:jetpack/rating-star -->

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/fixtures/jetpack__rating-star.json
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/fixtures/jetpack__rating-star.json
@@ -1,0 +1,16 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/rating-star",
+        "isValid": true,
+        "attributes": {
+            "rating": 3,
+            "maxRating": 7,
+            "color": "#39414D",
+            "align": "left",
+            "className": "is-style-outlined"
+        },
+        "innerBlocks": [],
+        "originalContent": "<figure class=\"wp-block-jetpack-rating-star is-style-outlined\" style=\"text-align:left\"><span style=\"color:#39414D\">★</span><span style=\"color:#39414D\">★</span><span style=\"color:#39414D\">★</span></figure>"
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/fixtures/jetpack__rating-star.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/fixtures/jetpack__rating-star.parsed.json
@@ -1,0 +1,25 @@
+[
+    {
+        "blockName": "jetpack/rating-star",
+        "attrs": {
+            "rating": 3,
+            "maxRating": 7,
+            "color": "#39414D",
+            "className": "is-style-outlined"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-jetpack-rating-star is-style-outlined\" style=\"text-align:left\"><span style=\"color:#39414D\">★</span><span style=\"color:#39414D\">★</span><span style=\"color:#39414D\">★</span></figure>\n",
+        "innerContent": [
+            "\n<figure class=\"wp-block-jetpack-rating-star is-style-outlined\" style=\"text-align:left\"><span style=\"color:#39414D\">★</span><span style=\"color:#39414D\">★</span><span style=\"color:#39414D\">★</span></figure>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/fixtures/jetpack__rating-star.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/fixtures/jetpack__rating-star.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/rating-star {"rating":3,"maxRating":7,"color":"#39414D","className":"is-style-outlined"} -->
+<figure class="wp-block-jetpack-rating-star is-style-outlined" style="text-align:left"><span style="color:#39414D">★</span><span style="color:#39414D">★</span><span style="color:#39414D">★</span></figure>
+<!-- /wp:jetpack/rating-star -->

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/icon.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/icon.js
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import { StarIcon } from '../icon';
+
+describe( 'StarIcon', () => {
+	const defaultProps = {
+		color: 'orange',
+		className: 'juice',
+	};
+
+	test( 'loads and applies default props to children', () => {
+		const { container } = render( <StarIcon /> );
+		expect( container.firstChild.getAttribute( 'color' ) ).toEqual( 'currentColor' );
+		expect( container.firstChild.firstChild.getAttribute( 'class' ) ).toEqual( '' )
+	} );
+
+	test( 'loads and applies passed props to children', () => {
+		const { container } = render( <StarIcon { ...defaultProps } /> );
+		expect( container.firstChild.getAttribute( 'color' ) ).toEqual( 'orange' );
+		expect( container.firstChild.firstChild ).toHaveClass( 'juice' );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/validate.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-import { settings } from '../';
+import { name, settings } from '../';
 import runBlockFixtureTests from '../../../shared/test/block-fixtures';
 
 // Need to include all the blocks involved in rendering this block.
 // The main block should be the first in the array.
-const blocks = [ { name: 'jetpack/rating-star', settings } ];
+const blocks = [ { name: `jetpack/${ name }`, settings } ];
 
-runBlockFixtureTests( 'jetpack/rating-star', blocks, __dirname );
+runBlockFixtureTests( `jetpack/${ name }`, blocks, __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/validate.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { settings } from '../';
+import runBlockFixtureTests from '../../../shared/test/block-fixtures';
+
+// Need to include all the blocks involved in rendering this block.
+// The main block should be the first in the array.
+const blocks = [ { name: 'jetpack/rating-star', settings } ];
+
+runBlockFixtureTests( 'jetpack/rating-star', blocks, __dirname );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds unit and block fixture parsing tests to the Star Ratings block

#### Jetpack product discussion
p1HpG7-b3G-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

Run this branch and insert a Star Ratings block. It should work as expected.

<img width="454" alt="Screen Shot 2021-03-03 at 10 25 32 am" src="https://user-images.githubusercontent.com/6458278/109728687-cca7d380-7c0a-11eb-8e17-7316ad7c39fa.png">

Tun the tests:

`cd projects/plugins/jetpack && yarn fixtures:test extensions/blocks/rating-star/test`

#### Proposed changelog entry for your changes:

_None_