### PR TITLE
Admin Menu: Remove submenus from hidden menus

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -221,6 +221,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 
 		// Exclude hidden menu items.
 		if ( false !== strpos( $menu_item[4], 'hide-if-js' ) ) {
+			// Exclude submenu items as well.
+			if ( ! empty( $submenu[ $menu_item[2] ] ) ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$submenu[ $menu_item[2] ] = array();
+			}
 			return array();
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/50550
Follows up https://github.com/Automattic/jetpack/pull/18898

#### Changes proposed in this Pull Request:

This PR ensures that submenus are not included as children of hidden menus in the `admin-menu` API endpoint, in order to replicate the behavior in WP Core.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Try to replicate first the issue on a Jetpack site running the `master` branch by adding the code below to a mu-plugin:
```
add_filter( 'jetpack_load_admin_menu_class', '__return_true' );

add_action( 'admin_menu', function () {
	add_menu_page( 'My Plugin', 'My Plugin', 'read', 'my-plugin', '', '', 0 );
	add_submenu_page( 'my-plugin', 'Submenu', 'Submenu', 'read', 'my-submenu' );

	global $menu;
	$menu[0][4] .= ' hide-if-js';
}, 1000000 );
```
- Load WP Admin and note how the menu and submenu are not visible: <img width="971" alt="Screen Shot 2021-03-02 at 11 05 40" src="https://user-images.githubusercontent.com/1233880/109633250-2d220c80-7b48-11eb-98bc-86befc565c9c.png">
- Load Calypso and note how the menu is visible with an empty text and the submenu is fully visible: <img width="454" alt="Screen Shot 2021-03-02 at 11 10 10" src="https://user-images.githubusercontent.com/1233880/109633356-4cb93500-7b48-11eb-9581-89c83b1301be.png">
- Switch to this branch and reload Calypso.
- Make sure neither the menu nor the submenu are visible: <img width="297" alt="Screen Shot 2021-03-02 at 11 14 11" src="https://user-images.githubusercontent.com/1233880/109633495-71151180-7b48-11eb-9895-2dd077d820fd.png">

#### Proposed changelog entry for your changes:
N/A.
