### PR TITLE
Connection UI: remove .github directory from production package

### DIFF
--- a/projects/packages/connection-ui/.gitattributes
+++ b/projects/packages/connection-ui/.gitattributes
@@ -1,5 +1,6 @@
 # Files not needed to be distributed in the package.
 .gitattributes    export-ignore
+.github/          export-ignore
 package.json      export-ignore
 webpack.config.js export-ignore
 gulpfile.babel.js export-ignore


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* We do not need the `.github` directory in the production package of the Connection UI.

#### Jetpack product discussion
N/A
#### Does this pull request change what data or activity we track or use?
No
#### Testing instructions:

* Not much to test here.

#### Proposed changelog entry for your changes:

* N/A
