### PR TITLE
CLI: Add a prefix for the name of a generated project.

### DIFF
--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -328,7 +328,18 @@ function createPackageJson( packageJson, answers ) {
  */
 async function createComposerJson( composerJson, answers ) {
 	composerJson.description = answers.description;
-	composerJson.name = 'automattic/' + answers.name;
+
+	// Add the name.
+	let name;
+	switch ( answers.type ) {
+		case 'github-action':
+			name = 'automattic/action-' + answers.name;
+			break;
+		default:
+			name = 'automattic/jetpack-' + answers.name;
+	}
+	composerJson.name = name;
+
 	if ( answers.monorepo ) {
 		composerJson.repositories = [
 			{
@@ -357,7 +368,7 @@ async function createComposerJson( composerJson, answers ) {
 	try {
 		if ( answers.mirrorrepo ) {
 			// For testing, add a third arg here for the org.
-			await mirrorRepo( composerJson, answers.name );
+			await mirrorRepo( composerJson, name );
 		}
 	} catch ( e ) {
 		// This means we couldn't create the mirror repo or something else failed, GitHub API is down, etc.
@@ -482,7 +493,7 @@ function createPluginHeader( answers ) {
 		'<?php\n' +
 		'/**\n' +
 		' *\n' +
-		` * Plugin Name: ${ answers.name }\n` +
+		` * Plugin Name: Jetpack ${ answers.name }\n` +
 		' * Plugin URI: TBD\n' +
 		` * Description: ${ answers.description }\n` +
 		` * Version: ${ answers.version }\n` +
@@ -491,7 +502,7 @@ function createPluginHeader( answers ) {
 		' * License: GPLv2 or later\n' +
 		' * Text Domain: jetpack\n' +
 		' *\n' +
-		` * @package automattic/${ answers.name }\n` +
+		` * @package automattic/jetpack-${ answers.name }\n` +
 		' */\n' +
 		'\n' +
 		'// Code some good stuff!\n';
@@ -507,7 +518,7 @@ function createPluginHeader( answers ) {
  */
 function createReadMeTxt( answers ) {
 	const content =
-		`=== ${ answers.name } ===\n` +
+		`=== Jetpack ${ answers.name } ===\n` +
 		'Contributors: automattic,\n' +
 		'Tags: jetpack, stuff\n' +
 		'Requires at least: 5.5\n' +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Adds a default prefix (action- or jetpack-) for a project slug.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* See above.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack generate` and start a new project. Confirm that the composer.json in the new project is automattic/{prefix}-{name}.
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* n/a
