### PR TITLE
Search: Polish copy for Result Format ctrl in Customizer

### DIFF
--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -153,12 +153,12 @@ class Jetpack_Search_Customize {
 			$id,
 			array(
 				'label'       => __( 'Result Format', 'jetpack' ),
-				'description' => __( 'Choose how the search results look.', 'jetpack' ),
+				'description' => __( 'Choose how the search results look. The expanded view will feature images associated with the search result.', 'jetpack' ),
 				'section'     => $section_id,
 				'type'        => 'select',
 				'choices'     => array(
 					'minimal'  => __( 'Minimal', 'jetpack' ),
-					'expanded' => __( 'Expanded', 'jetpack' ),
+					'expanded' => __( 'Expanded (shows images)', 'jetpack' ),
 				),
 			)
 		);

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -153,7 +153,7 @@ class Jetpack_Search_Customize {
 			$id,
 			array(
 				'label'       => __( 'Result Format', 'jetpack' ),
-				'description' => __( 'Choose how the search results look. The expanded view will feature images associated with the search result.', 'jetpack' ),
+				'description' => __( 'Choose how the search results look.', 'jetpack' ),
 				'section'     => $section_id,
 				'type'        => 'select',
 				'choices'     => array(


### PR DESCRIPTION
Fixes #18983.

#### Changes proposed in this Pull Request:
* Tweaks copy for the Result Format control inside the Customizer for Jetpack Search.

Before:
![109711397-d4b13600-7b6c-11eb-814a-72566006d44e](https://user-images.githubusercontent.com/4044428/109713769-daa01a80-7b5e-11eb-9a7a-16a5af7b5275.png)

After:
<img width="319" alt="Screen Shot 2021-03-02 at 1 54 05 PM" src="https://user-images.githubusercontent.com/4044428/109713689-c3612d00-7b5e-11eb-9abc-370b758f3ed3.png">


#### Jetpack product discussion
See #18983.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Navigate to your site's Customizer -> Jetpack Search.
* Ensure that you see the updated text copy for the Result Format controls.

#### Proposed changelog entry for your changes:
* None.