### PR TITLE
Fixes conflict with Newspack blocks

### DIFF
--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -452,11 +452,6 @@ function jetpack_og_get_image_gravatar( $email, $width ) {
  * @return string $description Cleaned up description string.
  */
 function jetpack_og_get_description( $description = '', $data = null ) {
-	// Calls the render methods for each block, so hidden content
-	// such as subscriber content in Premium Content blocks are not
-	// included in the meta tags.
-	$description = do_blocks( $description );
-
 	// Remove tags such as <style or <script.
 	$description = wp_strip_all_tags( $description );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR reverts  #18654 which was conflicting with Newspack blocks.
Fixes https://github.com/Automattic/wp-calypso/issues/50672

The issue:

Newspack blocks have a logic to prevent posts from being displayed more than once on the page, even by different blocks.

When we called `do_blocks` it was as if we were rendering a first version of the block. Then, when the actual block was being rendered, it would exclude all the posts that were returned in the first (fake) render.



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Revert #18654

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* p1614716941027400-slack-C02FMH4G8

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the slack thread

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Revert improvements to the `og:description` meta tag since it was conflicting with Newspack blocks