### PR TITLE
Jetpack Search: don't use Photon for Jetpack Sites unless the module is enabled

### DIFF
--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -159,6 +159,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$excluded_post_types = array();
 		}
 
+		$is_wpcom                  = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$is_jetpack_photon_enabled = method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'photon' );
+
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
@@ -177,12 +180,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'siteId'                => $this->jetpack_blog_id,
 			'postTypes'             => $post_type_labels,
 			'webpackPublicPath'     => plugins_url( '_inc/build/instant-search/', JETPACK__PLUGIN_FILE ),
+			'isPhotonEnabled'       => $is_wpcom || $is_jetpack_photon_enabled,
 
 			// config values related to private site support.
 			'apiRoot'               => esc_url_raw( rest_url() ),
 			'apiNonce'              => wp_create_nonce( 'wp_rest' ),
 			'isPrivateSite'         => '-1' === get_option( 'blog_public' ),
-			'isWpcom'               => defined( 'IS_WPCOM' ) && IS_WPCOM,
+			'isWpcom'               => $is_wpcom,
 
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -160,6 +160,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		}
 
 		$is_wpcom                  = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$is_private_site           = '-1' === get_option( 'blog_public' );
 		$is_jetpack_photon_enabled = method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'photon' );
 
 		$options = array(
@@ -180,12 +181,12 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'siteId'                => $this->jetpack_blog_id,
 			'postTypes'             => $post_type_labels,
 			'webpackPublicPath'     => plugins_url( '_inc/build/instant-search/', JETPACK__PLUGIN_FILE ),
-			'isPhotonEnabled'       => $is_wpcom || $is_jetpack_photon_enabled,
+			'isPhotonEnabled'       => ( $is_wpcom || $is_jetpack_photon_enabled ) && ! $is_private_site,
 
 			// config values related to private site support.
 			'apiRoot'               => esc_url_raw( rest_url() ),
 			'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-			'isPrivateSite'         => '-1' === get_option( 'blog_public' ),
+			'isPrivateSite'         => $is_private_site,
 			'isWpcom'               => $is_wpcom,
 
 			// search options.

--- a/projects/plugins/jetpack/modules/search/instant-search/components/photon-image.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/photon-image.jsx
@@ -23,12 +23,12 @@ const PhotonImage = ( {
 	maxWidth = 300,
 	maxHeight = 300,
 	alt,
-	isPrivateSite,
+	isPhotonEnabled,
 	...otherProps
 } ) => {
 	let srcToDisplay = src;
 
-	if ( ! isPrivateSite ) {
+	if ( isPhotonEnabled ) {
 		const photonSrc = photon( stripQueryString( src ), { resize: `${ maxWidth },${ maxHeight }` } );
 		if ( photonSrc !== null ) {
 			srcToDisplay = photonSrc;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -296,6 +296,7 @@ class SearchApp extends Component {
 					hasNextPage={ this.props.hasNextPage }
 					highlightColor={ this.state.overlayOptions.highlightColor }
 					isLoading={ this.props.isLoading }
+					isPhotonEnabled={ this.props.options.isPhotonEnabled }
 					isPrivateSite={ this.props.options.isPrivateSite }
 					isVisible={ this.state.showResults }
 					locale={ this.props.options.locale }

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
@@ -69,7 +69,7 @@ export default function SearchResultExpanded( props ) {
 						<PhotonImage
 							alt=""
 							className="jetpack-instant-search__search-result-expanded__image"
-							isPrivateSite={ this.props.isPrivateSite }
+							isPhotonEnabled={ this.props.isPhotonEnabled }
 							src={ `//${ firstImage }` }
 							useDiv
 						/>

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
@@ -42,7 +42,7 @@ class SearchResultProduct extends Component {
 						<PhotonImage
 							alt=""
 							className="jetpack-instant-search__search-result-product-img"
-							isPrivateSite={ this.props.isPrivateSite }
+							isPhotonEnabled={ this.props.isPhotonEnabled }
 							src={ `//${ firstImage }` }
 						/>
 					) : (

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
@@ -135,7 +135,7 @@ class SearchResults extends Component {
 						{ results.map( ( result, index ) => (
 							<SearchResult
 								index={ index }
-								isPrivateSite={ this.props.isPrivateSite }
+								isPhotonEnabled={ this.props.isPhotonEnabled }
 								locale={ this.props.locale }
 								query={ this.props.query }
 								railcar={ this.props.isVisible ? result.railcar : null }

--- a/projects/plugins/jetpack/modules/search/instant-search/components/test/photon-image.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/test/photon-image.test.js
@@ -15,15 +15,15 @@ import '@testing-library/jest-dom/extend-expect';
  */
 import PhotonImage from '../photon-image';
 
-test( 'returns a Photon URL for a public site', () => {
+test( 'returns a Photon URL for a site with Photon enabled', () => {
 	const { getByRole } = render(
-		<PhotonImage src={ 'http://example.com/okapi.jpg' } isPrivateSite={ false } />
+		<PhotonImage src={ 'http://example.com/okapi.jpg' } isPhotonEnabled={ true } />
 	);
 	expect( getByRole( 'img' ).src ).toMatch( /i[0-9]\.wp\.com/ );
 } );
 
 test( 'returns the original URL for a private site', () => {
 	const imageUrl = 'http://example.com/okapi.jpg';
-	const { getByRole } = render( <PhotonImage src={ imageUrl } isPrivateSite={ true } /> );
+	const { getByRole } = render( <PhotonImage src={ imageUrl } isPhotonEnabled={ false } /> );
 	expect( getByRole( 'img' ).src ).toEqual( imageUrl );
 } );


### PR DESCRIPTION
Fixes #18988.

#### Changes proposed in this Pull Request:
* Adds a check to see if Photon is enabled before using Photon to process images.

#### Does this pull request change what data or activity we track or use?
No. 

#### Testing instructions:
1. Go to Jetpack performance settings (/wp-admin/admin.php?page=jetpack#/performance)
2. Ensure that 'Instant Search' is enabled and 'Speed up image load times' is turned off
3. In the Customizer, ensure the Instant Search result format is set to "Expanded (show images)"
4. On the front end of the site, perform a search that returns pages or posts with images.
5. Ensure that the images are loaded from the site itself, not Photon (URL doesn't start with i[0-3].wp.com)

Repeat the steps with 'Speed up image load times' enabled. The images should then come from i[0-3].wp.com rather than the site itself.

#### Proposed changelog entry for your changes:
* Jetpack Search: only use site accelerator for displaying images if it is enabled on the site.
