### PR TITLE
Contact Info: Add unit tests and fixtures for the contact-info blocks address, email, and phone

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/edit.js
@@ -43,125 +43,127 @@ const defaultProps = {
 	setAttributes,
 };
 
-beforeEach( () => {
-	setAttributes.mockClear();
-} );
+describe( 'Address', () => {
+	beforeEach( () => {
+		setAttributes.mockClear();
+	} );
 
-test( 'renders placeholders if not selected, and no content is entered', () => {
-	const propsNotSelected = { ...defaultProps, isSelected: false };
-	render( <AddressEdit { ...propsNotSelected } /> );
+	test( 'renders placeholders if not selected, and no content is entered', () => {
+		const propsNotSelected = { ...defaultProps, isSelected: false };
+		render( <AddressEdit { ...propsNotSelected } /> );
 
-	expect( screen.getByPlaceholderText( 'Street Address' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'Address Line 2' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'Address Line 3' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'City' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'State/Province/Region' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'Postal/Zip Code' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'Country' ) ).toBeInTheDocument();
-	expect( screen.getByLabelText( 'Link address to Google Maps' ) ).toBeInTheDocument();
-} );
+		expect( screen.getByPlaceholderText( 'Street Address' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'Address Line 2' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'Address Line 3' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'City' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'State/Province/Region' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'Postal/Zip Code' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Link address to Google Maps' ) ).toBeInTheDocument();
+	} );
 
-test( 'renders partial address, and no placeholders, when not selected', () => {
-	const propsNotSelected = {
-		...defaultProps,
-		attributes: { ...defaultAttributes, ...partialAddress },
-		isSelected: false,
-	};
-	render( <AddressEdit { ...propsNotSelected } /> );
+	test( 'renders partial address, and no placeholders, when not selected', () => {
+		const propsNotSelected = {
+			...defaultProps,
+			attributes: { ...defaultAttributes, ...partialAddress },
+			isSelected: false,
+		};
+		render( <AddressEdit { ...propsNotSelected } /> );
 
-	expect( screen.getByText( '987 Photon Drive' ) ).toBeInTheDocument();
-	expect( screen.queryByPlaceholderText( 'Street Address' ) ).not.toBeInTheDocument();
-	expect( screen.queryByPlaceholderText( 'Address Line 2' ) ).not.toBeInTheDocument();
-	expect( screen.queryByPlaceholderText( 'Address Line 3' ) ).not.toBeInTheDocument();
-	expect( screen.queryByPlaceholderText( 'City' ) ).not.toBeInTheDocument();
-	expect( screen.queryByPlaceholderText( 'State/Province/Region' ) ).not.toBeInTheDocument();
-	expect( screen.queryByPlaceholderText( 'Postal/Zip Code' ) ).not.toBeInTheDocument();
-	expect( screen.queryByPlaceholderText( 'Country' ) ).not.toBeInTheDocument();
-	expect( screen.queryByLabelText( 'Link address to Google Maps' ) ).not.toBeInTheDocument();
-} );
+		expect( screen.getByText( '987 Photon Drive' ) ).toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Street Address' ) ).not.toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Address Line 2' ) ).not.toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Address Line 3' ) ).not.toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'City' ) ).not.toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'State/Province/Region' ) ).not.toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Postal/Zip Code' ) ).not.toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Country' ) ).not.toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Link address to Google Maps' ) ).not.toBeInTheDocument();
+	} );
 
-test( 'renders partial address, and all other placeholders, when selected', () => {
-	const propsSelected = {
-		...defaultProps,
-		attributes: { ...defaultAttributes, ...partialAddress },
-		isSelected: true,
-	};
-	render( <AddressEdit { ...propsSelected } /> );
+	test( 'renders partial address, and all other placeholders, when selected', () => {
+		const propsSelected = {
+			...defaultProps,
+			attributes: { ...defaultAttributes, ...partialAddress },
+			isSelected: true,
+		};
+		render( <AddressEdit { ...propsSelected } /> );
 
-	expect( screen.getByPlaceholderText( 'Street Address' ).value ).toEqual( '987 Photon Drive' );
-	expect( screen.getByPlaceholderText( 'Address Line 2' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'Address Line 3' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'City' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'State/Province/Region' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'Postal/Zip Code' ) ).toBeInTheDocument();
-	expect( screen.getByPlaceholderText( 'Country' ) ).toBeInTheDocument();
-	expect( screen.getByLabelText( 'Link address to Google Maps' ) ).toBeInTheDocument();
-} );
+		expect( screen.getByPlaceholderText( 'Street Address' ).value ).toEqual( '987 Photon Drive' );
+		expect( screen.getByPlaceholderText( 'Address Line 2' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'Address Line 3' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'City' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'State/Province/Region' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'Postal/Zip Code' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Link address to Google Maps' ) ).toBeInTheDocument();
+	} );
 
-test( 'updates Google Maps setting when selected', () => {
-	const propsSelected = {
-		...defaultProps,
-		attributes: { ...defaultAttributes, ...completeAddress },
-		isSelected: true,
-	};
-	render( <AddressEdit { ...propsSelected } /> );
-	userEvent.click( screen.getByLabelText( 'Link address to Google Maps' ) );
+	test( 'updates Google Maps setting when selected', () => {
+		const propsSelected = {
+			...defaultProps,
+			attributes: { ...defaultAttributes, ...completeAddress },
+			isSelected: true,
+		};
+		render( <AddressEdit { ...propsSelected } /> );
+		userEvent.click( screen.getByLabelText( 'Link address to Google Maps' ) );
 
-	expect( setAttributes ).toHaveBeenCalledWith( { linkToGoogleMaps: true } );
-} );
+		expect( setAttributes ).toHaveBeenCalledWith( { linkToGoogleMaps: true } );
+	} );
 
-test( 'entering value into the address field updates the address', () => {
-	const propsSelected = { ...defaultProps, isSelected: true };
-	render( <AddressEdit { ...propsSelected } /> );
-	userEvent.paste( screen.getByPlaceholderText( 'Street Address' ), 'ATTN: Test Person' );
+	test( 'entering value into the address field updates the address', () => {
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <AddressEdit { ...propsSelected } /> );
+		userEvent.paste( screen.getByPlaceholderText( 'Street Address' ), 'ATTN: Test Person' );
 
-	expect( setAttributes ).toHaveBeenCalledWith( { address: completeAddress.addressLine1 } );
-} );
+		expect( setAttributes ).toHaveBeenCalledWith( { address: completeAddress.addressLine1 } );
+	} );
 
-test( 'entering value into the addressLine2 field updates the address', () => {
-	const propsSelected = { ...defaultProps, isSelected: true };
-	render( <AddressEdit { ...propsSelected } /> );
-	userEvent.paste( screen.getByPlaceholderText( 'Address Line 2' ), '987 Photon Drive' );
+	test( 'entering value into the addressLine2 field updates the address', () => {
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <AddressEdit { ...propsSelected } /> );
+		userEvent.paste( screen.getByPlaceholderText( 'Address Line 2' ), '987 Photon Drive' );
 
-	expect( setAttributes ).toHaveBeenCalledWith( { addressLine2: completeAddress.addressLine2 } );
-} );
+		expect( setAttributes ).toHaveBeenCalledWith( { addressLine2: completeAddress.addressLine2 } );
+	} );
 
-test( 'entering value into the addressLine3 field updates the address', () => {
-	const propsSelected = { ...defaultProps, isSelected: true };
-	render( <AddressEdit { ...propsSelected } /> );
-	userEvent.paste( screen.getByPlaceholderText( 'Address Line 3' ), 'Apartment 5' );
+	test( 'entering value into the addressLine3 field updates the address', () => {
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <AddressEdit { ...propsSelected } /> );
+		userEvent.paste( screen.getByPlaceholderText( 'Address Line 3' ), 'Apartment 5' );
 
-	expect( setAttributes ).toHaveBeenCalledWith( { addressLine3: completeAddress.addressLine3 } );
-} );
+		expect( setAttributes ).toHaveBeenCalledWith( { addressLine3: completeAddress.addressLine3 } );
+	} );
 
-test( 'entering value into the city field updates the city', () => {
-	const propsSelected = { ...defaultProps, isSelected: true };
-	render( <AddressEdit { ...propsSelected } /> );
-	userEvent.paste( screen.getByPlaceholderText( 'City' ), 'Speedyville' );
+	test( 'entering value into the city field updates the city', () => {
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <AddressEdit { ...propsSelected } /> );
+		userEvent.paste( screen.getByPlaceholderText( 'City' ), 'Speedyville' );
 
-	expect( setAttributes ).toHaveBeenCalledWith( { city: completeAddress.city } );
-} );
+		expect( setAttributes ).toHaveBeenCalledWith( { city: completeAddress.city } );
+	} );
 
-test( 'entering value into the region field updates the region', () => {
-	const propsSelected = { ...defaultProps, isSelected: true };
-	render( <AddressEdit { ...propsSelected } /> );
-	userEvent.paste( screen.getByPlaceholderText( 'State/Province/Region' ), 'CA' );
+	test( 'entering value into the region field updates the region', () => {
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <AddressEdit { ...propsSelected } /> );
+		userEvent.paste( screen.getByPlaceholderText( 'State/Province/Region' ), 'CA' );
 
-	expect( setAttributes ).toHaveBeenCalledWith( { region: completeAddress.region } );
-} );
+		expect( setAttributes ).toHaveBeenCalledWith( { region: completeAddress.region } );
+	} );
 
-test( 'entering value into the postal field updates the postal code', () => {
-	const propsSelected = { ...defaultProps, isSelected: true };
-	render( <AddressEdit { ...propsSelected } /> );
-	userEvent.paste( screen.getByPlaceholderText( 'Postal/Zip Code' ), '12345' );
+	test( 'entering value into the postal field updates the postal code', () => {
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <AddressEdit { ...propsSelected } /> );
+		userEvent.paste( screen.getByPlaceholderText( 'Postal/Zip Code' ), '12345' );
 
-	expect( setAttributes ).toHaveBeenCalledWith( { postal: completeAddress.postal } );
-} );
+		expect( setAttributes ).toHaveBeenCalledWith( { postal: completeAddress.postal } );
+	} );
 
-test( 'entering value into the country field updates the country', () => {
-	const propsSelected = { ...defaultProps, isSelected: true };
-	render( <AddressEdit { ...propsSelected } /> );
-	userEvent.paste( screen.getByPlaceholderText( 'Country' ), 'USA' );
+	test( 'entering value into the country field updates the country', () => {
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <AddressEdit { ...propsSelected } /> );
+		userEvent.paste( screen.getByPlaceholderText( 'Country' ), 'USA' );
 
-	expect( setAttributes ).toHaveBeenCalledWith( { country: completeAddress.country } );
+		expect( setAttributes ).toHaveBeenCalledWith( { country: completeAddress.country } );
+	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/edit.js
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import AddressEdit from '../edit';
+
+const defaultAttributes = {
+	address: '',
+	addressLine2: '',
+	addressLine3: '',
+	city: '',
+	region: '',
+	postal: '',
+	country: '',
+	linkToGoogleMaps: false,
+};
+
+const completeAddress = {
+	addressLine1: 'ATTN: Test Person',
+	addressLine2: '987 Photon Drive',
+	addressLine3: 'Apartment 5',
+	city: 'Speedyville',
+	region: 'CA',
+	postal: '12345',
+	country: 'USA',
+};
+
+const partialAddress = {
+	address: '987 Photon Drive',
+};
+
+const setAttributes = jest.fn();
+
+const defaultProps = {
+	attributes: defaultAttributes,
+	isSelected: false,
+	setAttributes,
+};
+
+beforeEach( () => {
+	setAttributes.mockClear();
+} );
+
+test( 'renders placeholders if not selected, and no content is entered', () => {
+	const propsNotSelected = { ...defaultProps, isSelected: false };
+	render( <AddressEdit { ...propsNotSelected } /> );
+
+	expect( screen.getByPlaceholderText( 'Street Address' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'Address Line 2' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'Address Line 3' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'City' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'State/Province/Region' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'Postal/Zip Code' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'Country' ) ).toBeInTheDocument();
+	expect( screen.getByLabelText( 'Link address to Google Maps' ) ).toBeInTheDocument();
+} );
+
+test( 'renders partial address, and no placeholders, when not selected', () => {
+	const propsNotSelected = {
+		...defaultProps,
+		attributes: { ...defaultAttributes, ...partialAddress },
+		isSelected: false,
+	};
+	render( <AddressEdit { ...propsNotSelected } /> );
+
+	expect( screen.getByText( '987 Photon Drive' ) ).toBeInTheDocument();
+	expect( screen.queryByPlaceholderText( 'Street Address' ) ).not.toBeInTheDocument();
+	expect( screen.queryByPlaceholderText( 'Address Line 2' ) ).not.toBeInTheDocument();
+	expect( screen.queryByPlaceholderText( 'Address Line 3' ) ).not.toBeInTheDocument();
+	expect( screen.queryByPlaceholderText( 'City' ) ).not.toBeInTheDocument();
+	expect( screen.queryByPlaceholderText( 'State/Province/Region' ) ).not.toBeInTheDocument();
+	expect( screen.queryByPlaceholderText( 'Postal/Zip Code' ) ).not.toBeInTheDocument();
+	expect( screen.queryByPlaceholderText( 'Country' ) ).not.toBeInTheDocument();
+	expect( screen.queryByLabelText( 'Link address to Google Maps' ) ).not.toBeInTheDocument();
+} );
+
+test( 'renders partial address, and all other placeholders, when selected', () => {
+	const propsSelected = {
+		...defaultProps,
+		attributes: { ...defaultAttributes, ...partialAddress },
+		isSelected: true,
+	};
+	render( <AddressEdit { ...propsSelected } /> );
+
+	expect( screen.getByPlaceholderText( 'Street Address' ).value ).toEqual( '987 Photon Drive' );
+	expect( screen.getByPlaceholderText( 'Address Line 2' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'Address Line 3' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'City' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'State/Province/Region' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'Postal/Zip Code' ) ).toBeInTheDocument();
+	expect( screen.getByPlaceholderText( 'Country' ) ).toBeInTheDocument();
+	expect( screen.getByLabelText( 'Link address to Google Maps' ) ).toBeInTheDocument();
+} );
+
+test( 'updates Google Maps setting when selected', () => {
+	const propsSelected = {
+		...defaultProps,
+		attributes: { ...defaultAttributes, ...completeAddress },
+		isSelected: true,
+	};
+	render( <AddressEdit { ...propsSelected } /> );
+	userEvent.click( screen.getByLabelText( 'Link address to Google Maps' ) );
+
+	expect( setAttributes ).toHaveBeenCalledWith( { linkToGoogleMaps: true } );
+} );
+
+test( 'entering value into the address field updates the address', () => {
+	const propsSelected = { ...defaultProps, isSelected: true };
+	render( <AddressEdit { ...propsSelected } /> );
+	userEvent.paste( screen.getByPlaceholderText( 'Street Address' ), 'ATTN: Test Person' );
+
+	expect( setAttributes ).toHaveBeenCalledWith( { address: completeAddress.addressLine1 } );
+} );
+
+test( 'entering value into the addressLine2 field updates the address', () => {
+	const propsSelected = { ...defaultProps, isSelected: true };
+	render( <AddressEdit { ...propsSelected } /> );
+	userEvent.paste( screen.getByPlaceholderText( 'Address Line 2' ), '987 Photon Drive' );
+
+	expect( setAttributes ).toHaveBeenCalledWith( { addressLine2: completeAddress.addressLine2 } );
+} );
+
+test( 'entering value into the addressLine3 field updates the address', () => {
+	const propsSelected = { ...defaultProps, isSelected: true };
+	render( <AddressEdit { ...propsSelected } /> );
+	userEvent.paste( screen.getByPlaceholderText( 'Address Line 3' ), 'Apartment 5' );
+
+	expect( setAttributes ).toHaveBeenCalledWith( { addressLine3: completeAddress.addressLine3 } );
+} );
+
+test( 'entering value into the city field updates the city', () => {
+	const propsSelected = { ...defaultProps, isSelected: true };
+	render( <AddressEdit { ...propsSelected } /> );
+	userEvent.paste( screen.getByPlaceholderText( 'City' ), 'Speedyville' );
+
+	expect( setAttributes ).toHaveBeenCalledWith( { city: completeAddress.city } );
+} );
+
+test( 'entering value into the region field updates the region', () => {
+	const propsSelected = { ...defaultProps, isSelected: true };
+	render( <AddressEdit { ...propsSelected } /> );
+	userEvent.paste( screen.getByPlaceholderText( 'State/Province/Region' ), 'CA' );
+
+	expect( setAttributes ).toHaveBeenCalledWith( { region: completeAddress.region } );
+} );
+
+test( 'entering value into the postal field updates the postal code', () => {
+	const propsSelected = { ...defaultProps, isSelected: true };
+	render( <AddressEdit { ...propsSelected } /> );
+	userEvent.paste( screen.getByPlaceholderText( 'Postal/Zip Code' ), '12345' );
+
+	expect( setAttributes ).toHaveBeenCalledWith( { postal: completeAddress.postal } );
+} );
+
+test( 'entering value into the country field updates the country', () => {
+	const propsSelected = { ...defaultProps, isSelected: true };
+	render( <AddressEdit { ...propsSelected } /> );
+	userEvent.paste( screen.getByPlaceholderText( 'Country' ), 'USA' );
+
+	expect( setAttributes ).toHaveBeenCalledWith( { country: completeAddress.country } );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address.html
@@ -1,0 +1,5 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/address {"address":"987  Photon Drive","addressLine2":"Apartment 5","city":"Speedyville","region":"CA","postal":"12345","country":"USA"} -->
+	<div class="wp-block-jetpack-address"><div class="jetpack-address__address jetpack-address__address1">987  Photon Drive</div><div class="jetpack-address__address jetpack-address__address2">Apartment 5</div><div><span class="jetpack-address__city">Speedyville</span>, <span class="jetpack-address__region">CA</span> <span class="jetpack-address__postal">12345</span></div><div class="jetpack-address__country">USA</div></div>
+	<!-- /wp:jetpack/address --></div>
+	<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address.json
@@ -1,0 +1,28 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/contact-info",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "jetpack/address",
+                "isValid": true,
+                "attributes": {
+                    "address": "987  Photon Drive",
+                    "addressLine2": "Apartment 5",
+                    "addressLine3": "",
+                    "city": "Speedyville",
+                    "region": "CA",
+                    "postal": "12345",
+                    "country": "USA",
+                    "linkToGoogleMaps": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<div class=\"wp-block-jetpack-address\"><div class=\"jetpack-address__address jetpack-address__address1\">987  Photon Drive</div><div class=\"jetpack-address__address jetpack-address__address2\">Apartment 5</div><div><span class=\"jetpack-address__city\">Speedyville</span>, <span class=\"jetpack-address__region\">CA</span> <span class=\"jetpack-address__postal\">12345</span></div><div class=\"jetpack-address__country\">USA</div></div>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-jetpack-contact-info\"></div>"
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address.parsed.json
@@ -1,0 +1,39 @@
+[
+    {
+        "blockName": "jetpack/contact-info",
+        "attrs": {},
+        "innerBlocks": [
+            {
+                "blockName": "jetpack/address",
+                "attrs": {
+                    "address": "987  Photon Drive",
+                    "addressLine2": "Apartment 5",
+                    "city": "Speedyville",
+                    "region": "CA",
+                    "postal": "12345",
+                    "country": "USA"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t<div class=\"wp-block-jetpack-address\"><div class=\"jetpack-address__address jetpack-address__address1\">987  Photon Drive</div><div class=\"jetpack-address__address jetpack-address__address2\">Apartment 5</div><div><span class=\"jetpack-address__city\">Speedyville</span>, <span class=\"jetpack-address__region\">CA</span> <span class=\"jetpack-address__postal\">12345</span></div><div class=\"jetpack-address__country\">USA</div></div>\n\t",
+                "innerContent": [
+                    "\n\t<div class=\"wp-block-jetpack-address\"><div class=\"jetpack-address__address jetpack-address__address1\">987  Photon Drive</div><div class=\"jetpack-address__address jetpack-address__address2\">Apartment 5</div><div><span class=\"jetpack-address__city\">Speedyville</span>, <span class=\"jetpack-address__region\">CA</span> <span class=\"jetpack-address__postal\">12345</span></div><div class=\"jetpack-address__country\">USA</div></div>\n\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-jetpack-contact-info\"></div>\n\t",
+        "innerContent": [
+            "\n<div class=\"wp-block-jetpack-contact-info\">",
+            null,
+            "</div>\n\t"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/address {"address":"987  Photon Drive","addressLine2":"Apartment 5","city":"Speedyville","region":"CA","postal":"12345","country":"USA"} -->
+<div class="wp-block-jetpack-address"><div class="jetpack-address__address jetpack-address__address1">987  Photon Drive</div><div class="jetpack-address__address jetpack-address__address2">Apartment 5</div><div><span class="jetpack-address__city">Speedyville</span>, <span class="jetpack-address__region">CA</span> <span class="jetpack-address__postal">12345</span></div><div class="jetpack-address__country">USA</div></div>
+<!-- /wp:jetpack/address --></div>
+<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address__link-address-to-google-maps.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address__link-address-to-google-maps.html
@@ -1,0 +1,5 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/address {"address":"987  Photon Drive","addressLine2":"Apartment 5","city":"Speedyville","region":"CA","postal":"12345","country":"USA","linkToGoogleMaps":true} -->
+	<div class="wp-block-jetpack-address"><a href="https://www.google.com/maps/search/987+ Photon Drive,Apartment 5,+Speedyville,+CA,+12345+USA" target="_blank" rel="noopener noreferrer" title="Open address in Google Maps"><div class="jetpack-address__address jetpack-address__address1">987  Photon Drive</div><div class="jetpack-address__address jetpack-address__address2">Apartment 5</div><div><span class="jetpack-address__city">Speedyville</span>, <span class="jetpack-address__region">CA</span> <span class="jetpack-address__postal">12345</span></div><div class="jetpack-address__country">USA</div></a></div>
+	<!-- /wp:jetpack/address --></div>
+	<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address__link-address-to-google-maps.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address__link-address-to-google-maps.json
@@ -1,0 +1,28 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/contact-info",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "jetpack/address",
+                "isValid": true,
+                "attributes": {
+                    "address": "987  Photon Drive",
+                    "addressLine2": "Apartment 5",
+                    "addressLine3": "",
+                    "city": "Speedyville",
+                    "region": "CA",
+                    "postal": "12345",
+                    "country": "USA",
+                    "linkToGoogleMaps": true
+                },
+                "innerBlocks": [],
+                "originalContent": "<div class=\"wp-block-jetpack-address\"><a href=\"https://www.google.com/maps/search/987+ Photon Drive,Apartment 5,+Speedyville,+CA,+12345+USA\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"Open address in Google Maps\"><div class=\"jetpack-address__address jetpack-address__address1\">987  Photon Drive</div><div class=\"jetpack-address__address jetpack-address__address2\">Apartment 5</div><div><span class=\"jetpack-address__city\">Speedyville</span>, <span class=\"jetpack-address__region\">CA</span> <span class=\"jetpack-address__postal\">12345</span></div><div class=\"jetpack-address__country\">USA</div></a></div>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-jetpack-contact-info\"></div>"
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address__link-address-to-google-maps.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address__link-address-to-google-maps.parsed.json
@@ -1,0 +1,40 @@
+[
+    {
+        "blockName": "jetpack/contact-info",
+        "attrs": {},
+        "innerBlocks": [
+            {
+                "blockName": "jetpack/address",
+                "attrs": {
+                    "address": "987  Photon Drive",
+                    "addressLine2": "Apartment 5",
+                    "city": "Speedyville",
+                    "region": "CA",
+                    "postal": "12345",
+                    "country": "USA",
+                    "linkToGoogleMaps": true
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t<div class=\"wp-block-jetpack-address\"><a href=\"https://www.google.com/maps/search/987+ Photon Drive,Apartment 5,+Speedyville,+CA,+12345+USA\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"Open address in Google Maps\"><div class=\"jetpack-address__address jetpack-address__address1\">987  Photon Drive</div><div class=\"jetpack-address__address jetpack-address__address2\">Apartment 5</div><div><span class=\"jetpack-address__city\">Speedyville</span>, <span class=\"jetpack-address__region\">CA</span> <span class=\"jetpack-address__postal\">12345</span></div><div class=\"jetpack-address__country\">USA</div></a></div>\n\t",
+                "innerContent": [
+                    "\n\t<div class=\"wp-block-jetpack-address\"><a href=\"https://www.google.com/maps/search/987+ Photon Drive,Apartment 5,+Speedyville,+CA,+12345+USA\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"Open address in Google Maps\"><div class=\"jetpack-address__address jetpack-address__address1\">987  Photon Drive</div><div class=\"jetpack-address__address jetpack-address__address2\">Apartment 5</div><div><span class=\"jetpack-address__city\">Speedyville</span>, <span class=\"jetpack-address__region\">CA</span> <span class=\"jetpack-address__postal\">12345</span></div><div class=\"jetpack-address__country\">USA</div></a></div>\n\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-jetpack-contact-info\"></div>\n\t",
+        "innerContent": [
+            "\n<div class=\"wp-block-jetpack-contact-info\">",
+            null,
+            "</div>\n\t"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address__link-address-to-google-maps.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/fixtures/jetpack__address__link-address-to-google-maps.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/address {"address":"987  Photon Drive","addressLine2":"Apartment 5","city":"Speedyville","region":"CA","postal":"12345","country":"USA","linkToGoogleMaps":true} -->
+<div class="wp-block-jetpack-address"><a href="https://www.google.com/maps/search/987+ Photon Drive,Apartment 5,+Speedyville,+CA,+12345+USA" target="_blank" rel="noopener noreferrer" title="Open address in Google Maps"><div class="jetpack-address__address jetpack-address__address1">987  Photon Drive</div><div class="jetpack-address__address jetpack-address__address2">Apartment 5</div><div><span class="jetpack-address__city">Speedyville</span>, <span class="jetpack-address__region">CA</span> <span class="jetpack-address__postal">12345</span></div><div class="jetpack-address__country">USA</div></a></div>
+<!-- /wp:jetpack/address --></div>
+<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/validate.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { settings } from '../';
+import { settings as contactInfoSettings } from '../../';
+import runBlockFixtureTests from '../../../../shared/test/block-fixtures';
+
+// Need to include all the blocks involved in rendering this block.
+// The main block should be the first in the array.
+const blocks = [
+	{ name: 'jetpack/address', settings },
+	{ name: 'jetpack/contact-info', settings: contactInfoSettings },
+];
+
+runBlockFixtureTests( 'jetpack/address', blocks, __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/edit.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import EmailEdit from '../edit';
+
+const setAttributes = jest.fn();
+
+const defaultAttributes = {
+	email: '',
+};
+
+const defaultProps = {
+	attributes: defaultAttributes,
+	isSelected: false,
+	setAttributes,
+};
+
+describe( 'Email', () => {
+	beforeEach( () => {
+		setAttributes.mockClear();
+	} );
+
+	test( 'renders placeholder if not selected, and no content is entered', () => {
+		const propsNotSelected = { ...defaultProps, isSelected: false };
+		render( <EmailEdit { ...propsNotSelected } /> );
+
+		expect( screen.getByPlaceholderText( 'Email' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders email, and no placeholders, when not selected', () => {
+		const propsNotSelected = {
+			...defaultProps,
+			attributes: { email: 'test@example.com' },
+			isSelected: false,
+		};
+		render( <EmailEdit { ...propsNotSelected } /> );
+
+		expect( screen.getByText( 'test@example.com' ) ).toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Email' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders email link separately from other text, when not selected', () => {
+		const propsNotSelected = {
+			...defaultProps,
+			attributes: { email: 'email me at: test@example.com' },
+			isSelected: false,
+		};
+		render( <EmailEdit { ...propsNotSelected } /> );
+
+		expect( screen.getByRole( 'link', { name: 'test@example.com' } ).getAttribute( 'href' ) ).toEqual( 'mailto:test@example.com' );
+		expect( screen.getByText( 'email me at:' ) ).toBeInTheDocument();
+	} );
+
+	test( 'entering value into the email field updates the email attribute', () => {
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <EmailEdit { ...propsSelected } /> );
+		userEvent.paste( screen.getByPlaceholderText( 'Email' ), 'test@example.com' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { email: 'test@example.com' } );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/edit.js
@@ -54,7 +54,9 @@ describe( 'Email', () => {
 		};
 		render( <EmailEdit { ...propsNotSelected } /> );
 
-		expect( screen.getByRole( 'link', { name: 'test@example.com' } ).getAttribute( 'href' ) ).toEqual( 'mailto:test@example.com' );
+		expect(
+			screen.getByRole( 'link', { name: 'test@example.com' } ).getAttribute( 'href' )
+		).toEqual( 'mailto:test@example.com' );
 		expect( screen.getByText( 'email me at:' ) ).toBeInTheDocument();
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/fixtures/jetpack__email.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/fixtures/jetpack__email.html
@@ -1,0 +1,5 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/email {"email":"hello@yourjetpack.blog"} -->
+	<div class="wp-block-jetpack-email"><a href="mailto:hello@yourjetpack.blog">hello@yourjetpack.blog</a></div>
+	<!-- /wp:jetpack/email --></div>
+	<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/fixtures/jetpack__email.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/fixtures/jetpack__email.json
@@ -1,0 +1,21 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/contact-info",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "jetpack/email",
+                "isValid": true,
+                "attributes": {
+                    "email": "hello@yourjetpack.blog"
+                },
+                "innerBlocks": [],
+                "originalContent": "<div class=\"wp-block-jetpack-email\"><a href=\"mailto:hello@yourjetpack.blog\">hello@yourjetpack.blog</a></div>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-jetpack-contact-info\"></div>"
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/fixtures/jetpack__email.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/fixtures/jetpack__email.parsed.json
@@ -1,0 +1,34 @@
+[
+    {
+        "blockName": "jetpack/contact-info",
+        "attrs": {},
+        "innerBlocks": [
+            {
+                "blockName": "jetpack/email",
+                "attrs": {
+                    "email": "hello@yourjetpack.blog"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t<div class=\"wp-block-jetpack-email\"><a href=\"mailto:hello@yourjetpack.blog\">hello@yourjetpack.blog</a></div>\n\t",
+                "innerContent": [
+                    "\n\t<div class=\"wp-block-jetpack-email\"><a href=\"mailto:hello@yourjetpack.blog\">hello@yourjetpack.blog</a></div>\n\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-jetpack-contact-info\"></div>\n\t",
+        "innerContent": [
+            "\n<div class=\"wp-block-jetpack-contact-info\">",
+            null,
+            "</div>\n\t"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/fixtures/jetpack__email.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/fixtures/jetpack__email.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/email {"email":"hello@yourjetpack.blog"} -->
+<div class="wp-block-jetpack-email"><a href="mailto:hello@yourjetpack.blog">hello@yourjetpack.blog</a></div>
+<!-- /wp:jetpack/email --></div>
+<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/validate.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { settings } from '../';
+import { settings as contactInfoSettings } from '../../';
+import runBlockFixtureTests from '../../../../shared/test/block-fixtures';
+
+// Need to include all the blocks involved in rendering this block.
+// The main block should be the first in the array.
+const blocks = [
+	{ name: 'jetpack/email', settings },
+	{ name: 'jetpack/contact-info', settings: contactInfoSettings },
+];
+
+runBlockFixtureTests( 'jetpack/email', blocks, __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/edit.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import PhoneEdit from '../edit';
+
+const setAttributes = jest.fn();
+
+const defaultAttributes = {
+	phone: '',
+};
+
+const defaultProps = {
+	attributes: defaultAttributes,
+	isSelected: false,
+	setAttributes,
+};
+
+describe( 'Phone', () => {
+	beforeEach( () => {
+		setAttributes.mockClear();
+	} );
+
+	test( 'renders placeholder if not selected, and no content is entered', () => {
+		const propsNotSelected = { ...defaultProps, isSelected: false };
+		render( <PhoneEdit { ...propsNotSelected } /> );
+
+		expect( screen.getByPlaceholderText( 'Phone number' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders phone number, and no placeholders, when not selected', () => {
+		const propsNotSelected = {
+			...defaultProps,
+			attributes: { phone: '123-456-7890' },
+			isSelected: false,
+		};
+		render( <PhoneEdit { ...propsNotSelected } /> );
+
+		expect( screen.getByText( '123-456-7890' ) ).toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Phone number' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders phone link separately from other text, when not selected', () => {
+		const propsNotSelected = {
+			...defaultProps,
+			attributes: { phone: 'call me on: +1-123-456-7890' },
+			isSelected: false,
+		};
+		render( <PhoneEdit { ...propsNotSelected } /> );
+
+		expect(
+			screen.getByRole( 'link', { name: '+1-123-456-7890' } ).getAttribute( 'href' )
+		).toEqual( 'tel:+11234567890' );
+		expect( screen.getByText( 'call me on:' ) ).toBeInTheDocument();
+	} );
+
+	test( 'entering value into the phone field updates the phone attribute', () => {
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <PhoneEdit { ...propsSelected } /> );
+		userEvent.paste( screen.getByPlaceholderText( 'Phone number' ), '123-456-7890' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { phone: '123-456-7890' } );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/fixtures/jetpack__phone.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/fixtures/jetpack__phone.html
@@ -1,0 +1,5 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/phone {"phone":"123-456-7890"} -->
+	<div class="wp-block-jetpack-phone"><a href="tel:1234567890">123-456-7890</a></div>
+	<!-- /wp:jetpack/phone --></div>
+	<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/fixtures/jetpack__phone.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/fixtures/jetpack__phone.json
@@ -1,0 +1,21 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/contact-info",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "jetpack/phone",
+                "isValid": true,
+                "attributes": {
+                    "phone": "123-456-7890"
+                },
+                "innerBlocks": [],
+                "originalContent": "<div class=\"wp-block-jetpack-phone\"><a href=\"tel:1234567890\">123-456-7890</a></div>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-jetpack-contact-info\"></div>"
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/fixtures/jetpack__phone.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/fixtures/jetpack__phone.parsed.json
@@ -1,0 +1,34 @@
+[
+    {
+        "blockName": "jetpack/contact-info",
+        "attrs": {},
+        "innerBlocks": [
+            {
+                "blockName": "jetpack/phone",
+                "attrs": {
+                    "phone": "123-456-7890"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t<div class=\"wp-block-jetpack-phone\"><a href=\"tel:1234567890\">123-456-7890</a></div>\n\t",
+                "innerContent": [
+                    "\n\t<div class=\"wp-block-jetpack-phone\"><a href=\"tel:1234567890\">123-456-7890</a></div>\n\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-jetpack-contact-info\"></div>\n\t",
+        "innerContent": [
+            "\n<div class=\"wp-block-jetpack-contact-info\">",
+            null,
+            "</div>\n\t"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/fixtures/jetpack__phone.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/fixtures/jetpack__phone.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/phone {"phone":"123-456-7890"} -->
+<div class="wp-block-jetpack-phone"><a href="tel:1234567890">123-456-7890</a></div>
+<!-- /wp:jetpack/phone --></div>
+<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/validate.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { settings } from '../';
+import { settings as contactInfoSettings } from '../../';
+import runBlockFixtureTests from '../../../../shared/test/block-fixtures';
+
+// Need to include all the blocks involved in rendering this block.
+// The main block should be the first in the array.
+const blocks = [
+	{ name: 'jetpack/phone', settings },
+	{ name: 'jetpack/contact-info', settings: contactInfoSettings },
+];
+
+runBlockFixtureTests( 'jetpack/phone', blocks, __dirname );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR adds tests for the blocks used by the Contact Info block (address, email and phone). Note: tests aren't included for the parent Contact Info block since it is a fairly simple container block that renders `InnerBlocks` and it seemed to me that it might be a bit more effort than it's worth to get that running under these tests. If you're reviewing this and think it could do with adding them (or additional fixture tests), let me know and I'm happy to continue investigating.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add block fixture parsing tests to the address, email, and phone blocks used by the Contact Info parent block.
* Add unit tests for the Edit components for the address, email, and phone blocks.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See p1HpG7-b3G-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Change directory to `cd projects/plugins/jetpack` and run the following tests making sure they all pass:
* `yarn jest extensions/blocks/contact-info/address/test/`
* `yarn jest extensions/blocks/contact-info/email/test/`
* `yarn jest extensions/blocks/contact-info/phone/test/`


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. --><!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
None
