### PR TITLE
E2E tests: Remove e2e-test-utils

### DIFF
--- a/projects/plugins/jetpack/tests/e2e/README.md
+++ b/projects/plugins/jetpack/tests/e2e/README.md
@@ -79,10 +79,6 @@ We use the following tools to write e2e tests:
 
 Tests are kept in `/specs` folder. Every file represents a test suite, which is designed around specific feature under test. Most of the tests rely on an active Jetpack Connection, so we connect a site before running the actual test suite. Its logic can be found in the [`test-setup#maybePreConnect`](lib/env/test-setup.js) function. For test suites where pre-connection is not needed, it can be disabled by setting `SKIP_CONNECT` env var to false. Check [`connection.test.js`](./specs/connection.test.js) for example use.
 
-The following packages are being used to write tests:
-
-- `e2e-test-utils` - End-To-End (E2E) test utils for WordPress. You can find the full list of utils [here](https://github.com/WordPress/gutenberg/tree/master/packages/e2e-test-utils).
-
 ## Tests Architecture
 
 The tests are using the `PageObject` pattern, which is a way to separate test logic from implementation. Page objects are basically abstractions around specific pages and page components. All the pages are extending the [`Page`](./lib/pages/page.js) class, and don't really have any specific requirements, except maybe the way how page constructors are designed. `expectedSelector` is a CSS selector that identifies the specific page/component. Make sure to pass `page` instance together with the `expectedSelector` to the `super` call as follows:

--- a/projects/plugins/jetpack/tests/e2e/lib/blocks/word-ads.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/blocks/word-ads.js
@@ -1,5 +1,3 @@
-import { clickBlockToolbarButton } from '@wordpress/e2e-test-utils';
-
 export default class WordAdsBlock {
 	constructor( blockId, page ) {
 		this.blockTitle = WordAdsBlock.title();
@@ -16,11 +14,8 @@ export default class WordAdsBlock {
 	}
 
 	async switchFormat( buttonNumber ) {
-		await clickBlockToolbarButton( 'Pick an ad format' );
-
+		await this.page.click( '.wp-block-jetpack-wordads__format-picker-icon' );
 		const formatButtonSelector = `.wp-block-jetpack-wordads__format-picker button:nth-child(${ buttonNumber })`;
-		await this.page.waitForSelector( formatButtonSelector );
-		await this.page.waitForTimeout( 500 );
 		return await this.page.click( formatButtonSelector );
 	}
 

--- a/projects/plugins/jetpack/tests/e2e/lib/env/global-setup.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/env/global-setup.js
@@ -4,7 +4,7 @@ import TunnelManager from './tunnel-manager';
 module.exports = async function () {
 	// Create tunnel. Make it global so we can access it in global-teardown
 	global.tunnelManager = new TunnelManager();
-	await global.tunnelManager.create();
+	await global.tunnelManager.create( process.env.SKIP_CONNECT );
 
 	// Create the file used to save browser storage to skip login actions
 	// If the file is missing Playwright context creation will fail

--- a/projects/plugins/jetpack/tests/e2e/lib/env/global-setup.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/env/global-setup.js
@@ -4,7 +4,7 @@ import TunnelManager from './tunnel-manager';
 module.exports = async function () {
 	// Create tunnel. Make it global so we can access it in global-teardown
 	global.tunnelManager = new TunnelManager();
-	await global.tunnelManager.create( process.env.SKIP_CONNECT );
+	await global.tunnelManager.create();
 
 	// Create the file used to save browser storage to skip login actions
 	// If the file is missing Playwright context creation will fail

--- a/projects/plugins/jetpack/tests/e2e/lib/logger.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/logger.js
@@ -15,6 +15,12 @@ const myCustomLevels = {
 	},
 };
 
+let consoleLogLevel = process.env.CONSOLE_LOG_LEVEL || 'debug';
+
+if ( process.env.CI ) {
+	consoleLogLevel = 'error';
+}
+
 /**
  * Log only the messages the match `level`.
  *
@@ -91,13 +97,7 @@ const logger = createLogger( {
 				} )
 			),
 		} ),
-	],
-} );
 
-// If we're running tests locally with debug enabled then **ALSO** log to the `console`
-// with the colorized simple format.
-if ( process.env.E2E_DEBUG || ! process.env.CI ) {
-	logger.add(
 		new transports.Console( {
 			format: format.combine(
 				format.timestamp(),
@@ -106,9 +106,9 @@ if ( process.env.E2E_DEBUG || ! process.env.CI ) {
 					return `${ timestamp } ${ level }: ${ message }`;
 				} )
 			),
-			level: 'debug',
-		} )
-	);
-}
+			level: consoleLogLevel,
+		} ),
+	],
+} );
 
 export default logger;

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/page.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/page.js
@@ -16,7 +16,7 @@ export default class Page {
 	/**
 	 * Static method which initialize a page object. Also waits for `this.expectedSelector` to become visible, which kinda simulates page loads
 	 *
-	 * @param {page} page Playwright representation of the page.
+	 * @param {Page} page Playwright representation of the page.
 	 *
 	 * @return {Page} Instance of the Page Object class
 	 */
@@ -28,7 +28,7 @@ export default class Page {
 
 	/**
 	 *
-	 * @param {page} page Playwright representation of the page
+	 * @param {Page} page Playwright representation of the page
 	 * @param {string} pageURL Page URL
 	 */
 	static async visit( page, pageURL = null ) {

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
@@ -3,7 +3,6 @@
  */
 import Page from '../page';
 import { getTunnelSiteUrl } from '../../utils-helper';
-import { searchForBlock } from '@wordpress/e2e-test-utils';
 
 export default class BlockEditorPage extends Page {
 	constructor( page ) {
@@ -30,37 +29,77 @@ export default class BlockEditorPage extends Page {
 		return it;
 	}
 
+	//region selectors
+
+	get insertBlockBtnSel() {
+		return '.edit-post-header-toolbar__inserter-toggle';
+	}
+
+	get searchBlockFldSel() {
+		return '.block-editor-inserter__search-input';
+	}
+
+	blockSel( blockName ) {
+		return `.editor-block-list-item-jetpack-${ blockName }`;
+	}
+
+	insertedBlockSel( blockName ) {
+		return `div[data-type='jetpack/${ blockName }']`;
+	}
+
+	get publishPanelToggleBtnSel() {
+		return '.editor-post-publish-panel__toggle';
+	}
+
+	get publishPostBtnSel() {
+		return '.editor-post-publish-button';
+	}
+
+	get postPublishBtnSel() {
+		return '.post-publish-panel__postpublish-buttons';
+	}
+
+	get postPublishViewPostBtnSel() {
+		// return `${ this.postPublishBtnSel } a`;
+		return '.post-publish-panel__postpublish-buttons a';
+	}
+
+	get postTitleFldSel() {
+		return '.editor-post-title__input';
+	}
+
+	//endregion
+
+	async searchForBlock( searchTerm ) {
+		await this.page.click( this.insertBlockBtnSel );
+		await this.page.type( this.searchBlockFldSel, searchTerm );
+	}
+
 	async insertBlock( blockName, blockTitle ) {
-		await searchForBlock( blockTitle );
-		await this.page.click( `.editor-block-list-item-jetpack-${ blockName }` );
+		await this.searchForBlock( blockTitle );
+		await this.page.click( this.blockSel( blockName ) );
 		return await this.getInsertedBlock( blockName );
 	}
 
 	async getInsertedBlock( blockName ) {
-		return (
-			await this.page.waitForSelector( `div[data-type='jetpack/${ blockName }']` )
-		 ).getAttribute( 'data-block' );
+		return ( await this.page.waitForSelector( this.insertedBlockSel( blockName ) ) ).getAttribute(
+			'data-block'
+		);
 	}
 
 	async publishPost() {
-		await this.page.click( '.editor-post-publish-panel__toggle' );
-
-		// Disable reason: Wait for the animation to complete, since otherwise the
-		// click attempt may occur at the wrong point.
-		// Also, for some reason post-publish bar wont show up it we click to fast :/
-		await this.page.click( '.editor-post-publish-button' );
-		await this.page.waitForSelector( '.components-snackbar' );
-		return await this.page.waitForSelector( '.post-publish-panel__postpublish-buttons a' );
+		await this.page.click( this.publishPanelToggleBtnSel );
+		await this.page.click( this.publishPostBtnSel );
+		await this.page.waitForSelector( this.postPublishViewPostBtnSel );
 	}
 
 	async viewPost() {
-		await this.page.waitForSelector( '.post-publish-panel__postpublish-buttons a' );
-		await this.page.click( '.post-publish-panel__postpublish-buttons a' );
+		await this.page.click( this.postPublishViewPostBtnSel );
 	}
 
-	async focus() {
-		await this.page.focus( '.editor-post-title__input' );
-		await this.page.click( '.editor-post-title__input' );
+	async selectPostTitle() {
+		await this.page.focus( this.postTitleFldSel );
+		await this.page.click( this.postTitleFldSel );
 	}
 
 	async waitForAvailableBlock( blockSlug ) {

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/jetpack.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/jetpack.js
@@ -22,22 +22,22 @@ export default class JetpackPage extends Page {
 
 	async isFree() {
 		const freePlanImage = ".my-plan-card__icon img[src*='free']";
-		return await isEventuallyVisible( this.page, freePlanImage, 20000 );
+		return isEventuallyVisible( this.page, freePlanImage, 20000 );
 	}
 
 	async isComplete() {
 		const premiumPlanImage = ".my-plan-card__icon img[src*='complete']";
-		return await isEventuallyVisible( this.page, premiumPlanImage, 20000 );
+		return isEventuallyVisible( this.page, premiumPlanImage, 20000 );
 	}
 
 	async isSecurity() {
 		const proPlanImage = ".my-plan-card__icon img[src*='security']";
-		return await isEventuallyVisible( this.page, proPlanImage, 20000 );
+		return isEventuallyVisible( this.page, proPlanImage, 20000 );
 	}
 
 	async isConnected() {
 		const connectionInfo = '.jp-connection-settings__info';
-		return await isEventuallyVisible( this.page, connectionInfo, 5000 );
+		return isEventuallyVisible( this.page, connectionInfo, 5000 );
 	}
 
 	async forceVariation( variation = 'original' ) {

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -26,7 +26,6 @@
 		"@babel/core": "7.12.10",
 		"@babel/preset-env": "7.12.11",
 		"@slack/web-api": "6.0.0",
-		"@wordpress/e2e-test-utils": "4.3.1",
 		"@wordpress/env": "1.6.0",
 		"@wordpress/eslint-plugin": "8.0.2",
 		"axios": "0.21.1",

--- a/projects/plugins/jetpack/tests/e2e/specs/free-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/free-blocks.test.js
@@ -29,7 +29,7 @@ describe( 'Free blocks', () => {
 		} );
 
 		await step( 'Can publish a post with a Pinterest block', async () => {
-			await blockEditor.focus();
+			await blockEditor.selectPostTitle();
 			await blockEditor.publishPost();
 			await blockEditor.viewPost();
 		} );
@@ -55,7 +55,7 @@ describe( 'Free blocks', () => {
 		} );
 
 		await step( 'Can publish a post with a Eventbrite block', async () => {
-			await blockEditor.focus();
+			await blockEditor.selectPostTitle();
 			await blockEditor.publishPost();
 			await blockEditor.viewPost();
 		} );

--- a/projects/plugins/jetpack/tests/e2e/specs/pro-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/pro-blocks.test.js
@@ -13,7 +13,6 @@ import { step } from '../lib/env/test-setup';
 describe( 'Paid blocks', () => {
 	beforeAll( async () => {
 		await syncJetpackPlanData( 'complete' );
-
 		await activateModule( page, 'publicize' );
 		await activateModule( page, 'wordads' );
 	} );
@@ -40,9 +39,8 @@ describe( 'Paid blocks', () => {
 		} );
 
 		await step( 'Can publish a post and assert that MailChimp block is rendered', async () => {
-			await blockEditor.focus();
+			await blockEditor.selectPostTitle();
 			await blockEditor.publishPost();
-
 			await blockEditor.viewPost();
 			const frontend = await PostFrontendPage.init( page );
 			expect( await frontend.isRenderedBlockPresent( MailchimpBlock ) ).toBeTruthy();
@@ -71,10 +69,9 @@ describe( 'Paid blocks', () => {
 		await step(
 			'Can publish a post and assert that Pay with PayPal block is rendered',
 			async () => {
-				await blockEditor.focus();
+				await blockEditor.selectPostTitle();
 				await blockEditor.publishPost();
 				await blockEditor.viewPost();
-
 				const frontend = await PostFrontendPage.init( page );
 				expect( await frontend.isRenderedBlockPresent( SimplePaymentBlock ) ).toBeTruthy();
 			}
@@ -89,7 +86,7 @@ describe( 'Paid blocks', () => {
 			blockEditor = await BlockEditorPage.visit( page );
 			await blockEditor.waitForAvailableBlock( WordAdsBlock.name() );
 			blockId = await blockEditor.insertBlock( WordAdsBlock.name(), WordAdsBlock.title() );
-			await blockEditor.focus();
+			await blockEditor.selectPostTitle();
 		} );
 
 		await step( 'Can switch to Wide Skyscraper ad format', async () => {
@@ -99,7 +96,7 @@ describe( 'Paid blocks', () => {
 		} );
 
 		await step( 'Can publish a post and assert that WordAds block is rendered', async () => {
-			await blockEditor.focus();
+			await blockEditor.selectPostTitle();
 			await blockEditor.publishPost();
 			await blockEditor.viewPost();
 

--- a/projects/plugins/jetpack/tests/e2e/yarn.lock
+++ b/projects/plugins/jetpack/tests/e2e/yarn.lock
@@ -807,7 +807,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.8.4":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
   integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
@@ -1176,31 +1176,6 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tannin/compile@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tannin/compile/-/compile-1.1.0.tgz#1e4d1c5364cbfeffa1c20352c053e19ef20ffe93"
-  integrity sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==
-  dependencies:
-    "@tannin/evaluate" "^1.2.0"
-    "@tannin/postfix" "^1.1.0"
-
-"@tannin/evaluate@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@tannin/evaluate/-/evaluate-1.2.0.tgz#468a13c45eff45340108836fc46c708457199c3f"
-  integrity sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==
-
-"@tannin/plural-forms@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tannin/plural-forms/-/plural-forms-1.1.0.tgz#cffbb060d2640a56a314e3c77cbf6ea6072b51d5"
-  integrity sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==
-  dependencies:
-    "@tannin/compile" "^1.1.0"
-
-"@tannin/postfix@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tannin/postfix/-/postfix-1.1.0.tgz#6071f4204ae26c2e885cf3a3f1203a9f71e3f291"
-  integrity sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==
-
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
@@ -1414,17 +1389,6 @@
     "@typescript-eslint/types" "4.15.0"
     eslint-visitor-keys "^2.0.0"
 
-"@wordpress/e2e-test-utils@4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/e2e-test-utils/-/e2e-test-utils-4.3.1.tgz#cc3afc63ed8b6aef05084d2930836dc6490ee50e"
-  integrity sha512-5/JWB68PaXH8eYLwMc1CfmJcAwSIySuBBJA6KyizV+kXRh45KNqkqRO6XluhUsgzDP5WhrBvF8XmATDpmntptw==
-  dependencies:
-    "@babel/runtime" "^7.8.3"
-    "@wordpress/keycodes" "^2.9.0"
-    "@wordpress/url" "^2.11.0"
-    lodash "^4.17.15"
-    node-fetch "^1.7.3"
-
 "@wordpress/env@1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@wordpress/env/-/env-1.6.0.tgz#db4846d9052e8f6b505c98ed2f437ee9b6180c2d"
@@ -1463,48 +1427,10 @@
     prettier "npm:wp-prettier@2.2.1-beta-1"
     requireindex "^1.2.0"
 
-"@wordpress/hooks@^2.11.1":
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.11.1.tgz#86ad30cb20a8212f8c119894ff197574c84360e4"
-  integrity sha512-20nsvmLH5/iw9P6M7kiEBBQ7X7G3pEbqED/aN5dqkMCklDyar+OZqYBzdpGGsthXVYgomfNy6QQZWELkGJbcbw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
-"@wordpress/i18n@^3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-3.18.0.tgz#08f0ff63ef26fb6d2ac50683f4ad90d3b64b3960"
-  integrity sha512-e1uFWhWYnT0B6s3hyy+xS0S3bwabrvkZA84xxitiIcQvGnZDUPntqv6M9+VrgJVlmd2MR2TbCGJ5xKFAVFr/gA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@wordpress/hooks" "^2.11.1"
-    gettext-parser "^1.3.1"
-    lodash "^4.17.19"
-    memize "^1.1.0"
-    sprintf-js "^1.1.1"
-    tannin "^1.2.0"
-
-"@wordpress/keycodes@^2.9.0":
-  version "2.18.3"
-  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-2.18.3.tgz#116ea96bcf507daff7d6ccb4ef3dcd508eb2d61e"
-  integrity sha512-Lenyw+K2KgiqddBv5fDCh2JRfXFrONWNvPfv1DKXzHXTvBSI0JkU1RVP5WZTcVuEtctCZWL5JbhrkG2I26w68g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@wordpress/i18n" "^3.18.0"
-    lodash "^4.17.19"
-
 "@wordpress/prettier-config@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@wordpress/prettier-config/-/prettier-config-1.0.1.tgz#1ca9b2089b94ca3d95e60c0594d1e5409f504ce4"
   integrity sha512-LgnivcSTWqUgy5JE24+AKygtQsVvcdvNUGEyeM4K4urWgnyvmkeyZDfbN1nuK2b7E1oRMSSCCwxqQJDoxlFgUg==
-
-"@wordpress/url@^2.11.0":
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-2.21.2.tgz#7689e7e633aeab74fbf6c16e4d051b2fd7872a2f"
-  integrity sha512-bLHg4pTo/9mQUkK1s1MU/Sjgnzfy2AkPvPn4ObGA8/4CFkMsDhQGAVhhw5YuezcxvaJkBiKJ+BxgFJ1QKksF6w==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    lodash "^4.17.19"
-    react-native-url-polyfill "^1.1.2"
 
 abab@^2.0.3:
   version "2.0.5"
@@ -1895,11 +1821,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -2014,14 +1935,6 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
-
-buffer@^5.4.3:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -2749,13 +2662,6 @@ enabled@2.0.x:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
   integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
-
-encoding@^0.1.11, encoding@^0.1.12:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
-  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
-  dependencies:
-    iconv-lite "^0.6.2"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
@@ -3545,14 +3451,6 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gettext-parser@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-1.4.0.tgz#f8baf34a292f03d5e42f02df099d301f167a7ace"
-  integrity sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==
-  dependencies:
-    encoding "^0.1.12"
-    safe-buffer "^5.1.1"
-
 glob-parent@^5.0.0, glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
@@ -3799,18 +3697,6 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
-  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3.0.0"
-
-ieee754@^1.1.13:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore-walk@^3.0.1:
   version "3.0.3"
@@ -4084,7 +3970,7 @@ is-regex@^1.1.1:
     call-bind "^1.0.2"
     has-symbols "^1.0.1"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -4971,7 +4857,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.20, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@4.17.20, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -5038,11 +4924,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-memize@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/memize/-/memize-1.1.0.tgz#4a5a684ac6992a13b1299043f3e49b1af6a0b0d3"
-  integrity sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -5235,14 +5116,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-fetch@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-gyp@^4.0.0:
   version "4.0.0"
@@ -6072,13 +5945,6 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
-react-native-url-polyfill@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-1.2.0.tgz#cfc9c91d2d62cf66d968c6fe94d091dc668ca9a3"
-  integrity sha512-hpLZ8RyS3oGVyTOe/HjoqVoCOSkeJvrCoEB3bJsY7t9uh7kpQDV6kgvdlECEafYpxe3RzMrKLVcmWRbPU7CuAw==
-  dependencies:
-    whatwg-url-without-unicode "8.0.0-3"
-
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
@@ -6418,7 +6284,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -6685,11 +6551,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-sprintf-js@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
-  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -6915,13 +6776,6 @@ table@^6.0.4:
     lodash "^4.17.20"
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
-
-tannin@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tannin/-/tannin-1.2.0.tgz#1da6fe65280dca4c3d84efb075b077b1b94362a6"
-  integrity sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==
-  dependencies:
-    "@tannin/plural-forms" "^1.1.0"
 
 tar-fs@^1.16.3:
   version "1.16.3"
@@ -7352,15 +7206,6 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
-
-whatwg-url-without-unicode@8.0.0-3:
-  version "8.0.0-3"
-  resolved "https://registry.yarnpkg.com/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz#ab6df4bf6caaa6c85a59f6e82c026151d4bb376b"
-  integrity sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==
-  dependencies:
-    buffer "^5.4.3"
-    punycode "^2.1.1"
-    webidl-conversions "^5.0.0"
 
 whatwg-url@^8.0.0:
   version "8.4.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Move away from wordpress/e2e-test-utils. There were 2 simple actions in block editor used from this library: search for block and click on block toolbar
* Propose a Page class design in BlockEditorPage, with getters for elements selectors, so we don't spread selectors all over. It should help keep things more maintainable.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* All E2E tests should pass

#### Proposed changelog entry for your changes:
n/a
