### PR TITLE
Remove node's deprecated `url` from url-search

### DIFF
--- a/projects/plugins/jetpack/_inc/client/mixins/url-search/build-url.js
+++ b/projects/plugins/jetpack/_inc/client/mixins/url-search/build-url.js
@@ -1,26 +1,35 @@
-/**
- * External dependencies
- */
-import url from 'url';
-import { pick } from 'lodash';
+const BASE_PROTOCOL = 'http:';
+const BASE_HOST = '__domain__.invalid';
+const BASE_URL = `${ BASE_PROTOCOL }//${ BASE_HOST }`;
 
 /**
  * Given a URL or path and search terms, returns a path including the search
  * query parameter and preserving existing parameters.
  *
- * @param  {string} uri    URL or path to modify
- * @param  {string} search Search terms
- * @return {string}        Path including search terms
+ * @param  {string} uri    - URL or path to modify
+ * @param  {string} search - Search terms
+ * @returns {string}        Path including search terms
  */
-export default function ( uri, search ) {
-	let parsedUrl = url.parse( uri, true );
+export default function buildUrl( uri, search ) {
+	// URL can only represent absolute URLs, so we need to provide a base.
+	const dummyUrl = new URL( uri, BASE_URL );
 
 	if ( search ) {
-		parsedUrl.query.s = search;
+		dummyUrl.searchParams.set( 's', search );
 	} else {
-		delete parsedUrl.query.s;
+		dummyUrl.searchParams.delete( 's' );
 	}
 
-	parsedUrl = pick( parsedUrl, 'pathname', 'hash', 'query' );
-	return url.format( parsedUrl ).replace( /\%20/g, '+' );
+	// Normalize to the base protocol and host, so that we can run a replace.
+	dummyUrl.protocol = BASE_PROTOCOL;
+	dummyUrl.host = BASE_HOST;
+	dummyUrl.port = '';
+	dummyUrl.username = '';
+	dummyUrl.password = '';
+
+	let formattedPath = dummyUrl.href.replace( BASE_URL, '' );
+	// Remove the leading `/` if the original uri didn't have it.
+	formattedPath = uri.startsWith( '/' ) ? formattedPath : formattedPath.substring( 1 );
+
+	return formattedPath.replace( /%20/g, '+' );
 }


### PR DESCRIPTION
Node's `url` was being used in the `url-search` mixin. This module is deprecated and can be replaced with native URL functionality, which is already being polyfilled, as far as I can tell.

This PR won't be enough in getting rid of `url` in search, however, as it's also used in the `photon` dependency. I'll be preparing another PR with that change once a new version of `photon` is published, that doesn't use `url`.

#### Changes proposed in this Pull Request:
* Reimplement `url-search` without Node's deprecated `url` module

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Ensure that search continues to work correctly, with search URLs being correctly constructed. Double-check that there are no errors in browsers that don't support `URL` natively (such as IE 11), to make sure the polyfill is being loaded correctly.

I'm afraid I've been unable to test this locally myself, because I'm still struggling with getting a docker build to work.

#### Proposed changelog entry for your changes:
No changelog entry needed; this should be a seamless under-the-hood change.
