### PR TITLE
Conversation: Support uploading/parsing/composing transcript

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/conversation/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/attributes.js
@@ -6,4 +6,8 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+	createdFromScratch: {
+		type: 'boolean',
+		default: false,
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/conversation/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/attributes.js
@@ -6,7 +6,7 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
-	createdFromScratch: {
+	skipUpload: {
 		type: 'boolean',
 		default: false,
 	},

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -126,9 +126,12 @@ function ConversationEdit( {
 			return showTranscriptProcessErrorMessage( __( 'Transcript file not found.', 'jetpack' ) );
 		}
 
-		// Check file size.
-		if ( ! transcriptFile?.size || transcriptFile.size > TRANSCRIPT_MAX_FILE_SIZE ) {
-			return showTranscriptProcessErrorMessage( __( 'Invalid transcript file type.', 'jetpack' ) );
+		// Check file MAX size.
+		if (
+			transcriptFile?.size && transcriptFile.size <= 0 || // min size
+			! transcriptFile?.size || transcriptFile.size > TRANSCRIPT_MAX_FILE_SIZE // max size
+		) {
+			return showTranscriptProcessErrorMessage( __( 'Invalid transcript file size.', 'jetpack' ) );
 		}
 
 		// Check file type.

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -173,10 +173,20 @@ function ConversationEdit( {
 		return (
 			<Placeholder
 				label={ __( 'Conversation', 'jetpack' ) }
-				instructions={ __(
-					'Upload a transcript file or create a conversation with blank content.',
-					'jetpack'
-				) }
+				instructions={
+					<>
+						{ __(
+							'Upload a transcript file or create a conversation with blank content.',
+							'jetpack'
+						) }
+						<div>
+							<em>
+								{ __( 'Accepted file formats:', 'jetpack' ) }
+								<strong> { ACCEPTED_FILE_EXTENSIONS }</strong>.
+							</em>
+						</div>
+					</>
+				}
 				icon={ <BlockIcon icon={ icon } /> }
 				notices={ noticeUI }
 			>

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -34,7 +34,7 @@ function ConversationEdit( {
 	clientId,
 	noticeOperations,
  } ) {
-	const { participants = [], showTimestamps, createdFromScratch } = attributes;
+	const { participants = [], showTimestamps, skipUpload } = attributes;
 	const [ isProcessingFile, setIsProcessingFile ] = useState( '' );
 	const { insertBlocks } = useDispatch( 'core/block-editor' );
 
@@ -154,7 +154,7 @@ function ConversationEdit( {
 
 			setAttributes( {
 				participants: conversation.speakers,
-				createdFromScratch: ! conversation?.length,
+				skipUpload: ! conversation?.length,
 			} );
 			const dialogueBlocksTemplate = dialogues.map( ( dialogue ) => [
 				'jetpack/dialogue',
@@ -169,12 +169,12 @@ function ConversationEdit( {
 
 	const baseClassName = 'wp-block-jetpack-conversation';
 
-	if ( ! participants?.length && ! createdFromScratch ) {
+	if ( ! participants?.length && ! skipUpload ) {
 		return (
 			<Placeholder
 				label={ __( 'Conversation', 'jetpack' ) }
 				instructions={ __(
-					'Upload a transcript file or create a conversation from scratch.',
+					'Upload a transcript file or create a conversation with blank content.',
 					'jetpack'
 				) }
 				icon={ <BlockIcon icon={ icon } /> }
@@ -197,9 +197,9 @@ function ConversationEdit( {
 					<Button
 						isTertiary
 						disabled={ isProcessingFile }
-						onClick={ () => setAttributes( { createdFromScratch: true } ) }
+						onClick={ () => setAttributes( { skipUpload: true } ) }
 					>
-						{ __( 'From scratch', 'jetpack' ) }
+						{ __( 'Skip upload', 'jetpack' ) }
 					</Button>
 				</div>
 			</Placeholder>

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -156,10 +156,10 @@ function ConversationEdit( {
 				participants: conversation.speakers,
 				skipUpload: ! conversation?.length,
 			} );
-			const dialogueBlocksTemplate = dialogues.map( ( dialogue ) => [
-				'jetpack/dialogue',
-				dialogue,
-			] );
+
+			const dialogueBlocksTemplate = dialogues.map( ( dialogue ) => (
+				dialogue.slug ? [ 'jetpack/dialogue', dialogue ] : [ 'core/paragraph', dialogue ]
+			) );
 
 			const dialogueBlocks = createBlocksFromInnerBlocksTemplate( dialogueBlocksTemplate );
 			insertBlocks( dialogueBlocks, 0, clientId );

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -157,8 +157,12 @@ function ConversationEdit( {
 				skipUpload: ! conversation?.length,
 			} );
 
+			console.log( 'dialogues: ', dialogues );
+
 			const dialogueBlocksTemplate = dialogues.map( ( dialogue ) => (
-				dialogue.slug ? [ 'jetpack/dialogue', dialogue ] : [ 'core/paragraph', dialogue ]
+				dialogue.slug || dialogue.timestamp
+					? [ 'jetpack/dialogue', dialogue ]
+					: [ 'core/paragraph', dialogue ]
 			) );
 
 			const dialogueBlocks = createBlocksFromInnerBlocksTemplate( dialogueBlocksTemplate );

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -157,8 +157,6 @@ function ConversationEdit( {
 				skipUpload: ! conversation?.length,
 			} );
 
-			console.log( 'dialogues: ', dialogues );
-
 			const dialogueBlocksTemplate = dialogues.map( ( dialogue ) => (
 				dialogue.slug || dialogue.timestamp
 					? [ 'jetpack/dialogue', dialogue ]

--- a/projects/plugins/jetpack/extensions/blocks/conversation/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/editor.scss
@@ -10,3 +10,7 @@ $participant-height: 30px;
 .wp-block-jetpack-conversation__participant-label {
 	flex-grow: 2;
 }
+
+.wp-block-jetpack-conversation__placeholder {
+	display: flex;
+}

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -177,17 +177,24 @@ export function parseTranscriptFile( file, fn ) {
 			return fn( {}, __( 'Transcript content is empty', 'jetpack' ) );
 		}
 
+		let parsedData = {};
+
 		if ( fileExtension && fileExtension !== FILE_EXTENSION_TXT ) {
 			if ( fileExtension === FILE_EXTENSION_SRT ) {
-				return fn( SRT_parse( rawData ) );
+				parsedData = SRT_parse( rawData );
 			}
 		}
 
 		if ( fileExtension === FILE_EXTENSION_TXT ) {
-			return fn( TXT_parse( rawData ) );
+			parsedData = TXT_parse( rawData );
 		}
 
-		fn( {}, __( 'Transcript format not supported', 'jetpack' ) );
+		// Check parsing data results.
+		if ( ! parsedData.dialogues?.length ) {
+			return fn( {}, __( 'Transcript format not supported', 'jetpack' ) );
+		}
+
+		fn( parsedData );
 	} );
 
 	reader.readAsText( file );

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -59,8 +59,10 @@ export const TRANSCRIPT_MAX_FILE_SIZE = 100000;
  * ----------------------------
  * Serices: otter.ai, ...
  */
-const otterFormatRegExp = /(.*[^\s])\s{1,}(\d{1,2}(?::\d{1,2}?)+)\s+\n([\s\S]*?(?=\n{2}|$))/gm;
-const otterFormatTestRegExp = /(.*[^\s])\s{1,}(\d{1,2}(?::\d{1,2}?)+)\s+\n([\s\S]*?(?=\n{2}|$))/g;
+
+const otterRegExp = /(.*[^\s])\s{1,}(\d{1,2}(?::\d{1,2}?)+)\s+\n([\s\S]*?(?=\n{2}|$))/;
+const otterFormatRegExp = new RegExp( otterRegExp, 'gm' );
+const otterFormatTestRegExp = new RegExp( otterRegExp, 'g' );
 
 /*
  * ----------------------------
@@ -68,8 +70,9 @@ const otterFormatTestRegExp = /(.*[^\s])\s{1,}(\d{1,2}(?::\d{1,2}?)+)\s+\n([\s\S
  * ----------------------------
  * Serices: sonix.ai, ...
  */
-const sonixFormatRegExp = /(?:(.*[^\s]):\s*)?\[([\d{1,2}:]*)]\s([\s\S]*?(?=\n{1,2}|$))/gm;
-const sonixFormatTestRegExp = /(.*[^\s]):\s*\[([\d{1,2}:]*)]\s([\s\S]*?(?=\n{1,2}|$))/g;
+const sonixRegExp = /(?:(.*[^\s]):\s*)?\[([\d{1,2}:]*)]\s([\s\S]*?(?=\n{1,2}|$))/gm;
+const sonixFormatRegExp = new RegExp( sonixRegExp, 'gm' );
+const sonixFormatTestRegExp = new RegExp( sonixRegExp, 'gm' );
 
 const parsers = [
 	{

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -24,6 +24,16 @@ export function getPlainText( html, escape = false ) {
 	return escapeHTML( text );
 }
 
+/**
+ * Return the file extension according to the file name.
+ *
+ * @param {string} filename - file full name.
+ * @returns {string} File extension.
+ */
+export function pickExtensionFromFileName( filename ) {
+	return `.${ filename.substr( filename.lastIndexOf( '.' ) + 1 ) }`;
+}
+
 export const FILE_EXTENSION_SRT = '.srt';
 export const FILE_EXTENSION_TXT = '.txt';
 export const FILE_EXTENSION_VTT = '.vtt';
@@ -37,3 +47,115 @@ export const ACCEPTED_FILE_EXT_ARRAY = [
 ];
 
 export const ACCEPTED_FILE_EXTENSIONS = ACCEPTED_FILE_EXT_ARRAY.join( ', ' );
+
+/*
+ * Generic format / template.
+ * ----------------------------
+ * <speaker> <timestamp>
+ *  <content>
+ * ----------------------------
+ * Serices: otter.ai, ...
+ */
+export const speakerTimestampRegExp = /(.*[^\s])\s+(\d{1,2}(:\d{1,2})+)\s*\n([\s\S]*?(?=\n{2}|$))/gm;
+
+/* SRT format / template.
+ * ----------------------------
+ * <index>
+ * <startTime> --> <endTime>
+ * <content>
+ * ----------------------------
+ * Serices: otter.ai, youtube.com, etc.
+ */
+export const srtFormatRegExp = /(\d+)\n([\d:,]+)\s+-{2}>\s+([\d:,]+)\n([\s\S]*?(?=\n{2}|$))/gm;
+
+export function isValidTranscriptFormat( content ) {
+	return speakerTimestampRegExp.test( content );
+}
+
+export function isAcceptedTranscriptExtension( fileExtension ) {
+	return ACCEPTED_FILE_EXT_ARRAY.indexOf( fileExtension ) >= 0;
+}
+
+export function SRT_parse( content ) {
+	const result = {
+		conversation: {
+			speakers: [],
+		},
+		dialogues: [],
+	};
+
+	let matches;
+
+	while ( ( matches = srtFormatRegExp.exec( content ) ) !== null ) {
+		result.dialogues.push( {
+			timestamp: matches[ 2 ],
+			content: matches[ 4 ]
+		} );
+	}
+
+	return result;
+}
+
+export function TXT_parse ( content ) {
+	const result = {
+		dialogues: [],
+		conversation: {
+			speakers: [],
+		}
+	};
+
+	let matches;
+
+	while ( ( matches = speakerTimestampRegExp.exec( content ) ) != null ) {
+		if ( result.conversation.speakers.indexOf( matches[ 1 ] ) < 0 ) {
+			result.conversation.speakers.push( matches[ 1 ] );
+		}
+
+		result.dialogues.push( {
+			label: matches[ 1 ],
+			slug: `speaker-${ result.conversation.speakers.indexOf( matches[ 1 ] ) }`,
+			content: matches[ 4 ],
+			timestamp: matches[ 2 ],
+			showTimestamp: true,
+		} );
+	}
+
+	result.conversation.speakers = result.conversation.speakers.map( ( speaker, ind ) => ( {
+		label: speaker,
+		slug: `speaker-${ ind }`,
+	} ) );
+
+	return result;
+}
+
+export function parseTranscriptFile( file, fn ) {
+	const reader = new FileReader();
+	reader.addEventListener( 'load', ( ev ) => {
+		const rawData = ev.target.result
+			? ev.target.result.replace( /\r\n|\r|\n/g, '\n' )
+			: null;
+
+		if ( ! rawData?.length ) {
+			return;
+		}
+
+		// Detect format by extension.
+		const fileExtension = pickExtensionFromFileName( file?.name );
+
+		if (
+			fileExtension &&
+			fileExtension !== FILE_EXTENSION_TXT &&
+			isAcceptedTranscriptExtension( fileExtension )
+		) {
+			if ( fileExtension === FILE_EXTENSION_SRT ) {
+				return fn( SRT_parse( rawData ) );
+			}
+		}
+
+		if ( fileExtension === FILE_EXTENSION_TXT ) {
+			return fn( TXT_parse( rawData ) );
+		}
+	} );
+
+	reader.readAsText( file );
+}

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -59,7 +59,6 @@ export const TRANSCRIPT_MAX_FILE_SIZE = 100000;
  * ----------------------------
  * Serices: otter.ai, ...
  */
-
 const otterRegExp = /(.*[^\s])\s{1,}(\d{1,2}(?::\d{1,2}?)+)\s+\n([\s\S]*?(?=\n{2}|$))/;
 const otterFormatRegExp = new RegExp( otterRegExp, 'gm' );
 const otterFormatTestRegExp = new RegExp( otterRegExp, 'g' );
@@ -70,7 +69,7 @@ const otterFormatTestRegExp = new RegExp( otterRegExp, 'g' );
  * ----------------------------
  * Serices: sonix.ai, ...
  */
-const sonixRegExp = /(?:(.*[^\s]):\s*)?\[([\d{1,2}:]*)]\s([\s\S]*?(?=\n{1,2}|$))/;
+const sonixRegExp = /(?:(.*[^\s]):\s+)?(?:\[([\d{1,2}:]*)])?([\s\S]+?(?:\n+|$))/;
 const sonixFormatRegExp = new RegExp( sonixRegExp, 'gm' );
 const sonixFormatTestRegExp = new RegExp( sonixRegExp, 'g' );
 
@@ -141,7 +140,6 @@ export function TXT_parse ( content ) {
 	let matches;
 	while ( ( matches = parser.re.exec( content ) ) != null ) {
 		const speakerName = matches[ parser?.indexes?.speaker || 1 ] || '';
-
 		if (
 			speakerName?.length &&
 			result.conversation.speakers.indexOf( speakerName ) < 0
@@ -149,13 +147,18 @@ export function TXT_parse ( content ) {
 			result.conversation.speakers.push( speakerName );
 		}
 
-		result.dialogues.push( {
-			label: speakerName,
-			slug: `speaker-${ result.conversation.speakers.indexOf( speakerName ) }`,
+		const dialogue = {
 			content: matches[ parser?.indexes?.content || 3 ],
 			timestamp: matches[ parser?.indexes?.timestamp || 2 ],
 			showTimestamp: true,
-		} );
+		};
+
+		if ( speakerName?.length ) {
+			dialogue.label = speakerName;
+			dialogue.slug = `speaker-${ result.conversation.speakers.indexOf( speakerName ) }`;
+		}
+
+		result.dialogues.push( dialogue );
 	}
 
 	result.conversation.speakers = result.conversation.speakers.map( ( speaker, ind ) => ( {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -70,9 +70,9 @@ const otterFormatTestRegExp = new RegExp( otterRegExp, 'g' );
  * ----------------------------
  * Serices: sonix.ai, ...
  */
-const sonixRegExp = /(?:(.*[^\s]):\s*)?\[([\d{1,2}:]*)]\s([\s\S]*?(?=\n{1,2}|$))/gm;
+const sonixRegExp = /(?:(.*[^\s]):\s*)?\[([\d{1,2}:]*)]\s([\s\S]*?(?=\n{1,2}|$))/;
 const sonixFormatRegExp = new RegExp( sonixRegExp, 'gm' );
-const sonixFormatTestRegExp = new RegExp( sonixRegExp, 'gm' );
+const sonixFormatTestRegExp = new RegExp( sonixRegExp, 'g' );
 
 const parsers = [
 	{

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -174,7 +174,7 @@ export function parseTranscriptFile( file, fn ) {
 			: null;
 
 		if ( ! rawData?.length ) {
-			return;
+			return fn( {}, __( 'Transcript content is empty', 'jetpack' ) );
 		}
 
 		if ( fileExtension && fileExtension !== FILE_EXTENSION_TXT ) {

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -93,7 +93,7 @@ const parsers = [
  * <startTime> --> <endTime>
  * <content>
  * ----------------------------
- * Serices: otter.ai, youtube.com, etc.
+ * Services: otter.ai, youtube.com, etc.
  */
 export const srtFormatRegExp = /(\d+)\n([\d:,]+)\s+-{2}>\s+([\d:,]+)\n([\s\S]*?(?=\n{2}|$))/gm;
 

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -23,3 +23,17 @@ export function getPlainText( html, escape = false ) {
 
 	return escapeHTML( text );
 }
+
+export const FILE_EXTENSION_SRT = '.srt';
+export const FILE_EXTENSION_TXT = '.txt';
+export const FILE_EXTENSION_VTT = '.vtt';
+export const FILE_EXTENSION_SBV = '.sbv';
+
+export const ACCEPTED_FILE_EXT_ARRAY = [
+	FILE_EXTENSION_SRT,
+	FILE_EXTENSION_TXT,
+	FILE_EXTENSION_VTT,
+	FILE_EXTENSION_SBV,
+];
+
+export const ACCEPTED_FILE_EXTENSIONS = ACCEPTED_FILE_EXT_ARRAY.join( ', ' );

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -69,7 +69,7 @@ const otterFormatTestRegExp = new RegExp( otterRegExp, 'g' );
  * ----------------------------
  * Serices: sonix.ai, ...
  */
-const sonixRegExp = /(?:(.*[^\s]):\s+)?(?:\[([\d{1,2}:]*)])?(?:[\s])*?([^\s].+?(?:\n+|$))/;
+const sonixRegExp = /(?:(.*[^\s]):\s+)?(?:\[(\d+(?::\d+)*?(?:\.\d*)?)])?(?:[\s])*?([^\s].+?(?:\n+|$))/;
 const sonixFormatRegExp = new RegExp( sonixRegExp, 'gm' );
 const sonixFormatTestRegExp = new RegExp( sonixRegExp, 'g' );
 

--- a/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/utils.js
@@ -69,7 +69,7 @@ const otterFormatTestRegExp = new RegExp( otterRegExp, 'g' );
  * ----------------------------
  * Serices: sonix.ai, ...
  */
-const sonixRegExp = /(?:(.*[^\s]):\s+)?(?:\[([\d{1,2}:]*)])?([\s\S]+?(?:\n+|$))/;
+const sonixRegExp = /(?:(.*[^\s]):\s+)?(?:\[([\d{1,2}:]*)])?(?:[\s])*?([^\s].+?(?:\n+|$))/;
 const sonixFormatRegExp = new RegExp( sonixRegExp, 'gm' );
 const sonixFormatTestRegExp = new RegExp( sonixRegExp, 'g' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR implements a way to create a Conversation/Dialogue blocks composition by providing a transcript file.

### UX

Here, the Conversation block initially shows a placeholder that allows uploading a transcript video, or create a conversation from scratch.

<img src="https://user-images.githubusercontent.com/77539/109853614-d6dec780-7c34-11eb-986a-adb4955f6cb5.png" width="600px" />

## Implementation

### Workflow

The whole process can be split up into three parts.

* **UPLOADING**: The initial step. The user is able to upload the transcript file. Here, we try to validate the file by type and extension, check its size (100KB is the max size).
* **PARSING**: When the content format is detected early, this process applies the proper parser in order to data. It happens with the .srt files. It's a known format that makes the parsing process easier to do and less erratic.
When the file is simply a text file, the app tries to detect some patterns. We try to cover two formats so far, provided by otter.ai and sonix.ai.
* **COMPOSING**: It will transform the parsed data in a Conversation/Dialogue blocks composition.

## Known limitations / issues:

* It isn't possible to drop off the file into the placeholder.
* It isn't possible to drop off and parse the content straight in the editor canvas.
* There are other text formats still not supported (.vtt, .sbv, ...)

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Conversation: Support uploading/parsing/composing transcript

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create/edit a post
* Add a podcast block, setting with [this RSS feed](https://distributed.blog/2020/10/15/episode-25-davit-baghdasaryan-on-the-science-of-sound-in-a-distributed-work-world/).
* Select the episode `Episode 25: Davit Baghdasaryan on the Science of Sound in a Distributed Work World`
* Create a conversation block
* Upload the transcript file. You can [save the file from here](https://raw.githubusercontent.com/Automattic/automated-transcript-evaluation/trunk/otter-ai/Distributed-Episode-25-Davit-Baghdasaryan_otter.ai.txt?token=AAAS5YYODHNRWBLFOJ72EGLAJEK24).
* Confirm that the block compositions is done
* Confirm the timestamp is linked to the podcast player.

### VIDEO

https://user-images.githubusercontent.com/77539/109857782-ced55680-7c39-11eb-93e2-92bc4a29b858.mov


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*
