### PR TITLE
Anchor post publish link: Change to primary button

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -76,7 +76,13 @@ const ConvertToAudio = () => {
 					'jetpack'
 				) }
 			</p>
-			<div role="link" tabIndex={ 0 } onClick={ handleClick } onKeyDown={ handleClick }>
+			<div
+				role="link"
+				className="post-publish-panel__postpublish-buttons"
+				tabIndex={ 0 }
+				onClick={ handleClick }
+				onKeyDown={ handleClick }
+			>
 				<Button isPrimary href="https://anchor.fm/wordpressdotcom" target="_top">
 					{ __( 'Create a podcast episode', 'jetpack' ) }{ ' ' }
 					<Icon icon={ external } className="anchor-post-publish-outbound-link__external_icon" />

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -12,6 +12,7 @@ import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { external, Icon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
+import { Button } from '@wordpress/components';
 import '@wordpress/notices';
 
 /**
@@ -76,10 +77,10 @@ const ConvertToAudio = () => {
 				) }
 			</p>
 			<div role="link" tabIndex={ 0 } onClick={ handleClick } onKeyDown={ handleClick }>
-				<a href="https://anchor.fm/wordpressdotcom" target="_top">
-					{ __( 'Create a podcast episode', 'jetpack' ) }
+				<Button isPrimary href="https://anchor.fm/wordpressdotcom" target="_top">
+					{ __( 'Create a podcast episode', 'jetpack' ) }{ ' ' }
 					<Icon icon={ external } className="anchor-post-publish-outbound-link__external_icon" />
-				</a>
+				</Button>
 			</div>
 		</PluginPostPublishPanel>
 	);


### PR DESCRIPTION
Related to 515-gh-Automattic/dotcom-manage

#### Changes proposed in this Pull Request:

* Anchor post publish link: Change to primary button

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
_(How I test jetpack code; you may have a better way)_
* `cd projects/plugins/jetpack`
* `yarn build-extensions --watch`
* Rsync or copy  `./_inc` to `mu-plugins/jetpack/_inc` on sandbox
* Visit sandboxed site

_(These specific changes)_
* Create a new post
* Publish the post
* Check the post publish sidebar on the right side
* The anchor related link ("Create a podcast episode") is now a primary button instead of a text link
![2021-03-03_14-05](https://user-images.githubusercontent.com/937354/109865618-db51b300-7c29-11eb-959e-569ee8dbcd9e.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Anchor post publish link: Change to button