### PR TITLE
Search: Remove redundant url-polyfill import

### DIFF
--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import 'url-polyfill';
 import { encode } from 'qss';
 
 /**


### PR DESCRIPTION
Fixes #19003.

#### Changes proposed in this Pull Request:
Removes a redundantly importing `url-polyfill`. `core-js/modules/web.url.js` is already included in jp-`search-ie11-polyfill-payload.bundle.js`.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Try a site search. Ensure that the query string updates behave as expected in the browser address bar.

#### Proposed changelog entry for your changes:
* None.