### PR TITLE
Jetpack Search: add 'product' as a result format option in the Customizer

### DIFF
--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -159,6 +159,7 @@ class Jetpack_Search_Customize {
 				'choices'     => array(
 					'minimal'  => __( 'Minimal', 'jetpack' ),
 					'expanded' => __( 'Expanded (shows images)', 'jetpack' ),
+					'product'  => __( 'Product grid (for Woo stores)', 'jetpack' ),
 				),
 			)
 		);

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -159,7 +159,7 @@ class Jetpack_Search_Customize {
 				'choices'     => array(
 					'minimal'  => __( 'Minimal', 'jetpack' ),
 					'expanded' => __( 'Expanded (shows images)', 'jetpack' ),
-					'product'  => __( 'Product grid (for Woo stores)', 'jetpack' ),
+					'product'  => __( 'Product (for WooCommerce stores)', 'jetpack' ),
 				),
 			)
 		);

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -38,7 +38,7 @@ import {
 	isHistoryNavigation,
 	isLoading,
 } from '../store/selectors';
-import { bindCustomizerChanges } from '../lib/customize';
+import { bindCustomizerChanges, isInCustomizer } from '../lib/customize';
 import './search-app.scss';
 
 class SearchApp extends Component {
@@ -273,6 +273,7 @@ class SearchApp extends Component {
 			sort: this.props.sort,
 			postsPerPage: this.props.options.postsPerPage,
 			adminQueryFilter: this.props.options.adminQueryFilter,
+			isInCustomizer: isInCustomizer(),
 		} );
 	};
 

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/api.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/api.js
@@ -11,7 +11,7 @@ import lru from 'tiny-lru/lib/tiny-lru.esm';
  * Internal dependencies
  */
 import { getFilterKeys } from './filters';
-import { MINUTE_IN_MILLISECONDS, SERVER_OBJECT_NAME } from './constants';
+import { MINUTE_IN_MILLISECONDS, RESULT_FORMAT_PRODUCT, SERVER_OBJECT_NAME } from './constants';
 
 let cancelToken = CancelToken.source();
 
@@ -195,6 +195,7 @@ function generateApiQueryString( {
 	sort,
 	postsPerPage = 10,
 	adminQueryFilter,
+	isInCustomizer = false,
 } ) {
 	if ( query === null ) {
 		query = '';
@@ -212,17 +213,21 @@ function generateApiQueryString( {
 	];
 	const highlightFields = [ 'title', 'content', 'comments' ];
 
-	switch ( resultFormat ) {
-		case 'product':
-			fields = fields.concat( [
-				'meta._wc_average_rating.double',
-				'meta._wc_review_count.long',
-				'wc.formatted_price',
-				'wc.formatted_regular_price',
-				'wc.formatted_sale_price',
-				'wc.price',
-				'wc.sale_price',
-			] );
+	/* Fetch additional fields for product results
+	 *
+	 * We always need these in the Customizer too, because the API request is not
+	 * repeated when switching result format
+	 */
+	if ( resultFormat === RESULT_FORMAT_PRODUCT || isInCustomizer ) {
+		fields = fields.concat( [
+			'meta._wc_average_rating.double',
+			'meta._wc_review_count.long',
+			'wc.formatted_price',
+			'wc.formatted_regular_price',
+			'wc.formatted_sale_price',
+			'wc.price',
+			'wc.sale_price',
+		] );
 	}
 
 	return encode(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
There is already a product layout for Woo products in Jetpack Search, but it's currently only possible to trigger it with the query string (`?result_format=product`).

This PR adds 'product' as a configurable option in the Customizer.

<img width="316" alt="Screen Shot 2021-03-04 at 17 17 14" src="https://user-images.githubusercontent.com/17325/109910657-7d969700-7d0d-11eb-92fd-588a7dae6a99.png">


#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. On a site with Jetpack Search enabled, go to the Jetpack Search section of the Customizer (`/wp-admin/customize.php?return=%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack`).
2. Choose 'Product' under 'Result Format'.
3. Go to the front end of your site, perform a search, and ensure you see results in a grid like this:

<img width="757" alt="Screen Shot 2021-03-04 at 17 15 40" src="https://user-images.githubusercontent.com/17325/109910577-5213ac80-7d0d-11eb-9979-771b1b258f31.png">

Woo products should have prices displayed.

#### Proposed changelog entry for your changes:
Jetpack Search: add a product layout for search results from WooCommerce.