### PR TITLE
JITM: move pre-connection JITMs to Jetpack

### DIFF
--- a/projects/packages/jitm/README.md
+++ b/projects/packages/jitm/README.md
@@ -12,3 +12,40 @@ There are 2 main ways to use JITMs:
 ### Usage
 
 Instantiating the JITM Manager will facilitate the display of JITM messages in wp-admin
+
+### Adding Pre-Connection JITMs
+
+Plugins can add pre-connection JITMs uisng the `jetpack_pre_connection_jitms` filter. Each JITM message must be an array and must contain the following keys:
+ * id
+ * message_path
+ * message
+ * description
+ * button_link
+ * button_caption
+
+ If a JITM is missing one of the above keys, the JITM will not be displayed.
+
+ The Jetpack plugin's pre-connection JITMs can be found in the `Jetpack_Pre_Connection_JITMs` class.
+
+ #### Example
+
+
+    function add_preconnection_jitms( $messages ) {
+	    $example_jitm = array(
+			'id'             => 'example-jitm',
+			'message_path'   => '/wp:plugins:admin_notices/',
+			'message'        => __( 'An example message.', 'jetpack' ),
+			'description'    => __( 'An example description.', 'jetpack' ),
+			'button_link'    => 'https://example.com/path',
+			'button_caption' => __( 'Example button text', 'jetpack' ),
+	    );
+
+	    if ( ! is_array( $messages ) ) {
+			return array( $example_jitm );
+	    }
+
+	    return array_merge( $messages, array( $example_jitm ) );
+     }
+
+     add_filter( 'jetpack_pre_connection_jitms', 'add_preconnection_jitms' );
+

--- a/projects/packages/jitm/changelog/update-jitm_pre_connection_filter
+++ b/projects/packages/jitm/changelog/update-jitm_pre_connection_filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+JITM package: add a jetpack_pre_connection_jitms filter.

--- a/projects/packages/jitm/src/class-pre-connection-jitm.php
+++ b/projects/packages/jitm/src/class-pre-connection-jitm.php
@@ -26,7 +26,7 @@ class Pre_Connection_JITM extends JITM {
 		 * This filter allows plugins to add pre-connection JITMs that will be
 		 * displayed by the JITM package.
 		 *
-		 * @since 1.14.1
+		 * @since 9.6.0
 		 *
 		 * @param array An array of pre-connection messages.
 		 */

--- a/projects/packages/jitm/src/class-pre-connection-jitm.php
+++ b/projects/packages/jitm/src/class-pre-connection-jitm.php
@@ -13,58 +13,6 @@ namespace Automattic\Jetpack\JITMS;
 class Pre_Connection_JITM extends JITM {
 
 	/**
-	 * Returns all the pre-connection messages.
-	 */
-	private function get_raw_messages() {
-		$jetpack_setup_url = $this->generate_admin_url(
-			array(
-				'page'    => 'jetpack',
-				'#/setup' => '',
-			)
-		);
-
-		return array(
-			array(
-				'id'             => 'jpsetup-posts',
-				'message_path'   => '/wp:edit-post:admin_notices/',
-				'message'        => __( 'Do you know which of these posts gets the most traffic?', 'jetpack' ),
-				'description'    => __( 'Set up Jetpack to get in-depth stats about your content and visitors.', 'jetpack' ),
-				'button_link'    => $jetpack_setup_url,
-				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
-			),
-			array(
-				'id'             => 'jpsetup-upload',
-				'message_path'   => '/wp:upload:admin_notices/',
-				'message'        => __( 'Do you want lightning-fast images?', 'jetpack' ),
-				'description'    => __( 'Set up Jetpack, enable Site Accelerator, and start serving your images lightning fast, for free.', 'jetpack' ),
-				'button_link'    => $jetpack_setup_url,
-				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
-			),
-			array(
-				'id'             => 'jpsetup-widgets',
-				'message_path'   => '/wp:widgets:admin_notices/',
-				'message'        => __( 'Looking for even more widgets?', 'jetpack' ),
-				'description'    => __( 'Set up Jetpack for great additional widgets that display business contact info and maps, blog stats, and top posts.', 'jetpack' ),
-				'button_link'    => $jetpack_setup_url,
-				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
-			),
-		);
-	}
-
-	/**
-	 * Adds the input query arguments to the admin url.
-	 *
-	 * @param array $args The query arguments.
-	 *
-	 * @return string The admin url.
-	 */
-	private function generate_admin_url( $args ) {
-		$args = wp_parse_args( $args );
-		$url  = add_query_arg( $args, admin_url( 'admin.php' ) );
-		return $url;
-	}
-
-	/**
 	 * Filters and formats the messages for the client-side JS renderer
 	 *
 	 * @param string $message_path Current message path.
@@ -72,16 +20,24 @@ class Pre_Connection_JITM extends JITM {
 	 * @return array Formatted messages.
 	 */
 	private function filter_messages( $message_path ) {
-		$messages = $this->get_raw_messages();
+		/**
+		 * Allows filtering of the pre-connection JITMs.
+		 *
+		 * This filter allows plugins to add pre-connection JITMs that will be
+		 * displayed by the JITM package.
+		 *
+		 * @since 1.14.1
+		 *
+		 * @param array An array of pre-connection messages.
+		 */
+		$messages = apply_filters( 'jetpack_pre_connection_jitms', array() );
+
+		$messages = $this->validate_messages( $messages );
 
 		$formatted_messages = array();
 
 		foreach ( $messages as $message ) {
 			if ( ! preg_match( $message['message_path'], $message_path ) ) {
-				continue;
-			}
-
-			if ( 'jpsetup-posts' === $message['id'] && wp_count_posts()->publish < 5 ) {
 				continue;
 			}
 
@@ -104,6 +60,36 @@ class Pre_Connection_JITM extends JITM {
 		}
 
 		return $formatted_messages;
+	}
+
+	/**
+	 * Validates that each of the messages contains all of the required keys:
+	 *   - id
+	 *   - message_path
+	 *   - message
+	 *   - description
+	 *   - button_link
+	 *   - button_caption
+	 *
+	 * @param array $messages An array of JITM messages.
+	 *
+	 * @return array An array of JITM messages that contain all of the required keys.
+	 */
+	private function validate_messages( $messages ) {
+		if ( ! is_array( $messages ) ) {
+			return array();
+		}
+
+		$expected_keys = array_flip( array( 'id', 'message_path', 'message', 'description', 'button_link', 'button_caption' ) );
+
+		foreach ( $messages as $index => $message ) {
+			if ( count( array_intersect_key( $expected_keys, $message ) ) !== count( $expected_keys ) ) {
+				// Remove any messages that are missing expected keys.
+				unset( $messages[ $index ] );
+			}
+		}
+
+		return $messages;
 	}
 
 	/**

--- a/projects/packages/jitm/tests/php/test_JITM.php
+++ b/projects/packages/jitm/tests/php/test_JITM.php
@@ -24,6 +24,7 @@ class Test_Jetpack_JITM extends TestCase {
 		Functions\when( 'get_current_screen' )->justReturn( new \stdClass() );
 		Functions\when( 'site_url' )->justReturn( 'unit-test' );
 		Functions\when( 'wp_get_environment_type' )->justReturn( '' );
+		Functions\when( 'current_user_can' )->justReturn( true );
 	}
 
 	/**
@@ -35,35 +36,23 @@ class Test_Jetpack_JITM extends TestCase {
 		Monkey\tearDown();
 	}
 
-	public function test_jitm_disabled_by_filter() {
-		Functions\expect( 'apply_filters' )->once()->with(
-			'jetpack_just_in_time_msgs',
-			false
-		)->andReturn( false );
+	public function test_jitm_disabled_by_default() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->with(	'jetpack_just_in_time_msgs', false );
 
 		$jitm = new JITM();
 		$this->assertFalse( $jitm->register() );
 	}
 
-	public function test_jitm_enabled_by_default() {
-		Functions\expect( 'apply_filters' )->once()->with(
-			'jetpack_just_in_time_msgs',
-			false
-		)->andReturn( true );
+	public function test_jitm_enabled_by_filter() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'jetpack_just_in_time_msgs', false )
+			->andReturn( true );
 
 		$jitm = new JITM();
 		$this->assertTrue( $jitm->register() );
-	}
-
-	/**
-	 * Pre-connection JITMs are disabled by default,
-	 * unless a filter is used.
-	 */
-	public function test_pre_connection_jitms_disabled() {
-		add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_false' );
-
-		$jitm = new Pre_Connection_JITM();
-		$this->assertEmpty( $jitm->get_messages( '/wp:edit-post:admin_notices/', '', false ) );
 	}
 
 	/**

--- a/projects/packages/jitm/tests/php/test_pre_connection_jitm.php
+++ b/projects/packages/jitm/tests/php/test_pre_connection_jitm.php
@@ -1,0 +1,233 @@
+<?php  // phpcs:disable
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\JITMS\Pre_Connection_JITM;
+use Brain\Monkey;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class Test_Pre_Connection_JITM extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * An array containing a test pre-connection JITM.
+	 *
+	 * @var array
+	 */
+	private $test_jitms;
+
+	/**
+	 * The Pre_Connection_JITM instance.
+	 *
+	 * @var Pre_Connection_JITM
+	 */
+	private $jitm_instance;
+
+	/**
+	 * Set up.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		Monkey\setUp();
+
+		Functions\when( 'get_current_screen' )->justReturn( new \stdClass() );
+		Functions\when( 'site_url' )->justReturn( 'unit-test' );
+		Functions\when( 'wp_get_environment_type' )->justReturn( '' );
+		Functions\when( 'get_option' )->justReturn( '' );
+		Functions\when( '__' )->returnArg();
+
+		$this->test_jitms = array(
+			array(
+				'id'             => 'test-jitm',
+				'message_path'   => '/wp:plugins:admin_notices/',
+				'message'        => __( 'A test message.', 'jetpack' ),
+				'description'    => __( 'A test description.', 'jetpack' ),
+				'button_link'    => 'a/test/url',
+				'button_caption' => __( 'Test button text', 'jetpack' ),
+			),
+		);
+
+		$this->jitm_instance = new Pre_Connection_JITM();
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+		Monkey\tearDown();
+	}
+
+	/**
+	 * The pre-connection JITMs are disabled by default by the `jetpack_pre_connection_prompt_helpers` filter's default value.
+	 */
+	public function test_get_messages_prompt_helpers_default() {
+		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
+			->once()
+			->with( false );
+
+		Functions\expect( 'current_user_can' )
+			->atMost()
+			->once()
+			->andReturn( true );
+
+		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
+			->atMost()
+			->once()
+			->with( array() )
+			->andReturn( $this->test_jitms );
+
+		$this->assertEmpty( $this->jitm_instance->get_messages( '/wp:plugins:admin_notices/', '', false ) );
+	}
+
+	/**
+	 * The pre-connection JITMs are disabled when the current user does not have the 'install_plugins' capability.
+	 */
+	public function test_get_messages_user_cannot_install_plugins() {
+		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
+			->atMost()
+			->once()
+			->with( false )
+			->andReturns( true );
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->andReturn( false );
+
+		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
+			->atMost()
+			->once()
+			->with( array() )
+			->andReturn( $this->test_jitms );
+
+		$this->assertEmpty( $this->jitm_instance->get_messages( '/wp:plugins:admin_notices/', '', false ) );
+	}
+
+	/**
+	 * The pre-connection JITMs are empty by default. The default value of the 'jetpack_pre_connection_jitms' filter is 
+	 * an empty array.
+	 */
+	public function test_get_messages_jitms_filter_default() {
+		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
+			->atMost()
+			->once()
+			->with( false )
+			->andReturns( true );
+
+		Functions\expect( 'current_user_can' )
+			->atMost()
+			->once()
+			->andReturn( true );
+
+		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
+			->once()
+			->with( array() );
+
+		$this->assertEmpty( $this->jitm_instance->get_messages( '/wp:plugins:admin_notices/', '', false ) );
+	}
+
+	/**
+	 * The Pre_Connection_JITM::get_messages method returns an empty array when the the 'jetpack_pre_connection_jitms' filter
+	 * returns anything other than an array.
+	 */
+	public function test_get_messages_filter_returns_string() {
+		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
+			->atMost()
+			->once()
+			->with( false )
+			->andReturns( true );
+
+		Functions\expect( 'current_user_can' )
+			->atMost()
+			->once()
+			->andReturn( true );
+
+		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
+			->once()
+			->with( array() )
+			->andReturn( 'a string intead of an array' );
+
+		$this->assertEmpty( $this->jitm_instance->get_messages( '/wp:plugins:admin_notices/', '', false ) );
+	}
+
+	/**
+	 * The pre-connection JITMs are added using the `jetpack_pre_connection_jitms` filter.
+	 */
+	public function test_get_messages_return_message() {
+		$this->set_prompt_helpers_and_user_cap_conditions();
+
+		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
+			->once()
+			->with( array() )
+			->andReturn( $this->test_jitms );
+
+		$messages = $this->jitm_instance->get_messages( '/wp:plugins:admin_notices/', '', false );
+		$this->assertSame( $this->test_jitms[0]['id'], $messages[0]->id );
+	}
+
+	/**
+	 * A pre-connection JITM is only displayed if its message_path value matches the message path
+	 * passed to Pre_Connection_JITM::get_messages. In this test, the test JITM's path does not match the
+	 * tested path.
+	 */
+	public function test_get_messages_unmatched_message_path() {
+		$this->set_prompt_helpers_and_user_cap_conditions();
+
+		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
+			->once()
+			->with( array() )
+			->andReturn( $this->test_jitms );
+
+		$this->assertEmpty( $this->jitm_instance->get_messages( '/wp:edit-comments:admin_notices/', '', false ) );
+	}
+
+	/**
+	 * The pre-connection JITM is not displayed if the message array is missing a required key. In this test, the JITM is
+	 * missing the message_path key.
+	 */
+	public function test_get_messages_missing_key() {
+		$this->set_prompt_helpers_and_user_cap_conditions();
+
+		unset( $this->test_jitms[0]['message_path'] );
+
+		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
+			->once()
+			->with( array() )
+			->andReturn( $this->test_jitms );
+
+		$this->assertEmpty( $this->jitm_instance->get_messages( '/wp:plugins:admin_notices/', '', false ) );
+	}
+
+	/**
+	 * A pre-connection JITM is displayed if it has unexpected keys.
+	 */
+	public function test_get_messages_extra_key() {
+		$this->set_prompt_helpers_and_user_cap_conditions();
+
+		$this->test_jitms[0]['extra_key'] = 'extra jitm key';
+
+		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
+			->once()
+			->with( array() )
+			->andReturn( $this->test_jitms );
+
+		$messages = $this->jitm_instance->get_messages( '/wp:plugins:admin_notices/', '', false );
+		$this->assertSame( $this->test_jitms[0]['id'], $messages[0]->id );
+	}
+
+	private function set_prompt_helpers_and_user_cap_conditions() {
+		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
+			->once()
+			->with( false )
+			->andReturns( true );
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->andReturn( true );
+	}
+}

--- a/projects/plugins/jetpack/changelog/update-jitm_pre_connection_filter
+++ b/projects/plugins/jetpack/changelog/update-jitm_pre_connection_filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+JITMs: add pre-connection JITMs using the jetpack_pre_connection_jitms filter.

--- a/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
+++ b/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Jetpack's Pre-Connection JITMs class.
+ *
+ * @package jetpack
+ */
+
+/**
+ * Jetpack's Pre-Connection JITMs. These can be displayed with the JITM package.
+ */
+class Jetpack_Pre_Connection_JITMs {
+
+	/**
+	 * Returns all the pre-connection messages.
+	 *
+	 * @return array An array containing the pre-connection JITM messages.
+	 */
+	private function get_raw_messages() {
+		$jetpack_setup_url = $this->generate_admin_url(
+			array(
+				'page'    => 'jetpack',
+				'#/setup' => '',
+			)
+		);
+
+		$messages = array(
+			array(
+				'id'             => 'jpsetup-upload',
+				'message_path'   => '/wp:upload:admin_notices/',
+				'message'        => __( 'Do you want lightning-fast images?', 'jetpack' ),
+				'description'    => __( 'Set up Jetpack, enable Site Accelerator, and start serving your images lightning fast, for free.', 'jetpack' ),
+				'button_link'    => $jetpack_setup_url,
+				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
+			),
+			array(
+				'id'             => 'jpsetup-widgets',
+				'message_path'   => '/wp:widgets:admin_notices/',
+				'message'        => __( 'Looking for even more widgets?', 'jetpack' ),
+				'description'    => __( 'Set up Jetpack for great additional widgets that display business contact info and maps, blog stats, and top posts.', 'jetpack' ),
+				'button_link'    => $jetpack_setup_url,
+				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
+			),
+		);
+
+		if ( wp_count_posts()->publish >= 5 ) {
+			$messages[] = array(
+				'id'             => 'jpsetup-posts',
+				'message_path'   => '/wp:edit-post:admin_notices/',
+				'message'        => __( 'Do you know which of these posts gets the most traffic?', 'jetpack' ),
+				'description'    => __( 'Set up Jetpack to get in-depth stats about your content and visitors.', 'jetpack' ),
+				'button_link'    => $jetpack_setup_url,
+				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
+			);
+		}
+
+		return $messages;
+	}
+
+	/**
+	 * Adds the input query arguments to the admin url.
+	 *
+	 * @param array $args The query arguments.
+	 *
+	 * @return string The admin url.
+	 */
+	private function generate_admin_url( $args ) {
+		$url = add_query_arg( $args, admin_url( 'admin.php' ) );
+		return $url;
+	}
+
+	/**
+	 * Add the Jetpack pre-connection JITMs to the list of pre-connection JITM messages.
+	 *
+	 * @param array $pre_connection_messages An array of pre-connection JITMs.
+	 *
+	 * @return array The array of pre-connection JITMs.
+	 */
+	public function add_pre_connection_jitms( $pre_connection_messages ) {
+		$jetpack_messages = $this->get_raw_messages();
+
+		if ( ! is_array( $pre_connection_messages ) ) {
+			// The incoming messages aren't an array, so just return Jetpack's messages.
+			return $jetpack_messages;
+		}
+
+		return array_merge( $pre_connection_messages, $jetpack_messages );
+	}
+}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -727,6 +727,10 @@ class Jetpack {
 
 		add_filter( 'jetpack_just_in_time_msg_cache', '__return_true', 9 );
 
+		require_once JETPACK__PLUGIN_DIR . 'class-jetpack-pre-connection-jitms.php';
+		$jetpack_jitm_messages = ( new Jetpack_Pre_Connection_JITMs() );
+		add_filter( 'jetpack_pre_connection_jitms', array( $jetpack_jitm_messages, 'add_pre_connection_jitms' ) );
+
 		/*
 		 * If enabled, point edit post, page, and comment links to Calypso instead of WP-Admin.
 		 * We should make sure to only do this for front end links.

--- a/projects/plugins/jetpack/tests/php/general/test-class-jetpack-pre-connection-jitms.php
+++ b/projects/plugins/jetpack/tests/php/general/test-class-jetpack-pre-connection-jitms.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Contains the unit tests for the Jetpack_Pre_Connection_JITMs class.
+ *
+ * @package jetpack
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __FILE__ ) . '/../../../class-jetpack-pre-connection-jitms.php';
+
+/**
+ * Class WP_Test_Jetpack_Pre_Connection_JITMs.
+ */
+class WP_Test_Jetpack_Pre_Connection_JITMs extends TestCase {
+
+	/**
+	 * Tests the Jetpack_Pre_Connection_JITMs::add_pre_connection_jitms method with different
+	 * published post counts.
+	 *
+	 * @param int $posts_count          The number of published posts.
+	 * @param int $expected_jitms_count The expected number of JITMs that should be returned by
+	 *                                  Jetpack_Pre_Connection_JITMs::add_pre_connection_jitms.
+	 *
+	 * @dataProvider data_provider_test_add_pre_connection_jitms
+	 */
+	public function test_add_pre_connection_jitms( $posts_count, $expected_jitms_count ) {
+		add_filter(
+			'wp_count_posts',
+			function ( $counts ) use ( $posts_count ) {
+				$counts->publish = $posts_count;
+				return $counts;
+			}
+		);
+
+		$jitms    = new Jetpack_Pre_Connection_JITMs();
+		$messages = $jitms->add_pre_connection_jitms( array() );
+		$this->assertCount( $expected_jitms_count, $messages );
+	}
+
+	/**
+	 * Data provider for the test_add_pre_connection_jitms test method.
+	 *
+	 * Jetpack has three pre-connection JITMs. One JITM, jpsetup-posts, is only displayed
+	 * when the number of published posts is greater than or equal to five.
+	 *
+	 * @return array An array of test data.
+	 */
+	public function data_provider_test_add_pre_connection_jitms() {
+		return array(
+			'0 posts' => array( 0, 2 ),
+			'4 posts' => array( 4, 2 ),
+			'5 posts' => array( 5, 3 ),
+			'6 posts' => array( 6, 3 ),
+		);
+	}
+
+	/**
+	 * Verify that the pre-connection JITM button link ends with the expected query.
+	 */
+	public function test_add_pre_connection_jitms_button_link() {
+		$jitms    = new Jetpack_Pre_Connection_JITMs();
+		$messages = $jitms->add_pre_connection_jitms( array() );
+
+		$query = 'admin.php?page=jetpack&#/setup';
+
+		// Verify that the `jpsetup-upload` JITM is in the list of JITMs.
+		$index = array_search( 'jpsetup-upload', array_column( $messages, 'id' ), true );
+		$this->assertNotFalse( $index );
+
+		$this->assertSame( $query, substr( $messages[ $index ]['button_link'], -strlen( $query ) ) );
+	}
+
+	/**
+	 * Tests the add_pre_connection_jitms method when the input to the method is
+	 * an array containing a single JITM. The three Jetpack pre-connection JITMs
+	 * and the additional test JITM should be returned.
+	 */
+	public function test_add_pre_connection_jitms_existing_jitms() {
+		$test_jitm = array(
+			array(
+				'id'             => 'test-jitm',
+				'message_path'   => '/wp:plugins:admin_notices/',
+				'message'        => __( 'A test message.', 'jetpack' ),
+				'description'    => __( 'A test description.', 'jetpack' ),
+				'button_link'    => 'a/test/url',
+				'button_caption' => __( 'Test button text', 'jetpack' ),
+			),
+		);
+
+		add_filter(
+			'wp_count_posts',
+			function ( $counts ) {
+				$counts->publish = 7;
+				return $counts;
+			}
+		);
+
+		$jitms    = new Jetpack_Pre_Connection_JITMs();
+		$messages = $jitms->add_pre_connection_jitms( $test_jitm );
+
+		$this->assertCount( 4, $messages );
+	}
+
+	/**
+	 * Tests the add_pre_connection_jitms method when the input to the method is
+	 * not an array. The three Jetpack pre-connection JITMs should
+	 * be returned.
+	 */
+	public function test_add_pre_connection_jitms_not_an_array() {
+		add_filter(
+			'wp_count_posts',
+			function ( $counts ) {
+				$counts->publish = 7;
+				return $counts;
+			}
+		);
+
+		$jitms    = new Jetpack_Pre_Connection_JITMs();
+		$messages = $jitms->add_pre_connection_jitms( 'a test string' );
+
+		$this->assertCount( 3, $messages );
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The pre-connection JITMs should be shown only on sites that have Jetpack active. Move these JITMs from the JITM package to Jetpack.
* Add a filter, `jetpack_pre_connection_jitms`, which Jetpack will use to add its pre-connection JITMs. Other plugins can also use this filter to add pre-connection JITMs.

These changes help make the JITM package independent of Jetpack.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
##### Test the Jetpack Plugin's Pre-Connection JITMs
1. Install and activate this branch. Do not connect Jetpack.
2. Enable pre-connection settings using the `jetpack_pre_connection_prompt_helpers` filter:
    `add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );`
3. In wp-admin, navigate to `Media`. You should see a JITM: `Do you want lightning-fast images?`.
4. In wp-admin, navigate to `Appearance -> Widgets`. You should see a JITM: `Looking for even more widgets?`.
5. In wp-admin, navigate to `Posts`.
6. If you do not have at least five published posts, you should not see a JITM. Add at least five posts.
7. If you have at least five published posts, you should see a JITM: `Do you know which of theses posts gets the most traffic?`.

##### Test the Pre-Connection JITM Filter
1. Install and activate this branch. Do not connect Jetpack.
2. Add a pre-connection JITM using the `jetpack_pre_connection_jitms` filter For example, you can use the Code Snippets plugin, and add the following code to add a JITM to the plugins page:
```
function add_preconnection_jitms( $messages ) {
    $example_jitm = array(
        'id'             => 'example-jitm',
        'message_path'   => '/wp:plugins:admin_notices/',
	'message'        => __( 'An example message.', 'jetpack' ),
	'description'    => __( 'An example description.', 'jetpack' ),
	'button_link'    => 'https://example.com/path',
	'button_caption' => __( 'Example button text', 'jetpack' ),
    );

    if ( ! is_array( $messages ) ) {
        return array( $example_jitm );
    }

    return array_merge( $messages, array( $example_jitm ) );
}
add_filter( 'jetpack_pre_connection_jitms', 'add_preconnection_jitms' );
```

3. Navigate to the page that will display the JITM (the plugins page in the above example). Verify that the JITM is displayed.

##### Test the Post-Connection JITMS
The post-connection JITMs should not be affected by this PR, so verify that that display as expected.
1. Install and activate this branch. Connect Jetpack.
2. In wp-admin, navigate to `Jetpack`. You should see a JITM (assuming that you haven't previously dismissed it): `Give your site a speed boost`.

#### Proposed changelog entry for your changes:
tbd
