### PR TITLE
Fix Jetpack slug for Nav Unification

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -678,7 +678,7 @@ class Admin_Menu {
 
 		// TODO: Replace with proper SVG data url.
 		$jetpack_icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 32 32' %3E%3Cpath fill='%23a0a5aa' d='M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z'%3E%3C/path%3E%3Cpolygon fill='%23fff' points='15,19 7,19 15,3 '%3E%3C/polygon%3E%3Cpolygon fill='%23fff' points='17,29 17,13 25,13 '%3E%3C/polygon%3E%3C/svg%3E";
-		$jetpack_slug = 'https://wordpress.com/activity-log/' . $this->domain;
+		$jetpack_slug = 'jetpack';
 
 		$this->add_admin_menu_separator( $position++, 'manage_options' );
 		add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', $jetpack_slug, null, $jetpack_icon, $position );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -512,7 +512,7 @@ class Admin_Menu {
 		add_filter(
 			'parent_file',
 			function ( $parent_file ) use ( $menu_slug ) {
-				return 'jetpack' === $parent_file ? $menu_slug : $parent_file;
+				return 'plugins.php' === $parent_file ? $menu_slug : $parent_file;
 			}
 		);
 	}
@@ -678,7 +678,7 @@ class Admin_Menu {
 
 		// TODO: Replace with proper SVG data url.
 		$jetpack_icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 32 32' %3E%3Cpath fill='%23a0a5aa' d='M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z'%3E%3C/path%3E%3Cpolygon fill='%23fff' points='15,19 7,19 15,3 '%3E%3C/polygon%3E%3Cpolygon fill='%23fff' points='17,29 17,13 25,13 '%3E%3C/polygon%3E%3C/svg%3E";
-		$jetpack_slug = 'jetpack';
+		$jetpack_slug = 'https://wordpress.com/activity-log/' . $this->domain;
 
 		$this->add_admin_menu_separator( $position++, 'manage_options' );
 		add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', $jetpack_slug, null, $jetpack_icon, $position );


### PR DESCRIPTION
Note: this bug is fixed on Atomic via 628-gh-Automattic/wpcomsh but we need this follow up in JP 9.6 to sort things correctly.

Prior to application of 628-gh-Automattic/wpcomsh on a Jetpack site (in Atomic) going to /wp-admin/admin.php?page=jetpack#/dashboard will cause the **Plugins** menu item to be highlighted. This is because we have a bug in `add_plugins_menu` which uses an incorrect slug: 

```diff
diff --git a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
index 0231813e7..891c13b4e 100644
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -512,7 +512,7 @@ class Admin_Menu {
                add_filter(
                        'parent_file',
                        function ( $parent_file ) use ( $menu_slug ) {
-                               return 'jetpack' === $parent_file ? $menu_slug : $parent_file;
+                               return 'plugins.php' === $parent_file ? $menu_slug : $parent_file;
                        }
                );
        }
```

It should check against `plugins.php` not `jetpack`. This is why `Plugins` get selected when on a Jetpack sub page.

This PR will provide the long term fix. 628-gh-Automattic/wpcomsh provides a hotfix in the meantime.

Addresses https://github.com/Automattic/wp-calypso/issues/50713


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes so that `Jetpack` parent is selected when a Jetpack-related menu is clicked. Previously `Plugins` would be selected due to a bug.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No


#### Testing instructions:

* Setup your local JP site to mimic an Atomic env. Either follow instructions in Automattic/wpcomsh#quick-start or use A8c WP Env.
* **Make sure** that if you have WPCOMSH active then you have **commented out** the hotfix added in 628-gh-Automattic/wpcomsh.
* Go to `wp-admin/admin.php?page=jetpack#/dashboard`. 
* The `Jetpack` parent menu item should be expanded and `Dashboard` selected. 
* Repeat for all JP items that point to WPAdmin.
* Check that Nav functions in same way in Calypso equiv.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fixes bug where clicking on Jetpack-related menu items would cause `Plugins` top level menu item to be expanded and not `Jetpack`.