### PR TITLE
Search: Remove lodash `difference` usage

### DIFF
--- a/projects/plugins/jetpack/modules/search/instant-search/lib/filters.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/filters.js
@@ -1,8 +1,3 @@
-// NOTE: We only import the difference package here for to reduced bundle size.
-//       Do not import the entire lodash library!
-// eslint-disable-next-line lodash/import-scope
-import difference from 'lodash/difference';
-
 /**
  * Internal dependencies
  */
@@ -68,7 +63,8 @@ export function getSelectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?
  * @returns {string[]} filterKeys
  */
 export function getUnselectableFilterKeys( widgets = window[ SERVER_OBJECT_NAME ]?.widgets ) {
-	return difference( getFilterKeys(), getSelectableFilterKeys( widgets ) );
+	const selectable = getSelectableFilterKeys( widgets );
+	return getFilterKeys().filter( key => ! selectable.includes( key ) );
 }
 
 /**


### PR DESCRIPTION
`_.difference` is only used in one place, and is easy enough to replace with standard ES. This PR does just that.

Between this PR and #19001 (which removes the only usage of `_.pick`), the Instant Search bundle size should go down by about 8KB (2 KB gzipped).

#### Changes proposed in this Pull Request:
* Replace `_.difference` with standard ES2015

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
I was unable to test this locally, due to some ongoing issues with my local setup, but it should be sufficient to ensure that filter functionality in search continues to work correctly.

#### Proposed changelog entry for your changes:
No need for a changelog entry; this should be a seamless under-the-hood change.
