### PR TITLE
Fixes sidebar width in dialogue and notices components.

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -38,8 +38,13 @@
 
 @media (min-width: 961px) {
 	.auto-fold .interface-interface-skeleton,
-	.auto-fold .edit-post-layout .components-editor-notices__snackbar {
+	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
+	.jp-dialogue-modern-full__container {
 		left: 272px;
+	}
+
+	.global-notices {
+		max-width: calc( 100% - 48px - 272px );
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/50695

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
I scanned the codebase for `160px` which is the core sidebar width and found the following
https://github.com/Automattic/jetpack/blob/e13487d0dbbe4c743739b6f1a3e37c143a8c2614/projects/plugins/jetpack/_inc/client/components/global-notices/style.scss#L30
https://github.com/Automattic/jetpack/blob/e13487d0dbbe4c743739b6f1a3e37c143a8c2614/projects/plugins/jetpack/_inc/client/components/jetpack-dialogue-modern/style.scss#L16
which are changed to `272px` for nav-unification in this PR

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- I haven't found how to invoke this components

Before | 
-------|
![image](https://user-images.githubusercontent.com/12430020/110146923-ca4ca180-7de3-11eb-9145-b5d0524f0d78.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
*  Fixes wrong navbar width in jetpack modal / notices