### PR TITLE
Recommendations: when enabling Photon, also enable Tiled Galleries

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -80,7 +80,14 @@ export const mapDispatchToProps = ( dispatch, featureSlug ) => {
 		case 'site-accelerator':
 			return {
 				activateFeature: () => {
-					return dispatch( updateSettings( { photon: true, 'photon-cdn': true } ) );
+					return dispatch(
+						updateSettings( {
+							photon: true,
+							'photon-cdn': true,
+							tiled_galleries: true,
+							'tiled-gallery': true,
+						} )
+					);
 				},
 			};
 		case 'woocommerce':


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
﻿
The existing Site Accelerator toggle under Jetpack > Settings > Performance acts as a "multi-toggle". When you toggle it, it toggles the 2 child settings below it: Photon and Asset CDN (aka photon-cdn).

Behind the scenes, that toggle also controls 2 additional settings:

- It enables Tiled Galleries, the module that adds gallery type settings to the classic gallery modal.
- It enables the option that makes all existing classic galleries use the Tiled Gallery style by default (that option is visible under Settings > Media in wp-admin).

We built things this way before the block editor, and before we had a Tiled Gallery block that would be available and function regardless of your Photon settings. For "classic" tiled galleries (the ones that can be created via the classic editor or a classic block), the images rely on Photon to be resized on the fly. We consequently opted to enable the Tiled Galleries module as soon as you would turn on the Photon module, since the latter gave you the option to use tiled galleries.
Admittedly, things got a bit more complicated when the block editor and the Tiled Gallery block were introduced, but the basic idea remains: when you enable the Photon module, you should get access to the option to pick different gallery types when creating or editing galleries. For more details around this behaviour, you can check #7576.

This commit takes that existing behaviour, and brings it to the new Site Accelerator toggle we added in the Recommendations tab in #18437. When you enable Site Accelerator there, you'll also enable Tiled Galleries behind the scenes.

#### Jetpack product discussion

* N/A
#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a brand new site.
* Connect it to WordPress.com.
* When you land back on wp-admin, head to the old Modules page (see "Modules" link at the bottom of the Jetpack dashboard).
* Confirm that Photon, Asset CDN, and Tiled Galleries are off.
* Head to Jetpack > Recommendations.
* There, follow the prompts until you land on the option to enable Site Accelerator.
* Enable Site Accelerator.
* Once settings are saved, go to the old Modules page once again: all 3 modules should now be active.
* Go to Settings > Media: the Tiled Gallery option should be checked.

#### Proposed changelog entry for your changes:

* Recommendations: when enabling Site Accelerator, also enable Tiled Galleries
