### PR TITLE
Switch to photon 4.0.0

### DIFF
--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -123,7 +123,7 @@
 		"markdown-it": "12.0.4",
 		"node-sass": "4.14.1",
 		"page": "1.7.1",
-		"photon": "2.1.0",
+		"photon": "4.0.0",
 		"plugin-error": "1.0.1",
 		"postcss-custom-properties": "10.0.0",
 		"preact": "10.5.7",

--- a/projects/plugins/jetpack/yarn.lock
+++ b/projects/plugins/jetpack/yarn.lock
@@ -6300,7 +6300,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-crc32@0.2.2:
+crc32@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/crc32/-/crc32-0.2.2.tgz#7ad220d6ffdcd119f9fc127a7772cacea390a4ba"
   integrity sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=
@@ -6734,7 +6734,7 @@ debug@4.2.0:
   dependencies:
     ms "2.1.2"
 
-debug@4.3.1, debug@^4.3.1:
+debug@4.3.1, debug@^4.0.0, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -13060,15 +13060,15 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-photon@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/photon/-/photon-2.1.0.tgz#a8d9aecdc91f8b9b267f3782a15892d5e9c4eb20"
-  integrity sha512-ouotmk51C1Ve4K0w3/t24qePIYbB8wMIc3fgzOyo5RaLUygcaQJQUjf2YimmN5AXl8UGnxP13cO2I3EYMjgR/w==
+photon@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/photon/-/photon-4.0.0.tgz#471a80884009a5fd978df1e9c8b15dcf2cbe1f8f"
+  integrity sha512-RD3buB17jW9B+OOPjIqv/cE9imCyR+WJ4ALWtb1Q1mVg8OfYnHAyvdVTxa/+bZFNI2FWaQBKry3i1mItmW3H3A==
   dependencies:
-    crc32 "0.2.2"
-    debug "^3.2.6"
-    seed-random "2.2.0"
-    url "^0.11.0"
+    "@babel/runtime" "^7.12.5"
+    crc32 "^0.2.2"
+    debug "^4.0.0"
+    seed-random "^2.2.0"
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
@@ -15153,7 +15153,7 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
-seed-random@2.2.0:
+seed-random@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/seed-random/-/seed-random-2.2.0.tgz#2a9b19e250a817099231a5b99a4daf80b7fbed54"
   integrity sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=


### PR DESCRIPTION
This PR updates the version of `photon` in use in Jetpack, so that it no longer depends on the deprecated `url` Node module.

#### Changes proposed in this Pull Request:
* Update `photon` package to 4.0.0

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
**Important note:** I haven't been able to test this interactively myself due to ongoing local setup issues, so please be thorough in your testing. There weren't any issues with building or with any unit tests, however.

`photon` is currently used in Instant Search, Tiled Gallery and "at-a-glance", which will all need to be tested. It may be a good idea to test with IE 11 specifically, which makes use of a URL polyfill.

#### Proposed changelog entry for your changes:
No need for a changelog entry; this should be a seamless under-the-hood change.
