### PR TITLE
Autoloader: Fix Uninstallation Fatal

### DIFF
--- a/projects/packages/autoloader/src/class-container.php
+++ b/projects/packages/autoloader/src/class-container.php
@@ -118,6 +118,7 @@ class Container {
 
 		// Register any classes that we will use elsewhere.
 		require_once __DIR__ . '/class-version-loader.php';
+		require_once __DIR__ . '/class-shutdown-handler.php';
 	}
 
 	/**

--- a/projects/packages/autoloader/src/class-shutdown-handler.php
+++ b/projects/packages/autoloader/src/class-shutdown-handler.php
@@ -1,0 +1,75 @@
+<?php
+/* HEADER */ // phpcs:ignore
+
+/**
+ * This class handles the shutdown of the autoloader.
+ */
+class Shutdown_Handler {
+
+	/**
+	 * The Plugins_Handler instance.
+	 *
+	 * @var Plugins_Handler
+	 */
+	private $plugins_handler;
+
+	/**
+	 * The plugins cached by this autoloader.
+	 *
+	 * @var string[]
+	 */
+	private $cached_plugins;
+
+	/**
+	 * Indicates whether or not this autoloader was included by another.
+	 *
+	 * @var bool
+	 */
+	private $was_included_by_autoloader;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Plugins_Handler $plugins_handler The Plugins_Handler instance to use.
+	 * @param string[]        $cached_plugins The plugins cached by the autoloaer.
+	 * @param bool            $was_included_by_autoloader Indicates whether or not the autoloader was included by another.
+	 */
+	public function __construct( $plugins_handler, $cached_plugins, $was_included_by_autoloader ) {
+		$this->plugins_handler            = $plugins_handler;
+		$this->cached_plugins             = $cached_plugins;
+		$this->was_included_by_autoloader = $was_included_by_autoloader;
+	}
+
+	/**
+	 * Handles the shutdown of the autoloader.
+	 */
+	public function __invoke() {
+		// Don't save a broken cache if an error happens during some plugin's initialization.
+		if ( ! did_action( 'plugins_loaded' ) ) {
+			// Ensure that the cache is emptied to prevent consecutive failures if the cache is to blame.
+			if ( ! empty( $this->cached_plugins ) ) {
+				$this->plugins_handler->cache_plugins( array() );
+			}
+
+			return;
+		}
+
+		// Load the active plugins fresh since the list we pulled earlier might not contain
+		// plugins that were activated but did not reset the autoloader. This happens
+		// when a plugin is in the cache but not "active" when the autoloader loads.
+		// We also want to make sure that plugins which are deactivating are not
+		// considered "active" so that they will be removed from the cache now.
+		$active_plugins = $this->plugins_handler->get_active_plugins( false, ! $this->was_included_by_autoloader );
+
+		// The paths should be sorted for easy comparisons with those loaded from the cache.
+		// Note we don't need to sort the cached entries because they're already sorted.
+		sort( $active_plugins );
+
+		// We don't want to waste time saving a cache that hasn't changed.
+		if ( $this->cached_plugins === $active_plugins ) {
+			return;
+		}
+
+		$this->plugins_handler->cache_plugins( $active_plugins );
+	}
+}

--- a/projects/packages/autoloader/src/class-shutdown-handler.php
+++ b/projects/packages/autoloader/src/class-shutdown-handler.php
@@ -59,7 +59,16 @@ class Shutdown_Handler {
 		// when a plugin is in the cache but not "active" when the autoloader loads.
 		// We also want to make sure that plugins which are deactivating are not
 		// considered "active" so that they will be removed from the cache now.
-		$active_plugins = $this->plugins_handler->get_active_plugins( false, ! $this->was_included_by_autoloader );
+		try {
+			$active_plugins = $this->plugins_handler->get_active_plugins( false, ! $this->was_included_by_autoloader );
+		} catch ( \Exception $ex ) {
+			// When the package is deleted before shutdown it will throw an exception.
+			// In the event this happens we should erase the cache.
+			if ( ! empty( $this->cached_plugins ) ) {
+				$this->plugins_handler->cache_plugins( array() );
+			}
+			return;
+		}
 
 		// The paths should be sorted for easy comparisons with those loaded from the cache.
 		// Note we don't need to sort the cached entries because they're already sorted.

--- a/projects/packages/autoloader/tests/php/tests/unit/ShutdownHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/ShutdownHandlerTest.php
@@ -80,4 +80,22 @@ class ShutdownHandlerTest extends TestCase {
 
 		( new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false ) )();
 	}
+
+	/**
+	 * Tests that expected exceptions thrown during shutdown aren't propogated.
+	 */
+	public function test_shutdown_handles_exceptions() {
+		$this->plugins_handler->expects( $this->once() )
+			->method( 'get_active_plugins' )
+			->with( false, true )
+			->willThrowException( new \RuntimeException() );
+		$this->plugins_handler->expects( $this->once() )
+			->method( 'cache_plugins' )
+			->with( array() );
+
+		// Mark that the plugins have been loaded so that we can perform a safe shutdown.
+		do_action( 'plugins_loaded' );
+
+		( new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false ) )();
+	}
 }

--- a/projects/packages/autoloader/tests/php/tests/unit/ShutdownHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/ShutdownHandlerTest.php
@@ -1,0 +1,83 @@
+<?php // phpcs:ignore WordPress.Files.FileName
+/**
+ * Shutdown handler test suite.
+ *
+ * @package automattic/jetpack-autoloader
+ */
+
+// We live in the namespace of the test autoloader to avoid many use statements.
+namespace Automattic\Jetpack\Autoloader\jpCurrent;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test suite class for the Shutdown_Handler.
+ */
+class ShutdownHandlerTest extends TestCase {
+
+	/**
+	 * The mock Plugins_Handler instance.
+	 *
+	 * @var Plugins_Handler|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $plugins_handler;
+
+	/**
+	 * Setup runs before each test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		$this->plugins_handler = $this->getMockBuilder( Plugins_Handler::class )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	/**
+	 * Tests that the shutdown handler caches the active plugins.
+	 */
+	public function test_shutdown_caches_active_plugins() {
+		$this->plugins_handler->expects( $this->once() )
+			->method( 'get_active_plugins' )
+			->with( false, true )
+			->willReturn( array( TEST_PLUGIN_DIR ) );
+		$this->plugins_handler->expects( $this->once() )
+			->method( 'cache_plugins' )
+			->with( array( TEST_PLUGIN_DIR ) );
+
+		// Mark that the plugins have been loaded so that we can perform a safe shutdown.
+		do_action( 'plugins_loaded' );
+
+		( new Shutdown_Handler( $this->plugins_handler, array(), false ) )();
+	}
+
+	/**
+	 * Tests that the shutdown handler does not update the cache if it has not changed.
+	 */
+	public function test_shutdown_does_not_save_unchanged_cache() {
+		$this->plugins_handler->expects( $this->once() )
+			->method( 'get_active_plugins' )
+			->with( false, true )
+			->willReturn( array( TEST_PLUGIN_DIR ) );
+		$this->plugins_handler->expects( $this->never() )
+			->method( 'cache_plugins' );
+
+		// Mark that the plugins have been loaded so that we can perform a safe shutdown.
+		do_action( 'plugins_loaded' );
+
+		( new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false ) )();
+	}
+
+	/**
+	 * Tests that shutting down early empties the cache.
+	 */
+	public function test_shutdown_early_empties_cache() {
+		$this->plugins_handler->expects( $this->once() )
+			->method( 'cache_plugins' )
+			->with( array() );
+
+		// Do NOT run plugins_loaded so that the shutdown can be considered early.
+
+		( new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false ) )();
+	}
+}

--- a/projects/packages/autoloader/tests/php/tests/unit/ShutdownHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/ShutdownHandlerTest.php
@@ -48,7 +48,8 @@ class ShutdownHandlerTest extends TestCase {
 		// Mark that the plugins have been loaded so that we can perform a safe shutdown.
 		do_action( 'plugins_loaded' );
 
-		( new Shutdown_Handler( $this->plugins_handler, array(), false ) )();
+		$handler = new Shutdown_Handler( $this->plugins_handler, array(), false );
+		$handler();
 	}
 
 	/**
@@ -65,7 +66,8 @@ class ShutdownHandlerTest extends TestCase {
 		// Mark that the plugins have been loaded so that we can perform a safe shutdown.
 		do_action( 'plugins_loaded' );
 
-		( new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false ) )();
+		$handler = new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false );
+		$handler();
 	}
 
 	/**
@@ -78,7 +80,8 @@ class ShutdownHandlerTest extends TestCase {
 
 		// Do NOT run plugins_loaded so that the shutdown can be considered early.
 
-		( new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false ) )();
+		$handler = new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false );
+		$handler();
 	}
 
 	/**
@@ -96,6 +99,7 @@ class ShutdownHandlerTest extends TestCase {
 		// Mark that the plugins have been loaded so that we can perform a safe shutdown.
 		do_action( 'plugins_loaded' );
 
-		( new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false ) )();
+		$handler = new Shutdown_Handler( $this->plugins_handler, array( TEST_PLUGIN_DIR ), false );
+		$handler();
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18996

#### Changes proposed in this Pull Request:

When `Plugin_Locator::find_current_plugin()` is unable to find the plugin containing the autoloader it throws an exception. Normally this should never happen but during uninstallation a plugin might be deleted in the same request it is deactivated. When this happens it won't be able to locate the plugin with the autoloader and will throw the exception. This PR takes the safest approach and clears the autoloader cache so that the next request can rebuild it (if necessary).

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Just noting here that I've added a test case covering the bug.

* Install Jetpack `wp plugin install jetpack --activate`
* Uninstall Jetpack `wp plugin delete jetpack`
* Verify no error is present in console.

#### Proposed changelog entry for your changes:
* Autoloader: Fix uninstallation fatal.
