### PR TITLE
Fix instagram infinite loop bug

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/use-instagram-gallery.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/use-instagram-gallery.js
@@ -71,7 +71,8 @@ export default function useInstagramGallery( {
 				setAttributes( { accessToken: undefined, instagramUser: undefined } );
 				setSelectedAccount( undefined );
 			} );
-	}, [ accessToken, noticeOperations, setAttributes, setSelectedAccount ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ accessToken, setAttributes, setSelectedAccount ] );
 
 	return { images, isLoadingGallery, setImages };
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Removes notices dependency as this is causing an infinite rerender issue https://github.com/WordPress/gutenberg/pull/29491. This gutenberg patch doesn't fix the issue for the Instagram block, as it used noticeOperations instead of createErrorNotice as a dependency.

#### Jetpack product discussion

Primary issue: #19038 

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
* Add instagram latest posts block along with latest gutenberg plugin release and make sure block operates as normal

#### Proposed changelog entry for your changes:
* Removes the notices dependency in the customhook useEffect as changes in the notices dependency shouldn't cause the api calls to rerun.
