### PR TITLE
Podcast Player: Remove the noticeOperation dependencies from the API callback

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
@@ -153,7 +153,7 @@ const PodcastPlayerEdit = ( {
 				}
 			);
 		}, 300 ),
-		[ replaceWithEmbedBlock, createErrorNotice, removeAllNotices, setAttributes ]
+		[ replaceWithEmbedBlock, setAttributes ]
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

A bug with a refactor of `withNotices` in Gutenberg WordPress/gutenberg#28676 causes the Podcast Player block to get stuck in an infinite loop. This was fixed in Gutenberg WordPress/gutenberg#29491 but the problem is still present for anyone with Jetpack and Gutenberg 10.1 active - which is currently the case on WordPress.com 😱 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove the `noticeOperations` dependencies from the `useEffect` in the podcast player block.

#### Jetpack product discussion

Primary issue: #19038 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have both Jetpack and Gutenberg 10.1.0 active on a site
* Insert a podcast player block
* Set the RSS URL
* Notice it gets stuck in a loop
* With this patch the problem should be fixed

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
I'm not sure if it needs one but
* Fixed an infinite loop when loading the podcast player block
