### PR TITLE
Recommendations: display footer.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -310,7 +310,7 @@ class Main extends React.Component {
 	}
 
 	shouldShowFooter() {
-		// Only show on the dashboard and settings page
+		// Only show on the dashboard, settings, and recommendations pages
 		return [ ...dashboardRoutes, ...settingsRoutes, ...recommendationsRoutes ].includes(
 			this.props.location.pathname
 		);

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -311,7 +311,9 @@ class Main extends React.Component {
 
 	shouldShowFooter() {
 		// Only show on the dashboard and settings page
-		return [ ...dashboardRoutes, ...settingsRoutes ].includes( this.props.location.pathname );
+		return [ ...dashboardRoutes, ...settingsRoutes, ...recommendationsRoutes ].includes(
+			this.props.location.pathname
+		);
 	}
 
 	shouldShowAuthIframe() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When navigating the different pages of the Jetpack dashboard, we aim to display a footer with useful links. Let's display that footer when on Recommendations pages as well.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Jetpack > Dashboard. You should see a footer with links.
* Navigate to Jetpack > Recommendations: you should see the footer there as well.

#### Proposed changelog entry for your changes:

* N/A

