### PR TITLE
Master bar admin menu: check for DOM element before using it

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -3,6 +3,10 @@
 		var adminbar = document.querySelector( '#wpadminbar' );
 		var wpwrap = document.querySelector( '#wpwrap' );
 
+		if ( ! adminbar ) {
+			return;
+		}
+
 		function setAriaExpanded( value ) {
 			var anchors = adminbar.querySelectorAll( '#wp-admin-bar-blog a' );
 			for ( var i = 0; i < anchors.length; i++ ) {


### PR DESCRIPTION
Fixes #18493 

#### Changes proposed in this Pull Request:
On certain pages, the admin menu js attempts to access DOM elements that are not there...

E.g., https://wordpress.com/post/{yoursite}

<img width="553" alt="Screen Shot 2021-03-05 at 8 46 33 pm" src="https://user-images.githubusercontent.com/6458278/110109262-486b7100-7e01-11eb-8c1b-f27a5c61e71f.png">

This diff adds a check for the container element and returns if not found.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
This must be tested on WordPress.com

Apply the generated Phabricator patch D58175-code and create a new post in a sandboxed simple site. 

The editor should be in the calypso iframe, e.g., E.g., https://wordpress.com/post/{yoursite}

Check that the error is not thrown in your console.

See D58175-code for where the plugin code lives on WPCOM

#### Proposed changelog entry for your changes:
None
