### PR TITLE
Opentable: Remove noticeOperations from the useEffect dependencies

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/opentable/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/edit.js
@@ -89,7 +89,8 @@ function OpenTableEdit( {
 			);
 			noticeOperations.createNotice( { status: 'warning', content } );
 		}
-	}, [ __isBlockPreview, align, isPlaceholder, noticeOperations, rid, style ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ __isBlockPreview, align, isPlaceholder, rid, style ] );
 
 	// Don't allow button style with multiple restaurant IDs.
 	useEffect( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Like #19034, this fixes the same issue with the Opentable block. Having `noticeOperations` in the dependency array causes the editor to hang as it gets into a render loop.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Primary issue: #19038

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an Opentable block with Gutenberg 10.1.0 active
* The editor will hang
* With this PR, it should work as expected
* Check that you still receive a notice when the block is not wide or full aligned and the wide style is selected

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Remove the noticeOperations dependency from the useEffect in the OpenTable block to prevent a loop caused from a change in Gutenberg 10.1.0
