### PR TITLE
Instant Search: Replace color literals at build time

### DIFF
--- a/projects/plugins/jetpack/changelog/update-instant-search-colors-at-build-time
+++ b/projects/plugins/jetpack/changelog/update-instant-search-colors-at-build-time
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: No need for a changelog entry; this should be a seamless under-the-hood change.
+
+

--- a/projects/plugins/jetpack/modules/search/instant-search/components/jetpack-colophon.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/jetpack-colophon.jsx
@@ -1,11 +1,16 @@
 /** @jsx h */
 
+// The PALETTE global comes from '@automattic/color-studio' at build time.
+// This is done so that the individual color values are bundled as hardcoded literals, rather than
+// having to include the entire color set in the bundle.
+// This will work as long as the keys are always literals as well.
+/* global PALETTE */
+
 /**
  * External dependencies
  */
 import { h, Fragment } from 'preact';
 import { __ } from '@wordpress/i18n';
-import { colors as PALETTE } from '@automattic/color-studio';
 
 /**
  * Internal dependencies

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -8,6 +8,7 @@ const {
 	defaultRequestToHandle,
 } = require( '@wordpress/dependency-extraction-webpack-plugin/util' );
 const path = require( 'path' );
+const webpack = require( 'webpack' );
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
@@ -67,6 +68,21 @@ module.exports = {
 	},
 	devtool: isDevelopment ? 'source-map' : false,
 	plugins: [
+		new webpack.DefinePlugin( {
+			// Replace palette colors as individual literals in the bundle.
+			PALETTE: ( () => {
+				const colors = require( '@automattic/color-studio' ).colors;
+				const stringifiedColors = {};
+
+				// DefinePlugin replaces the values as unescaped text.
+				// We therefore need to double-quote each value, to ensure it ends up as a string.
+				for ( const color in colors ) {
+					stringifiedColors[ color ] = `"${ colors[ color ] }"`;
+				}
+
+				return stringifiedColors;
+			} )(),
+		} ),
 		...baseWebpackConfig.plugins,
 		new DependencyExtractionWebpackPlugin( {
 			injectPolyfill: true,


### PR DESCRIPTION
Currently, the entire `@automattic/color-studio` color configuration is being bundled into the Instant Search main bundle, even though only two values are used out of that set.

This PR instead replaces the color values being used with literals at build-time. This maintains all the benefits of relying on the external package for configuration and having the entire set at one's disposal, while bringing the Instant Search main bundle size down by about 4KB (1.5KB gzipped). All it takes is a little build-time magic, with `webpack`'s built-in `DefinePlugin`.

#### Changes proposed in this Pull Request:
* Replace color literals at build time in Instant Search

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Ensuring that the build completes successfully should be enough. Some smoke-testing that the Jetpack colophon is still rendered using the correct colors is probably a good idea as well.

#### Proposed changelog entry for your changes:
No need for a changelog entry; this should be a seamless under-the-hood change. That said, this and other ongoing performance improvements to Instant Search could probably be grouped into a single entry along the lines of: 
* Instant Search: improved performance by reducing JavaScript file size.
