### PR TITLE
Instant Search: Remove `debug` from production build

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-debug-from-production-instant-search
+++ b/projects/plugins/jetpack/changelog/update-remove-debug-from-production-instant-search
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: No need for a changelog entry; this should be a seamless under-the-hood change.
+
+

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/dummy-debug.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/dummy-debug.js
@@ -1,0 +1,8 @@
+const noop = () => {};
+
+/**
+ * Used to replace `debug` calls in production.
+ *
+ * @returns {Function} A noop function.
+ */
+export default () => noop;

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -8,6 +8,7 @@ const {
 	defaultRequestToHandle,
 } = require( '@wordpress/dependency-extraction-webpack-plugin/util' );
 const path = require( 'path' );
+const webpack = require( 'webpack' );
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
@@ -68,6 +69,15 @@ module.exports = {
 	devtool: isDevelopment ? 'source-map' : false,
 	plugins: [
 		...baseWebpackConfig.plugins,
+		// Replace 'debug' module with a dummy implementation in production
+		...( isDevelopment
+			? []
+			: [
+					new webpack.NormalModuleReplacementPlugin(
+						/^debug$/,
+						path.resolve( __dirname, '../modules/search/instant-search/lib/dummy-debug' )
+					),
+			  ] ),
 		new DependencyExtractionWebpackPlugin( {
 			injectPolyfill: true,
 			useDefaults: false,


### PR DESCRIPTION
The `debug` npm module is currently only used by `photon`. Since that debug information is not particularly useful in production, this PR replaces it with a dummy implementation in the production build, using `webpack`'s built-in `NormalModuleReplacementPlugin`.

This should remove around 6KB (2KB gzipped) from the main Instant Search bundle.

#### Changes proposed in this Pull Request:
* Instant Search: remove `debug` from production bundle

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Some simple smoke-testing to ensure that Instant Search still works correctly should be enough, particularly if you're able to bring up search results with images.
I tested this in my wpcom sandbox environment, but I couldn't get any images to be shown on the test site I used.

#### Proposed changelog entry for your changes:
* No need for a changelog entry; this should be a seamless under-the-hood change.
