### PR TITLE
Instant Search: Lazy load

### DIFF
--- a/projects/plugins/jetpack/.size-limit.js
+++ b/projects/plugins/jetpack/.size-limit.js
@@ -2,6 +2,11 @@ module.exports = [
 	{
 		path: '_inc/build/instant-search/jp-search-main.bundle.js',
 		running: false,
+		limit: '4 KB',
+	},
+	{
+		path: '_inc/build/instant-search/jp-search.chunk-main-payload-*.js',
+		running: false,
 		limit: '50 KB',
 	},
 ];

--- a/projects/plugins/jetpack/changelog/update-lazy-load-instant-search
+++ b/projects/plugins/jetpack/changelog/update-lazy-load-instant-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Instant Search: improve performance by lazily loading more of the library

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -65,12 +65,10 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
 		$polyfill_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle.js';
 		$script_relative_path   = $path_prefix . '_inc/build/instant-search/jp-search-main.bundle.js';
-		$style_relative_path    = $path_prefix . '_inc/build/instant-search/jp-search-main.bundle.css';
 
 		if (
 			! file_exists( JETPACK__PLUGIN_DIR . $polyfill_relative_path ) ||
-			! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ||
-			! file_exists( JETPACK__PLUGIN_DIR . $style_relative_path )
+			! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path )
 		) {
 			return;
 		}
@@ -90,10 +88,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		wp_set_script_translations( 'jetpack-instant-search', 'jetpack' );
 		$this->load_and_initialize_tracks();
 		$this->inject_javascript_options();
-
-		$style_version = Jetpack_Search_Helpers::get_asset_version( $style_relative_path );
-		$style_path    = plugins_url( $style_relative_path, $plugin_base_path );
-		wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/search/instant-search/index.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/index.jsx
@@ -18,7 +18,6 @@ import { getThemeOptions } from './lib/dom';
 import { SERVER_OBJECT_NAME } from './lib/constants';
 import { initializeTracks, identifySite, resetTrackingCookies } from './lib/tracks';
 import { buildFilterAggregations } from './lib/api';
-import { bindCustomizerChanges } from './lib/customize';
 import store from './store';
 
 const injectSearchApp = () => {
@@ -43,15 +42,14 @@ const injectSearchApp = () => {
 	);
 };
 
-if ( window[ SERVER_OBJECT_NAME ] ) {
-	bindCustomizerChanges();
-}
-
-document.addEventListener( 'DOMContentLoaded', function () {
-	if ( !! window[ SERVER_OBJECT_NAME ] && 'siteId' in window[ SERVER_OBJECT_NAME ] ) {
+/**
+ * Main function.
+ */
+export function initialize() {
+	if ( window[ SERVER_OBJECT_NAME ] && 'siteId' in window[ SERVER_OBJECT_NAME ] ) {
 		initializeTracks();
 		resetTrackingCookies();
 		identifySite( window[ SERVER_OBJECT_NAME ].siteId );
 		injectSearchApp();
 	}
-} );
+}

--- a/projects/plugins/jetpack/modules/search/instant-search/loader.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/loader.js
@@ -12,7 +12,9 @@ import { bindCustomizerChanges } from './lib/customize';
  * Loads and runs the main chunk for Instant Search.
  */
 function init() {
-	import( './index' ).then( instantSearch => instantSearch.initialize() );
+	import( /* webpackChunkName: "main-payload" */ './index' ).then( instantSearch =>
+		instantSearch.initialize()
+	);
 }
 
 // Bind customizer changes immediately.

--- a/projects/plugins/jetpack/modules/search/instant-search/loader.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/loader.js
@@ -1,0 +1,28 @@
+// NOTE: This must be imported first before any other imports.
+// See: https://github.com/webpack/webpack/issues/2776#issuecomment-233208623
+import './set-webpack-public-path';
+
+/**
+ * Internal dependencies
+ */
+import { SERVER_OBJECT_NAME } from './lib/constants';
+import { bindCustomizerChanges } from './lib/customize';
+
+/**
+ * Loads and runs the main chunk for Instant Search.
+ */
+function init() {
+	import( './index' ).then( instantSearch => instantSearch.initialize() );
+}
+
+// Bind customizer changes immediately.
+if ( window[ SERVER_OBJECT_NAME ] ) {
+	bindCustomizerChanges();
+}
+
+// Initialize Instant Search when DOMContentLoaded is fired, or immediately if it already has been.
+if ( document.readyState !== 'loading' ) {
+	init();
+} else {
+	document.addEventListener( 'DOMContentLoaded', init );
+}

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -75,4 +75,11 @@ module.exports = {
 			requestToHandle: defaultRequestToHandle,
 		} ),
 	],
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				vendors: false,
+			},
+		},
+	},
 };

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -15,7 +15,7 @@ const baseWebpackConfig = getBaseWebpackConfig(
 	{ WP: false },
 	{
 		entry: {
-			main: path.join( __dirname, '../modules/search/instant-search/index.jsx' ),
+			main: path.join( __dirname, '../modules/search/instant-search/loader.js' ),
 			'ie11-polyfill-loader': path.join(
 				__dirname,
 				'../modules/search/instant-search/ie11-polyfill.js'


### PR DESCRIPTION
Instant Search is currently served up as a (mostly) single bundle, with an additional polyfill chunk that only gets loaded for IE 11. Because of the way JS loading is traditionally done in WordPress, this is loaded as part of the critical path, delaying first render and page interactivity.

This PR explores one approach for changing this paradigm, by loading a much smaller amount of code in the critical path. It accomplishes this by moving most of the code to a dynamic import that only runs on `DOMContentLoaded` (i.e., when the document is done parsing).

This results in an order of magnitude less JavaScript in the critical path (from somewhere in the 40KB gzipped range to somewhere in the 2KB gzipped range) for the Instant Search feature, with relatively minor changes to the JS code and ~no~ minor changes needed to the PHP side of things.

Incidentally, the benefits extend to CSS as well, which automatically gets split and loaded similarly.

#### Changes proposed in this Pull Request:
* Lazily load Instant Search

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Load up a page using instant search, and smoke-test its functionality
* Ensure that loading a page with a search string (`https://example.com/?s=query`) correctly pops up Instant Search on open.

I tested this on my `wpcom` sandbox, so it may be a good idea for reviewers to try it out on e.g. a local install.

#### Proposed changelog entry for your changes:
* Instant Search: improve performance by lazily loading more of the library
