### PR TITLE
Prevent attempting to do Gravatar Hovercards for Pingbacks and Trackbacks

### DIFF
--- a/projects/plugins/jetpack/modules/gravatar-hovercards.php
+++ b/projects/plugins/jetpack/modules/gravatar-hovercards.php
@@ -27,7 +27,7 @@ function grofiles_hovercards_init() {
 
 	add_filter( 'jetpack_module_configuration_url_gravatar-hovercards', 'gravatar_hovercards_configuration_url' );
 
-	add_filter( 'get_comment_author_url', 'grofiles_amp_comment_author_url', 10, 1 );
+	add_filter( 'get_comment_author_url', 'grofiles_amp_comment_author_url', 10, 2 );
 }
 
 function gravatar_hovercards_configuration_url() {
@@ -135,11 +135,13 @@ function grofiles_gravatars_to_append( $author = null ) {
  * navigating to a new page
  *
  * @param string $url The comment author's URL.
+ * @param int    $id  The comment ID.
  *
  * @return string The adjusted URL
  */
-function grofiles_amp_comment_author_url( $url ) {
-	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+function grofiles_amp_comment_author_url( $url, $id ) {
+	if ( 'comment' === get_comment_type( $id ) && class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		// @todo Disabling the comment author link in this way is not ideal since clicking the link does not cause the lightbox to open in the same way as clicking the gravatar. Likely get_comment_author_url_link should be used instead so that the href attribute can be replaced with an `on` attribute that activates the gallery.
 		return '#!';
 	}
 

--- a/projects/plugins/jetpack/modules/gravatar-hovercards.php
+++ b/projects/plugins/jetpack/modules/gravatar-hovercards.php
@@ -156,7 +156,7 @@ function grofiles_amp_comment_author_url( $url, $id ) {
  * @param string $avatar The <img/> element of the avatar.
  * @param mixed $author User ID, email address, user login, comment object, user object, post object
  *
- * @return The <img/> element of the avatar.
+ * @return string The <img/> element of the avatar.
  */
 function grofiles_get_avatar( $avatar, $author ) {
 	$is_amp = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();


### PR DESCRIPTION
Fixes #19052

#### Changes proposed in this Pull Request:

* Prevent attempting to do Gravatar Hovercards for non-comment comments (e.g. Pingbacks and Trackbacks).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Activate the AMP plugin.
2. Enable Standard template mode or Transitional template mode.
3. Navigate to the AMP version of a post that has comments including pingbacks.
4. Verify the pingback URL goes to the expected location and not `#!`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
<!-- Guidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md -->
* Fix AMP compatibility with Gravatar Hovercards for Pingbacks and Trackbacks
