### PR TITLE
Connection: activate userless connection for Jetpack dev env

### DIFF
--- a/tools/docker/mu-plugins/.gitignore
+++ b/tools/docker/mu-plugins/.gitignore
@@ -6,3 +6,4 @@
 !jetpack-debug-helper-loader.php
 !/jetpack-debug-helper
 !connection-ui-activator.php
+!userless-connection-activator.php

--- a/tools/docker/mu-plugins/userless-connection-activator.php
+++ b/tools/docker/mu-plugins/userless-connection-activator.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Userless Connection Activator
+ * Description: Activates the Jetpack Userless Connection functionality.
+ * Version: 1.0
+ * Author: Automattic
+ * Author URI: https://automattic.com/
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Jetpack\Docker\MuPlugin\UserlessConnectionActivator;
+
+/**
+ * Activate the Jetpack Userless Connection.
+ */
+function jetpack_docker_userless_connection_activator() {
+	if ( ! defined( 'JETPACK_NO_USER_TEST_MODE' ) ) {
+		define( 'JETPACK_NO_USER_TEST_MODE', true );
+	}
+}
+
+add_filter( 'plugins_loaded', __NAMESPACE__ . '\jetpack_docker_userless_connection_activator' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This commit introduces new mu-plugin to activate Userless mode for Jetpack dev env by default.

To deactivate the Userless mode, you need to set the constant `JETPACK_NO_USER_TEST_MODE` to `false`:
```php
define( 'JETPACK_NO_USER_TEST_MODE', false );
```

#### Jetpack product discussion
p1HpG7-aJm-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Disconnect Jetpack. Make sure that the constant `JETPACK_NO_USER_TEST_MODE` is not defined.
2. Go to Jetpack Dashboard and click "Set up Jetpack" using the in-place flow.
3. Confirm that you see the "Continue without user account" button:
<img width="559" alt="Screen Shot 2021-03-08 at 11 49 28 AM" src="https://user-images.githubusercontent.com/1341249/110360580-7ff63b00-8004-11eb-8600-faa34f8a7035.png">
