### PR TITLE
rest-api: prevent duplicate post creation

### DIFF
--- a/projects/plugins/jetpack/changelog/19070-wpcomapi-update-prevent-duplicate-creation
+++ b/projects/plugins/jetpack/changelog/19070-wpcomapi-update-prevent-duplicate-creation
@@ -1,0 +1,3 @@
+Significance: patch
+Type: compat
+Comment: WPCOM API: sync with WordPress.com, not something worth mentioning in release changelog for Jetpack site owners.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -530,7 +530,10 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				}
 			}
 
-			$post_id = wp_insert_post( add_magic_quotes( $insert ), true );
+			$post_id = post_exists( $insert['post_title'], $insert['post_content'], $insert['post_date'], $post_type->name );
+			if ( $post_id === 0 ) {
+				$post_id = wp_insert_post( add_magic_quotes( $insert ), true );
+			}
 		} else {
 			$insert['ID'] = $post->ID;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -530,6 +530,8 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				}
 			}
 
+			$insert['post_date'] = isset( $insert['post_date'] ) ? $insert['post_date'] : '';
+
 			$post_id = post_exists( $insert['post_title'], $insert['post_content'], $insert['post_date'], $post_type->name );
 			if ( 0 === $post_id ) {
 				$post_id = wp_insert_post( add_magic_quotes( $insert ), true );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -531,7 +531,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			}
 
 			$post_id = post_exists( $insert['post_title'], $insert['post_content'], $insert['post_date'], $post_type->name );
-			if ( $post_id === 0 ) {
+			if ( 0 === $post_id ) {
 				$post_id = wp_insert_post( add_magic_quotes( $insert ), true );
 			}
 		} else {


### PR DESCRIPTION
Differential Revision: D58079-code

This commit syncs r222267-wpcom (and r222314-wpcom).

#### Changes proposed in this Pull Request:

Summary:
There's no duplicate post creation prevention in the WPCOM rest API.
Sending multiple identical requests will create a new post for each request.

Ahead of the [[ https://[private link] | Facebook DTP project ]], we'd like to make sure repeated attempts by FB users to export their posts to WP.com don't create duplicate posts.

This revision updates (only) the 1.2 version of this endpoint to prevent this, by using core's `post_exists()` function

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

This is covered by tests on WordPress.com. For more details, see D58079-code

Manual testing:
- sandbox [private link]
- use the developer console at https://[private link] to post to /sites/[YOURSITE]/posts/new
- Set the date, title, and content.
- Submit, and submit again

With the v1.1 endpoint, each attempt will return a new post (differentiated by the post id).
With the v1.2 endpoint, the first attempt will create a new post, but subsequent attempts will return the same one.
