### PR TITLE
changelogger: Fix autoload.php finding logic

### DIFF
--- a/projects/packages/changelogger/bin/changelogger
+++ b/projects/packages/changelogger/bin/changelogger
@@ -11,10 +11,27 @@ if ( 'cli' !== php_sapi_name() ) {
 	return;
 }
 
-// Find the Composer autoloader. Load it, then run the application.
-foreach ( array( '/../../autoload.php', '/../vendor/autoload.php', '/vendor/autoload.php' ) as $file ) {
-	if ( file_exists( __DIR__ . $file ) ) {
-		require __DIR__ . $file;
+$files = array(
+	// Pulled in via Composer?
+	__DIR__ . '/../../../autoload.php',
+	// Local repo?
+	__DIR__ . '/../vendor/autoload.php',
+	// Pulled in via Composer, but not symlinked from vendor/bin/?
+	__DIR__ . '/../autoload.php',
+);
+// Also check relative to the executed path if "vendor" is part of it,
+// in case composer symlinked it somewhere.
+if ( ! empty( $argv[0] ) ) {
+	$pos = strrpos( $argv[0], DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR );
+	if ( false !== $pos ) {
+		$files[] = substr( $argv[0], 0, $pos ) . '/vendor/autoload.php';
+	} elseif ( substr( $argv[0], 0, 7 ) === 'vendor' . DIRECTORY_SEPARATOR ) {
+		$files[] = './vendor/autoload.php';
+	}
+}
+foreach ( $files as $file ) {
+	if ( file_exists( $file ) ) {
+		require $file;
 		$app = new Automattic\Jetpack\Changelogger\Application();
 		exit( $app->run() );
 	}

--- a/projects/packages/changelogger/changelog/add-changelogs-for-everything.2
+++ b/projects/packages/changelogger/changelog/add-changelogs-for-everything.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix logic for finding autoload.php in the bin.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It only really worked right in the monorepo when changelogger had been
installed. It broke if it was symlinked in from the built copy or if
pulled in from packagist.

Split this out from #19031.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `bin/changelogger` from within `projects/packages/changelogger`, after running `composer install`.
* Delete `projects/packages/changelogger/vendor`, then try the following:
  * Go to `projects/plugins/jetpack`, run `composer install`, then try `vendor/bin/changelogger` and `vendor/automattic/jetpack-changelogger/bin/changelogger`.
  * Create a new "project" in `/tmp` or somewhere with a composer.json like
    ```json
    {
        "require-dev": {
            "automattic/jetpack-changelogger": "@dev"
        },
        "repositories": [ {
            "type": "path",
            "url": "/path/to/projects/packages/changelogger",
            "options": {
                "symlink": false
            }
        } ]
    }
    ```
    Do `composer install` and run `vendor/bin/changelogger` and `vendor/automattic/jetpack-changelogger/bin/changelogger`.
  * Same, but with `"symlink": true`. Remove `vendor` and `composer.lock` first if you're reusing the same directory as for the previous test.
