### PR TITLE
CI: Avoid spurious GH annotations when setting up test env

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -70,7 +70,16 @@ for PLUGIN in projects/plugins/*/composer.json; do
 	NAME="$(basename "$DIR")"
 	echo "::group::Installing plugin $NAME into WordPress"
 	cd "$DIR"
-	composer install || composer update
+	if [[ ! -f "composer.lock" ]]; then
+		echo 'No composer.lock, running `composer update`'
+		composer update
+	elif composer check-platform-reqs --lock; then
+		echo 'Platform reqs pass, running `composer install`'
+		composer install
+	else
+		echo 'Platform reqs failed, running `composer update`'
+		composer update
+	fi
 	cd "$BASE"
 
 	cp -r "$DIR" "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$NAME"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We started running `composer install || composer update` because we can
no longer have one composer.lock that works for all versions. But it
turns out that GH sees the error messages output by `composer install`
and creates (huge) annotations about them even though they didn't make
the test actually fail.

Let's try avoiding that by using `composer check-platform-reqs` to see
whether we need to run `composer update` or `composer install`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Are there spurious annotations from the PHP 5.6 and 6.0 jobs in the "Tests" workflow output?
