### PR TITLE
Search: Fix typo in filters autoconfig

### DIFF
--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -560,11 +560,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 		if ( ! empty( $post_types ) ) {
 			$settings['filters'][] = array(
-				array(
-					'name'  => '',
-					'type'  => 'post_type',
-					'count' => 5,
-				),
+				'name'  => '',
+				'type'  => 'post_type',
+				'count' => 5,
 			);
 		}
 


### PR DESCRIPTION
Fixes #16401.

#### Changes proposed in this Pull Request:
Corrects a typo during the post-purchase filters auto-configuration step for the Jetpack Search plan. This typo led to the creation of malformed filters for Jetpack Search.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this patch to your Jetpack site ***before*** purchasing Jetpack Search.
* Purchase the Jetpack Search subscription for your site.
* Review your site's notice logs (e.g. via the `WP Log Viewer` plugin) and ensure that no notices are spawned by `class.jetpack-search-helpers.php`.
* Also, ensure that the Jetpack Search widget in the overlay has been correctly auto-configured.