### PR TITLE
CLI: Add v/verbose to help text

### DIFF
--- a/tools/cli/cliRouter.js
+++ b/tools/cli/cliRouter.js
@@ -37,7 +37,19 @@ export async function cli() {
 	argv = watchDefine( argv );
 
 	// This adds usage information on failure and demands that a subcommand must be passed.
-	argv.showHelpOnFail( true ).demandCommand().version( false );
+	argv
+		.showHelpOnFail( true )
+		.demandCommand()
+		.version( false )
+		.options( {
+			v: {
+				alias: 'verbose',
+				default: false,
+				description: 'Enable verbose output',
+				type: 'boolean',
+				global: true,
+			},
+		} );
 
 	// Parse the args!
 	argv.parse();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #19077

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds details about -v flag to cli auto-generated help.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `jetpack --help` -- does it mention -v / --verbose?
* `jetpack build --help` -- does it mention -v / --verbose?
* `jetpack install --help` -- does it mention -v / --verbose?
