### PR TITLE
Actions: remind authors to commit their wpcom diffs with comment.

### DIFF
--- a/.github/actions/repo-gardening/src/index.js
+++ b/.github/actions/repo-gardening/src/index.js
@@ -11,6 +11,7 @@ const assignIssues = require( './tasks/assign-issues' );
 const addMilestone = require( './tasks/add-milestone' );
 const addLabels = require( './tasks/add-labels' );
 const checkDescription = require( './tasks/check-description' );
+const wpcomCommitReminder = require( './tasks/wpcom-commit-reminder' );
 const debug = require( './debug' );
 const ifNotFork = require( './if-not-fork' );
 const ifNotClosed = require( './if-not-closed' );
@@ -34,6 +35,10 @@ const automations = [
 		event: 'pull_request',
 		action: [ 'opened', 'reopened', 'synchronize', 'edited', 'labeled' ],
 		task: ifNotClosed( checkDescription ),
+	},
+	{
+		event: 'push',
+		task: ifNotFork( wpcomCommitReminder ),
 	},
 ];
 

--- a/.github/actions/repo-gardening/src/tasks/wpcom-commit-reminder/index.js
+++ b/.github/actions/repo-gardening/src/tasks/wpcom-commit-reminder/index.js
@@ -1,0 +1,130 @@
+/**
+ * Internal dependencies
+ */
+const debug = require( '../../debug' );
+const getAssociatedPullRequest = require( '../../get-associated-pull-request' );
+
+/* global GitHub, WebhookPayloadPush */
+
+/**
+ * Search for a previous comment from this task in our PR.
+ * If we find one, return its body.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - PR number.
+ *
+ * @returns {Promise<string>} Promise resolving to a string.
+ */
+async function getMatticBotComment( octokit, owner, repo, number ) {
+	let commentBody = '';
+
+	debug( `wpcom-commit-reminder: Looking for a comment from Matticbot on this PR.` );
+
+	for await ( const response of octokit.paginate.iterator( octokit.issues.listComments, {
+		owner: owner.login,
+		repo,
+		issue_number: +number,
+	} ) ) {
+		response.data.map( comment => {
+			if (
+				comment.user.login === 'matticbot' &&
+				comment.body.includes( 'This PR has changes that must be merged to WordPress.com' )
+			) {
+				commentBody = comment.body;
+			}
+		} );
+	}
+
+	return commentBody;
+}
+
+/**
+ * Search for a previous comment from this task in our PR.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - PR number.
+ *
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasReminderComment( octokit, owner, repo, number ) {
+	debug( `wpcom-commit-reminder: Looking for a previous comment from this task in our PR.` );
+
+	for await ( const response of octokit.paginate.iterator( octokit.issues.listComments, {
+		owner: owner.login,
+		repo,
+		issue_number: +number,
+	} ) ) {
+		response.data.map( comment => {
+			if (
+				comment.user.login === 'github-actions[bot]' &&
+				comment.body.includes( 'Great news! One last step' )
+			) {
+				return true;
+			}
+		} );
+	}
+
+	return false;
+}
+
+/**
+ * Checks the contents of a PR description.
+ *
+ * @param {WebhookPayloadPush} payload - Push event payload.
+ * @param {GitHub}             octokit - Initialized Octokit REST client.
+ */
+async function wpcomCommitReminder( payload, octokit ) {
+	const { commits, ref, repository } = payload;
+	const { name: repo, owner } = repository;
+
+	// We should not get to that point as the action is triggered on pushes to master, but...
+	if ( ref !== 'refs/heads/master' ) {
+		debug( 'wpcom-commit-reminder: Commit is not to `master`. Aborting' );
+		return;
+	}
+
+	const prNumber = getAssociatedPullRequest( commits[ 0 ] );
+	if ( ! prNumber ) {
+		debug( 'wpcom-commit-reminder: Commit is not a squashed PR. Aborting' );
+		return;
+	}
+
+	// Look for an existing check-description task comment.
+	const matticBotComment = await getMatticBotComment( octokit, owner, repo, prNumber );
+
+	// get diff id from comment body above.
+	const diffId = matticBotComment.match( /(D\d{5}-code)/ );
+
+	if ( 0 === diffId.length ) {
+		debug( 'wpcom-commit-reminder: We could not find a diff ID. Aborting' );
+		return;
+	}
+	// Build our comment body.
+	const comment = `
+Great news! One last step: head over to your WordPress.com diff, ${ diffId[ 0 ] }, and commit it.
+Once you've done so, come back to this PR and add a comment with your changeset ID.
+
+**Thank you!**
+	`;
+
+	// Look for an existing reminder comment.
+	const hasComment = await hasReminderComment( octokit, owner, repo, prNumber );
+
+	// If there is no comment yet, go ahead and comment.
+	if ( ! hasComment ) {
+		debug( `wpcom-commit-reminder: Posting comment to PR #${ prNumber }` );
+
+		await octokit.issues.createComment( {
+			owner: owner.login,
+			repo,
+			issue_number: +prNumber,
+			body: comment,
+		} );
+	}
+}
+
+module.exports = wpcomCommitReminder;

--- a/.github/actions/repo-gardening/src/tasks/wpcom-commit-reminder/readme.md
+++ b/.github/actions/repo-gardening/src/tasks/wpcom-commit-reminder/readme.md
@@ -1,0 +1,8 @@
+# WordPress.com Commit Reminder
+
+Post a comment on merged PRs to remind Automatticians to commit the matching WordPress.com change.
+
+## Rationale
+
+When an Automattician merges a change to a file in Jetpack that also exists on WordPress.com, it's nice to bring that change to WordPress.com site owners as well. We offer tools to automate some of that work, but the actual commit is your responsibility. 
+Once you've merged your Jetpack PR, we'll comment to remind you to commit to WordPress.com.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿As an a12n, once you merge a PR in Jetpack, it's nice to follow-up and also commit any matching WordPress.com diff that was created for you.
This commit adds a new task that will run every time a push to master happens, will look for the matching merged PR, and will add a reminder comment if that PR also included a previous comment from matticbot.

#### Jetpack product discussion

* Internal discussion: p1615302799197900-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I'm not quite sure how to best test this, since this is only triggered on merges to `master`.