### PR TITLE
Actions: fix milestone assignment and clean up owner references

### DIFF
--- a/.github/actions/repo-gardening/src/get-labels.js
+++ b/.github/actions/repo-gardening/src/get-labels.js
@@ -14,7 +14,7 @@ async function getLabels( octokit, owner, repo, number ) {
 	const labelList = [];
 
 	for await ( const response of octokit.paginate.iterator( octokit.issues.listLabelsOnIssue, {
-		owner: owner.login,
+		owner,
 		repo,
 		issue_number: +number,
 	} ) ) {

--- a/.github/actions/repo-gardening/src/tasks/add-milestone/index.js
+++ b/.github/actions/repo-gardening/src/tasks/add-milestone/index.js
@@ -15,34 +15,35 @@ const getPluginNames = require( '../../get-plugin-names' );
  * @param {GitHub}                    octokit - Initialized Octokit REST client.
  */
 async function addMilestone( payload, octokit ) {
+	const { commits, ref, repository } = payload;
+	const { name: repo, owner } = repository;
+	const ownerLogin = owner.login;
+
 	// We should not get to that point as the action is triggered on pushes to master, but...
-	if ( payload.ref !== 'refs/heads/master' ) {
+	if ( ref !== 'refs/heads/master' ) {
 		debug( 'add-milestone: Commit is not to `master`. Aborting' );
 		return;
 	}
 
-	const prNumber = getAssociatedPullRequest( payload.commits[ 0 ] );
+	const prNumber = getAssociatedPullRequest( commits[ 0 ] );
 	if ( ! prNumber ) {
 		debug( 'add-milestone: Commit is not a squashed PR. Aborting' );
 		return;
 	}
 
-	// No need to do anything if the PR already has a milestone.
-	const owner = payload.repository.owner.login;
-	const repo = payload.repository.name;
 	const {
 		data: { milestone: pullMilestone },
-	} = await octokit.issues.get( { owner, repo, issue_number: prNumber } );
+	} = await octokit.issues.get( { owner: ownerLogin, repo, issue_number: prNumber } );
 
 	if ( pullMilestone ) {
 		debug( 'add-milestone: Pull request already has a milestone. Aborting' );
 		return;
 	}
 
-	const plugins = await getPluginNames( octokit, owner, repo, prNumber );
+	const plugins = await getPluginNames( octokit, ownerLogin, repo, prNumber );
 
 	// Get next valid milestone (we can only add one).
-	const nextMilestone = await getNextValidMilestone( octokit, owner, repo, plugins[ 0 ] );
+	const nextMilestone = await getNextValidMilestone( octokit, ownerLogin, repo, plugins[ 0 ] );
 
 	if ( ! nextMilestone ) {
 		throw new Error( 'Could not find a valid milestone' );
@@ -51,7 +52,7 @@ async function addMilestone( payload, octokit ) {
 	debug( `add-milestone: Adding PR #${ prNumber } to milestone #${ nextMilestone.number }` );
 
 	await octokit.issues.update( {
-		owner,
+		owner: ownerLogin,
 		repo,
 		issue_number: prNumber,
 		milestone: nextMilestone.number,

--- a/.github/actions/repo-gardening/src/tasks/check-description/index.js
+++ b/.github/actions/repo-gardening/src/tasks/check-description/index.js
@@ -25,7 +25,7 @@ const getPluginNames = require( '../../get-plugin-names' );
  */
 async function hasUnverifiedCommit( octokit, owner, repo, number ) {
 	for await ( const response of octokit.paginate.iterator( octokit.pulls.listCommits, {
-		owner: owner.login,
+		owner,
 		repo,
 		pull_number: +number,
 	} ) ) {
@@ -126,12 +126,11 @@ async function getMilestoneDates( plugin, nextMilestone ) {
  */
 async function buildMilestoneInfo( octokit, owner, repo, number ) {
 	const plugins = await getPluginNames( octokit, owner, repo, number );
-	const ownerLogin = owner.login;
 	let pluginInfo;
 
 	// Get next valid milestone for each plugin.
 	for await ( const plugin of plugins ) {
-		const nextMilestone = await getNextValidMilestone( octokit, ownerLogin, repo, plugin );
+		const nextMilestone = await getNextValidMilestone( octokit, owner, repo, plugin );
 		debug( `check-description: Milestone found: ${ nextMilestone }` );
 
 		debug( `check-description: getting milestone info for ${ plugin }` );
@@ -159,7 +158,7 @@ async function getCheckComment( octokit, owner, repo, number ) {
 	debug( `check-description: Looking for a previous comment from this task in our PR.` );
 
 	for await ( const response of octokit.paginate.iterator( octokit.issues.listComments, {
-		owner: owner.login,
+		owner,
 		repo,
 		issue_number: +number,
 	} ) ) {
@@ -185,6 +184,7 @@ async function getCheckComment( octokit, owner, repo, number ) {
 async function checkDescription( payload, octokit ) {
 	const { base, body, head, number } = payload.pull_request;
 	const { name: repo, owner } = payload.repository;
+	const ownerLogin = owner.login;
 
 	debug( `check-description: start building our comment` );
 
@@ -201,14 +201,14 @@ When contributing to Jetpack, we have [a few suggestions](https://github.com/Aut
 
 	// Check all commits in PR.
 	// In this case, we use a different failure icon, as we do not consider this a blocker, it should not trigger label changes.
-	const isDirty = await hasUnverifiedCommit( octokit, owner, repo, number );
+	const isDirty = await hasUnverifiedCommit( octokit, ownerLogin, repo, number );
 	comment += `
 - ${ isDirty ? `:x:` : `:white_check_mark:` } All commits were linted before commit.<br>`;
 
 	// Use labels please!
 	// Only check this for PRs created by a12s. External contributors cannot add labels.
 	if ( head.repo.full_name === base.repo.full_name ) {
-		const isLabeled = await hasStatusLabels( octokit, owner, repo, number );
+		const isLabeled = await hasStatusLabels( octokit, ownerLogin, repo, number );
 		debug( `check-description: this PR is correctly labeled: ${ isLabeled }` );
 		comment += `
 - ${
@@ -241,15 +241,13 @@ If you are an automattician, once your PR is ready for review add the "[Status] 
 Once you’ve done so, switch to the "[Status] Needs Review" label; someone from Jetpack Crew will then review this PR and merge it to be included in the next Jetpack release.`;
 
 	// Gather info about the next release for that plugin.
-	const milestoneInfo = await buildMilestoneInfo( octokit, owner, repo, number );
+	const milestoneInfo = await buildMilestoneInfo( octokit, ownerLogin, repo, number );
 	if ( milestoneInfo ) {
 		comment += milestoneInfo;
 	}
 
 	// Look for an existing check-description task comment.
-	const existingComment = await getCheckComment( octokit, owner, repo, number );
-
-	const ownerLogin = owner.login;
+	const existingComment = await getCheckComment( octokit, ownerLogin, repo, number );
 
 	// If there is a comment already, update it.
 	if ( existingComment !== 0 ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿Milestone assignment was no longer automatically happening when merging PRs without a milestone, since #18558.
I cleaned things up a bit and made the difference between owner (the object) and owner.login (the owner's login name, what we actually need when interacting with the API) a bit clearer.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Do the existing Gardening tasks complete without failure?
* When we merge this PR, even though there is no milestone assigned to it, a milestone should get added by the action afterwards.
