### PR TITLE
Actions: do not check for fork on push event

### DIFF
--- a/.github/actions/repo-gardening/src/index.js
+++ b/.github/actions/repo-gardening/src/index.js
@@ -38,7 +38,7 @@ const automations = [
 	},
 	{
 		event: 'push',
-		task: ifNotFork( wpcomCommitReminder ),
+		task: wpcomCommitReminder,
 	},
 ];
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿Follow-up from #19092.

- We cannot use `ifNotFork` to check for a fork on push event, since we do not have info about the fork at that point, we only know about the merge commit.
- We do not need to check for a fork, since Matticbot will not comment on PRs that are opened by external contributors in the first place; diffs cannot be created from forks.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* This aims to fix errors that happen on an action that run on merge to `master`, so... We can merge this PR and see the resulting action? :)
