### PR TITLE
tools: Fix exit code in project-version.sh

### DIFF
--- a/projects/packages/changelogger/changelog/fix-project-version-exit-code
+++ b/projects/packages/changelogger/changelog/fix-project-version-exit-code
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Version bump, missed in the previous PR.
+
+

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '1.0.0';
+	const VERSION = '1.0.1-alpha';
 
 	/**
 	 * Constructor.

--- a/tools/project-version.sh
+++ b/tools/project-version.sh
@@ -192,7 +192,7 @@ jsver "$FILE" '.extra["branch-alias"]["dev-master"]' "$(sed -E 's/\.[0-9]+([-+].
 
 # Update declared constants
 FILE="$BASE/projects/$SLUG/composer.json"
-jq -r '.extra["version-constants"] // {} | to_entries | .[] | .key + " " + .value' "$FILE" | while IFS=" " read -r C F; do
+while IFS=" " read -r C F; do
 	debug "$OPING version constant $C in $F"
 	CE=$(sed 's/[.\[\]\\*^$\/()+?{}|]/\\&/g' <<<"${C}")
 
@@ -213,6 +213,6 @@ jq -r '.extra["version-constants"] // {} | to_entries | .[] | .key + " " + .valu
 		PAT="^([[:blank:]]*define\( '$CE', ')([^']*)(' \);)$"
 	fi
 	sedver "$BASE/projects/$SLUG/$F" "$PAT" "$VERSION" "version constant $C"
-done
+done < <(jq -r '.extra["version-constants"] // {} | to_entries | .[] | .key + " " + .value' "$FILE")
 
 exit $EXIT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Piping to the while doesn't work, as it results in the while being
executed in a subshell and so the main shell doesn't get EXIT=1. Use
process substitution instead.

Then apply a version bump to changelogger that should have been in
#19102 but was missed because this error made it not fail CI.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Undo the change in 364f2c6, run `tools/project-version.sh -v -u 1.0.1-alpha packages/changelogger` or `tools/changelogger-validate-all.sh`, and see that the exit code is not 0.
