### PR TITLE
Gardening: fix reference to owner <> owner.login

### DIFF
--- a/.github/actions/repo-gardening/src/tasks/check-description/index.js
+++ b/.github/actions/repo-gardening/src/tasks/check-description/index.js
@@ -274,7 +274,7 @@ Once you’ve done so, switch to the "[Status] Needs Review" label; someone from
 	if ( comment.includes( ':red_circle:' ) ) {
 		debug( `check-description: some of the checks are failing. Update labels accordingly.` );
 
-		const hasNeedsReview = await hasNeedsReviewLabel( octokit, owner, repo, number );
+		const hasNeedsReview = await hasNeedsReviewLabel( octokit, ownerLogin, repo, number );
 		if ( hasNeedsReview ) {
 			debug( `check-description: remove existing Needs review label.` );
 			await octokit.issues.removeLabel( {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

﻿Follow-up to #19093
I missed that one last reference that uses the owner object instead of the owner name.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I will not be adding any Status label to this PR, so the action should add one for me.
