### PR TITLE
Admin Menu: Do not alter menu slugs

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-admin-menu-migrate-submenu-hooks
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-migrate-submenu-hooks
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Migrates the hooks registered by submenus to the new unified menu slugs
+Admin Menu: Fix Settings submenus registered by third-party plugins

--- a/projects/plugins/jetpack/changelog/fix-admin-menu-migrate-submenu-hooks
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-migrate-submenu-hooks
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: major
 Type: bugfix
 
-Admin Menu: Fix Settings submenus registered by third-party plugins
+Admin Menu: Do not alter menu slugs

--- a/projects/plugins/jetpack/changelog/fix-admin-menu-migrate-submenu-hooks
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-migrate-submenu-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Migrates the hooks registered by submenus to the new unified menu slugs

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -128,53 +128,9 @@ class Admin_Menu {
 
 	/**
 	 * Adds My Home menu.
-	 *
-	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_my_home_menu( $wp_admin = false ) {
-		global $menu, $submenu;
-
-		$dashboard_menu_item     = null;
-		$dashboard_menu_position = null;
-
-		foreach ( $menu as $i => $item ) {
-			if ( 'index.php' === $item[2] ) {
-				$dashboard_menu_item     = $item;
-				$dashboard_menu_position = $i;
-				break;
-			}
-		}
-
-		if ( ! $dashboard_menu_item ) {
-			return;
-		}
-
-		$menu_slug = $wp_admin ? 'index.php' : 'https://wordpress.com/home/' . $this->domain;
-		$cap       = $wp_admin ? 'read' : 'manage_options'; // Calypso's My Home is only available for admins.
-
-		$dashboard_menu_item[0] = __( 'My Home', 'jetpack' );
-		$dashboard_menu_item[1] = $cap;
-		$dashboard_menu_item[2] = $menu_slug;
-		$dashboard_menu_item[3] = __( 'My Home', 'jetpack' );
-		$dashboard_menu_item[6] = 'dashicons-admin-home';
-
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$menu[ $dashboard_menu_position ] = $dashboard_menu_item;
-
-		remove_submenu_page( 'index.php', 'index.php' );
-
-		// Only add submenu when there are other submenu items.
-		if ( ! empty( $submenu['index.php'] ) ) {
-			add_submenu_page( $menu_slug, __( 'My Home', 'jetpack' ), __( 'My Home', 'jetpack' ), $cap, $menu_slug, null, 0 );
-		}
-
-		$this->migrate_submenus( 'index.php', $dashboard_menu_item[2] );
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $menu_slug ) {
-				return 'index.php' === $parent_file ? $menu_slug : $parent_file;
-			}
-		);
+	public function add_my_home_menu() {
+		$this->update_menu( 'index.php', 'https://wordpress.com/home/' . $this->domain, __( 'My Home', 'jetpack' ), 'manage_options', 'dashicons-admin-home' );
 	}
 
 	/**
@@ -188,21 +144,25 @@ class Admin_Menu {
 	 * Adds Upgrades menu.
 	 */
 	public function add_upgrades_menu() {
-		remove_menu_page( 'paid-upgrades.php' );
+		global $menu;
 
-		$menu_slug = 'https://wordpress.com/plans/' . $this->domain;
+		$menu_slug = null;
+		foreach ( $menu as $item ) {
+			if ( 'paid-upgrades.php' === $item[2] ) {
+				$menu_slug = $item[2];
+				break;
+			}
+		}
 
-		add_menu_page( __( 'Upgrades', 'jetpack' ), __( 'Upgrades', 'jetpack' ), 'manage_options', $menu_slug, null, 'dashicons-cart', 4 );
+		if ( ! $menu_slug ) {
+			$menu_slug = 'https://wordpress.com/plans/' . $this->domain;
+			add_menu_page( __( 'Upgrades', 'jetpack' ), __( 'Upgrades', 'jetpack' ), 'manage_options', $menu_slug, null, 'dashicons-cart', 4 );
+		}
+
 		add_submenu_page( $menu_slug, __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', $menu_slug, null, 5 );
 		add_submenu_page( $menu_slug, __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 15 );
 
-		$this->migrate_submenus( 'paid-upgrades.php', $menu_slug );
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $menu_slug ) {
-				return 'paid-upgrades.php' === $parent_file ? $menu_slug : $parent_file;
-			}
-		);
+		return $menu_slug;
 	}
 
 	/**
@@ -215,24 +175,11 @@ class Admin_Menu {
 			return;
 		}
 
-		$ptype_obj = get_post_type_object( 'post' );
-		$menu_slug = 'https://wordpress.com/posts/' . $this->domain;
-
-		remove_menu_page( 'edit.php' );
-		remove_submenu_page( 'edit.php', 'edit.php' );
-		remove_submenu_page( 'edit.php', 'post-new.php' );
-
-		add_menu_page( esc_attr( $ptype_obj->labels->menu_name ), $ptype_obj->labels->menu_name, $ptype_obj->cap->edit_posts, $menu_slug, null, 'dashicons-admin-post', $ptype_obj->menu_position );
-		add_submenu_page( $menu_slug, $ptype_obj->labels->all_items, $ptype_obj->labels->all_items, $ptype_obj->cap->edit_posts, $menu_slug, null, 5 );
-		add_submenu_page( $menu_slug, $ptype_obj->labels->add_new, $ptype_obj->labels->add_new, $ptype_obj->cap->create_posts, 'https://wordpress.com/post/' . $this->domain, null, 10 );
-
-		$this->migrate_submenus( 'edit.php', $menu_slug );
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $menu_slug ) {
-				return 'edit.php' === $parent_file ? $menu_slug : $parent_file;
-			}
+		$submenus_to_update = array(
+			'edit.php'     => 'https://wordpress.com/posts/' . $this->domain,
+			'post-new.php' => 'https://wordpress.com/post/' . $this->domain,
 		);
+		$this->update_submenus( 'edit.php', $submenus_to_update );
 	}
 
 	/**
@@ -241,23 +188,13 @@ class Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_media_menu( $wp_admin = false ) {
-		remove_submenu_page( 'upload.php', 'upload.php' );
+		if ( $wp_admin ) {
+			return;
+		}
+
 		remove_submenu_page( 'upload.php', 'media-new.php' );
 
-		if ( ! $wp_admin ) {
-			$menu_slug = 'https://wordpress.com/media/' . $this->domain;
-
-			remove_menu_page( 'upload.php' );
-			add_menu_page( __( 'Media', 'jetpack' ), __( 'Media', 'jetpack' ), 'upload_files', $menu_slug, null, 'dashicons-admin-media', 10 );
-			$this->migrate_submenus( 'upload.php', $menu_slug );
-
-			add_filter(
-				'parent_file',
-				function ( $parent_file ) use ( $menu_slug ) {
-					return 'upload.php' === $parent_file ? $menu_slug : $parent_file;
-				}
-			);
-		}
+		$this->update_menu( 'upload.php', 'https://wordpress.com/media/' . $this->domain );
 	}
 
 	/**
@@ -270,24 +207,11 @@ class Admin_Menu {
 			return;
 		}
 
-		$ptype_obj = get_post_type_object( 'page' );
-		$menu_slug = 'https://wordpress.com/pages/' . $this->domain;
-
-		remove_menu_page( 'edit.php?post_type=page' );
-		remove_submenu_page( 'edit.php?post_type=page', 'edit.php?post_type=page' );
-		remove_submenu_page( 'edit.php?post_type=page', 'post-new.php?post_type=page' );
-
-		add_menu_page( esc_attr( $ptype_obj->labels->menu_name ), $ptype_obj->labels->menu_name, $ptype_obj->cap->edit_posts, $menu_slug, null, 'dashicons-admin-page', $ptype_obj->menu_position );
-		add_submenu_page( $menu_slug, $ptype_obj->labels->all_items, $ptype_obj->labels->all_items, $ptype_obj->cap->edit_posts, $menu_slug, null, 5 );
-		add_submenu_page( $menu_slug, $ptype_obj->labels->add_new, $ptype_obj->labels->add_new, $ptype_obj->cap->create_posts, 'https://wordpress.com/page/' . $this->domain, null, 10 );
-
-		$this->migrate_submenus( 'edit.php?post_type=page', $menu_slug );
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $menu_slug ) {
-				return 'edit.php?post_type=page' === $parent_file ? $menu_slug : $parent_file;
-			}
+		$submenus_to_update = array(
+			'edit.php?post_type=page'     => 'https://wordpress.com/pages/' . $this->domain,
+			'post-new.php?post_type=page' => 'https://wordpress.com/page/' . $this->domain,
 		);
+		$this->update_submenus( 'edit.php?post_type=page', $submenus_to_update );
 	}
 
 	/**
@@ -312,59 +236,18 @@ class Admin_Menu {
 	 * Adds a custom post type menu.
 	 *
 	 * @param string $post_type Custom post type.
-	 * @param bool   $wp_admin  Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_custom_post_type_menu( $post_type, $wp_admin = false ) {
 		if ( $wp_admin ) {
 			return;
 		}
 
-		$ptype_obj = get_post_type_object( $post_type );
-		if ( empty( $ptype_obj ) ) {
-			return;
-		}
-
-		$cpt_slug  = 'edit.php?post_type=' . $post_type;
-		$menu_slug = 'https://wordpress.com/types/' . $post_type . '/' . $this->domain;
-
-		remove_menu_page( $cpt_slug );
-		remove_submenu_page( $cpt_slug, $cpt_slug );
-		remove_submenu_page( $cpt_slug, 'post-new.php?post_type=' . $post_type );
-
-		// Menu icon.
-		$menu_icon = 'dashicons-admin-post';
-		if ( is_string( $ptype_obj->menu_icon ) ) {
-			// Special handling for data:image/svg+xml and Dashicons.
-			if ( 0 === strpos( $ptype_obj->menu_icon, 'data:image/svg+xml;base64,' ) || 0 === strpos( $ptype_obj->menu_icon, 'dashicons-' ) ) {
-				$menu_icon = $ptype_obj->menu_icon;
-			} else {
-				$menu_icon = esc_url( $ptype_obj->menu_icon );
-			}
-		}
-
-		/*
-		 * Menu position.
-		 *
-		 * If $ptype_menu_position is already populated or will be populated
-		 * by a hard-coded value below, increment the position.
-		 */
-		$ptype_menu_position = is_int( $ptype_obj->menu_position ) ? $ptype_obj->menu_position : ++$GLOBALS['_wp_last_object_menu'];
-		$core_menu_positions = array( 59, 60, 65, 70, 75, 80, 85, 99 );
-		while ( isset( $GLOBALS['menu'][ $ptype_menu_position ] ) || in_array( $ptype_menu_position, $core_menu_positions, true ) ) {
-			$ptype_menu_position++;
-		}
-
-		add_menu_page( esc_attr( $ptype_obj->labels->menu_name ), $ptype_obj->labels->menu_name, $ptype_obj->cap->edit_posts, $menu_slug, null, $menu_icon, $ptype_menu_position );
-		add_submenu_page( $menu_slug, $ptype_obj->labels->all_items, $ptype_obj->labels->all_items, $ptype_obj->cap->edit_posts, $menu_slug, null, 5 );
-		add_submenu_page( $menu_slug, $ptype_obj->labels->add_new, $ptype_obj->labels->add_new, $ptype_obj->cap->create_posts, 'https://wordpress.com/edit/' . $post_type . '/' . $this->domain, null, 10 );
-		$this->migrate_submenus( $cpt_slug, $menu_slug );
-
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $cpt_slug, $menu_slug ) {
-				return $cpt_slug === $parent_file ? $menu_slug : $parent_file;
-			}
+		$submenus_to_update = array(
+			'edit.php?post_type=' . $post_type     => 'https://wordpress.com/types/' . $post_type . '/' . $this->domain,
+			'post-new.php?post_type=' . $post_type => 'https://wordpress.com/edit/' . $post_type . '/' . $this->domain,
 		);
+		$this->update_submenus( 'edit.php?post_type=' . $post_type, $submenus_to_update );
 	}
 
 	/**
@@ -373,32 +256,11 @@ class Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_comments_menu( $wp_admin = false ) {
-		if ( $wp_admin || ! current_user_can( 'edit_posts' ) ) {
+		if ( $wp_admin ) {
 			return;
 		}
 
-		$awaiting_mod      = wp_count_comments();
-		$awaiting_mod      = $awaiting_mod->moderated;
-		$awaiting_mod_i18n = number_format_i18n( $awaiting_mod );
-		/* translators: %s: Number of comments. */
-		$awaiting_mod_text = sprintf( _n( '%s Comment in moderation', '%s Comments in moderation', $awaiting_mod, 'jetpack' ), $awaiting_mod_i18n );
-
-		/* translators: %s: Number of comments. */
-		$menu_title = sprintf( __( 'Comments %s', 'jetpack' ), '<span class="awaiting-mod count-' . absint( $awaiting_mod ) . '"><span class="pending-count" aria-hidden="true">' . $awaiting_mod_i18n . '</span><span class="comments-in-moderation-text screen-reader-text">' . $awaiting_mod_text . '</span></span>' );
-		$menu_slug  = 'https://wordpress.com/comments/all/' . $this->domain;
-
-		remove_menu_page( 'edit-comments.php' );
-		remove_submenu_page( 'edit-comments.php', 'edit-comments.php' );
-
-		add_menu_page( esc_attr__( 'Comments', 'jetpack' ), $menu_title, 'edit_posts', $menu_slug, null, 'dashicons-admin-comments', 25 );
-
-		$this->migrate_submenus( 'edit-comments.php', $menu_slug );
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $menu_slug ) {
-				return 'edit-comments.php' === $parent_file ? $menu_slug : $parent_file;
-			}
-		);
+		$this->update_menu( 'edit-comments.php', 'https://wordpress.com/comments/all/' . $this->domain );
 	}
 
 	/**
@@ -407,79 +269,43 @@ class Admin_Menu {
 	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
 	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
-		$user_can_customize = current_user_can( 'customize' );
-		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
-		$themes_slug        = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
+	public function add_appearance_menu( $wp_admin_themes, $wp_admin_customize ) {
 		if ( ! $wp_admin_customize ) {
-			$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
-		} else {
+			$customize_url = 'https://wordpress.com/customize/' . $this->domain;
+		} elseif ( $this->is_api_request ) {
 			// In case this is an api request we will have to add the 'return' querystring via JS.
-			$customize_slug = $this->is_api_request ? 'customize.php' : add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-		}
-		remove_menu_page( 'themes.php' );
-		remove_submenu_page( 'themes.php', 'themes.php' );
-		remove_submenu_page( 'themes.php', 'theme-editor.php' );
-		remove_submenu_page( 'themes.php', add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' ) );
-		remove_submenu_page( 'themes.php', 'custom-header' );
-		remove_submenu_page( 'themes.php', 'custom-background' );
-
-		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), $appearance_cap, $themes_slug, null, 'dashicons-admin-appearance', 60 );
-		add_submenu_page( $themes_slug, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', $themes_slug, null, 0 );
-		add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $customize_slug, null, 1 );
-
-		// Maintain id as JS selector.
-		$GLOBALS['menu'][60][5] = 'menu-appearance'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		if ( current_theme_supports( 'custom-header' ) && $user_can_customize ) {
-			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_slug );
-			remove_submenu_page( 'themes.php', esc_url( $customize_header_url ) );
-
-			// TODO: Remove WPCom_Theme_Customizer::modify_header_menu_links() and WPcom_Custom_Header::modify_admin_menu_links().
-			$customize_header_url = admin_url( 'themes.php?page=custom-header' );
-			remove_submenu_page( 'themes.php', esc_url( $customize_header_url ) );
-
-			$customize_header_url = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_slug );
-			add_submenu_page( $themes_slug, __( 'Header', 'jetpack' ), __( 'Header', 'jetpack' ), 'customize', esc_url( $customize_header_url ), null, 15 );
+			$customize_url = 'customize.php';
+		} else {
+			$customize_url = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
 		}
 
-		if ( current_theme_supports( 'custom-background' ) && $user_can_customize ) {
-			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $customize_slug );
-			remove_submenu_page( 'themes.php', esc_url( $customize_background_url ) );
+		$default_customize_slug          = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
+		$default_customize_header_slug_1 = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $default_customize_slug );
+		// TODO: Remove WPCom_Theme_Customizer::modify_header_menu_links() and WPcom_Custom_Header::modify_admin_menu_links().
+		$default_customize_header_slug_2     = admin_url( 'themes.php?page=custom-header' );
+		$default_customize_background_slug_1 = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $default_customize_slug );
+		// TODO: Remove Colors_Manager::modify_header_menu_links() and Colors_Manager_Common::modify_header_menu_links().
+		$default_customize_background_slug_2 = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), admin_url( 'customize.php' ) );
 
-			// TODO: Remove Colors_Manager::modify_header_menu_links() and Colors_Manager_Common::modify_header_menu_links().
-			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), admin_url( 'customize.php' ) );
-			remove_submenu_page( 'themes.php', esc_url( $customize_background_url ) );
-
-			$customize_background_url = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), $customize_slug );
-			add_submenu_page( $themes_slug, esc_attr__( 'Background', 'jetpack' ), __( 'Background', 'jetpack' ), 'customize', esc_url( $customize_background_url ), null, 20 );
-		}
-
-		if ( current_theme_supports( 'widgets' ) ) {
-			remove_submenu_page( 'themes.php', 'widgets.php' );
-			remove_submenu_page( 'themes.php', 'gutenberg-widgets' );
-
-			$customize_widgets_url = $wp_admin_customize ? 'widgets.php' : add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $customize_slug );
-			add_submenu_page( $themes_slug, esc_attr__( 'Widgets', 'jetpack' ), __( 'Widgets', 'jetpack' ), 'customize', esc_url( $customize_widgets_url ), null, 20 );
-		}
-
-		if ( current_theme_supports( 'menus' ) || current_theme_supports( 'widgets' ) ) {
-			remove_submenu_page( 'themes.php', 'nav-menus.php' );
-
-			$customize_menus_url = $wp_admin_customize ? 'nav-menus.php' : add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $customize_slug );
-			add_submenu_page( $themes_slug, esc_attr__( 'Menus', 'jetpack' ), __( 'Menus', 'jetpack' ), 'customize', esc_url( $customize_menus_url ), null, 20 );
-		}
-
-		// Register menu for the Custom CSS Jetpack module, but don't add it as a menu item.
-		$GLOBALS['_registered_pages']['admin_page_editcss'] = true; // phpcs:ignore
-
-		$this->migrate_submenus( 'themes.php', $themes_slug );
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $themes_slug ) {
-				return 'themes.php' === $parent_file ? $themes_slug : $parent_file;
-			}
+		$submenus_to_update = array(
+			$default_customize_slug              => $customize_url,
+			$default_customize_header_slug_1     => add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_url ),
+			$default_customize_header_slug_2     => add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_url ),
+			$default_customize_background_slug_1 => add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), $customize_url ),
+			$default_customize_background_slug_2 => add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), $customize_url ),
 		);
+
+		if ( ! $wp_admin_themes ) {
+			$submenus_to_update['themes.php'] = 'https://wordpress.com/themes/' . $this->domain;
+		}
+
+		if ( ! $wp_admin_customize ) {
+			$submenus_to_update['widgets.php']       = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $customize_url );
+			$submenus_to_update['gutenberg-widgets'] = add_query_arg( array( 'autofocus' => array( 'panel' => 'widgets' ) ), $customize_url );
+			$submenus_to_update['nav-menus.php']     = add_query_arg( array( 'autofocus' => array( 'panel' => 'nav_menus' ) ), $customize_url );
+		}
+
+		$this->update_submenus( 'themes.php', $submenus_to_update );
 	}
 
 	/**
@@ -488,37 +314,14 @@ class Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_plugins_menu( $wp_admin = false ) {
-		$menu_slug = $wp_admin ? 'plugins.php' : 'https://wordpress.com/plugins/' . $this->domain;
-
-		remove_menu_page( 'plugins.php' );
-
-		// Keep submenus when links point to WP Admin.
-		if ( ! $wp_admin ) {
-			remove_submenu_page( 'plugins.php', 'plugins.php' );
-			remove_submenu_page( 'plugins.php', 'plugin-install.php' );
-			remove_submenu_page( 'plugins.php', 'plugin-editor.php' );
+		if ( $wp_admin ) {
+			return;
 		}
 
-		$count = '';
-		if ( ! is_multisite() && current_user_can( 'update_plugins' ) ) {
-			$update_data = wp_get_update_data();
-			$count       = sprintf(
-				'<span class="update-plugins count-%s"><span class="plugin-count">%s</span></span>',
-				$update_data['counts']['plugins'],
-				number_format_i18n( $update_data['counts']['plugins'] )
-			);
-		}
+		remove_submenu_page( 'plugins.php', 'plugin-install.php' );
+		remove_submenu_page( 'plugins.php', 'plugin-editor.php' );
 
-		/* translators: %s: Number of pending plugin updates. */
-		add_menu_page( esc_attr__( 'Plugins', 'jetpack' ), sprintf( __( 'Plugins %s', 'jetpack' ), $count ), 'activate_plugins', $menu_slug, null, 'dashicons-admin-plugins', 65 );
-
-		$this->migrate_submenus( 'plugins.php', $menu_slug );
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $menu_slug ) {
-				return 'plugins.php' === $parent_file ? $menu_slug : $parent_file;
-			}
-		);
+		$this->update_menu( 'plugins.php', 'https://wordpress.com/plugins/' . $this->domain );
 	}
 
 	/**
@@ -527,47 +330,24 @@ class Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_users_menu( $wp_admin = false ) {
-		$users_slug   = $wp_admin ? 'users.php' : 'https://wordpress.com/people/team/' . $this->domain;
-		$add_new_slug = $wp_admin ? 'user-new.php' : 'https://wordpress.com/people/new/' . $this->domain;
-		$profile_slug = $wp_admin ? 'profile.php' : 'https://wordpress.com/me';
-		$account_slug = 'https://wordpress.com/me/account';
-
 		if ( current_user_can( 'list_users' ) ) {
-			remove_menu_page( 'users.php' );
-			remove_submenu_page( 'users.php', 'users.php' );
-			remove_submenu_page( 'users.php', 'user-new.php' );
-			remove_submenu_page( 'users.php', 'profile.php' );
+			if ( ! $wp_admin ) {
+				$submenus_to_update = array(
+					'users.php'    => 'https://wordpress.com/people/team/' . $this->domain,
+					'user-new.php' => 'https://wordpress.com/people/new/' . $this->domain,
+					'profile.php'  => 'https://wordpress.com/me/',
+				);
+				$this->update_submenus( 'users.php', $submenus_to_update );
+			}
+
 			remove_submenu_page( 'users.php', 'grofiles-editor' );
 			remove_submenu_page( 'users.php', 'grofiles-user-settings' );
-
-			add_menu_page( esc_attr__( 'Users', 'jetpack' ), __( 'Users', 'jetpack' ), 'list_users', $users_slug, null, 'dashicons-admin-users', 70 );
-			add_submenu_page( $users_slug, esc_attr__( 'All People', 'jetpack' ), __( 'All People', 'jetpack' ), 'list_users', $users_slug );
-			add_submenu_page( $users_slug, esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', $add_new_slug );
-			add_submenu_page( $users_slug, esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', $profile_slug );
-			add_submenu_page( $users_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', $account_slug );
-
-			$this->migrate_submenus( 'users.php', $users_slug );
-			add_filter(
-				'parent_file',
-				function ( $parent_file ) use ( $users_slug ) {
-					return 'users.php' === $parent_file ? $users_slug : $parent_file;
-				}
-			);
+			add_submenu_page( 'users.php', esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
 		} else {
-			remove_menu_page( 'profile.php' );
 			remove_submenu_page( 'profile.php', 'grofiles-editor' );
 			remove_submenu_page( 'profile.php', 'grofiles-user-settings' );
 
-			add_menu_page( esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', $profile_slug, null, 'dashicons-admin-users', 70 );
-			add_submenu_page( $profile_slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', $account_slug, null, 5 );
-
-			$this->migrate_submenus( 'profile.php', $profile_slug );
-			add_filter(
-				'parent_file',
-				function ( $parent_file ) use ( $profile_slug ) {
-					return 'profile.php' === $parent_file ? $profile_slug : $parent_file;
-				}
-			);
+			$this->update_menu( 'profile.php', 'https://wordpress.com/me/account' );
 		}
 	}
 
@@ -578,31 +358,20 @@ class Admin_Menu {
 	 * @param bool $wp_admin_export Optional. Whether Export link should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_tools_menu( $wp_admin_import = false, $wp_admin_export = false ) {
-		$admin_slug = 'tools.php';
-		$menu_slug  = 'https://wordpress.com/marketing/tools/' . $this->domain;
+		$submenus_to_update = array();
+		if ( ! $wp_admin_import ) {
+			$submenus_to_update['import.php'] = 'https://wordpress.com/import/' . $this->domain;
+		}
+		if ( ! $wp_admin_export ) {
+			$submenus_to_update['export.php'] = 'https://wordpress.com/export/' . $this->domain;
+		}
+		$this->update_submenus( 'tools.php', $submenus_to_update );
 
-		remove_menu_page( $admin_slug );
-		remove_submenu_page( $admin_slug, $admin_slug );
-		remove_submenu_page( $admin_slug, 'delete-blog' );
-		remove_submenu_page( $admin_slug, 'import.php' );
-		remove_submenu_page( $admin_slug, 'export.php' );
+		remove_submenu_page( 'tools.php', 'tools.php' );
+		remove_submenu_page( 'tools.php', 'delete-blog' );
 
-		add_menu_page( esc_attr__( 'Tools', 'jetpack' ), __( 'Tools', 'jetpack' ), 'publish_posts', $menu_slug, null, 'dashicons-admin-tools', 75 );
-		add_submenu_page( $menu_slug, esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', $menu_slug );
-		add_submenu_page( $menu_slug, esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain );
-		add_submenu_page( $menu_slug, esc_attr__( 'Import', 'jetpack' ), __( 'Import', 'jetpack' ), 'import', $wp_admin_import ? 'import.php' : 'https://wordpress.com/import/' . $this->domain );
-		add_submenu_page( $menu_slug, esc_attr__( 'Export', 'jetpack' ), __( 'Export', 'jetpack' ), 'export', $wp_admin_export ? 'export.php' : 'https://wordpress.com/export/' . $this->domain );
-
-		$this->migrate_submenus( $admin_slug, $menu_slug );
-
-		add_submenu_page( $menu_slug, esc_attr__( 'Other tools', 'jetpack' ), __( 'Other tools', 'jetpack' ), 'manage_options', 'tools.php' );
-
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $menu_slug ) {
-				return 'tools.php' === $parent_file ? $menu_slug : $parent_file;
-			}
-		);
+		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
+		add_submenu_page( 'tools.php', esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
 	}
 
 	/**
@@ -615,76 +384,117 @@ class Admin_Menu {
 			return;
 		}
 
-		$options_slug = 'https://wordpress.com/settings/general/' . $this->domain;
+		$this->update_submenus( 'options-general.php', array( 'options-general.php' => 'https://wordpress.com/settings/general/' . $this->domain ) );
 
-		remove_menu_page( 'options-general.php' );
-		remove_submenu_page( 'options-general.php', 'options-general.php' );
 		remove_submenu_page( 'options-general.php', 'options-discussion.php' );
 		remove_submenu_page( 'options-general.php', 'options-writing.php' );
-
-		add_menu_page( esc_attr__( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_options', $options_slug, null, 'dashicons-admin-settings', 80 );
-		add_submenu_page( $options_slug, esc_attr__( 'General', 'jetpack' ), __( 'General', 'jetpack' ), 'manage_options', $options_slug, null, 10 );
-
-		$this->migrate_submenus( 'options-general.php', $options_slug );
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $options_slug ) {
-				return 'options-general.php' === $parent_file ? $options_slug : $parent_file;
-			}
-		);
 	}
 
 	/**
-	 * Migrates submenu items from wp-admin menu slugs to Calypso menu slugs.
-	 *
-	 * @param string $old_slug WP-Admin menu slug.
-	 * @param string $new_slug Calypso menu slug. (Calypso URL).
+	 * Adds Jetpack menu.
 	 */
-	public function migrate_submenus( $old_slug, $new_slug ) {
-		global $submenu, $admin_page_hooks;
+	public function add_jetpack_menu() {
+		global $menu;
 
-		if ( $old_slug !== $new_slug && ! empty( $submenu[ $old_slug ] ) ) {
-			if ( ! empty( $submenu[ $new_slug ] ) ) {
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$submenu[ $new_slug ] = array_replace( $submenu[ $new_slug ], $submenu[ $old_slug ] );
-			} else {
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$submenu[ $new_slug ] = $submenu[ $old_slug ];
+		$position = 50;
+		while ( isset( $menu[ $position ] ) ) {
+			$position ++;
+		}
+		$this->add_admin_menu_separator( $position ++, 'manage_options' );
+		$this->update_menu( 'jetpack', null, null, null, null, $position );
+
+		add_submenu_page( 'jetpack', esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, 2 );
+		add_submenu_page( 'jetpack', esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 3 );
+		/* translators: Jetpack sidebar menu item. */
+		add_submenu_page( 'jetpack', esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'read', 'https://wordpress.com/jetpack-search/' . $this->domain, null, 4 );
+
+		remove_submenu_page( 'jetpack', 'stats' );
+		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
+		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
+	}
+
+	/**
+	 * Updates the menu data of the given menu slug.
+	 *
+	 * @param string $slug Slug of the menu to update.
+	 * @param string $url New menu URL.
+	 * @param string $title New menu title.
+	 * @param string $cap New menu capability.
+	 * @param string $icon New menu icon.
+	 * @param int    $position New menu position.
+	 */
+	public function update_menu( $slug, $url = null, $title = null, $cap = null, $icon = null, $position = null ) {
+		global $menu, $submenu;
+
+		$menu_item     = null;
+		$menu_position = null;
+
+		foreach ( $menu as $i => $item ) {
+			if ( $slug === $item[2] ) {
+				$menu_item     = $item;
+				$menu_position = $i;
+				break;
 			}
+		}
 
-			// Keep WP Admin URLs pointing to the old slug. See https://core.trac.wordpress.org/browser/trunk/src/wp-admin/menu-header.php?rev=49193#L254.
-			foreach ( $submenu[ $old_slug ] as $i => $submenu_item ) {
-				$menu_file = $old_slug;
-				$menu_hook = get_plugin_page_hook( $submenu_item[2], $old_slug );
-				$sub_file  = $submenu_item[2];
-				$pos       = strpos( $sub_file, '?' );
-				if ( false !== $pos ) {
-					$sub_file = substr( $sub_file, 0, $pos );
-				}
-				if (
-					! empty( $menu_hook ) ||
-					(
-						( 'index.php' !== $submenu_item[2] ) &&
-						file_exists( WP_PLUGIN_DIR . "/$sub_file" ) &&
-						! file_exists( ABSPATH . "/wp-admin/$sub_file" )
-					)
-				) {
-					if ( file_exists( $menu_file ) ) {
-						$sub_item_url    = add_query_arg( array( 'page' => $submenu_item[2] ), $old_slug );
-						$submenu_item[2] = esc_url( $sub_item_url );
-						// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-						$submenu[ $new_slug ][ $i ] = $submenu_item;
-					}
-				}
+		if ( ! $menu_item ) {
+			return;
+		}
 
-				// Migrate page hooks to the new slugs. See https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/plugin.php?rev=49193#L1330.
-				if ( isset( $admin_page_hooks[ $old_slug ] ) ) {
-					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-					$admin_page_hooks[ $new_slug ] = $admin_page_hooks[ $old_slug ];
-				}
+		if ( $title ) {
+			$menu_item[0] = $title;
+			$menu_item[3] = esc_attr( $title );
+		}
+
+		if ( $cap ) {
+			$menu_item[1] = $cap;
+		}
+
+		// Change parent slug only if there are no submenus (the slug of the 1st submenu will be used if there are submenus).
+		if ( $url ) {
+			remove_submenu_page( $slug, $slug );
+			if ( empty( $submenu[ $slug ] ) ) {
+				$menu_item[2] = $url;
 			}
+		}
 
-			unset( $submenu[ $old_slug ] );
+		if ( $icon ) {
+			$menu_item[6] = $icon;
+		}
+
+		if ( $position ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			unset( $menu[ $menu_position ] );
+			$menu_position = $position;
+		}
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$menu[ $menu_position ] = $menu_item;
+
+		// Only add submenu when there are other submenu items.
+		if ( $url && ! empty( $submenu[ $slug ] ) ) {
+			add_submenu_page( $slug, $menu_item[3], $menu_item[0], $menu_item[1], $url, null, 0 );
+		}
+	}
+
+	/**
+	 * Updates the submenus of the given menu slug.
+	 *
+	 * @param string $slug Menu slug.
+	 * @param array  $submenus_to_update Array of new submenu slugs.
+	 */
+	public function update_submenus( $slug, $submenus_to_update ) {
+		global $submenu;
+
+		if ( ! isset( $submenu[ $slug ] ) ) {
+			return;
+		}
+
+		foreach ( $submenu[ $slug ] as $i => $submenu_item ) {
+			if ( array_key_exists( $submenu_item[2], $submenus_to_update ) ) {
+				$submenu_item[2] = $submenus_to_update[ $submenu_item[2] ];
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$submenu[ $slug ][ $i ] = $submenu_item;
+			}
 		}
 	}
 
@@ -703,51 +513,10 @@ class Admin_Menu {
 	}
 
 	/**
-	 * Adds Jetpack menu.
-	 */
-	public function add_jetpack_menu() {
-		global $menu;
-
-		$position = 50;
-		while ( isset( $menu[ $position ] ) ) {
-			$position++;
-		}
-
-		// TODO: Replace with proper SVG data url.
-		$jetpack_icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 32 32' %3E%3Cpath fill='%23a0a5aa' d='M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z'%3E%3C/path%3E%3Cpolygon fill='%23fff' points='15,19 7,19 15,3 '%3E%3C/polygon%3E%3Cpolygon fill='%23fff' points='17,29 17,13 25,13 '%3E%3C/polygon%3E%3C/svg%3E";
-		$jetpack_slug = 'https://wordpress.com/activity-log/' . $this->domain;
-
-		$this->add_admin_menu_separator( $position++, 'manage_options' );
-		add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', $jetpack_slug, null, $jetpack_icon, $position );
-
-		// Maintain id for jQuery selector.
-		$menu[ $position ][5] = 'toplevel_page_jetpack'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		remove_menu_page( 'jetpack' );
-		remove_submenu_page( 'jetpack', 'stats' );
-		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
-		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
-
-		$this->migrate_submenus( 'jetpack', $jetpack_slug );
-
-		add_submenu_page( $jetpack_slug, esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', $jetpack_slug, null, 2 );
-		add_submenu_page( $jetpack_slug, esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 3 );
-		/* translators: Jetpack sidebar menu item. */
-		add_submenu_page( $jetpack_slug, esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'read', 'https://wordpress.com/jetpack-search/' . $this->domain, null, 4 );
-
-		add_filter(
-			'parent_file',
-			function ( $parent_file ) use ( $jetpack_slug ) {
-				return 'jetpack' === $parent_file ? $jetpack_slug : $parent_file;
-			}
-		);
-	}
-
-	/**
 	 * Adds a menu separator.
 	 *
 	 * @param int    $position The position in the menu order this item should appear.
-	 * @param string $cap      Optional. The capability required for this menu to be displayed to the user.
+	 * @param string $cap Optional. The capability required for this menu to be displayed to the user.
 	 *                         Default: 'read'.
 	 */
 	public function add_admin_menu_separator( $position, $cap = 'read' ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -269,7 +269,7 @@ class Admin_Menu {
 	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
 	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_appearance_menu( $wp_admin_themes, $wp_admin_customize ) {
+	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
 		if ( ! $wp_admin_customize ) {
 			$customize_url = 'https://wordpress.com/customize/' . $this->domain;
 		} elseif ( $this->is_api_request ) {
@@ -335,7 +335,7 @@ class Admin_Menu {
 				$submenus_to_update = array(
 					'users.php'    => 'https://wordpress.com/people/team/' . $this->domain,
 					'user-new.php' => 'https://wordpress.com/people/new/' . $this->domain,
-					'profile.php'  => 'https://wordpress.com/me/',
+					'profile.php'  => 'https://wordpress.com/me',
 				);
 				$this->update_submenus( 'users.php', $submenus_to_update );
 			}
@@ -344,10 +344,16 @@ class Admin_Menu {
 			remove_submenu_page( 'users.php', 'grofiles-user-settings' );
 			add_submenu_page( 'users.php', esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
 		} else {
+			if ( ! $wp_admin ) {
+				$submenus_to_update = array(
+					'user-new.php' => 'https://wordpress.com/people/new/' . $this->domain,
+					'profile.php'  => 'https://wordpress.com/me',
+				);
+				$this->update_submenus( 'profile.php', $submenus_to_update );
+			}
 			remove_submenu_page( 'profile.php', 'grofiles-editor' );
 			remove_submenu_page( 'profile.php', 'grofiles-user-settings' );
-
-			$this->update_menu( 'profile.php', 'https://wordpress.com/me/account' );
+			add_submenu_page( 'profile.php', esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -311,6 +311,9 @@ class Admin_Menu {
 
 		$this->update_submenus( 'themes.php', $submenus_to_update );
 
+		remove_submenu_page( 'themes.php', 'custom-header' );
+		remove_submenu_page( 'themes.php', 'custom-background' );
+
 		return $customize_url;
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -417,7 +417,7 @@ class Admin_Menu {
 
 		$is_menu_updated = $this->update_menu( 'jetpack', null, null, null, $icon, $position );
 		if ( ! $is_menu_updated ) {
-			add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, $icon, $position );
+			add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'jetpack', null, $icon, $position );
 		}
 
 		add_submenu_page( 'jetpack', esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, 2 );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -430,6 +430,11 @@ class Admin_Menu {
 		remove_submenu_page( 'jetpack', 'stats' );
 		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
 		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
+
+		if ( ! $is_menu_updated ) {
+			// Remove the submenu auto-created by Core.
+			remove_submenu_page( 'jetpack', 'jetpack' );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -411,7 +411,10 @@ class Admin_Menu {
 		// TODO: Replace with proper SVG data url.
 		$icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 32 32' %3E%3Cpath fill='%23a0a5aa' d='M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z'%3E%3C/path%3E%3Cpolygon fill='%23fff' points='15,19 7,19 15,3 '%3E%3C/polygon%3E%3Cpolygon fill='%23fff' points='17,29 17,13 25,13 '%3E%3C/polygon%3E%3C/svg%3E";
 
-		$this->update_menu( 'jetpack', 'jetpack', __( 'Jetpack', 'jetpack' ), 'read', $icon, $position, true );
+		$is_menu_updated = $this->update_menu( 'jetpack', null, null, null, $icon, $position );
+		if ( ! $is_menu_updated ) {
+			add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'read', 'jetpack', null, set_url_scheme( $icon ), $position );
+		}
 
 		add_submenu_page( 'jetpack', esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, 2 );
 		add_submenu_page( 'jetpack', esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 3 );
@@ -432,9 +435,9 @@ class Admin_Menu {
 	 * @param string $cap New menu capability.
 	 * @param string $icon New menu icon.
 	 * @param int    $position New menu position.
-	 * @param bool   $create_if_missing Forces the creation of the menu when missing.
+	 * @return bool Whether the menu has been updated.
 	 */
-	public function update_menu( $slug, $url = null, $title = null, $cap = null, $icon = null, $position = null, $create_if_missing = false ) {
+	public function update_menu( $slug, $url = null, $title = null, $cap = null, $icon = null, $position = null ) {
 		global $menu, $submenu;
 
 		$menu_item     = null;
@@ -449,10 +452,7 @@ class Admin_Menu {
 		}
 
 		if ( ! $menu_item ) {
-			if ( $create_if_missing ) {
-				add_menu_page( esc_attr( $title ), $title, $cap, $url, null, $icon, $position );
-			}
-			return;
+			return false;
 		}
 
 		if ( $title ) {
@@ -473,6 +473,7 @@ class Admin_Menu {
 		}
 
 		if ( $icon ) {
+			$menu_item[4] = 'menu-top';
 			$menu_item[6] = $icon;
 		}
 
@@ -488,6 +489,8 @@ class Admin_Menu {
 		if ( $url && ! empty( $submenu[ $slug ] ) ) {
 			add_submenu_page( $slug, $menu_item[3], $menu_item[0], $menu_item[1], $url, null, 0 );
 		}
+
+		return true;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -641,7 +641,7 @@ class Admin_Menu {
 	 * @param string $new_slug Calypso menu slug. (Calypso URL).
 	 */
 	public function migrate_submenus( $old_slug, $new_slug ) {
-		global $submenu;
+		global $submenu, $wp_filter, $_registered_pages;
 
 		if ( $old_slug !== $new_slug && ! empty( $submenu[ $old_slug ] ) ) {
 			if ( ! empty( $submenu[ $new_slug ] ) ) {
@@ -651,6 +651,23 @@ class Admin_Menu {
 				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				$submenu[ $new_slug ] = $submenu[ $old_slug ];
 			}
+
+			// Migrate hooks.
+			foreach ( $submenu[ $old_slug ] as $submenu_item ) {
+				$old_hookname = get_plugin_page_hookname( $submenu_item[2], $old_slug );
+				$new_hookname = get_plugin_page_hookname( $submenu_item[2], $new_slug );
+				if ( empty( $old_hookname ) || empty( $new_hookname ) || $old_hookname === $new_hookname || ! isset( $wp_filter[ $old_hookname ] ) ) {
+					continue;
+				}
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$wp_filter[ $new_hookname ] = $wp_filter[ $old_hookname ];
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$_registered_pages[ $new_hookname ] = true;
+
+				unset( $wp_filter[ $old_hookname ] );
+				unset( $_registered_pages[ $old_hookname ] );
+			}
+
 			unset( $submenu[ $old_slug ] );
 		}
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -268,24 +268,26 @@ class Admin_Menu {
 	 *
 	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
 	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
+	 * @return string The Customizer URL.
 	 */
 	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
-		if ( ! $wp_admin_customize ) {
-			$customize_url = 'https://wordpress.com/customize/' . $this->domain;
-		} elseif ( $this->is_api_request ) {
-			// In case this is an api request we will have to add the 'return' querystring via JS.
-			$customize_url = 'customize.php';
-		} else {
-			$customize_url = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
-		}
-
-		$default_customize_slug          = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
+		$request_uri                     = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$default_customize_slug          = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), $request_uri ) ), 'customize.php' );
 		$default_customize_header_slug_1 = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $default_customize_slug );
 		// TODO: Remove WPCom_Theme_Customizer::modify_header_menu_links() and WPcom_Custom_Header::modify_admin_menu_links().
 		$default_customize_header_slug_2     = admin_url( 'themes.php?page=custom-header' );
 		$default_customize_background_slug_1 = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $default_customize_slug );
 		// TODO: Remove Colors_Manager::modify_header_menu_links() and Colors_Manager_Common::modify_header_menu_links().
 		$default_customize_background_slug_2 = add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), admin_url( 'customize.php' ) );
+
+		if ( ! $wp_admin_customize ) {
+			$customize_url = 'https://wordpress.com/customize/' . $this->domain;
+		} elseif ( $this->is_api_request ) {
+			// In case this is an api request we will have to add the 'return' querystring via JS.
+			$customize_url = 'customize.php';
+		} else {
+			$customize_url = $default_customize_slug;
+		}
 
 		$submenus_to_update = array(
 			$default_customize_slug              => $customize_url,
@@ -306,6 +308,8 @@ class Admin_Menu {
 		}
 
 		$this->update_submenus( 'themes.php', $submenus_to_update );
+
+		return $customize_url;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -146,23 +146,25 @@ class Admin_Menu {
 	public function add_upgrades_menu() {
 		global $menu;
 
-		$menu_slug = null;
+		$menu_exists = false;
 		foreach ( $menu as $item ) {
 			if ( 'paid-upgrades.php' === $item[2] ) {
-				$menu_slug = $item[2];
+				$menu_exists = true;
 				break;
 			}
 		}
 
-		if ( ! $menu_slug ) {
-			$menu_slug = 'https://wordpress.com/plans/' . $this->domain;
-			add_menu_page( __( 'Upgrades', 'jetpack' ), __( 'Upgrades', 'jetpack' ), 'manage_options', $menu_slug, null, 'dashicons-cart', 4 );
+		if ( ! $menu_exists ) {
+			add_menu_page( __( 'Upgrades', 'jetpack' ), __( 'Upgrades', 'jetpack' ), 'manage_options', 'paid-upgrades.php', null, 'dashicons-cart', 4 );
 		}
 
-		add_submenu_page( $menu_slug, __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', $menu_slug, null, 5 );
-		add_submenu_page( $menu_slug, __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 15 );
+		add_submenu_page( 'paid-upgrades.php', __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/' . $this->domain, null, 5 );
+		add_submenu_page( 'paid-upgrades.php', __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 15 );
 
-		return $menu_slug;
+		if ( ! $menu_exists ) {
+			// Remove the submenu auto-created by Core.
+			remove_submenu_page( 'paid-upgrades.php', 'paid-upgrades.php' );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -404,10 +404,14 @@ class Admin_Menu {
 
 		$position = 50;
 		while ( isset( $menu[ $position ] ) ) {
-			$position ++;
+			$position++;
 		}
-		$this->add_admin_menu_separator( $position ++, 'manage_options' );
-		$this->update_menu( 'jetpack', null, null, null, null, $position );
+		$this->add_admin_menu_separator( $position++, 'manage_options' );
+
+		// TODO: Replace with proper SVG data url.
+		$icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 32 32' %3E%3Cpath fill='%23a0a5aa' d='M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z'%3E%3C/path%3E%3Cpolygon fill='%23fff' points='15,19 7,19 15,3 '%3E%3C/polygon%3E%3Cpolygon fill='%23fff' points='17,29 17,13 25,13 '%3E%3C/polygon%3E%3C/svg%3E";
+
+		$this->update_menu( 'jetpack', 'jetpack', __( 'Jetpack', 'jetpack' ), 'read', $icon, $position, true );
 
 		add_submenu_page( 'jetpack', esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, 2 );
 		add_submenu_page( 'jetpack', esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 3 );
@@ -428,8 +432,9 @@ class Admin_Menu {
 	 * @param string $cap New menu capability.
 	 * @param string $icon New menu icon.
 	 * @param int    $position New menu position.
+	 * @param bool   $create_if_missing Forces the creation of the menu when missing.
 	 */
-	public function update_menu( $slug, $url = null, $title = null, $cap = null, $icon = null, $position = null ) {
+	public function update_menu( $slug, $url = null, $title = null, $cap = null, $icon = null, $position = null, $create_if_missing = false ) {
 		global $menu, $submenu;
 
 		$menu_item     = null;
@@ -444,6 +449,9 @@ class Admin_Menu {
 		}
 
 		if ( ! $menu_item ) {
+			if ( $create_if_missing ) {
+				add_menu_page( esc_attr( $title ), $title, $cap, $url, null, $icon, $position );
+			}
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -417,7 +417,7 @@ class Admin_Menu {
 
 		$is_menu_updated = $this->update_menu( 'jetpack', null, null, null, $icon, $position );
 		if ( ! $is_menu_updated ) {
-			add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'read', 'jetpack', null, set_url_scheme( $icon ), $position );
+			add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, $icon, $position );
 		}
 
 		add_submenu_page( 'jetpack', esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, 2 );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -346,8 +346,6 @@ class Admin_Menu {
 				$this->update_submenus( 'users.php', $submenus_to_update );
 			}
 
-			remove_submenu_page( 'users.php', 'grofiles-editor' );
-			remove_submenu_page( 'users.php', 'grofiles-user-settings' );
 			add_submenu_page( 'users.php', esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
 		} else {
 			if ( ! $wp_admin ) {
@@ -357,8 +355,7 @@ class Admin_Menu {
 				);
 				$this->update_submenus( 'profile.php', $submenus_to_update );
 			}
-			remove_submenu_page( 'profile.php', 'grofiles-editor' );
-			remove_submenu_page( 'profile.php', 'grofiles-user-settings' );
+
 			add_submenu_page( 'profile.php', esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
 		}
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -201,12 +201,12 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_options_menu( $wp_admin = false ) {
 		parent::add_options_menu( $wp_admin );
 
-		add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
 		// No need to add a menu linking to WP Admin if there is already one.
 		if ( ! $wp_admin ) {
-			add_options_page( esc_attr__( 'Advanced General', 'jetpack' ), __( 'Advanced General', 'jetpack' ), 'manage_options', 'options-general.php' );
-			add_options_page( esc_attr__( 'Advanced Writing', 'jetpack' ), __( 'Advanced Writing', 'jetpack' ), 'manage_options', 'options-writing.php' );
+			add_submenu_page( 'options-general.php', esc_attr__( 'Advanced General', 'jetpack' ), __( 'Advanced General', 'jetpack' ), 'manage_options', 'options-general.php' );
+			add_submenu_page( 'options-general.php', esc_attr__( 'Advanced Writing', 'jetpack' ), __( 'Advanced Writing', 'jetpack' ), 'manage_options', 'options-writing.php' );
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -35,10 +35,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function reregister_menu_items() {
 		parent::reregister_menu_items();
 
-		$wp_admin = $this->should_link_to_wp_admin();
-
-		$this->add_my_home_menu( $wp_admin );
-		$this->add_theme_install_menu( $wp_admin );
+		$this->add_my_home_menu();
 
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request ) {
@@ -78,6 +75,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds a custom element class for Site Switcher menu item.
 	 *
 	 * @param array $menu Associative array of administration menu items.
+	 *
 	 * @return array
 	 */
 	public function set_browse_sites_link_class( array $menu ) {
@@ -107,11 +105,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Attempt to get last position.
 		$position = 1000;
 		while ( isset( $menu[ $position ] ) ) {
-			$position++;
+			$position ++;
 		}
 
-		$this->add_admin_menu_separator( ++$position );
-		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt', ++$position );
+		$this->add_admin_menu_separator( ++ $position );
+		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt', ++ $position );
 	}
 
 	/**
@@ -151,6 +149,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds a custom element class and id for Site Card's menu item.
 	 *
 	 * @param array $menu Associative array of administration menu items.
+	 *
 	 * @return array
 	 */
 	public function set_site_card_menu_class( array $menu ) {
@@ -178,9 +177,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Upgrades menu.
 	 */
 	public function add_upgrades_menu() {
-		parent::add_upgrades_menu();
+		$menu_slug = parent::add_upgrades_menu();
 
-		add_submenu_page( 'https://wordpress.com/plans/' . $this->domain, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
+		add_submenu_page( $menu_slug, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
 	}
 
 	/**
@@ -200,27 +199,15 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_options_menu( $wp_admin = false ) {
-		add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
-
 		parent::add_options_menu( $wp_admin );
+
+		add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
 		// No need to add a menu linking to WP Admin if there is already one.
 		if ( ! $wp_admin ) {
-			$parent_menu_slug = 'https://wordpress.com/settings/general/' . $this->domain;
-			add_submenu_page( $parent_menu_slug, esc_attr__( 'Advanced General', 'jetpack' ), __( 'Advanced General', 'jetpack' ), 'manage_options', 'options-general.php' );
-			add_submenu_page( $parent_menu_slug, esc_attr__( 'Advanced Writing', 'jetpack' ), __( 'Advanced Writing', 'jetpack' ), 'manage_options', 'options-writing.php' );
+			add_options_page( esc_attr__( 'Advanced General', 'jetpack' ), __( 'Advanced General', 'jetpack' ), 'manage_options', 'options-general.php' );
+			add_options_page( esc_attr__( 'Advanced Writing', 'jetpack' ), __( 'Advanced Writing', 'jetpack' ), 'manage_options', 'options-writing.php' );
 		}
-	}
-
-	/**
-	 * Adds a WordPress.org theme install menu item.
-	 *
-	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
-	 */
-	public function add_theme_install_menu( $wp_admin = false ) {
-		$parent_menu_slug = $wp_admin ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
-
-		add_submenu_page( $parent_menu_slug, esc_attr__( 'Add New Theme', 'jetpack' ), __( 'Add New Theme', 'jetpack' ), 'install_themes', 'theme-install.php', null, 1 );
 	}
 
 	/**
@@ -233,9 +220,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Customize on Atomic sites is always done on WP Admin.
 		parent::add_appearance_menu( $wp_admin_themes, true );
 
-		// Add back the Theme Editor submenu.
-		$parent_slug = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
-		add_submenu_page( $parent_slug, __( 'Theme Editor', 'jetpack' ), __( 'Theme Editor', 'jetpack' ), 'edit_themes', 'theme-editor.php' );
+		add_submenu_page( 'themes.php', esc_attr__( 'Add New Theme', 'jetpack' ), __( 'Add New Theme', 'jetpack' ), 'install_themes', 'theme-install.php', null, 1 );
 	}
 
 	/**
@@ -251,8 +236,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			return;
 		}
 
-		$parent_menu_slug = 'https://wordpress.com/people/team/' . $this->domain;
-
-		add_submenu_page( $parent_menu_slug, esc_attr__( 'Advanced Users Management', 'jetpack' ), __( 'Advanced Users Management', 'jetpack' ), 'list_users', 'users.php', null, 2 );
+		add_submenu_page( 'users.php', esc_attr__( 'Advanced Users Management', 'jetpack' ), __( 'Advanced Users Management', 'jetpack' ), 'list_users', 'users.php', null, 2 );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -105,11 +105,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Attempt to get last position.
 		$position = 1000;
 		while ( isset( $menu[ $position ] ) ) {
-			$position ++;
+			$position++;
 		}
 
-		$this->add_admin_menu_separator( ++ $position );
-		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt', ++ $position );
+		$this->add_admin_menu_separator( ++$position );
+		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt', ++$position );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -177,9 +177,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Upgrades menu.
 	 */
 	public function add_upgrades_menu() {
-		$menu_slug = parent::add_upgrades_menu();
+		parent::add_upgrades_menu();
 
-		add_submenu_page( $menu_slug, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
+		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -59,20 +59,14 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin_export Optional. Whether Export link should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_tools_menu( $wp_admin_import = false, $wp_admin_export = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$admin_slug = 'tools.php';
-		$menu_slug  = 'https://wordpress.com/marketing/tools/' . $this->domain;
+		$this->remove_submenus( 'tools.php' );
 
-		remove_menu_page( $admin_slug );
-		$this->remove_submenus( $admin_slug );
-
-		add_menu_page( esc_attr__( 'Tools', 'jetpack' ), __( 'Tools', 'jetpack' ), 'publish_posts', $menu_slug, null, 'dashicons-admin-tools', 75 );
-		add_submenu_page( $menu_slug, esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', $menu_slug );
-		add_submenu_page( $menu_slug, esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain );
+		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain );
+		add_submenu_page( 'tools.php', esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain );
 
 		// Import/Export on Jetpack sites is always handled on WP Admin.
-		add_submenu_page( $menu_slug, esc_attr__( 'Import', 'jetpack' ), __( 'Import', 'jetpack' ), 'import', 'import.php' );
-		add_submenu_page( $menu_slug, esc_attr__( 'Export', 'jetpack' ), __( 'Export', 'jetpack' ), 'export', 'export.php' );
-
+		add_submenu_page( 'tools.php', esc_attr__( 'Import', 'jetpack' ), __( 'Import', 'jetpack' ), 'import', 'import.php' );
+		add_submenu_page( 'tools.php', esc_attr__( 'Export', 'jetpack' ), __( 'Export', 'jetpack' ), 'export', 'export.php' );
 	}
 
 	/**
@@ -80,10 +74,8 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_wp_admin_menu() {
 		global $menu;
-		$menu_slug = 'index.php';
 
-		remove_menu_page( $menu_slug );
-		$this->remove_submenus( $menu_slug );
+		$this->remove_submenus( 'index.php' );
 
 		// Attempt to get last position.
 		ksort( $menu );
@@ -91,8 +83,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		$position = key( $menu );
 
 		$this->add_admin_menu_separator( ++$position );
-
-		add_menu_page( __( 'WP Admin', 'jetpack' ), __( 'WP Admin', 'jetpack' ), 'read', $menu_slug, null, 'dashicons-wordpress-alt', $position );
+		$this->update_menu( 'index.php', null, __( 'WP Admin', 'jetpack' ), null, 'dashicons-wordpress-alt', $position );
 	}
 
 	/**
@@ -102,18 +93,11 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$appearance_cap = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
-		$admin_slug     = 'themes.php';
-		$menu_slug      = 'https://wordpress.com/themes/' . $this->domain;
-
 		// Remove all submenus except Themes and Customize to mimic the old Calypso navigation.
-		remove_menu_page( $admin_slug );
-		$this->remove_submenus( $admin_slug );
-		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), $appearance_cap, $menu_slug, null, 'dashicons-admin-appearance', 60 );
-		add_submenu_page( $menu_slug, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', $menu_slug );
-
+		$this->remove_submenus( 'themes.php' );
+		add_submenu_page( 'themes.php', esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', 'https://wordpress.com/themes/' . $this->domain );
 		// Customize on Jetpack sites is always done on WP Admin (unsupported by Calypso).
-		add_submenu_page( $menu_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', 'customize.php' );
+		add_submenu_page( 'themes.php', esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', 'customize.php' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -20,84 +20,29 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	public function reregister_menu_items() {
 		global $menu, $submenu;
 
+		// Change the menu only when rendered in Calypso.
 		if ( $this->is_api_request || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-			// Reset menus for API requests (i.e. Calypso) so there are no third-party plugin items.
+			// Reset menus so there are no third-party plugin items.
 			$menu    = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$submenu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+			parent::reregister_menu_items();
+
+			$this->add_feedback_menu();
+			$this->add_wp_admin_menu();
+
+			ksort( $GLOBALS['menu'] );
 		}
-
-		parent::reregister_menu_items();
-
-		$this->add_feedback_menu();
-		$this->add_wp_admin_menu();
-
-		ksort( $GLOBALS['menu'] );
 	}
 
 	/**
-	 * Adds Jetpack menu.
-	 */
-	public function add_jetpack_menu() {
-		parent::add_jetpack_menu();
-
-		// Place "Scan" submenu after Backup.
-		$position = 0;
-		global $submenu;
-		foreach ( $submenu['jetpack'] as $submenu_item ) {
-			$position++;
-			if ( __( 'Backup', 'jetpack' ) === $submenu_item[3] ) {
-				break;
-			}
-		}
-		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack' ), __( 'Scan', 'jetpack' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $position );
-	}
-
-	/**
-	 * Adds Tools menu.
+	 * Whether to use wp-admin pages rather than Calypso.
 	 *
-	 * @param bool $wp_admin_import Optional. Whether Import link should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param bool $wp_admin_export Optional. Whether Export link should point to Calypso or wp-admin. Default false (Calypso).
+	 * @return bool
 	 */
-	public function add_tools_menu( $wp_admin_import = false, $wp_admin_export = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$this->remove_submenus( 'tools.php' );
-
-		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain );
-		add_submenu_page( 'tools.php', esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain );
-
-		// Import/Export on Jetpack sites is always handled on WP Admin.
-		add_submenu_page( 'tools.php', esc_attr__( 'Import', 'jetpack' ), __( 'Import', 'jetpack' ), 'import', 'import.php' );
-		add_submenu_page( 'tools.php', esc_attr__( 'Export', 'jetpack' ), __( 'Export', 'jetpack' ), 'export', 'export.php' );
-	}
-
-	/**
-	 * Adds WP Admin menu.
-	 */
-	public function add_wp_admin_menu() {
-		global $menu;
-
-		$this->remove_submenus( 'index.php' );
-
-		// Attempt to get last position.
-		ksort( $menu );
-		end( $menu );
-		$position = key( $menu );
-
-		$this->add_admin_menu_separator( ++$position );
-		$this->update_menu( 'index.php', null, __( 'WP Admin', 'jetpack' ), null, 'dashicons-wordpress-alt', $position );
-	}
-
-	/**
-	 * Adds Appearance menu.
-	 *
-	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
-	 */
-	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Remove all submenus except Themes and Customize to mimic the old Calypso navigation.
-		$this->remove_submenus( 'themes.php' );
-		add_submenu_page( 'themes.php', esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', 'https://wordpress.com/themes/' . $this->domain );
-		// Customize on Jetpack sites is always done on WP Admin (unsupported by Calypso).
-		add_submenu_page( 'themes.php', esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', 'customize.php' );
+	public function should_link_to_wp_admin() {
+		// Force Calypso links on Jetpack sites since Nav Unification is disabled on WP Admin.
+		return false;
 	}
 
 	/**
@@ -106,10 +51,17 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_posts_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		parent::add_posts_menu();
+		$post = get_post_type_object( 'post' );
+		add_menu_page( esc_attr( $post->labels->menu_name ), $post->labels->menu_name, $post->cap->edit_posts, 'https://wordpress.com/posts/' . $this->domain, null, 'dashicons-admin-post' );
+	}
 
-		// Remove all submenus to mimic the old Calypso navigation.
-		$this->remove_submenus( 'edit.php' );
+	/**
+	 * Adds Media menu.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_media_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		add_menu_page( __( 'Media', 'jetpack' ), __( 'Media', 'jetpack' ), 'upload_files', 'https://wordpress.com/media/' . $this->domain, null, 'dashicons-admin-media' );
 	}
 
 	/**
@@ -118,10 +70,8 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_page_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		parent::add_page_menu();
-
-		// Remove all submenus to mimic the old Calypso navigation.
-		$this->remove_submenus( 'edit.php?post_type=page' );
+		$page = get_post_type_object( 'page' );
+		add_menu_page( esc_attr( $page->labels->menu_name ), $page->labels->menu_name, $page->cap->edit_posts, 'https://wordpress.com/pages/' . $this->domain, null, 'dashicons-admin-page' );
 	}
 
 	/**
@@ -131,22 +81,34 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 * @param bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_custom_post_type_menu( $post_type, $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		parent::add_custom_post_type_menu( $post_type );
+		$ptype_obj = get_post_type_object( $post_type );
+		if ( empty( $ptype_obj ) ) {
+			return;
+		}
 
-		// Remove all submenus to mimic the old Calypso navigation.
-		$this->remove_submenus( 'edit.php?post_type=' . $post_type );
+		$menu_slug = 'https://wordpress.com/types/' . $post_type . '/' . $this->domain;
+
+		// Menu icon.
+		$menu_icon = 'dashicons-admin-post';
+		if ( is_string( $ptype_obj->menu_icon ) ) {
+			// Special handling for data:image/svg+xml and Dashicons.
+			if ( 0 === strpos( $ptype_obj->menu_icon, 'data:image/svg+xml;base64,' ) || 0 === strpos( $ptype_obj->menu_icon, 'dashicons-' ) ) {
+				$menu_icon = $ptype_obj->menu_icon;
+			} else {
+				$menu_icon = esc_url( $ptype_obj->menu_icon );
+			}
+		}
+
+		add_menu_page( esc_attr( $ptype_obj->labels->menu_name ), $ptype_obj->labels->menu_name, $ptype_obj->cap->edit_posts, $menu_slug, null, $menu_icon );
 	}
 
 	/**
-	 * Adds Users menu.
+	 * Adds Comments menu.
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_users_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		parent::add_users_menu();
-
-		// Remove all submenus to mimic the old Calypso navigation.
-		$this->remove_submenus( 'users.php' );
+	public function add_comments_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		add_menu_page( esc_attr__( 'Comments', 'jetpack' ), __( 'Comments', 'jetpack' ), 'edit_posts', 'https://wordpress.com/comments/all/' . $this->domain, null, 'dashicons-admin-comments' );
 	}
 
 	/**
@@ -170,13 +132,34 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
-	 * Whether to use wp-admin pages rather than Calypso.
-	 *
-	 * @return bool
+	 * Adds Jetpack menu.
 	 */
-	public function should_link_to_wp_admin() {
-		// Force Calypso links on Jetpack sites since Nav Unification is disabled on WP Admin.
-		return false;
+	public function add_jetpack_menu() {
+		parent::add_jetpack_menu();
+
+		// Place "Scan" submenu after Backup.
+		$position = 0;
+		global $submenu;
+		foreach ( $submenu['jetpack'] as $submenu_item ) {
+			$position ++;
+			if ( __( 'Backup', 'jetpack' ) === $submenu_item[3] ) {
+				break;
+			}
+		}
+		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack' ), __( 'Scan', 'jetpack' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $position );
+	}
+
+	/**
+	 * Adds Appearance menu.
+	 *
+	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), 'switch_themes', 'https://wordpress.com/themes/' . $this->domain, null, 'dashicons-admin-appearance', 60 );
+		add_submenu_page( 'themes.php', esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', 'https://wordpress.com/themes/' . $this->domain );
+		// Customize on Jetpack sites is always done on WP Admin (unsupported by Calypso).
+		add_submenu_page( 'themes.php', esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', 'customize.php' );
 	}
 
 	/**
@@ -185,7 +168,60 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_plugins_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Plugins on Jetpack sites are always managed on Calypso.
-		parent::add_plugins_menu( false );
+		add_menu_page( esc_attr__( 'Plugins', 'jetpack' ), __( 'Plugins', 'jetpack' ), 'activate_plugins', 'https://wordpress.com/plugins/' . $this->domain, null, 'dashicons-admin-plugins', 65 );
+	}
+
+	/**
+	 * Adds Users menu.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_users_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( current_user_can( 'list_users' ) ) {
+			add_menu_page( esc_attr__( 'Users', 'jetpack' ), __( 'Users', 'jetpack' ), 'list_users', 'https://wordpress.com/people/team/' . $this->domain, null, 'dashicons-admin-users', 70 );
+		} else {
+			add_menu_page( esc_attr__( 'My Profile', 'jetpack' ), __( 'Profile', 'jetpack' ), 'read', 'https://wordpress.com/me', null, 'dashicons-admin-users', 70 );
+		}
+	}
+
+	/**
+	 * Adds Tools menu.
+	 *
+	 * @param bool $wp_admin_import Optional. Whether Import link should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param bool $wp_admin_export Optional. Whether Export link should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_tools_menu( $wp_admin_import = false, $wp_admin_export = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		add_menu_page( esc_attr__( 'Tools', 'jetpack' ), __( 'Tools', 'jetpack' ), 'publish_posts', 'https://wordpress.com/themes/' . $this->domain, null, 'dashicons-admin-tools', 75 );
+
+		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/themes/' . $this->domain );
+		add_submenu_page( 'tools.php', esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain );
+
+		// Import/Export on Jetpack sites is always handled on WP Admin.
+		add_submenu_page( 'tools.php', esc_attr__( 'Import', 'jetpack' ), __( 'Import', 'jetpack' ), 'import', 'import.php' );
+		add_submenu_page( 'tools.php', esc_attr__( 'Export', 'jetpack' ), __( 'Export', 'jetpack' ), 'export', 'export.php' );
+	}
+
+	/**
+	 * Adds Settings menu.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_options_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		add_menu_page( esc_attr__( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/general/' . $this->domain, null, 'dashicons-admin-settings', 80 );
+	}
+
+	/**
+	 * Adds WP Admin menu.
+	 */
+	public function add_wp_admin_menu() {
+		global $menu;
+
+		// Attempt to get last position.
+		ksort( $menu );
+		end( $menu );
+		$position = key( $menu );
+
+		$this->add_admin_menu_separator( ++ $position );
+		add_menu_page( __( 'WP Admin', 'jetpack' ), __( 'WP Admin', 'jetpack' ), 'read', 'index.php', null, 'dashicons-wordpress-alt', $position );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -44,7 +44,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		$position = 0;
 		global $submenu;
 		foreach ( $submenu['jetpack'] as $submenu_item ) {
-			$position ++;
+			$position++;
 			if ( __( 'Backup', 'jetpack' ) === $submenu_item[3] ) {
 				break;
 			}
@@ -90,7 +90,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		end( $menu );
 		$position = key( $menu );
 
-		$this->add_admin_menu_separator( ++ $position );
+		$this->add_admin_menu_separator( ++$position );
 
 		add_menu_page( __( 'WP Admin', 'jetpack' ), __( 'WP Admin', 'jetpack' ), 'read', $menu_slug, null, 'dashicons-wordpress-alt', $position );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -40,18 +40,16 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	public function add_jetpack_menu() {
 		parent::add_jetpack_menu();
 
-		$parent_slug = 'https://wordpress.com/activity-log/' . $this->domain;
-
 		// Place "Scan" submenu after Backup.
 		$position = 0;
 		global $submenu;
-		foreach ( $submenu[ $parent_slug ] as $submenu_item ) {
-			$position++;
+		foreach ( $submenu['jetpack'] as $submenu_item ) {
+			$position ++;
 			if ( __( 'Backup', 'jetpack' ) === $submenu_item[3] ) {
 				break;
 			}
 		}
-		add_submenu_page( $parent_slug, esc_attr__( 'Scan', 'jetpack' ), __( 'Scan', 'jetpack' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $position );
+		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack' ), __( 'Scan', 'jetpack' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $position );
 	}
 
 	/**
@@ -92,7 +90,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		end( $menu );
 		$position = key( $menu );
 
-		$this->add_admin_menu_separator( ++$position );
+		$this->add_admin_menu_separator( ++ $position );
 
 		add_menu_page( __( 'WP Admin', 'jetpack' ), __( 'WP Admin', 'jetpack' ), 'read', $menu_slug, null, 'dashicons-wordpress-alt', $position );
 	}
@@ -127,7 +125,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		parent::add_posts_menu();
 
 		// Remove all submenus to mimic the old Calypso navigation.
-		$this->remove_submenus( 'https://wordpress.com/posts/' . $this->domain );
+		$this->remove_submenus( 'edit.php' );
 	}
 
 	/**
@@ -139,20 +137,20 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		parent::add_page_menu();
 
 		// Remove all submenus to mimic the old Calypso navigation.
-		$this->remove_submenus( 'https://wordpress.com/pages/' . $this->domain );
+		$this->remove_submenus( 'edit.php?post_type=page' );
 	}
 
 	/**
 	 * Adds a custom post type menu.
 	 *
 	 * @param string $post_type Custom post type.
-	 * @param bool   $wp_admin  Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param bool   $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_custom_post_type_menu( $post_type, $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		parent::add_custom_post_type_menu( $post_type );
 
 		// Remove all submenus to mimic the old Calypso navigation.
-		$this->remove_submenus( 'https://wordpress.com/types/' . $post_type . '/' . $this->domain );
+		$this->remove_submenus( 'edit.php?post_type=' . $post_type );
 	}
 
 	/**
@@ -164,7 +162,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		parent::add_users_menu();
 
 		// Remove all submenus to mimic the old Calypso navigation.
-		$this->remove_submenus( 'https://wordpress.com/people/team/' . $this->domain );
+		$this->remove_submenus( 'users.php' );
 	}
 
 	/**
@@ -195,18 +193,6 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	public function should_link_to_wp_admin() {
 		// Force Calypso links on Jetpack sites since Nav Unification is disabled on WP Admin.
 		return false;
-	}
-
-	/**
-	 * Migrates submenu items from wp-admin menu slugs to Calypso menu slugs.
-	 *
-	 * @param string $old_slug WP-Admin menu slug.
-	 * @param string $new_slug Calypso menu slug. (Calypso URL).
-	 */
-	public function migrate_submenus( $old_slug, $new_slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Do not migrate menu on Jetpack sites, since we don't want WP Admin links.
-		// Instead we remove the submenu since they won't be used.
-		$this->remove_submenus( $old_slug );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -191,14 +191,17 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin_export Optional. Whether Export link should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_tools_menu( $wp_admin_import = false, $wp_admin_export = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		add_menu_page( esc_attr__( 'Tools', 'jetpack' ), __( 'Tools', 'jetpack' ), 'publish_posts', 'https://wordpress.com/themes/' . $this->domain, null, 'dashicons-admin-tools', 75 );
+		add_menu_page( esc_attr__( 'Tools', 'jetpack' ), __( 'Tools', 'jetpack' ), 'publish_posts', 'tools.php', null, 'dashicons-admin-tools', 75 );
 
-		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/themes/' . $this->domain );
+		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain );
 		add_submenu_page( 'tools.php', esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain );
 
 		// Import/Export on Jetpack sites is always handled on WP Admin.
 		add_submenu_page( 'tools.php', esc_attr__( 'Import', 'jetpack' ), __( 'Import', 'jetpack' ), 'import', 'import.php' );
 		add_submenu_page( 'tools.php', esc_attr__( 'Export', 'jetpack' ), __( 'Export', 'jetpack' ), 'export', 'export.php' );
+
+		// Remove the submenu auto-created by Core.
+		remove_submenu_page( 'tools.php', 'tools.php' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -195,11 +195,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds Upgrades menu.
 	 */
 	public function add_upgrades_menu() {
-		$menu_slug = parent::add_upgrades_menu();
+		parent::add_upgrades_menu();
 
-		add_submenu_page( $menu_slug, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
-
-		return $menu_slug;
+		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -313,6 +313,19 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_plugins_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// TODO: Remove wpcom_menu (/wp-content/admin-plugins/wpcom-misc.php).
+		$count = '';
+		if ( ! is_multisite() && current_user_can( 'update_plugins' ) ) {
+			$update_data = wp_get_update_data();
+			$count       = sprintf(
+				'<span class="update-plugins count-%s"><span class="plugin-count">%s</span></span>',
+				$update_data['counts']['plugins'],
+				number_format_i18n( $update_data['counts']['plugins'] )
+			);
+		}
+		/* translators: %s: Number of pending plugin updates. */
+		add_menu_page( esc_attr__( 'Plugins', 'jetpack' ), sprintf( __( 'Plugins %s', 'jetpack' ), $count ), 'activate_plugins', 'plugins.php', null, 'dashicons-admin-plugins', 65 );
+
 		// Plugins on Simple sites are always managed on Calypso.
 		parent::add_plugins_menu( false );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -259,11 +259,11 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_options_menu( $wp_admin = false ) {
 		parent::add_options_menu( $wp_admin );
 
-		add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
 		// Replace sharing menu if it exists. See Publicize_UI::sharing_menu.
 		if ( remove_submenu_page( 'options-general.php', 'sharing' ) ) {
-			add_options_page( esc_attr__( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/sharing-buttons/' . $this->domain, null, 30 );
+			add_submenu_page( 'options-general.php', esc_attr__( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/sharing-buttons/' . $this->domain, null, 30 );
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -316,12 +316,4 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		// Plugins on Simple sites are always managed on Calypso.
 		parent::add_plugins_menu( false );
 	}
-
-	/**
-	 * Adds Jetpack menu.
-	 */
-	public function add_jetpack_menu() {
-		parent::add_jetpack_menu();
-		remove_submenu_page( 'jetpack', 'jetpack' );
-	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -211,15 +211,22 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
 		parent::add_appearance_menu( $wp_admin_themes, $wp_admin_customize );
 
+		remove_submenu_page( 'themes.php', 'theme-editor.php' );
+
 		$user_can_customize = current_user_can( 'customize' );
 
 		if ( $user_can_customize ) {
-			$themes_slug    = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
-			$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
+			if ( ! $wp_admin_customize ) {
+				$customize_url = 'https://wordpress.com/customize/' . $this->domain;
+			} elseif ( $this->is_api_request ) {
+				$customize_url = 'customize.php';
+			} else {
+				$customize_url = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
+			}
 			// If the user does not have the custom CSS option then present them with the CSS nudge upsell section instead.
 			$custom_css_section = '1' === get_option( 'custom-design-upgrade' ) ? 'jetpack_custom_css' : 'css_nudge'; //phpcs:ignore
-			$customize_custom_css_url = add_query_arg( array( 'autofocus' => array( 'section' => $custom_css_section ) ), $customize_slug );
-			add_submenu_page( $themes_slug, esc_attr__( 'Edit CSS', 'jetpack' ), __( 'Edit CSS', 'jetpack' ), 'customize', esc_url( $customize_custom_css_url ), null, 20 );
+			$customize_custom_css_url = add_query_arg( array( 'autofocus' => array( 'section' => $custom_css_section ) ), $customize_url );
+			add_submenu_page( 'themes.php', esc_attr__( 'Edit CSS', 'jetpack' ), __( 'Edit CSS', 'jetpack' ), 'customize', esc_url( $customize_custom_css_url ), null, 20 );
 		}
 	}
 
@@ -317,17 +324,5 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_plugins_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// Plugins on Simple sites are always managed on Calypso.
 		parent::add_plugins_menu( false );
-	}
-
-	/**
-	 * Adds Appearance menu.
-	 *
-	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
-	 */
-	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
-		parent::add_appearance_menu( $wp_admin_themes, $wp_admin_customize );
-
-		remove_submenu_page( 'themes.php', 'theme-editor.php' );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -209,20 +209,13 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
-		parent::add_appearance_menu( $wp_admin_themes, $wp_admin_customize );
+		$customize_url = parent::add_appearance_menu( $wp_admin_themes, $wp_admin_customize );
 
 		remove_submenu_page( 'themes.php', 'theme-editor.php' );
 
 		$user_can_customize = current_user_can( 'customize' );
 
 		if ( $user_can_customize ) {
-			if ( ! $wp_admin_customize ) {
-				$customize_url = 'https://wordpress.com/customize/' . $this->domain;
-			} elseif ( $this->is_api_request ) {
-				$customize_url = 'customize.php';
-			} else {
-				$customize_url = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
-			}
 			// If the user does not have the custom CSS option then present them with the CSS nudge upsell section instead.
 			$custom_css_section = '1' === get_option( 'custom-design-upgrade' ) ? 'jetpack_custom_css' : 'css_nudge'; //phpcs:ignore
 			$customize_custom_css_url = add_query_arg( array( 'autofocus' => array( 'section' => $custom_css_section ) ), $customize_url );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -198,6 +198,8 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		$menu_slug = parent::add_upgrades_menu();
 
 		add_submenu_page( $menu_slug, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
+
+		return $menu_slug;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -38,7 +38,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		$wp_admin = $this->should_link_to_wp_admin();
 
-		$this->add_my_home_menu( $wp_admin );
+		$this->add_my_home_menu();
 
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request ) {
@@ -195,9 +195,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds Upgrades menu.
 	 */
 	public function add_upgrades_menu() {
-		parent::add_upgrades_menu();
+		$menu_slug = parent::add_upgrades_menu();
 
-		add_submenu_page( 'https://wordpress.com/plans/' . $this->domain, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
+		add_submenu_page( $menu_slug, __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
 	}
 
 	/**
@@ -248,14 +248,14 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_options_menu( $wp_admin = false ) {
+		parent::add_options_menu( $wp_admin );
+
 		add_options_page( esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
 		// Replace sharing menu if it exists. See Publicize_UI::sharing_menu.
 		if ( remove_submenu_page( 'options-general.php', 'sharing' ) ) {
 			add_options_page( esc_attr__( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/sharing-buttons/' . $this->domain, null, 30 );
 		}
-
-		parent::add_options_menu( $wp_admin );
 	}
 
 	/**
@@ -315,5 +315,17 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_plugins_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// Plugins on Simple sites are always managed on Calypso.
 		parent::add_plugins_menu( false );
+	}
+
+	/**
+	 * Adds Appearance menu.
+	 *
+	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
+	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
+		parent::add_appearance_menu( $wp_admin_themes, $wp_admin_customize );
+
+		remove_submenu_page( 'themes.php', 'theme-editor.php' );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -227,8 +227,21 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_users_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Users on Simple sites are always managed on Calypso.
-		parent::add_users_menu( false );
+		if ( current_user_can( 'list_users' ) ) {
+			$submenus_to_update = array(
+				'users.php'              => 'https://wordpress.com/people/team/' . $this->domain,
+				'grofiles-editor'        => 'https://wordpress.com/me',
+				'grofiles-user-settings' => 'https://wordpress.com/me/account',
+			);
+			$this->update_submenus( 'users.php', $submenus_to_update );
+		} else {
+			$submenus_to_update = array(
+				'grofiles-editor'        => 'https://wordpress.com/me',
+				'grofiles-user-settings' => 'https://wordpress.com/me/account',
+			);
+			$this->update_submenus( 'profile.php', $submenus_to_update );
+		}
+		add_submenu_page( 'users.php', esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -318,4 +318,12 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		// Plugins on Simple sites are always managed on Calypso.
 		parent::add_plugins_menu( false );
 	}
+
+	/**
+	 * Adds Jetpack menu.
+	 */
+	public function add_jetpack_menu() {
+		parent::add_jetpack_menu();
+		remove_submenu_page( 'jetpack', 'jetpack' );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -92,11 +92,11 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/admin-menu' );
 		$response = $this->server->dispatch( $request );
 
-		$menu      = wp_list_filter( $response->get_data(), array( 'title' => 'Jetpack' ) );
+		$menu      = wp_list_filter( $response->get_data(), array( 'title' => 'Tools' ) );
 		$menu_item = array_pop( $menu );
 
 		$this->assertNotEmpty( $menu_item );
-		$this->assertSame( $menu_item['children'][0]['slug'], $menu_item['slug'], 'Parent and submenu should be the same.' );
+		$this->assertSame( $menu_item['children'][0]['url'], $menu_item['url'], 'Parent and submenu should be the same.' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -92,7 +92,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/admin-menu' );
 		$response = $this->server->dispatch( $request );
 
-		$menu      = wp_list_filter( $response->get_data(), array( 'title' => 'Tools' ) );
+		$menu      = wp_list_filter( $response->get_data(), array( 'title' => 'Profile' ) );
 		$menu_item = array_pop( $menu );
 
 		$this->assertNotEmpty( $menu_item );

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -92,7 +92,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/admin-menu' );
 		$response = $this->server->dispatch( $request );
 
-		$menu      = wp_list_filter( $response->get_data(), array( 'title' => 'Profile' ) );
+		$menu      = wp_list_filter( $response->get_data(), array( 'title' => 'Settings' ) );
 		$menu_item = array_pop( $menu );
 
 		$this->assertNotEmpty( $menu_item );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/data/admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/data/admin-menu.php
@@ -82,6 +82,15 @@ function get_menu_fixture() {
 			'menu-pages',
 			'dashicons-admin-page',
 		),
+		30 => array(
+			'Custom Test Types',
+			'edit_posts',
+			'edit.php?post_type=custom_test_type',
+			'',
+			'menu-top menu-icon-page',
+			'menu-custom_test_type',
+			'dashicons-admin-post',
+		),
 		59 => array(
 			'',
 			'read',
@@ -238,6 +247,18 @@ function get_submenu_fixture() {
 				'post-new.php?post_type=page',
 			),
 		),
+		'edit.php?post_type=custom_test_type'  => array(
+			5  => array(
+				'All Custom Test Types',
+				'edit_pages',
+				'edit.php?post_type=custom_test_type',
+			),
+			10 => array(
+				'Add New',
+				'edit_pages',
+				'post-new.php?post_type=custom_test_type',
+			),
+		),
 		'themes.php'                           => array(
 			5  => array(
 				'Themes',
@@ -247,7 +268,7 @@ function get_submenu_fixture() {
 			6  => array(
 				'Customize',
 				'customize',
-				'customize.php?return=%2Ftrunk%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack',
+				'customize.php?return',
 				'',
 				'hide-if-no-customize',
 			),

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -205,13 +205,12 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_upgrades_menu
 	 */
 	public function test_add_upgrades_menu() {
-		global $menu, $submenu;
+		global $submenu;
 
 		static::$admin_menu->add_upgrades_menu();
 
-		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, $menu['4.80608'][2] );
-		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, array_shift( $submenu[ 'https://wordpress.com/plans/' . static::$domain ] )[2] );
-		$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, array_shift( $submenu[ 'https://wordpress.com/plans/' . static::$domain ] )[2] );
+		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, array_shift( $submenu['paid-upgrades.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, array_shift( $submenu['paid-upgrades.php'] )[2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -6,7 +6,6 @@
  */
 
 use Automattic\Jetpack\Dashboard_Customizations\Admin_Menu;
-use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
 require_jetpack_file( 'modules/masterbar/admin-menu/class-admin-menu.php' );
@@ -135,7 +134,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array_keys( $menu ),
-			array( 2, '3.86682', 4, 5, 10, 15, 20, 25, 50, 51, 59, 60, 65, 70, 75, 80 ),
+			array( 2, '3.86682', 4, 5, 10, 15, 20, 25, 30, 50, 51, 59, 60, 65, 70, 75, 80 ),
 			'Admin menu should not have unexpected top menu items.'
 		);
 
@@ -168,29 +167,11 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_my_home_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_my_home_menu( false );
-
-		$slug = 'https://wordpress.com/home/' . static::$domain;
-
-		$my_home_menu_item = array(
-			'My Home',
-			'manage_options',
-			$slug,
-			'My Home',
-			'menu-top menu-top-first menu-icon-dashboard',
-			'menu-dashboard',
-			'dashicons-admin-home',
-		);
-		$this->assertSame( $menu[2], $my_home_menu_item );
+		static::$admin_menu->add_my_home_menu();
 
 		// Has My Home submenu item when there are other submenu items.
-		$my_home_submenu_item = array(
-			'My Home',
-			'manage_options',
-			$slug,
-			'My Home',
-		);
-		$this->assertContains( $my_home_submenu_item, $submenu[ $slug ] );
+		$this->assertSame( 'https://wordpress.com/home/' . static::$domain, array_shift( $submenu['index.php'] )[2] );
+
 		// Reset data.
 		$menu    = static::$menu_data;
 		$submenu = static::$submenu_data;
@@ -200,9 +181,9 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			0 => array( 'Home', 'read', 'index.php' ),
 		);
 
-		static::$admin_menu->add_my_home_menu( false );
-
-		$this->assertArrayNotHasKey( 'https://wordpress.com/home/' . static::$domain, $submenu );
+		static::$admin_menu->add_my_home_menu();
+		$this->assertSame( 'https://wordpress.com/home/' . static::$domain, $menu[2][2] );
+		$this->assertEmpty( $submenu['index.php'] );
 	}
 
 	/**
@@ -211,31 +192,11 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_stats_menu
 	 */
 	public function test_add_stats_menu() {
-		global $menu, $submenu;
+		global $menu;
 
 		static::$admin_menu->add_stats_menu();
 
-		$menu_title = __( 'Stats', 'jetpack' );
-
-		if ( ! defined( 'TESTING_IN_JETPACK' ) || ! TESTING_IN_JETPACK ) {
-			$menu_title .= sprintf(
-				'<img class="sidebar-unified__sparkline" width="80" height="20" src="%1$s" alt="%2$s">',
-				esc_url( home_url( 'wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=' . get_current_blog_id() ) ),
-				esc_attr__( 'Hourly views', 'jetpack' )
-			);
-		}
-		$stats_menu_item = array(
-			$menu_title,
-			'view_stats',
-			'https://wordpress.com/stats/day/' . static::$domain,
-			'Stats',
-			'menu-top toplevel_page_https://wordpress.com/stats/day/' . static::$domain,
-			'toplevel_page_https://wordpress.com/stats/day/' . static::$domain,
-			'dashicons-chart-bar',
-		);
-
-		$this->assertSame( $menu['3.86682'], $stats_menu_item );
-		$this->assertArrayNotHasKey( 'https://wordpress.com/stats/day/' . static::$domain, $submenu );
+		$this->assertSame( 'https://wordpress.com/stats/day/' . static::$domain, $menu['3.86682'][2] );
 	}
 
 	/**
@@ -243,64 +204,14 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 *
 	 * @covers ::add_upgrades_menu
 	 */
-	public function test_add_wpcom_upgrades_menu() {
+	public function test_add_upgrades_menu() {
 		global $menu, $submenu;
 
 		static::$admin_menu->add_upgrades_menu();
 
-		$slug = 'https://wordpress.com/plans/' . static::$domain;
-
-		$upgrades_menu_item = array(
-			'Upgrades',
-			'manage_options',
-			$slug,
-			'Upgrades',
-			'menu-top toplevel_page_https://wordpress.com/plans/' . static::$domain,
-			'toplevel_page_https://wordpress.com/plans/' . static::$domain,
-			'dashicons-cart',
-		);
-		$this->assertSame( $menu['4.80608'], $upgrades_menu_item );
-
-		$plans_submenu_item = array(
-			'Plans',
-			'manage_options',
-			$slug,
-			'Plans',
-		);
-		$this->assertContains( $plans_submenu_item, $submenu[ $slug ] );
-
-		$purchases_submenu_item = array(
-			'Purchases',
-			'manage_options',
-			'https://wordpress.com/purchases/subscriptions/' . static::$domain,
-			'Purchases',
-		);
-		$this->assertContains( $purchases_submenu_item, $submenu[ $slug ] );
-	}
-
-	/**
-	 * Tests add_jetpack_upgrades_menu
-	 *
-	 * @covers ::add_jetpack_upgrades_menu
-	 */
-	public function test_add_jetpack_upgrades_menu() {
-		global $menu, $submenu;
-
-		static::$admin_menu->add_upgrades_menu();
-
-		$slug = 'https://wordpress.com/plans/' . static::$domain;
-
-		$upgrades_menu_item = array(
-			'Upgrades',
-			'manage_options',
-			$slug,
-			'Upgrades',
-			'menu-top toplevel_page_https://wordpress.com/plans/' . static::$domain,
-			'toplevel_page_https://wordpress.com/plans/' . static::$domain,
-			'dashicons-cart',
-		);
-		$this->assertSame( $menu['4.80608'], $upgrades_menu_item );
-		$this->assertArrayNotHasKey( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu );
+		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, $menu['4.80608'][2] );
+		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, array_shift( $submenu[ 'https://wordpress.com/plans/' . static::$domain ] )[2] );
+		$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, array_shift( $submenu[ 'https://wordpress.com/plans/' . static::$domain ] )[2] );
 	}
 
 	/**
@@ -309,22 +220,12 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_posts_menu
 	 */
 	public function test_add_posts_menu() {
-		global $menu, $submenu;
+		global $submenu;
 
-		static::$admin_menu->add_posts_menu( false );
+		static::$admin_menu->add_posts_menu();
 
-		$posts_menu_item = array(
-			'Posts',
-			'edit_posts',
-			'https://wordpress.com/posts/' . static::$domain,
-			'Posts',
-			'menu-top toplevel_page_https://wordpress.com/posts/' . static::$domain,
-			'toplevel_page_https://wordpress.com/posts/' . static::$domain,
-			'dashicons-admin-post',
-		);
-
-		$this->assertSame( $menu[5], $posts_menu_item );
-		$this->assertArrayNotHasKey( 'edit.php', $submenu );
+		$this->assertSame( 'https://wordpress.com/posts/' . static::$domain, array_shift( $submenu['edit.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/post/' . static::$domain, array_shift( $submenu['edit.php'] )[2] );
 	}
 
 	/**
@@ -335,36 +236,10 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_media_menu() {
 		global $menu, $submenu;
 
-		static::$admin_menu->add_media_menu( false );
+		static::$admin_menu->add_media_menu();
 
-		$slug = 'https://wordpress.com/media/' . static::$domain;
-
-		$media_menu_item = array(
-			'Media',
-			'upload_files',
-			$slug,
-			'Media',
-			'menu-top toplevel_page_' . $slug,
-			'toplevel_page_' . $slug,
-			'dashicons-admin-media',
-		);
-
-		$this->assertSame( $menu[10], $media_menu_item );
-		$this->assertArrayNotHasKey( $slug, $submenu );
-
-		$library_submenu_item = array(
-			'Library',
-			'upload_files',
-			'upload.php',
-		);
-		$this->assertNotContains( $library_submenu_item, $submenu['upload.php'] );
-
-		$add_new_submenu_item = array(
-			'Add New',
-			'upload_files',
-			'media-new.php',
-		);
-		$this->assertNotContains( $add_new_submenu_item, $submenu['upload.php'] );
+		$this->assertSame( 'https://wordpress.com/media/' . static::$domain, $menu[10][2] );
+		$this->assertEmpty( $submenu['upload.php'] );
 	}
 
 	/**
@@ -373,22 +248,12 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_page_menu
 	 */
 	public function test_add_page_menu() {
-		global $menu, $submenu;
+		global $submenu;
 
-		static::$admin_menu->add_page_menu( false );
+		static::$admin_menu->add_page_menu();
 
-		$posts_menu_item = array(
-			'Pages',
-			'edit_pages',
-			'https://wordpress.com/pages/' . static::$domain,
-			'Pages',
-			'menu-top toplevel_page_https://wordpress.com/pages/' . static::$domain,
-			'toplevel_page_https://wordpress.com/pages/' . static::$domain,
-			'dashicons-admin-page',
-		);
-
-		$this->assertSame( $menu[20], $posts_menu_item );
-		$this->assertEmpty( $submenu['edit.php?post_type=page'] );
+		$this->assertSame( 'https://wordpress.com/pages/' . static::$domain, array_shift( $submenu['edit.php?post_type=page'] )[2] );
+		$this->assertSame( 'https://wordpress.com/page/' . static::$domain, array_shift( $submenu['edit.php?post_type=page'] )[2] );
 	}
 
 	/**
@@ -400,8 +265,8 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		global $menu, $submenu;
 
 		// Don't show post types that don't want to be shown.
-		$revision = get_post_type_object( 'revision' );
-		static::$admin_menu->add_custom_post_type_menu( $revision, false );
+		get_post_type_object( 'revision' );
+		static::$admin_menu->add_custom_post_type_menu( 'revision' );
 
 		$last_item = array_pop( $menu );
 		$this->assertNotSame( 'https://wordpress.com/types/revision/' . static::$domain, $last_item[2] );
@@ -414,40 +279,14 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 				'menu_position' => 2020,
 			)
 		);
-		static::$admin_menu->add_custom_post_type_menu( 'custom_test_type', false );
+
+		static::$admin_menu->add_custom_post_type_menu( 'custom_test_type' );
 
 		// Clean up.
 		unregister_post_type( 'custom_test_type' );
 
-		$slug = 'https://wordpress.com/types/custom_test_type/' . static::$domain;
-
-		$custom_menu_item = array(
-			'Custom Test Types',
-			'edit_posts',
-			$slug,
-			'Custom Test Types',
-			'menu-top toplevel_page_' . $slug,
-			'toplevel_page_' . $slug,
-			'dashicons-admin-post',
-		);
-
-		$this->assertSame( $menu[2020], $custom_menu_item );
-
-		$custom_submenu_item = array(
-			'Custom Test Types',
-			'edit_posts',
-			'https://wordpress.com/types/custom_test_type/' . static::$domain,
-			'Custom Test Types',
-		);
-		$this->assertContains( $custom_submenu_item, $submenu[ $slug ] );
-
-		$add_new_submenu_item = array(
-			'Add New',
-			'edit_posts',
-			'https://wordpress.com/edit/custom_test_type/' . static::$domain,
-			'Add New',
-		);
-		$this->assertContains( $add_new_submenu_item, $submenu[ $slug ] );
+		$this->assertSame( 'https://wordpress.com/types/custom_test_type/' . static::$domain, array_shift( $submenu['edit.php?post_type=custom_test_type'] )[2] );
+		$this->assertSame( 'https://wordpress.com/edit/custom_test_type/' . static::$domain, array_shift( $submenu['edit.php?post_type=custom_test_type'] )[2] );
 	}
 
 	/**
@@ -458,29 +297,9 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_comments_menu() {
 		global $menu, $submenu;
 
-		// Only users that can edit posts get to see the comments menu.
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
-		$menu = array();
-		static::$admin_menu->add_comments_menu( false );
-		$this->assertEmpty( $menu );
+		static::$admin_menu->add_comments_menu();
 
-		// Reset.
-		wp_set_current_user( static::$user_id );
-		$menu = static::$menu_data;
-
-		static::$admin_menu->add_comments_menu( false );
-
-		$comments_menu_item = array(
-			'Comments <span class="awaiting-mod count-0"><span class="pending-count" aria-hidden="true">0</span><span class="comments-in-moderation-text screen-reader-text">0 Comments in moderation</span></span>',
-			'edit_posts',
-			'https://wordpress.com/comments/all/' . static::$domain,
-			'Comments',
-			'menu-top toplevel_page_https://wordpress.com/comments/all/' . static::$domain,
-			'toplevel_page_https://wordpress.com/comments/all/' . static::$domain,
-			'dashicons-admin-comments',
-		);
-
-		$this->assertSame( $menu[25], $comments_menu_item );
+		$this->assertSame( 'https://wordpress.com/comments/all/' . static::$domain, $menu[25][2] );
 		$this->assertEmpty( $submenu['edit-comments.php'] );
 	}
 
@@ -490,57 +309,14 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_appearance_menu
 	 */
 	public function test_add_appearance_menu() {
-		global $menu, $submenu;
-		$customize_slug = 'https://wordpress.com/customize/' . static::$domain;
-		static::$admin_menu->add_appearance_menu( false );
+		global $submenu;
 
-		$slug = 'https://wordpress.com/themes/' . static::$domain;
+		static::$admin_menu->add_appearance_menu();
 
-		$appearance_menu_item = array(
-			'Appearance',
-			'switch_themes',
-			$slug,
-			'Appearance',
-			'menu-top toplevel_page_' . $slug,
-			'menu-appearance',
-			'dashicons-admin-appearance',
-		);
-
-		$this->assertSame( $menu[60], $appearance_menu_item );
-		$this->assertArrayNotHasKey( 'themes.php', $submenu );
-
-		$themes_submenu_item = array(
-			'Themes',
-			'switch_themes',
-			'https://wordpress.com/themes/' . static::$domain,
-			'Themes',
-		);
-		$this->assertContains( $themes_submenu_item, $submenu[ $slug ] );
-
-		$customize_submenu_item = array(
-			'Customize',
-			'customize',
-			$customize_slug,
-			'Customize',
-		);
-
-		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
-
-		$widgets_submenu_item = array(
-			'Widgets',
-			'customize',
-			$customize_slug . '?autofocus%5Bpanel%5D=widgets',
-			'Widgets',
-		);
-		$this->assertContains( $widgets_submenu_item, $submenu[ $slug ] );
-
-		$menus_submenu_item = array(
-			'Menus',
-			'customize',
-			$customize_slug . '?autofocus%5Bpanel%5D=nav_menus',
-			'Menus',
-		);
-		$this->assertContains( $menus_submenu_item, $submenu[ $slug ] );
+		$this->assertSame( 'https://wordpress.com/themes/' . static::$domain, array_shift( $submenu['themes.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/customize/' . static::$domain, array_shift( $submenu['themes.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/customize/' . static::$domain . '?autofocus%5Bpanel%5D=nav_menus', array_shift( $submenu['themes.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/customize/' . static::$domain . '?autofocus%5Bpanel%5D=widgets', array_shift( $submenu['themes.php'] )[2] );
 	}
 
 	/**
@@ -551,26 +327,10 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_plugins_menu() {
 		global $menu, $submenu;
 
-		add_filter( 'wp_get_update_data', array( $this, 'mock_update_data' ) );
-		static::$admin_menu->add_plugins_menu( false );
-		remove_filter( 'wp_get_update_data', array( $this, 'mock_update_data' ) );
+		static::$admin_menu->add_plugins_menu();
 
-		$slug  = 'https://wordpress.com/plugins/' . static::$domain;
-		$label = is_multisite() ? 'Plugins ' : 'Plugins <span class="update-plugins count-0"><span class="plugin-count">0</span></span>';
-
-		$plugins_menu_item = array(
-			$label,
-			'activate_plugins',
-			$slug,
-			'Plugins',
-			'menu-top toplevel_page_' . $slug,
-			'toplevel_page_' . $slug,
-			'dashicons-admin-plugins',
-		);
-
-		$this->assertEquals( $plugins_menu_item, $menu[65] );
+		$this->assertSame( 'https://wordpress.com/plugins/' . static::$domain, $menu[65][2] );
 		$this->assertEmpty( $submenu['plugins.php'] );
-		$this->assertArrayNotHasKey( $slug, $submenu );
 
 		// Reset.
 		$menu    = static::$menu_data;
@@ -579,21 +339,6 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		// Check submenu are kept when using WP Admin links.
 		static::$admin_menu->add_plugins_menu( true );
 		$this->assertNotEmpty( $submenu['plugins.php'] );
-	}
-
-	/**
-	 * Filters the returned array of update data for plugins, themes, and WordPress core.
-	 */
-	public function mock_update_data() {
-		return array(
-			'counts' => array(
-				'plugins'      => 0,
-				'themes'       => 0,
-				'translations' => 0,
-				'wordpress'    => 0,
-			),
-			'title'  => '',
-		);
 	}
 
 	/**
@@ -606,81 +351,39 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		// Current user can't list users.
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'editor' ) ) );
-		$menu = array();
-
-		static::$admin_menu->add_users_menu( false );
-
-		$profile_menu_item = array(
-			'My Profile',
-			'read',
-			'https://wordpress.com/me',
-			'My Profile',
-			'menu-top toplevel_page_https://wordpress.com/me',
-			'toplevel_page_https://wordpress.com/me',
-			'dashicons-admin-users',
+		$menu    = array(
+			70 => array(
+				'Profile',
+				'read',
+				'profile.php',
+				'',
+				'menu-top menu-icon-users',
+				'menu-users',
+				'dashicons-admin-users',
+			),
 		);
-		$this->assertSame( $menu[70], $profile_menu_item );
-
-		$account_submenu_item = array(
-			'Account Settings',
-			'read',
-			'https://wordpress.com/me/account',
-			'Account Settings',
+		$submenu = array(
+			'profile.php' => array(
+				0 => array( 'Profile', 'read', 'profile.php' ),
+			),
 		);
-		$this->assertContains( $account_submenu_item, $submenu['https://wordpress.com/me'] );
-		$this->assertArrayNotHasKey( 'profile.php', $submenu );
+
+		static::$admin_menu->add_users_menu();
+
+		$this->assertSame( 'https://wordpress.com/me', array_shift( $submenu['profile.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/me/account', array_shift( $submenu['profile.php'] )[2] );
 
 		// Reset.
 		wp_set_current_user( static::$user_id );
-		$menu = static::$menu_data;
+		$menu    = static::$menu_data;
+		$submenu = static::$submenu_data;
 
-		static::$admin_menu->add_users_menu( false );
+		static::$admin_menu->add_users_menu();
 
-		$slug = 'https://wordpress.com/people/team/' . static::$domain;
-
-		$users_menu_item = array(
-			'Users',
-			'list_users',
-			$slug,
-			'Users',
-			'menu-top toplevel_page_' . $slug,
-			'toplevel_page_' . $slug,
-			'dashicons-admin-users',
-		);
-		$this->assertSame( $menu[70], $users_menu_item );
-		$this->assertEmpty( $submenu['users.php'] );
-
-		$all_people_submenu_item = array(
-			'All People',
-			'list_users',
-			$slug,
-			'All People',
-		);
-		$this->assertContains( $all_people_submenu_item, $submenu[ $slug ] );
-
-		$add_new_submenu_item = array(
-			'Add New',
-			'promote_users',
-			'https://wordpress.com/people/new/' . static::$domain,
-			'Add New',
-		);
-		$this->assertContains( $add_new_submenu_item, $submenu[ $slug ] );
-
-		$profile_submenu_item = array(
-			'My Profile',
-			'read',
-			'https://wordpress.com/me',
-			'My Profile',
-		);
-		$this->assertContains( $profile_submenu_item, $submenu[ $slug ] );
-
-		$account_submenu_item = array(
-			'Account Settings',
-			'read',
-			'https://wordpress.com/me/account',
-			'Account Settings',
-		);
-		$this->assertContains( $account_submenu_item, $submenu[ $slug ] );
+		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, array_shift( $submenu['users.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/people/new/' . static::$domain, array_shift( $submenu['users.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/me', array_shift( $submenu['users.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/me/account', array_shift( $submenu['users.php'] )[2] );
 	}
 
 	/**
@@ -689,81 +392,14 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_tools_menu
 	 */
 	public function test_add_tools_menu() {
-		global $menu, $submenu;
+		global $submenu;
 
-		$slug = 'https://wordpress.com/marketing/tools/' . static::$domain;
-		static::$admin_menu->add_tools_menu( false, false );
+		static::$admin_menu->add_tools_menu();
 
-		$tools_menu_item = array(
-			'Tools',
-			'publish_posts',
-			$slug,
-			'Tools',
-			'menu-top toplevel_page_' . $slug,
-			'toplevel_page_' . $slug,
-			'dashicons-admin-tools',
-		);
-
-		$this->assertSame( $menu[75], $tools_menu_item );
-		$this->assertArrayNotHasKey( 'tools.php', $submenu );
-
-		// Contains the following menu items.
-
-		$marketing_submenu_item = array(
-			'Marketing',
-			'publish_posts',
-			'https://wordpress.com/marketing/tools/' . static::$domain,
-			'Marketing',
-		);
-		$this->assertContains( $marketing_submenu_item, $submenu[ $slug ] );
-
-		$earn_submenu_item = array(
-			'Earn',
-			'manage_options',
-			'https://wordpress.com/earn/' . static::$domain,
-			'Earn',
-		);
-		$this->assertContains( $earn_submenu_item, $submenu[ $slug ] );
-
-		$import_submenu_item = array(
-			'Import',
-			'import',
-			'https://wordpress.com/import/' . static::$domain,
-			'Import',
-		);
-		$this->assertContains( $import_submenu_item, $submenu[ $slug ] );
-
-		$export_submenu_item = array(
-			'Export',
-			'export',
-			'https://wordpress.com/export/' . static::$domain,
-			'Export',
-		);
-		$this->assertContains( $export_submenu_item, $submenu[ $slug ] );
-
-		$other_tools_submenu_item = array(
-			'Other tools',
-			'manage_options',
-			'tools.php',
-			'Other tools',
-		);
-		$this->assertContains( $other_tools_submenu_item, $submenu[ $slug ] );
-
-		// NOT contains the following menu items.
-
-		$import_submenu_item = array(
-			'Import',
-			'import',
-			'import.php',
-		);
-		$this->assertNotContains( $import_submenu_item, $submenu[ $slug ] );
-
-		$export_submenu_item = array(
-			'Export',
-			'export',
-			'export.php',
-		);
-		$this->assertNotContains( $export_submenu_item, $submenu[ $slug ] );
+		$this->assertSame( 'https://wordpress.com/marketing/tools/' . static::$domain, array_shift( $submenu['tools.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/earn/' . static::$domain, array_shift( $submenu['tools.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/import/' . static::$domain, array_shift( $submenu['tools.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/export/' . static::$domain, array_shift( $submenu['tools.php'] )[2] );
 	}
 
 	/**
@@ -774,19 +410,9 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_options_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/settings/general/' . static::$domain;
-		static::$admin_menu->add_options_menu( false );
+		static::$admin_menu->add_options_menu();
 
-		$this->assertNotContains( 'options-discussion.php', $submenu[ $slug ] );
-		$this->assertNotContains( 'options-writing.php', $submenu[ $slug ] );
-
-		$general_submenu_item = array(
-			'General',
-			'manage_options',
-			$slug,
-			'General',
-		);
-		$this->assertContains( $general_submenu_item, $submenu[ $slug ] );
+		$this->assertSame( 'https://wordpress.com/settings/general/' . static::$domain, array_shift( $submenu['options-general.php'] )[2] );
 	}
 
 	/**
@@ -795,108 +421,12 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_jetpack_menu
 	 */
 	public function add_jetpack_menu() {
-		global $menu, $submenu;
-
-		$slug = 'https://wordpress.com/activity-log/' . static::$domain;
-		static::$admin_menu->add_jetpack_menu();
-
-		// TODO: Replace with proper SVG data url.
-		$jetpack_icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 32 32' %3E%3Cpath fill='%23a0a5aa' d='M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z'%3E%3C/path%3E%3Cpolygon fill='%23fff' points='15,19 7,19 15,3 '%3E%3C/polygon%3E%3Cpolygon fill='%23fff' points='17,29 17,13 25,13 '%3E%3C/polygon%3E%3C/svg%3E";
-
-		$jetpack_menu_item = array(
-			'Jetpack',
-			'manage_options',
-			$slug,
-			'Jetpack',
-			'menu-top toplevel_page_' . $slug,
-			'toplevel_page_' . $slug,
-			$jetpack_icon,
-		);
-
-		$this->assertSame( $menu[50], $jetpack_menu_item );
-		$this->assertArrayNotHasKey( 'jetpack', $submenu );
-
-		// Contains the following menu items.
-
-		$activity_log_submenu_item = array(
-			'Activity Log',
-			'manage_options',
-			'https://wordpress.com/activity-log/' . static::$domain,
-			'Activity Log',
-		);
-		$this->assertContains( $activity_log_submenu_item, $submenu[ $slug ] );
-
-		$backup_submenu_item = array(
-			'Backup',
-			'manage_options',
-			'https://wordpress.com/backup/' . static::$domain,
-			'Backup',
-		);
-		$this->assertContains( $backup_submenu_item, $submenu[ $slug ] );
-
-		$search_submenu_item = array(
-			'Search',
-			'read',
-			'https://wordpress.com/jetpack-search/' . static::$domain,
-			'Search',
-		);
-		$this->assertContains( $search_submenu_item, $submenu[ $slug ] );
-
-		// NOT contains the following menu items.
-
-		$stats_submenu_item = array(
-			'Stats',
-			'manage_options',
-			'stats',
-		);
-		$this->assertNotContains( $stats_submenu_item, $submenu[ $slug ] );
-
-		$backups_submenu_item = array(
-			'Backup &amp; Scan',
-			'manage_options',
-			esc_url( Redirect::get_url( 'calypso-backups' ) ),
-		);
-		$this->assertNotContains( $backups_submenu_item, $submenu[ $slug ] );
-	}
-
-	/**
-	 * Tests migrate_submenus
-	 *
-	 * @covers ::migrate_submenus
-	 */
-	public function test_migrate_submenus() {
 		global $submenu;
 
-		$new_slug = 'made-up-slug';
+		static::$admin_menu->add_jetpack_menu();
 
-		// Start with a clean slate.
-		$temp_submenu = $submenu;
-		$submenu      = static::$submenu_data;
-
-		// New slug doesn't exist yet.
-		static::$admin_menu->migrate_submenus( 'edit.php', $new_slug );
-		$this->assertArrayNotHasKey( 'edit.php', $submenu );
-		$this->assertSame( static::$submenu_data['edit.php'], $submenu[ $new_slug ] );
-
-		// New slug exists.
-		static::$admin_menu->migrate_submenus( 'upload.php', $new_slug );
-		$this->assertArrayNotHasKey( 'upload.php', $submenu );
-		$expected = array_replace( static::$submenu_data['edit.php'], static::$submenu_data['upload.php'] );
-		$this->assertSame( $expected, $submenu[ $new_slug ] );
-
-		// Old slug doesn't exist.
-		$this->assertArrayNotHasKey( 'unkown', $submenu );
-		$pre_migration = $submenu;
-		static::$admin_menu->migrate_submenus( 'unkown', $new_slug );
-		$this->assertSame( $pre_migration, $submenu );
-
-		// Slugs are the same.
-		$this->assertArrayHasKey( 'index.php', $submenu );
-		$pre_migration = $submenu;
-		static::$admin_menu->migrate_submenus( 'index.php', 'index.php' );
-		$this->assertSame( $pre_migration, $submenu );
-
-		// Restore filtered $submenu.
-		$submenu = $temp_submenu;
+		$this->assertSame( 'https://wordpress.com/activity-log/' . static::$domain, $submenu['jetpack'][2][2] );
+		$this->assertSame( 'https://wordpress.com/backup/' . static::$domain, $submenu['jetpack'][3][2] );
+		$this->assertSame( 'https://wordpress.com/jetpack-search/' . static::$domain, $submenu['jetpack'][4][2] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -345,7 +345,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 			$this->assertSame( 'customize.php?return', $submenu['themes.php'][2][2] );
 		} else {
 			// Check Customize menu always links to WP Admin.
-			$this->assertSame( 'customize.php?return', $submenu['themes.php'][1][2] );
+			$this->assertSame( 'customize.php?return', $submenu['themes.php'][6][2] );
 		}
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -272,7 +272,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_upgrades_menu();
 
-		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
+		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, array_pop( $submenu['paid-upgrades.php'] )[2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -267,18 +267,12 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	 *
 	 * @covers ::add_upgrades_menu
 	 */
-	public function test_add_wpcom_upgrades_menu() {
+	public function test_add_upgrades_menu() {
 		global $submenu;
 
 		static::$admin_menu->add_upgrades_menu();
 
-		$domains_submenu_item = array(
-			'Domains',
-			'manage_options',
-			'https://wordpress.com/domains/manage/' . static::$domain,
-			'Domains',
-		);
-		$this->assertContains( $domains_submenu_item, $submenu[ 'https://wordpress.com/plans/' . static::$domain ] );
+		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu[ 'https://wordpress.com/plans/' . static::$domain ][2][2] );
 	}
 
 	/**
@@ -289,17 +283,10 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_tools_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/marketing/tools/' . static::$domain;
-		static::$admin_menu->add_tools_menu( false, false );
+		static::$admin_menu->add_tools_menu();
 
-		// Check Export menu always links to WP Admin.
-		$export_submenu_item = array(
-			'Export',
-			'export',
-			'export.php',
-			'Export',
-		);
-		$this->assertContains( $export_submenu_item, $submenu[ $slug ] );
+		// Check Export menu item always links to WP Admin.
+		$this->assertSame( 'export.php', $submenu['tools.php'][3][2] );
 	}
 
 	/**
@@ -308,32 +295,21 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_options_menu
 	 */
 	public function test_add_options_menu() {
-		global $submenu;
+		global $submenu, $menu;
 
-		$general_submenu_item = array(
-			'Advanced General',
-			'manage_options',
-			'options-general.php',
-			'Advanced General',
-		);
+		static::$admin_menu->add_options_menu();
+		$this->assertSame( 'https://wordpress.com/hosting-config/' . static::$domain, $submenu['options-general.php'][6][2] );
+		$this->assertSame( 'options-writing.php', array_pop( $submenu['options-general.php'] )[2] );
+		$this->assertSame( 'options-general.php', array_pop( $submenu['options-general.php'] )[2] );
 
-		$writing_submenu_item = array(
-			'Advanced Writing',
-			'manage_options',
-			'options-writing.php',
-			'Advanced Writing',
-		);
-
-		$slug = 'https://wordpress.com/settings/general/' . static::$domain;
+		// Reset.
+		$menu    = static::$menu_data;
+		$submenu = static::$submenu_data;
 
 		static::$admin_menu->add_options_menu( true );
-		$this->assertNotContains( $general_submenu_item, $submenu['options-general.php'] );
-		$this->assertNotContains( $writing_submenu_item, $submenu['options-general.php'] );
-
-		static::$admin_menu->add_options_menu( false );
-		$this->assertContains( 'Hosting Configuration', $submenu[ $slug ][6] );
-		$this->assertContains( $general_submenu_item, $submenu[ $slug ] );
-		$this->assertContains( $writing_submenu_item, $submenu[ $slug ] );
+		$last_submenu = array_pop( $submenu['options-general.php'] );
+		$this->assertNotSame( 'options-writing.php', $last_submenu[2] );
+		$this->assertNotSame( 'options-general.php', $last_submenu[2] );
 	}
 
 	/**
@@ -347,35 +323,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_plugins_menu( false );
 
 		// Check Plugins menu always links to WP Admin.
-		$this->assertContains( 'plugins.php', $menu[65] );
-	}
-
-	/**
-	 * Tests add_theme_install_menu
-	 *
-	 * @covers ::add_theme_install_menu
-	 */
-	public function test_add_theme_install_menu() {
-		global $submenu;
-
-		$slug         = 'https://wordpress.com/themes/' . static::$domain;
-		$submenu_item = array(
-			'Add New Theme',
-			'install_themes',
-			'theme-install.php',
-			'Add New Theme',
-		);
-		static::$admin_menu->add_appearance_menu( false );
-		static::$admin_menu->add_theme_install_menu( false );
-
-		// Multisite users don't have the `install_themes` capability by default,
-		// so we have to make a dynamic check based on whether the current user can
-		// install themes.
-		if ( current_user_can( 'install_themes' ) ) {
-			$this->assertContains( $submenu_item, $submenu[ $slug ] );
-		} else {
-			$this->assertNotContains( $submenu_item, $submenu[ $slug ] );
-		}
+		$this->assertSame( 'plugins.php', $menu[65][2] );
 	}
 
 	/**
@@ -386,33 +334,18 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_appearance_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/themes/' . static::$domain;
-		static::$admin_menu->add_appearance_menu( false, false );
+		static::$admin_menu->add_appearance_menu();
 
-		// Check Customize menu always links to WP Admin.
-		$customize_submenu_item = array(
-			'Customize',
-			'customize',
-			'customize.php?return',
-			'Customize',
-		);
-
-		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
-
-		// Check Theme Editor is present.
-		$theme_editor_submenu_item = array(
-			'Theme Editor',
-			'edit_themes',
-			'theme-editor.php',
-			'Theme Editor',
-		);
-		// Multisite users don't have the `edit_themes` capability by default,
+		// Multisite users don't have the `install_themes` capability by default,
 		// so we have to make a dynamic check based on whether the current user can
 		// install themes.
 		if ( current_user_can( 'install_themes' ) ) {
-			$this->assertContains( $theme_editor_submenu_item, $submenu[ $slug ] );
+			$this->assertSame( 'theme-install.php', $submenu['themes.php'][1][2] );
+			// Check Customize menu always links to WP Admin.
+			$this->assertSame( 'customize.php?return', $submenu['themes.php'][2][2] );
 		} else {
-			$this->assertNotContains( $theme_editor_submenu_item, $submenu[ $slug ] );
+			// Check Customize menu always links to WP Admin.
+			$this->assertSame( 'customize.php?return', $submenu['themes.php'][1][2] );
 		}
 	}
 
@@ -422,19 +355,16 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_users_menu
 	 */
 	public function test_add_users_menu() {
-		global $submenu;
+		global $menu, $submenu;
 
-		$submenu_item = array(
-			'Advanced Users Management',
-			'list_users',
-			'users.php',
-			'Advanced Users Management',
-		);
+		static::$admin_menu->add_users_menu();
+		$this->assertSame( 'users.php', $submenu['users.php'][2][2] );
+
+		// Reset.
+		$menu    = static::$menu_data;
+		$submenu = static::$submenu_data;
 
 		static::$admin_menu->add_users_menu( true );
-		$this->assertNotContains( $submenu_item, $submenu['users.php'] );
-
-		static::$admin_menu->add_users_menu( false );
-		$this->assertContains( $submenu_item, $submenu[ 'https://wordpress.com/people/team/' . static::$domain ] );
+		$this->assertArrayNotHasKey( 2, $submenu['users.php'] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -272,7 +272,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_upgrades_menu();
 
-		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu[ 'https://wordpress.com/plans/' . static::$domain ][2][2] );
+		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -99,7 +99,7 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_jetpack_menu();
 
-		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][3][2] );
+		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][2][2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -69,8 +69,8 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 		static::$domain  = ( new Status() )->get_site_suffix();
 		static::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
-		static::$menu_data    = get_menu_fixture();
-		static::$submenu_data = get_submenu_fixture();
+		static::$menu_data    = array();
+		static::$submenu_data = array();
 	}
 
 	/**
@@ -99,7 +99,7 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_jetpack_menu();
 
-		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][4][2] );
+		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][3][2] );
 	}
 
 	/**
@@ -150,10 +150,11 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_posts_menu
 	 */
 	public function test_add_posts_menu() {
-		global $submenu;
+		global $menu;
 
 		static::$admin_menu->add_posts_menu();
-		$this->assertEmpty( $submenu['edit.php'] );
+
+		$this->assertSame( 'https://wordpress.com/posts/' . static::$domain, array_shift( $menu )[2] );
 	}
 
 	/**
@@ -162,10 +163,11 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_page_menu
 	 */
 	public function test_add_page_menu() {
-		global $submenu;
+		global $menu;
 
 		static::$admin_menu->add_page_menu();
-		$this->assertEmpty( $submenu['edit.php?post_type=page'] );
+
+		$this->assertSame( 'https://wordpress.com/pages/' . static::$domain, array_shift( $menu )[2] );
 	}
 
 	/**
@@ -174,10 +176,11 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_users_menu
 	 */
 	public function test_add_users_menu() {
-		global $submenu;
+		global $menu;
 
 		static::$admin_menu->add_users_menu();
-		$this->assertEmpty( $submenu['users.php'] );
+
+		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, array_shift( $menu )[2] );
 	}
 
 	/**
@@ -188,7 +191,9 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	public function add_feedback_menu() {
 		global $menu;
 
-		$this->assertSame( 'edit.php?post_type=feedback', $menu[45][2] );
+		static::$admin_menu->add_feedback_menu();
+
+		$this->assertSame( 'edit.php?post_type=feedback', array_shift( $menu )[2] );
 	}
 
 	/**
@@ -202,6 +207,6 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_plugins_menu( true );
 
 		// Check Plugins menu always links to Calypso.
-		$this->assertSame( 'https://wordpress.com/plugins/' . static::$domain, $menu[65][2] );
+		$this->assertSame( 'https://wordpress.com/plugins/' . static::$domain, array_shift( $menu )[2] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -99,13 +99,7 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_jetpack_menu();
 
-		$domains_submenu_item = array(
-			'Scan',
-			'manage_options',
-			'https://wordpress.com/scan/' . static::$domain,
-			'Scan',
-		);
-		$this->assertContains( $domains_submenu_item, $submenu[ 'https://wordpress.com/activity-log/' . static::$domain ] );
+		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][4][2] );
 	}
 
 	/**
@@ -116,26 +110,11 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_tools_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/marketing/tools/' . static::$domain;
 		static::$admin_menu->add_tools_menu( false, false );
 
-		// Check Import menu always links to WP Admin.
-		$import_submenu_item = array(
-			'Import',
-			'import',
-			'import.php',
-			'Import',
-		);
-		$this->assertContains( $import_submenu_item, $submenu[ $slug ] );
-
-		// Check Export menu always links to WP Admin.
-		$export_submenu_item = array(
-			'Export',
-			'export',
-			'export.php',
-			'Export',
-		);
-		$this->assertContains( $export_submenu_item, $submenu[ $slug ] );
+		// Check Import/Export menu always links to WP Admin.
+		$this->assertSame( 'export.php', array_pop( $submenu['tools.php'] )[2] );
+		$this->assertSame( 'import.php', array_pop( $submenu['tools.php'] )[2] );
 	}
 
 	/**
@@ -148,16 +127,7 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_wp_admin_menu();
 
-		$wp_admin_menu_item = array(
-			'WP Admin',
-			'read',
-			'index.php',
-			'WP Admin',
-			'menu-top toplevel_page_index',
-			'toplevel_page_index',
-			'dashicons-wordpress-alt',
-		);
-		$this->assertSame( end( $menu ), $wp_admin_menu_item );
+		$this->assertSame( 'index.php', array_pop( $menu )[2] );
 	}
 
 	/**
@@ -168,17 +138,10 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_appearance_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/themes/' . static::$domain;
 		static::$admin_menu->add_appearance_menu( false, false );
 
 		// Check Customize menu always links to WP Admin.
-		$customize_submenu_item = array(
-			'Customize',
-			'customize',
-			'customize.php',
-			'Customize',
-		);
-		$this->assertContains( $customize_submenu_item, $submenu[ $slug ] );
+		$this->assertSame( 'customize.php', array_pop( $submenu['themes.php'] )[2] );
 	}
 
 	/**
@@ -189,9 +152,8 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_posts_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/posts/' . static::$domain;
 		static::$admin_menu->add_posts_menu();
-		$this->assertEmpty( $submenu[ $slug ] );
+		$this->assertEmpty( $submenu['edit.php'] );
 	}
 
 	/**
@@ -202,9 +164,8 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_page_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/pages/' . static::$domain;
 		static::$admin_menu->add_page_menu();
-		$this->assertEmpty( $submenu[ $slug ] );
+		$this->assertEmpty( $submenu['edit.php?post_type=page'] );
 	}
 
 	/**
@@ -215,9 +176,8 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_users_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/people/team/' . static::$domain;
 		static::$admin_menu->add_users_menu();
-		$this->assertEmpty( $submenu[ $slug ] );
+		$this->assertEmpty( $submenu['users.php'] );
 	}
 
 	/**
@@ -228,16 +188,7 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	public function add_feedback_menu() {
 		global $menu;
 
-		$menu_item = array(
-			'Feedback',
-			'edit_posts',
-			'edit.php?post_type=feedback',
-			'Feedback',
-			'menu-top toplevel_page_index',
-			'toplevel_page_index',
-			'dashicons-feedback',
-		);
-		$this->assertSame( $menu[45], $menu_item );
+		$this->assertSame( 'edit.php?post_type=feedback', $menu[45][2] );
 	}
 
 	/**
@@ -251,6 +202,6 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_plugins_menu( true );
 
 		// Check Plugins menu always links to Calypso.
-		$this->assertContains( 'https://wordpress.com/plugins/' . static::$domain, $menu[65] );
+		$this->assertSame( 'https://wordpress.com/plugins/' . static::$domain, $menu[65][2] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -246,7 +246,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	 *
 	 * @covers ::add_upgrades_menu
 	 */
-	public function test_add_wpcom_upgrades_menu() {
+	public function test_add_upgrades_menu() {
 		global $submenu;
 
 		static::$admin_menu->add_upgrades_menu();

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -251,7 +251,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_upgrades_menu();
 
-		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
+		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, array_pop( $submenu['paid-upgrades.php'] )[2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -251,13 +251,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_upgrades_menu();
 
-		$domains_submenu_item = array(
-			'Domains',
-			'manage_options',
-			'https://wordpress.com/domains/manage/' . static::$domain,
-			'Domains',
-		);
-		$this->assertContains( $domains_submenu_item, $submenu[ 'https://wordpress.com/plans/' . static::$domain ] );
+		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu[ 'https://wordpress.com/plans/' . static::$domain ][2][2] );
 	}
 
 	/**
@@ -266,12 +260,12 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_users_menu
 	 */
 	public function test_add_users_menu() {
-		global $menu;
+		global $submenu;
 
 		static::$admin_menu->add_users_menu( true );
 
 		// Check that menu always links to Calypso.
-		$this->assertSame( $menu[70][2], 'https://wordpress.com/people/team/' . static::$domain );
+		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, array_shift( $submenu['users.php'] )[2] );
 	}
 
 	/**
@@ -282,17 +276,10 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_tools_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/marketing/tools/' . static::$domain;
 		static::$admin_menu->add_tools_menu( false, true );
 
 		// Check Export menu item always links to Calypso.
-		$export_submenu_item = array(
-			'Export',
-			'export',
-			'https://wordpress.com/export/' . static::$domain,
-			'Export',
-		);
-		$this->assertContains( $export_submenu_item, $submenu[ $slug ] );
+		$this->assertSame( 'https://wordpress.com/export/' . static::$domain, $submenu['tools.php'][3][2] );
 	}
 
 	/**
@@ -303,18 +290,10 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_options_menu() {
 		global $submenu;
 
-		$slug = 'https://wordpress.com/settings/general/' . static::$domain;
-		static::$admin_menu->add_options_menu( false );
+		static::$admin_menu->add_options_menu();
 
-		$this->assertContains( 'Hosting Configuration', $submenu[ $slug ][6] );
-
-		$sharing_submenu_item = array(
-			'Sharing',
-			'publish_posts',
-			'https://wordpress.com/marketing/sharing-buttons/' . static::$domain,
-			'Sharing Settings',
-		);
-		$this->assertContains( $sharing_submenu_item, $submenu[ $slug ] );
+		$this->assertSame( 'https://wordpress.com/hosting-config/' . static::$domain, $submenu['options-general.php'][6][2] );
+		$this->assertSame( 'https://wordpress.com/marketing/sharing-buttons/' . static::$domain, $submenu['options-general.php'][8][2] );
 	}
 
 	/**
@@ -357,6 +336,6 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_plugins_menu( true );
 
 		// Check Plugins menu always links to Calypso.
-		$this->assertContains( 'https://wordpress.com/plugins/' . static::$domain, $menu[65] );
+		$this->assertSame( 'https://wordpress.com/plugins/' . static::$domain, $menu[65][2] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -251,7 +251,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_upgrades_menu();
 
-		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu[ 'https://wordpress.com/plans/' . static::$domain ][2][2] );
+		$this->assertSame( 'https://wordpress.com/domains/manage/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/50950
Fixes https://github.com/Automattic/wp-calypso/issues/50945
Fixes https://github.com/Automattic/wp-calypso/issues/51018
Fixes https://github.com/Automattic/wp-calypso/issues/51024
Fixes https://github.com/Automattic/wp-calypso/issues/50939
Fixes https://github.com/Automattic/wp-calypso/issues/49915

### Changes proposed in this Pull Request:

Turns out that changing the menu slugs introduces a lot of side effects, mainly because the page hooks are still attached to the previous slugs:
- https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/plugin.php#L1469
- https://core.trac.wordpress.org/browser/trunk/src/wp-admin/menu-header.php#L245
- https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/plugin.php#L1331

To work around that, this PR explores a simpler approach: do not alter the menu slugs. Instead, we simply change the URL of the first submenu, since [that's the URL that's used in the parent menu](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/menu-header.php?rev=49193#L152). That removed the necessity of migrating submenus to new slugs, allowing us to have much less code to maintain which hopefully will make Nav Unification more robust.

### Jetpack product discussion
N/A.

### Does this pull request change what data or activity we track or use?
No.

### Testing instructions:

**Given the amount of changes, please take some time to smoke test on different sites and make sure there are no regressions on Calypso and WP Admin with [the "Show advanced dashboard pages" toggle on and off](https://wordpress.com/me/account).**

_Simple_
- Apply D58455-code to your WP.com sandbox.
- Sandbox the API and a simple site.
- Go to https://wordpress.com and switch to the sandboxed site.
- Check the menu under different scenarios (Calypso, WP Admin, toggle on/off) and make sure there are no regressions.

_Atomic_
- Install Jetpack Beta on a Atomic site and switch to the branch of this PR.
- Go to https://wordpress.com and switch to the WoA site.
- Check the menu under different scenarios (Calypso, WP Admin, toggle on/off) and make sure there are no regressions.

_Jetpack_
- Spin up a Jetpack site running this branch.
- Spin up a local instance of Calypso with [this code](https://github.com/Automattic/wp-calypso/blob/46541a684523325e4efd293d0f8b7f2530f4e6f2/client/state/selectors/is-nav-unification-enabled.js#L27-L31) removed/commented out.
- Go to http://calypso.localhost:3000 and switch to the Jetpack site.
- Check the menu in Calypso only (since Nav Unification is disabled on WP Admin) and make sure there are no regressions (all menus should point to Calypso regardless of the toggle, except Feedback, Customize, Import, Export and WP Admin).

After confirming there are no regressions, follow the instructions below to confirm that this indeed fixes the linked issues.

**https://github.com/Automattic/wp-calypso/issues/50950, https://github.com/Automattic/wp-calypso/issues/51018, https://github.com/Automattic/wp-calypso/issues/51024:**

- On the Atomic site, go to `/wp-admin/options-general.php`.
- Change the site language to a non-English language such as Spanish or Italian.
- Install the following plugins/themes:
  - [WP Headers and Footers](https://wordpress.org/plugins/wp-headers-and-footers/).
  - [UpdraftPlus](https://wordpress.org/plugins/updraftplus/).
  - [Compress JPEG & PNG images](https://wordpress.org/plugins/tiny-compress-images/).
  - [Commenter Emails](https://wordpress.org/plugins/commenter-emails/).
  - [Storefront](https://woocommerce.com/storefront/).
- Go to Jetpack > Settings > Sharing, and enable either "Publicize connections" or "Sharing buttons".
- Inspect the URL of the "Settings > WP Headers and Footers" submenu and make sure it points to `/wp-admin/options-general.php?page=wp-header-and-footer`.
- Click on it and make sure the page loads successfully.
- Inspect the URL of the "Settings > UpdraftPlus" submenu and make sure it points to `/wp-admin/options-general.php?page=updraftplus`.
- Click on it and make sure the page loads successfully.
- Inspect the URL of the "Settings > Sharing" submenu and make sure it points to `/wp-admin/options-general.php?page=sharing`.
- Click on it and make sure the page loads successfully.
- Click on "Media" (the parent menu, not the first submenu).
- Make sure the media library loads successfully.
- Click on "Comments" (the parent menu, not the first submenu).
- Make sure the comments page loads successfully.
- Inspect the URL of the "Appearance > Storefront" submenu and make sure it points to `/wp-admin/themes.php?page=storefront-welcome`.
- Click on it and make sure the page loads successfully.

**https://github.com/Automattic/wp-calypso/issues/50945**
- Make sure My Home is always visible on Simple and Atomic sites, even when the "Show advanced dashboard pages" toggle is off.
- Make sure there is no link to WP Admin on Simple and Atomic sites, but it's still accessible via the `/wp-admin` URL.

**https://github.com/Automattic/wp-calypso/issues/50939, https://github.com/Automattic/wp-calypso/issues/49915:**
- Install the Ovation theme on an Atomic site.
- Make sure there are no duplicated items under the Appearance menu under different scenarios (Calypso, WP Admin, toggle on/off).