### PR TITLE
changelogger: Allow "unreleased" as an entry date

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -109,7 +109,7 @@ for project in projects/packages/* projects/plugins/* projects/github-actions/*;
 		CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
 		if [[ -d "$CHANGES_DIR" && "$(ls -- "$CHANGES_DIR")" ]]; then
 			echo "::group::Updating changelog"
-			if ! $CHANGELOGGER write --prologue='This is an alpha version! The changes listed here are not final.' --default-first-version --prerelease=alpha --no-interaction --yes -vvv; then
+			if ! $CHANGELOGGER write --prologue='This is an alpha version! The changes listed here are not final.' --default-first-version --prerelease=alpha --release-date=unreleased --no-interaction --yes -vvv; then
 				echo "::endgroup::"
 				echo "::error::Changelog update for ${GIT_SLUG} failed"
 				EXIT=1

--- a/composer.lock
+++ b/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "77060c4834c2227a9368d3a5720e039bfa1363c2"
+                "reference": "4b69c92ad4a2241d267fcac82c83fb4237829c29"
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
@@ -23,7 +23,7 @@
                 "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "phpcodesniffer-standard",

--- a/projects/github-actions/push-to-mirrors/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/github-actions/push-to-mirrors/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/github-actions/push-to-mirrors/composer.json
+++ b/projects/github-actions/push-to-mirrors/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"repositories": [
 		{

--- a/projects/github-actions/required-review/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/github-actions/required-review/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/github-actions/required-review/composer.json
+++ b/projects/github-actions/required-review/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"scripts": {
 		"build-development": [

--- a/projects/packages/a8c-mc-stats/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/a8c-mc-stats/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/a8c-mc-stats/composer.json
+++ b/projects/packages/a8c-mc-stats/composer.json
@@ -6,7 +6,7 @@
 	"require": {},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/abtest/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/abtest/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/abtest/composer.json
+++ b/projects/packages/abtest/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"automattic/wordbless": "dev-master",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/analyzer/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/analyzer/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/analyzer/composer.json
+++ b/projects/packages/analyzer/composer.json
@@ -7,7 +7,7 @@
 		"nikic/php-parser": "^4.2"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/assets/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/assets/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/assets/composer.json
+++ b/projects/packages/assets/composer.json
@@ -9,7 +9,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/autoloader/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/autoloader/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/autoloader/composer.json
+++ b/projects/packages/autoloader/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/backup/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/backup/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"files": [

--- a/projects/packages/blocks/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/blocks/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/blocks/composer.json
+++ b/projects/packages/blocks/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"automattic/wordbless": "dev-master",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/changelogger/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/changelogger/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow "unreleased" as the date for a changelog entry.

--- a/projects/packages/changelogger/composer.json
+++ b/projects/packages/changelogger/composer.json
@@ -45,7 +45,7 @@
 	"prefer-stable": true,
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.0.x-dev"
+			"dev-master": "1.1.x-dev"
 		},
 		"mirror-repo": "Automattic/jetpack-changelogger",
 		"version-constants": {

--- a/projects/packages/changelogger/lib/ChangelogEntry.php
+++ b/projects/packages/changelogger/lib/ChangelogEntry.php
@@ -35,7 +35,7 @@ class ChangelogEntry implements JsonSerializable {
 	/**
 	 * Entry timestamp.
 	 *
-	 * @var DateTime
+	 * @var DateTime|null
 	 */
 	protected $timestamp;
 
@@ -136,7 +136,9 @@ class ChangelogEntry implements JsonSerializable {
 	/**
 	 * Get the timestamp.
 	 *
-	 * @return DateTime
+	 * The timestamp may be null, which should be interpreted as "unreleased".
+	 *
+	 * @return DateTime|null
 	 */
 	public function getTimestamp() {
 		return $this->timestamp;
@@ -145,12 +147,14 @@ class ChangelogEntry implements JsonSerializable {
 	/**
 	 * Set the timestamp.
 	 *
-	 * @param DateTime|string $timestamp Timestamp to set.
+	 * The timestamp may be null, which should be interpreted as "unreleased".
+	 *
+	 * @param DateTime|string|null $timestamp Timestamp to set.
 	 * @returns $this
 	 * @throws InvalidArgumentException If an argument is invalid.
 	 */
 	public function setTimestamp( $timestamp ) {
-		if ( ! $timestamp instanceof DateTime ) {
+		if ( null !== $timestamp && ! $timestamp instanceof DateTime ) {
 			try {
 				$timestamp = new DateTime( $timestamp );
 			} catch ( \Exception $ex ) {
@@ -292,7 +296,7 @@ class ChangelogEntry implements JsonSerializable {
 			'__class__' => static::class,
 			'version'   => $this->version,
 			'link'      => $this->link,
-			'timestamp' => $this->timestamp->format( DateTime::ISO8601 ),
+			'timestamp' => null === $this->timestamp ? null : $this->timestamp->format( DateTime::ISO8601 ),
 			'prologue'  => $this->prologue,
 			'epilogue'  => $this->epilogue,
 			'changes'   => $this->changes,

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '1.0.1-alpha';
+	const VERSION = '1.1.0-alpha';
 
 	/**
 	 * Constructor.

--- a/projects/packages/changelogger/src/WriteCommand.php
+++ b/projects/packages/changelogger/src/WriteCommand.php
@@ -71,6 +71,7 @@ class WriteCommand extends Command {
 			->addOption( 'use-significance', null, InputOption::VALUE_REQUIRED, 'When determining the new version, use this significance instead of using the actual change files' )
 			->addOption( 'prerelease', 'p', InputOption::VALUE_REQUIRED, 'When determining the new version, include this prerelease suffix' )
 			->addOption( 'buildinfo', 'b', InputOption::VALUE_REQUIRED, 'When fetching the next version, include this buildinfo suffix' )
+			->addOption( 'release-date', null, InputOption::VALUE_REQUIRED, 'Release date, as a valid PHP date or "unreleased"', 'now' )
 			->addOption( 'default-first-version', null, InputOption::VALUE_NONE, 'If the changelog is currently empty, guess a "first" version instead of erroring' )
 			->addOption( 'deduplicate', null, InputOption::VALUE_REQUIRED, 'Deduplicate new changes against the last N versions', 1 )
 			->addOption( 'prologue', null, InputOption::VALUE_REQUIRED, 'Prologue text for the new changelog entry' )
@@ -182,13 +183,17 @@ EOF
 	protected function addEntry( InputInterface $input, OutputInterface $output, Changelog $changelog, $version, array $changes ) {
 		$output->writeln( 'Creating new changelog entry.', OutputInterface::VERBOSITY_DEBUG );
 		$data = array(
-			'prologue' => (string) $input->getOption( 'prologue' ),
-			'epilogue' => (string) $input->getOption( 'epilogue' ),
-			'link'     => $input->getOption( 'link' ),
-			'changes'  => $changes,
+			'prologue'  => (string) $input->getOption( 'prologue' ),
+			'epilogue'  => (string) $input->getOption( 'epilogue' ),
+			'link'      => $input->getOption( 'link' ),
+			'changes'   => $changes,
+			'timestamp' => (string) $input->getOption( 'release-date' ),
 		);
 		if ( null === $data['link'] && $changelog->getLatestEntry() ) {
 			$data['link'] = Config::link( $changelog->getLatestEntry()->getVersion(), $version );
+		}
+		if ( 'unreleased' === $data['timestamp'] ) {
+			$data['timestamp'] = null;
 		}
 		try {
 			$changelog->addEntry( $this->formatter->newChangelogEntry( $version, $data ) );

--- a/projects/packages/changelogger/tests/php/tests/lib/ChangelogEntryTest.php
+++ b/projects/packages/changelogger/tests/php/tests/lib/ChangelogEntryTest.php
@@ -37,11 +37,12 @@ class ChangelogEntryTest extends TestCase {
 		$this->assertSame( '', $entry->getPrologue() );
 		$this->assertSame( '', $entry->getEpilogue() );
 
-		$this->assertSame( $entry, $entry->setVersion( '2.0' )->setPrologue( 'Foo' )->setEpilogue( 'Bar' )->setLink( 'https://example.org' ) );
+		$this->assertSame( $entry, $entry->setVersion( '2.0' )->setTimestamp( null )->setPrologue( 'Foo' )->setEpilogue( 'Bar' )->setLink( 'https://example.org' ) );
 		$this->assertSame( 'https://example.org', $entry->getLink() );
 		$this->assertSame( '2.0', $entry->getVersion() );
 		$this->assertSame( 'Foo', $entry->getPrologue() );
 		$this->assertSame( 'Bar', $entry->getEpilogue() );
+		$this->assertNull( $entry->getTimestamp() );
 
 		$this->assertSame( $entry, $entry->setVersion( 111 )->setPrologue( 222 )->setEpilogue( 333 )->setLink( '' ) );
 		$this->assertSame( '111', $entry->getVersion() );
@@ -230,11 +231,11 @@ class ChangelogEntryTest extends TestCase {
 	 */
 	public function provideJson() {
 		return array(
-			'Basic serialization'              => array(
+			'Basic serialization'               => array(
 				'{"__class__":"Automattic\\\\Jetpack\\\\Changelog\\\\ChangelogEntry","version":"1.0","link":null,"timestamp":"2021-02-18T00:00:00+0000","prologue":"","epilogue":"","changes":[]}',
 				( new ChangelogEntry( '1.0' ) )->setTimestamp( '2021-02-18' ),
 			),
-			'Serialization with data'          => array(
+			'Serialization with data'           => array(
 				'{"__class__":"Automattic\\\\Jetpack\\\\Changelog\\\\ChangelogEntry","version":"1.0","link":"https:\\/\\/example.org","timestamp":"2021-02-18T12:07:16-0500","prologue":"Foo","epilogue":"Bar","changes":[{"__class__":"Automattic\\\\Jetpack\\\\Changelog\\\\ChangeEntry","significance":null,"timestamp":"2021-02-17T00:00:00+0000","subheading":"","author":"","content":""},{"__class__":"Automattic\\\\Jetpack\\\\Changelog\\\\ChangeEntry","significance":null,"timestamp":"2021-02-18T00:00:00+0000","subheading":"","author":"","content":""}]}',
 				( new ChangelogEntry( '1.0' ) )->setTimestamp( '2021-02-18T12:07:16-0500' )->setPrologue( 'Foo' )->setEpilogue( 'Bar' )->setLink( 'https://example.org' )->setChanges(
 					array(
@@ -243,15 +244,19 @@ class ChangelogEntryTest extends TestCase {
 					)
 				),
 			),
-			'Bad unserialization, no class'    => array(
+			'Serialization with null timestamp' => array(
+				'{"__class__":"Automattic\\\\Jetpack\\\\Changelog\\\\ChangelogEntry","version":"1.0","link":null,"timestamp":null,"prologue":"","epilogue":"","changes":[]}',
+				new ChangelogEntry( '1.0', array( 'timestamp' => null ) ),
+			),
+			'Bad unserialization, no class'     => array(
 				'{"version":"1.0","link":null,"timestamp":"2021-02-18T00:00:00+0000","prologue":"","epilogue":"","changes":[]}',
 				'Invalid data',
 			),
-			'Bad unserialization, no version'  => array(
+			'Bad unserialization, no version'   => array(
 				'{"__class__":"Automattic\\\\Jetpack\\\\Changelog\\\\ChangelogEntry","link":null,"timestamp":"2021-02-18T00:00:00+0000","prologue":"","epilogue":"","changes":[]}',
 				'Invalid data',
 			),
-			'Bad unserialization, wrong class' => array(
+			'Bad unserialization, wrong class'  => array(
 				'{"__class__":"Automattic\\\\Jetpack\\\\Changelog\\\\Changelog","version":"1.0","prologue":"","epilogue":"","entries":[]}',
 				'Cannot instantiate Automattic\\Jetpack\\Changelog\\Changelog via Automattic\\Jetpack\\Changelog\\ChangelogEntry::jsonUnserialize',
 			),

--- a/projects/packages/changelogger/tests/php/tests/lib/fixtures/KeepAChangelogParserTest.options.md
+++ b/projects/packages/changelogger/tests/php/tests/lib/fixtures/KeepAChangelogParserTest.options.md
@@ -6,7 +6,8 @@
       {
           "bullet": " *",
           "dateFormat": "j F Y",
-          "parseAuthors": true
+          "parseAuthors": true,
+          "unreleased": "NOT RELEASED"
       }
   ]
   ~~~~~~~~
@@ -20,7 +21,7 @@
    * Who did this? (me)
    * Not an author: (me).
 
-  ## 0.9 - 2021-02-17
+  ## 0.9 - NOT RELEASED
 
   * Wrong bullet.
 
@@ -83,7 +84,7 @@
               "__class__": "Automattic\\Jetpack\\Changelog\\ChangelogEntry",
               "version": "0.9",
               "link": null,
-              "timestamp": "2021-02-17T00:00:00+0000",
+              "timestamp": null,
               "prologue": "* Wrong bullet.",
               "epilogue": "",
               "changes": []
@@ -110,7 +111,7 @@
    * Who did this? (me)
    * Not an author: (me).
 
-  ## 0.9 - 17 February 2021
+  ## 0.9 - NOT RELEASED
 
   * Wrong bullet.
 

--- a/projects/packages/changelogger/tests/php/tests/lib/fixtures/KeepAChangelogParserTest.simple.md
+++ b/projects/packages/changelogger/tests/php/tests/lib/fixtures/KeepAChangelogParserTest.simple.md
@@ -22,6 +22,8 @@
 
   Epilogue text.
 
+  ## 1.0.0-alpha - unreleased
+
   ## [1.0.0] - 2021-02-17
 
   - Initial release.
@@ -75,6 +77,15 @@
                       "content": "A typo. (me)"
                   }
               ]
+          },
+          {
+              "__class__": "Automattic\\Jetpack\\Changelog\\ChangelogEntry",
+              "version": "1.0.0-alpha",
+              "link": null,
+              "timestamp": null,
+              "prologue": "",
+              "epilogue": "",
+              "changes": []
           },
           {
               "__class__": "Automattic\\Jetpack\\Changelog\\ChangelogEntry",

--- a/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
@@ -148,18 +148,31 @@ class WriteCommandTest extends CommandTestCase {
 			),
 			'Run with extra command line args'             => array(
 				array(
-					'--prerelease' => 'dev',
-					'--buildinfo'  => 'g1234567',
-					'--prologue'   => 'Prologue for the new entry',
-					'--epilogue'   => 'Epilogue for the new entry',
-					'--link'       => 'https://example.org/link',
+					'--prerelease'   => 'dev',
+					'--buildinfo'    => 'g1234567',
+					'--prologue'     => 'Prologue for the new entry',
+					'--epilogue'     => 'Epilogue for the new entry',
+					'--link'         => 'https://example.org/link',
+					'--release-date' => '2021-02-06',
 				),
 				array(),
 				array(),
 				0,
 				array( '/^$/' ),
 				true,
-				"# Changelog\n\n## [1.0.2-dev+g1234567] - $date\n\nPrologue for the new entry\n\n### Fixed\n- Fixed a thing.\n\nEpilogue for the new entry\n\n## 1.0.1 - 2021-02-23\n\nPrologue for v1.0.1\n\n### Added\n- Stuff.\n\n### Removed\n- Other stuff.\n\nEpilogue for v1.0.1\n\n## 1.0.0 - 2021-02-23\n\n- Initial release.\n\n[1.0.2-dev+g1234567]: https://example.org/link\n",
+				"# Changelog\n\n## [1.0.2-dev+g1234567] - 2021-02-06\n\nPrologue for the new entry\n\n### Fixed\n- Fixed a thing.\n\nEpilogue for the new entry\n\n## 1.0.1 - 2021-02-23\n\nPrologue for v1.0.1\n\n### Added\n- Stuff.\n\n### Removed\n- Other stuff.\n\nEpilogue for v1.0.1\n\n## 1.0.0 - 2021-02-23\n\n- Initial release.\n\n[1.0.2-dev+g1234567]: https://example.org/link\n",
+			),
+			'Run with extra command line args (2)'         => array(
+				array(
+					'--prerelease'   => 'alpha',
+					'--release-date' => 'unreleased',
+				),
+				array(),
+				array(),
+				0,
+				array( '/^$/' ),
+				true,
+				"# Changelog\n\n## 1.0.2-alpha - unreleased\n### Fixed\n- Fixed a thing.\n\n## 1.0.1 - 2021-02-23\n\nPrologue for v1.0.1\n\n### Added\n- Stuff.\n\n### Removed\n- Other stuff.\n\nEpilogue for v1.0.1\n\n## 1.0.0 - 2021-02-23\n\n- Initial release.\n",
 			),
 
 			'Invalid formatter'                            => array(

--- a/projects/packages/codesniffer/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/codesniffer/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -12,7 +12,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/compat/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/compat/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/compat/composer.json
+++ b/projects/packages/compat/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"files": [

--- a/projects/packages/config/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/config/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/config/composer.json
+++ b/projects/packages/config/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/connection-ui/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/connection-ui/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/connection-ui/composer.json
+++ b/projects/packages/connection-ui/composer.json
@@ -7,7 +7,7 @@
 		"automattic/jetpack-connection": "^1.24"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/connection/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/connection/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -15,7 +15,7 @@
 		"automattic/wordbless": "@dev",
 		"yoast/phpunit-polyfills": "0.2.0",
 		"brain/monkey": "2.6.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"files": [

--- a/projects/packages/constants/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/constants/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/constants/composer.json
+++ b/projects/packages/constants/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/device-detection/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/device-detection/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/device-detection/composer.json
+++ b/projects/packages/device-detection/composer.json
@@ -6,7 +6,7 @@
 	"require": {},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/error/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/error/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/error/composer.json
+++ b/projects/packages/error/composer.json
@@ -6,7 +6,7 @@
 	"require": {},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/heartbeat/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/heartbeat/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/heartbeat/composer.json
+++ b/projects/packages/heartbeat/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-options": "^1.11"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/jitm/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/jitm/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -17,7 +17,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/lazy-images/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/lazy-images/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/lazy-images/composer.json
+++ b/projects/packages/lazy-images/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"automattic/wordbless": "dev-master",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/licensing/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/licensing/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/licensing/composer.json
+++ b/projects/packages/licensing/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"automattic/wordbless": "@dev",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/logo/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/logo/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/logo/composer.json
+++ b/projects/packages/logo/composer.json
@@ -6,7 +6,7 @@
 	"require": {},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/options/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/options/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/options/composer.json
+++ b/projects/packages/options/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/partner/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/partner/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/partner/composer.json
+++ b/projects/packages/partner/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/redirect/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/redirect/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/redirect/composer.json
+++ b/projects/packages/redirect/composer.json
@@ -9,7 +9,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/roles/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/roles/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/roles/composer.json
+++ b/projects/packages/roles/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/status/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/status/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/sync/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/sync/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-status": "^1.7"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/terms-of-service/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/terms-of-service/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/terms-of-service/composer.json
+++ b/projects/packages/terms-of-service/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/tracking/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/tracking/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -11,7 +11,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/plugins/beta/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/plugins/beta/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"autoload": {},
 	"repositories": [

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa9235aa03dc841cc58fa67d45ddc3a0",
+    "content-hash": "777b48e88f9391655babeda184b2e987",
     "packages": [],
     "packages-dev": [
         {
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "c6f15397211680f953a04cf839563b531b73011d"
+                "reference": "dff2b641a296f469289f9e9ce09c958665e1e528"
             },
             "require": {
                 "php": ">=5.6",
@@ -31,7 +31,7 @@
             "type": "project",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/debug-helper/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/plugins/debug-helper/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies.

--- a/projects/plugins/debug-helper/composer.json
+++ b/projects/plugins/debug-helper/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"repositories": [
 		{

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3509798320ac1571a92cf136912bd317",
+    "content-hash": "d61b8c01d13effc96340b1a6b15bffac",
     "packages": [],
     "packages-dev": [
         {
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "c6f15397211680f953a04cf839563b531b73011d"
+                "reference": "dff2b641a296f469289f9e9ce09c958665e1e528"
             },
             "require": {
                 "php": ">=5.6",
@@ -31,7 +31,7 @@
             "type": "project",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/jetpack/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/plugins/jetpack/changelog/update-changelogger-allow-unreleased-date
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Update changelogger dep.
+
+

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -40,7 +40,7 @@
 		"nojimage/twitter-text-php": "3.1.1"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.0.x-dev"
+		"automattic/jetpack-changelogger": "1.1.x-dev"
 	},
 	"scripts": {
 		"build-production": [

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0a0a17b4d5fbc4d29ec4c31f72d78f7",
+    "content-hash": "5b74d119b86d0bac6969c1ef19b8ee29",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,10 +12,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "ad3948510507a743337926e4e84d6d1515c7be54"
+                "reference": "f662708969edb26a8acdd7845ee6c92d097d3ed2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -61,14 +61,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/abtest",
-                "reference": "0419eb99e8bc1e079e15b16690678651a97158b4"
+                "reference": "88cba470baacd708cdeaa975d96c2c665d568faf"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.24",
                 "automattic/jetpack-error": "^1.3"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "automattic/wordbless": "dev-master",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -118,13 +118,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "f2e85ecf8e0e4cfc6a94ec0d7e8e791c8c69cc38"
+                "reference": "750a02d32a85ec4bd14550cc67a882f5b8f965b1"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -171,13 +171,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "46cac049e964fbe6039ca04301a4679f76182d70"
+                "reference": "6c3ebd7e09edd636d71e4e87ce316ffbc8f9f567"
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "composer-plugin",
@@ -228,10 +228,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "00b5bc360e38473b3720f1b87cce0ef530bea887"
+                "reference": "d3f75f574e4b644734bbf77a56ad8c2ac1ac35c9"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev"
+                "automattic/jetpack-changelogger": "1.1.x-dev"
             },
             "type": "library",
             "extra": {
@@ -266,10 +266,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "1d688379d36a070b7cb39865421c92bcf9ae5e02"
+                "reference": "0deefeaefb355c075c200207bbc312bd4cedb1fc"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "automattic/wordbless": "dev-master",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -319,10 +319,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/compat",
-                "reference": "ac4d9941c8a255dcca3d2fbcb4b16fbbafbf5cd0"
+                "reference": "0a01140f3f45fbfee74243bdd09552295136ccae"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev"
+                "automattic/jetpack-changelogger": "1.1.x-dev"
             },
             "type": "library",
             "extra": {
@@ -357,10 +357,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "2f8ed233397fde534a04dc8eb9f9b2aebc531ddb"
+                "reference": "81115241e47b081e13cc0ba61e547a3f1bb2718b"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev"
+                "automattic/jetpack-changelogger": "1.1.x-dev"
             },
             "type": "library",
             "extra": {
@@ -392,7 +392,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "0be00c975c608d903808cb7aedab16e45f57c0b2"
+                "reference": "a1285622214531176b61066767260c25937910b7"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6",
@@ -403,7 +403,7 @@
                 "automattic/jetpack-tracking": "^1.13"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "automattic/wordbless": "@dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
@@ -458,13 +458,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "4081deb2fc857d42a153e318cb6c0339985a5cbf"
+                "reference": "70a57319a468fa865c9114a7a4ec54422c9b3356"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.24"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev"
+                "automattic/jetpack-changelogger": "1.1.x-dev"
             },
             "type": "library",
             "extra": {
@@ -506,10 +506,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "5c017ccd21e79a0194f51c47bce369c7c2d4a171"
+                "reference": "ef2fb6fcd1f79e6b6b6516c9a4bf401fba57b99a"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -556,10 +556,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "f9fb4a36b63b08e18410f91563a84ca06ca522f2"
+                "reference": "22f3a4fec17aef4079ad8591eb3e69ad6f80a3f8"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -605,10 +605,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/error",
-                "reference": "87d998f673d02beb241111aca2b362f889ac47de"
+                "reference": "fff48d3d285dcb299cc4fcd9c29298dcde386a7b"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -654,14 +654,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/heartbeat",
-                "reference": "06f899364fa7a310b5062adf9984723dbc12caa4"
+                "reference": "92faeca91bda23782272f76f9af8eb68537eb51d"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
                 "automattic/jetpack-options": "^1.11"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev"
+                "automattic/jetpack-changelogger": "1.1.x-dev"
             },
             "type": "library",
             "extra": {
@@ -693,7 +693,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "769a3623e3dcfd806545c44944933f7501f8b1f1"
+                "reference": "1ac9a29d97ee0dcbcb5e8a0d399a33bc85b5c6c3"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
@@ -707,7 +707,7 @@
                 "automattic/jetpack-tracking": "^1.13"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -765,14 +765,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/lazy-images",
-                "reference": "7e781468b6faf7a8ea0aab35b854bd943eef01dc"
+                "reference": "ca815af21ad1360cf5081f422a5733af194b6970"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "automattic/wordbless": "dev-master",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -830,14 +830,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "a830255fbb71c47f811cf724bf70805773049c2a"
+                "reference": "7307122038822613d76aa3c8dc974811fe7f3456"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.24",
                 "automattic/jetpack-options": "^1.11"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -887,10 +887,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "9692a792d762dd3af9681553706635884a617af8"
+                "reference": "a37b01720e4c15ececa53192133a5122d9f87121"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -936,13 +936,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/options",
-                "reference": "98b3561722a093de3b13dff7683ebf8a87872409"
+                "reference": "7460b9679c9a99dd05809735288b15d336ec4409"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -975,10 +975,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "4b48a9a36fb1bc056535ec1732cf348828beb360"
+                "reference": "5e98f77f594a785e9309d393814ac7ca267adde5"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1025,13 +1025,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "f353cdc686cfd003b431b70be51ba1b978216a7c"
+                "reference": "63a074342c395775eca87c7c5afc501b2e8edc6d"
             },
             "require": {
                 "automattic/jetpack-status": "^1.7"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1078,10 +1078,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "b61cfac272cc3d9a6b9d8a9589c9da06f8a1a36f"
+                "reference": "204d82908358392be04305dcfce93d3be0d90145"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1128,10 +1128,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c5c0476b911705fbc49840eb4aae4a71718fde7"
+                "reference": "e528f7867762b3359da8e5500d886ce082b1ca05"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1178,7 +1178,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "a512d085cae8cd7fa7ed2a5163fb7262a8e767ea"
+                "reference": "f79d7f002b9daaa38c4ea6b89a8c27d3ec103181"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.24",
@@ -1189,7 +1189,7 @@
                 "automattic/jetpack-status": "^1.7"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev"
+                "automattic/jetpack-changelogger": "1.1.x-dev"
             },
             "type": "library",
             "extra": {
@@ -1221,14 +1221,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/terms-of-service",
-                "reference": "126aaf8417a432cf6157e46a88f7ee528a08e89e"
+                "reference": "e4f16272eb09fd66406138580cccf9f312b43f5f"
             },
             "require": {
                 "automattic/jetpack-options": "^1.11",
                 "automattic/jetpack-status": "^1.7"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1275,7 +1275,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "0af20e0ec680bb5f7f0beb266114626ca9aedd61"
+                "reference": "705971e55db88cb8bcc31d650a47512f5d9fc519"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
@@ -1284,7 +1284,7 @@
                 "automattic/jetpack-terms-of-service": "^1.9"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "1.0.x-dev",
+                "automattic/jetpack-changelogger": "1.1.x-dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -1403,7 +1403,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "c6f15397211680f953a04cf839563b531b73011d"
+                "reference": "dff2b641a296f469289f9e9ce09c958665e1e528"
             },
             "require": {
                 "php": ">=5.6",
@@ -1421,7 +1421,7 @@
             "type": "project",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
I noticed that the build was producing spurious updates to the mirrors because it was updating the date of the "alpha" version in the generated changelog. Let's make it valid to have "unreleased" as the date there to avoid that.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Look at the output of the Build job, do the changelogs all have "unreleased" as the date of the alpha version at the top?