### PR TITLE
cli: Exit with an error status on error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build
 on: [ push, pull_request ]
 
+env:
+  COMPOSER_ROOT_VERSION: "dev-master"
+
 jobs:
   build:
     name: Build all projects

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -103,6 +103,7 @@ export async function build( project, production, composerJson, verbose ) {
 
 	builder.run().catch( err => {
 		console.error( err );
+		process.exit( err.exitCode || 1 );
 	} );
 }
 

--- a/tools/cli/commands/install.js
+++ b/tools/cli/commands/install.js
@@ -46,6 +46,7 @@ export async function install( argv ) {
 
 	installs.run().catch( err => {
 		console.error( err );
+		process.exit( err.exitCode || 1 );
 	} );
 }
 

--- a/tools/project-version.sh
+++ b/tools/project-version.sh
@@ -192,7 +192,7 @@ jsver "$FILE" '.extra["branch-alias"]["dev-master"]' "$(sed -E 's/\.[0-9]+([-+].
 
 # Update declared constants
 FILE="$BASE/projects/$SLUG/composer.json"
-jq -r '.extra["version-constants"] // {} | to_entries | .[] | .key + " " + .value' "$FILE" | while IFS=" " read -r C F; do
+while IFS=" " read -r C F; do
 	debug "$OPING version constant $C in $F"
 	CE=$(sed 's/[.\[\]\\*^$\/()+?{}|]/\\&/g' <<<"${C}")
 
@@ -213,6 +213,6 @@ jq -r '.extra["version-constants"] // {} | to_entries | .[] | .key + " " + .valu
 		PAT="^([[:blank:]]*define\( '$CE', ')([^']*)(' \);)$"
 	fi
 	sedver "$BASE/projects/$SLUG/$F" "$PAT" "$VERSION" "version constant $C"
-done
+done < <(jq -r '.extra["version-constants"] // {} | to_entries | .[] | .key + " " + .value' "$FILE")
 
 exit $EXIT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
I noticed that the Build job wasn't failing if a build failed. This turned out to be because the cli build command would still exit with a successful status even if the build failed.

Also fixed the thing that caused the build I looked at to be failing.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Introduce an install/build failure, e.g. change a dep in composer.json for something with a build step to an unavailable version.
* Try `jetpack install` or `jetpack build` for that project. Does it exit with a failure status?
* Make a PR that introduces the build failure. Does the Build job fail?
