### PR TITLE
Docs: Add changelogger info to monorepo.md

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -228,3 +228,46 @@ If you have set `.extra.mirror-repo`, `.extra.release-branch-prefix`, and `.extr
 * `tools/create-release-branch.sh` will help you create the correctly named release branch, and will automatically update version numbers and versions of monorepo packages for you. The GitHub Action will then mirror this branch to your plugin's mirror repo.
 * `tools/deploy-to-svn.sh` will prepare a temporary directory with the content of the mirror repo branch that is ready to be pushed to WordPress.org SVN.
 * `tools/revert-release.sh` will prepare a temporary directory that updates the "Stable version" tag in `readme.txt` to the previous version, in case an emergency rollback is required.
+
+## Jetpack Changelogger
+
+The [Jetpack Changelogger](https://packagist.org/packages/automattic/jetpack-changelogger) tool helps in managing a changelog for a project by having each PR drop a specially-formatted "change file" into a changelog directory, which the tool can then process for a release.
+
+As implemented by the Jetpack Monorepo, any PR that touches the Jetpack plugin itself, or anything else in the `/projects` directory will require a specially-formatted file to the project's specified `changelog` directory; there is a [command](#using-the-jetpack-changelogger) mentioned below that can help create the change file.
+
+**What does the change file look like?** It’s a text file with a header-and-body format, like HTTP or email. A change file might look like this:
+
+```
+Significance: patch
+Type: compat
+
+Block Editor: update all blocks to be fully compatible with WordPress 5.7.
+```
+
+The “Significance” header specifies the significance of change in the style of [semantic versioning](https://semver.org/): patch, minor, or major.
+
+The “Type” header categorizes the change in the changelog. In Jetpack, for example, our changelog divides changes into “Major Enhancements”, “Enhancements”, “Improved compatibility”, and “Bugfixes”.
+
+The body is separated from the headers by a blank line, and is the text that actually goes into the changelog. This should follow our recommendations for [writing a good changelog entry](https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md). Feel free to (sparingly) use Markdown in the body text.
+
+### Using the Jetpack Changelogger
+
+The changelogger tool is dev-required by each project via Composer, and after `composer install`, may be run to interactively add a change file using:
+
+`vendor/bin/changelogger add`
+
+**Does it matter what the change file is named?** Starting the file name with `.` should not be used. Also consider avoiding names that have extensions like `.php` or `.js` to avoid confusing other tools.
+
+**What if a change is so trivial that it doesn’t need a changelog entry?** The change file is still required. If you specify the significance as “patch”, changelogger will allow the body section to be empty so as to not generate an entry in the changelog. In this case, use the “Comment” header instead, for example:
+
+```
+Significance: patch
+Type: compat
+Comment: Update composer.lock, no need for a changelog entry
+```
+
+**Adding the first PR to a project after a release?** If a PR is the first to Jetpack after a release, version numbers may need to be bumped. This also applies to the first semantic versioning “minor” or “major” change to any projects that use semantic versioning.
+
+The “Linting / Changelogger validity” GitHub Actions check will help in making sure that all these version numbers are in sync with the version inferred from the changelog and change files. You can also check this locally with `tools/changelogger-validate-all.sh`.
+
+Within a single project, changlogger’s `version next` command can tell you the next version, and the monorepo script `tools/project-version.sh` can be used to check and update the version numbers.

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -233,7 +233,7 @@ If you have set `.extra.mirror-repo`, `.extra.release-branch-prefix`, and `.extr
 
 The [Jetpack Changelogger](https://packagist.org/packages/automattic/jetpack-changelogger) tool helps in managing a changelog for a project by having each PR drop a specially-formatted "change file" into a changelog directory, which the tool can then process for a release.
 
-As implemented by the Jetpack Monorepo, any PR that touches the Jetpack plugin itself, or anything else in the `/projects` directory will require a specially-formatted file to the project's specified `changelog` directory; there is a [command](#using-the-jetpack-changelogger) mentioned below that can help create the change file.
+As implemented by the Jetpack Monorepo, any PR that touches the Jetpack plugin itself, or anything else in the `/projects` directory will need to add a specially-formatted file to the project's specified `changelog` directory; there is a [command](#using-the-jetpack-changelogger) mentioned below that can help create the change file.
 
 **What does the change file look like?** It’s a text file with a header-and-body format, like HTTP or email. A change file might look like this:
 
@@ -252,7 +252,7 @@ The body is separated from the headers by a blank line, and is the text that act
 
 ### Using the Jetpack Changelogger
 
-The changelogger tool is dev-required by each project via Composer, and after `composer install`, may be run to interactively add a change file using:
+The changelogger tool is dev-required by each project via Composer, and after `composer install` may be run to interactively add a change file using:
 
 `vendor/bin/changelogger add`
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -248,7 +248,7 @@ The “Significance” header specifies the significance of change in the style 
 
 The “Type” header categorizes the change in the changelog. In Jetpack, for example, our changelog divides changes into “Major Enhancements”, “Enhancements”, “Improved compatibility”, and “Bugfixes”.
 
-The body is separated from the headers by a blank line, and is the text that actually goes into the changelog. This should follow our recommendations for [writing a good changelog entry](https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md). Feel free to (sparingly) use Markdown in the body text.
+The body is separated from the headers by a blank line, and is the text that actually goes into the changelog. This should follow our recommendations for [writing a good changelog entry](./writing-a-good-changelog-entry.md). Feel free to (sparingly) use Markdown in the body text.
 
 ### Using the Jetpack Changelogger
 

--- a/docs/writing-a-good-changelog-entry.md
+++ b/docs/writing-a-good-changelog-entry.md
@@ -1,24 +1,22 @@
-# Writing a good Changelog Entry
+# Writing A Good Changelog Entry
 
-Part of our standard PR template is "Proposed changelog entry for your changes". This document will help you write a good one.
+Part of our standard [Pull Request process](./monorepo.md#jetpack-changelogger) includes submitting a changelog entry for your changes, which this document provides guidance on.
 
-## Do I even need one?
+## Do I even need to write a changelog entry?
 
-Our changelog is intended for the users of Jetpack, primarily end users but also third-party developers who use our public APIs and packages.
+For Jetpack, our changelog is intended primarily for end users and third-party developers who use our public APIs and packages. Other projects in the Jetpack monorepo also benefit from managing an accurate changelog.
 
-If you've changed something that users will notice, like improving the display of a block or fixing a bug that prevents a site feature from working, then by all means suggest a changelog entry.
+If you've changed something that users will notice, like improving the display of a block or fixing a bug that prevents a feature from working, then by all means submit a suggested changelog entry.
 
-If you've improved our CI or development environments, or refactored old code without user-visible changes, or something like that, it's probably not something that's worth mentioning in the changelog. But don't worry, we still appreciate it! And remember to say so in the appropriate section of the PR template, don't just leave it blank.
+If you've improved our CI or development environments, or refactored old code without user-visible changes, it's probably not a change that needs a changelog entry intended for end users. However, you would still submit a changelog entry with a ["Comment" header](./monorepo.md#using-the-jetpack-changelogger) which would be omitted from the generated changelog, but still serve as documentation to other developers.
 
-If you're unsure, feel free to go ahead and suggest a changelog entry, or to ask.
-
-P.S. If your PR doesn't need a changelog entry, feel free to remove the "Needs Changelog" tag that a bot adds after merging.
+If you're ever unsure, feel free to ask for help.
 
 ## What should I write?
 
-Our changelog entries typically begin with a component name, such as "Payments Block" or "Sync".
+The actual changelog text typically begins with a relevant component name, feature, tool, or other topic, followed by a colon, such as "Payments Block:" or "Sync:".
 
-The rest of the changelog entry is a sentence fragment (beginning with a bare infinitive verb) describing what the PR does. Remember that this is aimed at end users, so be wary of jargon and details of the code. If it helps, consider filling in blank in the sentence "This PR will ______".
+The rest of the changelog entry is a sentence fragment (beginning with a bare infinitive verb) describing what the PR does. Remember that this is aimed at end users, so be wary of jargon and details of the code. If it helps, think about filling in the blank "This PR will ______".
 
 Some good examples:
 
@@ -32,4 +30,4 @@ Some good examples:
 * General: ensure Jetpack's full compatibility with the upcoming WordPress 5.6 release.
 * General: update Jetpack's minimum required WordPress version to 5.5, in anticipation of the upcoming WordPress 5.6 release.
 
-You can find many more examples by looking through [changelog.txt](../changelog.txt).
+You can find more examples by looking at [prior Jetpack releases](https://github.com/Automattic/jetpack-production/releases).

--- a/docs/writing-a-good-changelog-entry.md
+++ b/docs/writing-a-good-changelog-entry.md
@@ -8,7 +8,7 @@ For Jetpack, our changelog is intended primarily for end users and third-party d
 
 If you've changed something that users will notice, like improving the display of a block or fixing a bug that prevents a feature from working, then by all means submit a suggested changelog entry.
 
-If you've improved our CI or development environments, or refactored old code without user-visible changes, it's probably not a change that needs a changelog entry intended for end users. However, you would still submit a changelog entry with a ["Comment" header](./monorepo.md#using-the-jetpack-changelogger) which would be omitted from the generated changelog, but still serve as documentation to other developers.
+If you've improved our CI or development environments, or refactored old code without user-visible changes, it's probably not a change that needs a changelog entry intended for end users. However, you would still include a change file with a ["Comment" header](./monorepo.md#using-the-jetpack-changelogger) which would be omitted from the generated changelog, but still serve as documentation to other developers.
 
 If you're ever unsure, feel free to ask for help.
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add changelogger info to `monorepo.md`
* Update `writing-a-good-changelog-entry.md` with changelogger info; removing info about the previously used `Needs Changelog` labeling/template.

#### Jetpack product discussion

* Internal: p1HpG7-bqa-p2

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

* Proofread updated documents.