### PR TITLE
WordAds: Add block tests and fixtures

### DIFF
--- a/projects/plugins/jetpack/changelog/add-wordads-tests-and-fixtures
+++ b/projects/plugins/jetpack/changelog/add-wordads-tests-and-fixtures
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+WordAds: Added block tests and fixtures.

--- a/projects/plugins/jetpack/extensions/blocks/wordads/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/controls.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import FormatPicker from './format-picker';
+
+export const AdVisibilityToggle = ( { value, onChange } ) => (
+	<PanelBody title={ __( 'Visibility', 'jetpack' ) }>
+		<ToggleControl
+			className="jetpack-wordads__mobile-visibility"
+			checked={ !! value }
+			label={ __( 'Hide on mobile', 'jetpack' ) }
+			help={ __( 'Hides this block for site visitors on mobile devices.', 'jetpack' ) }
+			onChange={ onChange }
+		/>
+	</PanelBody>
+);
+
+const AdControls = ( { attributes: { format, hideMobile }, setAttributes } ) => {
+	return (
+		<>
+			<BlockControls>
+				<FormatPicker
+					value={ format }
+					onChange={ nextFormat => setAttributes( { format: nextFormat } ) }
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<AdVisibilityToggle
+					value={ hideMobile }
+					onChange={ hide => setAttributes( { hideMobile: !! hide } ) }
+				/>
+			</InspectorControls>
+		</>
+	);
+};
+
+export default AdControls;

--- a/projects/plugins/jetpack/extensions/blocks/wordads/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/edit.js
@@ -1,15 +1,7 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import { Component, Fragment } from '@wordpress/element';
-import { PanelBody, ToggleControl } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
-import FormatPicker from './format-picker';
+import AdControls from './controls';
 import { AD_FORMATS } from './constants';
 
 import './editor.scss';
@@ -22,62 +14,38 @@ import leaderboardExample from './example_728x90.png';
 import mobileLeaderboardExample from './example_320x50.png';
 import wideSkyscraperExample from './example_160x600.png';
 
-class WordAdsEdit extends Component {
-	handleHideMobileChange = hideMobile => {
-		this.props.setAttributes( { hideMobile: !! hideMobile } );
+const WordAdsEdit = ( { attributes, setAttributes } ) => {
+	const { format } = attributes;
+	const selectedFormatObject = AD_FORMATS.find( ( { tag } ) => tag === format );
+
+	const getExampleAd = formatting => {
+		switch ( formatting ) {
+			case 'leaderboard':
+				return leaderboardExample;
+			case 'mobile_leaderboard':
+				return mobileLeaderboardExample;
+			case `wideskyscraper`:
+				return wideSkyscraperExample;
+			default:
+				return rectangleExample;
+		}
 	};
 
-	render() {
-		const { attributes, setAttributes, isSelected } = this.props;
-		const { format, hideMobile } = attributes;
-		const selectedFormatObject = AD_FORMATS.filter( ( { tag } ) => tag === format )[ 0 ];
-		const adControls = (
-			<InspectorControls>
-				<PanelBody title={ __( 'Visibility', 'jetpack' ) }>
-					<ToggleControl
-						className="jetpack-wordads__mobile-visibility"
-						checked={ Boolean( hideMobile ) }
-						label={ __( 'Hide on mobile', 'jetpack' ) }
-						help={ __( 'Hides this block for site visitors on mobile devices.', 'jetpack' ) }
-						onChange={ this.handleHideMobileChange }
-					/>
-				</PanelBody>
-			</InspectorControls>
-		);
-		function getExampleAd( formatting ) {
-			switch ( formatting ) {
-				case 'leaderboard':
-					return leaderboardExample;
-				case 'mobile_leaderboard':
-					return mobileLeaderboardExample;
-				case `wideskyscraper`:
-					return wideSkyscraperExample;
-				default:
-					return rectangleExample;
-			}
-		}
-		return (
-			<Fragment>
-				<BlockControls>
-					<FormatPicker
-						value={ format }
-						onChange={ nextFormat => setAttributes( { format: nextFormat } ) }
-					/>
-				</BlockControls>
-				<div className={ `wp-block-jetpack-wordads jetpack-wordads-${ format }` }>
-					<div
-						className="jetpack-wordads__ad"
-						style={ {
-							width: selectedFormatObject.width,
-							height: selectedFormatObject.height,
-							backgroundImage: `url( ${ getExampleAd( format ) } )`,
-							backgroundSize: 'cover',
-						} }
-					></div>
-					{ isSelected && adControls }
-				</div>
-			</Fragment>
-		);
-	}
-}
+	return (
+		<>
+			<AdControls { ...{ attributes, setAttributes } } />
+			<div className={ `wp-block-jetpack-wordads jetpack-wordads-${ format }` }>
+				<div
+					className="jetpack-wordads__ad"
+					style={ {
+						width: selectedFormatObject.width,
+						height: selectedFormatObject.height,
+						backgroundImage: `url( ${ getExampleAd( format ) } )`,
+						backgroundSize: 'cover',
+					} }
+				></div>
+			</div>
+		</>
+	);
+};
 export default WordAdsEdit;

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/controls.js
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import FormatPicker from '../format-picker';
+import { AD_FORMATS, DEFAULT_FORMAT } from '../constants';
+import { AdVisibilityToggle } from '../controls';
+
+const getFormat = format => AD_FORMATS.find( ( { tag } ) => tag === format );
+
+describe( 'AdVisibilityToggle', () => {
+	const onChange = jest.fn();
+	const defaultProps = { value: false, onChange };
+	const checkedProps = { value: true, onChange };
+
+	beforeEach( () => {
+		onChange.mockClear();
+	} );
+
+	test( 'renders visibility panel header', () => {
+		render( <AdVisibilityToggle { ...defaultProps } /> );
+
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Visibility' );
+	} );
+
+	test( 'applies correct class to toggle control', () => {
+		const { container } = render( <AdVisibilityToggle { ...defaultProps } /> );
+		const toggle = container.querySelector( '.components-toggle-control' );
+
+		expect( toggle ).toHaveClass( 'jetpack-wordads__mobile-visibility' );
+	} );
+
+	test( 'renders unchecked checkbox', () => {
+		render( <AdVisibilityToggle { ...defaultProps } /> );
+		const checkbox = screen.getByRole( 'checkbox' );
+
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).not.toBeChecked();
+	} );
+
+	test( 'renders checked checkbox', () => {
+		render( <AdVisibilityToggle { ...checkedProps } /> );
+		const checkbox = screen.getByRole( 'checkbox' );
+
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).toBeChecked();
+	} );
+
+	test( 'renders supplied label', () => {
+		render( <AdVisibilityToggle { ...defaultProps } /> );
+
+		expect( screen.getByText( 'Hide on mobile' ) ).toBeInTheDocument();
+	} );
+
+	test( 'displays help text', () => {
+		render( <AdVisibilityToggle { ...defaultProps } /> );
+		const help = 'Hides this block for site visitors on mobile devices.';
+
+		expect( screen.getByText( help ) ).toBeInTheDocument();
+	} );
+
+	test( 'calls onChange when checkbox clicked', () => {
+		render( <AdVisibilityToggle { ...defaultProps } /> );
+
+		userEvent.click( screen.getByRole( 'checkbox' ) );
+		expect( onChange ).toHaveBeenCalledWith( true );
+	} );
+
+	test( 'calls onChange when label clicked', () => {
+		render( <AdVisibilityToggle { ...checkedProps } /> );
+
+		userEvent.click( screen.getByText( 'Hide on mobile' ) );
+		expect( onChange ).toHaveBeenCalledWith( false );
+	} );
+} );
+
+describe( 'FormatPicker', () => {
+	const onChange = jest.fn();
+	const defaultFormat = getFormat( DEFAULT_FORMAT );
+	const defaultProps = { value: DEFAULT_FORMAT, onChange };
+
+	beforeEach( () => {
+		onChange.mockClear();
+	} );
+
+	test( 'renders toolbar settings button with formats not visible', () => {
+		render( <FormatPicker { ...defaultProps } /> );
+
+		expect( screen.getByLabelText( 'Pick an ad format' ) ).toBeInTheDocument();
+		expect( screen.queryByText( defaultFormat.name ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'displays dropdown with available options on toolbar button click', async () => {
+		render( <FormatPicker { ...defaultProps } /> );
+
+		userEvent.click( screen.getByLabelText( 'Pick an ad format' ) );
+		await waitFor( () => screen.getByText( defaultFormat.name ) );
+
+		AD_FORMATS.forEach( format => {
+			expect( screen.getByText( format.name ) ).toBeInTheDocument();
+		} );
+	} );
+
+	test( 'selects current format in dropdown', async () => {
+		render( <FormatPicker { ...defaultProps } /> );
+
+		userEvent.click( screen.getByLabelText( 'Pick an ad format' ) );
+		await waitFor( () => screen.getByText( defaultFormat.name ) );
+
+		expect( screen.getByText( defaultFormat.name ) ).toBeChecked();
+	} );
+
+	test( 'applies correct class to toolbar button', () => {
+		render( <FormatPicker { ...defaultProps } /> );
+
+		expect( screen.getByLabelText( 'Pick an ad format' ) ).toHaveClass( 'wp-block-jetpack-wordads__format-picker-icon' );
+	} );
+
+	test( 'applies format picker class to menu', async () => {
+		render( <FormatPicker { ...defaultProps } /> );
+
+		userEvent.click( screen.getByLabelText( 'Pick an ad format' ) );
+		await waitFor( () => screen.getByText( defaultFormat.name ) );
+		const menu = screen.getByRole( 'menu' );
+
+		expect( menu ).toBeInTheDocument();
+		expect( menu ).toHaveClass( 'wp-block-jetpack-wordads__format-picker' );
+	} );
+
+	test( 'calls onChange when option is clicked', async () => {
+		render( <FormatPicker { ...defaultProps } /> );
+		const leaderboard = getFormat( 'leaderboard' );
+
+		userEvent.click( screen.getByLabelText( 'Pick an ad format' ) );
+		await waitFor( () => screen.getByText( leaderboard.name ) );
+		userEvent.click( screen.getByText( leaderboard.name ) );
+
+		expect( onChange ).toHaveBeenCalledWith( leaderboard.tag );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/edit.js
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import WordAdsEdit from '../edit';
+import { AD_FORMATS, DEFAULT_FORMAT } from '../constants';
+
+/**
+ * Example images
+ */
+import rectangleExample from '../example_300x250.png';
+import leaderboardExample from '../example_728x90.png';
+import mobileLeaderboardExample from '../example_320x50.png';
+import wideSkyscraperExample from '../example_160x600.png';
+
+describe( 'WordAdsEdit', () => {
+	const defaultAttributes = { format: DEFAULT_FORMAT };
+	const defaultProps = { attributes: defaultAttributes };
+
+	const getFormat = format => AD_FORMATS.find( ( { tag } ) => tag === format );
+
+	const renderWordAdsEdit = ( props ) => {
+		const { container } = render( <WordAdsEdit { ...props } /> );
+
+		return container.firstChild.firstChild;
+	};
+
+	// Renders the component, extracting the inner placeholder element and finding
+	// selected format object styles are created from.
+	const renderFormatted = ( format ) => {
+		const placeholder = renderWordAdsEdit( {
+			...defaultProps,
+			attributes: { format }
+		} );
+		const selectedFormat = getFormat( format );
+
+		return { placeholder, selectedFormat };
+	};
+
+	test( 'renders wrapper with correct css class', () => {
+		const { container } = render( <WordAdsEdit { ...defaultProps } /> );
+
+		expect( container.firstChild ).toHaveClass( 'wp-block-jetpack-wordads' );
+		expect( container.firstChild ).toHaveClass( `jetpack-wordads-${ defaultAttributes.format }` );
+	} );
+
+	test( 'renders ad placeholder with correct css class and styles', () => {
+		const placeholder = renderWordAdsEdit( defaultProps );
+		const selectedFormat = getFormat( defaultAttributes.format );
+
+		expect( placeholder ).toHaveClass( 'jetpack-wordads__ad' );
+		expect( placeholder ).toHaveStyle( `width: ${ selectedFormat.width }px` );
+		expect( placeholder ).toHaveStyle( `height: ${ selectedFormat.height }px` );
+		expect( placeholder ).toHaveStyle( `backgroundImage: url( ${ rectangleExample } )` );
+		expect( placeholder ).toHaveStyle( `backgroundSize: cover` );
+	} );
+
+	test( 'renders leaderboard format correctly', () => {
+		const { placeholder, selectedFormat } = renderFormatted( 'leaderboard' );
+
+		expect( placeholder ).toHaveStyle( `width: ${ selectedFormat.width }px` );
+		expect( placeholder ).toHaveStyle( `height: ${ selectedFormat.height }px` );
+		expect( placeholder ).toHaveStyle( `backgroundImage: url( ${ leaderboardExample } )` );
+	} );
+
+	test( 'renders mobile_leaderboard format correctly', () => {
+		const { placeholder, selectedFormat } = renderFormatted( 'mobile_leaderboard' );
+
+		expect( placeholder ).toHaveStyle( `width: ${ selectedFormat.width }px` );
+		expect( placeholder ).toHaveStyle( `height: ${ selectedFormat.height }px` );
+		expect( placeholder ).toHaveStyle( `backgroundImage: url( ${ mobileLeaderboardExample } )` );
+	} );
+
+	test( 'renders wideskyscraper format correctly', () => {
+		const { placeholder, selectedFormat } = renderFormatted( 'wideskyscraper' );
+
+		expect( placeholder ).toHaveStyle( `width: ${ selectedFormat.width }px` );
+		expect( placeholder ).toHaveStyle( `height: ${ selectedFormat.height }px` );
+		expect( placeholder ).toHaveStyle( `backgroundImage: url( ${ wideSkyscraperExample } )` );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/fixtures/jetpack__wordads.html
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/fixtures/jetpack__wordads.html
@@ -1,0 +1,1 @@
+<!-- wp:jetpack/wordads {"format":"leaderboard"} /-->

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/fixtures/jetpack__wordads.json
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/fixtures/jetpack__wordads.json
@@ -1,0 +1,14 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/wordads",
+        "isValid": true,
+        "attributes": {
+            "align": "center",
+            "format": "leaderboard",
+            "hideMobile": false
+        },
+        "innerBlocks": [],
+        "originalContent": ""
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/fixtures/jetpack__wordads.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/fixtures/jetpack__wordads.parsed.json
@@ -1,0 +1,20 @@
+[
+    {
+        "blockName": "jetpack/wordads",
+        "attrs": {
+            "format": "leaderboard"
+        },
+        "innerBlocks": [],
+        "innerHTML": "",
+        "innerContent": []
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/fixtures/jetpack__wordads.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/fixtures/jetpack__wordads.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:jetpack/wordads {"format":"leaderboard"} /-->

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/validate.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { name, settings } from '../';
+import runBlockFixtureTests from '../../../shared/test/block-fixtures';
+
+const blocks = [ { name: `jetpack/${ name }`, settings } ];
+runBlockFixtureTests( `jetpack/${ name }`, blocks, __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
@@ -74,7 +74,7 @@ class WordAds {
 			Jetpack_Gutenberg::set_extension_unavailable( self::BLOCK_NAME, 'WordAds unavailable' );
 			return;
 		}
-		// Make the block available. Just in case it wasn't registed before.
+		// Make the block available. Just in case it wasn't registered before.
 		Jetpack_Gutenberg::set_extension_available( self::BLOCK_NAME );
 	}
 
@@ -106,7 +106,7 @@ class WordAds {
 			return $wordads->get_ad( 'inline', 'house' );
 		}
 
-		// section_id is mostly depricated at this point, but it helps us (devs) keep track of which ads end up where
+		// section_id is mostly deprecated at this point, but it helps us (devs) keep track of which ads end up where
 		// 6 is to keep track of gutenblock ads.
 		$section_id = $wordads->params->blog_id . '6';
 		$align      = 'center';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Refactors WordAds block to functional component and extracts controls
* Adds fixtures and block tests for the WordAds block

#### Does this pull request change what data or activity we track or use?
No change.

#### Testing instructions:

1. Checkout this PR branch
2. Run the WordAds block tests `cd projects/plugins/jetpack && yarn jest extensions/blocks/wordads/test/`
3. Test the block still functions correctly in the post editor