### PR TITLE
My plan body: Changing title to sentence case for consistency

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -253,7 +253,7 @@ class MyPlanBody extends React.Component {
 					</div>
 					<div className="jp-landing__plan-features-text">
 						<h3 className="jp-landing__plan-features-title">
-							{ __( 'Instant Search and Filtering', 'jetpack' ) }
+							{ __( 'Instant search and filtering', 'jetpack' ) }
 						</h3>
 						<p>
 							{ __(

--- a/projects/plugins/jetpack/changelog/Enhancement-fixing-capitalization-issue
+++ b/projects/plugins/jetpack/changelog/Enhancement-fixing-capitalization-issue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Admin Page: tweak capitalization
+
+


### PR DESCRIPTION
Changing the "Instant Search and Filtering" title on the my plans page from camel case to sentence case for consistency with all of the other cards.

Before:
![Screen Shot 2021-03-11 at 10 58 10 AM](https://user-images.githubusercontent.com/214813/110815868-d22f9a00-8258-11eb-912a-059618eadc99.png)


After:
![Screen Shot 2021-03-11 at 10 58 39 AM](https://user-images.githubusercontent.com/214813/110815894-d78ce480-8258-11eb-968b-fe1bf1e2982a.png)

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Jetpack > My Plan
* Check the different card titles

#Hackweek