### PR TITLE
Jetpack: Add a "Backend and non-user-facing changes" section to the changelog

### DIFF
--- a/projects/plugins/jetpack/changelog/try-jetpack-changelog-backend-section
+++ b/projects/plugins/jetpack/changelog/try-jetpack-changelog-backend-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: backend
+
+Added this new section going forward for changes that had been left out in the past.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -107,7 +107,8 @@
 				"major": "Major Enhancements",
 				"enhancement": "Enhancements",
 				"compat": "Improved compatibility",
-				"bugfix": "Bug fixes"
+				"bugfix": "Bug fixes",
+				"backend": "Backend and non-user-facing changes"
 			}
 		}
 	}

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "206a7775519adf7eadfcf621d1e648e3",
+    "content-hash": "6c69b4d75a728a10383ebc4ba28ce269",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Jetpack is weird in that we currently ignore a whole category of changes
that would normally be in a changelog. This makes it less weird.

If we do decide to do this, we should probably merge it just after 9.6 is branched
so as to not have to go back and fill in entries for everything added to 9.6 so far.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
May as well have the discussion here. (:

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See that `changelogger add` in Jetpack gives the new option.