### PR TITLE
Full Site Editing: menu parity with plugin, across platforms

### DIFF
--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -412,7 +412,7 @@ class Admin_Menu {
 		$user_can_customize  = current_user_can( 'customize' );
 		$appearance_cap      = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
 		$themes_slug         = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
-		$request_uri         = isset( $_SERVER['REQUEST_URI'] ) && esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$request_uri         = isset( $_SERVER['REQUEST_URI'] ) && esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$core_customize_slug = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), $request_uri ) ), 'customize.php' );
 		if ( ! $wp_admin_customize ) {
 			$customize_slug = 'https://wordpress.com/customize/' . $this->domain;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -408,25 +408,30 @@ class Admin_Menu {
 	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
-		$user_can_customize = current_user_can( 'customize' );
-		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
-		$themes_slug        = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
+		$user_can_customize  = current_user_can( 'customize' );
+		$appearance_cap      = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
+		$themes_slug         = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
+		$request_uri         = isset( $_SERVER['REQUEST_URI'] ) && esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$core_customize_slug = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), $request_uri ) ), 'customize.php' );
 		if ( ! $wp_admin_customize ) {
 			$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 		} else {
 			// In case this is an api request we will have to add the 'return' querystring via JS.
-			$customize_slug = $this->is_api_request ? 'customize.php' : add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			$customize_slug = $this->is_api_request ? 'customize.php' : $core_customize_slug;
 		}
 		remove_menu_page( 'themes.php' );
 		remove_submenu_page( 'themes.php', 'themes.php' );
 		remove_submenu_page( 'themes.php', 'theme-editor.php' );
-		remove_submenu_page( 'themes.php', add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' ) );
+		$has_customizer = (bool) remove_submenu_page( 'themes.php', $core_customize_slug );
 		remove_submenu_page( 'themes.php', 'custom-header' );
 		remove_submenu_page( 'themes.php', 'custom-background' );
 
 		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), $appearance_cap, $themes_slug, null, 'dashicons-admin-appearance', 60 );
 		add_submenu_page( $themes_slug, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', $themes_slug, null, 0 );
-		add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $customize_slug, null, 1 );
+		// Customizer is removed by Gutenberg when FSE is active. Only add it back if it was still there.
+		if ( $has_customizer ) {
+			add_submenu_page( $themes_slug, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $customize_slug, null, 1 );
+		}
 
 		// Maintain id as JS selector.
 		$GLOBALS['menu'][60][5] = 'menu-appearance'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -412,7 +412,7 @@ class Admin_Menu {
 		$user_can_customize = current_user_can( 'customize' );
 		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
 		$themes_slug        = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
-		$request_uri        = isset( $_SERVER['REQUEST_URI'] ) && esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		$request_uri        = isset( $_SERVER['REQUEST_URI'] ) && esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ); // phpcs:ignore
 		$wp_customize_slug  = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), $request_uri ) ), 'customize.php' );
 		if ( ! $wp_admin_customize ) {
 			$customize_slug = 'https://wordpress.com/customize/' . $this->domain;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -118,6 +118,7 @@ class Admin_Menu {
 
 		$this->add_options_menu( $wp_admin );
 		$this->add_jetpack_menu();
+		$this->add_gutenberg_menus( $wp_admin );
 
 		// Remove Links Manager menu since its usage is discouraged.
 		// @see https://core.trac.wordpress.org/ticket/21307#comment:73.
@@ -658,6 +659,36 @@ class Admin_Menu {
 			}
 			unset( $submenu[ $old_slug ] );
 		}
+	}
+
+	/**
+	 * 1. Remove the Gutenberg plugin menu
+	 * 2. Re-add the Site Editor menu
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_gutenberg_menus( $wp_admin = false ) {
+		// We can bail if we don't meet the conditions of the Site Editor.
+		if ( ! ( function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme() ) ) {
+			return;
+		}
+
+		// Core Gutenberg registers without an explicit position, and we don't want the (beta) tag.
+		remove_menu_page( 'gutenberg-edit-site' );
+		// Core Gutenberg tries to manage its position, foiling our best laid plans. Unfoil.
+		remove_filter( 'menu_order', 'gutenberg_menu_order' );
+
+		$link = $wp_admin ? 'gutenberg-edit-site' : 'https://wordpress.com/site-editor/' . $this->domain;
+
+		add_menu_page(
+			__( 'Site Editor', 'jetpack' ),
+			__( 'Site Editor', 'jetpack' ),
+			'edit_theme_options',
+			$link,
+			$wp_admin ? 'gutenberg_edit_site_page' : null,
+			'dashicons-layout',
+			61 // Just under Appearance.
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -409,21 +409,21 @@ class Admin_Menu {
 	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
-		$user_can_customize  = current_user_can( 'customize' );
-		$appearance_cap      = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
-		$themes_slug         = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
-		$request_uri         = isset( $_SERVER['REQUEST_URI'] ) && esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-		$core_customize_slug = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), $request_uri ) ), 'customize.php' );
+		$user_can_customize = current_user_can( 'customize' );
+		$appearance_cap     = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
+		$themes_slug        = $wp_admin_themes ? 'themes.php' : 'https://wordpress.com/themes/' . $this->domain;
+		$request_uri        = isset( $_SERVER['REQUEST_URI'] ) && esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		$wp_customize_slug  = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), $request_uri ) ), 'customize.php' );
 		if ( ! $wp_admin_customize ) {
 			$customize_slug = 'https://wordpress.com/customize/' . $this->domain;
 		} else {
 			// In case this is an api request we will have to add the 'return' querystring via JS.
-			$customize_slug = $this->is_api_request ? 'customize.php' : $core_customize_slug;
+			$customize_slug = $this->is_api_request ? 'customize.php' : $wp_customize_slug;
 		}
 		remove_menu_page( 'themes.php' );
 		remove_submenu_page( 'themes.php', 'themes.php' );
 		remove_submenu_page( 'themes.php', 'theme-editor.php' );
-		$has_customizer = (bool) remove_submenu_page( 'themes.php', $core_customize_slug );
+		$has_customizer = (bool) remove_submenu_page( 'themes.php', $wp_customize_slug );
 		remove_submenu_page( 'themes.php', 'custom-header' );
 		remove_submenu_page( 'themes.php', 'custom-background' );
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -239,6 +239,18 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Remove the Gutenberg plugin menu
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_gutenberg_menus( $wp_admin = false ) {
+		parent::add_gutenberg_menus( $wp_admin );
+
+		// Always remove the Gutenberg plugin menu on Atomic.
+		remove_menu_page( 'gutenberg' );
+	}
+
+	/**
 	 * Adds Users menu.
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -47,8 +47,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 			$this->add_new_site_link();
 		}
 
-		$this->add_gutenberg_menus( $wp_admin );
-
 		ksort( $GLOBALS['menu'] );
 	}
 
@@ -259,36 +257,15 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
-	 * 1. Remove the Gutenberg plugin menu
-	 * 2. Re-add the Site Editor menu
+	 * Remove the Gutenberg plugin menu
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_gutenberg_menus( $wp_admin = false ) {
-		// Always remove the Gutenberg menu.
+		parent::add_gutenberg_menus( $wp_admin );
+
+		// Always remove the Gutenberg plugin menu on WPCom.
 		remove_menu_page( 'gutenberg' );
-
-		// We can bail if we don't meet the conditions of the Site Editor.
-		if ( ! ( function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme() ) ) {
-			return;
-		}
-
-		// Core Gutenberg registers without an explicit position, and we don't want the (beta) tag.
-		remove_menu_page( 'gutenberg-edit-site' );
-		// Core Gutenberg tries to manage its position, foiling our best laid plans. Unfoil.
-		remove_filter( 'menu_order', 'gutenberg_menu_order' );
-
-		$link = $wp_admin ? 'gutenberg-edit-site' : 'https://wordpress.com/site-editor/' . $this->domain;
-
-		add_menu_page(
-			__( 'Site Editor', 'jetpack' ),
-			__( 'Site Editor', 'jetpack' ),
-			'edit_theme_options',
-			$link,
-			$wp_admin ? 'gutenberg_edit_site_page' : null,
-			'dashicons-layout',
-			61 // Just under Appearance.
-		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/data/admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/data/admin-menu.php
@@ -12,7 +12,7 @@
  */
 function get_menu_fixture() {
 	return array(
-		2  => array(
+		2   => array(
 			'Dashboard',
 			'read',
 			'index.php',
@@ -21,7 +21,7 @@ function get_menu_fixture() {
 			'menu-dashboard',
 			'dashicons-dashboard',
 		),
-		3  => array(
+		3   => array(
 			'Jetpack',
 			'jetpack_admin_page',
 			'jetpack',
@@ -30,14 +30,14 @@ function get_menu_fixture() {
 			'toplevel_page_jetpack',
 			'div',
 		),
-		4  => array(
+		4   => array(
 			'',
 			'read',
 			'separator1',
 			'',
 			'wp-menu-separator',
 		),
-		10 => array(
+		10  => array(
 			'Media',
 			'upload_files',
 			'upload.php',
@@ -46,7 +46,7 @@ function get_menu_fixture() {
 			'menu-media',
 			'dashicons-admin-media',
 		),
-		15 => array(
+		15  => array(
 			'Links',
 			'manage_links',
 			'edit-tags.php?taxonomy=link_category',
@@ -55,7 +55,7 @@ function get_menu_fixture() {
 			'menu-links',
 			'dashicons-admin-links',
 		),
-		25 => array(
+		25  => array(
 			'Comments <span class="awaiting-mod count-3"><span class="pending-count" aria-hidden="true">3</span><span class="comments-in-moderation-text screen-reader-text">3 Comments in moderation</span></span>',
 			'edit_posts',
 			'edit-comments.php',
@@ -64,7 +64,7 @@ function get_menu_fixture() {
 			'menu-comments',
 			'dashicons-admin-comments',
 		),
-		5  => array(
+		5   => array(
 			'Posts',
 			'edit_posts',
 			'edit.php',
@@ -73,7 +73,7 @@ function get_menu_fixture() {
 			'menu-posts',
 			'dashicons-admin-post',
 		),
-		20 => array(
+		20  => array(
 			'Pages',
 			'edit_pages',
 			'edit.php?post_type=page',
@@ -82,14 +82,14 @@ function get_menu_fixture() {
 			'menu-pages',
 			'dashicons-admin-page',
 		),
-		59 => array(
+		59  => array(
 			'',
 			'read',
 			'separator2',
 			'',
 			'wp-menu-separator',
 		),
-		60 => array(
+		60  => array(
 			'Appearance',
 			'switch_themes',
 			'themes.php',
@@ -98,7 +98,7 @@ function get_menu_fixture() {
 			'menu-appearance',
 			'dashicons-admin-appearance',
 		),
-		65 => array(
+		65  => array(
 			'Plugins <span class="update-plugins count-4"><span class="plugin-count">4</span></span>',
 			'activate_plugins',
 			'plugins.php',
@@ -107,7 +107,7 @@ function get_menu_fixture() {
 			'menu-plugins',
 			'dashicons-admin-plugins',
 		),
-		70 => array(
+		70  => array(
 			'Users <span class="update-plugins count-0"><span class="plugin-count">0</span></span>',
 			'list_users',
 			'users.php',
@@ -116,7 +116,7 @@ function get_menu_fixture() {
 			'menu-users',
 			'dashicons-admin-users',
 		),
-		75 => array(
+		75  => array(
 			'Tools',
 			'edit_posts',
 			'tools.php',
@@ -125,7 +125,7 @@ function get_menu_fixture() {
 			'menu-tools',
 			'dashicons-admin-tools',
 		),
-		80 => array(
+		80  => array(
 			'Settings',
 			'manage_options',
 			'options-general.php',
@@ -133,6 +133,15 @@ function get_menu_fixture() {
 			'menu-top menu-icon-settings',
 			'menu-settings',
 			'dashicons-admin-settings',
+		),
+		100 => array(
+			'Site Editor <span class="awaiting-mod">beta</span>',
+			'edit_theme_options',
+			'gutenberg-edit-site',
+			'Site Editor (beta)',
+			'menu-top toplevel_page_gutenberg-edit-site',
+			'toplevel_page_gutenberg-edit-site',
+			'dashicons-layout',
 		),
 	);
 }
@@ -144,15 +153,6 @@ function get_menu_fixture() {
  */
 function get_wpcom_menu_fixture() {
 	$gutenberg_menus = array(
-		100 => array(
-			'Site Editor <span class="awaiting-mod">beta</span>',
-			'edit_theme_options',
-			'gutenberg-edit-site',
-			'Site Editor (beta)',
-			'menu-top toplevel_page_gutenberg-edit-site',
-			'toplevel_page_gutenberg-edit-site',
-			'dashicons-layout',
-		),
 		101 => array(
 			'Gutenberg',
 			'edit_posts',
@@ -247,7 +247,7 @@ function get_submenu_fixture() {
 			6  => array(
 				'Customize',
 				'customize',
-				'customize.php?return=%2Ftrunk%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack',
+				'customize.php?return',
 				'',
 				'hide-if-no-customize',
 			),

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -135,7 +135,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array_keys( $menu ),
-			array( 2, '3.86682', 4, 5, 10, 15, 20, 25, 50, 51, 59, 60, 65, 70, 75, 80 ),
+			array( 2, '3.86682', 4, 5, 10, 15, 20, 25, 50, 51, 59, 60, 61, 65, 70, 75, 80 ),
 			'Admin menu should not have unexpected top menu items.'
 		);
 
@@ -858,6 +858,32 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			esc_url( Redirect::get_url( 'calypso-backups' ) ),
 		);
 		$this->assertNotContains( $backups_submenu_item, $submenu[ $slug ] );
+	}
+
+	/**
+	 * Tests add_gutenberg_menus
+	 *
+	 * @covers ::add_gutenberg_menus
+	 */
+	public function test_add_gutenberg_menus() {
+		global $menu;
+		static::$admin_menu->add_gutenberg_menus( false );
+
+		// FSE is no longer where it was put by default.
+		$this->assertArrayNotHasKey( 100, $menu );
+		$this->assertArrayHasKey( 61, $menu );
+
+		$fse_link = 'https://wordpress.com/site-editor/' . static::$domain;
+		$fse_menu = array(
+			'Site Editor',
+			'edit_theme_options',
+			$fse_link,
+			'Site Editor',
+			'menu-top toplevel_page_' . $fse_link,
+			'toplevel_page_' . $fse_link,
+			'dashicons-layout',
+		);
+		$this->assertSame( $menu[61], $fse_menu );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -507,7 +507,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $menu[60], $appearance_menu_item );
-		$this->assertArrayNotHasKey( 'themes.php', $submenu );
+		$this->assertEmpty( $submenu['themes.php'] );
 
 		$themes_submenu_item = array(
 			'Themes',
@@ -515,6 +515,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 			'https://wordpress.com/themes/' . static::$domain,
 			'Themes',
 		);
+
 		$this->assertContains( $themes_submenu_item, $submenu[ $slug ] );
 
 		$customize_submenu_item = array(

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -68,7 +68,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( $factory ) {
 		static::$domain       = ( new Status() )->get_site_suffix();
 		static::$user_id      = $factory->user->create( array( 'role' => 'administrator' ) );
-		static::$menu_data    = get_menu_fixture();
+		static::$menu_data    = get_wpcom_menu_fixture();
 		static::$submenu_data = get_submenu_fixture();
 	}
 
@@ -436,5 +436,18 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_users_menu( false );
 		$this->assertContains( $submenu_item, $submenu[ 'https://wordpress.com/people/team/' . static::$domain ] );
+	}
+
+	/**
+	 * Tests add_gutenberg_menus
+	 *
+	 * @covers ::add_gutenberg_menus
+	 */
+	public function test_add_gutenberg_menus() {
+		global $menu;
+		static::$admin_menu->add_gutenberg_menus( false );
+
+		// Gutenberg plugin menu should not be visible.
+		$this->assertArrayNotHasKey( 101, $menu );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -328,22 +328,6 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 
 		// Gutenberg plugin menu should not be visible.
 		$this->assertArrayNotHasKey( 101, $menu );
-
-		// FSE is no longer where it was put by default.
-		$this->assertArrayNotHasKey( 100, $menu );
-		$this->assertArrayHasKey( 61, $menu );
-
-		$fse_link = 'https://wordpress.com/site-editor/' . static::$domain;
-		$fse_menu = array(
-			'Site Editor',
-			'edit_theme_options',
-			$fse_link,
-			'Site Editor',
-			'menu-top toplevel_page_' . $fse_link,
-			'toplevel_page_' . $fse_link,
-			'dashicons-layout',
-		);
-		$this->assertSame( $menu[61], $fse_menu );
 	}
 
 	/**


### PR DESCRIPTION
This PR provides the previously WPCom Simple-only changes to FSE menu item positioning introduced in #18800 to Atomic and Jetpack sites. It also keeps the Customizer removed when FSE is active.

Fixes Automattic/wp-calypso#50405
Fixes Automattic/wp-calypso#50894

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Atomic and Jetpack sites now also reposition the FSE menu
* Gutenberg plugin menu removed on WPCom Simple and Jetpack
* Keep the Customizer removed when it's been removed by FSE

#### Jetpack product discussion
Unifying behaviour is the whole Nav Unification deal right?

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

For WPCom Simple and Atomic, you should see:
1. Site Editor with no (beta) label, underneath Appearance
2. No Customizer entry underneath Appearance

WPCom Simple:
* Apply D58574-code to your sandbox
* Sandbox a site created through the [Horizon FSE flow](https://horizon.wordpress.com/new?flags=gutenboarding/site-editor)
* Sandbox `public-api.wordpress.com`
* Visit your test site's `wp-admin`
* Verify that both wp-admin and Caplyso should show the menu as above.


Atomic:
1. Have/create an Atomic site
2. Install and activate Jetpack, Gutenberg, Jetpack Beta plugins
3. Install and activate an FSE theme
4. Checkout this branch in the Jetpack Beta plugin
5. Verify that both wp-admin and Caplyso should show the menu as above.

Jetpack:
1. This doesn't apply to non-Atomic Jetpack
