### PR TITLE
Search: Prevent IE11 from spawning overlay on load

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-ie11-modal-summon
+++ b/projects/plugins/jetpack/changelog/fix-search-ie11-modal-summon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Instant Search:  Prevent IE11 from spawning overlay on load.

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -51,7 +51,7 @@ class SearchApp extends Component {
 		this.input = createRef();
 		this.state = {
 			overlayOptions: { ...this.props.initialOverlayOptions },
-			showResults: this.props.initialShowResults,
+			showResults: !! this.props.initialShowResults, // initialShowResults can be undefined
 		};
 		this.getResults = debounce( this.getResults, 200 );
 		this.props.initializeQueryValues();

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-box.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-box.jsx
@@ -50,7 +50,9 @@ const SearchBox = props => {
 						id={ inputId }
 						className="search-field jetpack-instant-search__box-input"
 						inputmode="search"
-						onInput={ props.onChange }
+						// IE11 will immediately fire an onChange event when the placeholder contains a unicode character.
+						// Ensure that the search application is visible before invoking the onChange callback to guard against this.
+						onChange={ props.isVisible ? props.onChange : null }
 						ref={ inputRef }
 						placeholder={ __( 'Search…', 'jetpack' ) }
 						type="search"


### PR DESCRIPTION
Fixes #19100.

#### Changes proposed in this Pull Request:
* Prevents the onChange handler from binding to SearchBox when the modal is not visible. This prevents IE11 from triggering an onChange event on window load, which occurs when the input's placeholder contains a Unicode character.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Navigate to `/` in Internet Explorer 11 :)
* Ensure that the search modal does not appear upon loading the page.
* Perform a site search and ensure that the search modal appears as expected.
* Alter the query via the modal search input. Ensure that the interface works as expected.
