### PR TITLE
Userless Connection: editorial

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/monitor.jsx
@@ -38,7 +38,7 @@ class DashMonitor extends Component {
 	connect = () => this.props.authorizeUserInPlace();
 
 	getContent() {
-		const labelName = __( 'Downtime monitor', 'jetpack' );
+		const labelName = __( 'Downtime monitoring', 'jetpack' );
 
 		const support = {
 			text: __(
@@ -72,7 +72,7 @@ class DashMonitor extends Component {
 					}
 			  )
 			: __(
-					'Get alerts when your site goes offline, we’ll let you know when it’s back up, too.',
+					'Get alerts if your site goes offline. We’ll let you know when it’s back up, too.',
 					'jetpack'
 			  );
 
@@ -92,7 +92,7 @@ class DashMonitor extends Component {
 				{ ! this.props.isOfflineMode && ! this.props.hasConnectedOwner && (
 					<p className="jp-dash-item__description jp-dash-item__connect">
 						{ createInterpolateElement(
-							__( '<a>Connect your WordPress.com</a> user account to use this feature', 'jetpack' ),
+							__( '<a>Connect your WordPress.com</a> account to use this feature.', 'jetpack' ),
 							{
 								a: <a href="javascript:void(0)" onClick={ this.connect } />,
 							}

--- a/projects/plugins/jetpack/_inc/client/components/connect-user-bar/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-user-bar/index.jsx
@@ -30,18 +30,24 @@ const ConnectUserBar = props => {
 
 	return (
 		<Card compact className="jp-connect-user-bar__card">
-			{ ! showConnect && <div className="jp-connect-user-bar__text">{ props.text }</div> }
+			{ ! showConnect && (
+				<div className="jp-connect-user-bar__text">
+					This feature is provided by the WordPress.com cloud. { props.text }
+				</div>
+			) }
 			{ ! showConnect && (
 				<div className="jp-connect-user-bar__button">
 					<ConnectButton
 						connectUser={ true }
 						from="unlinked-user-connect"
-						connectLegend={ __( 'Connect my user account', 'jetpack' ) }
+						connectLegend={ __( 'Connect my WordPress.com account', 'jetpack' ) }
 						customConnect={ customConnect }
 					/>
 				</div>
 			) }
-			{ showConnect && <ConnectUserFrame source="connect-user-bar" /> }
+			{ showConnect && (
+				<ConnectUserFrame source="connect-user-bar" featureLabel={ props.featureLabel } />
+			) }
 		</Card>
 	);
 };
@@ -49,6 +55,7 @@ const ConnectUserBar = props => {
 ConnectUserBar.propTypes = {
 	text: PropTypes.string.isRequired,
 	feature: PropTypes.string,
+	featureLabel: PropTypes.string,
 };
 
 export default ConnectUserBar;

--- a/projects/plugins/jetpack/_inc/client/components/connect-user-bar/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/connect-user-bar/style.scss
@@ -27,6 +27,7 @@
 			font-size: 13px;
 			line-height: 16px;
 			color: #0071A1;
+			text-align: center;
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/connect-user-frame/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-user-frame/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -16,7 +16,17 @@ const ConnectUserFrame = props => {
 	return (
 		<div className="jp-connect-user-frame">
 			<div className="jp-connect-user-frame__left">
-				<h2>{ __( 'Unlock Monitoring and more amazing features', 'jetpack' ) }</h2>
+				{ props.featureLabel ? (
+					<h2>
+						{ sprintf(
+							/* translators: placeholder is a feature label (e.g. SEO, Notifications) */
+							__( 'Unlock %s and other features', 'jetpack' ),
+							props.featureLabel
+						) }
+					</h2>
+				) : (
+					<h2>{ __( 'Unlock this and other features', 'jetpack' ) }</h2>
+				) }
 
 				<ul>
 					<li>
@@ -25,7 +35,7 @@ const ConnectUserFrame = props => {
 					</li>
 					<li>
 						<Gridicon icon="checkmark-circle" />{ ' ' }
-						{ __( 'Automatically share your content on social media', 'jetpack' ) }
+						{ __( 'Automatically promote your posts on social media', 'jetpack' ) }
 					</li>
 					<li>
 						<Gridicon icon="checkmark-circle" />{ ' ' }
@@ -33,11 +43,11 @@ const ConnectUserFrame = props => {
 					</li>
 					<li>
 						<Gridicon icon="checkmark-circle" />{ ' ' }
-						{ __( 'Receive notifications about new likes and comments', 'jetpack' ) }
+						{ __( 'Receive notifications of likes and comments', 'jetpack' ) }
 					</li>
 					<li>
 						<Gridicon icon="checkmark-circle" />{ ' ' }
-						{ __( 'Let visitors share your content on social media', 'jetpack' ) }
+						{ __( 'Let visitors easily share your content', 'jetpack' ) }
 					</li>
 				</ul>
 
@@ -73,6 +83,7 @@ const ConnectUserFrame = props => {
 
 ConnectUserFrame.propTypes = {
 	source: PropTypes.string,
+	featureLabel: PropTypes.string,
 };
 
 export default ConnectUserFrame;

--- a/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
+++ b/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
@@ -149,10 +149,8 @@ class SubscriptionsComponent extends React.Component {
 				{ ! this.props.isLinked && (
 					<ConnectUserBar
 						feature="subscriptions"
-						text={ __(
-							'Subscriptions feature provided by the WordPress.com cloud. Sign in to view your email followers.',
-							'jetpack'
-						) }
+						featureLabel={ __( 'Subscriptions', 'jetpack' ) }
+						text={ __( 'Sign in to manage your subscriptions settings.', 'jetpack' ) }
 					/>
 				) }
 			</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/searchable-modules/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/searchable-modules/index.jsx
@@ -119,10 +119,8 @@ class ActiveCard extends Component {
 				{ userlessMode && (
 					<ConnectUserBar
 						feature={ m.module }
-						text={ __(
-							'The feature is provided by the WordPress.com cloud. Sign in to configure it.',
-							'jetpack'
-						) }
+						featureLabel={ m.name }
+						text={ __( 'Sign in to configure.', 'jetpack' ) }
 					/>
 				) }
 			</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/security/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/monitor.jsx
@@ -76,10 +76,8 @@ export const Monitor = withModuleSettingsFormHelpers(
 					{ ! this.props.hasConnectedOwner && (
 						<ConnectUserBar
 							feature="monitor"
-							text={ __(
-								'Monitoring provided by the WordPress.com cloud. Sign in to configure personal email alerts.',
-								'jetpack'
-							) }
+							featureLabel={ __( 'Downtime Monitoring', 'jetpack' ) }
+							text={ __( 'Sign in to set up your status alerts.', 'jetpack' ) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -129,10 +129,8 @@ export const SSO = withModuleSettingsFormHelpers(
 					{ ! this.props.hasConnectedOwner && (
 						<ConnectUserBar
 							feature="sso"
-							text={ __(
-								'WordPress.com login provided by the WordPress.com cloud. Sign in to configure the WordPress.com login.',
-								'jetpack'
-							) }
+							featureLabel={ __( 'Secure Sign-On', 'jetpack' ) }
+							text={ __( 'Sign in to enable WordPress.com Secure Sign-On.', 'jetpack' ) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/sharing/likes.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/likes.jsx
@@ -39,7 +39,7 @@ export const Likes = withModuleSettingsFormHelpers(
 					>
 						<p>
 							{ __(
-								'When WordPress.com users enjoy your content, let them show it with a Like.',
+								'The Like button is a way for people on WordPress.com to show their appreciation for your content.',
 								'jetpack'
 							) }
 						</p>

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -107,10 +107,8 @@ export const Publicize = withModuleSettingsFormHelpers(
 					{ ! this.props.isLinked && (
 						<ConnectUserBar
 							feature="publicize"
-							text={ __(
-								'Publicize provided by the WordPress.com cloud. Sign in to configure the publicize connections.',
-								'jetpack'
-							) }
+							featureLabel={ __( 'Publicize', 'jetpack' ) }
+							text={ __( 'Sign in to connect your social media accounts.', 'jetpack' ) }
 						/>
 					) }
 

--- a/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
@@ -113,10 +113,8 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 					{ ! this.props.isLinked && (
 						<ConnectUserBar
 							feature="sharedaddy"
-							text={ __(
-								'Sharing buttons provided by the WordPress.com cloud. Sign in to configure the sharing buttons.',
-								'jetpack'
-							) }
+							featureLabel={ __( 'Sharing Buttons', 'jetpack' ) }
+							text={ __( 'Sign in to add sharing buttons on your site.', 'jetpack' ) }
 						/>
 					) }
 

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -74,10 +74,8 @@ export const SEO = withModuleSettingsFormHelpers(
 					{ ! this.props.hasConnectedOwner && (
 						<ConnectUserBar
 							feature="monitor"
-							text={ __(
-								'Monitoring provided by the WordPress.com cloud. Sign in to configure personal email alerts.',
-								'jetpack'
-							) }
+							featureLabel={ __( 'SEO', 'jetpack' ) }
+							text={ __( 'Sign in to optimize your site for search engines.', 'jetpack' ) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/writing/masterbar.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/masterbar.jsx
@@ -60,10 +60,8 @@ export const Masterbar = withModuleSettingsFormHelpers(
 					{ ! this.props.isUnavailableInOfflineMode( 'masterbar' ) && ! this.props.isLinked && (
 						<ConnectUserBar
 							feature="masterbar"
-							text={ __(
-								'WordPress.com toolbar provided by the WordPress.com cloud. Sign in to configure the WordPress.com toolbar.',
-								'jetpack'
-							) }
+							featureLabel={ __( 'WordPress.com Toolbar', 'jetpack' ) }
+							text={ __( 'Sign in to enable the WordPress.com toolbar.', 'jetpack' ) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
@@ -119,10 +119,8 @@ class PostByEmail extends React.Component {
 				{ ! this.props.isUnavailableInOfflineMode( 'post-by-email' ) && ! this.props.isLinked && (
 					<ConnectUserBar
 						feature="post-by-email"
-						text={ __(
-							'Post by email provided by the WordPress.com cloud. Sign in to configure personal email alerts.',
-							'jetpack'
-						) }
+						featureLabel={ __( 'Post by Email', 'jetpack' ) }
+						text={ __( 'Sign in to enable publishing via email.', 'jetpack' ) }
 					/>
 				) }
 			</SettingsCard>

--- a/projects/plugins/jetpack/changelog/userless-editorial
+++ b/projects/plugins/jetpack/changelog/userless-editorial
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+General: Updating copy for Jetpack userless mode components.

--- a/projects/plugins/jetpack/class.jetpack-connection-banner.php
+++ b/projects/plugins/jetpack/class.jetpack-connection-banner.php
@@ -387,8 +387,10 @@ class Jetpack_Connection_Banner {
 		} else {
 			$bottom_connect_url_from = 'landing-page-bottom';
 		}
+
+		$is_no_user_testing_mode = ( new Status() )->is_no_user_testing_mode();
 		?>
-		<div class="jp-connect-full__container"><div class="jp-connect-full__container-card">
+		<div class="jp-connect-full__container <?php echo $is_no_user_testing_mode ? 'jp-jetpack-connect__userless' : ''; ?>"><div class="jp-connect-full__container-card">
 
 				<?php if ( 'plugins' === $current_screen->base ) : ?>
 					<?php
@@ -425,11 +427,11 @@ class Jetpack_Connection_Banner {
 					</a>
 				</p>
 
-				<?php if ( ( new Status() )->is_no_user_testing_mode() ) : ?>
+				<?php if ( $is_no_user_testing_mode ) : ?>
 					<div id="jp-authenticate-no_user_test_mode">
-						<h2><?php esc_html_e( 'Or start using Jetpack now', 'jetpack' ); ?></h2>
-						<p><?php esc_html_e( 'Jump in and start using Jetpack right away. Some features will not be available, but you’ll be able to connect your user account at any point to unlock them.', 'jetpack' ); ?></p>
-						<a class="dops-button jp-no-user-mode-button" href="<?php echo esc_url( Redirect::get_url( 'jetpack-connect-plans', array( 'unlinked' => '1' ) ) ); ?>"><?php esc_html_e( 'Continue without user account', 'jetpack' ); ?></a>
+						<h2><?php esc_html_e( 'Or connect without an account', 'jetpack' ); ?></h2>
+						<p><?php esc_html_e( 'Jump in to enjoy Jetpack right away. Some features will not be immediately available, but you will be able to connect your account later to unlock them.', 'jetpack' ); ?></p>
+						<a class="dops-button jp-no-user-mode-button" href="<?php echo esc_url( Redirect::get_url( 'jetpack-connect-plans', array( 'unlinked' => '1' ) ) ); ?>"><?php esc_html_e( 'Continue without signing in', 'jetpack' ); ?></a>
 						<a class="jp-no-user-all-features" target="_blank" href="https://jetpack.com/support/features/">
 							<?php esc_html_e( 'See all Jetpack features', 'jetpack' ); ?>
 							<svg width="16" height="16" viewBox="0 0 24 24" class="gridicon gridicons-external">

--- a/projects/plugins/jetpack/scss/jetpack-connect.scss
+++ b/projects/plugins/jetpack/scss/jetpack-connect.scss
@@ -12,9 +12,12 @@
 
 	@media (min-width: 491px) {
 		background: #FFFFFF;
-		border: 2px solid #C1D0E8;
-		box-sizing: border-box;
-		border-radius: 6px;
+
+		.jp-jetpack-connect__userless & {
+			border: 2px solid #C1D0E8;
+			box-sizing: border-box;
+			border-radius: 6px;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- updated copy for the userless connection components (see #18837)
- removed the connection iframe border in "userful" mode

#### Jetpack product discussion
p2JRYi-5fn-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
0. Go through the changed copy and check for typos 🙂 
1. Define the JETPACK_NO_USER_TEST_MODE, disconnect Jetpack and connect again in the userless mode.
2. Go to "Jetpack -> Settings" and use the "This feature is provided by the WordPress.com cloud..." connection bar to connect the user.
3. Complete the connection process, the greyed out modules should get available.