### PR TITLE
Search: Ensure escape key always closes search modal

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-esc-binding
+++ b/projects/plugins/jetpack/changelog/fix-search-esc-binding
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Instant Search: Prevent escape key from stopping page reload
+Instant Search: ensure Escape key always closes search modal

--- a/projects/plugins/jetpack/changelog/fix-search-esc-binding
+++ b/projects/plugins/jetpack/changelog/fix-search-esc-binding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instant Search: Prevent escape key from stopping page reload

--- a/projects/plugins/jetpack/modules/search/instant-search/components/overlay.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/overlay.jsx
@@ -14,7 +14,10 @@ import './overlay.scss';
 
 const callOnEscapeKey = callback => event => {
 	// IE11 uses 'Esc'
-	( event.key === 'Escape' || event.key === 'Esc' ) && callback();
+	if ( event.key === 'Escape' || event.key === 'Esc' ) {
+		event.preventDefault();
+		callback();
+	}
 };
 
 const Overlay = props => {


### PR DESCRIPTION
Fixes #19125.

#### Changes proposed in this Pull Request:
Prevent the escape key from interrupting a page reload. If the user initializes the window on a search page (e.g. `/?s=anything`), pressing the escape key is supposed to strip search-related query values from the address bar and reload the page (e.g. effectively navigating them to `/`).

The default browser behavior for the escape key is to invoke the browser stop button. This PR prevents the default browser behavior.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Initialize a window to a page with a search query value (`/?s=`).
* Press escape. Ensure that the browser navigates to a location with the search queries removed (`/`).
* Repeat your tests with multiple browsers (Chrome, Firefox, Safari, etc.)
