### PR TITLE
Avoid creating jetpack-temp directory in WP root

### DIFF
--- a/projects/packages/backup/changelog/update-jetpack-temp-directory
+++ b/projects/packages/backup/changelog/update-jetpack-temp-directory
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Avoid creating jetpack-temp directory in WP root

--- a/projects/packages/backup/src/class-helper-script-manager.php
+++ b/projects/packages/backup/src/class-helper-script-manager.php
@@ -331,17 +331,13 @@ class Helper_Script_Manager {
 	 * @return array Array, with keys specifying the full path of install locations, and values with the equivalent URL.
 	 */
 	public static function get_install_locations() {
-		// Include WordPress root and wp-content.
-		$install_locations = array(
-			\ABSPATH        => \get_site_url(),
-			\WP_CONTENT_DIR => \WP_CONTENT_URL,
+		$upload_dir_info = \wp_upload_dir();
+		// Include uploads folder, wp-content and WordPress root.
+		return array(
+			$upload_dir_info['basedir'] => $upload_dir_info['baseurl'],
+			\WP_CONTENT_DIR             => \WP_CONTENT_URL,
+			\ABSPATH                    => \get_site_url(),
 		);
-
-		// Include uploads folder.
-		$upload_dir_info                                  = \wp_upload_dir();
-		$install_locations[ $upload_dir_info['basedir'] ] = $upload_dir_info['baseurl'];
-
-		return $install_locations;
 	}
 
 }


### PR DESCRIPTION
Fixes #mypain

#### Changes proposed in this Pull Request:

Try to create jetpack-temp directory in wp-content in the first place.

#### Some background

I'd like to keep all installations highly clean: git + Composer + separate directory for WordPress core files.

![kép](https://user-images.githubusercontent.com/952007/111027750-8a447a80-83f2-11eb-9903-95000be91e44.png)
(🖼️ file change alert notification)

So the document root contains 2 directories:

1. core
2. and wp-content

It needs 2 lines in wp-config.
https://wordpress.org/support/article/giving-wordpress-its-own-directory/

As of today Jetpack **writes** into core's directory (ABSPATH).
This PR prioritizes uploads and wp-content directory.