### PR TITLE
Execute Jetpack::init only once

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-double-init-call
+++ b/projects/plugins/jetpack/changelog/remove-double-init-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Revome the later Jetpack::init call.

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -74,7 +74,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.core-rest-api-endpoints.php';
 
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
-add_action( 'init', array( 'Jetpack', 'init' ) );
 add_filter( 'is_jetpack_site', '__return_true' );
 
 if ( JETPACK__SANDBOX_DOMAIN ) {


### PR DESCRIPTION
Already executed in line number 86.

Fixes #19166
Fixes #5684 

All is explained in the above issue.

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Try using different parts of Jetpack depending on `init`.
* Try updating from the stable version of Jetpack to a new version with this patch, and ensure that the upgrade routine works well. 
