### PR TITLE
Update/block validation method

### DIFF
--- a/projects/plugins/jetpack/changelog/update-block-validation-method
+++ b/projects/plugins/jetpack/changelog/update-block-validation-method
@@ -1,4 +1,3 @@
 Significance: patch
 Type: enhancement
-
-Block parsing tests: make call for main block settings more robust (no public changelog required)
+Comment: Block parsing tests: make call for main block settings more robust

--- a/projects/plugins/jetpack/changelog/update-block-validation-method
+++ b/projects/plugins/jetpack/changelog/update-block-validation-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Block parsing tests: make call for main block settings more robust (no public changelog required)

--- a/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
+++ b/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
@@ -26,7 +26,12 @@ export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) 
 	setFixturesDir( fixturesPath );
 
 	const blockBasenames = getAvailableBlockFixturesBasenames();
-	const settings = blocks[ 0 ].settings;
+	let primaryBlockSettings;
+	try {
+		primaryBlockSettings = blocks.find( block => block.name === blockName ).settings;
+	} catch ( err ) {
+		throw new Error( `Settings can't be found for main block under test: ${ blockName }` );
+	}
 
 	if ( process.env.REGENERATE_FIXTURES ) {
 		const fullPath = `${ fixturesPath }/fixtures`;
@@ -155,11 +160,11 @@ export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) 
 			} );
 		} );
 
-		if ( settings.deprecated?.length ) {
+		if ( primaryBlockSettings.deprecated?.length ) {
 			test( 'fixture is present for each block deprecation', () => {
 				const nameToFilename = blockNameToFixtureBasename( blockName );
 				const errors = [];
-				settings.deprecated.forEach( ( deprecation, index ) => {
+				primaryBlockSettings.deprecated.forEach( ( deprecation, index ) => {
 					if (
 						deprecation &&
 						! blockBasenames.includes( `${ nameToFilename }__deprecated-${ index + 1 }` )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Makes the call to the get the settings for the main block under test more robust - currently just getting first block in array, but easy for dev to put blocks in array in different order so this PR updates it to get main block settings by block name, and throws exception if not found

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

- Check out PR
- In `/projects/plugins/jetpack` dir run `yarn fixtures:regenerate extensions/blocks/slideshow/test/validate.js` and make sure it completes successfully
- In `projects/plugins/jetpack/extensions/blocks/slideshow/test/validate.js` file change line 9 to `const blocks = [ { name: 'jetpackx/slideshow', settings } ];` and run above test again. It should fail this time with `Settings can't be found for main block under test: jetpack/slideshow` error.

