### PR TITLE
Add mailchimp block unit and fixture tests

### DIFF
--- a/projects/plugins/jetpack/changelog/add-mailchimp-block-tests
+++ b/projects/plugins/jetpack/changelog/add-mailchimp-block-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Added block unit and parsing tests
+
+

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/constants.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/constants.js
@@ -1,0 +1,3 @@
+export const NOTIFICATION_PROCESSING = 'processing';
+export const NOTIFICATION_SUCCESS = 'success';
+export const NOTIFICATION_ERROR = 'error';

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/controls.js
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+
+import { __ } from '@wordpress/i18n';
+import { ExternalLink, PanelBody, TextControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import MailchimpGroups from './mailchimp-groups';
+
+export function MailChimpBlockControls( {
+	emailPlaceholder,
+	updateEmailPlaceholder,
+	processingLabel,
+	updateProcessingText,
+	successLabel,
+	updateSuccessText,
+	errorLabel,
+	updateErrorText,
+	interests,
+	setAttributes,
+	signupFieldTag,
+	signupFieldValue,
+	connectURL,
+} ) {
+	return (
+		<>
+			<PanelBody title={ __( 'Text Elements', 'jetpack' ) }>
+				<TextControl
+					label={ __( 'Email Placeholder', 'jetpack' ) }
+					value={ emailPlaceholder }
+					onChange={ updateEmailPlaceholder }
+				/>
+			</PanelBody>
+			<PanelBody title={ __( 'Notifications', 'jetpack' ) }>
+				<TextControl
+					label={ __( 'Processing text', 'jetpack' ) }
+					value={ processingLabel }
+					onChange={ updateProcessingText }
+				/>
+				<TextControl
+					label={ __( 'Success text', 'jetpack' ) }
+					value={ successLabel }
+					onChange={ updateSuccessText }
+				/>
+				<TextControl
+					label={ __( 'Error text', 'jetpack' ) }
+					value={ errorLabel }
+					onChange={ updateErrorText }
+				/>
+			</PanelBody>
+			<PanelBody title={ __( 'Mailchimp Groups', 'jetpack' ) }>
+				<MailchimpGroups
+					interests={ interests }
+					onChange={ ( id, checked ) => {
+						// Create a Set to insure no duplicate interests
+						const deDupedInterests = [ ...new Set( [ ...interests, id ] ) ];
+						// Filter the clicked interest based on checkbox's state.
+						const updatedInterests = deDupedInterests.filter( item =>
+							item === id && ! checked ? false : item
+						);
+						setAttributes( {
+							interests: updatedInterests,
+						} );
+					} }
+				/>
+				<ExternalLink href="https://mailchimp.com/help/send-groups-audience/">
+					{ __( 'Learn about groups', 'jetpack' ) }
+				</ExternalLink>
+			</PanelBody>
+			<PanelBody title={ __( 'Signup Location Tracking', 'jetpack' ) }>
+				<TextControl
+					label={ __( 'Signup Field Tag', 'jetpack' ) }
+					placeholder={ __( 'SIGNUP', 'jetpack' ) }
+					value={ signupFieldTag }
+					onChange={ value => setAttributes( { signupFieldTag: value } ) }
+				/>
+				<TextControl
+					label={ __( 'Signup Field Value', 'jetpack' ) }
+					placeholder={ __( 'website', 'jetpack' ) }
+					value={ signupFieldValue }
+					onChange={ value => setAttributes( { signupFieldValue: value } ) }
+				/>
+				<ExternalLink href="https://mailchimp.com/help/determine-webpage-signup-location/">
+					{ __( 'Learn about signup location tracking', 'jetpack' ) }
+				</ExternalLink>
+			</PanelBody>
+			<PanelBody title={ __( 'Mailchimp Connection', 'jetpack' ) }>
+				<ExternalLink href={ connectURL }>{ __( 'Manage Connection', 'jetpack' ) }</ExternalLink>
+			</PanelBody>
+		</>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/controls.js
@@ -9,22 +9,41 @@ import { ExternalLink, PanelBody, TextControl } from '@wordpress/components';
  * Internal dependencies
  */
 import MailchimpGroups from './mailchimp-groups';
+import { NOTIFICATION_PROCESSING, NOTIFICATION_SUCCESS, NOTIFICATION_ERROR } from './constants';
 
 export function MailChimpBlockControls( {
-	emailPlaceholder,
-	updateEmailPlaceholder,
-	processingLabel,
-	updateProcessingText,
-	successLabel,
-	updateSuccessText,
-	errorLabel,
-	updateErrorText,
-	interests,
+	auditionNotification,
+	clearAudition,
 	setAttributes,
+	emailPlaceholder,
+	processingLabel,
+	successLabel,
+	errorLabel,
+	interests,
 	signupFieldTag,
 	signupFieldValue,
 	connectURL,
 } ) {
+	const updateProcessingText = processing => {
+		setAttributes( { processingLabel: processing } );
+		auditionNotification( NOTIFICATION_PROCESSING );
+	};
+
+	const updateEmailPlaceholder = email => {
+		setAttributes( { emailPlaceholder: email } );
+		clearAudition();
+	};
+
+	const updateSuccessText = success => {
+		setAttributes( { successLabel: success } );
+		auditionNotification( NOTIFICATION_SUCCESS );
+	};
+
+	const updateErrorText = error => {
+		setAttributes( { errorLabel: error } );
+		auditionNotification( NOTIFICATION_ERROR );
+	};
+
 	return (
 		<>
 			<PanelBody title={ __( 'Text Elements', 'jetpack' ) }>

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
@@ -4,15 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	ExternalLink,
-	PanelBody,
-	Placeholder,
-	Spinner,
-	TextControl,
-	withNotices,
-} from '@wordpress/components';
+import { Button, Placeholder, Spinner, TextControl, withNotices } from '@wordpress/components';
 import { InnerBlocks, InspectorControls, RichText } from '@wordpress/block-editor';
 import { Fragment, Component } from '@wordpress/element';
 
@@ -20,7 +12,7 @@ import { Fragment, Component } from '@wordpress/element';
  * Internal dependencies
  */
 import { icon, innerButtonBlock } from '.';
-import MailchimpGroups from './mailchimp-groups';
+import { MailChimpBlockControls } from './controls';
 
 const API_STATE_LOADING = 0;
 const API_STATE_CONNECTED = 1;
@@ -170,69 +162,21 @@ class MailchimpSubscribeEdit extends Component {
 		);
 		const inspectorControls = (
 			<InspectorControls>
-				<PanelBody title={ __( 'Text Elements', 'jetpack' ) }>
-					<TextControl
-						label={ __( 'Email Placeholder', 'jetpack' ) }
-						value={ emailPlaceholder }
-						onChange={ this.updateEmailPlaceholder }
-					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Notifications', 'jetpack' ) }>
-					<TextControl
-						label={ __( 'Processing text', 'jetpack' ) }
-						value={ processingLabel }
-						onChange={ this.updateProcessingText }
-					/>
-					<TextControl
-						label={ __( 'Success text', 'jetpack' ) }
-						value={ successLabel }
-						onChange={ this.updateSuccessText }
-					/>
-					<TextControl
-						label={ __( 'Error text', 'jetpack' ) }
-						value={ errorLabel }
-						onChange={ this.updateErrorText }
-					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Mailchimp Groups', 'jetpack' ) }>
-					<MailchimpGroups
-						interests={ interests }
-						onChange={ ( id, checked ) => {
-							// Create a Set to insure no duplicate interests
-							const deDupedInterests = [ ...new Set( [ ...interests, id ] ) ];
-							// Filter the clicked interest based on checkbox's state.
-							const updatedInterests = deDupedInterests.filter( item =>
-								item === id && ! checked ? false : item
-							);
-							setAttributes( {
-								interests: updatedInterests,
-							} );
-						} }
-					/>
-					<ExternalLink href="https://mailchimp.com/help/send-groups-audience/">
-						{ __( 'Learn about groups', 'jetpack' ) }
-					</ExternalLink>
-				</PanelBody>
-				<PanelBody title={ __( 'Signup Location Tracking', 'jetpack' ) }>
-					<TextControl
-						label={ __( 'Signup Field Tag', 'jetpack' ) }
-						placeholder={ __( 'SIGNUP', 'jetpack' ) }
-						value={ signupFieldTag }
-						onChange={ value => setAttributes( { signupFieldTag: value } ) }
-					/>
-					<TextControl
-						label={ __( 'Signup Field Value', 'jetpack' ) }
-						placeholder={ __( 'website', 'jetpack' ) }
-						value={ signupFieldValue }
-						onChange={ value => setAttributes( { signupFieldValue: value } ) }
-					/>
-					<ExternalLink href="https://mailchimp.com/help/determine-webpage-signup-location/">
-						{ __( 'Learn about signup location tracking', 'jetpack' ) }
-					</ExternalLink>
-				</PanelBody>
-				<PanelBody title={ __( 'Mailchimp Connection', 'jetpack' ) }>
-					<ExternalLink href={ connectURL }>{ __( 'Manage Connection', 'jetpack' ) }</ExternalLink>
-				</PanelBody>
+				<MailChimpBlockControls
+					emailPlaceholder={ emailPlaceholder }
+					updateEmailPlaceholder={ this.updateEmailPlaceholder }
+					processingLabel={ processingLabel }
+					updateProcessingText={ this.updateProcessingText }
+					successLabel={ successLabel }
+					updateSuccessText={ this.updateSuccessText }
+					errorLabel={ errorLabel }
+					updateErrorText={ this.updateErrorText }
+					interests={ interests }
+					setAttributes={ this.props.setAttributes }
+					signupFieldTag={ signupFieldTag }
+					signupFieldValue={ signupFieldValue }
+					connectURL={ connectURL }
+				/>
 			</InspectorControls>
 		);
 		const blockClasses = classnames( className, {

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
@@ -124,7 +124,7 @@ class MailchimpSubscribeEdit extends Component {
 					'jetpack'
 				) }
 			>
-				<Button isDefault isLarge href={ connectURL } target="_blank">
+				<Button isSecondary isLarge href={ connectURL } target="_blank">
 					{ __( 'Set up Mailchimp form', 'jetpack' ) }
 				</Button>
 				<div className={ `${ classPrefix }-recheck` }>

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
@@ -18,9 +18,7 @@ const API_STATE_LOADING = 0;
 const API_STATE_CONNECTED = 1;
 const API_STATE_NOTCONNECTED = 2;
 
-const NOTIFICATION_PROCESSING = 'processing';
-const NOTIFICATION_SUCCESS = 'success';
-const NOTIFICATION_ERROR = 'error';
+import { NOTIFICATION_PROCESSING, NOTIFICATION_SUCCESS, NOTIFICATION_ERROR } from './constants';
 
 class MailchimpSubscribeEdit extends Component {
 	constructor() {
@@ -73,30 +71,6 @@ class MailchimpSubscribeEdit extends Component {
 
 	clearAudition = () => {
 		this.setState( { audition: null } );
-	};
-
-	updateProcessingText = processingLabel => {
-		const { setAttributes } = this.props;
-		setAttributes( { processingLabel } );
-		this.auditionNotification( NOTIFICATION_PROCESSING );
-	};
-
-	updateSuccessText = successLabel => {
-		const { setAttributes } = this.props;
-		setAttributes( { successLabel } );
-		this.auditionNotification( NOTIFICATION_SUCCESS );
-	};
-
-	updateErrorText = errorLabel => {
-		const { setAttributes } = this.props;
-		setAttributes( { errorLabel } );
-		this.auditionNotification( NOTIFICATION_ERROR );
-	};
-
-	updateEmailPlaceholder = emailPlaceholder => {
-		const { setAttributes } = this.props;
-		setAttributes( { emailPlaceholder } );
-		this.clearAudition();
 	};
 
 	labelForAuditionType = audition => {
@@ -163,14 +137,12 @@ class MailchimpSubscribeEdit extends Component {
 		const inspectorControls = (
 			<InspectorControls>
 				<MailChimpBlockControls
+					auditionNotification={ this.auditionNotification }
+					clearAudition={ this.clearAudition }
 					emailPlaceholder={ emailPlaceholder }
-					updateEmailPlaceholder={ this.updateEmailPlaceholder }
 					processingLabel={ processingLabel }
-					updateProcessingText={ this.updateProcessingText }
 					successLabel={ successLabel }
-					updateSuccessText={ this.updateSuccessText }
 					errorLabel={ errorLabel }
-					updateErrorText={ this.updateErrorText }
 					interests={ interests }
 					setAttributes={ this.props.setAttributes }
 					signupFieldTag={ signupFieldTag }

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
+// 👀 Remove any unneeded imports from above.
+
+/**
+ * Internal dependencies
+ */
+// 👀 Import the edit component you are testing.
+// e.g. import WhatsAppButtonControls from '../controls';
+
+describe( '', () => {
+	const defaultAttributes = {
+		// 👀 Setup default block attributes.
+	};
+
+	const setAttributes = jest.fn();
+	const defaultProps = {
+		// 👀 Setup default block props.
+		attributes: defaultAttributes,
+		setAttributes,
+		clientId: 1,
+	};
+
+	// 👀 Tests setup.
+	beforeEach( () => {
+		setAttributes.mockClear();
+	} );
+
+	/**
+	 * 👀 Write tests specific to this block controls.
+	 *
+	 * These may cover whatever controls are added by the block
+	 * e.g. Inspector or Block Toolbar controls.
+	 *
+	 * Tests may cover behaviour such as:
+	 * - Correct fields included in controls
+	 * - Appropriate attributes and defaults are applied
+	 * - User interactions trigger correct event handlers etc.
+	 */
+
+	/**
+	 * 👀 Example:
+	 * test( 'loads settings when toolbar button clicked', async () => {
+	 *		render( <WhatsAppButtonConfiguration { ...props } /> );
+	 *		userEvent.click( screen.getByLabelText( 'WhatsApp Button Settings' ) );
+	 *		await waitFor( () => screen.getByLabelText( 'Country code' ) );
+	 *
+	 *		expect( screen.getByLabelText( 'Country code' ) ).toBeInTheDocument();
+	 * } );
+	 */
+	test( '', () => {
+
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import '@testing-library/jest-dom/extend-expect';

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
@@ -7,14 +7,49 @@
  */
 import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import { MailChimpBlockControls } from '../controls';
 
+const originalFetch = window.fetch;
+
+/**
+ * Mock return value for a successful fetch JSON return value.
+ *
+ * @return {Promise} Mock return value.
+ */
+const RESOLVED_FETCH_PROMISE = Promise.resolve( {
+	interest_categories: [
+		{
+			interests: [
+				{ id: 1, name: 'golf' },
+				{ id: 2, name: 'baseball' },
+			],
+		},
+	],
+} );
+const DEFAULT_FETCH_MOCK_RETURN = Promise.resolve( {
+	status: 200,
+	json: () => RESOLVED_FETCH_PROMISE,
+} );
+
 describe( '', () => {
+	beforeEach( () => {
+		window.fetch = jest.fn();
+		window.fetch.mockReturnValue( DEFAULT_FETCH_MOCK_RETURN );
+	} );
+
+	afterEach( async () => {
+		await act( () => RESOLVED_FETCH_PROMISE );
+	} );
+
+	afterAll( () => {
+		window.fetch = originalFetch;
+	} );
+
 	const setAttributes = jest.fn();
 	const auditionNotification = jest.fn();
 	const clearAudition = jest.fn();
@@ -27,7 +62,7 @@ describe( '', () => {
 		processingLabel: 'Processing ...',
 		successLabel: 'Woop woop!',
 		errorLabel: 'Dang!',
-		interests: 'Darning socks',
+		interests: [],
 		signupFieldTag: 'SIGNUP',
 		signupFieldValue: 'Sign up',
 		connectURL: 'https://mailchimp.com',
@@ -39,18 +74,66 @@ describe( '', () => {
 		clearAudition.mockClear();
 	} );
 
-	test( 'loads email placeholder input', async () => {
-		render( <MailChimpBlockControls { ...defaultProps } /> );
-
-		expect( screen.getByLabelText( 'Email Placeholder' ) ).toBeInTheDocument();
-	} );
-
 	test( 'updates email placeholder attribute', async () => {
 		render( <MailChimpBlockControls { ...defaultProps } /> );
-
 		userEvent.paste( screen.getByLabelText( 'Email Placeholder' ), 'Enter an email address' );
+
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			emailPlaceholder: 'Enter your emailEnter an email address',
+		} );
+	} );
+
+	test( 'updates processing text attribute', async () => {
+		render( <MailChimpBlockControls { ...defaultProps } /> );
+		userEvent.paste( screen.getByLabelText( 'Processing text' ), ' Relax!' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			processingLabel: 'Processing ... Relax!',
+		} );
+	} );
+
+	test( 'updates success text attribute', async () => {
+		render( <MailChimpBlockControls { ...defaultProps } /> );
+		userEvent.paste( screen.getByLabelText( 'Success text' ), ' It Worked!' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			successLabel: 'Woop woop! It Worked!',
+		} );
+	} );
+
+	test( 'updates error text attribute', async () => {
+		render( <MailChimpBlockControls { ...defaultProps } /> );
+		userEvent.paste( screen.getByLabelText( 'Error text' ), ' Epic fail!' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			errorLabel: 'Dang! Epic fail!',
+		} );
+	} );
+
+	test( 'updates signup field tag attribute', async () => {
+		render( <MailChimpBlockControls { ...defaultProps } /> );
+		userEvent.paste( screen.getByLabelText( 'Signup Field Tag' ), 'NOW' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			signupFieldTag: 'SIGNUPNOW',
+		} );
+	} );
+
+	test( 'updates signup field value attribute', async () => {
+		render( <MailChimpBlockControls { ...defaultProps } /> );
+		userEvent.paste( screen.getByLabelText( 'Signup Field Value' ), ' please' );
+		screen.debug();
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			signupFieldValue: 'Sign up please',
+		} );
+	} );
+
+	test( 'updates selected groups', async () => {
+		render( <MailChimpBlockControls { ...defaultProps } /> );
+		await waitFor( () => screen.getByLabelText( 'golf' ) );
+		userEvent.click( screen.getByLabelText( 'golf' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			interests: [ 1 ],
 		} );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
@@ -118,7 +118,6 @@ describe( 'Mailchimp block controls component', () => {
 	test( 'updates signup field value attribute', async () => {
 		render( <MailChimpBlockControls { ...defaultProps } /> );
 		userEvent.paste( screen.getByLabelText( 'Signup Field Value' ), ' please' );
-		screen.debug();
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			signupFieldValue: 'Sign up please',
 		} );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
@@ -8,55 +8,49 @@
 import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/react';
-// 👀 Remove any unneeded imports from above.
 
 /**
  * Internal dependencies
  */
-// 👀 Import the edit component you are testing.
-// e.g. import WhatsAppButtonControls from '../controls';
+import { MailChimpBlockControls } from '../controls';
 
 describe( '', () => {
-	const defaultAttributes = {
-		// 👀 Setup default block attributes.
-	};
-
 	const setAttributes = jest.fn();
+	const auditionNotification = jest.fn();
+	const clearAudition = jest.fn();
+
 	const defaultProps = {
-		// 👀 Setup default block props.
-		attributes: defaultAttributes,
+		auditionNotification,
+		clearAudition,
 		setAttributes,
-		clientId: 1,
+		emailPlaceholder: 'Enter your email',
+		processingLabel: 'Processing ...',
+		successLabel: 'Woop woop!',
+		errorLabel: 'Dang!',
+		interests: 'Darning socks',
+		signupFieldTag: 'SIGNUP',
+		signupFieldValue: 'Sign up',
+		connectURL: 'https://mailchimp.com',
 	};
 
-	// 👀 Tests setup.
 	beforeEach( () => {
 		setAttributes.mockClear();
+		auditionNotification.mockClear();
+		clearAudition.mockClear();
 	} );
 
-	/**
-	 * 👀 Write tests specific to this block controls.
-	 *
-	 * These may cover whatever controls are added by the block
-	 * e.g. Inspector or Block Toolbar controls.
-	 *
-	 * Tests may cover behaviour such as:
-	 * - Correct fields included in controls
-	 * - Appropriate attributes and defaults are applied
-	 * - User interactions trigger correct event handlers etc.
-	 */
+	test( 'loads email placeholder input', async () => {
+		render( <MailChimpBlockControls { ...defaultProps } /> );
 
-	/**
-	 * 👀 Example:
-	 * test( 'loads settings when toolbar button clicked', async () => {
-	 *		render( <WhatsAppButtonConfiguration { ...props } /> );
-	 *		userEvent.click( screen.getByLabelText( 'WhatsApp Button Settings' ) );
-	 *		await waitFor( () => screen.getByLabelText( 'Country code' ) );
-	 *
-	 *		expect( screen.getByLabelText( 'Country code' ) ).toBeInTheDocument();
-	 * } );
-	 */
-	test( '', () => {
+		expect( screen.getByLabelText( 'Email Placeholder' ) ).toBeInTheDocument();
+	} );
 
+	test( 'updates email placeholder attribute', async () => {
+		render( <MailChimpBlockControls { ...defaultProps } /> );
+
+		userEvent.paste( screen.getByLabelText( 'Email Placeholder' ), 'Enter an email address' );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			emailPlaceholder: 'Enter your emailEnter an email address',
+		} );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
@@ -32,7 +32,7 @@ const DEFAULT_FETCH_MOCK_RETURN = Promise.resolve( {
 	json: () => RESOLVED_FETCH_PROMISE,
 } );
 
-describe( '', () => {
+describe( 'Mailchimp block controls component', () => {
 	beforeEach( () => {
 		window.fetch = jest.fn();
 		window.fetch.mockReturnValue( DEFAULT_FETCH_MOCK_RETURN );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
@@ -9,9 +9,7 @@ import { render, screen, act, waitFor } from '@testing-library/react';
 // to operate
 jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
-	InnerBlocks: jest.fn().mockReturnValue( () => {
-		return '<button>Mocked button</button>';
-	} ),
+	InnerBlocks: () => <button>Mocked button</button>,
 } ) );
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+// 👀 Remove any unneeded imports from above.
+
+/**
+ * Internal dependencies
+ */
+import MailchimpSubscribeEdit from '../edit';
+
+describe( '', () => {
+	const defaultAttributes = {
+		// 👀 Setup default block attributes.
+	};
+
+	const setAttributes = jest.fn();
+	const defaultProps = {
+		// 👀 Setup default block props.
+		attributes: defaultAttributes,
+		setAttributes,
+		clientId: 1,
+	};
+
+	// 👀 Tests setup.
+	beforeEach( () => {
+		setAttributes.mockClear();
+	} );
+
+	/**
+	 * 👀 Write tests specific to this block's edit component.
+	 *
+	 * Tests may cover behaviour such as:
+	 * - Loading correctly
+	 * - Children are rendered
+	 * - Event handler callbacks are called
+	 * - Correct attributes are applied in markup
+	 * - Appropriate CSS classes applied
+	 */
+
+	/**
+	 * 👀 Example:
+	 * test( 'displays with customText attribute', () => {
+	 * 		render( <YourEditComponent { ...defaultProps } /> );
+	 * 		expect( screen.getByText( 'Custom text rendered in block' ) ).toBeInTheDocument();
+	 * } );
+	 */
+	test( '', () => {} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
@@ -70,7 +70,7 @@ describe( '', () => {
 		processingLabel: 'Processing ...',
 		successLabel: 'Woop woop!',
 		errorLabel: 'Dang!',
-		preview: true,
+		preview: false,
 	};
 	const defaultProps = {
 		attributes,
@@ -96,9 +96,10 @@ describe( '', () => {
 		expect( screen.getByText( 'Re-check Connection' ) ).toBeInTheDocument();
 	} );
 
-	test.only( 'shows set up mailchimp button and recheck connection if not connected', async () => {
+	test( 'shows enter your email message if connected', async () => {
 		window.fetch.mockReturnValue( CONNECTED_FETCH_MOCK_RETURN );
-		render( <MailchimpSubscribeEdit { ...defaultProps } /> );
+		const connectedProps = { ...defaultProps, attributes: { ...attributes, preview: true } };
+		render( <MailchimpSubscribeEdit { ...connectedProps } /> );
 		await waitFor( () => screen.getByLabelText( 'Enter your email' ) );
 		expect( screen.getByLabelText( 'Enter your email' ) ).toBeInTheDocument();
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import '@testing-library/jest-dom/extend-expect';
-
 import { render, screen, act, waitFor } from '@testing-library/react';
 
 // We need to mock InnerBlocks before importing our edit component as it requires the Gutenberg store setup
@@ -33,11 +32,6 @@ const NOT_CONNECTED_RESOLVED_FETCH_PROMISE = Promise.resolve( {
 	connect_url: undefined,
 } );
 
-const CONNECTED_RESOLVED_FETCH_PROMISE = Promise.resolve( {
-	connected: true,
-	connect_url: 'https://mailchimp.com',
-} );
-
 const DEFAULT_FETCH_MOCK_RETURN = Promise.resolve( {
 	status: 200,
 	json: () => NOT_CONNECTED_RESOLVED_FETCH_PROMISE,
@@ -45,10 +39,14 @@ const DEFAULT_FETCH_MOCK_RETURN = Promise.resolve( {
 
 const CONNECTED_FETCH_MOCK_RETURN = Promise.resolve( {
 	status: 200,
-	json: () => CONNECTED_RESOLVED_FETCH_PROMISE,
+	json: () =>
+		Promise.resolve( {
+			connected: true,
+			connect_url: 'https://mailchimp.com',
+		} ),
 } );
 
-describe( '', () => {
+describe( 'Mailchimp block edit component', () => {
 	beforeEach( () => {
 		window.fetch = jest.fn();
 		window.fetch.mockReturnValue( DEFAULT_FETCH_MOCK_RETURN );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp.html
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/mailchimp -->
+<!-- wp:jetpack/button {"element":"button","uniqueId":"mailchimp-widget-id","text":"Join my email list"} /-->
+<!-- /wp:jetpack/mailchimp -->

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp.json
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp.json
@@ -1,0 +1,32 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/mailchimp",
+        "isValid": true,
+        "attributes": {
+            "emailPlaceholder": "Enter your email",
+            "consentText": "By clicking submit, you agree to share your email address with the site owner and Mailchimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.",
+            "interests": [],
+            "processingLabel": "Processing…",
+            "successLabel": "Success! You're on the list.",
+            "errorLabel": "Whoops! There was an error and we couldn't process your subscription. Please reload the page and try again.",
+            "preview": false
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "jetpack/button",
+                "isValid": true,
+                "attributes": {
+                    "element": "button",
+                    "saveInPostContent": false,
+                    "uniqueId": "mailchimp-widget-id",
+                    "text": "Join my email list"
+                },
+                "innerBlocks": [],
+                "originalContent": ""
+            }
+        ],
+        "originalContent": ""
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp.parsed.json
@@ -1,0 +1,34 @@
+[
+    {
+        "blockName": "jetpack/mailchimp",
+        "attrs": {},
+        "innerBlocks": [
+            {
+                "blockName": "jetpack/button",
+                "attrs": {
+                    "element": "button",
+                    "uniqueId": "mailchimp-widget-id",
+                    "text": "Join my email list"
+                },
+                "innerBlocks": [],
+                "innerHTML": "",
+                "innerContent": []
+            }
+        ],
+        "innerHTML": "\n\n",
+        "innerContent": [
+            "\n",
+            null,
+            "\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/mailchimp -->
+<!-- wp:jetpack/button {"element":"button","uniqueId":"mailchimp-widget-id","text":"Join my email list"} /-->
+<!-- /wp:jetpack/mailchimp -->

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp__deprecated-1.html
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp__deprecated-1.html
@@ -1,0 +1,2 @@
+<!-- wp:jetpack/mailchimp {	"submitButtonText":"Subscribe","backgroundButtonColor":"white","textButtonColor":"black","submitButtonClasses":"rounded","customBackgroundButtonColor":"#CCCCCC","customTextButtonColor":"#000000"} -->
+<!-- /wp:jetpack/mailchimp -->

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp__deprecated-1.json
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp__deprecated-1.json
@@ -1,0 +1,35 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/mailchimp",
+        "isValid": true,
+        "attributes": {
+            "emailPlaceholder": "Enter your email",
+            "consentText": "By clicking submit, you agree to share your email address with the site owner and Mailchimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.",
+            "interests": [],
+            "processingLabel": "Processing…",
+            "successLabel": "Success! You're on the list.",
+            "errorLabel": "Whoops! There was an error and we couldn't process your subscription. Please reload the page and try again.",
+            "preview": false
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "jetpack/button",
+                "isValid": true,
+                "attributes": {
+                    "element": "button",
+                    "saveInPostContent": false,
+                    "uniqueId": "mailchimp-widget-id",
+                    "text": "Subscribe",
+                    "textColor": "black",
+                    "customTextColor": "#000000",
+                    "backgroundColor": "white",
+                    "customBackgroundColor": "#CCCCCC"
+                },
+                "innerBlocks": []
+            }
+        ],
+        "originalContent": ""
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp__deprecated-1.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp__deprecated-1.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "jetpack/mailchimp",
+        "attrs": {
+            "submitButtonText": "Subscribe",
+            "backgroundButtonColor": "white",
+            "textButtonColor": "black",
+            "submitButtonClasses": "rounded",
+            "customBackgroundButtonColor": "#CCCCCC",
+            "customTextButtonColor": "#000000"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp__deprecated-1.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/fixtures/jetpack__mailchimp__deprecated-1.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/mailchimp {"interests":[]} -->
+<!-- wp:jetpack/button {"element":"button","uniqueId":"mailchimp-widget-id","text":"Subscribe","textColor":"black","customTextColor":"#000000","backgroundColor":"white","customBackgroundColor":"#CCCCCC"} /-->
+<!-- /wp:jetpack/mailchimp -->

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/validate.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { name, settings } from '../';
+import runBlockFixtureTests from '../../../shared/test/block-fixtures';
+import { settings as buttonSettings } from '../../button';
+
+/**
+ * Update this array of blocks to contain the name and settings for all blocks
+ * involved in this set of tests.
+ *
+ * Example containing multiple blocks:
+ * const blocks = [
+ *		{ name: 'jetpack/whatsapp-button', settings },
+ *		{ name: 'jetpack/send-a-message', settings: parentSettings },
+ * ];
+ */
+const blocks = [
+	{ name: `jetpack/${ name }`, settings },
+	{ name: `jetpack/button`, settings: buttonSettings },
+];
+runBlockFixtureTests( `jetpack/${ name }`, blocks, __dirname );

--- a/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
+++ b/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
@@ -169,8 +169,9 @@ export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) 
 						);
 					}
 				} );
-				expect( errors.length ).toEqual( 0 );
-				if ( errors.length ) {
+				try {
+					expect( errors.length ).toEqual( 0 );
+				} catch ( error ) {
 					throw new Error( 'Problem(s) with fixture files:\n\n' + errors.join( '\n' ) );
 				}
 			} );

--- a/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
+++ b/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
@@ -189,7 +189,7 @@ function checkParseValid( block, fixtureName ) {
 	}
 }
 
-function registerBlocks( blocks ) {
+export function registerBlocks( blocks ) {
 	// Need to add a valid category or block registration fails
 	setCategories( [
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds block parsing and unit tests to the mailchimp block

#### Jetpack product discussion
p1HpG7-b3G-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Running the unit tests:

cd projects/plugins/jetpack && yarn fixtures:test extensions/blocks/mailchimp/test/

We should also ensure that the block works as expected in the editor and frontend  on a site.
