### PR TITLE
[WIP] Map block: Add support to render Map as a static image (PHP approach)

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/map/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/controls.js
@@ -162,6 +162,12 @@ export default ( {
 					checked={ attributes.showFullscreenButton }
 					onChange={ value => setAttributes( { showFullscreenButton: value } ) }
 				/>
+				<ToggleControl
+					label={ __( 'Display map as static image', 'jetpack' ) }
+					help={ __( 'Displays the map as a non-interactive static image', 'jetpack' ) }
+					checked={ attributes.isStaticMap }
+					onChange={ value => setAttributes( { isStaticMap: value } ) }
+				/>
 			</PanelBody>
 			{ attributes.points.length ? (
 				<PanelBody title={ __( 'Markers', 'jetpack' ) } initialOpen={ false }>

--- a/projects/plugins/jetpack/extensions/blocks/map/map.php
+++ b/projects/plugins/jetpack/extensions/blocks/map/map.php
@@ -100,6 +100,10 @@ function load_assets( $attr, $content ) {
 
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
+	if ( ! empty( $attr['isStaticMap'] ) && true === boolval( $attr['isStaticMap'] ) ) {
+		return '<div><img src="https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/-122.3486,37.8169,9,0/300x200?access_token=' . $access_token['key'] . '" /></div>';
+	}
+
 	return preg_replace( '/<div /', '<div data-api-key="' . esc_attr( $access_token['key'] ) . '" ', $content, 1 );
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/map/map.php
+++ b/projects/plugins/jetpack/extensions/blocks/map/map.php
@@ -193,7 +193,17 @@ function render_static_map_image_block( $attr, $content, $access_token_key ) {
 		$url_with_paths
 	);
 
-	return '<div class="wp-block-jetpack-map--static_image"><img src="' . $url . '" /></div>';
+	// Set alignment class to support wide and full width alignment.
+	$class_names = 'wp-block-jetpack-map--static_image';
+	if ( isset( $attr['align'] ) ) {
+		$class_names .= ' align' . esc_attr( $attr['align'] );
+	}
+
+	return sprintf(
+		'<div class="%s"><img src="%s" /></div>',
+		$class_names,
+		$url
+	);
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/map/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/settings.js
@@ -82,6 +82,10 @@ export const settings = {
 			type: 'boolean',
 			default: true,
 		},
+		isStaticMap: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 	supports: {
 		defaultStylePicker: false,

--- a/projects/plugins/jetpack/extensions/blocks/map/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/map/style.scss
@@ -24,3 +24,11 @@
 		border-radius: 0;
 	}
 }
+
+.wp-block-jetpack-map--static_image {
+	img {
+		display: block;
+		margin: 0 auto;
+		max-width: 100%;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

***NOTE: This approach will likely be abandoned in favour of #19315*** 

Add support for rendering the Map block on the front end using the Mapbox Static Image API so that we display an image to the user instead of a dynamic map. 

This is still a work-in-progress, but most features appear to be working so far:

![image](https://user-images.githubusercontent.com/14988353/112427401-9f73be80-8d8d-11eb-9257-77e053b06d21.png)

#### Relevant Mapbox documentation

* https://docs.mapbox.com/api/maps/static-images/
* https://docs.mapbox.com/playground/static/
* https://docs.mapbox.com/help/getting-started/static-maps/

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* TBC

#### To-dos

* [x] Support custom height
* [x] Support custom zoom level
* [x] Use longitude / latitude settings
* [x] Use show streets setting (looks like there's limited support for this in the Static Image API, so only works on satellite style)
* [x] Use custom marker color
* [x] Pass in coordinates for all map markers
* [ ] Skip loading additional Mapbox CSS and JS if the current map has static image set
* [ ] However, if multiple maps are in the post, and at least one of them is dynamic, we should load it
* [ ] In that case, ensure that the container for the static image map is not converted into a dynamic map
* [x] Render block markup with the correct alignment class added (support wide and full width alignment)
* [ ] Make sure CSS does what we'd expect to the image if the browser window is larger than the max width of the image when in full width alignment
* [ ] Add tests
* [ ] Add AMP support?
* [ ] Do we need a deprecation? I don't _think_ so, but good to double-check.
* [ ] Add changelog entry

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/14827

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* TBC
