### PR TITLE
Use `composer update` rather than `install` when lockfile isn't checked in.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "4b69c92ad4a2241d267fcac82c83fb4237829c29"
+                "reference": "98548854b6bbf45106ed0d96be733371a9ab7c9c"
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
@@ -46,11 +46,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [

--- a/projects/packages/a8c-mc-stats/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/a8c-mc-stats/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/a8c-mc-stats/composer.json
+++ b/projects/packages/a8c-mc-stats/composer.json
@@ -15,11 +15,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/abtest/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/abtest/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/abtest/composer.json
+++ b/projects/packages/abtest/composer.json
@@ -19,12 +19,12 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/assets/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/assets/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/assets/composer.json
+++ b/projects/packages/assets/composer.json
@@ -18,11 +18,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/autoloader/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/autoloader/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/autoloader/composer.json
+++ b/projects/packages/autoloader/composer.json
@@ -20,11 +20,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-php \"./tests/php/tmp/coverage-report.php\"",
 			"php ./tests/php/bin/test-coverage.php \"$COVERAGE_DIR/clover.xml\""
 		],

--- a/projects/packages/blocks/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/blocks/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/blocks/composer.json
+++ b/projects/packages/blocks/composer.json
@@ -16,12 +16,12 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/changelogger/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/changelogger/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/changelogger/composer.json
+++ b/projects/packages/changelogger/composer.json
@@ -30,11 +30,11 @@
 	],
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/codesniffer/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/codesniffer/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -24,11 +24,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": "./tests/action-test-php.sh"

--- a/projects/packages/connection/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/connection/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -28,12 +28,12 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/constants/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/constants/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/constants/composer.json
+++ b/projects/packages/constants/composer.json
@@ -16,11 +16,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/device-detection/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/device-detection/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/device-detection/composer.json
+++ b/projects/packages/device-detection/composer.json
@@ -15,11 +15,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/error/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/error/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/error/composer.json
+++ b/projects/packages/error/composer.json
@@ -15,11 +15,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/jitm/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/jitm/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -43,11 +43,11 @@
 			"yarn build"
 		],
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/lazy-images/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/lazy-images/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/lazy-images/composer.json
+++ b/projects/packages/lazy-images/composer.json
@@ -27,12 +27,12 @@
 			"yarn build"
 		],
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/licensing/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/licensing/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/licensing/composer.json
+++ b/projects/packages/licensing/composer.json
@@ -19,12 +19,12 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/logo/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/logo/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/logo/composer.json
+++ b/projects/packages/logo/composer.json
@@ -15,11 +15,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/partner/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/partner/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/partner/composer.json
+++ b/projects/packages/partner/composer.json
@@ -16,11 +16,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/password-checker/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/password-checker/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/password-checker/composer.json
+++ b/projects/packages/password-checker/composer.json
@@ -16,11 +16,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/redirect/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/redirect/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/redirect/composer.json
+++ b/projects/packages/redirect/composer.json
@@ -18,11 +18,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/roles/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/roles/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/roles/composer.json
+++ b/projects/packages/roles/composer.json
@@ -16,11 +16,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/status/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/status/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -16,11 +16,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/terms-of-service/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/terms-of-service/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/terms-of-service/composer.json
+++ b/projects/packages/terms-of-service/composer.json
@@ -19,11 +19,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/tracking/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/tracking/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -30,11 +30,11 @@
 	],
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/plugins/beta/changelog/fix-cli-composer-install-vs-update
+++ b/projects/plugins/beta/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock
+
+

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "dff2b641a296f469289f9e9ce09c958665e1e528"
+                "reference": "69b94231de9ccb5b0c244bf05b985c6eacc874ba"
             },
             "require": {
                 "php": ">=5.6",
@@ -55,11 +55,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [

--- a/projects/plugins/debug-helper/changelog/fix-cli-composer-install-vs-update
+++ b/projects/plugins/debug-helper/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock
+
+

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "dff2b641a296f469289f9e9ce09c958665e1e528"
+                "reference": "69b94231de9ccb5b0c244bf05b985c6eacc874ba"
             },
             "require": {
                 "php": ">=5.6",
@@ -55,11 +55,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [

--- a/projects/plugins/jetpack/changelog/fix-cli-composer-install-vs-update
+++ b/projects/plugins/jetpack/changelog/fix-cli-composer-install-vs-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Update composer.lock
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "f662708969edb26a8acdd7845ee6c92d097d3ed2"
+                "reference": "941fb334722542cb9f45155c9babd6734c6ee3b1"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -35,11 +35,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -61,7 +61,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/abtest",
-                "reference": "6fde951fd87f2b42a07551c27782086a0d5ff9e1"
+                "reference": "5b5ae690655d16c51f7f4732b86522eaad4f56ff"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.25",
@@ -89,14 +89,14 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "post-update-cmd": [
                     "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -118,7 +118,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "750a02d32a85ec4bd14550cc67a882f5b8f965b1"
+                "reference": "81df84cf7ba03928fd3e5d9fe5168085fcc17981"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -145,11 +145,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -171,7 +171,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "6c3ebd7e09edd636d71e4e87ce316ffbc8f9f567"
+                "reference": "7e7651188ecc0a02a22e6f433bd5a614c930aaff"
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0"
@@ -201,11 +201,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-php \"./tests/php/tmp/coverage-report.php\"",
                     "php ./tests/php/bin/test-coverage.php \"$COVERAGE_DIR/clover.xml\""
                 ],
@@ -266,7 +266,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "0deefeaefb355c075c200207bbc312bd4cedb1fc"
+                "reference": "7d2beb6ef393d0f6a08ba5437e379535f68d255a"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -290,14 +290,14 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "post-update-cmd": [
                     "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -392,7 +392,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "e4a2510dc79f62061bc4a7107731b1952b17970f"
+                "reference": "7152acf69517f4b6a79e275489bc042017f5a07e"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6",
@@ -429,14 +429,14 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "post-update-cmd": [
                     "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -506,7 +506,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "ef2fb6fcd1f79e6b6b6516c9a4bf401fba57b99a"
+                "reference": "1b3c06f9c4105ca977dd4790ec34bf1d4fdf1f63"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -530,11 +530,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -556,7 +556,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "d112311c1bf01e057d95d0c7f7787e018117ca9d"
+                "reference": "bea33c92dcfa8be4a8ef462e1958bc0a094b8a29"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -579,11 +579,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -605,7 +605,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/error",
-                "reference": "fff48d3d285dcb299cc4fcd9c29298dcde386a7b"
+                "reference": "a83341e31df1e6713507d981f4a1ce57588a0099"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -628,11 +628,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -693,7 +693,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "cfdbfdbaec1be35f7a7277222904c772b1f04137"
+                "reference": "3d5e6e516d77b6d1bc13db3720791519674f84bb"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
@@ -739,11 +739,11 @@
                     "yarn build"
                 ],
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -765,7 +765,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/lazy-images",
-                "reference": "ca815af21ad1360cf5081f422a5733af194b6970"
+                "reference": "acac1b5d31826fd95093537521364834086e1f61"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
@@ -801,14 +801,14 @@
                     "yarn build"
                 ],
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "post-update-cmd": [
                     "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -830,7 +830,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "7471ca78293802b0899272127619236192be4ba6"
+                "reference": "35f2d3bb709be626d4cf92aa0550eb2f57687d11"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.25",
@@ -858,14 +858,14 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "post-update-cmd": [
                     "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -887,7 +887,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "a37b01720e4c15ececa53192133a5122d9f87121"
+                "reference": "852db8e92d3a965e84376fcb2927b9ecf629cf49"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -910,11 +910,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -975,7 +975,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "5e98f77f594a785e9309d393814ac7ca267adde5"
+                "reference": "a39ef639b7d1833e38597a5546a97440e7e1e6ad"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -999,11 +999,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -1025,7 +1025,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "63a074342c395775eca87c7c5afc501b2e8edc6d"
+                "reference": "71c071fdf66a9726ddf63e2698832ced0e2e899f"
             },
             "require": {
                 "automattic/jetpack-status": "^1.7"
@@ -1052,11 +1052,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -1078,7 +1078,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "204d82908358392be04305dcfce93d3be0d90145"
+                "reference": "25bd74812feaca32a8de8fd0862cc671d8edfda1"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -1102,11 +1102,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -1128,7 +1128,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "e528f7867762b3359da8e5500d886ce082b1ca05"
+                "reference": "98f78bf34737a6863954895c96903cfc45c1c3a0"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -1152,11 +1152,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -1221,7 +1221,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/terms-of-service",
-                "reference": "e4f16272eb09fd66406138580cccf9f312b43f5f"
+                "reference": "574e246688d086fbdca902888ec06b3acbcf7d4c"
             },
             "require": {
                 "automattic/jetpack-options": "^1.11",
@@ -1249,11 +1249,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -1275,7 +1275,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "705971e55db88cb8bcc31d650a47512f5d9fc519"
+                "reference": "ed8d3d91a236480f94aceba456f5a1ebde591a92"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
@@ -1305,11 +1305,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [
@@ -1403,7 +1403,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "dff2b641a296f469289f9e9ce09c958665e1e528"
+                "reference": "69b94231de9ccb5b0c244bf05b985c6eacc874ba"
             },
             "require": {
                 "php": ">=5.6",
@@ -1445,11 +1445,11 @@
             },
             "scripts": {
                 "phpunit": [
-                    "@composer install",
+                    "@composer update",
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
                 "test-coverage": [
-                    "@composer install",
+                    "@composer update",
                     "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
                 ],
                 "test-php": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Partially fixes #18753

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The CLI needs to detect whether the lockfile is checked in or not.
* It also has a bug where it wasn't doing the installs concurrently like it intended to.
* All the packages' `composer.json` should use `@composer update` in the scripts.

This PR doesn't fix the cli `generate` command's composer.json, as it currently doesn't seem to have logic determining whether composer.lock is checked in or not. Thus this doesn't completely fix #18753.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#18753

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try `jetpack install` for projects with and without the lock files checked in, and for those without it checked in try it with or without the lock file existing. Ensure the correct command was run.