### PR TITLE
Story block: Playback improvements

### DIFF
--- a/projects/plugins/jetpack/changelog/update-story-playback-improvements
+++ b/projects/plugins/jetpack/changelog/update-story-playback-improvements
@@ -1,0 +1,3 @@
+Significance: patch
+Type: bugfix
+Comment: Updates to story block, not yet available on web.

--- a/projects/plugins/jetpack/extensions/blocks/story/player/components/header.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/components/header.js
@@ -18,7 +18,7 @@ export default function Header( { fullscreen, onExitFullscreen, siteIconUrl, sto
 	return (
 		<div className="wp-story-meta">
 			<div className="wp-story-icon">
-				<img alt="Site icon" src={ siteIconUrl } />
+				<img alt="Site icon" src={ siteIconUrl } width="40" height="40" />
 			</div>
 			<div>
 				<div className="wp-story-title">{ storyTitle }</div>

--- a/projects/plugins/jetpack/extensions/blocks/story/player/components/header.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/components/header.js
@@ -18,7 +18,7 @@ export default function Header( { fullscreen, onExitFullscreen, siteIconUrl, sto
 	return (
 		<div className="wp-story-meta">
 			<div className="wp-story-icon">
-				<img alt="Site icon" src={ siteIconUrl } width="40" height="40" />
+				<img alt={ __( 'Site icon', 'jetpack' ) } src={ siteIconUrl } width="40" height="40" />
 			</div>
 			<div>
 				<div className="wp-story-title">{ storyTitle }</div>

--- a/projects/plugins/jetpack/extensions/blocks/story/player/components/media.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/components/media.js
@@ -27,7 +27,7 @@ export const Image = ( { title, alt, className, id, mediaRef, mime, sizes, srcse
 	/>
 );
 
-export const Video = ( { title, className, id, mediaRef, mime, url } ) => (
+export const Video = ( { title, className, id, mediaRef, mime, url, poster } ) => (
 	// eslint-disable-next-line jsx-a11y/media-has-caption
 	<video
 		className={ classNames( 'wp-story-video', 'intrinsic-ignore', `wp-video-${ id }`, className ) }
@@ -36,6 +36,7 @@ export const Video = ( { title, className, id, mediaRef, mime, url } ) => (
 		title={ title }
 		type={ mime }
 		src={ url }
+		poster={ poster }
 		playsInline
 	></video>
 );

--- a/projects/plugins/jetpack/extensions/blocks/story/player/lib/wait-media-ready.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/lib/wait-media-ready.js
@@ -7,6 +7,11 @@ export default async function waitMediaReady( mediaElement, fullLoad = false ) {
 		await new Promise( resolve => {
 			mediaElement.addEventListener( 'load', resolve, { once: true } );
 		} );
+	} else if ( 'video' === elementTag && mediaElement.poster ) {
+		await new Promise( resolve => {
+			mediaElement.addEventListener( 'loadeddata', resolve, { once: true } );
+			mediaElement.load();
+		} );
 	} else if ( 'video' === elementTag || 'audio' === elementTag ) {
 		const src = mediaElement.src;
 		// only load the full video if it's on the same origin

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -92,6 +92,13 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 
 				// Set the poster attribute for the video tag if a poster image is available.
 				if ( ! empty( $video_meta['videopress']['poster'] ) ) {
+					$poster_url = $video_meta['videopress']['poster'];
+				} elseif ( ! empty( $video_meta['thumb'] ) ) {
+					$video_url  = wp_get_attachment_url( $attachment_id );
+					$poster_url = str_replace( wp_basename( $video_url ), $video_meta['thumb'], $video_url );
+				}
+
+				if ( $poster_url ) {
 					$poster_width  = esc_attr( $media_file['width'] );
 					$poster_height = esc_attr( $media_file['height'] );
 					$content_width = Jetpack::get_content_width();
@@ -102,7 +109,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 					$media_file = array_merge(
 						$media_file,
 						array(
-							'poster' => $video_meta['videopress']['poster'] . '?resize=' . $poster_width . ',' . $poster_height,
+							'poster' => $poster_url . '?resize=' . $poster_width . ',' . $poster_height,
 						)
 					);
 				}

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -356,7 +356,7 @@ function render_block( $attributes ) {
 				<div class="wp-story-container">
 					<div class="wp-story-meta">
 						<div class="wp-story-icon">
-							<img alt="%4$s" src="%5$s" width="32" height=32>
+							<img alt="%4$s" src="%5$s" width="40" height="40">
 						</div>
 						<div>
 							<div class="wp-story-title">
@@ -381,7 +381,7 @@ function render_block( $attributes ) {
 		esc_attr( 'wp-story-' . get_the_ID() ),
 		filter_var( wp_json_encode( $settings ), FILTER_SANITIZE_SPECIAL_CHARS ),
 		__( 'Site icon', 'jetpack' ),
-		esc_attr( get_site_icon_url( 40, includes_url( 'images/w-logo-blue.png' ) ) ),
+		esc_attr( get_site_icon_url( 80, includes_url( 'images/w-logo-blue.png' ) ) ),
 		esc_html( get_the_title() ),
 		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : '',
 		get_permalink() . '?wp-story-load-in-fullscreen=true&amp;wp-story-play-on-load=true',

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -73,7 +73,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 				);
 			} else {
 				$video_meta = wp_get_attachment_metadata( $attachment_id );
-				if ( ! isset( $video_meta['width'] ) || ! isset( $video_meta['width'] ) ) {
+				if ( ! isset( $video_meta['width'] ) || ! isset( $video_meta['height'] ) ) {
 					return $media_file;
 				}
 				$url         = ! empty( $video_meta['original']['url'] ) ? $video_meta['original']['url'] : $media_file['url'];

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack\Extensions\Story;
 
 use Automattic\Jetpack\Blocks;
+use Jetpack;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'story';
@@ -77,7 +78,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 				}
 				$url         = ! empty( $video_meta['original']['url'] ) ? $video_meta['original']['url'] : $media_file['url'];
 				$description = ! empty( $video_meta['videopress']['description'] ) ? $video_meta['videopress']['description'] : $media_file['alt'];
-				return array_merge(
+				$media_file  = array_merge(
 					$media_file,
 					array(
 						'width'   => absint( $video_meta['width'] ),
@@ -88,6 +89,24 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 						'caption' => wp_get_attachment_caption( $attachment_id ),
 					)
 				);
+
+				// Set the poster attribute for the video tag if a poster image is available.
+				if ( ! empty( $video_meta['videopress']['poster'] ) ) {
+					$poster_width  = esc_attr( $media_file['width'] );
+					$poster_height = esc_attr( $media_file['height'] );
+					$content_width = Jetpack::get_content_width();
+					if ( is_numeric( $content_width ) ) {
+						$poster_height = round( ( $content_width * $poster_height ) / $poster_width );
+						$poster_width  = $content_width;
+					}
+					$media_file = array_merge(
+						$media_file,
+						array(
+							'poster' => $video_meta['videopress']['poster'] . '?resize=' . $poster_width . ',' . $poster_height,
+						)
+					);
+				}
+				return $media_file;
 			}
 		},
 		$media_files

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -225,7 +225,7 @@ function render_video( $media ) {
 			esc_attr( $description ),
 			'wp-block-jetpack-story_image wp-story-image ' .
 			get_image_crop_class( $meta_width, $meta_height ),
-			add_query_arg( 'resize', rawurlencode( $poster_width . ',' . $poster_height ), esc_attr( $poster_url ) ),
+			esc_attr( add_query_arg( 'resize', rawurlencode( $poster_width . ',' . $poster_height ), $poster_url ) ),
 			! empty( $meta_width ) ? ' width="' . esc_attr( $meta_width ) . '"' : '',
 			! empty( $meta_height ) ? ' height="' . esc_attr( $meta_height ) . '"' : ''
 		);

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -109,7 +109,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 					$media_file = array_merge(
 						$media_file,
 						array(
-							'poster' => $poster_url . '?resize=' . $poster_width . ',' . $poster_height,
+							'poster' => $poster_url . '?resize=' . rawurlencode( $poster_width . ',' . $poster_height ),
 						)
 					);
 				}
@@ -225,7 +225,7 @@ function render_video( $media ) {
 			esc_attr( $description ),
 			'wp-block-jetpack-story_image wp-story-image ' .
 			get_image_crop_class( $meta_width, $meta_height ),
-			esc_attr( $poster_url ) . '?resize=' . $poster_width . ',' . $poster_height,
+			esc_attr( $poster_url ) . '?resize=' . rawurlencode( $poster_width . ',' . $poster_height ),
 			! empty( $meta_width ) ? ' width="' . esc_attr( $meta_width ) . '"' : '',
 			! empty( $meta_height ) ? ' height="' . esc_attr( $meta_height ) . '"' : ''
 		);

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -212,13 +212,20 @@ function render_video( $media ) {
 	}
 
 	if ( ! empty( $poster_url ) ) {
+		$poster_width  = esc_attr( $meta_width );
+		$poster_height = esc_attr( $meta_height );
+		$content_width = Jetpack::get_content_width();
+		if ( is_numeric( $content_width ) ) {
+			$poster_height = round( ( $content_width * $poster_height ) / $poster_width );
+			$poster_width  = $content_width;
+		}
 		return sprintf(
 			'<img title="%1$s" alt="%2$s" class="%3$s" src="%4$s"%5$s%6$s>',
 			esc_attr( get_the_title( $media['id'] ) ),
 			esc_attr( $description ),
 			'wp-block-jetpack-story_image wp-story-image ' .
 			get_image_crop_class( $meta_width, $meta_height ),
-			esc_attr( $poster_url ),
+			esc_attr( $poster_url ) . '?resize=' . $poster_width . ',' . $poster_height,
 			! empty( $meta_width ) ? ' width="' . esc_attr( $meta_width ) . '"' : '',
 			! empty( $meta_height ) ? ' height="' . esc_attr( $meta_height ) . '"' : ''
 		);

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -101,7 +101,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 				if ( $poster_url ) {
 					$poster_width  = esc_attr( $media_file['width'] );
 					$poster_height = esc_attr( $media_file['height'] );
-					$content_width = intval( Jetpack::get_content_width() );
+					$content_width = (int) Jetpack::get_content_width();
 					if ( is_numeric( $content_width ) ) {
 						$poster_height = round( ( $content_width * $poster_height ) / $poster_width );
 						$poster_width  = $content_width;
@@ -214,7 +214,7 @@ function render_video( $media ) {
 	if ( ! empty( $poster_url ) ) {
 		$poster_width  = esc_attr( $meta_width );
 		$poster_height = esc_attr( $meta_height );
-		$content_width = intval( Jetpack::get_content_width() );
+		$content_width = (int) Jetpack::get_content_width();
 		if ( is_numeric( $content_width ) ) {
 			$poster_height = round( ( $content_width * $poster_height ) / $poster_width );
 			$poster_width  = $content_width;

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -109,7 +109,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 					$media_file = array_merge(
 						$media_file,
 						array(
-							'poster' => $poster_url . '?resize=' . rawurlencode( $poster_width . ',' . $poster_height ),
+							'poster' => add_query_arg( 'resize', rawurlencode( $poster_width . ',' . $poster_height ), $poster_url ),
 						)
 					);
 				}
@@ -225,7 +225,7 @@ function render_video( $media ) {
 			esc_attr( $description ),
 			'wp-block-jetpack-story_image wp-story-image ' .
 			get_image_crop_class( $meta_width, $meta_height ),
-			esc_attr( $poster_url ) . '?resize=' . rawurlencode( $poster_width . ',' . $poster_height ),
+			add_query_arg( 'resize', rawurlencode( $poster_width . ',' . $poster_height ), esc_attr( $poster_url ) ),
 			! empty( $meta_width ) ? ' width="' . esc_attr( $meta_width ) . '"' : '',
 			! empty( $meta_height ) ? ' height="' . esc_attr( $meta_height ) . '"' : ''
 		);

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -101,7 +101,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 				if ( $poster_url ) {
 					$poster_width  = esc_attr( $media_file['width'] );
 					$poster_height = esc_attr( $media_file['height'] );
-					$content_width = Jetpack::get_content_width();
+					$content_width = intval( Jetpack::get_content_width() );
 					if ( is_numeric( $content_width ) ) {
 						$poster_height = round( ( $content_width * $poster_height ) / $poster_width );
 						$poster_width  = $content_width;
@@ -214,7 +214,7 @@ function render_video( $media ) {
 	if ( ! empty( $poster_url ) ) {
 		$poster_width  = esc_attr( $meta_width );
 		$poster_height = esc_attr( $meta_height );
-		$content_width = Jetpack::get_content_width();
+		$content_width = intval( Jetpack::get_content_width() );
 		if ( is_numeric( $content_width ) ) {
 			$poster_height = round( ( $content_width * $poster_height ) / $poster_width );
 			$poster_width  = $content_width;


### PR DESCRIPTION
Resolves a few issues with Stories playback:

https://github.com/Automattic/story-block/issues/11
https://github.com/Automattic/story-block/issues/12

#### Changes proposed in this Pull Request:
##### Doubles the size attribute for the site icon to prevent pixelation/blurriness (seems to only affect WPcom):

![beforeafter-clipped](https://user-images.githubusercontent.com/9613966/111578768-1a6e2f80-87f8-11eb-8468-7218661a7e64.png)

##### Where possible (i.e. when VideoPress is enabled), sets the `poster` attribute on VideoPress videos.

This should improve the issue mentioned above, where sometimes the loading animation would show indefinitely (I believe this may be due to a race condition issue when the video was already cached and load was completed before the listener to hide the loading indicator was registered, but I'm not sure). It should also be a load time optimization in general.

This also improves the preview on some mobile browsers/webviews (see https://github.com/wordpress-mobile/WordPress-Android/issues/13809), where videos are not predownloaded for bandwidth reasons - the poster image will still be downloaded in those situations.

#### Does this pull request change what data or activity we track or use?
No changes.

#### Testing instructions:
On a Jetpack site with VideoPress enabled:
1. Open a post containing a story with a VideoPress video as its first slide
2. Inspect the story html and notice that the video tag has a poster attribute set:

<img width="801" alt="Screen Shot 2021-03-18 at 2 36 05 PM" src="https://user-images.githubusercontent.com/9613966/111578423-75ebed80-87f7-11eb-9cca-4cc813aa26d8.png">

3. Check the network requests and verify that the poster image is only requested once, and that it has resize parameters applied:

<img width="1132" alt="Screen Shot 2021-03-18 at 2 36 55 PM" src="https://user-images.githubusercontent.com/9613966/111578452-83a17300-87f7-11eb-88c0-3b087cbb82c3.png">

On a WP.com site:
1. Do the same tests as for Jetpack.