### PR TITLE
Replace axios with native fetch in Instant Search

### DIFF
--- a/projects/plugins/jetpack/changelog/update-replace-axios-with-fetch-in-instant-search
+++ b/projects/plugins/jetpack/changelog/update-replace-axios-with-fetch-in-instant-search
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: No need for a changelog entry; this should be a seamless under-the-hood change.
+
+

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/api.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/api.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import axios, { CancelToken } from 'axios';
 import { encode } from 'qss';
 import { flatten } from 'q-flat';
 import stringify from 'fast-json-stable-stringify';
@@ -13,12 +12,15 @@ import lru from 'tiny-lru/lib/tiny-lru.esm';
 import { getFilterKeys } from './filters';
 import { MINUTE_IN_MILLISECONDS, RESULT_FORMAT_PRODUCT, SERVER_OBJECT_NAME } from './constants';
 
-let cancelToken = CancelToken.source();
+let abortController;
 
 const isLengthyArray = array => Array.isArray( array ) && array.length > 0;
 // Cache contents evicted after fixed time-to-live
 const cache = lru( 30, 5 * MINUTE_IN_MILLISECONDS );
 const backupCache = lru( 30, 30 * MINUTE_IN_MILLISECONDS );
+
+// Set up initial abort controller
+resetAbortController();
 
 /**
  * Builds ElasticSerach aggregations for filters defined by search widgets.
@@ -37,7 +39,7 @@ export function buildFilterAggregations( widgets = [] ) {
 }
 
 /**
- * Builds ElasticSerach aggregations for a given filter.
+ * Builds ElasticSearch aggregations for a given filter.
  *
  * @param {object[]} filter - a filter object from a widget configuration object.
  * @returns {object} filter aggregations
@@ -185,6 +187,14 @@ function mapSortToApiValue( sort ) {
 	return SORT_QUERY_MAP.get( sort, 'score_default' );
 }
 
+/* eslint-disable jsdoc/require-param,jsdoc/check-param-names */
+/**
+ * Generate the query string for an API request
+ *
+ * @param {object} options - Options object for the function
+ *
+ * @returns {string} The generated query string.
+ */
 function generateApiQueryString( {
 	aggregations,
 	excludedPostTypes,
@@ -243,7 +253,15 @@ function generateApiQueryString( {
 		} )
 	);
 }
+/* eslint-enable jsdoc/require-param,jsdoc/check-param-names */
 
+/**
+ * Turn a proxy request into a promise
+ *
+ * @param {Function} proxyRequest - The wpcom-proxy-request function
+ * @param {string} path - The API path to use
+ * @returns {Promise} A promise to a proxy request response
+ */
 function promiseifedProxyRequest( proxyRequest, path ) {
 	return new Promise( function ( resolve, reject ) {
 		proxyRequest( { path, apiVersion: '1.3' }, function ( err, body, headers ) {
@@ -255,13 +273,19 @@ function promiseifedProxyRequest( proxyRequest, path ) {
 	} );
 }
 
+/**
+ * Generate an error handler for a given cache key
+ *
+ * @param {string} cacheKey - The cache key to use
+ * @returns {Function} An error handler to be used with a search request
+ */
 function errorHandlerFactory( cacheKey ) {
 	return function errorHandler( error ) {
 		// TODO: Display a message about falling back to a cached value in the interface.
 		const fallbackValue = cache.get( cacheKey ) || backupCache.get( cacheKey );
 
 		// Fallback to cached value if request has been cancelled.
-		if ( axios.isCancel( error ) ) {
+		if ( error.name === 'AbortError' ) {
 			return fallbackValue
 				? { _isCached: true, _isError: false, _isOffline: false, ...fallbackValue }
 				: null;
@@ -276,6 +300,12 @@ function errorHandlerFactory( cacheKey ) {
 	};
 }
 
+/**
+ * Generate a response handler for a given cache key
+ *
+ * @param {string} cacheKey - The cache key to use
+ * @returns {Function} A response handler to be used with a search request
+ */
 function responseHandlerFactory( cacheKey ) {
 	return function responseHandler( responseJson ) {
 		cache.set( cacheKey, responseJson );
@@ -284,6 +314,22 @@ function responseHandlerFactory( cacheKey ) {
 	};
 }
 
+/**
+ * Abort the existing request and set up a new abort controller, for new requests.
+ */
+function resetAbortController() {
+	if ( abortController ) {
+		abortController.abort();
+	}
+	abortController = new AbortController();
+}
+
+/**
+ * Perform a search.
+ *
+ * @param {object} options - Search options
+ * @returns {Promise} A promise to the JSON response object
+ */
 export function search( options ) {
 	const key = stringify( Array.from( arguments ) );
 
@@ -326,15 +372,13 @@ export function search( options ) {
 	const urlForPrivateApi = `${ apiRoot }wpcom/v2/search?${ queryString }`;
 	const url = isPrivateSite ? urlForPrivateApi : urlForPublicApi;
 
-	cancelToken.cancel( 'New search requested, cancelling previous search requests.' );
-	cancelToken = CancelToken.source();
+	resetAbortController();
 
 	// NOTE: API Nonce is necessary to authenticate requests to class-wpcom-rest-api-v2-endpoint-search.php.
-	return axios( {
-		url,
-		cancelToken: cancelToken.token,
+	return fetch( url, {
 		headers: isPrivateSite ? { 'X-WP-Nonce': apiNonce } : {},
-		withCredentials: isPrivateSite,
+		credentials: isPrivateSite ? 'include' : 'same-origin',
+		signal: abortController.signal,
 	} )
 		.then( response => {
 			if ( response.status !== 200 ) {
@@ -344,7 +388,7 @@ export function search( options ) {
 			}
 			return response;
 		} )
-		.then( r => r.data )
+		.then( r => r.json() )
 		.then( responseHandler )
 		.catch( errorHandler );
 }

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -87,7 +87,7 @@
 		"@wordpress/i18n": "3.9.0",
 		"@wordpress/icons": "2.7.0",
 		"@wordpress/url": "2.11.0",
-		"axios": "0.21.1",
+		"abortcontroller-polyfill": "1.7.1",
 		"babel-jest": "26.6.3",
 		"babel-loader": "8.2.2",
 		"bounding-client-rect": "1.0.5",
@@ -149,7 +149,8 @@
 		"url-polyfill": "1.1.12",
 		"uuid": "8.3.2",
 		"webpack": "4.46.0",
-		"webpack-cli": "4.5.0"
+		"webpack-cli": "4.5.0",
+		"whatwg-fetch": "3.6.2"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "2.4.0",

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -20,7 +20,12 @@ const baseWebpackConfig = getBaseWebpackConfig(
 				__dirname,
 				'../modules/search/instant-search/ie11-polyfill.js'
 			),
-			'ie11-polyfill-payload': [ 'core-js', 'regenerator-runtime/runtime' ],
+			'ie11-polyfill-payload': [
+				'core-js',
+				'regenerator-runtime/runtime',
+				'whatwg-fetch',
+				'abortcontroller-polyfill/dist/polyfill-patch-fetch',
+			],
 		},
 		'output-chunk-filename': 'jp-search.chunk-[name]-[hash].js',
 		'output-filename': 'jp-search-[name].bundle.js',

--- a/projects/plugins/jetpack/yarn.lock
+++ b/projects/plugins/jetpack/yarn.lock
@@ -4233,6 +4233,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abortcontroller-polyfill@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz#27084bac87d78a7224c8ee78135d05df430c2d2f"
+  integrity sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA==
+
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -4880,13 +4885,6 @@ axe-core@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.2.tgz#c7cf7378378a51fcd272d3c09668002a4990b1cb"
   integrity sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==
-
-axios@0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  dependencies:
-    follow-redirects "^1.10.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -8347,11 +8345,6 @@ focus-trap@6.3.0:
   integrity sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==
   dependencies:
     tabbable "^5.1.5"
-
-follow-redirects@^1.10.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
-  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -17218,6 +17211,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-fetch@>=0.10.0:
   version "3.0.0"

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -188,7 +188,6 @@
 	"projects/plugins/jetpack/modules/search/instant-search/components/test/photon-image.test.js",
 	"projects/plugins/jetpack/modules/search/instant-search/external/query-string-decode.js",
 	"projects/plugins/jetpack/modules/search/instant-search/external/wpcom-proxy-request.js",
-	"projects/plugins/jetpack/modules/search/instant-search/lib/api.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/array-overlap.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/colors.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/customize.js",


### PR DESCRIPTION
This PR replaces the use of `axios`, a 14KB (4.6 gzipped) 3rd-party library, with `fetch` functionality that's natively built into modern browsers.

IE 11 gets the functionality polyfilled through its dedicated bundle, thus preserving the byte savings for modern browsers.

Fixes #19041.

#### Changes proposed in this Pull Request:
* Replace usage of `axios` with native fetch in Instant Search

#### Jetpack product discussion
See #19041.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Ensure that searches continue to work correctly.
* To test that the abort functionality works correctly, limit the network speeds for your browser and quickly type and delete various keywords. There should be no errors, and the latest results should always be displayed correctly.
* Test in IE 11 and ensure that everything works normally
* Test with a private site and ensure that everything works correctly (I was unable to test this myself)
