### PR TITLE
FSE: FSE menu item platform parity

### DIFF
--- a/projects/plugins/jetpack/changelog/update-gutenberg-menus
+++ b/projects/plugins/jetpack/changelog/update-gutenberg-menus
@@ -1,0 +1,3 @@
+Significance: patch
+Type: compat
+Comment: Admin Menu: Gutenberg menu placement parity on Atomic

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -118,6 +118,7 @@ class Admin_Menu {
 
 		$this->add_options_menu( $wp_admin );
 		$this->add_jetpack_menu();
+		$this->add_gutenberg_menus( $wp_admin );
 
 		// Remove Links Manager menu since its usage is discouraged.
 		// @see https://core.trac.wordpress.org/ticket/21307#comment:73.
@@ -435,6 +436,35 @@ class Admin_Menu {
 			// Remove the submenu auto-created by Core.
 			remove_submenu_page( 'jetpack', 'jetpack' );
 		}
+	}
+
+	/**
+	 * Re-adds the Site Editor menu without the (beta) tag, and where we want it.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_gutenberg_menus( $wp_admin = false ) {
+		// We can bail if we don't meet the conditions of the Site Editor.
+		if ( ! ( function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme() ) ) {
+			return;
+		}
+
+		// Core Gutenberg registers without an explicit position, and we don't want the (beta) tag.
+		remove_menu_page( 'gutenberg-edit-site' );
+		// Core Gutenberg tries to manage its position, foiling our best laid plans. Unfoil.
+		remove_filter( 'menu_order', 'gutenberg_menu_order' );
+
+		$link = $wp_admin ? 'gutenberg-edit-site' : 'https://wordpress.com/site-editor/' . $this->domain;
+
+		add_menu_page(
+			__( 'Site Editor', 'jetpack' ),
+			__( 'Site Editor', 'jetpack' ),
+			'edit_theme_options',
+			$link,
+			$wp_admin ? 'gutenberg_edit_site_page' : null,
+			'dashicons-layout',
+			61 // Just under Appearance.
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -239,4 +239,15 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		add_submenu_page( 'users.php', esc_attr__( 'Advanced Users Management', 'jetpack' ), __( 'Advanced Users Management', 'jetpack' ), 'list_users', 'users.php', null, 2 );
 	}
+
+	/**
+	 * Also remove the Gutenberg plugin menu.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
+	 */
+	public function add_gutenberg_menus( $wp_admin = false ) {
+		// Always remove the Gutenberg menu.
+		remove_menu_page( 'gutenberg' );
+		parent::add_gutenberg_menus( $wp_admin );
+	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -273,36 +273,14 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
-	 * 1. Remove the Gutenberg plugin menu
-	 * 2. Re-add the Site Editor menu
+	 * Also remove the Gutenberg plugin menu.
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_gutenberg_menus( $wp_admin = false ) {
 		// Always remove the Gutenberg menu.
 		remove_menu_page( 'gutenberg' );
-
-		// We can bail if we don't meet the conditions of the Site Editor.
-		if ( ! ( function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme() ) ) {
-			return;
-		}
-
-		// Core Gutenberg registers without an explicit position, and we don't want the (beta) tag.
-		remove_menu_page( 'gutenberg-edit-site' );
-		// Core Gutenberg tries to manage its position, foiling our best laid plans. Unfoil.
-		remove_filter( 'menu_order', 'gutenberg_menu_order' );
-
-		$link = $wp_admin ? 'gutenberg-edit-site' : 'https://wordpress.com/site-editor/' . $this->domain;
-
-		add_menu_page(
-			__( 'Site Editor', 'jetpack' ),
-			__( 'Site Editor', 'jetpack' ),
-			'edit_theme_options',
-			$link,
-			$wp_admin ? 'gutenberg_edit_site_page' : null,
-			'dashicons-layout',
-			61 // Just under Appearance.
-		);
+		parent::add_gutenberg_menus( $wp_admin );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -36,8 +36,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function reregister_menu_items() {
 		parent::reregister_menu_items();
 
-		$wp_admin = $this->should_link_to_wp_admin();
-
 		$this->add_my_home_menu();
 
 		// Not needed outside of wp-admin.
@@ -46,8 +44,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 			$this->add_site_card_menu();
 			$this->add_new_site_link();
 		}
-
-		$this->add_gutenberg_menus( $wp_admin );
 
 		ksort( $GLOBALS['menu'] );
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/data/admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/data/admin-menu.php
@@ -12,7 +12,7 @@
  */
 function get_menu_fixture() {
 	return array(
-		2  => array(
+		2   => array(
 			'Dashboard',
 			'read',
 			'index.php',
@@ -21,7 +21,7 @@ function get_menu_fixture() {
 			'menu-dashboard',
 			'dashicons-dashboard',
 		),
-		3  => array(
+		3   => array(
 			'Jetpack',
 			'jetpack_admin_page',
 			'jetpack',
@@ -30,14 +30,14 @@ function get_menu_fixture() {
 			'toplevel_page_jetpack',
 			'div',
 		),
-		4  => array(
+		4   => array(
 			'',
 			'read',
 			'separator1',
 			'',
 			'wp-menu-separator',
 		),
-		10 => array(
+		10  => array(
 			'Media',
 			'upload_files',
 			'upload.php',
@@ -46,7 +46,7 @@ function get_menu_fixture() {
 			'menu-media',
 			'dashicons-admin-media',
 		),
-		15 => array(
+		15  => array(
 			'Links',
 			'manage_links',
 			'edit-tags.php?taxonomy=link_category',
@@ -55,7 +55,7 @@ function get_menu_fixture() {
 			'menu-links',
 			'dashicons-admin-links',
 		),
-		25 => array(
+		25  => array(
 			'Comments <span class="awaiting-mod count-3"><span class="pending-count" aria-hidden="true">3</span><span class="comments-in-moderation-text screen-reader-text">3 Comments in moderation</span></span>',
 			'edit_posts',
 			'edit-comments.php',
@@ -64,7 +64,7 @@ function get_menu_fixture() {
 			'menu-comments',
 			'dashicons-admin-comments',
 		),
-		5  => array(
+		5   => array(
 			'Posts',
 			'edit_posts',
 			'edit.php',
@@ -73,7 +73,7 @@ function get_menu_fixture() {
 			'menu-posts',
 			'dashicons-admin-post',
 		),
-		20 => array(
+		20  => array(
 			'Pages',
 			'edit_pages',
 			'edit.php?post_type=page',
@@ -82,7 +82,7 @@ function get_menu_fixture() {
 			'menu-pages',
 			'dashicons-admin-page',
 		),
-		30 => array(
+		30  => array(
 			'Custom Test Types',
 			'edit_posts',
 			'edit.php?post_type=custom_test_type',
@@ -91,14 +91,14 @@ function get_menu_fixture() {
 			'menu-custom_test_type',
 			'dashicons-admin-post',
 		),
-		59 => array(
+		59  => array(
 			'',
 			'read',
 			'separator2',
 			'',
 			'wp-menu-separator',
 		),
-		60 => array(
+		60  => array(
 			'Appearance',
 			'switch_themes',
 			'themes.php',
@@ -107,7 +107,7 @@ function get_menu_fixture() {
 			'menu-appearance',
 			'dashicons-admin-appearance',
 		),
-		65 => array(
+		65  => array(
 			'Plugins <span class="update-plugins count-4"><span class="plugin-count">4</span></span>',
 			'activate_plugins',
 			'plugins.php',
@@ -116,7 +116,7 @@ function get_menu_fixture() {
 			'menu-plugins',
 			'dashicons-admin-plugins',
 		),
-		70 => array(
+		70  => array(
 			'Users <span class="update-plugins count-0"><span class="plugin-count">0</span></span>',
 			'list_users',
 			'users.php',
@@ -125,7 +125,7 @@ function get_menu_fixture() {
 			'menu-users',
 			'dashicons-admin-users',
 		),
-		75 => array(
+		75  => array(
 			'Tools',
 			'edit_posts',
 			'tools.php',
@@ -134,7 +134,7 @@ function get_menu_fixture() {
 			'menu-tools',
 			'dashicons-admin-tools',
 		),
-		80 => array(
+		80  => array(
 			'Settings',
 			'manage_options',
 			'options-general.php',
@@ -142,6 +142,15 @@ function get_menu_fixture() {
 			'menu-top menu-icon-settings',
 			'menu-settings',
 			'dashicons-admin-settings',
+		),
+		100 => array(
+			'Site Editor <span class="awaiting-mod">beta</span>',
+			'edit_theme_options',
+			'gutenberg-edit-site',
+			'Site Editor (beta)',
+			'menu-top toplevel_page_gutenberg-edit-site',
+			'toplevel_page_gutenberg-edit-site',
+			'dashicons-layout',
 		),
 	);
 }
@@ -153,15 +162,6 @@ function get_menu_fixture() {
  */
 function get_wpcom_menu_fixture() {
 	$gutenberg_menus = array(
-		100 => array(
-			'Site Editor <span class="awaiting-mod">beta</span>',
-			'edit_theme_options',
-			'gutenberg-edit-site',
-			'Site Editor (beta)',
-			'menu-top toplevel_page_gutenberg-edit-site',
-			'toplevel_page_gutenberg-edit-site',
-			'dashicons-layout',
-		),
 		101 => array(
 			'Gutenberg',
 			'edit_posts',

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -134,7 +134,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array_keys( $menu ),
-			array( 2, '3.86682', 4, 5, 10, 15, 20, 25, 30, 50, 51, 59, 60, 65, 70, 75, 80 ),
+			array( 2, '3.86682', 4, 5, 10, 15, 20, 25, 30, 50, 51, 59, 60, 61, 65, 70, 75, 80 ),
 			'Admin menu should not have unexpected top menu items.'
 		);
 
@@ -427,5 +427,31 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		$this->assertSame( 'https://wordpress.com/activity-log/' . static::$domain, $submenu['jetpack'][2][2] );
 		$this->assertSame( 'https://wordpress.com/backup/' . static::$domain, $submenu['jetpack'][3][2] );
 		$this->assertSame( 'https://wordpress.com/jetpack-search/' . static::$domain, $submenu['jetpack'][4][2] );
+	}
+
+	/**
+	 * Tests add_gutenberg_menus
+	 *
+	 * @covers ::add_gutenberg_menus
+	 */
+	public function test_add_gutenberg_menus() {
+		global $menu;
+		static::$admin_menu->add_gutenberg_menus( false );
+
+		// FSE is no longer where it was put by default.
+		$this->assertArrayNotHasKey( 100, $menu );
+		$this->assertArrayHasKey( 61, $menu );
+
+		$fse_link = 'https://wordpress.com/site-editor/' . static::$domain;
+		$fse_menu = array(
+			'Site Editor',
+			'edit_theme_options',
+			$fse_link,
+			'Site Editor',
+			'menu-top toplevel_page_' . $fse_link,
+			'toplevel_page_' . $fse_link,
+			'dashicons-layout',
+		);
+		$this->assertSame( $menu[61], $fse_menu );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -68,7 +68,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( $factory ) {
 		static::$domain       = ( new Status() )->get_site_suffix();
 		static::$user_id      = $factory->user->create( array( 'role' => 'administrator' ) );
-		static::$menu_data    = get_menu_fixture();
+		static::$menu_data    = get_wpcom_menu_fixture();
 		static::$submenu_data = get_submenu_fixture();
 	}
 
@@ -366,5 +366,18 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_users_menu( true );
 		$this->assertArrayNotHasKey( 2, $submenu['users.php'] );
+	}
+
+	/**
+	 * Tests add_gutenberg_menus
+	 *
+	 * @covers ::add_gutenberg_menus
+	 */
+	public function test_add_gutenberg_menus() {
+		global $menu;
+		static::$admin_menu->add_gutenberg_menus( false );
+
+		// Gutenberg plugin menu should not be visible.
+		$this->assertArrayNotHasKey( 101, $menu );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -307,22 +307,6 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 
 		// Gutenberg plugin menu should not be visible.
 		$this->assertArrayNotHasKey( 101, $menu );
-
-		// FSE is no longer where it was put by default.
-		$this->assertArrayNotHasKey( 100, $menu );
-		$this->assertArrayHasKey( 61, $menu );
-
-		$fse_link = 'https://wordpress.com/site-editor/' . static::$domain;
-		$fse_menu = array(
-			'Site Editor',
-			'edit_theme_options',
-			$fse_link,
-			'Site Editor',
-			'menu-top toplevel_page_' . $fse_link,
-			'toplevel_page_' . $fse_link,
-			'dashicons-layout',
-		);
-		$this->assertSame( $menu[61], $fse_menu );
 	}
 
 	/**


### PR DESCRIPTION
This PR provides the previously WPCom Simple-only changes to FSE menu item positioning introduced in #18800 to Atomic sites.

Fixes Automattic/wp-calypso#50894

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Atomic and Jetpack sites now also reposition the FSE menu
* Gutenberg plugin menu removed on WPCom Simple and Jetpack
* Keep the Customizer removed when it's been removed by FSE

#### Jetpack product discussion
Unifying behaviour is the whole Nav Unification deal right?

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

For WPCom Simple and Atomic, you should see:
**Site Editor with no (beta) label, underneath Appearance**

##### WPCom Simple:
* Apply D58831-code  to your sandbox
* Sandbox a site created through the [Horizon FSE flow](https://horizon.wordpress.com/new?flags=gutenboarding/site-editor)
* Sandbox `public-api.wordpress.com`
* Visit your test site's `wp-admin`
* Verify that both wp-admin and Caplyso should show the menu as above.


##### Atomic:
1. Have/create an Atomic site
2. Install and activate Jetpack, Gutenberg, Jetpack Beta plugins
3. Install and activate an FSE theme
4. Checkout this branch in the Jetpack Beta plugin
5. Verify that both wp-admin and Caplyso should show the menu as above.

##### Jetpack:
1. This doesn't apply to non-Atomic Jetpack
