### PR TITLE
mirrors: Add an auto-tagger

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -128,6 +128,11 @@ for project in projects/packages/* projects/plugins/* projects/github-actions/*;
 	# Copy standard .github
 	cp -r "$BASE/.github/files/mirror-.github" "$BUILD_DIR/.github"
 
+	# Copy autotagger if enabled
+	if jq -e '.extra.autotagger // false' composer.json > /dev/null; then
+		cp -r "$BASE/.github/files/gh-autotagger/." "$BUILD_DIR/.github/."
+	fi
+
 	# Copy only wanted files, based on .gitignore and .gitattributes.
 	{
 		# Include unignored files by default.

--- a/.github/files/gh-autotagger/workflows/autotagger.yml
+++ b/.github/files/gh-autotagger/workflows/autotagger.yml
@@ -1,0 +1,23 @@
+name: Auto-tagger
+
+on:
+  push:
+    branches: [ 'master' ]
+
+jobs:
+  tag:
+    name: Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tag
+        run: |
+          VER=$(sed -nEe 's/^## \[?([^]]*)\]? - .*/\1/;T;p;q' CHANGELOG.md || true)
+          echo "Version from changelog is ${VER:-<unknown>}"
+          if [[ "$VER" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
+            git config --global user.name "matticbot"
+            git config --global user.email "matticbot@users.noreply.github.com"
+            git remote set-url origin "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
+            git tag "v$VER"
+            git push --tags
+          fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The optional auto-tagger workflow will add a tag in the mirror repo when
a CHANGELOG.md is pushed with a non-prerelease version.

This PR doesn't actually enable it anywhere.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Mentioned somewhere. Can't remember where.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that the build output doesn't have the new workflow file.
* Set `.extra.autotagger` to true and build. See that the new workflow file is copied into that mirror's tree.
* Copy the workflow into a testing repo and try it out. Or look [here](https://github.com/anomiex/testing/actions/workflows/autotagger.yml) where I did that.
