### PR TITLE
Licensing: Fix stored licenses not being attached on option creation

### DIFF
--- a/projects/packages/licensing/changelog/fix-licenses-not-attached-on-option-creation
+++ b/projects/packages/licensing/changelog/fix-licenses-not-attached-on-option-creation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix stored licenses not being attached on option creation

--- a/projects/packages/licensing/src/class-licensing.php
+++ b/projects/packages/licensing/src/class-licensing.php
@@ -59,6 +59,7 @@ class Licensing {
 	 * @return void
 	 */
 	public function initialize() {
+		add_action( 'add_option_' . self::LICENSES_OPTION_NAME, array( $this, 'attach_stored_licenses' ) );
 		add_action( 'update_option_' . self::LICENSES_OPTION_NAME, array( $this, 'attach_stored_licenses' ) );
 		add_action( 'jetpack_authorize_ending_authorized', array( $this, 'attach_stored_licenses_on_connection' ) );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fix stored licenses not being attached on option creation. Licensing was only hooking into update_option_jetpack_licenses where it should've hooked into add_option_jetpack_licenses as well.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

1. Checkout `master` and build Jetpack. The examples below are using WP CLI via docker.
2. Connect Jetpack.
3. `yarn docker:wp option delete jetpack_licenses`
4. `yarn docker:wp option update jetpack_licenses '["SOME_VALID_LICENSE_KEY"'] --format=json`
5. Refresh the My Plan tab in your browser - the product for the license in the previous step will be missing.
7. Checkout this PR.
8. Repeat steps 3 (CRUCIAL), 4 and 5 - the product should now show up under My Plan.