### PR TITLE
Search: updated default photon image size

### DIFF
--- a/projects/plugins/jetpack/changelog/update-photon-image-size
+++ b/projects/plugins/jetpack/changelog/update-photon-image-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: updated default photon image size

--- a/projects/plugins/jetpack/modules/search/instant-search/components/photon-image.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/photon-image.jsx
@@ -20,8 +20,8 @@ function stripQueryString( url ) {
 const PhotonImage = ( {
 	useDiv,
 	src,
-	maxWidth = 300,
-	maxHeight = 300,
+	maxWidth = 600,
+	maxHeight = 600,
 	alt,
 	isPhotonEnabled,
 	...otherProps


### PR DESCRIPTION
Requested in p4Kr4c-42v-p2#comment-17418 

#### Changes proposed in this Pull Request:
Requested by special project team who requested larger image in search results.
* Updated default photon image size from 300x300 to 600x600.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Go to a test site with Instant Search enabled. The test site should be on WordPress.com or Jetpack with Site Accelerator, so that Photon is used for image resizing.
2. Change your search result type to ‘Expanded’ in Customizer.
3. Using your browser developer tools, inspect the images in the search results and make sure they are resized to max dimensions of 600x600.
