### PR TITLE
Calendly Block: Add block tests and fixtures

### DIFF
--- a/projects/plugins/jetpack/changelog/add-calendly-tests-and-fixtures
+++ b/projects/plugins/jetpack/changelog/add-calendly-tests-and-fixtures
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Calendly: Added block tests and fixtures.

--- a/projects/plugins/jetpack/extensions/blocks/calendly/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/controls.js
@@ -1,0 +1,109 @@
+/**
+ * WordPress dependencies
+ */
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import {
+	Button,
+	ExternalLink,
+	Notice,
+	PanelBody,
+	ToggleControl,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockStylesSelector from '../../shared/components/block-styles-selector';
+
+export const CalendlyBlockControls = ( { onEditClick } ) => {
+	return (
+		<ToolbarGroup>
+			<ToolbarButton onClick={ () => onEditClick( true ) }>
+				{ __( 'Edit', 'jetpack' ) }
+			</ToolbarButton>
+		</ToolbarGroup>
+	);
+};
+
+export const CalendlyInspectorControls = props => {
+	const {
+		attributes: { hideEventTypeDetails, url },
+		defaultClassName,
+		embedCode,
+		parseEmbedCode,
+		setAttributes,
+		setEmbedCode,
+	} = props;
+
+	return (
+		<>
+			<PanelBody PanelBody title={ __( 'Calendar settings', 'jetpack' ) } initialOpen={ false }>
+				<form onSubmit={ parseEmbedCode } className={ `${ defaultClassName }-embed-form-sidebar` }>
+					<input
+						type="text"
+						id="embedCode"
+						onChange={ event => setEmbedCode( event.target.value ) }
+						placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
+						value={ embedCode }
+						className="components-placeholder__input"
+					/>
+					<div>
+						<Button isSecondary type="submit">
+							{ _x( 'Embed', 'button label', 'jetpack' ) }
+						</Button>
+					</div>
+				</form>
+
+				<ToggleControl
+					label={ __( 'Hide event type details', 'jetpack' ) }
+					checked={ hideEventTypeDetails }
+					onChange={ () => setAttributes( { hideEventTypeDetails: ! hideEventTypeDetails } ) }
+				/>
+			</PanelBody>
+			{ url && (
+				<Notice className={ `${ defaultClassName }-color-notice` } isDismissible={ false }>
+					<ExternalLink href="https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-">
+						{ __( 'Follow these instructions to change the colors in this block.', 'jetpack' ) }
+					</ExternalLink>
+				</Notice>
+			) }
+		</>
+	);
+};
+
+const CalendlyControls = props => {
+	const { attributes, clientId, isEditingUrl, setAttributes, setIsEditingUrl } = props;
+	const { style, url } = attributes;
+	const styleOptions = [
+		{ value: 'inline', label: __( 'Inline', 'jetpack' ) },
+		{ value: 'link', label: __( 'Link', 'jetpack' ) },
+	];
+
+	return (
+		<>
+			{ url && ! isEditingUrl && (
+				<BlockControls>
+					<CalendlyBlockControls onEditClick={ setIsEditingUrl } />
+				</BlockControls>
+			) }
+			{ url && (
+				<BlockStylesSelector
+					clientId={ clientId }
+					styleOptions={ styleOptions }
+					onSelectStyle={ setAttributes }
+					activeStyle={ style }
+					attributes={ attributes }
+					viewportWidth={ 500 }
+				/>
+			) }
+			<InspectorControls>
+				<CalendlyInspectorControls { ...props } />
+			</InspectorControls>
+		</>
+	);
+};
+
+export default CalendlyControls;

--- a/projects/plugins/jetpack/extensions/blocks/calendly/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/deprecated/v1/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty, omit, pick, some } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
@@ -14,17 +9,17 @@ import { __ } from '@wordpress/i18n';
  */
 import colorValidator from '../../../../shared/colorValidator';
 
+/**
+ * Deprecation reason:
+ *
+ * Submit button replaced with Jetpack Button inner block.
+ *
+ * Button properties stored in the Calendly block attributes were made
+ * consistent with the Button block's. The original link content was then
+ * replaced with the Button inner block.
+ */
+
 const urlValidator = url => ! url || url.startsWith( 'https://calendly.com/' );
-const deprecatedAttributes = [
-	'submitButtonText',
-	'submitButtonTextColor',
-	'submitButtonBackgroundColor',
-	'submitButtonClasses',
-	'backgroundButtonColor',
-	'textButtonColor',
-	'customBackgroundButtonColor',
-	'customTextButtonColor',
-];
 const migrateAttributes = oldAttributes => ( {
 	text: oldAttributes.submitButtonText || __( 'Schedule time with me', 'jetpack' ),
 	textColor: oldAttributes.submitButtonTextColor || oldAttributes.textButtonColor,
@@ -91,7 +86,19 @@ export default {
 		},
 	},
 	migrate: attributes => {
-		const newAttributes = omit( attributes, deprecatedAttributes );
+		// Filter out deprecated attributes, collecting the rest in newAttributes.
+		const {
+			submitButtonText,
+			submitButtonTextColor,
+			submitButtonBackgroundColor,
+			submitButtonClasses,
+			backgroundButtonColor,
+			textButtonColor,
+			customBackgroundButtonColor,
+			customTextButtonColor,
+			...newAttributes
+		} = attributes;
+
 		const buttonAttributes = migrateAttributes( attributes );
 		const newInnerBlocks = [
 			createBlock( 'jetpack/button', {
@@ -103,8 +110,5 @@ export default {
 
 		return [ newAttributes, newInnerBlocks ];
 	},
-	isEligible: ( attributes, innerBlocks ) =>
-		'link' === attributes.style &&
-		( isEmpty( innerBlocks ) || some( pick( attributes, deprecatedAttributes ), Boolean ) ),
 	save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
 };

--- a/projects/plugins/jetpack/extensions/blocks/calendly/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/edit.js
@@ -8,19 +8,8 @@ import queryString from 'query-string';
 /**
  * WordPress dependencies
  */
-import { BlockControls, BlockIcon, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
-import {
-	Button,
-	ExternalLink,
-	Notice,
-	PanelBody,
-	Placeholder,
-	Spinner,
-	ToggleControl,
-	ToolbarButton,
-	ToolbarGroup,
-	withNotices,
-} from '@wordpress/components';
+import { BlockIcon, InnerBlocks } from '@wordpress/block-editor';
+import { Button, ExternalLink, Placeholder, Spinner, withNotices } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getBlockDefaultClassName } from '@wordpress/blocks';
@@ -35,11 +24,11 @@ import icon from './icon';
 import attributeDetails from './attributes';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import { getAttributesFromEmbedCode } from './utils';
-import BlockStylesSelector from '../../shared/components/block-styles-selector';
 import { CALENDLY_EXAMPLE_URL, innerButtonBlock } from './';
 import testEmbedUrl from '../../shared/test-embed-url';
+import CalendlyControls from './controls';
 
-function CalendlyEdit( props ) {
+export function CalendlyEdit( props ) {
 	const {
 		attributes,
 		className,
@@ -58,7 +47,6 @@ function CalendlyEdit( props ) {
 
 	const {
 		backgroundColor,
-		submitButtonText,
 		hideEventTypeDetails,
 		primaryColor,
 		textColor,
@@ -129,31 +117,6 @@ function CalendlyEdit( props ) {
 			} );
 	};
 
-	const embedCodeForm = (
-		<>
-			<form onSubmit={ parseEmbedCode }>
-				<input
-					type="text"
-					id="embedCode"
-					onChange={ event => setEmbedCode( event.target.value ) }
-					placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
-					value={ embedCode }
-					className="components-placeholder__input"
-				/>
-				<div>
-					<Button isSecondary isLarge type="submit">
-						{ _x( 'Embed', 'button label', 'jetpack' ) }
-					</Button>
-				</div>
-			</form>
-			<div className={ `${ defaultClassName }-learn-more` }>
-				<ExternalLink href="https://help.calendly.com/hc/en-us/articles/223147027-Embed-options-overview">
-					{ __( 'Need help finding your embed code?', 'jetpack' ) }
-				</ExternalLink>
-			</div>
-		</>
-	);
-
 	const blockEmbedding = (
 		<div className="wp-block-embed is-loading">
 			<Spinner />
@@ -168,7 +131,26 @@ function CalendlyEdit( props ) {
 			icon={ <BlockIcon icon={ icon } /> }
 			notices={ noticeUI }
 		>
-			{ embedCodeForm }
+			<form onSubmit={ parseEmbedCode }>
+				<input
+					type="text"
+					id="embedCode"
+					onChange={ event => setEmbedCode( event.target.value ) }
+					placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
+					value={ embedCode }
+					className="components-placeholder__input"
+				/>
+				<div>
+					<Button isSecondary type="submit">
+						{ _x( 'Embed', 'button label', 'jetpack' ) }
+					</Button>
+				</div>
+			</form>
+			<div className={ `${ defaultClassName }-learn-more` }>
+				<ExternalLink href="https://help.calendly.com/hc/en-us/articles/223147027-Embed-options-overview">
+					{ __( 'Need help finding your embed code?', 'jetpack' ) }
+				</ExternalLink>
+			</div>
 		</Placeholder>
 	);
 
@@ -215,89 +197,13 @@ function CalendlyEdit( props ) {
 		/>
 	);
 
-	const linkPreview = (
-		<>
-			<a style={ { alignSelf: 'flex-start', border: 'none' } } className="wp-block-button__link">
-				{ submitButtonText }
-			</a>
-		</>
-	);
-
-	const blockPreview = ( previewStyle, disabled ) => {
+	const blockPreview = previewStyle => {
 		if ( previewStyle === 'inline' ) {
 			return inlinePreview;
 		}
 
-		if ( disabled ) {
-			return linkPreview;
-		}
-
 		return buttonPreview;
 	};
-
-	const styleOptions = [
-		{ value: 'inline', label: __( 'Inline', 'jetpack' ) },
-		{ value: 'link', label: __( 'Link', 'jetpack' ) },
-	];
-
-	const inspectorControls = (
-		<>
-			{ url && ! isEditingUrl && (
-				<BlockControls>
-					<ToolbarGroup>
-						<ToolbarButton onClick={ () => setIsEditingUrl( true ) }>
-							{ __( 'Edit', 'jetpack' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
-			{ url && (
-				<BlockStylesSelector
-					clientId={ clientId }
-					styleOptions={ styleOptions }
-					onSelectStyle={ setAttributes }
-					activeStyle={ style }
-					attributes={ attributes }
-					viewportWidth={ 500 }
-				/>
-			) }
-			<InspectorControls>
-				<PanelBody title={ __( 'Calendar Settings', 'jetpack' ) } initialOpen={ false }>
-					<form
-						onSubmit={ parseEmbedCode }
-						className={ `${ defaultClassName }-embed-form-sidebar` }
-					>
-						<input
-							type="text"
-							id="embedCode"
-							onChange={ event => setEmbedCode( event.target.value ) }
-							placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
-							value={ embedCode }
-							className="components-placeholder__input"
-						/>
-						<div>
-							<Button isSecondary isLarge type="submit">
-								{ _x( 'Embed', 'button label', 'jetpack' ) }
-							</Button>
-						</div>
-					</form>
-
-					<ToggleControl
-						label={ __( 'Hide Event Type Details', 'jetpack' ) }
-						checked={ hideEventTypeDetails }
-						onChange={ () => setAttributes( { hideEventTypeDetails: ! hideEventTypeDetails } ) }
-					/>
-				</PanelBody>
-				{ url && (
-					<Notice className={ `${ defaultClassName }-color-notice` } isDismissible={ false }>
-						<ExternalLink href="https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-">
-							{ __( 'Follow these instructions to change the colors in this block.', 'jetpack' ) }
-						</ExternalLink>
-					</Notice>
-				) }
-			</InspectorControls>
-		</>
-	);
 
 	if ( isResolvingUrl ) {
 		return blockEmbedding;
@@ -307,7 +213,17 @@ function CalendlyEdit( props ) {
 
 	return (
 		<div className={ classes }>
-			{ inspectorControls }
+			<CalendlyControls
+				{ ...{
+					...props,
+					defaultClassName,
+					embedCode,
+					isEditingUrl,
+					parseEmbedCode,
+					setEmbedCode,
+					setIsEditingUrl,
+				} }
+			/>
 			{ url && ! isEditingUrl ? blockPreview( style ) : blockPlaceholder }
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/calendly/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/save.js
@@ -4,7 +4,7 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function save( { attributes: { url } } ) {
+export default function save() {
 	return (
 		<div>
 			<InnerBlocks.Content />

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/controls.js
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { CalendlyBlockControls, CalendlyInspectorControls } from '../controls';
+
+describe( 'CalendlyBlockControls', () => {
+	const onEditClick = jest.fn();
+	const defaultProps = { onEditClick };
+
+	beforeEach( () => {
+		onEditClick.mockClear();
+	} );
+
+	test( 'displays edit toolbar button', () => {
+		render( <CalendlyBlockControls { ...defaultProps } /> );
+		const wrapper = screen.getByText( 'Edit' );
+
+		expect( wrapper ).toBeInTheDocument();
+		expect( wrapper.firstChild ).toHaveAttribute( 'type', 'button' );
+	} );
+
+	test( 'triggers onEditClick when user clicks button', () => {
+		render( <CalendlyBlockControls { ...defaultProps } /> );
+
+		userEvent.click( screen.getByRole( 'button' ) );
+		expect( onEditClick ).toHaveBeenCalledWith( true );
+	} );
+} );
+
+describe( 'CalendlyInspectorControls', () => {
+	const defaultAttributes = {
+		hideEventTypeDetails: false,
+		url: 'http://calendly.com/username',
+	};
+
+	const parseEmbedCode = jest.fn();
+	const setAttributes = jest.fn();
+	const setEmbedCode = jest.fn();
+
+	const defaultProps = {
+		attributes: defaultAttributes,
+		defaultClassName: 'wp-block-jetpack-calendly',
+		embedCode: 'http://calendly.com/username', // Kept the same as URL for brevity.
+		parseEmbedCode,
+		setAttributes,
+		setEmbedCode,
+	};
+
+	beforeEach( () => {
+		parseEmbedCode.mockClear();
+		setAttributes.mockClear();
+		setEmbedCode.mockClear();
+	} );
+
+	const renderExpandedSettings = ( props ) => {
+		render( <CalendlyInspectorControls { ...props } /> );
+		userEvent.click( screen.getByText( 'Calendar settings' ) );
+	};
+
+	test( 'displays calendar settings panel', () => {
+		render( <CalendlyInspectorControls { ...defaultProps } /> );
+		const panelHeaderButton = screen.getByText( 'Calendar settings' );
+		const panel = panelHeaderButton.closest( '.components-panel__body' );
+
+		expect( panelHeaderButton ).toBeInTheDocument();
+		expect( panel ).not.toHaveClass( 'is-opened' );
+	} );
+
+	test( 'renders embed form when panel is expanded', () => {
+		renderExpandedSettings( defaultProps );
+
+		const input = screen.getByPlaceholderText( 'Calendly web address or embed code…' );
+		const button = screen.getByText( 'Embed' );
+
+		expect( input ).toBeInTheDocument();
+		expect( input ).toHaveAttribute( 'id', 'embedCode' );
+		expect( input ).toHaveAttribute( 'type', 'text' );
+		expect( input ).toHaveValue( defaultProps.embedCode );
+
+		expect( button ).toBeInTheDocument();
+		expect( button ).toHaveAttribute( 'type', 'submit' );
+		expect( button ).toHaveClass( 'is-secondary' );
+	} );
+
+	test( 'updates embedCode as when input value changes', () => {
+		renderExpandedSettings( defaultProps );
+
+		const input = screen.getByPlaceholderText( 'Calendly web address or embed code…' );
+
+		userEvent.paste( input, '/30min' );
+		expect( setEmbedCode ).toHaveBeenLastCalledWith( `${ defaultProps.embedCode }/30min` );
+	} );
+
+	test( 'parses embed code when form is submitted', async () => {
+		renderExpandedSettings( defaultProps );
+
+		const submitButton = await screen.findByText( 'Embed' );
+
+		// fireEvent used as userEvent click on the Embed button fails to trigger submit.
+		await fireEvent.submit( submitButton.closest( 'form' ) );
+
+		expect( parseEmbedCode ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'displays toggle control for hiding event details', () => {
+		renderExpandedSettings( defaultProps );
+
+		const label = screen.getByLabelText( 'Hide event type details' );
+		const checkbox = screen.getByRole( 'checkbox' );
+
+		expect( label ).toBeInTheDocument();
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).not.toBeChecked();
+	} );
+
+	test( 'displays checked toggle control for hiding event details', () => {
+		const attributes = { ...defaultAttributes, hideEventTypeDetails: true };
+
+		renderExpandedSettings( { ...defaultProps, attributes } );
+
+		expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
+	} );
+
+	test( 'updates block attributes when hide event details toggled', () => {
+		renderExpandedSettings( defaultProps );
+		userEvent.click( screen.getByLabelText( 'Hide event type details' ) );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			hideEventTypeDetails: ! defaultAttributes.hideEventTypeDetails,
+		} );
+	} );
+
+	test( 'displays notice and link when URL present', () => {
+		renderExpandedSettings( defaultProps );
+
+		const colorHelpUrl = 'https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-';
+		const noticeClass = `${ defaultProps.defaultClassName }-color-notice`;
+		const linkText = 'Follow these instructions to change the colors in this block.';
+		const link = screen.getByText( linkText );
+
+		expect( link ).toBeInTheDocument();
+		expect( link ).toHaveAttribute( 'href', colorHelpUrl );
+		expect( link.closest( '.components-notice' ) ).toHaveClass( noticeClass );
+	} );
+
+	test( 'omits notice when no URL', () => {
+		const noticeClass = `.${ defaultProps.defaultClassName }-color-notice`;
+		const attributes = { ...defaultAttributes, url: undefined };
+		const { container } = render( <CalendlyInspectorControls { ...{ ...defaultProps, attributes } } /> );
+
+		userEvent.click( screen.getByText( 'Calendar settings' ) );
+
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+		expect( container.querySelector( noticeClass ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/edit.js
@@ -117,15 +117,12 @@ describe( 'CalendlyEdit', () => {
 			expect( createErrorNotice ).toHaveBeenCalled();
 		} );
 
-		test.skip( 'updates inner button block when new link embed code parsed', () => {
-			// TODO: Work out how to test this dispatched action.
-		} );
-
 		test( 'parsed embed code is tested before updating attributes', async () => {
 			render( <CalendlyEdit { ...propsWithoutUrl } /> );
 
 			userEvent.type( screen.getByRole( 'textbox' ), 'https://calendly.com/valid-url' );
 			userEvent.click( screen.getByRole( 'button', { name: 'Embed' } ) );
+
 			await waitFor( () =>
 				expect( testEmbedUrl ).toHaveBeenCalledWith(
 					'https://calendly.com/valid-url',
@@ -147,6 +144,7 @@ describe( 'CalendlyEdit', () => {
 
 		let iframe;
 		await waitFor( () => ( iframe = screen.getByTitle( 'Calendly' ) ) );
+
 		expect( iframe ).toBeInTheDocument();
 		expect( iframe.parentElement ).toHaveClass( 'calendly-style-inline' );
 		expect( iframe.previousElementSibling ).toHaveClass( 'wp-block-jetpack-calendly-overlay' );
@@ -175,17 +173,5 @@ describe( 'CalendlyEdit', () => {
 
 		expect( link ).toBeInTheDocument();
 		expect( link.parentElement ).toHaveClass( 'wp-block-jetpack-calendly-learn-more' );
-	} );
-
-	test.skip( 'displays placeholder when url present but it is being edited', () => {
-		render( <CalendlyEdit { ...defaultProps } /> );
-
-		// How do I update state in a non-frowned upon way? Should I even test this?
-		// I'd like to because the state will alter how this behaves for the user.
-		// Without rendering the block toolbar controls don't think I could
-		// simulate via actions made by a user.
-		expect(
-			screen.getByText( 'Enter your Calendly web address or embed code below.' )
-		).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/edit.js
@@ -9,6 +9,13 @@ import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 
+// Need to mock InnerBlocks before import the CalendlyEdit component as it
+// requires the Gutenberg store setup to operate.
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	InnerBlocks: () => <button>Mocked button</button>,
+} ) );
+
 /**
  * Internal dependencies
  */
@@ -26,7 +33,6 @@ jest.mock(
 		} )
 	} )
 );
-
 describe( 'CalendlyEdit', () => {
 	const defaultAttributes = {
 		backgroundColor: '#ffffff',
@@ -79,7 +85,7 @@ describe( 'CalendlyEdit', () => {
 		const attributes = { ...defaultAttributes, url: 'https://calendly.com/invalid-url' };
 		render( <CalendlyEdit { ...{ ...defaultProps, attributes } } /> );
 
-		expect( testEmbedUrl ).toHaveBeenCalledTimes( 1 );
+		expect( testEmbedUrl ).toHaveBeenCalledWith( attributes.url, expect.anything() );
 
 		// Render is supposed to be wrapped in an act call. How do I wait for
 		// testEmbedUrl promise to resolve to check that the appropriate
@@ -134,7 +140,7 @@ describe( 'CalendlyEdit', () => {
 			userEvent.type( screen.getByRole( 'textbox' ), 'https://calendly.com/valid-url' );
 			userEvent.click( screen.getByRole( 'button', { name: 'Embed' } ) );
 
-			expect( testEmbedUrl ).toHaveBeenCalledTimes( 1 );
+			expect( testEmbedUrl ).toHaveBeenCalledWith( 'https://calendly.com/valid-url', expect.anything() );
 		} );
 	} );
 
@@ -154,12 +160,11 @@ describe( 'CalendlyEdit', () => {
 		expect( iframe.previousElementSibling ).toHaveClass( 'wp-block-jetpack-calendly-overlay' );
 	} );
 
-	test.skip( 'renders button preview when link style selected', () => {
-		//
+	test( 'renders button preview when link style selected', () => {
 		const attributes = { ...defaultAttributes, style: 'link' };
 		render( <CalendlyEdit { ...{ ...defaultProps, attributes } } /> );
 
-		expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Mocked button' } ) ).toBeInTheDocument();
 	} );
 
 	test.skip( 'displays placeholder when no url', () => {

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/edit.js
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import testEmbedUrl from '../../../shared/test-embed-url';
+import CalendlyEdit from '../edit';
+
+jest.mock(
+	'../../../shared/test-embed-url',
+	() => ( {
+		__esModule: true,
+		default: jest.fn().mockImplementation( ( url ) => {
+			return new Promise( ( resolve, reject ) => {
+				url === 'https://calendly.com/invalid-url' ? reject() : resolve( url );
+			} );
+		} )
+	} )
+);
+
+describe( 'CalendlyEdit', () => {
+	const defaultAttributes = {
+		backgroundColor: '#ffffff',
+		hideEventTypeDetails: false,
+		primaryColor: '#7d7d7d',
+		textColor: '#000000',
+		style: 'inline',
+		url: 'https://calendly.com/username',
+	};
+
+	const createErrorNotice = jest.fn();
+	const removeAllNotices = jest.fn();
+	const setAttributes = jest.fn();
+
+	const defaultProps = {
+		attributes: defaultAttributes,
+		setAttributes,
+		className: '',
+		clientId: 1,
+		name: 'jetpack/calendly',
+		noticeOperations: {
+			removeAllNotices,
+			createErrorNotice,
+		},
+	};
+
+	const propsWithoutUrl = {
+		...defaultProps,
+		attributes: {
+			...defaultAttributes,
+			url: undefined,
+		},
+	};
+
+	beforeEach( () => {
+		createErrorNotice.mockClear();
+		removeAllNotices.mockClear();
+		setAttributes.mockClear();
+	} );
+
+	test( 'validates block attributes', () => {
+		const attributes = { ...defaultAttributes, invalid: true };
+
+		render( <CalendlyEdit { ...{ ...defaultProps, attributes } } /> );
+
+		expect( setAttributes ).toHaveBeenCalledWith( defaultAttributes );
+	} );
+
+	test.skip( 'set undefined url and displays error when invalid url supplied', async () => {
+		const attributes = { ...defaultAttributes, url: 'https://calendly.com/invalid-url' };
+		render( <CalendlyEdit { ...{ ...defaultProps, attributes } } /> );
+
+		expect( testEmbedUrl ).toHaveBeenCalledTimes( 1 );
+
+		// Render is supposed to be wrapped in an act call. How do I wait for
+		// testEmbedUrl promise to resolve to check that the appropriate
+		// error notice functions were called and url attribute cleared?
+
+		expect( setAttributes ).toHaveBeenCalledWith( { url: undefined } );
+		expect( removeAllNotices ).toHaveBeenCalled();
+		expect( createErrorNotice ).toHaveBeenCalled();
+	} );
+
+	describe( 'parseEmbedCode', () => {
+		test( 'displays error notice when empty embed url submitted', () => {
+			render( <CalendlyEdit { ...propsWithoutUrl } /> );
+
+			userEvent.click( screen.getByRole( 'button', { name: 'Embed' } ) );
+
+			expect( removeAllNotices ).toHaveBeenCalled();
+			expect( createErrorNotice ).toHaveBeenCalled();
+		} );
+
+		test.skip( 'displays error notice when updated embed code fails to parse', () => {
+			render( <CalendlyEdit { ...propsWithoutUrl } /> );
+
+			// I'm getting something wrong here as well. I get a passing test
+			// although there is a warning/error printed stating a component is
+			// changing an uncontrolled input to a controlled input.
+
+			// fireEvent.change( screen.getByRole( 'textbox' ), { target: { value: 'invalid-url' } } );
+			// userEvent.type( screen.getByPlaceholderText( 'Calendly web address or embed code…' ), 'invalid-url' );
+			// screen.getByRole( 'textbox' ).value = 'invalid-url';
+			userEvent.type( screen.getByRole( 'textbox' ), 'invalid-url' );
+			userEvent.click( screen.getByRole( 'button', { name: 'Embed' } ) );
+
+			expect( removeAllNotices ).toHaveBeenCalled();
+			expect( createErrorNotice ).toHaveBeenCalled();
+		} );
+
+		test.skip( 'updates inner button block when new link embed code parsed', () => {
+			// TODO: Work out how to test this dispatched action.
+		} );
+
+		test.skip( 'parsed embed code is tested before updating attributes', () => {
+			render( <CalendlyEdit { ...propsWithoutUrl } /> );
+
+			// Same uncontrolled to controlled input issue.
+			// In addition parseEmbedCode sets state and should be wrapped in a
+			// call to act(). Not sure how to approach this.
+
+			// fireEvent.change( screen.getByRole( 'textbox' ), { target: { value: 'invalid-url' } } );
+			// userEvent.type( screen.getByPlaceholderText( 'Calendly web address or embed code…' ), 'invalid-url' );
+			// screen.getByRole( 'textbox' ).value = 'invalid-url';
+			userEvent.type( screen.getByRole( 'textbox' ), 'https://calendly.com/valid-url' );
+			userEvent.click( screen.getByRole( 'button', { name: 'Embed' } ) );
+
+			expect( testEmbedUrl ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	test.skip( 'displays a spinner while the block is embedding', () => {
+		// When internal state is set to resolving url, spinner should be shown.
+		// The setter for this internal state is passed to `testEmbedUrl`
+		// where it is set to true until the promise is resolved.
+	} );
+
+	test( 'renders inline preview with iframe component', () => {
+		render( <CalendlyEdit { ...defaultProps } /> );
+
+		const iframe = screen.getByTitle( 'Calendly' );
+
+		expect( iframe ).toBeInTheDocument();
+		expect( iframe.parentElement ).toHaveClass( 'calendly-style-inline' );
+		expect( iframe.previousElementSibling ).toHaveClass( 'wp-block-jetpack-calendly-overlay' );
+	} );
+
+	test.skip( 'renders button preview when link style selected', () => {
+		//
+		const attributes = { ...defaultAttributes, style: 'link' };
+		render( <CalendlyEdit { ...{ ...defaultProps, attributes } } /> );
+
+		expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
+	} );
+
+	test.skip( 'displays placeholder when no url', () => {
+		render( <CalendlyEdit { ...propsWithoutUrl } /> );
+
+		expect( screen.getByText( 'Calendly' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Enter your Calendly web address or embed code below.' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'Calendly web address or embed code…' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Embed' ) ).toBeInTheDocument();
+
+		const link = screen.getByText( 'Need help finding your embed code?' );
+
+		expect( link ).toBeInTheDocument();
+		expect( link.parentElement ).toHaveClass( 'wp-block-jetpack-calendly-learn-more' );
+	} );
+
+	test.skip( 'displays placeholder when url present but it is being edited', () => {
+		render( <CalendlyEdit { ...defaultProps } /> );
+
+		// How do I update state in a non-frowned upon way? Should I even test this?
+		// I'd like to because the state will alter how this behaves for the user.
+		// Without rendering the block toolbar controls don't think I could
+		// simulate via actions made by a user.
+		expect( screen.getByText( 'Enter your Calendly web address or embed code below.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly.html
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/calendly {"url":"https://calendly.com/username"} -->
+<div class="wp-block-jetpack-calendly"></div>
+<!-- /wp:jetpack/calendly -->

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly.json
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly.json
@@ -1,0 +1,17 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/calendly",
+        "isValid": true,
+        "attributes": {
+            "backgroundColor": "ffffff",
+            "hideEventTypeDetails": false,
+            "primaryColor": "00A2FF",
+            "textColor": "4D5055",
+            "style": "inline",
+            "url": "https://calendly.com/username"
+        },
+        "innerBlocks": [],
+        "originalContent": "<div class=\"wp-block-jetpack-calendly\"></div>"
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly.parsed.json
@@ -1,0 +1,13 @@
+[
+    {
+        "blockName": "jetpack/calendly",
+        "attrs": {
+            "url": "https://calendly.com/username"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<div class=\"wp-block-jetpack-calendly\"></div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-jetpack-calendly\"></div>\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/calendly {"url":"https://calendly.com/username"} -->
+<div class="wp-block-jetpack-calendly"></div>
+<!-- /wp:jetpack/calendly -->

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__deprecated-1.html
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__deprecated-1.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/calendly {"submitButtonBackgroundColor":"212020","hideEventTypeDetails":true,"primaryColor":"19ff00","submitButtonTextColor":"801249","style":"link","url":"https://calendly.com/username"} -->
+<a href="https://calendly.com/username" class="wp-block-jetpack-calendly">https://calendly.com/username</a>
+<!-- /wp:jetpack/calendly -->

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__deprecated-1.json
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__deprecated-1.json
@@ -1,0 +1,33 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/calendly",
+        "isValid": true,
+        "attributes": {
+            "backgroundColor": "ffffff",
+            "hideEventTypeDetails": true,
+            "primaryColor": "19ff00",
+            "textColor": "4D5055",
+            "style": "link",
+            "url": "https://calendly.com/username"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "jetpack/button",
+                "isValid": true,
+                "attributes": {
+                    "element": "a",
+                    "saveInPostContent": false,
+                    "uniqueId": "calendly-widget-id",
+                    "text": "Schedule time with me",
+                    "url": "https://calendly.com/username",
+                    "textColor": "801249",
+                    "backgroundColor": "212020"
+                },
+                "innerBlocks": []
+            }
+        ],
+        "originalContent": "<a href=\"https://calendly.com/username\" class=\"wp-block-jetpack-calendly\">https://calendly.com/username</a>"
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__deprecated-1.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__deprecated-1.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "jetpack/calendly",
+        "attrs": {
+            "submitButtonBackgroundColor": "212020",
+            "hideEventTypeDetails": true,
+            "primaryColor": "19ff00",
+            "submitButtonTextColor": "801249",
+            "style": "link",
+            "url": "https://calendly.com/username"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<a href=\"https://calendly.com/username\" class=\"wp-block-jetpack-calendly\">https://calendly.com/username</a>\n",
+        "innerContent": [
+            "\n<a href=\"https://calendly.com/username\" class=\"wp-block-jetpack-calendly\">https://calendly.com/username</a>\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__deprecated-1.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__deprecated-1.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/calendly {"hideEventTypeDetails":true,"primaryColor":"19ff00","style":"link","url":"https://calendly.com/username"} -->
+<div class="wp-block-jetpack-calendly"><!-- wp:jetpack/button {"element":"a","uniqueId":"calendly-widget-id","text":"Schedule time with me","url":"https://calendly.com/username","textColor":"801249","backgroundColor":"212020"} /--></div>
+<!-- /wp:jetpack/calendly -->

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__link.html
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__link.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/calendly {"style":"link","url":"https://calendly.com/username"} -->
+<div class="wp-block-jetpack-calendly"><!-- wp:jetpack/button {"element":"a","uniqueId":"calendly-widget-id","passthroughAttributes":{"url":"url"},"text":"Schedule time with me","url":"https://calendly.com/username"} /--></div>
+<!-- /wp:jetpack/calendly -->

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__link.json
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__link.json
@@ -1,0 +1,35 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "jetpack/calendly",
+        "isValid": true,
+        "attributes": {
+            "backgroundColor": "ffffff",
+            "hideEventTypeDetails": false,
+            "primaryColor": "00A2FF",
+            "textColor": "4D5055",
+            "style": "link",
+            "url": "https://calendly.com/username"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "jetpack/button",
+                "isValid": true,
+                "attributes": {
+                    "element": "a",
+                    "saveInPostContent": false,
+                    "uniqueId": "calendly-widget-id",
+                    "passthroughAttributes": {
+                        "url": "url"
+                    },
+                    "text": "Schedule time with me",
+                    "url": "https://calendly.com/username"
+                },
+                "innerBlocks": [],
+                "originalContent": ""
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-jetpack-calendly\"></div>"
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__link.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__link.parsed.json
@@ -1,0 +1,32 @@
+[
+    {
+        "blockName": "jetpack/calendly",
+        "attrs": {
+            "style": "link",
+            "url": "https://calendly.com/username"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "jetpack/button",
+                "attrs": {
+                    "element": "a",
+                    "uniqueId": "calendly-widget-id",
+                    "passthroughAttributes": {
+                        "url": "url"
+                    },
+                    "text": "Schedule time with me",
+                    "url": "https://calendly.com/username"
+                },
+                "innerBlocks": [],
+                "innerHTML": "",
+                "innerContent": []
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-jetpack-calendly\"></div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-jetpack-calendly\">",
+            null,
+            "</div>\n"
+        ]
+    }
+]

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__link.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/fixtures/jetpack__calendly__link.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:jetpack/calendly {"style":"link","url":"https://calendly.com/username"} -->
+<div class="wp-block-jetpack-calendly"><!-- wp:jetpack/button {"element":"a","uniqueId":"calendly-widget-id","passthroughAttributes":{"url":"url"},"text":"Schedule time with me","url":"https://calendly.com/username"} /--></div>
+<!-- /wp:jetpack/calendly -->

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/validate.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import runBlockFixtureTests from '../../../shared/test/block-fixtures';
+import { name, settings } from '../';
+import { settings as buttonSettings } from '../../button';
+
+const primaryBlock = { name: `jetpack/${ name }`, settings };
+const innerBlocks = [
+	{ name: 'jetpack/button', settings: buttonSettings },
+];
+
+runBlockFixtureTests( `jetpack/${ name }`, [ primaryBlock, ...innerBlocks ], __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/calendly/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/utils.js
@@ -11,7 +11,7 @@ export const getURLFromEmbedCode = embedCode => {
 };
 
 export const getTextFromEmbedCode = embedCode => {
-	let text = embedCode.match( /false;"\>([^<]+)\<\// );
+	let text = embedCode.match( /false;">([^<]+)<\// );
 	if ( text ) {
 		return text[ 1 ];
 	}

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -104,8 +104,6 @@
 	"projects/plugins/jetpack/_inc/lib/debugger/jetpack-debugger-site-health.js",
 	"projects/plugins/jetpack/_inc/polldaddy-shortcode.js",
 	"projects/plugins/jetpack/_inc/twitter-timeline.js",
-	"projects/plugins/jetpack/extensions/blocks/calendly/save.js",
-	"projects/plugins/jetpack/extensions/blocks/calendly/utils.js",
 	"projects/plugins/jetpack/extensions/blocks/contact-form/attributes.js",
 	"projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings-creativemail.js",
 	"projects/plugins/jetpack/extensions/blocks/donations/edit.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds block tests and fixtures to the Calendly block
* Extracts the block controls from the Edit component to ease testing

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No change.

#### Testing instructions:
1. Checkout this PR
2. Run `cd projects/plugins/jetpack && yarn jest extensions/blocks/calendly/test/`
3. Test the Calendly block still functions with the post editor and frontend. In particular test the block's controls.
