### PR TITLE
E2E tests: Bump wordpress/env to 4.0.0

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-e2e-wp-env-bump
+++ b/projects/plugins/jetpack/changelog/fix-e2e-wp-env-bump
@@ -1,0 +1,2 @@
+Significance: patch
+Type: compat

--- a/projects/plugins/jetpack/tests/e2e/.wp-env.json
+++ b/projects/plugins/jetpack/tests/e2e/.wp-env.json
@@ -1,5 +1,4 @@
 {
-  	"core": null,
 	"plugins": [ "./plugins/e2e-plan-data-interceptor.php" ],
 	"config": {
 		"WP_DEBUG": true,

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -26,7 +26,7 @@
 		"@babel/core": "7.12.10",
 		"@babel/preset-env": "7.12.11",
 		"@slack/web-api": "6.0.0",
-		"@wordpress/env": "https://gitpkg.now.sh/WordPress/gutenberg/packages/env?trunk",
+		"@wordpress/env": "4.0.0",
 		"@wordpress/eslint-plugin": "8.0.2",
 		"axios": "0.21.1",
 		"babel-jest": "26.6.3",

--- a/projects/plugins/jetpack/tests/e2e/yarn.lock
+++ b/projects/plugins/jetpack/tests/e2e/yarn.lock
@@ -1367,9 +1367,10 @@
     "@typescript-eslint/types" "4.15.0"
     eslint-visitor-keys "^2.0.0"
 
-"@wordpress/env@https://gitpkg.now.sh/WordPress/gutenberg/packages/env?trunk":
-  version "3.0.2"
-  resolved "https://gitpkg.now.sh/WordPress/gutenberg/packages/env?trunk#c003113da504453ac58bc354def593b486c5b0b3"
+"@wordpress/env@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/env/-/env-4.0.0.tgz#2bba5daeba3d1955ffe8304a70c23ec513e2b37d"
+  integrity sha512-e/86uoT15PigMGEOyblLQX1/CzR+ruNxuzy6iCTFmcw0VllNHFJteOWJjd9MVo8AhhDg89KK2sTQ8GmM3lXSLw==
   dependencies:
     chalk "^4.0.0"
     copy-dir "^1.3.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Bumps wordpress/env version to 4.0.0. This should fix the env database connection issue.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:

```
yarn install
yarn wp-env destroy
yarn wp-env start
```
WP env should start successfully.