### PR TITLE
rest-api: Handle FB DTP metadata

### DIFF
--- a/projects/packages/sync/changelog/fusion-sync-yoavf-r222889-wpcom-1615978885
+++ b/projects/packages/sync/changelog/fusion-sync-yoavf-r222889-wpcom-1615978885
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Sync: add docblock to document filter usage.
+
+

--- a/projects/packages/sync/src/class-functions.php
+++ b/projects/packages/sync/src/class-functions.php
@@ -256,7 +256,17 @@ class Functions {
 	 * @return array Array of allowed metadata.
 	 */
 	public static function rest_api_allowed_public_metadata() {
-		/** This filter is documented in json-endpoints/class.wpcom-json-api-post-endpoint.php */
+		/**
+		 * Filters the meta keys accessible by the REST API.
+		 *
+		 * @see https://developer.wordpress.com/2013/04/26/custom-post-type-and-metadata-support-in-the-rest-api/
+		 *
+		 * @module json-api
+		 *
+		 * @since 2.2.3
+		 *
+		 * @param array $whitelisted_meta Array of metadata that is accessible by the REST API.
+		 */
 		return apply_filters( 'rest_api_allowed_public_metadata', array() );
 	}
 

--- a/projects/plugins/jetpack/changelog/fusion-sync-yoavf-r222889-wpcom-1615978885
+++ b/projects/plugins/jetpack/changelog/fusion-sync-yoavf-r222889-wpcom-1615978885
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+WordPress.com REST API: allow Facebook Metadata to be saved alongside posts created via the API.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -507,6 +507,10 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			$media_id_string = join( ',', array_filter( array_map( 'absint', $media_results['media_ids'] ) ) );
 		}
 
+		if ( in_array( '_dtp_fb', wp_list_pluck( $metadata, 'key' ), true ) ) {
+			add_filter( 'rest_api_allowed_public_metadata', array( $this, 'dtp_fb_allowed_metadata' ) );
+		}
+
 		if ( $new ) {
 			if ( isset( $input['content'] ) && ! has_shortcode( $input['content'], 'gallery' ) && ( $has_media || $has_media_by_url ) ) {
 				switch ( ( $has_media + $has_media_by_url ) ) {
@@ -885,5 +889,17 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		}
 
 		return ! empty( $type ) && ! in_array( $type, array( 'post', 'revision' ) );
+	}
+
+	/**
+	 * Filter for rest_api_allowed_public_metadata.
+	 * Adds FB's DTP specific metadata.
+	 *
+	 * @param array $keys
+	 *
+	 * @return array
+	 */
+	public function dtp_fb_allowed_metadata( $keys ) {
+		return array_merge( $keys, array( '_dtp_fb', '_dtp_fb_geo_points' ) );
 	}
 }

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -895,7 +895,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 	 * Filter for rest_api_allowed_public_metadata.
 	 * Adds FB's DTP specific metadata.
 	 *
-	 * @param array $keys
+	 * @param array $keys Array of metadata that is accessible by the REST API.
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
Differential Revision: D58776-code

This commit syncs r222889-wpcom.

#### Changes proposed in this Pull Request:
* If the `_dtp_fb` metadata is present, add a filter for allowed post metadata on create/save post API endpoint.


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
See D58776-code
