### PR TITLE
Calypsoify: Fix use_block_editor_for_post_type undefined error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-calypsoify-undefined-function
+++ b/projects/plugins/jetpack/changelog/fix-calypsoify-undefined-function
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Calypsoify: Move all initialisation to the admin_init hook

--- a/projects/plugins/jetpack/modules/calypsoify/class-jetpack-calypsoify.php
+++ b/projects/plugins/jetpack/modules/calypsoify/class-jetpack-calypsoify.php
@@ -30,7 +30,7 @@ class Jetpack_Calypsoify {
 	 * Jetpack_Calypsoify constructor.
 	 */
 	private function __construct() {
-		add_action( 'wp_loaded', array( $this, 'setup' ) );
+		add_action( 'admin_init', array( $this, 'setup' ), 4 );
 	}
 
 	/**
@@ -66,7 +66,7 @@ class Jetpack_Calypsoify {
 	public function setup() {
 		$this->is_calypsoify_enabled = isset( $_GET['calypsoify'] ) && 1 === (int) $_GET['calypsoify'] && $this->is_page_gutenberg(); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		add_action( 'admin_init', array( $this, 'check_meta' ), 4 );
+		$this->check_meta();
 
 		if ( $this->is_calypsoify_enabled ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_for_gutenberg' ), 100 );


### PR DESCRIPTION
In #17826 I added the check for whether to load the block editor in the
initial setup function, which gets called during `wp_loaded`. If the
editor was being loaded for a post type other than a 'post' then a call
was made to `use_block_editor_for_post_type`, which wasn't yet
available.


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This change moves all the setup and initialisation to the `admin_init`
hook, which is late enough for the file with this function to have been
included. It seems there are no checks for `is_calypsoified_enabled`
between these two points in the life cycle, so this should be safe.

#### Jetpack product discussion
This is a bug fix

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Add a new page to your Jetpack site from Calypso. This will add the `calypsoify=1&post_type=page` parameters to the request
* Without this PR you will get an error, which is a PHP error saying that `use_block_editor_for_post_type` is undefined
* With this PR the editor should load as expected
