### PR TITLE
Gardening: provide feedback in comments about failing checks

### DIFF
--- a/.github/actions/repo-gardening/src/index.js
+++ b/.github/actions/repo-gardening/src/index.js
@@ -12,6 +12,7 @@ const addMilestone = require( './tasks/add-milestone' );
 const addLabels = require( './tasks/add-labels' );
 const checkDescription = require( './tasks/check-description' );
 const wpcomCommitReminder = require( './tasks/wpcom-commit-reminder' );
+const checkTests = require( './tasks/check-tests' );
 const debug = require( './debug' );
 const ifNotFork = require( './if-not-fork' );
 const ifNotClosed = require( './if-not-closed' );
@@ -39,6 +40,11 @@ const automations = [
 	{
 		event: 'push',
 		task: wpcomCommitReminder,
+	},
+	{
+		event: 'check_suite',
+		action: [ 'completed' ],
+		task: checkTests,
 	},
 ];
 

--- a/.github/actions/repo-gardening/src/tasks/check-tests/index.js
+++ b/.github/actions/repo-gardening/src/tasks/check-tests/index.js
@@ -1,0 +1,75 @@
+/**
+ * Internal dependencies
+ */
+const debug = require( '../../debug' );
+const getLabels = require( '../../get-labels' );
+
+/* global GitHub, WebhookPayload */
+
+/**
+ * Check for a Needs review status label on a PR.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - PR number.
+ *
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasStatusLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're only interested in the Needs Team Review and Needs Review labels.
+	return !! labels.find( label => label.match( /^\[Status\]\sNeeds(\sTeam)?\sReview$/ ) );
+}
+
+/**
+ * Checks the contents of a PR description.
+ *
+ * @param {WebhookPayload} payload - Check Suite event payload.
+ * @param {GitHub}         octokit - Initialized Octokit REST client.
+ */
+async function checkTests( payload, octokit ) {
+	const { pull_requests, conclusion, id, repository } = payload;
+	const { name: repo, owner } = repository;
+	const ownerLogin = owner.login;
+
+	// Only examine checks that run against pull requests.
+	if ( ! pull_requests || pull_requests.length === 0 ) {
+		debug( 'check-tests: check suite is not for a PR. Aborting' );
+		return;
+	}
+
+	// If the test succeeed, we're not interested in it. It means all is well.
+	if ( conclusion === 'success' ) {
+		debug( `check-tests: test ${ id } succeeeded. All good. Aborting` );
+	}
+
+	debug( `check-tests: the ${ id } test's conclusion was ${ conclusion }` );
+
+	// Get associated PR number for that run.
+	const number = pull_requests[ 0 ].number;
+
+	// Check if the PR was labeled as needing a review.
+	const isLabeled = await hasStatusLabel( octokit, ownerLogin, repo, number );
+
+	if ( ! isLabeled ) {
+		debug(
+			`check-tests: the PR ${ number } has some failing tests, but it hasn't been labeled for review yet. Aborting.`
+		);
+	}
+
+	debug(
+		`check-tests: the PR ${ number } has at least one failing test, and it's been labeled for review. Comment.`
+	);
+
+	const comment = `You should check the checks.`;
+
+	await octokit.issues.createComment( {
+		owner: ownerLogin,
+		repo,
+		issue_number: +number,
+		body: comment,
+	} );
+}
+
+module.exports = checkTests;

--- a/.github/actions/repo-gardening/src/tasks/check-tests/readme.md
+++ b/.github/actions/repo-gardening/src/tasks/check-tests/readme.md
@@ -1,0 +1,7 @@
+# Check Tests
+
+Provide feedback to PR authors if they've marked a PR as ready for review while some of the checks on the PR are failing.
+
+## Rationale
+
+Before one asks for a review on their PR, that PR should be ready to be reviewed, free of errors that can be detected by our automated test suite. Since checks can take a little while to complete, it can take a few minutes before tests report some problems on a PR you've been working on. At this point, a comment on the PR can be a useful reminder to come back to look at your PR since it's not quite ready for a review yet.

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master # Every time a PR is merged to master.
+  check_suite: # When a check suite has completed.
+    types: [completed]
 
 jobs:
   # review-crew-afk:


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR aims to provide more feedback to PR authors, and remind them to check why a check may be failing before they mark a PR as ready for review.

To do so, we'll do 2 things:
﻿- Listen for completed check runs in our Gardening action.
- If a completed check has not succeeded, and if the PR was marked for review, comment.

**To Do**

- See if we can only care for required checks.
- See if we can give as much information as possible about the failing checks right there in the comment.
- Should we update the status label to Needs Author Reply?

**References**

- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#check_suite
- https://github.com/Automattic/jetpack/actions?query=event%3Acheck_suite

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* TBD
