### PR TITLE
Search: Auto-open/close modal in Customizer -> Jetpack Search

### DIFF
--- a/projects/plugins/jetpack/changelog/update-search-customizer-autospawn
+++ b/projects/plugins/jetpack/changelog/update-search-customizer-autospawn
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: Auto-spawn modal while in Search section of the Customizer

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -38,8 +38,8 @@ class Jetpack_Search_Customize {
 	 * @param WP_Customize_Manager $wp_customize Customizer instance.
 	 */
 	public function customize_register( $wp_customize ) {
-		require_once __DIR__ . '/customize-controls/class-label-control.php';
-		require_once __DIR__ . '/customize-controls/class-excluded-post-types-control.php';
+		require_once dirname( JETPACK__PLUGIN_FILE ) . '/modules/search/customize-controls/class-label-control.php';
+		require_once dirname( JETPACK__PLUGIN_FILE ) . '/modules/search/customize-controls/class-excluded-post-types-control.php';
 		$section_id     = 'jetpack_search';
 		$setting_prefix = Jetpack_Search_Options::OPTION_PREFIX;
 

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -27,6 +27,7 @@ class Jetpack_Search_Customize {
 	 */
 	public function __construct() {
 		add_action( 'customize_register', array( $this, 'customize_register' ) );
+		add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_controls_enqueue_scripts' ) );
 	}
 
 	/**
@@ -261,5 +262,22 @@ class Jetpack_Search_Customize {
 			)
 		);
 	}
-}
 
+	/**
+	 * Enqueue assets for Customizer controls.
+	 *
+	 * @since 9.6.0
+	 */
+	public function customize_controls_enqueue_scripts() {
+		$script_relative_path = 'modules/search/customize-controls/customize-controls.js';
+		$script_version       = Jetpack_Search_Helpers::get_asset_version( $script_relative_path );
+		$script_path          = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
+		wp_enqueue_script(
+			'jetpack-instant-search-customizer',
+			$script_path,
+			array( 'customize-controls' ),
+			$script_version,
+			true
+		);
+	}
+}

--- a/projects/plugins/jetpack/modules/search/customize-controls/class-excluded-post-types-control.php
+++ b/projects/plugins/jetpack/modules/search/customize-controls/class-excluded-post-types-control.php
@@ -26,12 +26,12 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 		$style_relative_path = 'modules/search/customize-controls/class-excluded-post-types-control.css';
 		$style_version       = Jetpack_Search_Helpers::get_asset_version( $style_relative_path );
 		$style_path          = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
-		wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
+		wp_enqueue_style( 'jetpack-instant-search-customizer-excluded-post-types', $style_path, array(), $style_version );
 
 		$script_relative_path = 'modules/search/customize-controls/class-excluded-post-types-control.js';
 		$script_version       = Jetpack_Search_Helpers::get_asset_version( $script_relative_path );
 		$script_path          = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
-		wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
+		wp_enqueue_script( 'jetpack-instant-search-customizer-excluded-post-types', $script_path, array(), $script_version, true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/search/customize-controls/class-excluded-post-types-control.php
+++ b/projects/plugins/jetpack/modules/search/customize-controls/class-excluded-post-types-control.php
@@ -31,7 +31,7 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 		$script_relative_path = 'modules/search/customize-controls/class-excluded-post-types-control.js';
 		$script_version       = Jetpack_Search_Helpers::get_asset_version( $script_relative_path );
 		$script_path          = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
-		wp_enqueue_script( 'jetpack-instant-search-customizer-excluded-post-types', $script_path, array(), $script_version, true );
+		wp_enqueue_script( 'jetpack-instant-search-customizer-excluded-post-types', $script_path, array( 'customize-controls' ), $script_version, true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/search/customize-controls/class-label-control.php
+++ b/projects/plugins/jetpack/modules/search/customize-controls/class-label-control.php
@@ -18,7 +18,7 @@ class Label_Control extends WP_Customize_Control {
 		$style_relative_path = 'modules/search/customize-controls/class-label-control.css';
 		$style_version       = Jetpack_Search_Helpers::get_asset_version( $style_relative_path );
 		$style_path          = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
-		wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
+		wp_enqueue_style( 'jetpack-instant-search-customizer-label', $style_path, array(), $style_version );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/search/customize-controls/class-label-control.php
+++ b/projects/plugins/jetpack/modules/search/customize-controls/class-label-control.php
@@ -18,7 +18,7 @@ class Label_Control extends WP_Customize_Control {
 		$style_relative_path = 'modules/search/customize-controls/class-label-control.css';
 		$style_version       = Jetpack_Search_Helpers::get_asset_version( $style_relative_path );
 		$style_path          = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
-		wp_enqueue_style( 'jetpack-instant-search-customizer-label', $style_path, array(), $style_version );
+		wp_enqueue_style( 'jetpack-instant-search-customizer-label', $style_path, array( 'customize-controls' ), $style_version );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/search/customize-controls/customize-controls.js
+++ b/projects/plugins/jetpack/modules/search/customize-controls/customize-controls.js
@@ -7,7 +7,7 @@ function postSectionMessage( expanded ) {
 	// window.wp.customize.previewer.preview is not available until both customize and customize.previewer are ready.
 	window.wp.customize.previewer.preview
 		.targetWindow()
-		.postMessage( { key: 'jetpackSearchSectionOpen', expanded } );
+		.postMessage( { key: 'jetpackSearchSectionOpen', expanded: expanded } ); // Assume ES5 envorinment.
 }
 
 /**

--- a/projects/plugins/jetpack/modules/search/customize-controls/customize-controls.js
+++ b/projects/plugins/jetpack/modules/search/customize-controls/customize-controls.js
@@ -1,0 +1,32 @@
+/**
+ * Binds iframe messages from the Customizer to SearchApp.
+ *
+ * @param {boolean} expanded - whether jetpack_search section is expanded and visible.
+ */
+function postSectionMessage( expanded ) {
+	// window.wp.customize.previewer.preview is not available until both customize and customize.previewer are ready.
+	window.wp.customize.previewer.preview
+		.targetWindow()
+		.postMessage( { key: 'jetpackSearchSectionOpen', expanded } );
+}
+
+/**
+ * Adds functionality for Jetpack Search section detection in the Customizer.
+ */
+function init() {
+	window.wp.customize.bind( 'ready', function () {
+		window.wp.customize.previewer.bind( 'ready', function () {
+			postSectionMessage( window.wp.customize.section( 'jetpack_search' ).expanded() );
+			window.wp.customize.section( 'jetpack_search' ).expanded.bind( postSectionMessage );
+			window.wp.customize.state( 'processing' ).bind( function () {
+				postSectionMessage( window.wp.customize.section( 'jetpack_search' ).expanded() );
+			} );
+		} );
+	} );
+}
+
+if ( document.readyState !== 'loading' ) {
+	init();
+} else {
+	document.addEventListener( 'DOMContentLoaded', init );
+}

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -87,7 +87,7 @@ class SearchApp extends Component {
 
 	addEventListeners() {
 		bindCustomizerChanges( this.handleOverlayOptionsUpdate );
-		bindCustomizerMessages( this.showResults );
+		bindCustomizerMessages( this.toggleResults );
 
 		window.addEventListener( 'popstate', this.handleHistoryNavigation );
 
@@ -239,6 +239,12 @@ class SearchApp extends Component {
 			},
 			isHistoryNav
 		);
+	};
+
+	toggleResults = showResults => {
+		this.setState( { showResults }, () => {
+			showResults ? this.preventBodyScroll() : this.restoreBodyScroll();
+		} );
 	};
 
 	onChangeQueryString = isHistoryNav => {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -38,7 +38,7 @@ import {
 	isHistoryNavigation,
 	isLoading,
 } from '../store/selectors';
-import { bindCustomizerChanges, isInCustomizer } from '../lib/customize';
+import { bindCustomizerChanges, bindCustomizerMessages, isInCustomizer } from '../lib/customize';
 import './search-app.scss';
 
 class SearchApp extends Component {
@@ -87,6 +87,7 @@ class SearchApp extends Component {
 
 	addEventListeners() {
 		bindCustomizerChanges( this.handleOverlayOptionsUpdate );
+		bindCustomizerMessages( this.showResults );
 
 		window.addEventListener( 'popstate', this.handleHistoryNavigation );
 

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/customize.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/customize.js
@@ -39,8 +39,8 @@ export function bindCustomizerMessages( callback ) {
 		if ( event.target !== window || event.data?.key !== 'jetpackSearchSectionOpen' ) {
 			return;
 		}
-		if ( event.data.expanded === true ) {
-			callback();
+		if ( 'expanded' in event.data ) {
+			callback( event.data.expanded );
 		}
 	} );
 }

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/customize.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/customize.js
@@ -13,10 +13,43 @@ const SETTINGS_TO_STATE_MAP = new Map( [
 	[ 'jetpack_search_result_format', 'resultFormat' ],
 ] );
 
+/**
+ * Detects if the current environment is within WP's Customizer.
+ *
+ * @returns {boolean} is in customizer.
+ */
 export function isInCustomizer() {
 	return typeof window?.wp?.customize === 'function';
 }
 
+/**
+ * Binds iframe messages from the Customizer to SearchApp.
+ *
+ * @param {Function} callback - function to be invoked following Jetpack Search panel expansion.
+ */
+export function bindCustomizerMessages( callback ) {
+	if ( ! isInCustomizer() ) {
+		return;
+	}
+
+	window.addEventListener( 'message', event => {
+		if ( ! event.data ) {
+			return;
+		}
+		if ( event.target !== window || event.data?.key !== 'jetpackSearchSectionOpen' ) {
+			return;
+		}
+		if ( event.data.expanded === true ) {
+			callback();
+		}
+	} );
+}
+
+/**
+ * Binds changes to Customizer controls to SearchApp state.
+ *
+ * @param {Function} callback - function to be invoked following Customizer changes.
+ */
 export function bindCustomizerChanges( callback ) {
 	if ( ! isInCustomizer() ) {
 		return;

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -191,7 +191,6 @@
 	"projects/plugins/jetpack/modules/search/instant-search/lib/api.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/array-overlap.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/colors.js",
-	"projects/plugins/jetpack/modules/search/instant-search/lib/customize.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/dom.js",
 	"projects/plugins/jetpack/modules/search/instant-search/lib/tracks.js",
 	"projects/plugins/jetpack/modules/shortcodes/js/jmpress.js",


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/50979.

#### Changes proposed in this Pull Request:
The Jetpack Search interface will automatically be summoned when the Jetpack Search section of the Customizer is open.

* Adds a message event emitter within the Customizer to indicate when the Jetpack Search section is opened/closed.
* Adds a message event handler within the search application to automatically opens/closes the interface when the Jetpack Search section is open in the Customizer.
* Fixes incorrectly named script handles and dependencies for custom Customizer controls for Jetpack Search.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Navigate to the Jetpack Search section of the WordPress Customizer.
* Ensure that the Jetpack Search interface opens automatically in the Customizer preview.
* Try changing various Jetpack Search settings; some will live-update the interface, others will refresh the Customizer preview.
* Ensure that the Jetpack Search interface opens automatically following a Customizer preview refresh.
