### PR TITLE
tools: Fix js-package handling in find-project-deps.php

### DIFF
--- a/tools/find-project-deps.php
+++ b/tools/find-project-deps.php
@@ -28,18 +28,30 @@ function get_dependencies() {
 	// Collect package name→slug mappings.
 	$package_map = array();
 	foreach ( glob( "$base/projects/packages/*/composer.json" ) as $file ) {
+		$slug = substr( $file, $l + 10, -14 );
+		if ( ! isset( $output[ $slug ] ) ) {
+			// Not an actual project (should never happen here, but...).
+			continue;
+		}
+
 		$json = json_decode( file_get_contents( $file ), true );
 		if ( isset( $json['name'] ) ) {
-			$package_map[ $json['name'] ] = substr( $file, $l + 10, -14 );
+			$package_map[ $json['name'] ] = $slug;
 		}
 	}
 
 	// Collect js-package name→slug mappings.
 	$js_package_map = array();
 	foreach ( glob( "$base/projects/js-packages/*/package.json" ) as $file ) {
+		$slug = substr( $file, $l + 10, -13 );
+		if ( ! isset( $output[ $slug ] ) ) {
+			// Not an actual project.
+			continue;
+		}
+
 		$json = json_decode( file_get_contents( $file ), true );
 		if ( isset( $json['name'] ) ) {
-			$js_package_map[ $json['name'] ] = substr( $file, $l + 10, -14 );
+			$js_package_map[ $json['name'] ] = $slug;
 		}
 	}
 
@@ -49,9 +61,9 @@ function get_dependencies() {
 
 		// Collect composer require, require-dev, and .extra.dependencies.
 		$json = json_decode( file_get_contents( "$path/composer.json" ), true );
-		foreach ( $package_map as $package => $p ) {
+		foreach ( $package_map as $package => $pkgslug ) {
 			if ( isset( $json['require'][ $package ] ) || isset( $json['require-dev'][ $package ] ) ) {
-				$deps[] = $p;
+				$deps[] = $pkgslug;
 			}
 		}
 		if ( isset( $json['extra']['dependencies'] ) ) {
@@ -61,9 +73,9 @@ function get_dependencies() {
 		// Collect yarn dependencies and devDependencies.
 		if ( file_exists( "$path/package.json" ) ) {
 			$json = json_decode( file_get_contents( "$path/package.json" ), true );
-			foreach ( $js_package_map as $package => $p ) {
+			foreach ( $js_package_map as $package => $pkgslug ) {
 				if ( isset( $json['dependencies'][ $package ] ) || isset( $json['devDependencies'][ $package ] ) ) {
-					$deps[] = $p;
+					$deps[] = $pkgslug;
 				}
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Two errors:

* It was cutting off the last character of the slug.
* It was counting directories that aren't actually projects (i.e. no
  composer.json) as dependencies if they had a package.json, which
  confused other tooling.

Also did some other cleanup while I was looking at it.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1616015585089400-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try cherry picking this into https://github.com/Automattic/jetpack/pull/19134/commits/3293dd0857de15b5c9ca2b6eb6129dfbd04b6496, run it and see what happens.
* Same with the current version of #19134.