### PR TITLE
Contact Form: Move state updates to a hook

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-form-insertion-error
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-insertion-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Contact Form: Fix console error for bad setState that did not impact block behavior.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -116,6 +116,17 @@ export function JetpackContactFormEdit( {
 		}
 	} );
 
+	useEffect( () => {
+		if ( to === undefined && postAuthorEmail ) {
+			setAttributes( { to: postAuthorEmail } );
+		}
+
+		if ( subject === undefined && siteTitle !== undefined && postTitle !== undefined ) {
+			const emailSubject = '[' + siteTitle + '] ' + postTitle;
+			setAttributes( { subject: emailSubject } );
+		}
+	}, [ to, postAuthorEmail, subject, siteTitle, postTitle, setAttributes ] );
+
 	const validateEmail = email => {
 		email = email.trim();
 
@@ -189,19 +200,8 @@ export function JetpackContactFormEdit( {
 	};
 
 	const renderFormSettings = () => {
-		let emailAddr = to !== undefined ? to : '';
-
-		if ( to === undefined && postAuthorEmail ) {
-			emailAddr = postAuthorEmail;
-			setAttributes( { to: emailAddr } );
-		}
-
-		let emailSubject = subject !== undefined ? subject : '';
-
-		if ( subject === undefined && siteTitle !== undefined && postTitle !== undefined ) {
-			emailSubject = '[' + siteTitle + '] ' + postTitle;
-			setAttributes( { subject: emailSubject } );
-		}
+		const emailAddr = to !== undefined ? to : '';
+		const emailSubject = subject !== undefined ? subject : '';
 
 		return (
 			<>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 249-gh-Automattic/view-design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
There were some `setAttributes` being called in the render function to update the default `to` and `subject` attributes for the Contact Form block. This was causing a console error (`Cannot update a component while rendering a different component`) when inserting the block.

This PR moves the updates into a hook to only run it when the data changed and not on every component props update.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Confirm that the error disappears.**
1. Check out the master branch of Jetpack.
2. Create a post and insert a Contact Form block. Verify that you can see the error in the console.
3. Checkout this branch.
4. Insert a _new_ Contact Form block and verify that you no longer see the error. (Error only happens on inserting new block, so do not just refresh the page).

This logic was introduced in order to update the default email address and subject in #17697, so you'll also need to run through the tests from the original PR to make sure they still work. This is easiest to test on an atomic site using the Jetpack beta plugin to switch between the master branch and this branch.

**Confirm that the changes do not change the behavior of existing contact forms.**

1. On an atomic site, install the Jetpack Beta Tester plugin.
2. Activate the "Latest Stable" for Jetpack.
3. Through the User settings, create a secondary admin user with an email address that is different than the site's admin email address. (This needs to be an alternate WordPress account you have access to).
4. While logged in as the secondary admin, create a post.
5. Add a title to the post.
6. Add a contact form to the post.
7. Open the Inspector Settings and note that the email is the email address for the secondary admin user, not for the original admin (since they are the post author). Note that the subject is in the format: `[<site title>]: <post title>`
8. Publish the post.
9. Navigate to the contact form post in an incognito window and submit a contact form message.
10. Note the destination address and subject line of the form submission email. They should match the form block settings. 11. You should actually receive the email at the expected email address with the expected title.
12. In the settings for the Jetpack Beta Tester plugin, search for and activate this branch.
13. Open the post in the editor and verify in the Inspector Settings that the email and subject have not changed.
14. Open the post in an incognito window and submit another message. Verify that you receive the email at the expected address with the expected title.

**Test the behavior of a newly created contact form.**

1. With Jetpack still checked out to this branch through the Beta Tester plugin, repeat steps 4-11.

**Test that the Contact Form still works for the primary admin as well.**

1. Log back into the WordPress account of the primary admin.
2. Create a new post and add a new Contact Form. Verify that the email address is set correctly to this user, and not to the secondary admin's email.
3. Publish the post.
4. Submit a message through the contact form from an incognito window.
5. Verify that the email is sent to the primary admin's email address, with the correct subject.