### PR TITLE
(WIP) tiled-gallery: Private+atomic blogs load images through atomic-auth-proxy

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-joltw.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-joltw.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * joltw - To be named. jetpack#19212
+ * Jetpack interface for calling atomic-auth-proxy on wpcom.
+ *
+ * @package automattic/jetpack
+ * @since ???
+ */
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * joltw - Call wpcom atomic-auth-proxy from jetpack.
+ *
+ * @since ???
+ */
+class WPCOM_REST_API_V2_Endpoint_Joltw extends WP_REST_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'joltw';
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the route.
+	 */
+	public function register_routes() {
+		register_rest_route($this->namespace, '/' . $this->rest_base . '/file(?P<path>/.+)?', [
+			[
+				'show_in_index' => false,
+				'methods' => WP_REST_Server::READABLE,
+				'callback' => [ $this, 'fetch_remote_media_file' ],
+				'permission_callback' => [ $this, 'permission_check' ],
+				'args' => [],
+			],
+		] );
+	}
+
+	public function permission_check( WP_REST_Request $request ) {
+		return true;
+		/*
+		return (
+			$this->is_requested_by_trusted_client() &&
+			$this->is_site_accessible_by_current_user() &&
+			$this->is_atomic_site() &&
+			$this->is_active_site()
+		);
+		 */
+	}
+
+	public function fetch_remote_media_file( WP_REST_Request $request ) {
+		$query_parameters = $request->get_query_params();
+		if ( isset( $query_parameters['path'] ) ) {
+			$path = $query_parameters['path'];
+			unset( $query_parameters['path'] );
+		} else {
+			$path = $request->get_param( 'path' );
+		}
+
+		// 	'https://public-api.wordpress.com/wpcom/v2/sites/testsitemmrtag.wordpress.com/atomic-auth-proxy/file/wp-content/uploads/2021/03/drone-4.jpg?resize=214%2C214'
+		$site_id = 190440205; // testsitemmrtag.wordpress.com
+		$file_path = 'wp-content/uploads/2021/03/drone-4.jpg?resize=214%2C214';
+		$endpoint = sprintf( '/sites/%d/atomic-auth-proxy/file/', $site_id ) . $file_path;
+		/* return ['this' => 'works']; */
+
+		//$abc = Client::wpcom_json_api_request_as_blog( 
+		$abc = Client::wpcom_json_api_request_as_user( 
+			$endpoint, 
+			'2', 
+			array(), //$args, 
+			null,
+			'wpcom' 
+		); 
+		return ['this' => 'works2', 'abc' => $abc];
+
+		/*
+		$remote_file_url = $this->build_remote_file_url(
+			$path,
+			$query_parameters
+		);
+		if ( is_wp_error( $remote_file_url ) ) {
+			return $remote_file_url;
+		}
+
+		$cookies = $this->cached_fetch_read_access_cookies();
+		if ( is_wp_error( $cookies ) ) {
+			return $cookies;
+		}
+
+		$result = $this->stream_remote_file_to_browser( $request->get_method(), $remote_file_url, $cookies );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		die();
+		*/
+	}
+}
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Joltw' );

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -737,6 +737,7 @@ class Jetpack_Gutenberg {
 				'tracksUserData'   => $user_data,
 				'wpcomBlogId'      => $blog_id,
 				'allowedMimeTypes' => wp_get_mime_types(),
+				'siteUrl'          => site_url(),
 			)
 		);
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -13,6 +13,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { close, downChevron, leftChevron, rightChevron, upChevron } from '../icons';
+import withProxy from './withProxy';
 
 class GalleryImageEdit extends Component {
 	img = createRef();
@@ -169,7 +170,7 @@ class GalleryImageEdit extends Component {
 	}
 }
 
-export default withSelect( ( select, ownProps ) => {
+const GalleryImageEditSelect = withSelect( ( select, ownProps ) => {
 	const { getMedia } = select( 'core' );
 	const { id } = ownProps;
 
@@ -177,3 +178,5 @@ export default withSelect( ( select, ownProps ) => {
 		image: id ? getMedia( id ) : null,
 	};
 } )( GalleryImageEdit );
+
+export default withProxy( GalleryImageEditSelect );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/withProxy.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/withProxy.js
@@ -3,13 +3,8 @@
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
-//import apiFetch from '@wordpress/api-fetch';
-//import { addQueryArgs } from '@wordpress/url';
-
-/**
- * Internal dependencies
- */
-import wpcomProxyRequest from '../../../../modules/search/instant-search/external/wpcom-proxy-request'; // Unsure about reaching this far "over", but this file may be removed soonish:  https://github.com/Automattic/jetpack/issues/19308
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 
 const cache = {};
 const cacheResponse = ( requestId, blob, freshness ) => {
@@ -37,14 +32,6 @@ const withProxy = WrappedComponent => props => {
 	const requestId = 'tiled-gallery-proxied-image-';
 	useEffect( () => {
 		if ( ! proxyIsEnabled || imageObjectUrl || isFetching || isError ) {
-			console.log( 'Deciding not to fetch' );
-			console.log( {
-				proxyIsEnabled,
-				imageObjectUrl,
-				isFetching,
-				isError,
-			} );
-
 			return;
 		}
 		if ( cache[ requestId ] ) {
@@ -68,43 +55,6 @@ const withProxy = WrappedComponent => props => {
 			// fetch(
 			// 	'https://public-api.wordpress.com/wpcom/v2/sites/testsitemmrtag.wordpress.com/atomic-auth-proxy/file/wp-content/uploads/2021/03/drone-4.jpg?resize=214%2C214'
 			// )
-			const responseHandler = data => {
-				setIsFetching( false );
-
-				if ( data.ok ) {
-					cacheResponse( requestId, data );
-					setImageObjectUrl( URL.createObjectURL( data ) );
-					console.log( 'got image from API', { requestId, imageObjectUrl, data } );
-				} else {
-					console.log( 'Got non-200 response', { data } );
-					setIsError( true );
-				}
-			};
-			const errorHandler = error => {
-				console.log( { error } );
-				setIsFetching( false );
-				setIsError( true );
-				console.error( 'Fetch failed', error );
-			};
-
-			console.log( 'Fetching via wpcomProxyRequest...' );
-			const pathForPublicApi =
-				'/sites/mmrtt1.wpcomstaging.com/atomic-auth-proxy/file?path=/wp-content/uploads/2020/09/qi-bin-w4hbafegiac-unsplash.jpg&ssl=1&resize=219%2C219';
-			// const ppr = promiseifedProxyRequest( wpcomProxyRequest, pathForPublicApi )
-			// 	.then( responseHandler )
-			// 	.catch( errorHandler );
-			// console.log( { ppr } );
-			const xhr = wpcomProxyRequest( { path: pathForPublicApi, apiVersion: '2' } );
-			console.log( { xhr } );
-			xhr.then( responseHandler ).catch( errorHandler );
-			console.log( { xhr } );
-			// wpcomProxyRequest.then( ( { default: proxyRequest } ) => {
-			// return promiseifedProxyRequest( proxyRequest, pathForPublicApi )
-			// .then( responseHandler )
-			// .catch( errorHandler );
-			// } );
-
-			/*
 			fetch(
 				'https://public-api.wordpress.com/wpcom/v2/sites/flarypod.jurassic.tube/atomic-auth-proxy/file/wp-content/uploads/2021/03/drone-2-1.jpg?resize=214%2C214'
 			)
@@ -126,7 +76,6 @@ const withProxy = WrappedComponent => props => {
 					setIsError( true );
 					console.error( 'Fetch failed', error );
 				} );
-                */
 		}
 	}, [ proxyIsEnabled, imageObjectUrl, isFetching, isError, proxyQuery ] );
 
@@ -135,25 +84,5 @@ const withProxy = WrappedComponent => props => {
 	}
 	return <WrappedComponent { ...restProps } />;
 };
-
-/**
- * Turn a proxy request into a promise
- *
- * @param {Function} proxyRequest - The wpcom-proxy-request function
- * @param {string} path - The API path to use
- * @returns {Promise} A promise to a proxy request response
- */
-function promiseifedProxyRequest( proxyRequest, path ) {
-	return new Promise( function ( resolve, reject ) {
-		console.log( 'Calling proxyRequest...' );
-		proxyRequest( { path, apiVersion: '2' }, function ( err, body, headers ) {
-			console.log( { err, body, headers } );
-			if ( err ) {
-				reject( err );
-			}
-			resolve( body, headers );
-		} );
-	} );
-}
 
 export default createHigherOrderComponent( withProxy, 'withProxy' );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/withProxy.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/withProxy.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useState, useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+const cache = {};
+const cacheResponse = ( requestId, blob, freshness ) => {
+	// Cache at most 100 items
+	const cacheKeys = Object.keys( cache );
+	if ( cacheKeys.length > 100 ) {
+		delete cache[ cacheKeys[ 0 ] ];
+	}
+
+	cache[ requestId ] = blob;
+
+	// Self-remove this entry after `freshness` ms
+	setTimeout( () => {
+		delete cache[ requestId ];
+	}, freshness );
+};
+
+const withProxy = WrappedComponent => props => {
+	const { proxyIsEnabled, proxySiteIdOrSlug, proxyMediaPath, proxyQuery, ...restProps } = props;
+
+	const [ imageObjectUrl, setImageObjectUrl ] = useState( '' );
+	const [ isFetching, setIsFetching ] = useState( false );
+	const [ isError, setIsError ] = useState( false );
+
+	const requestId = 'tiled-gallery-proxied-image-';
+	useEffect( () => {
+		if ( ! proxyIsEnabled || imageObjectUrl || isFetching || isError ) {
+			return;
+		}
+		if ( cache[ requestId ] ) {
+			// Load image from cache
+			const url = URL.createObjectURL( cache[ requestId ] );
+			setImageObjectUrl( url );
+			console.log( 'got image from cache', { url } );
+		} else {
+			// Not in cache, send a request
+			setIsFetching( true );
+			const safeQuery = ( proxyQuery || '' ).replace( /^\?/, '' );
+			/*
+			apiFetch( {
+				//path: `/sites/${ proxySiteIdOrSlug }/atomic-auth-proxy/file?path=${ proxyMediaPath }&${ safeQuery }`,
+				//path: `https://public-api.wordpress.com/sites/${ proxySiteIdOrSlug }/atomic-auth-proxy/file?path=${ proxyMediaPath }&${ safeQuery }`,
+				apiNamespace: 'wpcom/v2',
+			} )
+            */
+			//testsitemmrtag.files.wordpress.com/2021/03/drone-4.jpg?resize=750x750
+			// https://flarypod.jurassic.tube/wp-content/uploads/2021/03/drone-2-1.jpg
+			// fetch(
+			// 	'https://public-api.wordpress.com/wpcom/v2/sites/testsitemmrtag.wordpress.com/atomic-auth-proxy/file/wp-content/uploads/2021/03/drone-4.jpg?resize=214%2C214'
+			// )
+			fetch(
+				'https://public-api.wordpress.com/wpcom/v2/sites/flarypod.jurassic.tube/atomic-auth-proxy/file/wp-content/uploads/2021/03/drone-2-1.jpg?resize=214%2C214'
+			)
+				.then( data => {
+					setIsFetching( false );
+
+					if ( data.ok ) {
+						cacheResponse( requestId, data );
+						setImageObjectUrl( URL.createObjectURL( data ) );
+						console.log( 'got image from API', { requestId, imageObjectUrl, data } );
+					} else {
+						console.log( 'Got non-200 response', { data } );
+						setIsError( true );
+					}
+				} )
+				.catch( error => {
+					console.log( { error } );
+					setIsFetching( false );
+					setIsError( true );
+					console.error( 'Fetch failed', error );
+				} );
+		}
+	}, [ proxyIsEnabled, imageObjectUrl, isFetching, isError, proxyQuery ] );
+
+	if ( proxyIsEnabled ) {
+		return <WrappedComponent { ...restProps } src={ imageObjectUrl } srcSet={ null } />;
+	}
+	return <WrappedComponent { ...restProps } />;
+};
+
+export default createHigherOrderComponent( withProxy, 'withProxy' );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/withProxy.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/withProxy.js
@@ -42,22 +42,13 @@ const withProxy = WrappedComponent => props => {
 		} else {
 			// Not in cache, send a request
 			setIsFetching( true );
-			const safeQuery = ( proxyQuery || '' ).replace( /^\?/, '' );
-			/*
-			apiFetch( {
-				//path: `/sites/${ proxySiteIdOrSlug }/atomic-auth-proxy/file?path=${ proxyMediaPath }&${ safeQuery }`,
-				//path: `https://public-api.wordpress.com/sites/${ proxySiteIdOrSlug }/atomic-auth-proxy/file?path=${ proxyMediaPath }&${ safeQuery }`,
-				apiNamespace: 'wpcom/v2',
-			} )
-            */
+			//const safeQuery = ( proxyQuery || '' ).replace( /^\?/, '' );
 			//testsitemmrtag.files.wordpress.com/2021/03/drone-4.jpg?resize=750x750
-			// https://flarypod.jurassic.tube/wp-content/uploads/2021/03/drone-2-1.jpg
 			// fetch(
 			// 	'https://public-api.wordpress.com/wpcom/v2/sites/testsitemmrtag.wordpress.com/atomic-auth-proxy/file/wp-content/uploads/2021/03/drone-4.jpg?resize=214%2C214'
 			// )
-			fetch(
-				'https://public-api.wordpress.com/wpcom/v2/sites/flarypod.jurassic.tube/atomic-auth-proxy/file/wp-content/uploads/2021/03/drone-2-1.jpg?resize=214%2C214'
-			)
+			console.log( 'apifetching..' );
+			apiFetch( { path: '/wpcom/v2/joltw/file?path=/wp-content/uploads/2021/03/drone-2-1.jpg' } )
 				.then( data => {
 					setIsFetching( false );
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
@@ -15,6 +15,8 @@ import Square from './square';
 import { isSquareishLayout, photonizedImgProps } from '../utils';
 import { LAYOUT_CIRCLE, MAX_ROUNDED_CORNERS } from '../constants';
 import { isAtomicSite, isPrivateSite } from '../../../shared/site-type-utils';
+import getWpcomBlogId from '../../../shared/wpcom-blog-id';
+import getSiteUrl from '../../../shared/site-url';
 
 export default class Layout extends Component {
 	// This is tricky:
@@ -49,8 +51,18 @@ export default class Layout extends Component {
 		const { src, srcSet } = photonizedImgProps( img, { layoutStyle } );
 
 		const origUrlObject = new URL( img.url );
-		const isRequestAgainstBlog = true; // TODO How do I know if the image is on my own blog?
-		const proxySiteIdOrSlug = 'flarypod.jurassic.tube'; // TODO How do I find my site_id?
+		const proxySiteIdOrSlug = getWpcomBlogId();
+		const siteUrl = getSiteUrl();
+		const isRequestAgainstBlog = proxySiteIdOrSlug && siteUrl && img.url?.startsWith( siteUrl );
+
+		console.log( {
+			url: img.url,
+			origUrlObject,
+			isRequestAgainstBlog,
+			proxySiteIdOrSlug,
+			siteUrl,
+			version: '5.1',
+		} );
 		return (
 			<Image
 				alt={ img.alt }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
@@ -14,6 +14,7 @@ import Mosaic from './mosaic';
 import Square from './square';
 import { isSquareishLayout, photonizedImgProps } from '../utils';
 import { LAYOUT_CIRCLE, MAX_ROUNDED_CORNERS } from '../constants';
+import { isAtomicSite, isPrivateSite } from '../../../shared/site-type-utils';
 
 export default class Layout extends Component {
 	// This is tricky:
@@ -47,6 +48,9 @@ export default class Layout extends Component {
 
 		const { src, srcSet } = photonizedImgProps( img, { layoutStyle } );
 
+		const origUrlObject = new URL( img.url );
+		const isRequestAgainstBlog = true; // TODO How do I know if the image is on my own blog?
+		const proxySiteIdOrSlug = 'flarypod.jurassic.tube'; // TODO How do I find my site_id?
 		return (
 			<Image
 				alt={ img.alt }
@@ -66,6 +70,10 @@ export default class Layout extends Component {
 				onRemove={ isSave ? undefined : onRemoveImage( i ) }
 				onSelect={ isSave ? undefined : onSelectImage( i ) }
 				origUrl={ img.url }
+				proxyIsEnabled={ isRequestAgainstBlog && isAtomicSite() && isPrivateSite() }
+				proxySiteIdOrSlug={ proxySiteIdOrSlug }
+				proxyMediaPath={ origUrlObject.pathname }
+				proxyQuery={ origUrlObject.search || '' }
 				setAttributes={ isSave ? undefined : setImageAttributes( i ) }
 				showMovers={ images.length > 1 }
 				srcSet={ srcSet }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
@@ -53,15 +53,22 @@ export default class Layout extends Component {
 		const origUrlObject = new URL( img.url );
 		const proxySiteIdOrSlug = getWpcomBlogId();
 		const siteUrl = getSiteUrl();
-		const isRequestAgainstBlog = proxySiteIdOrSlug && siteUrl && img.url?.startsWith( siteUrl );
+		const isRequestAgainstBlog =
+			proxySiteIdOrSlug &&
+			siteUrl &&
+			( img.url?.startsWith( siteUrl ) || img.url?.startsWith( 'blob:' + siteUrl ) );
 
 		console.log( {
-			url: img.url,
-			origUrlObject,
+			siteUrl,
+			imgUrl: img.url,
+			match: img.url?.startsWith( siteUrl ),
 			isRequestAgainstBlog,
 			proxySiteIdOrSlug,
-			siteUrl,
-			version: '5.1',
+			isAtomic: isAtomicSite(),
+			isPrivate: isPrivateSite(),
+			proxyIsEnabled: isRequestAgainstBlog && isAtomicSite() && isPrivateSite(),
+			origUrlObject,
+			version: '6.0',
 		} );
 		return (
 			<Image

--- a/projects/plugins/jetpack/extensions/shared/site-type-utils.js
+++ b/projects/plugins/jetpack/extensions/shared/site-type-utils.js
@@ -34,6 +34,7 @@ export function isSimpleSite() {
  * @returns {boolean} True for Atomic sites.
  */
 export function isAtomicSite() {
+	return true;
 	return getSiteType() === 'atomic';
 }
 

--- a/projects/plugins/jetpack/extensions/shared/site-type-utils.js
+++ b/projects/plugins/jetpack/extensions/shared/site-type-utils.js
@@ -34,7 +34,6 @@ export function isSimpleSite() {
  * @returns {boolean} True for Atomic sites.
  */
 export function isAtomicSite() {
-	return true;
 	return getSiteType() === 'atomic';
 }
 

--- a/projects/plugins/jetpack/extensions/shared/site-url.js
+++ b/projects/plugins/jetpack/extensions/shared/site-url.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackData from './get-jetpack-data';
+
+export default function getSiteUrl() {
+	console.log( 'site url getter running' );
+	return get( getJetpackData(), [ 'siteUrl' ], null );
+}

--- a/projects/plugins/jetpack/extensions/shared/wpcom-blog-id.js
+++ b/projects/plugins/jetpack/extensions/shared/wpcom-blog-id.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackData from './get-jetpack-data';
+
+export default function getWpcomBlogId() {
+	let blogId = get( getJetpackData(), [ 'wpcomBlogId' ], null );
+	if ( blogId ) {
+		blogId = parseInt( blogId, 10 );
+	}
+	return blogId;
+}


### PR DESCRIPTION
Improves https://github.com/Automattic/wp-calypso/issues/41272# 

## Does not work. Is rough, needs a lot of improvement.
** Testing instructions are copied from #19201 and need updating - once this works **

#### Issues with this PR
* Authenticated requests to public-api don't work
* Need detection of "is this image hosted on my blog"
* Need to find a way to get my site id
* How to regain the resizing benefit - the proxy api doesn't match the photonize api at all
* Not even sure if this entire workflow if it worked, would function in jetpack the way I'm using it

#### Changes proposed in this Pull Request:
* **The tiled-gallery block will not "photonize" images when used on sites that are both private and atomic.**
  * The photon CDN cannot handle authentication. Previously, it was never able to load these images, meaning users would see blank rectangles after adding images to a tiled-gallery on a private atomic site.
  * This is a stop-gap that allows the images to show, but does not support the resizing that the tiled-gallery block uses to save bandwidth. However, showing something is better than showing nothing.
  * This may later be improved upon further by "Proxied Images", or teaching the `<GalleryImageEdit>` and `<GalleryImageSave>` components inside tiled-gallery block to make XHR requests to public-api, download private+atomic image blobs, then render those to the user. See discussion in https://github.com/Automattic/wp-calypso/issues/41272.
    * This trick is from Calypso, which uses it here: [Link](https://github.com/Automattic/wp-calypso/blob/ef76ff4b6871663ced67b361ae17fac301f5248e/client/my-sites/media-library/proxied-image.tsx#L77-L81)
    * Could there be another way to solve this problem?

#### Jetpack product discussion
* None so far.
 
### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions (Hacks to run before setup)
* Edit `projects/plugins/jetpack/extensions/shared/site-type-utils.js` and change `isAtomicSite()` to always return true.
* (Optional) Add `define( 'JETPACK__SANDBOX_DOMAIN', 'sandbox.domain.goes.here' );` to `tools/docker/mu-plugins/debug.php`.
  * If doing this, do it only after you've connected jetpack.
* (Optional) On your sandbox, temporarily allow global requests and bypass security checks for atomic-auth-proxy. See: 28de3-pb
* (Optional) Edit security checks in wpcom's atomic-auth-proxy-abstract.php: See: 28de3-pb

#### Testing instructions (Initial Setup):

* Check out this branch.
* Set up a jetpack development environment with docker and JT (jurassic-tube, ngrok-like service for A8Cs) ( PCYsg-efV-p2 )
* Edit the docker volume configuration to allow for image uploads.
  * Create the `tools/docker/uploads` directory and chmod 777 it: `cd tools/docker ; mkdir uploads ; chmod 777 uploads`.
  * Add this line to `tools/docker/compose-volumes.yml`: 
```
- ./uploads:/var/www/html/wp-content/uploads
```
* (Optional) Reset the docker blog. `yarn docker:clean`, `yarn docker:up`, `yarn docker:install`. Note that the docker:install command assumes you have a `tools/docker/default.env` file with the l/p you want. Or you can install it manually if you would like by visiting http://localhost and filling the prompts.
* Run the docker environment. In three tabs:
  * `yarn docker:up`
  * `yarn docker:jt-up`
  * `cd projects/plugins/jetpack ; yarn build-extensions --watch`
* Ensure the blog is connected to WordPress.com. `/wp-admin/admin.php?page=jetpack#/my-plan` should not show "Offline Mode". If it does, visit `/wp-admin/` and click the green connect Jetpack button, click approve, click start for free.
  * I am finding that each new day, my connection is lost and the only way to reconnect it is to clean docker, reinstall and reconnect.

#### Testing instructions (Verify Images Continue to be Photonized for Public Blogs):
* Ensure the blog is public
  * Visit http://localhost/wp-admin/options.php . `blog_public` should be `0` or `1`.
* Go to media library and upload 2 images.
* Create a new post
* Add a tiled-gallery block
* Add the two images
* Inspect element on the two images and look at the `srcset`. They should have urls like `i1.wp.com` (number may vary). This means they are still being photonized, which is the default behavior.
* Public the post and view the post outside the editor.
* Inspect element on the two images and look at the `srcset`. They should have urls like `i1.wp.com` (number may vary). This means they are still being photonized, which is the default behavior.

#### Testing instructions (Verify Images are not Photonized for Private Blogs):
* Ensure the blog is private
  * Visit http://localhost/wp-admin/options.php . Change `blog_public` to `-1`.
* Q: "Hey, but the other condition is Atomic..."
  * A: Yes. Terribly sorry, but I don't know how to test this. The PR is written with  `'isAtomicSite'  => true` inside `tiled-gallery.php`, to hardcode that condition, which should be replaced with `'isAtomicSite'  => jetpack_is_atomic_site(),` before merging.
* Create a new post
* Add a tiled-gallery block
* Add the two images
* Inspect element on the two images and look at the `srcset`. They should **NOT** have urls like `i1.wp.com` (number may vary). This means they are not being photonized.
* Public the post and view the post outside the editor.
* Inspect element on the two images and look at the `srcset`. They should **NOT** have urls like `i1.wp.com` (number may vary). This means they are not being photonized.