### PR TITLE
tools: Accept slugs to plugin scripts

### DIFF
--- a/tools/includes/plugin-functions.sh
+++ b/tools/includes/plugin-functions.sh
@@ -42,8 +42,11 @@ function find_plugin_file {
 # Process a "plugin" argument to set PLUGIN_DIR and PLUGIN_FILE.
 # Returns success of failure as appropriate.
 function process_plugin_arg {
-	if [[ "$1" != "*/*" && -d "$BASE/projects/plugins/$1" ]]; then
+	if [[ "$1" != */* && -d "$BASE/projects/plugins/$1" ]]; then
 		PLUGIN_DIR="$BASE/projects/plugins/$1"
+		find_plugin_file
+	elif [[ "$1" == plugins/* && "$1" != plugins/*/* && -d "$BASE/projects/$1" ]]; then
+		PLUGIN_DIR="$BASE/projects/$1"
 		find_plugin_file
 	elif [[ -d "$1" ]]; then
 		PLUGIN_DIR="${1%/}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Scripts that take a "plugin" currently accept the plugin directory name,
a full directory path, or a full path to the WP plugin file.

To avoid confusion with scripts that take a project slug, also accept
the "plugins/name" style slug.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/19183#pullrequestreview-615497553

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try `tools/plugin-version.sh plugins/jetpack`
