### PR TITLE
actions: Bracket multiline messages for better visibility in GH's logs

### DIFF
--- a/.github/files/check-composer-locks.sh
+++ b/.github/files/check-composer-locks.sh
@@ -12,7 +12,9 @@ for FILE in $(git ls-files 'composer.lock' '**/composer.lock'); do
 	composer update --root-reqs
 	echo "::endgroup::"
 	if ! git diff --exit-code composer.lock; then
+		echo "---" # Bracket message containing newlines for better visibility in GH's logs.
 		echo "::error file=$FILE::$FILE is not up to date!%0AYou can probably fix this by running \`composer update --root-reqs\` in the appropriate directory."
+		echo "---"
 		EXIT=1
 	fi
 	cd "$OLDPWD"

--- a/.github/files/check-excludelist-diff.js
+++ b/.github/files/check-excludelist-diff.js
@@ -37,7 +37,9 @@ diff.forEach( file => {
 				case 'del':
 					x = c.content.replace( /^-\s*|,?\s*$/g, '' );
 					lines.push(
-						`::warning file=${ file.to },line=${ c.ln }::Good job! ${ x } no longer has any lint errors,%0Aand should be removed from the exclude list.`
+						'---', // Bracket message containing newlines for better visibility in GH's logs.
+						`::warning file=${ file.to },line=${ c.ln }::Good job! ${ x } no longer has any lint errors,%0Aand should be removed from the exclude list.`,
+						'---'
 					);
 					break;
 				case 'normal':
@@ -47,9 +49,11 @@ diff.forEach( file => {
 	} );
 	if ( anyAdded ) {
 		exit = 1;
+		console.log( '---' ); // Bracket message containing newlines for better visibility in GH's logs.
 		console.log(
 			`::error file=${ file.to }::When checking for fixed exclusions, CI found added lines.%0AThis probably means you didn't maintain binary sort order when editing this file.%0APlease fix.`
 		);
+		console.log( '---' );
 	} else if ( lines.length ) {
 		exit = 1;
 		console.log( lines.join( '\n' ) );

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -102,7 +102,7 @@ function error( ...$args ) {
 		)
 	);
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	fprintf( STDERR, "::error::%s\n", $msg );
+	fprintf( STDERR, "---\n::error::%s\n---\n", $msg );
 }
 
 /**

--- a/.github/files/require-change-file-for-touched-projects.php
+++ b/.github/files/require-change-file-for-touched-projects.php
@@ -128,12 +128,14 @@ ksort( $touched_projects );
 $exit = 0;
 foreach ( $touched_projects as $slug => $files ) {
 	if ( empty( $ok_projects[ $slug ] ) ) {
+		printf( "---\n" ); // Bracket message containing newlines for better visibility in GH's logs.
 		printf(
 			"::error::Project %s is being changed, but no change file in %s is touched!%%0A%%0AGo to that project and use `%s add` to add a change file.%%0AGuidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md\n",
 			$slug,
 			"projects/$slug/{$changelogger_projects[ $slug ]['changes-dir']}/",
 			'packages/changelogger' === $slug ? 'bin/changelogger' : 'vendor/bin/changelogger'
 		);
+		printf( "---\n" );
 		$exit = 1;
 	}
 }

--- a/tools/project-version.sh
+++ b/tools/project-version.sh
@@ -116,7 +116,9 @@ function sedver {
 		EXIT=1
 		LINE=$(grep --line-number --max-count=1 -E "$2" "$1" || true)
 		if [[ -n "$CI" ]]; then
-			echo "::error file=${1#$BASE/},line=${LINE%%:*}::Version mismatch, expected $3 but found $VER!%0A%0AYou might use \`tools/project-version.sh -u $VERSION $SLUG\` to fix this."
+			echo "---" # Bracket message containing newlines for better visibility in GH's logs.
+			echo "::error file=${1#$BASE/},line=${LINE%%:*}::Version mismatch, expected $3 but found $VER!%0AYou might use \`tools/project-version.sh -u $VERSION $SLUG\` to fix this."
+			echo "---"
 		else
 			error "${1#$BASE/}:${LINE%%:*}: Version mismatch, expected $3 but found $VER!"
 		fi
@@ -159,7 +161,9 @@ function jsver {
 		VE=$(jq --arg v "$VER" -n '$v' | sed 's/[.\[\]\\*^$\/()+?{}|]/\\&/g')
 		LINE=$(grep --line-number --max-count=1 -E "^	{$N}\"${X##*.}\": $VE,?$" "$1" || true)
 		if [[ -n "$CI" ]]; then
-			echo "::error file=${1#$BASE/},line=${LINE%%:*}::Version mismatch, expected $3 but found $VER!%0A%0AYou might use \`tools/project-version.sh -u $VERSION $SLUG\` to fix this."
+			echo "---" # Bracket message containing newlines for better visibility in GH's logs.
+			echo "::error file=${1#$BASE/},line=${LINE%%:*}::Version mismatch, expected $3 but found $VER!%0AYou might use \`tools/project-version.sh -u $VERSION $SLUG\` to fix this."
+			echo "---"
 		else
 			error "${1#$BASE/}:${LINE%%:*}: Version mismatch, expected $3 but found $VER!"
 		fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
GitHub's highlighting in the logs replaces the `%0A` with a newline, but
doesn't color the subsequent lines in red like it does the first to tie
them together. Add `---` before and after multiline messages to better
set them off for human readers looking at the logs.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1616087631140300-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a PR introducing errors that trigger these messages, and then look at the logs.