### PR TITLE
Connection: Handle reconnecting a userless connection

### DIFF
--- a/projects/packages/connection/changelog/update-userless-connection-reconnect
+++ b/projects/packages/connection/changelog/update-userless-connection-reconnect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+User-less connection: Reconnect without asking the user to connect their WPCOM account

--- a/projects/packages/connection/tests/php/test_Manager_integration.php
+++ b/projects/packages/connection/tests/php/test_Manager_integration.php
@@ -452,4 +452,76 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 		$this->assertFalse( ( new Tokens() )->get_access_token( 123 ) );
 		$this->assertInstanceOf( 'WP_Error', ( new Tokens() )->get_access_token( 123, '', false ) );
 	}
+
+	/**
+	 * Test the `is_userless' method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::is_userless
+	 * @dataProvider data_provider_for_test_is_userless
+	 *
+	 * @param boolean $is_connected              If the blog is connected.
+	 * @param boolean $has_connected_user        If the blog has a connected user.
+	 * @param boolean $master_user_option_is_set If the master_user option is set.
+	 * @param boolean $expected                  The expected output.
+	 */
+	public function test_is_userless( $is_connected, $has_connected_user, $master_user_option_is_set, $expected ) {
+		$id_admin = wp_insert_user(
+			array(
+				'user_login' => 'admin',
+				'user_pass'  => 'pass',
+				'role'       => 'administrator',
+			)
+		);
+
+		if ( $is_connected ) {
+			\Jetpack_Options::update_option( 'id', 1234 );
+			\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		} else {
+			\Jetpack_Options::delete_option( 'blog_token' );
+			\Jetpack_Options::delete_option( 'id' );
+		}
+
+		if ( $has_connected_user ) {
+			\Jetpack_Options::update_option(
+				'user_tokens',
+				array(
+					$id_admin => 'asd123',
+				)
+			);
+		} else {
+			\Jetpack_Options::delete_option( 'user_tokens' );
+		}
+
+		if ( $master_user_option_is_set ) {
+			\Jetpack_Options::update_option( 'master_user', $id_admin );
+		} else {
+			\Jetpack_Options::delete_option( 'master_user' );
+		}
+
+		$this->assertEquals( $expected, $this->manager->is_userless() );
+	}
+
+	/**
+	 * Data provider for test_is_userless.
+	 *
+	 * Structure of the test data arrays:
+	 *     [0] => 'is_connected'              boolean If the blog is connected.
+	 *     [1] => 'has_connected_user'        boolean If the blog has a connected user.
+	 *     [2] => 'master_user_option_is_set' boolean If the master_user option is set.
+	 *     [3] => 'expected'                  boolean The expected output of the call to is_userless.
+	 */
+	public function data_provider_for_test_is_userless() {
+
+		return array(
+			'connected, has connected_user, master_user option is set'         => array( true, true, true, false ),
+			'not connected, has connected_user, master_user option is set'     => array( false, true, true, false ),
+			'connected, no connected_user, master_user option is set'          => array( true, false, true, false ),
+			'not connected, no connected_user, master_user option is set'      => array( false, false, true, false ),
+			'not connected, has connected_user, master_user option is not set' => array( false, true, false, false ),
+			'not connected, no connected_user, master_user option is not set'  => array( false, false, false, false ),
+			'connected, has connected_user, master_user option is not set'     => array( true, true, false, false ),
+			'connected, no connected_user, master_user option is not set'      => array( true, false, false, true ),
+		);
+	}
+
 }


### PR DESCRIPTION
When a Jetpack site is experiencing token related errors, the user is asked to reconnect Jetpack.
Upon reconnection we decide if a partial of full reconnect is needed.
In cases of a full reconnection or a user token partial reconnection we also ask the user to reconnect their WPCOM account.
Under the user-less context, upon fixing connection errors (aka reconnecting) we should not ask the user to connect their WPCOM account, as this is definitely not part of the solution.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Connection : Introduce `is_userless` method in `Manager`
* Connection: Update `restore` method in `Manager` to take "userless" into account.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable userless Jetpack mode (`define( 'JETPACK_NO_USER_TEST_MODE', true );`)
* Connect Jetpack only at a site level (skip user auth)
* Using the Jetpack Debug->Broken Token set an invalid blog token
* A reconnect notice will appear, click on the "Reconnect Jetpack" button
* Jetpack should reconnect without asking you to connect your WPCOM account and the reconnect notice should disappear (indicating you now have a health Jetpack connected at a site level)

Bonus points for testing the reconnection process with a full-connected Jetpack to verify nothing has changed.
