### PR TITLE
Always adds Calypso Users menu.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sso_atomic_users
+++ b/projects/plugins/jetpack/changelog/fix-sso_atomic_users
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Always adds Calypso Users menus when nav unification is enabled.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -340,18 +340,16 @@ class Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_users_menu( $wp_admin = false ) {
-		$submenus_to_update = array();
 		if ( current_user_can( 'list_users' ) ) {
+			// We shall add the Calypso user management & add new user screens at all cases ( Calypso & Atomic ).
+			$submenus_to_update = array(
+				'user-new.php' => 'https://wordpress.com/people/new/' . $this->domain,
+				'users.php'    => 'https://wordpress.com/people/team/' . $this->domain,
+			);
 			if ( ! $wp_admin ) {
-				$submenus_to_update = array(
-					'user-new.php' => 'https://wordpress.com/people/new/' . $this->domain,
-					'profile.php'  => 'https://wordpress.com/me',
-				);
+				$submenus_to_update = array_merge( $submenus_to_update, array( 'profile.php' => 'https://wordpress.com/me' ) );
 			}
-			// We shall add the Calypso User management screen at all cases ( Calypso & Atomic ).
-			$submenus_to_update = array_merge( $submenus_to_update, array( 'users.php' => 'https://wordpress.com/people/team/' . $this->domain ) );
 			$this->update_submenus( 'users.php', $submenus_to_update );
-
 			add_submenu_page( 'users.php', esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
 		} else {
 			if ( ! $wp_admin ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -347,7 +347,7 @@ class Admin_Menu {
 				'users.php'    => 'https://wordpress.com/people/team/' . $this->domain,
 			);
 			if ( ! $wp_admin ) {
-				$submenus_to_update = array_merge( $submenus_to_update, array( 'profile.php' => 'https://wordpress.com/me' ) );
+				$submenus_to_update['profile.php'] = 'https://wordpress.com/me';
 			}
 			$this->update_submenus( 'users.php', $submenus_to_update );
 			add_submenu_page( 'users.php', esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -340,15 +340,17 @@ class Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_users_menu( $wp_admin = false ) {
+		$submenus_to_update = array();
 		if ( current_user_can( 'list_users' ) ) {
 			if ( ! $wp_admin ) {
 				$submenus_to_update = array(
-					'users.php'    => 'https://wordpress.com/people/team/' . $this->domain,
 					'user-new.php' => 'https://wordpress.com/people/new/' . $this->domain,
 					'profile.php'  => 'https://wordpress.com/me',
 				);
-				$this->update_submenus( 'users.php', $submenus_to_update );
 			}
+			// We shall add the Calypso User management screen at all cases ( Calypso & Atomic ).
+			$submenus_to_update = array_merge( $submenus_to_update, array( 'users.php' => 'https://wordpress.com/people/team/' . $this->domain ) );
+			$this->update_submenus( 'users.php', $submenus_to_update );
 
 			add_submenu_page( 'users.php', esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
 		} else {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -232,11 +232,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_users_menu( $wp_admin = false ) {
 		parent::add_users_menu( $wp_admin );
 
-		// No need to add a menu linking to WP Admin if there is already one.
-		if ( $wp_admin ) {
-			return;
-		}
-
 		add_submenu_page( 'users.php', esc_attr__( 'Advanced Users Management', 'jetpack' ), __( 'Advanced Users Management', 'jetpack' ), 'list_users', 'users.php', null, 2 );
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -365,7 +365,8 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		$submenu = static::$submenu_data;
 
 		static::$admin_menu->add_users_menu( true );
-		$this->assertArrayNotHasKey( 2, $submenu['users.php'] );
+
+		$this->assertArrayHasKey( 2, $submenu['users.php'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -355,18 +355,10 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_users_menu
 	 */
 	public function test_add_users_menu() {
-		global $menu, $submenu;
+		global $submenu;
 
 		static::$admin_menu->add_users_menu();
 		$this->assertSame( 'users.php', $submenu['users.php'][2][2] );
-
-		// Reset.
-		$menu    = static::$menu_data;
-		$submenu = static::$submenu_data;
-
-		static::$admin_menu->add_users_menu( true );
-
-		$this->assertArrayHasKey( 2, $submenu['users.php'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/51232

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR aims to make the Calypso Users menu available at all cases so that Atomic administrators have a chance to add an SSO user.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Turn on advanced wp-admin pages under /me/account
- Go to an atomic site's dashboard
- "Users" -> should redirect to Calypso Users management screen
- "Add new" -> should redirect to Calypso Users management screen
- "Advanced Users Management" -> should redirect to WP Admin
- Now, turn off advanced wp-admin pages under /me/account
- Try the menus again, the results should be identical

![](https://cln.sh/J4fKFK+)
