### PR TITLE
Update Sync lock and retry-after options to use update_option

### DIFF
--- a/projects/packages/sync/changelog/sync-memcache-delete-lock
+++ b/projects/packages/sync/changelog/sync-memcache-delete-lock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Migrate locks to update_option to avaoid memcache inconsistencies that ccan be introduced by delete_option usage.

--- a/projects/packages/sync/changelog/sync-memcache-delete-lock
+++ b/projects/packages/sync/changelog/sync-memcache-delete-lock
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Migrate locks to update_option to avaoid memcache inconsistencies that ccan be introduced by delete_option usage.
+Migrate locks to update_option to avaoid memcache inconsistencies that can be introduced by delete_option usage.

--- a/projects/packages/sync/src/class-lock.php
+++ b/projects/packages/sync/src/class-lock.php
@@ -46,9 +46,9 @@ class Lock {
 		$locked_time = get_option( $lock_name );
 
 		if ( $locked_time ) {
-			// If expired delete but don't send. Send will occurr in new request to avoid race conditions.
+			// If expired update to false but don't send. Send will occurr in new request to avoid race conditions.
 			if ( microtime( true ) > $locked_time ) {
-				delete_option( $lock_name );
+				update_option( $lock_name, false, false );
 			}
 			return false;
 		}
@@ -71,7 +71,7 @@ class Lock {
 
 		// Only remove lock if current value matches our lock.
 		if ( true === $lock_expiration || (string) get_option( $lock_name ) === (string) $lock_expiration ) {
-			delete_option( $lock_name );
+			update_option( $lock_name, false, false );
 		}
 	}
 }

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -345,9 +345,9 @@ class Sender {
 		// Return early if we've gotten a retry-after header response.
 		$retry_time = get_option( Actions::RETRY_AFTER_PREFIX . $queue->id );
 		if ( $retry_time ) {
-			// If expired delete but don't send. Send will occurr in new request to avoid race conditions.
+			// If expired update to false but don't send. Send will occurr in new request to avoid race conditions.
 			if ( microtime( true ) > $retry_time ) {
-				delete_option( Actions::RETRY_AFTER_PREFIX . $queue->id );
+				update_option( Actions::RETRY_AFTER_PREFIX . $queue->id, false, false );
 			}
 			return new \WP_Error( 'retry_after' );
 		}

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -341,7 +341,7 @@ class Full_Sync_Immediately extends Module {
 		if ( $retry_time ) {
 			// If expired delete but don't send. Send will occurr in new request to avoid race conditions.
 			if ( microtime( true ) > $retry_time ) {
-				delete_option( Actions::RETRY_AFTER_PREFIX . 'immediate-send' );
+				update_option( Actions::RETRY_AFTER_PREFIX . 'immediate-send', false, false );
 			}
 			return false;
 		}


### PR DESCRIPTION
delete_option leaves options vulnerable to memcache inconsistencies (race conditions).  The [early return](https://core.trac.wordpress.org/browser/tags/5.7/src/wp-includes/option.php#L653) of delete_option will cause an out of date memcache value to remain persisted  if called when the option was successfully deleted from the database previously.  By switching to update_option( name, false ); we instead will trigger the db and memcache update if the memcache value is different than the db value due to update_options check for equality based on the get_option value which will return the memcache value if it exists.

#### Changes proposed in this Pull Request:
* Update Sync locks to use update_option.

#### Does this pull request change what data or activity we track or use?
* NO

#### Testing instructions:

* Sync behavior is covered in unit (integration) tests.
* In addition you can verify the following scenarios

Sync Lock clears
* update_option( 'jp_sync_lock_sync', microtime( true ) + 300, false );
* Perform site updates.
* Verify that sync does not send for 5 minutes
* Verify that after 5 minutes sync data does flow to WP.com without any manual changes to the option

Retry-After clears
* update_option( 'jp_sync_retry_after_sync', microtime( true ) + 300, false );
* Perform site updates.
* Verify that sync does not send data for 5 minutes
* Verify that after 5 minutes sync does send data to WP.com without any manual changes to the option.
