### PR TITLE
Docker docs: add Mac M1/Apple Silicon Docker workaround

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -81,6 +81,16 @@ You can use the file `tools/docker/compose-extras.yml` to add mounts or alter th
 
 You can use the file `tools/docker/compose-volumes.yml` to add additional mounts for WordPress plugins and themes. Refer to the section [Custom plugins & themes in the container](#custom-plugins--themes-in-the-container) for more details.
 
+### Building on M1 Macs
+
+If you're using the new [M1/Apple Silicon version of Docker](https://docs.docker.com/docker-for-mac/apple-m1/), you will need to add the following to your `tools/docker/compose-extras.yml` file to ensure a successful build:
+
+```
+services:
+  db:
+    platform: linux/x86_64
+```
+
 ## Working with containers
 
 ### Quick install WordPress


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When using the new Docker RC for M1 Mac/Apple Silicon, you need to add a snippet to your compose-extras.yml in order to get MySQL to build. @jeherve shared this with me, and I'm sure others will run into it, so I thought it'd be good to add it to the docs.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Read the docs changes.