### PR TITLE
blocks, changelogger: Enable auto-tagger

### DIFF
--- a/projects/packages/blocks/changelog/add-enable-package-autotagger-to-test
+++ b/projects/packages/blocks/changelog/add-enable-package-autotagger-to-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Enable GitHub action for auto-tagging releases from monorepo pushes.

--- a/projects/packages/blocks/composer.json
+++ b/projects/packages/blocks/composer.json
@@ -40,6 +40,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-blocks",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-blocks/compare/v${old}...v${new}"

--- a/projects/packages/changelogger/changelog/add-enable-package-autotagger-to-test
+++ b/projects/packages/changelogger/changelog/add-enable-package-autotagger-to-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Enable GitHub action for auto-tagging releases from monorepo pushes.

--- a/projects/packages/changelogger/composer.json
+++ b/projects/packages/changelogger/composer.json
@@ -44,6 +44,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autotagger": true,
 		"branch-alias": {
 			"dev-master": "1.1.x-dev"
 		},

--- a/projects/plugins/beta/changelog/add-enable-package-autotagger-to-test
+++ b/projects/plugins/beta/changelog/add-enable-package-autotagger-to-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "69b94231de9ccb5b0c244bf05b985c6eacc874ba"
+                "reference": "ae11a2161c4a3b72cfd2dce8e76f820c99fb1937"
             },
             "require": {
                 "php": ">=5.6",
@@ -30,6 +30,7 @@
             ],
             "type": "project",
             "extra": {
+                "autotagger": true,
                 "branch-alias": {
                     "dev-master": "1.1.x-dev"
                 },

--- a/projects/plugins/debug-helper/changelog/add-enable-package-autotagger-to-test
+++ b/projects/plugins/debug-helper/changelog/add-enable-package-autotagger-to-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "69b94231de9ccb5b0c244bf05b985c6eacc874ba"
+                "reference": "ae11a2161c4a3b72cfd2dce8e76f820c99fb1937"
             },
             "require": {
                 "php": ">=5.6",
@@ -30,6 +30,7 @@
             ],
             "type": "project",
             "extra": {
+                "autotagger": true,
                 "branch-alias": {
                     "dev-master": "1.1.x-dev"
                 },

--- a/projects/plugins/jetpack/changelog/add-enable-package-autotagger-to-test
+++ b/projects/plugins/jetpack/changelog/add-enable-package-autotagger-to-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -266,7 +266,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "fe49272ca7f89b26115a031c02e2afdba9f2de28"
+                "reference": "330abb72ac6b6a2eed8f0147be7d3d70430a2b17"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "1.1.x-dev",
@@ -275,6 +275,7 @@
             },
             "type": "library",
             "extra": {
+                "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-blocks",
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-blocks/compare/v${old}...v${new}"
@@ -1403,7 +1404,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "69b94231de9ccb5b0c244bf05b985c6eacc874ba"
+                "reference": "ae11a2161c4a3b72cfd2dce8e76f820c99fb1937"
             },
             "require": {
                 "php": ">=5.6",
@@ -1420,6 +1421,7 @@
             ],
             "type": "project",
             "extra": {
+                "autotagger": true,
                 "branch-alias": {
                     "dev-master": "1.1.x-dev"
                 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When we next do a release with tools/changelogger-release.sh and merge
the resulting PR, the new versions of these packages should be
automatically tagged in the mirror repos.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1616427747259300-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the output of the Build workflow, the new action should be present for these projects (but not any others).
* Once this is merged, check that the mirror repos did not auto-tag (because this isn't a release).
* When we do do a release, check that the mirror repos get correctly tagged.