### PR TITLE
Force Posts and Pages to WPAdmin for Atomic

### DIFF
--- a/projects/plugins/jetpack/changelog/try-force-atomic-posts-pages-to-wpadmin
+++ b/projects/plugins/jetpack/changelog/try-force-atomic-posts-pages-to-wpadmin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Force Posts and Pages menu items to link to WPAdmin on Atomic sites

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -64,6 +64,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_posts_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return false; // return explicit `false` to force WPAdmin links.
 	}
 
 	/**
@@ -73,6 +74,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_page_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return false; // return explicit `false` to force WPAdmin links.
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -60,11 +60,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	/**
 	 * Forces Posts menu to WPAdmin for Atomic sites only.
 	 * Overloads `add_posts_menu` in parent class.
-	 *
-	 * @return void
 	 */
 	public function add_posts_menu() {
-		return;
 	}
 
 	/**
@@ -72,7 +69,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Overloads `add_page_menu` in parent class.
 	 */
 	public function add_page_menu() {
-		return;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -60,15 +60,19 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	/**
 	 * Forces Posts menu to WPAdmin for Atomic sites only.
 	 * Overloads `add_posts_menu` in parent class.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_posts_menu() {
+	public function add_posts_menu( $wp_admin ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	}
 
 	/**
 	 * Forces Pages menu to WPAdmin for Atomic sites only.
 	 * Overloads `add_page_menu` in parent class.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_page_menu() {
+	public function add_page_menu( $wp_admin ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -63,7 +63,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_posts_menu( $wp_admin ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function add_posts_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	}
 
 	/**
@@ -72,7 +72,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_page_menu( $wp_admin ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function add_page_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -58,6 +58,24 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Forces Posts menu to WPAdmin for Atomic sites only.
+	 * Overloads `add_posts_menu` in parent class.
+	 *
+	 * @return void
+	 */
+	public function add_posts_menu() {
+		return;
+	}
+
+	/**
+	 * Forces Pages menu to WPAdmin for Atomic sites only.
+	 * Overloads `add_page_menu` in parent class.
+	 */
+	public function add_page_menu() {
+		return;
+	}
+
+	/**
 	 * Adds Plugins menu.
 	 *
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).


### PR DESCRIPTION
It was requested that for Atomic both Posts and Pages default to WPAdmin and ignore the setting that allows toggling between Calypso and WPAdmin.

Fixes https://github.com/Automattic/wp-calypso/issues/51283

See also hotfix in 648-gh-Automattic/wpcomsh

#### Changes proposed in this Pull Request:
* Force both Posts and Pages menus to link to WPAdmin on Atomic sites.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
Nope

#### Testing instructions:

* Activate this branch via JP Beta on Atomic site.
* Check that `Posts` and `Pages` menu items _always_ link to WPAdmin.
* Toggle the toggle under https://wordpress.com/me/account.
* Check both menu items _still_ continue to link to WPAdmin.

Once done testing please revert back to Jetpack Beta `master` branch and then test the hotfix 648-gh-Automattic/wpcomsh