### PR TITLE
Gardening: use full project path for displayed recommendation

### DIFF
--- a/.github/actions/repo-gardening/src/tasks/check-description/index.js
+++ b/.github/actions/repo-gardening/src/tasks/check-description/index.js
@@ -236,7 +236,7 @@ async function getChangelogEntries( octokit, owner, repo, number ) {
 			) + '/';
 		const found = files.find( file => file.startsWith( changelogDir ) );
 		if ( ! found ) {
-			acc.push( project );
+			acc.push( `projects/${ project }` );
 		}
 		return acc;
 	}, [] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿When we recommend adding a changelog entry for a given project, let's use the full project path (e.g. projects/plugins/jetpack) instead of the partial one (plugins/jetpack), so one can copy the path and cd into it straight from their terminal.


#### Jetpack product discussion

* Internal reference: p1616432372272500-slack-jetpack-crew

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Check the comment on this PR for an example: #19245 
