### PR TITLE
Search: add review link to product results

### DIFF
--- a/projects/plugins/jetpack/changelog/add-search-review-link
+++ b/projects/plugins/jetpack/changelog/add-search-review-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: link review count to product reviews in the product result format.

--- a/projects/plugins/jetpack/modules/search/instant-search/components/product-price.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/product-price.scss
@@ -1,4 +1,6 @@
+@import '../lib/styles/_helper.scss';
+
 .jetpack-instant-search__product-price-regular {
-	color: #555; // replace with a color variable when modal is updated
+	color: $color-text-lighter;
 	padding-right: 0.25em;
 }

--- a/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.jsx
@@ -21,6 +21,7 @@ import './product-ratings.scss';
  * @param {object} props - Component properties.
  * @param {number} props.count - Number of ratings.
  * @param {number} props.rating - Average rating out of five.
+ * @param {string} props.permalink - Permalink URL to product page.
  * @returns {object} Product rating component.
  */
 export default function ProductRatings( { rating = 0, count = 0, permalink } ) {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.jsx
@@ -35,13 +35,12 @@ export default function ProductRatings( { rating = 0, count = 0, permalink } ) {
 				aria-hidden
 				className="jetpack-instant-search__product-rating-count"
 				href={ permalink + '#reviews' }
-				title={ sprintf(
+			>
+				{ sprintf(
 					/* Translators: the placeholder is the number of product reviews. */
-					_n( '(%s customer review)', '(%s customer reviews)', count, 'jetpack' ),
+					_n( '%s review', '%s reviews', count, 'jetpack' ),
 					count
 				) }
-			>
-				{ count }
 			</a>
 			<span className="screen-reader-text">
 				{ sprintf(

--- a/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.jsx
@@ -39,7 +39,7 @@ export default function ProductRatings( { rating = 0, count = 0, permalink } ) {
 			>
 				{ sprintf(
 					/* Translators: the placeholder is the number of product reviews. */
-					_n( '%s review', '%s reviews', count, 'jetpack' ),
+					_n( '%d review', '%d reviews', count, 'jetpack' ),
 					count
 				) }
 			</a>
@@ -47,8 +47,8 @@ export default function ProductRatings( { rating = 0, count = 0, permalink } ) {
 				{ sprintf(
 					/* Translators: the first placeholder is the average product rating out of 5; the second is the number of product reviews. */
 					_n(
-						'Average rating of %s out of 5 from %s review.',
-						'Average rating of %s out of 5 from %s reviews.',
+						'Average rating of %d out of 5 from %d review.',
+						'Average rating of %d out of 5 from %d reviews.',
 						count,
 						'jetpack'
 					),

--- a/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.jsx
@@ -23,7 +23,7 @@ import './product-ratings.scss';
  * @param {number} props.rating - Average rating out of five.
  * @returns {object} Product rating component.
  */
-export default function ProductRatings( { rating = 0, count = 0 } ) {
+export default function ProductRatings( { rating = 0, count = 0, permalink } ) {
 	return (
 		<div className="jetpack-instant-search__product-rating">
 			<span aria-hidden className="jetpack-instant-search__product-rating-stars">
@@ -31,9 +31,10 @@ export default function ProductRatings( { rating = 0, count = 0 } ) {
 					.fill( <Gridicon size={ 16 } icon="star-outline" /> )
 					.fill( <Gridicon size={ 16 } icon="star" />, 0, rating ) }
 			</span>{ ' ' }
-			<span
+			<a
 				aria-hidden
 				className="jetpack-instant-search__product-rating-count"
+				href={ permalink + '#reviews' }
 				title={ sprintf(
 					/* Translators: the placeholder is the number of product reviews. */
 					_n( '(%s customer review)', '(%s customer reviews)', count, 'jetpack' ),
@@ -41,7 +42,7 @@ export default function ProductRatings( { rating = 0, count = 0 } ) {
 				) }
 			>
 				{ count }
-			</span>
+			</a>
 			<span className="screen-reader-text">
 				{ sprintf(
 					/* Translators: the first placeholder is the average product rating out of 5; the second is the number of product reviews. */

--- a/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/product-ratings.scss
@@ -5,6 +5,9 @@
 	fill: $studio-yellow-20;
 }
 
-.jetpack-instant-search__product-rating-count {
+.jetpack-instant-search a.jetpack-instant-search__product-rating-count {
+	color: $color-text-lighter;
+	font-size: 0.9em;
+	text-decoration: underline;
 	vertical-align: text-top;
 }

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
@@ -71,6 +71,7 @@ class SearchResultProduct extends Component {
 					<ProductRatings
 						count={ fields[ 'meta._wc_review_count.long' ] }
 						rating={ fields[ 'meta._wc_average_rating.double' ] }
+						permalink={ `//${ fields[ 'permalink.url.raw' ] }` }
 					/>
 				) }
 				<div


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add a link to reviews from the review count in product search results.

<img width="360" alt="Screen Shot 2021-03-23 at 15 34 35" src="https://user-images.githubusercontent.com/17325/112084223-4a994200-8bed-11eb-9cc9-7abd37493009.png">

#### Jetpack product discussion
Designs in pcNPJE-V-p2.

#### Does this pull request change what data or activity we track or use?
No. 

#### Testing instructions:
On a WooCommerce site with Jetpack Search enabled, ensure that a review link is present for all products with reviews.