### PR TITLE
Search: Hide "filters" menu on mobile if there are no filters to display

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-hide-filter-widget-on-empty
+++ b/projects/plugins/jetpack/changelog/fix-hide-filter-widget-on-empty
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Search: hide "filters" menu on mobile if there are no filters to display

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -123,10 +123,11 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		}
 		unset( $filter );
 
-		$has_other_widgets = false;
+		$has_non_search_widgets = false;
 		foreach ( $overlay_widget_ids as $overlay_widget_id ) {
 			if ( strpos( $overlay_widget_id, Jetpack_Search_Helpers::FILTER_WIDGET_BASE ) === false ) {
-				$has_other_widgets = true;
+				$has_non_search_widgets = true;
+				break;
 			}
 		}
 
@@ -198,7 +199,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'hasOverlayWidgets'     => count( $overlay_widget_ids ) > 0,
 			'widgets'               => array_values( $widgets ),
 			'widgetsOutsideOverlay' => array_values( $widgets_outside_overlay ),
-			'hasOtherWidgets'       => $has_other_widgets,
+			'hasNonSearchWidgets'   => $has_non_search_widgets,
 		);
 
 		/**

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -123,6 +123,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		}
 		unset( $filter );
 
+		$has_other_widgets = false;
+		foreach ( $overlay_widget_ids as $overlay_widget_id ) {
+			if ( strpos( $overlay_widget_id, Jetpack_Search_Helpers::FILTER_WIDGET_BASE ) === false ) {
+				$has_other_widgets = true;
+			}
+		}
+
 		$post_type_objs   = get_post_types( array( 'exclude_from_search' => false ), 'objects' );
 		$post_type_labels = array();
 		foreach ( $post_type_objs as $key => $obj ) {
@@ -191,6 +198,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'hasOverlayWidgets'     => count( $overlay_widget_ids ) > 0,
 			'widgets'               => array_values( $widgets ),
 			'widgetsOutsideOverlay' => array_values( $widgets_outside_overlay ),
+			'hasOtherWidgets'       => $has_other_widgets,
 		);
 
 		/**

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -320,7 +320,7 @@ class SearchApp extends Component {
 					sort={ this.props.sort }
 					widgets={ this.props.options.widgets }
 					widgetOutsideOverlay={ this.props.widgetOutsideOverlay }
-					hasOtherWidgets={ this.props.options.hasOtherWidgets }
+					hasNonSearchWidgets={ this.props.options.hasNonSearchWidgets }
 				/>
 			</Overlay>,
 			document.body

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -320,6 +320,7 @@ class SearchApp extends Component {
 					sort={ this.props.sort }
 					widgets={ this.props.options.widgets }
 					widgetOutsideOverlay={ this.props.widgetOutsideOverlay }
+					hasOtherWidgets={ this.props.options.hasOtherWidgets }
 				/>
 			</Overlay>,
 			document.body

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
@@ -44,12 +44,12 @@ class SearchResults extends Component {
 		}
 	};
 
-	hasAnyWidgets() {
+	hasFilterOptions() {
 		let widgets = [ ...this.props.widgets ];
 		if ( this.props.widgetOutsideOverlay?.filters?.length > 0 ) {
 			widgets = [ this.props.widgetOutsideOverlay, ...widgets ];
 		}
-		return widgets;
+		return widgets.length > 0;
 	}
 
 	getSearchTitle() {
@@ -217,7 +217,7 @@ class SearchResults extends Component {
 					resultFormat={ this.props.resultFormat }
 					sort={ this.props.sort }
 				>
-					{ this.hasAnyWidgets() && (
+					{ ( this.hasFilterOptions() || this.props.hasNonSearchWidgets ) && (
 						<div
 							role="button"
 							onClick={ this.toggleMobileSecondary }


### PR DESCRIPTION
Fixes #18989.

#### Changes proposed in this Pull Request

In Jetpack Instant Search, hide the "filters" menu on mobile breakpoints when no filters are defined. We currently show the menu even if it doesn't contain anything.

<img width="447" alt="Screen Shot 2021-03-25 at 15 05 11" src="https://user-images.githubusercontent.com/17325/112408085-07210e00-8d7c-11eb-886f-17a6365711be.png">

Implementation notes:

1. Added **hasNonSearchWidgets** to server object and frontend to consume it. There was not enough information from the server object,  which has only hasOverlayWidgets available, to determine whether there are other non-search widgets on the search sidebar. 

2. Fixed a typo to test whether an Array is empty. 

3. Changed the logic to show "Filters" when there are filter options configured or there are non-search widgets existing on the search sidebar

#### Jetpack product discussion
p1616361118002000-slack-jetpack-search-backstage

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Go to a site with Jetpack Instant Search enabled, add a search widget to the search sidebar with no filters set up
- Perform a search on a mobile screen width

1. Hide if no widgets in sidebar
    - Test passed if "Filters" menu is hidden

2. Show if there are non-search widgets
    - Add a category widget to Search widget
    - Test passed Filters if menu is shown regardless

3. Hide if no widgets configured
    - Remove all widgets from search sidebar
    - Test passed if "Filters" menu is hidden