### PR TITLE
Connection: Replace is_active usage with appropriate methods

### DIFF
--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -241,7 +241,7 @@ class Jetpack_XMLRPC_Server {
 			return $this->error( new \WP_Error( 'user_unknown', 'User not found.', 404 ), 'remote_authorize' );
 		}
 
-		if ( $this->connection->is_active() && $this->connection->is_user_connected( $request['state'] ) ) {
+		if ( $this->connection->has_connected_owner() && $this->connection->is_user_connected( $request['state'] ) ) {
 			return $this->error( new \WP_Error( 'already_connected', 'User already connected.', 400 ), 'remote_authorize' );
 		}
 
@@ -379,7 +379,7 @@ class Jetpack_XMLRPC_Server {
 
 		$site_icon = get_site_icon_url();
 
-		$auto_enable_sso = ( ! $this->connection->is_active() || Jetpack::is_module_active( 'sso' ) );
+		$auto_enable_sso = ( ! $this->connection->has_connected_owner() || Jetpack::is_module_active( 'sso' ) );
 
 		/** This filter is documented in class.jetpack-cli.php */
 		if ( apply_filters( 'jetpack_start_enable_sso', $auto_enable_sso ) ) {
@@ -407,7 +407,7 @@ class Jetpack_XMLRPC_Server {
 			'user_login'   => $user->user_login,
 			'scope'        => $this->connection->sign_role( $role, $user->ID ),
 			'secret'       => $secrets['secret_1'],
-			'is_active'    => $this->connection->is_active(),
+			'is_active'    => $this->connection->has_connected_owner(), // TODO: Confirm this.
 		);
 
 		if ( $site_icon ) {
@@ -431,7 +431,7 @@ class Jetpack_XMLRPC_Server {
 	 * @return mixed
 	 */
 	public function remote_connect( $request, $ixr_client = false ) {
-		if ( $this->connection->is_active() ) {
+		if ( $this->connection->has_connected_owner() ) {
 			return $this->error(
 				new WP_Error(
 					'already_connected',
@@ -495,7 +495,7 @@ class Jetpack_XMLRPC_Server {
 
 		$this->do_post_authorization();
 
-		return $this->connection->is_active();
+		return $this->connection->has_connected_owner();
 	}
 
 	/**

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -73,13 +73,13 @@ class Manager {
 
 		$manager->setup_xmlrpc_handlers(
 			$_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$manager->is_active(),
+			$manager->is_connected(),
 			$manager->verify_xml_rpc_signature()
 		);
 
 		$manager->error_handler = Error_Handler::get_instance();
 
-		if ( $manager->is_active() ) {
+		if ( $manager->is_connected() ) {
 			add_filter( 'xmlrpc_methods', array( $manager, 'public_xmlrpc_methods' ) );
 		}
 
@@ -101,7 +101,7 @@ class Manager {
 	 * Sets up the XMLRPC request handlers.
 	 *
 	 * @param array                  $request_params incoming request parameters.
-	 * @param Boolean                $is_active whether the connection is currently active.
+	 * @param Boolean                $is_active whether the site-level connection is currently active.
 	 * @param Boolean                $is_signed whether the signature check has been successful.
 	 * @param \Jetpack_XMLRPC_Server $xmlrpc_server (optional) an instance of the server to use instead of instantiating a new one.
 	 */
@@ -249,7 +249,7 @@ class Manager {
 		remove_all_filters( 'authenticate' );
 		remove_all_actions( 'wp_login_failed' );
 
-		if ( $this->is_active() ) {
+		if ( $this->is_connected() ) {
 			// Allow Jetpack authentication.
 			add_filter( 'authenticate', array( $this, 'authenticate_jetpack' ), 10, 3 );
 		}
@@ -1566,7 +1566,7 @@ class Manager {
 				'scope'         => $signed_role,
 				'user_email'    => $user->user_email,
 				'user_login'    => $user->user_login,
-				'is_active'     => $this->is_active(),
+				'is_active'     => $this->is_connected(), // TODO Confirm this.
 				'jp_version'    => Constants::get_constant( 'JETPACK__VERSION' ),
 				'auth_type'     => $auth_type,
 				'secret'        => $secrets['secret_1'],
@@ -1905,7 +1905,7 @@ class Manager {
 	 */
 	public function xmlrpc_options( $options ) {
 		$jetpack_client_id = false;
-		if ( $this->is_active() ) {
+		if ( $this->is_connected() ) {
 			$jetpack_client_id = \Jetpack_Options::get_option( 'id' );
 		}
 		$options['jetpack_version'] = array(
@@ -2116,14 +2116,14 @@ class Manager {
 	}
 
 	/**
-	 * If connection is active, add the list of plugins using connection to the heartbeat (except Jetpack itself)
+	 * If the site-level connection is active, add the list of plugins using connection to the heartbeat (except Jetpack itself)
 	 *
 	 * @param array $stats The Heartbeat stats array.
 	 * @return array $stats
 	 */
 	public function add_stats_to_heartbeat( $stats ) {
 
-		if ( ! $this->is_active() ) {
+		if ( ! $this->is_connected() ) {
 			return $stats;
 		}
 

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -46,7 +46,7 @@ class REST_Connector {
 			'jetpack'
 		);
 
-		if ( ! $this->connection->is_active() ) {
+		if ( ! $this->connection->is_connected() ) {
 			// Register a site.
 			register_rest_route(
 				'jetpack/v4',
@@ -153,7 +153,7 @@ class REST_Connector {
 		$connection = new Manager();
 
 		$connection_status = array(
-			'isActive'          => $connection->is_active(),
+			'isActive'          => $connection->is_connected(),
 			'isStaging'         => $status->is_staging_site(),
 			'isRegistered'      => $connection->is_connected(),
 			'hasConnectedOwner' => $connection->has_connected_owner(),

--- a/projects/packages/connection/src/class-webhooks.php
+++ b/projects/packages/connection/src/class-webhooks.php
@@ -68,7 +68,7 @@ class Webhooks {
 	 * Perform the authorization action.
 	 */
 	public function handle_authorize() {
-		if ( $this->connection->is_active() && $this->connection->is_user_connected() ) {
+		if ( $this->connection->is_connected() && $this->connection->is_user_connected() ) {
 			$redirect_url = apply_filters( 'jetpack_client_authorize_already_authorized_url', admin_url() );
 			wp_safe_redirect( $redirect_url );
 


### PR DESCRIPTION
Replace `is_active` functionality with more appropriate methods in `Manager`.
With user-less in mind we will be slowly deprecating the `is_active` method.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
TODO

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
TODO

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

TODO
