### PR TITLE
repo-gardening: Remove broken use of Object.assign()

### DIFF
--- a/.github/actions/repo-gardening/src/tasks/check-description/index.js
+++ b/.github/actions/repo-gardening/src/tasks/check-description/index.js
@@ -408,13 +408,17 @@ async function postComment( payload, octokit, comment ) {
 	// If there is a comment already, update it.
 	if ( existingComment !== 0 ) {
 		debug( `check-description: update comment ID ${ existingComment } with our new remarks` );
-		await octokit.issues.updateComment(
-			Object.assign( commentOpts, { comment_id: +existingComment } )
-		);
+		await octokit.issues.updateComment( {
+			...commentOpts,
+			comment_id: +existingComment,
+		} );
 	} else {
 		// If no comment was published before, publish one now.
 		debug( `check-description: Posting comment to PR #${ number }` );
-		await octokit.issues.createComment( Object.assign( commentOpts, { issue_number: +number } ) );
+		await octokit.issues.createComment( {
+			...commentOpts,
+			issue_number: +number,
+		} );
 	}
 }
 
@@ -439,15 +443,17 @@ async function updateLabels( payload, octokit ) {
 	const hasNeedsReview = await hasNeedsReviewLabel( octokit, ownerLogin, repo, number );
 	if ( hasNeedsReview ) {
 		debug( `check-description: remove existing Needs review label.` );
-		await octokit.issues.removeLabel(
-			Object.assign( labelOpts, { name: '[Status] Needs Review' } )
-		);
+		await octokit.issues.removeLabel( {
+			...labelOpts,
+			name: '[Status] Needs Review',
+		} );
 	}
 
 	debug( `check-description: add Needs Author Reply label.` );
-	await octokit.issues.addLabels(
-		Object.assign( labelOpts, { labels: [ '[Status] Needs Author Reply' ] } )
-	);
+	await octokit.issues.addLabels( {
+		...labelOpts,
+		labels: [ '[Status] Needs Author Reply' ],
+	} );
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
As its name implies, `Object.assign()` assigns to the object. Which
breaks when the same object is used again later in the method.

Better to just create a new object with spread syntax.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Did it comment correctly on this PR?
* Do something that makes it both remove "[Status] Needs Review" and add "[Status] Needs Author Reply". Did that work correctly?