### PR TITLE
Search: Lazy load images

### DIFF
--- a/projects/plugins/jetpack/changelog/add-search-img-lazy-load
+++ b/projects/plugins/jetpack/changelog/add-search-img-lazy-load
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: Lazy load images

--- a/projects/plugins/jetpack/changelog/add-search-img-lazy-load
+++ b/projects/plugins/jetpack/changelog/add-search-img-lazy-load
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Search: Lazy load images
+Search: Lazy load images for improved performance

--- a/projects/plugins/jetpack/modules/search/instant-search/components/photon-image.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/photon-image.jsx
@@ -18,7 +18,7 @@ const PhotonImage = props => {
 		maxHeight = 600,
 		maxWidth = 600,
 		src: originalSrc,
-		useDiv,
+		lazyLoad = true,
 		...otherProps
 	} = props;
 
@@ -34,7 +34,7 @@ const PhotonImage = props => {
 		}
 
 		let observer = null;
-		if ( 'IntersectionObserver' in window ) {
+		if ( lazyLoad && 'IntersectionObserver' in window ) {
 			observer = new window.IntersectionObserver( ( entries, obs ) => {
 				for ( const entry of entries ) {
 					if ( entry.isIntersecting ) {
@@ -50,7 +50,7 @@ const PhotonImage = props => {
 		return () => {
 			observer?.disconnect();
 		};
-	}, [ src ] );
+	}, [ lazyLoad, src ] );
 
 	return <img alt={ alt } ref={ image } src={ lazySrc } { ...otherProps } />;
 };

--- a/projects/plugins/jetpack/modules/search/instant-search/components/photon-image.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/photon-image.jsx
@@ -4,46 +4,55 @@
  * External dependencies
  */
 import { h } from 'preact';
-import photon from 'photon';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
 /**
- * Strips query string values from URLs; photon can't handle them.
- *
- * @param {string} url - Image URL
- *
- * @returns {string} - Image URL without any query strings.
+ * Internal dependencies
  */
-function stripQueryString( url ) {
-	return url.split( '?', 1 )[ 0 ];
-}
+import { usePhoton } from '../lib/hooks/use-photon';
 
-const PhotonImage = ( {
-	useDiv,
-	src,
-	maxWidth = 600,
-	maxHeight = 600,
-	alt,
-	isPhotonEnabled,
-	...otherProps
-} ) => {
-	let srcToDisplay = src;
+const PhotonImage = props => {
+	const {
+		alt,
+		isPhotonEnabled,
+		maxHeight = 600,
+		maxWidth = 600,
+		src: originalSrc,
+		useDiv,
+		...otherProps
+	} = props;
 
-	if ( isPhotonEnabled ) {
-		const photonSrc = photon( stripQueryString( src ), { resize: `${ maxWidth },${ maxHeight }` } );
-		if ( photonSrc !== null ) {
-			srcToDisplay = photonSrc;
+	const image = useRef();
+	const [ lazySrc, setLazySrc ] = useState( null );
+	const src = usePhoton( originalSrc, maxWidth, maxHeight, isPhotonEnabled );
+
+	// Enable lazy loading via IntersectionObserver if possible.
+	useEffect( () => {
+		// Wait until src is available
+		if ( ! src ) {
+			return;
 		}
-	}
 
-	return useDiv ? (
-		<div
-			style={ { backgroundImage: `url("${ srcToDisplay }")` } }
-			title={ alt }
-			{ ...otherProps }
-		/>
-	) : (
-		<img src={ srcToDisplay } alt={ alt } { ...otherProps } />
-	);
+		let observer = null;
+		if ( 'IntersectionObserver' in window ) {
+			observer = new window.IntersectionObserver( ( entries, obs ) => {
+				for ( const entry of entries ) {
+					if ( entry.isIntersecting ) {
+						setLazySrc( src );
+						obs.unobserve( entry.target );
+					}
+				}
+			} );
+			observer.observe( image.current );
+		} else {
+			setLazySrc( src );
+		}
+		return () => {
+			observer?.disconnect();
+		};
+	}, [ src ] );
+
+	return <img alt={ alt } ref={ image } src={ lazySrc } { ...otherProps } />;
 };
 
 export default PhotonImage;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
@@ -57,25 +57,24 @@ export default function SearchResultExpanded( props ) {
 
 				{ highlight.comments && <SearchResultComments comments={ highlight.comments } /> }
 			</div>
-			<div className="jetpack-instant-search__search-result-expanded__image-container">
-				<a
-					className="jetpack-instant-search__search-result-expanded__image-link"
-					href={ `//${ fields[ 'permalink.url.raw' ] }` }
-					onClick={ props.onClick }
-				>
+			<a
+				className="jetpack-instant-search__search-result-expanded__image-link"
+				href={ `//${ fields[ 'permalink.url.raw' ] }` }
+				onClick={ props.onClick }
+			>
+				<div className="jetpack-instant-search__search-result-expanded__image-container">
 					{ firstImage ? (
 						// NOTE: Wouldn't it be amazing if we filled the container's background
 						//       with the primary color of the image?
 						<PhotonImage
-							alt=""
+							alt={ highlight.title }
 							className="jetpack-instant-search__search-result-expanded__image"
 							isPhotonEnabled={ this.props.isPhotonEnabled }
 							src={ `//${ firstImage }` }
-							useDiv
 						/>
 					) : null }
-				</a>
-			</div>
+				</div>
+			</a>
 		</li>
 	);
 }

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.scss
@@ -35,7 +35,6 @@ $image-square-size: 128px;
 	max-width: 100%;
 
 	@include break-small-up() {
-		min-height: $image-square-size;
 		width: 100%;
 	}
 
@@ -49,13 +48,18 @@ $image-square-size: 128px;
 	color: $color-text;
 }
 
-.jetpack-instant-search__search-result-expanded__image-container {
+.jetpack-instant-search__search-result-expanded__image-link {
 	margin-left: 1em;
+	@include break-small-down() {
+		order: -1;
+		margin: 0 auto 0.5em auto;
+	}
+}
+
+.jetpack-instant-search__search-result-expanded__image-container {
 	width: $image-square-size;
 
 	@include break-small-down() {
-		margin: 0 auto 0.5em auto;
-		order: -1;
 		width: 2 * $image-square-size;
 	}
 
@@ -64,27 +68,25 @@ $image-square-size: 128px;
 	}
 }
 
+// Aspect ratio box trick
+// See https://css-tricks.com/aspect-ratio-boxes/
+.jetpack-instant-search__search-result-expanded__image-container {
+	position: relative;
+	&:before {
+		display: block;
+		content: '';
+		width: 100%;
+		padding-top: 100%;
+	}
+}
 .jetpack-instant-search__search-result-expanded__image {
-	min-height: $image-square-size;
-	width: $image-square-size;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+}
+
+.jetpack-instant-search__search-result-expanded__image {
 	border-radius: 5px;
-
-	// Image is shown above text content in mobile view, make bigger
-	@include break-small-down() {
-		min-height: 2 * $image-square-size;
-		width: 2 * $image-square-size;
-	}
-}
-.jetpack-instant-search__search-result-expanded__image {
-	background-size: contain;
-	background-position: center;
-	background-repeat: no-repeat;
-
-	@include break-small-up() {
-		background-size: cover;
-	}
-}
-
-.jetpack-instant-search__search-result-expanded__img {
-	margin: 0.5em 0.5em 0.5em 0;
 }

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.scss
@@ -85,6 +85,9 @@ $image-square-size: 128px;
 	right: 0;
 	bottom: 0;
 	left: 0;
+	height: 100%;
+	object-fit: cover;
+	width: 100%;
 }
 
 .jetpack-instant-search__search-result-expanded__image {

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import photon from 'photon';
+import { useEffect, useState } from 'preact/hooks';
+
+/**
+ * Strips query string values from URLs; photon can't handle them.
+ *
+ * @param {string} url - Image URL
+ *
+ * @returns {string} - Image URL without any query strings.
+ */
+function stripQueryString( url ) {
+	return url.split( '?', 1 )[ 0 ];
+}
+
+/**
+ * Hook for returning a Photonized image URL given width and height parameters.
+ *
+ * @param {string} initialSrc - Image URL
+ * @param {number} width - width in pixels
+ * @param {number} height - height in pixels
+ * @param {boolean} isPhotonEnabled - Toggle photon on/off
+ *
+ * @returns {string} - Photonized image URL if service is available; initialSrc otherwise.
+ */
+export function usePhoton( initialSrc, width, height, isPhotonEnabled = true ) {
+	const [ src, setSrc ] = useState( null );
+
+	useEffect( () => {
+		if ( isPhotonEnabled ) {
+			const photonSrc = photon( stripQueryString( initialSrc ), {
+				resize: `${ width },${ height }`,
+			} );
+			setSrc( photonSrc ? photonSrc : initialSrc );
+		} else {
+			setSrc( initialSrc );
+		}
+	}, [ initialSrc, width, height, isPhotonEnabled ] );
+
+	return src;
+}


### PR DESCRIPTION
Fixes #19171.

#### Changes proposed in this Pull Request:
* Modularizes `photon` library invocation into a `usePhoton` hook.
* If `IntersectionObserver` is available, enable lazy loading of images. Otherwise, greedily load images as before.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* With either the Expanded or Product result format enabled, perform a search.
* Ensure that the result images are loaded lazily. You can confirm this via your browser's network console.
* Using a browser that doesn't support [`IntersectionObserver`](https://caniuse.com/intersectionobserver), repeat the testing instructions above. Ensure that the images (greedily) load as expected.