### PR TITLE
Add a "PR is up-to-date" check

### DIFF
--- a/.github/files/pr-update-to.sh
+++ b/.github/files/pr-update-to.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eo pipefail
+
+function die {
+	echo "::error::$*"
+	exit 1
+}
+
+[[ "$GITHUB_EVENT_NAME" == "push" ]] || die "Must be a push event"
+[[ "$GITHUB_REF" == "refs/heads/master" ]] || die "Must be a push to master"
+
+function update_tag {
+	echo 'Updating tag!'
+	git config --global user.name "matticbot"
+	git config --global user.email "matticbot@users.noreply.github.com"
+	git remote set-url origin "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
+	git tag --force pr-update-to HEAD
+	git push --force origin pr-update-to
+	exit 0
+}
+
+cd $(dirname "${BASH_SOURCE[0]}")/../..
+BASE="$PWD"
+
+# If this commit updated a changelog, assume it was a release and update the tag.
+echo "Checking for changes to changelogs..."
+FILES=()
+for FILE in projects/*/*/composer.json; do
+	PROJECT="${FILE%/composer.json}"
+	cd "$BASE/$PROJECT"
+	FILES+=( "$(realpath -m --relative-to="$BASE" "$(jq -r '.extra.changelogger.changelog // "CHANGELOG.md"' composer.json)")" )
+done
+cd "$BASE"
+git diff --exit-code --name-only HEAD^..HEAD "${FILES[@]}" || update_tag
+
+echo 'Done, no tag update needed.'

--- a/.github/workflows/pr-is-up-to-date.yml
+++ b/.github/workflows/pr-is-up-to-date.yml
@@ -1,0 +1,34 @@
+name: PR is up-to-date
+on:
+  pull_request_target:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+    tags: [ pr-update-to ]
+
+jobs:
+  check_prs:
+    name: Check PR
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.ref != 'refs/heads/master'
+    timeout-minutes: 5  # 2021-03-23: The run on push to the tag might take a minute or two.
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./projects/github-actions/pr-is-up-to-date
+        with:
+          tag: pr-update-to
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+
+  check_commit:
+    name: Check master commit
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    timeout-minutes: 5  # 2021-03-23: Should be quick, but let's give it some room.
+    steps:
+      - uses: actions/checkout@v2
+      - name: Wait for prior instances of the workflow to finish
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check whether the tag needs updating
+        run: .github/files/pr-update-to.sh

--- a/projects/github-actions/pr-is-up-to-date/.gitattributes
+++ b/projects/github-actions/pr-is-up-to-date/.gitattributes
@@ -1,0 +1,2 @@
+# Files to exclude from the mirror repo, but included in the monorepo.
+changelog/**      production-exclude

--- a/projects/github-actions/pr-is-up-to-date/.gitignore
+++ b/projects/github-actions/pr-is-up-to-date/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/projects/github-actions/pr-is-up-to-date/CHANGELOG.md
+++ b/projects/github-actions/pr-is-up-to-date/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/github-actions/pr-is-up-to-date/README.md
+++ b/projects/github-actions/pr-is-up-to-date/README.md
@@ -1,0 +1,67 @@
+# PR is Up-to-Date
+
+This [Github Action](https://github.com/features/actions) will check that PRs in the repo
+are up to date with respect to a tag.
+
+The idea is to work like GitHub's "Require branches to be up to date before merging" setting,
+but using a tag rather than the HEAD of the target branch.
+
+## Example
+
+```yaml
+name: PR is up-to-date
+on:
+  pull_request_target:
+    branches: [ master ]
+  push:
+    tags: [ latest ]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Automattic/action-pr-is-up-to-date@v1
+        with:
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+          tag: latest
+```
+
+## Usage
+
+This action is intended to be triggered by `pull_request_target` or `pull_request` targeting the specified branch, and by a `push` to the specified tag.
+It will not work for pushes to anything else.
+
+```yaml
+- uses: Automattic/action-pr-is-up-to-date@v1
+  with:
+    # Branch to use. Defaults to the repository's default branch.
+    branch:
+
+    # Specify the "context" for the status to set. This is what shows up in the
+    # PR's checks list. The default is "PR is up to date with ${{ inputs.tag }}".
+    status:
+
+    # Specify the "description" when the PR is out of date.
+    # The default is "This PR needs a ${{ inputs.branch }} merge or rebase.".
+    description-fail:
+
+    # Specify the "description" when the PR is up to date. The default is empty.
+    description-ok:
+
+    # Specify the tag that is used for the check. The tag must point to a commit that
+    # is reachable from the input branch.
+    tag:
+
+    # GitHub Access Token. This token must allow for pushing to all relevant
+    # branches of all relevant mirror repos.
+    token:
+```
+
+The specified tag must, of course, exist. You may update it manually, for example from the command line with
+```
+git tag --force $TAG $COMMIT
+git push --force origin $TAG
+```
+Or you might use another action to examine pushes to your branch and update the tag accordingly.
+Either way, the push of the tag will update the status on all open PRs targeting the branch.

--- a/projects/github-actions/pr-is-up-to-date/action.yml
+++ b/projects/github-actions/pr-is-up-to-date/action.yml
@@ -1,0 +1,40 @@
+name: pr-is-up-to-date
+description: Check that PRs are up to date with respect to a tag.
+inputs:
+  branch:
+    description: Only check PRs being merged into this branch. Defaults to the repo's default branch.
+    required: false
+    default: ${{ github.event.repository.default_branch }}
+  status:
+    description: Status context for the status check. Default is "PR is up to date with $TAG".
+    required: false
+  description-fail:
+    description: Description field for the status check when the PR is out of date. Default is "This PR needs a $BRANCH merge or rebase."
+    required: false
+  description-ok:
+    description: Description field for the status check when the PR is up to date. Default is empty.
+    required: false
+  tag:
+    description: Tag that PRs must be up to date with.
+    required: true
+  token:
+    description: >
+      GitHub Access Token. The user associated with this token will show up
+      as the "creator" of the status check.
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        API_TOKEN: ${{ inputs.token }}
+        BRANCH: ${{ inputs.branch }}
+        CONTEXT: ${{ inputs.status }}
+        DESCRIPTION_FAIL: ${{ inputs.description-fail }}
+        DESCRIPTION_OK: ${{ inputs.description-ok }}
+        TAG: ${{ inputs.tag }}
+      run: ${{ github.action_path }}/run.sh
+branding:
+  color: green
+  icon: clock

--- a/projects/github-actions/pr-is-up-to-date/changelog/add-pr-up-to-date-check
+++ b/projects/github-actions/pr-is-up-to-date/changelog/add-pr-up-to-date-check
@@ -1,0 +1,4 @@
+Significance: major
+Type: added
+
+Initial release.

--- a/projects/github-actions/pr-is-up-to-date/composer.json
+++ b/projects/github-actions/pr-is-up-to-date/composer.json
@@ -1,0 +1,25 @@
+{
+	"name": "automattic/action-pr-is-up-to-date",
+	"description": "GitHub Action to check that PRs are up to date with respect to a tag.",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"require-dev": {
+		"automattic/jetpack-changelogger": "1.1.x-dev"
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"extra": {
+		"mirror-repo": "Automattic/action-pr-is-up-to-date",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/action-pr-is-up-to-date/compare/v${old}...v${new}"
+		}
+	}
+}

--- a/projects/github-actions/pr-is-up-to-date/license.txt
+++ b/projects/github-actions/pr-is-up-to-date/license.txt
@@ -1,0 +1,14 @@
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA.

--- a/projects/github-actions/pr-is-up-to-date/run.sh
+++ b/projects/github-actions/pr-is-up-to-date/run.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+set -eo pipefail
+
+function die {
+	echo "::error::$*"
+	exit 1
+}
+
+GITHUB_API_URL="${GITHUB_API_URL:-https://api.github.com}"
+GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+[[ -n "$API_TOKEN" ]] || die "API_TOKEN must be set"
+[[ -n "$GITHUB_REPOSITORY" ]] || die "GITHUB_REPOSITORY must be set"
+[[ -n "$TAG" ]] || die "TAG must be set"
+[[ -n "$BRANCH" ]] || die "BRANCH must be set"
+CONTEXT="${CONTEXT:-PR is up to date with $TAG}"
+DESCRIPTION_FAIL="${DESCRIPTION_FAIL:-This PR needs a $BRANCH merge or rebase.}"
+DESCRIPTION_OK="${DESCRIPTION_OK:-}"
+
+DATA_FAIL="$(jq --arg url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" --arg context "$CONTEXT" --arg desc "$DESCRIPTION_FAIL" -n '{ "state": "failure", "target_url": $url, "context": $context, "description": $desc }')"
+DATA_OK="$(jq --arg url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" --arg context "$CONTEXT" --arg desc "$DESCRIPTION_OK" -n '{ "state": "success", "target_url": $url, "context": $context, "description": $desc }')"
+
+case "$GITHUB_EVENT_NAME" in
+	pull_request)
+		if [[ "$GITHUB_REF" =~ ^refs/pull/[0-9]+/merge ]]; then
+			PR="${GITHUB_REF#refs/pull/}"
+			PR="${PR%/merge}"
+		else
+			die "Could not determine PR number from GITHUB_REF $GITHUB_REF"
+		fi
+		;;
+	pull_request_target)
+		PR="$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")"
+		if [[ -z "$PR" ]]; then
+			echo "::error::Could not determine PR number from event data"
+			cat $GITHUB_EVENT_PATH
+			exit 1
+		fi
+		;;
+	push)
+		if [[ "$GITHUB_REF" != "refs/tags/$TAG" ]]; then
+			die "Push event for incorrect tag, $GITHUB_REF != refs/tags/$TAG"
+		fi
+		;;
+	*)
+		die "Unsupported event $GITHUB_EVENT_NAME"
+		;;
+esac
+
+TMPDIR="${TMPDIR:-/tmp}"
+DIR=$(mktemp -d "${TMPDIR%/}/check-prs-are-up-to-date.XXXXXXXX")
+trap "rm -rf $DIR" EXIT
+cd $DIR
+
+echo "::group::Initializing repo"
+git init -q .
+git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+git fetch --depth=1 origin "$TAG"
+TAG_COMMIT="$(git rev-parse FETCH_HEAD)"
+git repack -d  # Work around a git bug
+echo "::endgroup::"
+echo "Tag $TAG points to $TAG_COMMIT"
+
+echo "::group::Sanity check"
+git fetch --shallow-exclude="$TAG" origin "$BRANCH"
+git repack -d  # Work around a git bug
+git fetch --deepen=1 origin "$BRANCH"
+echo "::endgroup::"
+if ! git merge-base --is-ancestor "$TAG_COMMIT" "origin/$BRANCH"; then
+	die "Tag $TAG is not an ancestor of $BRANCH! Aborting."
+fi
+
+function do_fetch {
+	local PR REFS=()
+	for PR in "$@"; do
+		REFS+=( "+refs/pull/$PR/head:refs/remotes/pulls/$PR" )
+	done
+
+	git fetch --shallow-exclude="$TAG" origin "${REFS[@]}"
+	git repack -d  # Work around a git bug
+	git fetch --deepen=1 origin "${REFS[@]}"
+}
+
+function process_prs {
+	local PR COMMIT
+	for PR in "$@"; do
+		COMMIT="$(git rev-parse "pulls/$PR")"
+		if git merge-base --is-ancestor "$TAG_COMMIT" "$COMMIT"; then
+			printf "\e[1;32mPR $PR is up to date\e[0m\n"
+			if $NOTIFY_SUCCESS && [[ -n "$CI" ]]; then
+				curl -v \
+					--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${COMMIT}" \
+					--header "authorization: Bearer $API_TOKEN" \
+					--header 'content-type: application/json' \
+					--data "$DATA_OK"
+			fi
+		else
+			printf "\e[1;31mPR $PR is outdated\e[0m\n"
+			if [[ -n "$CI" ]]; then
+				curl -v \
+					--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${COMMIT}" \
+					--header "authorization: Bearer $API_TOKEN" \
+					--header 'content-type: application/json' \
+					--data "$DATA_FAIL"
+			fi
+		fi
+	done
+}
+
+NOTIFY_SUCCESS=false
+case "$GITHUB_EVENT_NAME" in
+	pull_request)
+	pull_request_target)
+		NOTIFY_SUCCESS=true
+		echo "::group::Fetching PR $PR"
+		do_fetch "$PR"
+		echo "::endgroup::"
+		process_prs "$PR"
+		;;
+	push)
+		declare -i PAGE=1
+		while :; do
+			echo "::group::Fetching PRs (page $PAGE)"
+			JSON=$(curl --fail --get --header "authorization: Bearer $API_TOKEN" --data-urlencode "base=${BRANCH}" "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100&page=${PAGE}")
+
+			PRS=()
+			mapfile -t PRS < <( jq -r '.[].number' <<<"$JSON" )
+			[[ ${#PRS[@]} != 0 ]] || break
+			do_fetch "${PRS[@]}"
+
+			echo "::endgroup::"
+
+			process_prs "${PRS[@]}"
+
+			jq -e 'length == 100' <<<"$JSON" >/dev/null || break
+			PAGE+=1
+		done
+		;;
+	*)
+		die "Unsupported event $GITHUB_EVENT_NAME"
+		;;
+esac


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
GitHub's built-in "Require branches to be up to date before merging"
seems a bit too strict, as every time someone merges anything it'll
require a master merge and therefore a re-run of all the CI checks.

On the other hand, it would be advantageous to have a check that
requires branches be up to date to the most recent time we did a release
to avoid the need for PRs like #19266.

So what we do here is define a tag indicating the master commit that PRs
need to be up to date with respect to. A push to master runs a job that
might update this tag, and any push to the tag will check all open PRs
and set a status check to "failed" for any that aren't up to date.

I'm not at all attached to the tag name proposed in this PR. Feel free to suggest
something better.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I suppose you might copy the new action to a test repo and try it out. Otherwise, it seems pretty hard to test.