### PR TITLE
Video Block: fix/display fallback when video 404s

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-display-fallback-when-video-404s
+++ b/projects/plugins/jetpack/changelog/fix-display-fallback-when-video-404s
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Video Block: Display fallback when fetching video 404s.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -170,17 +170,24 @@ const VideoPressEdit = CoreVideoEdit =>
 			}
 
 			this.setState( { isFetchingMedia: true } );
-			const media = await apiFetch( { path: `/wp/v2/media/${ id }` } );
-			this.setState( { isFetchingMedia: false } );
+			await apiFetch( { path: `/wp/v2/media/${ id }` } )
+				.then( media => {
+					const { id: currentId } = this.props.attributes;
+					if ( id !== currentId ) {
+						// Video was changed in the editor while fetching data for the previous video;
+						return null;
+					}
 
-			const { id: currentId } = this.props.attributes;
-			if ( id !== currentId ) {
-				// Video was changed in the editor while fetching data for the previous video;
-				return null;
-			}
-
-			this.setState( { media, lastRequestedMediaId: id } );
-			return media;
+					this.setState( { media, lastRequestedMediaId: id } );
+					return media;
+				} )
+				.catch( () => {
+					this.fallbackToCore();
+					return null;
+				} )
+				.finally( () => {
+					this.setState( { isFetchingMedia: false } );
+				} );
 		};
 
 		switchToEditing = () => {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -172,7 +172,7 @@ const VideoPressEdit = CoreVideoEdit =>
 			this.setState( { isFetchingMedia: true } );
 			const media = await apiFetch( { path: `/wp/v2/media/${ id }` } )
 				.catch( () => {
-					this.fallbackToCore();
+					this.setState( { fallback: true } );
 					return null;
 				} )
 				.finally( () => {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -172,6 +172,9 @@ const VideoPressEdit = CoreVideoEdit =>
 			this.setState( { isFetchingMedia: true } );
 			const media = await apiFetch( { path: `/wp/v2/media/${ id }` } )
 				.catch( () => {
+					// Renders the fallback in the editor when there is an error fetching the media. Do not clear
+					// the guid, as this would cause the placeholder to render on the frontend for posts saved in
+					// this state, resulting in inconsistent behavior.
 					this.setState( { fallback: true } );
 					return null;
 				} )

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -170,17 +170,7 @@ const VideoPressEdit = CoreVideoEdit =>
 			}
 
 			this.setState( { isFetchingMedia: true } );
-			await apiFetch( { path: `/wp/v2/media/${ id }` } )
-				.then( media => {
-					const { id: currentId } = this.props.attributes;
-					if ( id !== currentId ) {
-						// Video was changed in the editor while fetching data for the previous video;
-						return null;
-					}
-
-					this.setState( { media, lastRequestedMediaId: id } );
-					return media;
-				} )
+			const media = await apiFetch( { path: `/wp/v2/media/${ id }` } )
 				.catch( () => {
 					this.fallbackToCore();
 					return null;
@@ -188,6 +178,15 @@ const VideoPressEdit = CoreVideoEdit =>
 				.finally( () => {
 					this.setState( { isFetchingMedia: false } );
 				} );
+
+			const { id: currentId } = this.props.attributes;
+			if ( id !== currentId ) {
+				// Video was changed in the editor while fetching data for the previous video;
+				return null;
+			}
+
+			this.setState( { media, lastRequestedMediaId: id } );
+			return media;
 		};
 
 		switchToEditing = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/51151

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When a user deletes a video from their Media Library, any Video blocks that are linked to that file will break because the GUID remains saved in the block attributes. When the block attempts to fetch the video with that GUID, it will 404. In the editor, it gets stuck in a loading spinner and the user cannot access block controls in order to fix/remove the block.

This PR catches the error and displays the fallback in the editor, allowing the user to replace the video or delete the block if desired. It does not change the behavior on the frontend.


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Verifying the bug
Test on a wpcom simple site with a premium plan.

1. Create a post and insert a Video block.
2. Upload a new video or use an existing video from your media library.
3. Publish the post.
4. Go to the Media Library and permanently delete the video.
5. Revisit the post in the editor. You will see a loading spinner with "Generating preview..." and no way to delete the block as it is not selectable.
<img width="733" alt="Screen Shot 2021-03-23 at 12 24 02 PM" src="https://user-images.githubusercontent.com/63313398/112206607-5b3cbe80-8bd3-11eb-82d1-372b4f15dcfe.png">

6. Visit the post on the frontend. You will see a videopress link; clicking this opens an error page ("Video not found").

<img width="571" alt="Screen Shot 2021-03-23 at 12 02 18 PM" src="https://user-images.githubusercontent.com/63313398/112206623-5ed04580-8bd3-11eb-9290-b39dff78d503.png">


#### Verifying the fix
Either checkout this branch, build jetpack locally, and sync it to your sandbox - or apply the diff.

1. Revisit the post on the frontend. You should see the same link that opens the "Video not found" error page.
2. Revisit the post in the editor. You should now see the black placeholder. Clicking the block should allow you to access the normal block controls so you can delete the block/replace the video file:
<img width="829" alt="Screen Shot 2021-03-23 at 11 58 26 AM" src="https://user-images.githubusercontent.com/63313398/112231208-80412980-8bf3-11eb-90f3-9ee7fb194630.png">

2. Update the post.
3. Revisit the post on the frontend. You should see the same behavior as before.


#### Verify that adding a new video still works.

1. In the editor, add a new Video block and upload a new video file.
2. Verify that the video plays correctly on the frontend.