### PR TITLE
Check if any links have been added to the Links Manager before removi…

### DIFF
--- a/projects/plugins/jetpack/changelog/update-link-manager-only-when-in-use
+++ b/projects/plugins/jetpack/changelog/update-link-manager-only-when-in-use
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Only remove the Links menu item if the user has added their own links. Auto-generated default links will not be counted in order to deprecate this feature.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -62,11 +62,36 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->add_jetpack_menu();
 		$this->add_gutenberg_menus( $wp_admin );
 
-		// Remove Links Manager menu since its usage is discouraged.
+		// Remove Links Manager menu since its usage is discouraged. https://github.com/Automattic/wp-calypso/issues/51188.
 		// @see https://core.trac.wordpress.org/ticket/21307#comment:73.
-		remove_menu_page( 'link-manager.php' );
+		if ( $this->should_disable_links_manager() ) {
+			remove_menu_page( 'link-manager.php' );
+		}
 
 		ksort( $GLOBALS['menu'] );
+	}
+
+	/**
+	 * Check if Links Manager is being used.
+	 */
+	public function should_disable_links_manager() {
+		// The max ID number of the auto-generated links.
+		$max_default_id = 10;
+
+		$link_manager_links = get_bookmarks(
+			array(
+				'orderby' => 'link_id',
+				'order'   => 'DESC',
+				'limit'   => $max_default_id,
+			)
+		);
+
+		// Ordered links by ID descending, check if the first ID is more than $max_default_id.
+		if ( count( $link_manager_links ) > 0 && $link_manager_links[0]->link_id > $max_default_id ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -76,6 +76,7 @@ class Admin_Menu extends Base_Admin_Menu {
 	 */
 	public function should_disable_links_manager() {
 		// The max ID number of the auto-generated links.
+		// See /wp-content/mu-plugins/wpcom-wp-install-defaults.php in WP.com.
 		$max_default_id = 10;
 
 		$link_manager_links = get_bookmarks(


### PR DESCRIPTION
Fixes #https://github.com/Automattic/wp-calypso/issues/51188

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Only remove the Links menu item when it is in use.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Simple sites

* Apply the below patch to your Sandbox and create a new site at `/new`
* Check that Links doesn't exist as a menu item
* Go directly to `/wp-admin/link-add.php` and add a new link
* Check that Links exists as a menu item
* Delete all links
* Check that Links doesn't exist as a menu item

#### Atomic sites

* Install Jetpack Beta plugin and active this branch.
* Check that Links doesn't exist as a menu item
* Go directly to `/wp-admin/link-add.php` and add a new link
* Check that Links exists as a menu item
* Delete all links
* Check that Links doesn't exist as a menu item
