### PR TITLE
wpcom-api: make sure post metadata is always an array 

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-yoavf-r223277-wpcom-1616596994
+++ b/projects/plugins/jetpack/changelog/fusion-sync-yoavf-r223277-wpcom-1616596994
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WordPress.com REST API: make sure post metadata is always an array

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -146,11 +146,7 @@ abstract class SAL_Post {
 			}
 		}
 
-		if ( ! empty( $metadata ) ) {
-			return $metadata;
-		} else {
-			return false;
-		}
+		return $metadata;
 	}
 
 	public function get_meta() {


### PR DESCRIPTION
#### Summary:

The documentation for the post metadata field specifies it is an array.
However, when there is no metadata, the return value will be
- `false` for wpcom sites
- `[ false ]` for Jetpack sites

This change makes sure we always return an array.

Tags: #touches_jetpack_files

Differential Revision: D59107-code

This commit syncs r223277-wpcom.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* wpcom-api: make sure post metadata is always an array as documented.

#### Does this pull request change what data or activity we track or use?
NO

#### Testing instructions:
See D59107-code
