### PR TITLE
JITM: Replace connection is_active check

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm-replace-connection-is-active
+++ b/projects/packages/jitm/changelog/update-jitm-replace-connection-is-active
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: changed
 
 JITM: Use is_connected instead of is_active to instantiate Pre/Post_Connection_JITM

--- a/projects/packages/jitm/changelog/update-jitm-replace-connection-is-active
+++ b/projects/packages/jitm/changelog/update-jitm-replace-connection-is-active
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+JITM: Use is_connected instead of is_active to instantiate Pre/Post_Connection_JITM

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -65,7 +65,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.14.x-dev"
+			"dev-master": "1.15.x-dev"
 		}
 	}
 }

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -65,7 +65,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.15.x-dev"
+			"dev-master": "1.14.x-dev"
 		}
 	}
 }

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -35,7 +35,7 @@ class JITM {
 	 * @return Post_Connection_JITM|Pre_Connection_JITM JITM instance.
 	 */
 	public static function get_instance() {
-		if ( ( new Connection_Manager() )->is_active() ) {
+		if ( ( new Connection_Manager() )->is_connected() ) {
 			$jitm = new Post_Connection_JITM();
 		} else {
 			$jitm = new Pre_Connection_JITM();

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -19,7 +19,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '1.14.1-alpha';
+	const PACKAGE_VERSION = '1.15.0-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -19,7 +19,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '1.15.0-alpha';
+	const PACKAGE_VERSION = '1.14.1-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.


### PR DESCRIPTION
Replace Connection's `is_active` check with `is_connected`.
With user-less in mind we will be slowly deprecating the `is_active` method in the `Manager` class.

**Changes proposed in this Pull Request:**
`is_active` was audited and replaced by `is_connected`, which indicates an established **site-level** connection.

**Jetpack product discussion**
1191179647901802-as-1200087466875449

Does this pull request change what data or activity we track or use?
No

**Testing instructions:**
Basically look at the code to validate the logic.