### PR TITLE
Renovate: reviewer list should be an array

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,7 +33,7 @@
 				"uuid",
 				"@testing-library/preact"
 			],
-			"reviewers": "team:jetpack-search",
+			"reviewers": [ "team:jetpack-search" ],
 			"labels": [ "Search", "Instant Search" ]
 		}
 	],


### PR DESCRIPTION
Fixes #18465

#### Changes proposed in this Pull Request:

Follow-up from #17842. Reviewers list should be an array.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Renovate shouldn't reopen that issue when we merge this.
