### PR TITLE
Licensing: Replace connection is_active

### DIFF
--- a/projects/packages/licensing/changelog/update-licenses-replace-connection-is-active
+++ b/projects/packages/licensing/changelog/update-licenses-replace-connection-is-active
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Replace usage of deprecated is_active method

--- a/projects/packages/licensing/src/class-licensing.php
+++ b/projects/packages/licensing/src/class-licensing.php
@@ -152,8 +152,8 @@ class Licensing {
 	 * @return array|WP_Error Results for each license (which may include WP_Error instances) or a WP_Error instance.
 	 */
 	public function attach_licenses( array $licenses ) {
-		if ( ! $this->connection()->is_active() ) {
-			return new WP_Error( 'not_connected', __( 'Jetpack is not connected.', 'jetpack' ) );
+		if ( ! $this->connection()->has_connected_owner() ) {
+			return new WP_Error( 'not_connected', __( 'Jetpack doesn\'t have a connected owner.', 'jetpack' ) );
 		}
 
 		if ( empty( $licenses ) ) {

--- a/projects/packages/licensing/tests/php/class-test-licensing.php
+++ b/projects/packages/licensing/tests/php/class-test-licensing.php
@@ -117,7 +117,7 @@ class Test_Licensing extends BaseTestCase {
 	public function test_attach_licenses__without_connection() {
 		$connection = $this->createMock( Connection_Manager::class );
 
-		$connection->method( 'is_active' )->willReturn( false );
+		$connection->method( 'has_connected_owner' )->willReturn( false );
 
 		$licensing = $this->createPartialMock(
 			Licensing::class,
@@ -138,7 +138,7 @@ class Test_Licensing extends BaseTestCase {
 	public function test_attach_licenses__empty_input() {
 		$connection = $this->createMock( Connection_Manager::class );
 
-		$connection->method( 'is_active' )->willReturn( true );
+		$connection->method( 'has_connected_owner' )->willReturn( true );
 
 		$licensing = $this->createPartialMock(
 			Licensing::class,
@@ -158,7 +158,7 @@ class Test_Licensing extends BaseTestCase {
 
 		$connection = $this->createMock( Connection_Manager::class );
 
-		$connection->method( 'is_active' )->willReturn( true );
+		$connection->method( 'has_connected_owner' )->willReturn( true );
 
 		$licensing = $this->createPartialMock(
 			Licensing::class,
@@ -194,7 +194,7 @@ class Test_Licensing extends BaseTestCase {
 
 		$connection = $this->createMock( Connection_Manager::class );
 
-		$connection->method( 'is_active' )->willReturn( true );
+		$connection->method( 'has_connected_owner' )->willReturn( true );
 
 		$licensing = $this->createPartialMock(
 			Licensing::class,


### PR DESCRIPTION
Replace Connection's `is_active` check with `has_connected_owner`.
With user-less in mind we will be slowly deprecating the is_active method in the Manager class.

Changes proposed in this Pull Request:
`is_active` was audited and replaced by `has_connected_owner`, which indicates an established user-level connection.

Jetpack product discussion
1191179647901802-as-1200087466875449

Does this pull request change what data or activity we track or use?
No

Testing instructions:
Basically look at the code to validate the logic.