### PR TITLE
Premium Content Block: Fix center alignment of premium content login button

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-premium-content-button-separation
+++ b/projects/plugins/jetpack/changelog/fix-premium-content-button-separation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed center alignment of premium content login button.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
@@ -154,3 +154,9 @@
 .wp-block-premium-content-login-button {
 	display: inline-block;
 }
+
+.wp-block[data-align='center'] > .wp-block-premium-content-login-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/attributes.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default {
+	text: {
+		type: 'string',
+		source: 'html',
+		selector: 'a',
+		default: __( 'Log in', 'jetpack' ),
+	},
+	borderRadius: {
+		type: 'number',
+	},
+	backgroundColor: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	gradient: {
+		type: 'string',
+	},
+	style: {
+		type: 'object',
+	},
+};

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/deprecated/v1/index.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import getColorAndStyleProps from '../../color-props';
+
+export default {
+	attributes: {
+		text: {
+			type: 'string',
+			source: 'html',
+			selector: 'a',
+			default: __( 'Log in', 'jetpack' ),
+		},
+		borderRadius: {
+			type: 'number',
+		},
+		backgroundColor: {
+			type: 'string',
+		},
+		textColor: {
+			type: 'string',
+		},
+		gradient: {
+			type: 'string',
+		},
+		style: {
+			type: 'object',
+		},
+	},
+	supports: {
+		align: true,
+		alignWide: false,
+		html: false,
+		lightBlockWrapper: true,
+		inserter: false,
+	},
+	save: ( { attributes } ) => {
+		const { borderRadius, text } = attributes;
+		const colorProps = getColorAndStyleProps( attributes );
+		const buttonClasses = classnames( 'wp-block-button__link', colorProps.className, {
+			'no-border-radius': borderRadius === 0,
+		} );
+		const buttonStyle = {
+			borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+			...colorProps.style,
+		};
+		return (
+			<div className="wp-block-button">
+				<RichText.Content
+					tagName="a"
+					className={ buttonClasses }
+					style={ buttonStyle }
+					value={ text }
+				/>
+			</div>
+		);
+	},
+};

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/index.js
@@ -9,6 +9,8 @@ import { __ } from '@wordpress/i18n';
  */
 import edit from './edit';
 import save from './save';
+import attributes from './attributes';
+import deprecatedV1 from './deprecated/v1';
 
 const name = 'premium-content/login-button';
 
@@ -31,29 +33,7 @@ const settings = {
 		'jetpack'
 	),
 	category: 'grow',
-	attributes: {
-		text: {
-			type: 'string',
-			source: 'html',
-			selector: 'a',
-			default: __( 'Log in', 'jetpack' ),
-		},
-		borderRadius: {
-			type: 'number',
-		},
-		backgroundColor: {
-			type: 'string',
-		},
-		textColor: {
-			type: 'string',
-		},
-		gradient: {
-			type: 'string',
-		},
-		style: {
-			type: 'object',
-		},
-	},
+	attributes,
 	icon,
 	keywords: [ __( 'link', 'jetpack' ) ],
 	supports: {
@@ -69,6 +49,7 @@ const settings = {
 	],
 	edit,
 	save,
+	deprecated: [ deprecatedV1 ],
 };
 
 export { name, settings };

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/save.js
@@ -14,8 +14,15 @@ import { RichText } from '@wordpress/block-editor';
 import getColorAndStyleProps from './color-props';
 
 export default function save( { attributes } ) {
-	const { borderRadius, text } = attributes;
+	const { borderRadius, text, align } = attributes;
 	const colorProps = getColorAndStyleProps( attributes );
+	const containerClasses = classnames(
+		'wp-block-button',
+		'wp-block-premium-content-login-button',
+		{ alignleft: align === 'left' },
+		{ aligncenter: align === 'center' },
+		{ alignright: align === 'right' }
+	);
 	const buttonClasses = classnames( 'wp-block-button__link', colorProps.className, {
 		'no-border-radius': borderRadius === 0,
 	} );
@@ -25,7 +32,7 @@ export default function save( { attributes } ) {
 	};
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		<div className="wp-block-button">
+		<div className={ containerClasses }>
 			<RichText.Content
 				tagName="a"
 				className={ buttonClasses }

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -73,7 +73,8 @@ function render_block( $attributes, $content ) {
 		return $stripe_nudge . $content;
 	}
 
-	Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
+	// We don't use FEATURE_NAME here because styles are not in /container folder.
+	Jetpack_Gutenberg::load_styles_as_required( 'premium-content' );
 	return $content;
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
@@ -17,9 +17,13 @@
 }
 
 /* Login button */
-
-.wp-block-premium-content-login-button {
-	margin-bottom: 8px;
+.wp-block-premium-content-login-button.aligncenter {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+.wp-block-premium-content-login-button.alignright {
+	float: right;
 }
 
 /* Legacy Subscribe/Login buttons */


### PR DESCRIPTION
Fixes: https://github.com/Automattic/view-design/issues/222

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make sure that when a premium content login button is moved outside of the premium content block, and alignment is set to center, it actually aligns center.
* Add in a css class for the login button, and add a new deprecation.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a Premium Content block.
* Drag the login button outside of the premium content block
* Add center alignment to the login button
* Confirm that the button centers in both the editor and the front end.
* Add a premium content block using the master branch and publish
* Apply this branch and refresh the editor, confirm the deprecation applies correctly.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No