### PR TITLE
fix local test suite for userless connections

### DIFF
--- a/projects/packages/connection/changelog/2021-03-25-13-46-08-443012
+++ b/projects/packages/connection/changelog/2021-03-25-13-46-08-443012
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+add option to token validate not validate user token

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -480,8 +480,10 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__connection_token_health() {
 		$name = __FUNCTION__;
 
-		$m                = new Connection_Manager();
-		$user_id          = get_current_user_id() ? get_current_user_id() : $m->get_connection_owner_id();
+		$m       = new Connection_Manager();
+		$user_id = get_current_user_id() ? get_current_user_id() : $m->get_connection_owner_id();
+
+		// If no user is logged in and no connection owner is found, $user_id will be false and we will not try to validate it.
 		$validated_tokens = ( new Tokens() )->validate( $user_id );
 
 		if ( ! is_array( $validated_tokens ) || count( array_diff_key( array_flip( array( 'blog_token', 'user_token' ) ), $validated_tokens ) ) ) {

--- a/projects/plugins/jetpack/changelog/2021-03-25-13-45-32-118262
+++ b/projects/plugins/jetpack/changelog/2021-03-25-13-45-32-118262
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: it's just a comment
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Adapts the local suite tests to work with user-less.

If the test is called in a context without a logged in user and without a connection owner, it will skip the check for the user token health.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adapt local test suite for user-less connections

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect your site only at a site level (if not using the docker env, you need to activate user-less testing mode)
* Visit the Jetpack Debugger no WP Admin
* Visit the Jetpack Debugger on jptools.wordpress.com . 
* Make sure tests pass
* Connect the user and run the tests again
