### PR TITLE
Connection: making Protect unavailable in Userless mode

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
 import DashItem from 'components/dash-item';
 import { getProtectCount } from 'state/at-a-glance';
 import getRedirectUrl from 'lib/jp-redirect';
-import { isOfflineMode } from 'state/connection';
+import { isOfflineMode, hasConnectedOwner, authorizeUserInPlace } from 'state/connection';
 import { isModuleAvailable } from 'state/modules';
 import { numberFormat } from 'components/number-format';
 import QueryProtectCount from 'components/data/query-dash-protect';
@@ -27,9 +27,13 @@ class DashProtect extends Component {
 		isOfflineMode: PropTypes.bool.isRequired,
 		protectCount: PropTypes.any.isRequired,
 		isModuleAvailable: PropTypes.bool.isRequired,
+		hasConnectedOwner: PropTypes.bool.isRequired,
+		authorizeUserInPlace: PropTypes.func.isRequired,
 	};
 
 	activateProtect = () => this.props.updateOptions( { protect: true } );
+
+	connect = () => this.props.authorizeUserInPlace();
 
 	getContent() {
 		const labelName = __( 'Protect', 'jetpack' );
@@ -41,7 +45,11 @@ class DashProtect extends Component {
 			link: getRedirectUrl( 'jetpack-support-protect' ),
 		};
 
-		if ( this.props.getOptionValue( 'protect' ) ) {
+		if (
+			this.props.getOptionValue( 'protect' ) &&
+			! this.props.isOfflineMode &&
+			this.props.hasConnectedOwner
+		) {
 			const protectCount = this.props.protectCount;
 
 			if ( false === protectCount || '0' === protectCount || 'N/A' === protectCount ) {
@@ -83,17 +91,31 @@ class DashProtect extends Component {
 				className="jp-dash-item__is-inactive"
 			>
 				<p className="jp-dash-item__description">
-					{ this.props.isOfflineMode
-						? __( 'Unavailable in Offline Mode', 'jetpack' )
-						: createInterpolateElement(
-								__(
-									'<a>Activate Protect</a> to keep your site protected from malicious sign in attempts.',
-									'jetpack'
-								),
-								{
-									a: <a href="javascript:void(0)" onClick={ this.activateProtect } />,
-								}
-						  ) }
+					{ this.props.isOfflineMode && __( 'Unavailable in Offline Mode', 'jetpack' ) }
+
+					{ ! this.props.isOfflineMode &&
+						! this.props.hasConnectedOwner &&
+						createInterpolateElement(
+							__(
+								'<a>Connect your WordPress.com</a> to keep your site protected from malicious sign in attempts.',
+								'jetpack'
+							),
+							{
+								a: <a href="javascript:void(0)" onClick={ this.connect } />,
+							}
+						) }
+
+					{ ! this.props.isOfflineMode &&
+						this.props.hasConnectedOwner &&
+						createInterpolateElement(
+							__(
+								'<a>Activate Protect</a> to keep your site protected from malicious sign in attempts.',
+								'jetpack'
+							),
+							{
+								a: <a href="javascript:void(0)" onClick={ this.activateProtect } />,
+							}
+						) }
 				</p>
 			</DashItem>
 		);
@@ -111,8 +133,16 @@ class DashProtect extends Component {
 	}
 }
 
-export default connect( state => ( {
-	protectCount: getProtectCount( state ),
-	isOfflineMode: isOfflineMode( state ),
-	isModuleAvailable: isModuleAvailable( state, 'protect' ),
-} ) )( DashProtect );
+export default connect(
+	state => ( {
+		protectCount: getProtectCount( state ),
+		isOfflineMode: isOfflineMode( state ),
+		isModuleAvailable: isModuleAvailable( state, 'protect' ),
+		hasConnectedOwner: hasConnectedOwner( state ),
+	} ),
+	dispatch => ( {
+		authorizeUserInPlace: () => {
+			return dispatch( authorizeUserInPlace() );
+		},
+	} )
+)( DashProtect );

--- a/projects/plugins/jetpack/_inc/client/components/foldable-card/style2.scss
+++ b/projects/plugins/jetpack/_inc/client/components/foldable-card/style2.scss
@@ -2,6 +2,12 @@
 
 .dops-foldable-card.dops-card {
 
+	.jp-form-settings-group.foldable-wrapper & {
+		padding-right: 0;
+		margin-bottom: 0;
+		box-shadow: none;
+	}
+
 	&.offlinemode-disabled {
 		.dops-foldable-card__summary,
 		.dops-foldable-card__summary_expanded {

--- a/projects/plugins/jetpack/_inc/client/components/settings-group/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-group/style.scss
@@ -73,4 +73,8 @@
 		padding: 0;
 		box-shadow: none;
 	}
+
+	&.foldable-wrapper > .dops-card {
+		padding: 0;
+	}
 }

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -19,6 +19,7 @@ import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import ConnectUserBar from 'components/connect-user-bar';
 
 export const Protect = withModuleSettingsFormHelpers(
 	class extends Component {
@@ -97,77 +98,94 @@ export const Protect = withModuleSettingsFormHelpers(
 					header={ _x( 'Brute force attack protection', 'Settings header', 'jetpack' ) }
 					saveDisabled={ this.props.isSavingAnyOption( 'jetpack_protect_global_whitelist' ) }
 				>
-					<FoldableCard
-						onOpen={ this.trackOpenCard }
-						header={ toggle }
-						className={ classNames( { 'jp-foldable-settings-disable': unavailableInOfflineMode } ) }
+					<SettingsGroup
+						hasChild
+						disableInOfflineMode
+						disableInUserlessMode
+						module={ this.props.getModule( 'protect' ) }
+						className="foldable-wrapper"
 					>
-						<SettingsGroup
-							hasChild
-							disableInOfflineMode
-							module={ this.props.getModule( 'protect' ) }
-							support={ {
-								text: __(
-									'Protects your site from traditional and distributed brute force login attacks.',
-									'jetpack'
-								),
-								link: getRedirectUrl( 'jetpack-support-protect' ),
-							} }
+						<FoldableCard
+							onOpen={ this.trackOpenCard }
+							header={ toggle }
+							className={ classNames( {
+								'jp-foldable-settings-disable': unavailableInOfflineMode,
+							} ) }
 						>
-							<FormFieldset>
-								{ this.props.currentIp && (
-									<div>
-										<div className="jp-form-label-wide">
-											{ sprintf(
-												/* translators: placeholder is an IP address. */
-												__( 'Your current IP: %s', 'jetpack' ),
-												this.props.currentIp
-											) }
-										</div>
-										{
-											<Button
-												disabled={
-													! isProtectActive ||
-													unavailableInOfflineMode ||
-													this.currentIpIsSafelisted() ||
-													this.props.isSavingAnyOption( [
-														'protect',
-														'jetpack_protect_global_whitelist',
-													] )
-												}
-												onClick={ this.addToSafelist }
-											>
-												{ __( 'Add to Always Allowed list', 'jetpack' ) }
-											</Button>
-										}
-									</div>
-								) }
-								<FormLabel>
-									<FormLegend>{ __( 'Always allowed IP addresses', 'jetpack' ) }</FormLegend>
-									<Textarea
-										disabled={
-											! isProtectActive ||
-											unavailableInOfflineMode ||
-											this.props.isSavingAnyOption( [
-												'protect',
-												'jetpack_protect_global_whitelist',
-											] )
-										}
-										name={ 'jetpack_protect_global_whitelist' }
-										placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
-										onChange={ this.updateText }
-										value={ this.state.safelist }
-									/>
-								</FormLabel>
-								<span className="jp-form-setting-explanation">
-									{ __(
-										'You may mark an IP address (or series of addresses) as "Always allowed", preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100',
+							<SettingsGroup
+								hasChild
+								module={ this.props.getModule( 'protect' ) }
+								support={ {
+									text: __(
+										'Protects your site from traditional and distributed brute force login attacks.',
 										'jetpack'
+									),
+									link: getRedirectUrl( 'jetpack-support-protect' ),
+								} }
+							>
+								<FormFieldset>
+									{ this.props.currentIp && (
+										<div>
+											<div className="jp-form-label-wide">
+												{ sprintf(
+													/* translators: placeholder is an IP address. */
+													__( 'Your current IP: %s', 'jetpack' ),
+													this.props.currentIp
+												) }
+											</div>
+											{
+												<Button
+													disabled={
+														! isProtectActive ||
+														unavailableInOfflineMode ||
+														this.currentIpIsSafelisted() ||
+														this.props.isSavingAnyOption( [
+															'protect',
+															'jetpack_protect_global_whitelist',
+														] )
+													}
+													onClick={ this.addToSafelist }
+												>
+													{ __( 'Add to Always Allowed list', 'jetpack' ) }
+												</Button>
+											}
+										</div>
 									) }
-								</span>
-							</FormFieldset>
-						</SettingsGroup>
-					</FoldableCard>
+									<FormLabel>
+										<FormLegend>{ __( 'Always allowed IP addresses', 'jetpack' ) }</FormLegend>
+										<Textarea
+											disabled={
+												! isProtectActive ||
+												unavailableInOfflineMode ||
+												this.props.isSavingAnyOption( [
+													'protect',
+													'jetpack_protect_global_whitelist',
+												] )
+											}
+											name={ 'jetpack_protect_global_whitelist' }
+											placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
+											onChange={ this.updateText }
+											value={ this.state.safelist }
+										/>
+									</FormLabel>
+									<span className="jp-form-setting-explanation">
+										{ __(
+											'You may mark an IP address (or series of addresses) as "Always allowed", preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100',
+											'jetpack'
+										) }
+									</span>
+								</FormFieldset>
+							</SettingsGroup>
+						</FoldableCard>
+					</SettingsGroup>
+
+					{ ! this.props.hasConnectedOwner && (
+						<ConnectUserBar
+							feature="protect"
+							featureLabel={ __( 'Brute Force Attack Protection', 'jetpack' ) }
+							text={ __( 'Sign in to set up brute force attack protection.', 'jetpack' ) }
+						/>
+					) }
 				</SettingsCard>
 			);
 		}

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -95,7 +95,7 @@ export const Protect = withModuleSettingsFormHelpers(
 				<SettingsCard
 					{ ...this.props }
 					module="protect"
-					header={ _x( 'Brute force attack protection', 'Settings header', 'jetpack' ) }
+					header={ _x( 'Protect', 'Settings header', 'jetpack' ) }
 					saveDisabled={ this.props.isSavingAnyOption( 'jetpack_protect_global_whitelist' ) }
 				>
 					<SettingsGroup
@@ -182,7 +182,7 @@ export const Protect = withModuleSettingsFormHelpers(
 					{ ! this.props.hasConnectedOwner && (
 						<ConnectUserBar
 							feature="protect"
-							featureLabel={ __( 'Brute Force Attack Protection', 'jetpack' ) }
+							featureLabel={ __( 'Protect', 'jetpack' ) }
 							text={ __( 'Sign in to set up brute force attack protection.', 'jetpack' ) }
 						/>
 					) }

--- a/projects/plugins/jetpack/changelog/update-userless-protect
+++ b/projects/plugins/jetpack/changelog/update-userless-protect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Connection: making Protect unavailable in Userless mode

--- a/projects/plugins/jetpack/modules/protect.php
+++ b/projects/plugins/jetpack/modules/protect.php
@@ -6,6 +6,7 @@
  * Recommendation Order: 4
  * First Introduced: 3.4
  * Requires Connection: Yes
+ * Requires User Connection: Yes
  * Auto Activate: Yes
  * Module Tags: Recommended
  * Feature: Security


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The "Protect" module requires Calypso access, which means it cannot fully function without user connection.
This PR makes the card only available in fully connected mode.

#### Jetpack product discussion
p9dueE-25J-p2#comment-4589

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Connect Jetpack in Userless mode (do not connect the user).
2. Go to "Jetpack -> Settings -> Security" and find the "Brute force attack protection" card. Confirm that it's greyed out, and its elements are not clickable: <img width="1061" alt="Screen Shot 2021-03-25 at 12 17 41 PM" src="https://user-images.githubusercontent.com/1341249/112515284-21e78880-8d64-11eb-8e3c-c234251e1e82.png">
3. Click "Connect my WordPress.com account" and connect the user.
4. Confirm that the module can be switched on/off, and the settings can be unfolded.
5. Disconnect Jetpack, reconnect in Userless mode.
6. Go to Jetpack Dashboard and confirm that the "Protect" card suggests you to connect: <img width="526" alt="Screen Shot 2021-03-25 at 5 24 19 PM" src="https://user-images.githubusercontent.com/1341249/112551439-00e85d00-8d8f-11eb-8a1d-8c0311263fc3.png">
7. Click "Connect", In-Place connection process should begin. Complete the connection, confirm that the card is now available.