### PR TITLE
add Blog token health check

### DIFF
--- a/projects/packages/connection/changelog/add-test_blog_token_health
+++ b/projects/packages/connection/changelog/add-test_blog_token_health
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new test for blog token health to support user-less sites

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -483,9 +483,19 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 */
 	protected function test__connection_token_health() {
 		$m       = new Connection_Manager();
-		$user_id = get_current_user_id() ? get_current_user_id() : $m->get_connection_owner_id();
+		$user_id = get_current_user_id();
 
-		if ( $user_id && $m->is_user_connected( $user_id ) ) {
+		// Check if there's a connected logged in user.
+		if ( $user_id && ! $m->is_user_connected( $user_id ) ) {
+				$user_id = false;
+		}
+
+		// If no logged in user to check, let's see if there's a master_user set.
+		if ( ! $user_id ) {
+				$user_id = Jetpack_Options::get_option( 'master_user' );
+		}
+
+		if ( $user_id ) {
 			return $this->check_tokens_health( $user_id );
 		} else {
 			return $this->check_blog_token_health();

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -471,28 +471,56 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	}
 
 	/**
-	 * Tests blog and current user's token against wp.com's check-token-health endpoint.
+	 * Tests the health of the Connection tokens.
+	 *
+	 * This will always check the blog token health. It will also check the user token health if
+	 * a user is logged in and connected, or if there's a connected owner.
 	 *
 	 * @since 9.0.0
+	 * @since 9.6.0 Checks only blog token if current user not connected or site does not have a connected owner.
 	 *
 	 * @return array Test results.
 	 */
 	protected function test__connection_token_health() {
-		$name = __FUNCTION__;
-
 		$m       = new Connection_Manager();
 		$user_id = get_current_user_id() ? get_current_user_id() : $m->get_connection_owner_id();
 
-		// If no current user or blog owner, this site must be running user-less. Blog token will be validated in its own test.
-		if ( ! $user_id ) {
-			return self::skipped_test(
-				array(
-					'name'              => $name,
-					'short_description' => __( 'There\'s no user token to be checked.', 'jetpack' ),
-				)
-			);
+		if ( $user_id && $m->is_user_connected( $user_id ) ) {
+			return $this->check_tokens_health( $user_id );
+		} else {
+			return $this->check_blog_token_health();
 		}
+	}
 
+	/**
+	 * Tests blog and user's token against wp.com's check-token-health endpoint.
+	 *
+	 * @since 9.6.0
+	 *
+	 * @return array Test results.
+	 */
+	protected function check_blog_token_health() {
+		$name  = 'test__connection_token_health';
+		$valid = ( new Tokens() )->validate_blog_token();
+
+		if ( ! $valid ) {
+			return self::connection_failing_test( $name, __( 'Blog token validation failed.', 'jetpack' ) );
+		} else {
+			return self::passing_test( array( 'name' => $name ) );
+		}
+	}
+
+	/**
+	 * Tests blog token against wp.com's check-token-health endpoint.
+	 *
+	 * @since 9.6.0
+	 *
+	 * @param int $user_id The user ID to check the tokens for.
+	 *
+	 * @return array Test results.
+	 */
+	protected function check_tokens_health( $user_id ) {
+		$name             = 'test__connection_token_health';
 		$validated_tokens = ( new Tokens() )->validate( $user_id );
 
 		if ( ! is_array( $validated_tokens ) || count( array_diff_key( array_flip( array( 'blog_token', 'user_token' ) ), $validated_tokens ) ) ) {
@@ -519,25 +547,6 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$connection_error = __( 'Invalid Jetpack connection tokens.', 'jetpack' );
 
 		return self::connection_failing_test( $name, $connection_error );
-	}
-
-	/**
-	 * Tests blog token against wp.com's check-token-health endpoint.
-	 *
-	 * @since 9.6.0
-	 *
-	 * @return array Test results.
-	 */
-	protected function test__connection_blog_token_health() {
-		$name  = __FUNCTION__;
-		$valid = ( new Tokens() )->validate_blog_token();
-
-		if ( ! $valid ) {
-			return self::connection_failing_test( $name, __( 'Blog token validation failed.', 'jetpack' ) );
-		} else {
-			return self::passing_test( array( 'name' => $name ) );
-		}
-
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -485,7 +485,6 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		// If no current user or blog owner, this site must be running user-less. Blog token will be validated in its own test.
 		if ( ! $user_id ) {
-			l( 'skip' );
 			return self::skipped_test(
 				array(
 					'name'              => $name,

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -482,6 +482,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 * @return array Test results.
 	 */
 	protected function test__connection_token_health() {
+		$name    = __FUNCTION__;
 		$m       = new Connection_Manager();
 		$user_id = get_current_user_id();
 
@@ -493,6 +494,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		// If no logged in user to check, let's see if there's a master_user set.
 		if ( ! $user_id ) {
 				$user_id = Jetpack_Options::get_option( 'master_user' );
+			if ( $user_id && ! $m->is_user_connected( $user_id ) ) {
+				return self::connection_failing_test( $name, __( 'Missing token for the connection owner.', 'jetpack' ) );
+			}
 		}
 
 		if ( $user_id ) {

--- a/projects/plugins/jetpack/changelog/add-test_blog_token_health
+++ b/projects/plugins/jetpack/changelog/add-test_blog_token_health
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Add new test for blog token health to support user-less sites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Adapts the local suite tests to work with user-less.

If the test is called in a context without a logged in user and without a connection owner, it will skip the check for the user token health.

If there is a connected logged in user, or if the site has a connected owner, it will also check for the user token health

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adapt local test suite for user-less connections

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect your site only at a site level (if not using the docker env, you need to activate user-less testing mode)
* Visit the Jetpack Debugger no WP Admin
* Visit the Jetpack Debugger on jptools.wordpress.com . 
* Make sure tests pass
* Connect the user and run the tests again

Invalidate the Blog token and see that the test fails
