### PR TITLE
Deprecate is_active and filter connection status

### DIFF
--- a/projects/packages/connection/changelog/update-is_active_deprecation
+++ b/projects/packages/connection/changelog/update-is_active_deprecation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+add deprecation notice and remove user-less check in is_active

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -484,7 +484,7 @@ class Manager {
 	/**
 	 * Returns true if the current site is connected to WordPress.com and has the minimum requirements to enable Jetpack UI.
 	 *
-	 * This method is deprecated since Jetpack 9.6.0. Please use one has_connected_owner instead.
+	 * This method is deprecated since Jetpack 9.6.0. Please use has_connected_owner instead.
 	 *
 	 * Since this method has a wide spread use, we decided not to throw any deprecation warnings for now.
 	 *

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -484,12 +484,15 @@ class Manager {
 	/**
 	 * Returns true if the current site is connected to WordPress.com and has the minimum requirements to enable Jetpack UI.
 	 *
+	 * This method is deprecated since Jetpack 9.6.0. Please use one has_connected_owner instead.
+	 *
+	 * Since this method has a wide spread use, we decided not to throw any deprecation warnings for now.
+	 *
+	 * @deprecated 9.6.0
+	 * @see Manager::has_connected_owner
 	 * @return Boolean is the site connected?
 	 */
 	public function is_active() {
-		if ( ( new Status() )->is_no_user_testing_mode() ) {
-			return $this->is_connected();
-		}
 		return (bool) $this->get_tokens()->get_access_token( true );
 	}
 

--- a/projects/packages/connection/tests/php/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/test-rest-endpoints.php
@@ -165,6 +165,29 @@ class Test_REST_Endpoints extends TestCase {
 	}
 
 	/**
+	 * Testing the `/jetpack/v4/connection` endpoint jetpack_connection_status filter.
+	 */
+	public function test_connection_jetpack_connection_status_filter() {
+		add_filter(
+			'jetpack_connection_status',
+			function ( $status_data ) {
+				$this->assertTrue( is_array( $status_data ) );
+				return array();
+			}
+		);
+		try {
+			$this->request = new WP_REST_Request( 'GET', '/jetpack/v4/connection' );
+
+			$response = $this->server->dispatch( $this->request );
+			$data     = $response->get_data();
+
+			$this->assertSame( array(), $data );
+		} finally {
+			remove_all_filters( 'jetpack_connection_status' );
+		}
+	}
+
+	/**
 	 * Testing the `/jetpack/v4/connection/plugins` endpoint.
 	 */
 	public function test_connection_plugins() {

--- a/projects/plugins/jetpack/changelog/update-is_active_deprecation
+++ b/projects/plugins/jetpack/changelog/update-is_active_deprecation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Deprecate is_active and add filter to the Connection Status API

--- a/projects/plugins/jetpack/class-jetpack-connection-status.php
+++ b/projects/plugins/jetpack/class-jetpack-connection-status.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Jetpack Connection Status.
+ *
+ * Filters the Connection Status API response
+ *
+ * @package jetpack
+ */
+
+/**
+ * Filters the Connection Status API response
+ */
+class Jetpack_Connection_Status {
+
+	/**
+	 * Initialize the main hooks.
+	 */
+	public static function init() {
+		add_filter( 'jetpack_connection_status', array( __CLASS__, 'filter_connection_status' ) );
+	}
+
+	/**
+	 * Filters the connection status API response of the Connection package and modifies isActive value expected by the UI.
+	 *
+	 * @param array $status An array containing the connection status data.
+	 */
+	public static function filter_connection_status( $status ) {
+
+		$status['isActive'] = Jetpack::is_connection_ready();
+
+		return $status;
+	}
+
+}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1715,6 +1715,13 @@ class Jetpack {
 	 * Is Jetpack active?
 	 * The method only checks if there's an existing token for the master user. It doesn't validate the token.
 	 *
+	 * This method is deprecated since 9.6.0. Please use one of the methods provided by the Manager class in the Connection package,
+	 * or Jetpack::is_connection_ready if you want to know when the Jetpack plugin starts considering the connection ready to be used.
+	 *
+	 * Since this method has a wide spread use, we decided not to throw any deprecation warnings for now.
+	 *
+	 * @deprecated 9.6.0
+	 *
 	 * @return bool
 	 */
 	public static function is_active() {

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -61,6 +61,9 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
 require_once JETPACK__PLUGIN_DIR . 'class-jetpack-xmlrpc-methods.php';
 Jetpack_XMLRPC_Methods::init();
 
+require_once JETPACK__PLUGIN_DIR . 'class-jetpack-connection-status.php';
+Jetpack_Connection_Status::init();
+
 jetpack_require_lib( 'class-jetpack-recommendations' );
 require_once JETPACK__PLUGIN_DIR . 'class-jetpack-recommendations-banner.php';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This is a follow-up PR after the changes in Licensing package: https://github.com/Automattic/jetpack/pull/19283, JITM package: https://github.com/Automattic/jetpack/pull/19280 Jetpack: https://github.com/Automattic/jetpack/pull/19276  and Connection package: https://github.com/Automattic/jetpack/pull/19259

The `is_active` method is deprecated. The default response of the Connection Status API endpoint will still return the value of the deprecated method, for now, but is going to be filtered by the Jetpack plugin. This will allow us to enable the Jetpack UI for user-less connection when we want.

Since these methods are widely used, we decided not to throw any deprecation notices for now, and only inform it in the doc blocks. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a deprecation note to the doc block of Jetpack::is_active and Connection\Manager::is_active
* Remove the temporary check for user-less testing mode from Connection\Manager::is_active
* Add a new filter to the connection status API response, so that the Jetpack plugin can inform the UI that the connection is ready to be used via the `isActive` parameter.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1191179647901802-as-1200087466875449

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Nothing should change. 

Test a new connection, disconnection, reconnection, test if modules work, widgets, blocks, etc.