### PR TITLE
Search: Fix modal opening bug within the Customizer

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-customizer-auto-open-close
+++ b/projects/plugins/jetpack/changelog/fix-search-customizer-auto-open-close
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Search: Fix modal opening bug within the Customizer

--- a/projects/plugins/jetpack/modules/search/customize-controls/customize-controls.js
+++ b/projects/plugins/jetpack/modules/search/customize-controls/customize-controls.js
@@ -14,12 +14,24 @@ function postSectionMessage( expanded ) {
  * Adds functionality for Jetpack Search section detection in the Customizer.
  */
 function init() {
+	var firstInitialization = true; // eslint-disable-line no-var
+
 	window.wp.customize.bind( 'ready', function () {
+		// window.wp.customize.previewer will emit 'ready' multiple times, not just during initialization.
 		window.wp.customize.previewer.bind( 'ready', function () {
-			postSectionMessage( window.wp.customize.section( 'jetpack_search' ).expanded() );
-			window.wp.customize.section( 'jetpack_search' ).expanded.bind( postSectionMessage );
-			window.wp.customize.state( 'processing' ).bind( function () {
+			// Upon first initialization, open/close the modal if the Jetpack Search section is open/closed.
+			firstInitialization &&
 				postSectionMessage( window.wp.customize.section( 'jetpack_search' ).expanded() );
+			firstInitialization = false;
+
+			// If the Jetpack Search section is opened/closed, emit a message to open/close the modal.
+			window.wp.customize.section( 'jetpack_search' ).expanded.bind( function () {
+				postSectionMessage( window.wp.customize.section( 'jetpack_search' ).expanded() );
+			} );
+
+			// If Customizer values have changed while Jetpack Search section is open, emit a message to open the modal.
+			window.wp.customize.state( 'processing' ).bind( function () {
+				window.wp.customize.section( 'jetpack_search' ).expanded() && postSectionMessage( true );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Fixes bug introduced by #19207.

#### Changes proposed in this Pull Request:
While in the customizer, typing into the search input will cause the modal to open and then immediately close the search modal. The expected behavior is for the search modal to remain open.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Navigate to the WordPress customizer.
* While outside of the Jetpack Search section, try invoking the search modal within the preview panel (e.g. type a query into a search input).
* Ensure that the search modal opens and remains open.
* Try changing parts of the Customizer unrelated to Search (e.g. widget title). Ensure that the search modal remains open.
* Close the search modal.
* Navigate to the Jetpack Search section on the left side of the Customizer. Ensure that the search modal opens automatically.
* Navigate away from the Jetpack Search section. Ensure that the search modal closes automatically.
