### PR TITLE
renovate: Close old PRs

### DIFF
--- a/.github/files/renovate-close-old-PRs.sh
+++ b/.github/files/renovate-close-old-PRs.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -eo pipefail
+
+function die {
+	echo "::error::$*"
+	exit 1
+}
+
+[[ -n "$GITHUB_TOKEN" ]] || die "GITHUB_TOKEN must be set"
+[[ -n "$GITHUB_API_URL" ]] || die "GITHUB_API_URL must be set"
+[[ -n "$GITHUB_REPOSITORY" ]] || die "GITHUB_REPOSITORY must be set"
+
+echo "::group::Check that the renovate bug is still open..."
+JSON=$(curl -v --fail --url 'https://api.github.com/repos/renovatebot/renovate/issues/4803') || { echo "$JSON"; exit 1; }
+jq -e '.state == "open"' <<<"$JSON" >/dev/null || die "Renovate issue #​4803 <https://git.io/JYt4a> is not open. Aborting."
+echo "::endgroup::"
+
+echo "::group::Fetching 1000th PR..."
+JSON=$(curl -v --fail \
+	--header "authorization: Bearer $GITHUB_TOKEN" \
+	--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls?per_page=100&state=all&page=10" \
+) || { echo "$JSON"; exit 1; }
+echo "::endgroup::"
+if jq -e 'length < 100' <<<"$JSON" >/dev/null; then
+	echo "Fewer than 1000 PRs. Nothing to do."
+	exit 0
+fi
+MIN_PR=$(jq -r '.[99].number' <<<"$JSON")
+echo "The 1000th PR is #$MIN_PR"
+
+declare -i PAGE=1
+while :; do
+	echo "::group::Fetching open PRs (page $PAGE)"
+	JSON=$(curl -v --fail \
+		--header "authorization: Bearer $GITHUB_TOKEN" \
+		--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls?state=open&base=master&per_page=100&page=${PAGE}&direction=asc" \
+	) || { echo "$JSON"; exit 1; }
+	echo "::endgroup::"
+
+	for PR in $(jq '.[] | select( .user.login == "renovate[bot]" ) | .number' <<<"$JSON"); do
+		if [[ $PR -ge $MIN_PR ]]; then
+			echo "PR #$PR is ok"
+			continue
+		fi
+		echo "PR #$PR is too old! Closing."
+		echo "::group::Posting comment..."
+		curl -v --fail \
+			--header "authorization: Bearer $GITHUB_TOKEN" \
+			--header 'content-type: application/json' \
+			--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/$PR/comments" \
+			--data '{"body":"This renovate PR is too old: renovate loses track of its own PRs when they'\''re beyond the latest 1000 in the repo. See [renovate issue #4803](https://git.io/JYt4a).\n\nClosing the PR so renovate can re-create it."}'
+		echo "::endgroup::"
+		echo "::group::Closing..."
+		curl -v --fail \
+			--request PATCH \
+			--header "authorization: Bearer $GITHUB_TOKEN" \
+			--header 'content-type: application/json' \
+			--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/$PR" \
+			--data '{"state":"closed"}'
+		echo "::endgroup::"
+	done
+
+	jq -e 'length == 100' <<<"$JSON" >/dev/null || break
+	PAGE+=1
+done
+

--- a/.github/workflows/renovate-cleanup.yml
+++ b/.github/workflows/renovate-cleanup.yml
@@ -1,0 +1,17 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  COMPOSER_ROOT_VERSION: "dev-master"
+
+jobs:
+  cleanup:
+    name: Close old PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15  # 2021-03-25: Wild guess.
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/files/renovate-close-old-PRs.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Renovate loses track of its own PRs when they're beyond the latest 1000
in the repo. See [renovate issue #​4803](https://git.io/JYt4a).

This adds a workflow that will check for such PRs and close them.
Renovate will re-create them later on, despite recreateClosed being
false, because of that same bug.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1616624425493000-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ran it manually to produce https://github.com/Automattic/jetpack/pull/11978#issuecomment-807470473
* Otherwise, merge then see if it worked.