### PR TITLE
Search: Improve product results layout

### DIFF
--- a/projects/plugins/jetpack/changelog/update-search-product-layout
+++ b/projects/plugins/jetpack/changelog/update-search-product-layout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: Improve product result format

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -75,6 +75,30 @@ class Jetpack_Search_Customize {
 			)
 		);
 
+		$id = $setting_prefix . 'result_format';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default'   => 'minimal',
+				'transport' => 'postMessage',
+				'type'      => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			$id,
+			array(
+				'label'       => __( 'Result Format', 'jetpack' ),
+				'description' => __( 'Choose how the search results look.', 'jetpack' ),
+				'section'     => $section_id,
+				'type'        => 'select',
+				'choices'     => array(
+					'minimal'  => __( 'Minimal', 'jetpack' ),
+					'expanded' => __( 'Expanded (shows images)', 'jetpack' ),
+					'product'  => __( 'Product (for WooCommerce stores)', 'jetpack' ),
+				),
+			)
+		);
+
 		$id = $setting_prefix . 'default_sort';
 		$wp_customize->add_setting(
 			$id,
@@ -138,30 +162,6 @@ class Jetpack_Search_Customize {
 					'label'       => __( 'Excluded Post Types', 'jetpack' ),
 					'section'     => $section_id,
 				)
-			)
-		);
-
-		$id = $setting_prefix . 'result_format';
-		$wp_customize->add_setting(
-			$id,
-			array(
-				'default'   => 'minimal',
-				'transport' => 'postMessage',
-				'type'      => 'option',
-			)
-		);
-		$wp_customize->add_control(
-			$id,
-			array(
-				'label'       => __( 'Result Format', 'jetpack' ),
-				'description' => __( 'Choose how the search results look.', 'jetpack' ),
-				'section'     => $section_id,
-				'type'        => 'select',
-				'choices'     => array(
-					'minimal'  => __( 'Minimal', 'jetpack' ),
-					'expanded' => __( 'Expanded (shows images)', 'jetpack' ),
-					'product'  => __( 'Product (for WooCommerce stores)', 'jetpack' ),
-				),
 			)
 		);
 

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-box.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-box.scss
@@ -60,11 +60,13 @@ input.jetpack-instant-search__box-input.search-field {
 	color: $color-text-lighter;
 	cursor: pointer;
 	font-size: 1em;
+	font-weight: normal;
 	height: 60px;
 	line-height: 1;
 	margin: 0 0.25em 0 0;
 	transition: 0.1s linear all;
 	width: 60px;
+	word-wrap: normal;
 
 	&:hover,
 	&:focus {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-controls.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-controls.scss
@@ -25,11 +25,9 @@
 	@include break-medium-down() {
 		margin-left: $results-margin-sm;
 		margin-right: $results-margin-sm;
-		margin-bottom: 1em;
 	}
 
 	@include break-large-up() {
-		margin-top: 32px;
 		position: absolute;
 		right: $sidebar-width;
 	}

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-controls.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-controls.scss
@@ -25,6 +25,7 @@
 	@include break-medium-down() {
 		margin-left: $results-margin-sm;
 		margin-right: $results-margin-sm;
+		margin-bottom: 1em;
 	}
 
 	@include break-large-up() {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
@@ -36,9 +36,10 @@ class SearchResultProduct extends Component {
 				: __( 'No title', 'jetpack' );
 
 		// TODO: Remove this check once checking result.highlight is more reliable.
-		const hasQuery = this.props.searchQuery !== '';
+		const hasQuery =
+			typeof this.props.searchQuery === 'string' && this.props.searchQuery.trim() !== '';
 		const titleHasMark = title.includes( '<mark>' );
-		const hasMatch =
+		const showMatchHint =
 			hasQuery &&
 			! titleHasMark &&
 			Array.isArray( highlight.content ) &&
@@ -98,7 +99,7 @@ class SearchResultProduct extends Component {
 						rating={ fields[ 'meta._wc_average_rating.double' ] }
 					/>
 				) }
-				{ hasMatch && (
+				{ showMatchHint && (
 					<div className="jetpack-instant-search__search-result-product-match">
 						<mark>
 							<Gridicon icon="search" style={ {} } title={ false } />

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.jsx
@@ -52,7 +52,13 @@ class SearchResultProduct extends Component {
 					href={ `//${ fields[ 'permalink.url.raw' ] }` }
 					onClick={ this.props.onClick }
 				>
-					<div className="jetpack-instant-search__search-result-product-img-container">
+					<div
+						className={ `jetpack-instant-search__search-result-product-img-container ${
+							firstImage
+								? ''
+								: 'jetpack-instant-search__search-result-product-img-container--placeholder'
+						}` }
+					>
 						{ firstImage ? (
 							<PhotonImage
 								alt={ title }

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.scss
@@ -59,9 +59,12 @@ $item-spacing: 16px;
 }
 
 .jetpack-instant-search__search-result-product-img-container {
-	background: $studio-gray-10;
 	border-radius: 5px;
 	color: transparent;
+
+	&.jetpack-instant-search__search-result-product-img-container--placeholder {
+		background: $studio-gray-10;
+	}
 
 	.gridicon {
 		fill: $color-modal-background;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-product.scss
@@ -23,12 +23,13 @@ $item-spacing: 16px;
 	position: relative;
 
 	// On mobile and responsive viewports, we allow only a single column.
-	width: calc( 100% - #{$item-spacing} );
+	$column-count: 2;
+	width: calc( ( 100% - ( #{$item-spacing} * #{$column-count} ) ) / #{$column-count} );
+	margin-right: $item-spacing;
 
 	@include break-small-up {
 		$column-count: 3;
 		width: calc( ( 100% - ( #{$item-spacing} * #{$column-count} ) ) / #{$column-count} );
-		margin-right: $item-spacing;
 	}
 
 	@include break-medium-up {
@@ -36,7 +37,18 @@ $item-spacing: 16px;
 		width: calc( ( 100% - ( #{$item-spacing} * #{$column-count} ) ) / #{$column-count} );
 	}
 
+	@include break-large-up {
+		// Lower column count due to sidebar no longer being collapsed.
+		$column-count: 3;
+		width: calc( ( 100% - ( #{$item-spacing} * #{$column-count} ) ) / #{$column-count} );
+	}
+
 	@include break-xlarge-up {
+		$column-count: 4;
+		width: calc( ( 100% - ( #{$item-spacing} * #{$column-count} ) ) / #{$column-count} );
+	}
+
+	@include break-xxlarge-up {
 		$column-count: 5;
 		width: calc( ( 100% - ( #{$item-spacing} * #{$column-count} ) ) / #{$column-count} );
 	}

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-results.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-results.scss
@@ -41,6 +41,7 @@ $modal-max-width-lg: 95%;
 	color: $color-text-lighter;
 	cursor: pointer;
 	display: flex;
+	flex-shrink: 0;
 	font-size: 12px;
 	margin: 0;
 	padding: 8px;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-results.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-results.scss
@@ -153,18 +153,17 @@ $modal-max-width-lg: 95%;
 	line-height: 1.3;
 	word-break: break-word;
 
-	margin: 0.5em $results-margin-lg 1.5em;
+	margin: 1em $results-margin-lg 1.5em;
 	padding: 0;
 
 	@include break-large-down() {
 		margin-left: $results-margin-md;
+		margin-right: $results-margin-md;
+		margin-bottom: 1em;
 	}
 	@include break-medium-down() {
 		margin-left: $results-margin-sm;
-	}
-
-	@include break-large-up() {
-		margin-top: 32px;
+		margin-right: $results-margin-sm;
 	}
 }
 

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/styles/_mixins.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/styles/_mixins.scss
@@ -47,6 +47,17 @@
 	}
 }
 
+@mixin break-xxlarge-up() {
+	@media ( min-width: #{ ( $break-xxl ) } ) {
+		@content;
+	}
+}
+@mixin break-xxlarge-down() {
+	@media ( max-width: #{ ( $break-xxl - .02px ) } ) {
+		@content;
+	}
+}
+
 @mixin remove-button-styling() {
 	appearance: none;
 	background: none;

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/styles/_mixins.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/styles/_mixins.scss
@@ -66,6 +66,7 @@
 	outline: none;
 	padding: 0;
 	text-decoration: none;
+	text-transform: none;
 
 	&:hover,
 	&:focus {

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/styles/_variables.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/styles/_variables.scss
@@ -8,6 +8,7 @@ $break-sm: 576px;
 $break-md: 768px;
 $break-lg: 992px;
 $break-xl: 1200px;
+$break-xxl: 1400px;
 
 // Side margins for search results container
 $results-margin-sm: 20px;


### PR DESCRIPTION
A follow-up to #18868. Fixes #19313.

#### Changes proposed in this Pull Request:
* Improves responsive layout.
  * Mobile viewports now show 2 columns of products. 
    > <img width="494" alt="Screen Shot 2021-03-25 at 3 29 57 PM" src="https://user-images.githubusercontent.com/4044428/112546574-2f5e3c00-8d7f-11eb-94c6-7d9543e5190c.png">
  * Small viewports now show 3 columns of products.
    > <img width="576" alt="Screen Shot 2021-03-25 at 3 30 12 PM" src="https://user-images.githubusercontent.com/4044428/112546571-2f5e3c00-8d7f-11eb-94a1-a4c87727dc90.png">
  * Medium viewports now show 4 columns of products.
    > <img width="752" alt="Screen Shot 2021-03-25 at 3 30 24 PM" src="https://user-images.githubusercontent.com/4044428/112546570-2ec5a580-8d7f-11eb-80e8-4ce028f9fbfe.png">
  * Large viewports now show 3 columns of products. This reduction is due to the sidebar being shown in the modal.
    > <img width="895" alt="Screen Shot 2021-03-25 at 3 30 39 PM" src="https://user-images.githubusercontent.com/4044428/112546566-2e2d0f00-8d7f-11eb-8089-c45618ad64d3.png">
  * XL and XXL viewports now show 4 and 5 columns of products, respectively.
    > <img width="1100" alt="Screen Shot 2021-03-25 at 3 30 51 PM" src="https://user-images.githubusercontent.com/4044428/112546563-2d947880-8d7f-11eb-8869-4d52eb7cc7c2.png">
    > <img width="1443" alt="Screen Shot 2021-03-25 at 3 30 59 PM" src="https://user-images.githubusercontent.com/4044428/112546549-2a998800-8d7f-11eb-9b12-f813686f24ce.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply these changes to your site with a Jetpack Search subscription.
* Ensure that the product layout works as expected.
