### PR TITLE
Search: Fix filter checkboxes in Safari on 2020 and 2021 themes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-safari-checkboxes-twenty-twenty-themes
+++ b/projects/plugins/jetpack/changelog/fix-search-safari-checkboxes-twenty-twenty-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fix visibility of filter checkboxes in Safari on Twenty Twenty and Twenty Twenty One themes

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
@@ -48,7 +48,7 @@
 		top: 0; // Ensures align-items: center; works as expected.
 
 		// Remove any custom checkbox styling
-		appearance: auto;
+		appearance: checkbox;
 		background: none;
 		border: none;
 		height: initial;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/19295.

#### Changes proposed in this Pull Request
Ensure that filter checkboxes are shown in Safari on themes that use checkbox customisation, like Twenty Twenty and Twenty Twenty One.

#### Background 

The Twenty Twenty and Twenty Twenty One themes both do some customisation of checkbox appearance using the `appearance` rule. We do our best to override all of the checkbox customisations from the theme in the search modal.

When setting `appearance: auto`, we missed that the current version of Safari does not support the `auto` value, meaning it inherited `appearance: none` from the theme:

https://caniuse.com/css-appearance

> "The appearance property is supported with the none value, but not auto."

This meant the checkbox was not displayed at all on Safari in those themes 😬

<img width="363" alt="Screen Shot 2021-03-26 at 15 25 13" src="https://user-images.githubusercontent.com/17325/112568526-7adc1d00-8e47-11eb-8967-e8ddfcdc04da.png">

This PR replaces `appearance: auto` with `appearance: checkbox`. This is treated the same way as `auto` in browsers that support that value (like Firefox), and Safari shows the checkbox.

https://developer.mozilla.org/en-US/docs/Web/CSS/appearance

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Go to a test site with Instant Search enabled in Mac or iOS Safari and using the Twenty Twenty or Twenty Twenty One theme. Ensure that filter checkboxes are displayed in the search modal sidebar.

For example, in iOS Safari:

<img width="473" alt="Screen Shot 2021-03-26 at 15 13 56" src="https://user-images.githubusercontent.com/17325/112568709-c5f63000-8e47-11eb-8107-5f4c2aebc4ca.png">
 