### PR TITLE
Admin Menu: Handle RTL styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-admin-menu-rtl-styles
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-rtl-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Admin Menu: Handle RTL styles

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/class-admin-color-schemes.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/class-admin-color-schemes.php
@@ -187,8 +187,7 @@ class Admin_Color_Schemes {
 	public function enqueue_core_color_schemes_overrides() {
 		$core_color_schemes = array( 'blue', 'coffee', 'ectoplasm', 'fresh', 'light', 'midnight', 'modern', 'ocean', 'sunrise' );
 		$color_scheme       = get_user_option( 'admin_color' );
-		$dependencies       = array();
-		$rtl                = is_rtl() ? '-rtl' : '';
+		$rtl                = get_user_option( 'jetpack_wpcom_is_rtl' ) ? '-rtl' : '';
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$dependencies = array( 'wpcom-admin-bar', 'wpcom-masterbar-css', 'notes-admin-bar-rest' . $rtl );
 		} else {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -41,9 +41,12 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 	/**
 	 * Determines whether the current locale is right-to-left (RTL).
+	 *
+	 * Performs the check against the current locale set on the WordPress.com's account settings.
+	 * See `Masterbar::__construct` in `modules/masterbar/masterbar/class-masterbar.php`.
 	 */
 	public function is_rtl() {
-		return 'rtl' === get_user_option( 'jetpack_text_direction' );
+		return get_user_option( 'jetpack_wpcom_is_rtl' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -40,6 +40,13 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Determines whether the current locale is right-to-left (RTL).
+	 */
+	public function is_rtl() {
+		return 'rtl' === get_user_option( 'jetpack_text_direction' );
+	}
+
+	/**
 	 * Create the desired menu output.
 	 */
 	public function reregister_menu_items() {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -200,13 +200,13 @@ abstract class Base_Admin_Menu {
 
 		if ( $is_wpcom ) {
 			$style_dependencies = array( 'wpcom-admin-bar', 'wpcom-masterbar-css' );
-		} elseif ( is_rtl() ) {
+		} elseif ( $this->is_rtl() ) {
 			$style_dependencies = array( 'a8c-wpcom-masterbar-rtl', 'a8c-wpcom-masterbar-overrides-rtl' );
 		} else {
 			$style_dependencies = array( 'a8c-wpcom-masterbar', 'a8c-wpcom-masterbar-overrides' );
 		}
 
-		if ( is_rtl() ) {
+		if ( $this->is_rtl() ) {
 			if ( $is_wpcom ) {
 				$css_path = 'rtl/admin-menu-rtl.css';
 			} else {
@@ -244,6 +244,13 @@ abstract class Base_Admin_Menu {
 			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$submenu[ $slug ] = array();
 		}
+	}
+
+	/**
+	 * Determines whether the current locale is right-to-left (RTL).
+	 */
+	public function is_rtl() {
+		return is_rtl();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -202,12 +202,26 @@ abstract class Base_Admin_Menu {
 		} else {
 			$style_dependencies = array( 'a8c-wpcom-masterbar' . $rtl, 'a8c-wpcom-masterbar-overrides' . $rtl );
 		}
-		wp_enqueue_style(
-			'jetpack-admin-menu',
-			plugins_url( 'admin-menu.css', __FILE__ ),
-			$style_dependencies,
-			JETPACK__VERSION
-		);
+		if ( is_rtl() ) {
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				wp_enqueue_style( 'jetpack-admin-menu', $this->wpcom_static_url( '/wp-content/mu-plugins/masterbar/admin-menu/rtl/admin-menu-rtl.css' ), array(), JETPACK__VERSION );
+			} else {
+				wp_enqueue_style(
+					'jetpack-admin-menu',
+					plugins_url( 'admin-menu-rtl.css', __FILE__ ),
+					$style_dependencies,
+					JETPACK__VERSION
+				);
+			}
+		} else {
+			wp_enqueue_style(
+				'jetpack-admin-menu',
+				plugins_url( 'admin-menu.css', __FILE__ ),
+				$style_dependencies,
+				JETPACK__VERSION
+			);
+		}
+
 		wp_enqueue_script(
 			'jetpack-admin-menu',
 			plugins_url( 'admin-menu.js', __FILE__ ),

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -203,16 +203,12 @@ abstract class Base_Admin_Menu {
 			$style_dependencies = array( 'a8c-wpcom-masterbar' . $rtl, 'a8c-wpcom-masterbar-overrides' . $rtl );
 		}
 		if ( is_rtl() ) {
-			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				wp_enqueue_style( 'jetpack-admin-menu', $this->wpcom_static_url( '/wp-content/mu-plugins/masterbar/admin-menu/rtl/admin-menu-rtl.css' ), array(), JETPACK__VERSION );
-			} else {
-				wp_enqueue_style(
-					'jetpack-admin-menu',
-					plugins_url( 'admin-menu-rtl.css', __FILE__ ),
-					$style_dependencies,
-					JETPACK__VERSION
-				);
-			}
+			wp_enqueue_style(
+				'jetpack-admin-menu',
+				plugins_url( 'admin-menu-rtl.css', __FILE__ ),
+				$style_dependencies,
+				JETPACK__VERSION
+			);
 		} else {
 			wp_enqueue_style(
 				'jetpack-admin-menu',

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -210,7 +210,7 @@ abstract class Base_Admin_Menu {
 			if ( $is_wpcom ) {
 				$css_path = 'rtl/admin-menu-rtl.css';
 			} else {
-				$css_path = 'rtl/admin-menu.css';
+				$css_path = 'admin-menu-rtl.css';
 			}
 		} else {
 			$css_path = 'admin-menu.css';

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -201,9 +201,9 @@ abstract class Base_Admin_Menu {
 		if ( $is_wpcom ) {
 			$style_dependencies = array( 'wpcom-admin-bar', 'wpcom-masterbar-css' );
 		} elseif ( is_rtl() ) {
-			$style_dependencies = array( 'a8c-wpcom-masterbar', 'a8c-wpcom-masterbar-overrides' );
-		} else {
 			$style_dependencies = array( 'a8c-wpcom-masterbar-rtl', 'a8c-wpcom-masterbar-overrides-rtl' );
+		} else {
+			$style_dependencies = array( 'a8c-wpcom-masterbar', 'a8c-wpcom-masterbar-overrides' );
 		}
 
 		if ( is_rtl() ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -196,27 +196,32 @@ abstract class Base_Admin_Menu {
 	 * Enqueues scripts and styles.
 	 */
 	public function enqueue_scripts() {
-		$rtl = is_rtl() ? '-rtl' : '';
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+
+		if ( $is_wpcom ) {
 			$style_dependencies = array( 'wpcom-admin-bar', 'wpcom-masterbar-css' );
+		} elseif ( is_rtl() ) {
+			$style_dependencies = array( 'a8c-wpcom-masterbar', 'a8c-wpcom-masterbar-overrides' );
 		} else {
-			$style_dependencies = array( 'a8c-wpcom-masterbar' . $rtl, 'a8c-wpcom-masterbar-overrides' . $rtl );
+			$style_dependencies = array( 'a8c-wpcom-masterbar-rtl', 'a8c-wpcom-masterbar-overrides-rtl' );
 		}
+
 		if ( is_rtl() ) {
-			wp_enqueue_style(
-				'jetpack-admin-menu',
-				plugins_url( 'admin-menu-rtl.css', __FILE__ ),
-				$style_dependencies,
-				JETPACK__VERSION
-			);
+			if ( $is_wpcom ) {
+				$css_path = 'rtl/admin-menu-rtl.css';
+			} else {
+				$css_path = 'rtl/admin-menu.css';
+			}
 		} else {
-			wp_enqueue_style(
-				'jetpack-admin-menu',
-				plugins_url( 'admin-menu.css', __FILE__ ),
-				$style_dependencies,
-				JETPACK__VERSION
-			);
+			$css_path = 'admin-menu.css';
 		}
+
+		wp_enqueue_style(
+			'jetpack-admin-menu',
+			plugins_url( $css_path, __FILE__ ),
+			$style_dependencies,
+			JETPACK__VERSION
+		);
 
 		wp_enqueue_script(
 			'jetpack-admin-menu',

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -32,6 +32,13 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Determines whether the current locale is right-to-left (RTL).
+	 */
+	public function is_rtl() {
+		return 'rtl' === get_user_option( 'jetpack_text_direction' );
+	}
+
+	/**
 	 * Create the desired menu output.
 	 */
 	public function reregister_menu_items() {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -33,9 +33,12 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 
 	/**
 	 * Determines whether the current locale is right-to-left (RTL).
+	 *
+	 * Performs the check against the current locale set on the WordPress.com's account settings.
+	 * See `Masterbar::__construct` in `modules/masterbar/masterbar/class-masterbar.php`.
 	 */
 	public function is_rtl() {
-		return 'rtl' === get_user_option( 'jetpack_text_direction' );
+		return get_user_option( 'jetpack_wpcom_is_rtl' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -78,7 +78,7 @@ class Masterbar {
 	/**
 	 * Whether the text direction is RTL (based on connected WordPress.com user's interface settings).
 	 *
-	 * @var string
+	 * @var boolean
 	 */
 	private $is_rtl;
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -76,7 +76,7 @@ class Masterbar {
 	 */
 	private $primary_site_slug;
 	/**
-	 * Whether the text direction is RLT (based on connected WordPress.com user's interface settings).
+	 * Whether the text direction is RTL (based on connected WordPress.com user's interface settings).
 	 *
 	 * @var string
 	 */

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -110,10 +110,9 @@ class Masterbar {
 		// by other files of the masterbar module without making another XMLRPC
 		// request. Although `get_connected_user_data` tries to save the data for
 		// future uses on a transient, the data is not guaranteed to be cached.
+		update_user_option( $this->user_id, 'jetpack_wpcom_is_rtl', $this->is_rtl );
 		if ( isset( $this->user_data['use_wp_admin_links'] ) ) {
-			$user_id = get_current_user_id();
-			update_user_option( $user_id, 'jetpack_admin_menu_link_destination', $this->user_data['use_wp_admin_links'] );
-			update_user_option( $user_id, 'jetpack_wpcom_is_rtl', $this->is_rtl );
+			update_user_option( $this->user_id, 'jetpack_admin_menu_link_destination', $this->user_data['use_wp_admin_links'] );
 		}
 
 		add_action( 'admin_bar_init', array( $this, 'init' ) );

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -99,18 +99,21 @@ class Masterbar {
 			return;
 		}
 
-		$this->user_data       = $connection_manager->get_connected_user_data( $this->user_id );
-		$this->user_login      = $this->user_data['login'];
-		$this->user_email      = $this->user_data['email'];
-		$this->display_name    = $this->user_data['display_name'];
-		$this->user_site_count = $this->user_data['site_count'];
+		$this->user_data           = $connection_manager->get_connected_user_data( $this->user_id );
+		$this->user_login          = $this->user_data['login'];
+		$this->user_email          = $this->user_data['email'];
+		$this->display_name        = $this->user_data['display_name'];
+		$this->user_site_count     = $this->user_data['site_count'];
+		$this->user_text_direction = $this->user_data['text_direction'];
 
 		// Store part of the connected user data as user options so it can be used
 		// by other files of the masterbar module without making another XMLRPC
 		// request. Although `get_connected_user_data` tries to save the data for
 		// future uses on a transient, the data is not guaranteed to be cached.
 		if ( isset( $this->user_data['use_wp_admin_links'] ) ) {
-			update_user_option( get_current_user_id(), 'jetpack_admin_menu_link_destination', $this->user_data['use_wp_admin_links'] );
+			$user_id = get_current_user_id();
+			update_user_option( $user_id, 'jetpack_admin_menu_link_destination', $this->user_data['use_wp_admin_links'] );
+			update_user_option( $user_id, 'jetpack_text_direction', $this->user_text_direction );
 		}
 
 		add_action( 'admin_bar_init', array( $this, 'init' ) );
@@ -167,9 +170,6 @@ class Masterbar {
 
 		// Used for display purposes and for building WP Admin links.
 		$this->primary_site_url = str_replace( '::', '/', $this->primary_site_slug );
-
-		// We need to use user's setting here, instead of relying on current blog's text direction.
-		$this->user_text_direction = $this->user_data['text_direction'];
 
 		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
 

--- a/projects/plugins/jetpack/tools/builder/admin-css.js
+++ b/projects/plugins/jetpack/tools/builder/admin-css.js
@@ -35,6 +35,7 @@ const admincss = [
 	'modules/widget-visibility/widget-conditions/widget-conditions.css',
 	'modules/widgets/gallery/css/admin.css',
 	'modules/sso/jetpack-sso-login.css', // Displayed when logging into the site.
+	'modules/masterbar/admin-menu/admin-menu.css',
 ];
 
 // Minimizes admin css for modules.  Outputs to same folder as min.css


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/49779

#### Changes proposed in this Pull Request:
- Add the admin menu styles to the build process that generates the RTL CSS files.
- Load the appropriate RTL admin menu styles when the language is a RTL language.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Try to reproduce first the issue:
* Go to https://wordpress.com/me/account.
* Change your language to a RTL language like Arabic or Hebrew. Save the settings.
* Toggle the "Show advanced pages" setting or change the color scheme and save. (This is to flush the cache on your Atomic sites).
* On an Atomic site, load `wp-admin/options-general.php` and change the site language to the same language you've set for your account.
* Open the responsiveness dev tools in your browser and switch to a mobile viewport.
* Note how the content is misplaced to the right:

<img width="451" alt="Screen Shot 2021-03-26 at 16 28 02" src="https://user-images.githubusercontent.com/1233880/112655009-43be3980-8e50-11eb-8957-47d879fbb8e3.png">

Now check this PR solves the issue:
* Install Jetpack Beta and switch to this branch.
* Reload the affected WP Admin screen.
* Make sure the content fits the full width available.
<img width="484" alt="Screen Shot 2021-03-26 at 14 51 45" src="https://user-images.githubusercontent.com/1233880/112641627-d22bbe80-8e42-11eb-82d1-9055d2ee90bc.png">

Make sure there are no regressions when using a non-RTL language. Check also there are no regressions on Simple sites when D59369-code is applied.