### PR TITLE
renovate: Fix "close old PRs" script

### DIFF
--- a/.github/files/renovate-close-old-PRs.sh
+++ b/.github/files/renovate-close-old-PRs.sh
@@ -7,7 +7,7 @@ function die {
 	exit 1
 }
 
-[[ -n "$GITHUB_TOKEN" ]] || die "GITHUB_TOKEN must be set"
+[[ -n "$API_TOKEN_GITHUB" ]] || die "API_TOKEN_GITHUB must be set"
 [[ -n "$GITHUB_API_URL" ]] || die "GITHUB_API_URL must be set"
 [[ -n "$GITHUB_REPOSITORY" ]] || die "GITHUB_REPOSITORY must be set"
 
@@ -18,7 +18,7 @@ echo "::endgroup::"
 
 echo "::group::Fetching 1000th PR..."
 JSON=$(curl -v --fail \
-	--header "authorization: Bearer $GITHUB_TOKEN" \
+	--header "authorization: Bearer $API_TOKEN_GITHUB" \
 	--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls?per_page=100&state=all&page=10" \
 ) || { echo "$JSON"; exit 1; }
 echo "::endgroup::"
@@ -33,7 +33,7 @@ declare -i PAGE=1
 while :; do
 	echo "::group::Fetching open PRs (page $PAGE)"
 	JSON=$(curl -v --fail \
-		--header "authorization: Bearer $GITHUB_TOKEN" \
+		--header "authorization: Bearer $API_TOKEN_GITHUB" \
 		--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls?state=open&base=master&per_page=100&page=${PAGE}&direction=asc" \
 	) || { echo "$JSON"; exit 1; }
 	echo "::endgroup::"
@@ -46,7 +46,7 @@ while :; do
 		echo "PR #$PR is too old! Closing."
 		echo "::group::Posting comment..."
 		curl -v --fail \
-			--header "authorization: Bearer $GITHUB_TOKEN" \
+			--header "authorization: Bearer $API_TOKEN_GITHUB" \
 			--header 'content-type: application/json' \
 			--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/$PR/comments" \
 			--data '{"body":"This renovate PR is too old: renovate loses track of its own PRs when they'\''re beyond the latest 1000 in the repo. See [renovate issue #4803](https://git.io/JYt4a).\n\nClosing the PR so renovate can re-create it."}'
@@ -54,7 +54,7 @@ while :; do
 		echo "::group::Closing..."
 		curl -v --fail \
 			--request PATCH \
-			--header "authorization: Bearer $GITHUB_TOKEN" \
+			--header "authorization: Bearer $API_TOKEN_GITHUB" \
 			--header 'content-type: application/json' \
 			--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/$PR" \
 			--data '{"state":"closed"}'

--- a/.github/workflows/renovate-cleanup.yml
+++ b/.github/workflows/renovate-cleanup.yml
@@ -15,3 +15,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: .github/files/renovate-close-old-PRs.sh
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We need to pass the token in explicitly, GH doesn't do that
automatically.

Also, may as well pass matticbot's token rather than GH Action's so the
comment and close show up as being from our own bot.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge, then check tomorrow whether it worked.
