### PR TITLE
Jetpack Recommendations: Fix fetching upsell on userless

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -778,6 +778,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error( 'site_not_registered', esc_html__( 'Site not registered.', 'jetpack' ) );
 		}
 
+		$user_connected = ( new Connection_Manager( 'jetpack' ) )->is_user_connected( get_current_user_id() );
+		if ( ! $user_connected ) {
+			$response = array(
+				'hide_upsell' => true,
+			);
+
+			return $response;
+		}
+
 		$request_path  = sprintf( '/sites/%s/jetpack-recommendations/upsell?locale=' . get_user_locale(), $blog_id );
 		$wpcom_request = Client::wpcom_json_api_request_as_user(
 			$request_path,

--- a/projects/plugins/jetpack/changelog/fix-jetpack-recommendations-on-userless
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-recommendations-on-userless
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix recommendations for user-less connections


### PR DESCRIPTION
This PR fixes the Jetpack Recommendations feature for User-less Jetpack Connections and secondary users without a connected WPCOM account.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Checks if the current user is connected and hides the upsell card if yes.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
1191179647901802-as-1199661507903018/f

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
**Before**:
- Connect Jetpack in User-less mode, aka by skipping user authentication after setting up Jetpack. (In JN, check `JETPACK_NO_USER_TEST_MODE` in Settings->Jetpack Constants )
- Run the Recommendations wizard
- Notice in the final step `admin.php?page=jetpack#/recommendations/summary` will be blank and the following error in your browser console: `react-dom.min.js:125 TypeError: Cannot read property 'symbol' of null`

**After**:
- Notice in the final step `admin.php?page=jetpack#/recommendations/summary` everything works as expected and no errors in your browser console.

**Note**: The same behaviour can be reproduced by running the Recommendations Wizard as a secondary user (eg a site admin) without a connected WPCOM account.