### PR TITLE
Connection: do not display Connect Bar when in Offline mode, and make SEO userless

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/connect-user-bar/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-user-bar/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -32,7 +32,11 @@ const ConnectUserBar = props => {
 		<Card compact className="jp-connect-user-bar__card">
 			{ ! showConnect && (
 				<div className="jp-connect-user-bar__text">
-					This feature is provided by the WordPress.com cloud. { props.text }
+					{ sprintf(
+						/* translators: placeholder is text adding extra instructions on what to do next. */
+						__( 'This feature is provided by the WordPress.com cloud. %s', 'jetpack' ),
+						props.text
+					) }
 				</div>
 			) }
 			{ ! showConnect && (

--- a/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
+++ b/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
@@ -146,7 +146,7 @@ class SubscriptionsComponent extends React.Component {
 				</SettingsGroup>
 				{ getSubClickableCard() }
 
-				{ ! this.props.isLinked && (
+				{ ! this.props.isLinked && ! this.props.isOfflineMode && (
 					<ConnectUserBar
 						feature="subscriptions"
 						featureLabel={ __( 'Subscriptions', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/security/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/monitor.jsx
@@ -23,7 +23,9 @@ export const Monitor = withModuleSettingsFormHelpers(
 		};
 
 		render() {
-			const isMonitorActive = this.props.getOptionValue( 'monitor' ),
+			const hasConnectedOwner = this.props.hasConnectedOwner,
+				isOfflineMode = this.props.isOfflineMode,
+				isMonitorActive = this.props.getOptionValue( 'monitor' ),
 				unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'monitor' );
 			return (
 				<SettingsCard
@@ -47,7 +49,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 					>
 						<ModuleToggle
 							slug="monitor"
-							disabled={ unavailableInOfflineMode || ! this.props.hasConnectedOwner }
+							disabled={ unavailableInOfflineMode || ! hasConnectedOwner }
 							activated={ isMonitorActive }
 							toggling={ this.props.isSavingAnyOption( 'monitor' ) }
 							toggleModule={ this.props.toggleModuleNow }
@@ -60,7 +62,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 							</span>
 						</ModuleToggle>
 					</SettingsGroup>
-					{ this.props.hasConnectedOwner && (
+					{ hasConnectedOwner && (
 						<Card
 							compact
 							className="jp-settings-card__configure-link"
@@ -73,7 +75,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 						</Card>
 					) }
 
-					{ ! this.props.hasConnectedOwner && (
+					{ ! hasConnectedOwner && ! isOfflineMode && (
 						<ConnectUserBar
 							feature="monitor"
 							featureLabel={ __( 'Downtime Monitoring', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import { includes } from 'lodash';
-import classNames from 'classnames';
 import { __, _x, sprintf } from '@wordpress/i18n';
 
 /**
@@ -108,9 +107,6 @@ export const Protect = withModuleSettingsFormHelpers(
 						<FoldableCard
 							onOpen={ this.trackOpenCard }
 							header={ toggle }
-							className={ classNames( {
-								'jp-foldable-settings-disable': unavailableInOfflineMode,
-							} ) }
 						>
 							<SettingsGroup
 								hasChild

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -104,10 +104,7 @@ export const Protect = withModuleSettingsFormHelpers(
 						module={ this.props.getModule( 'protect' ) }
 						className="foldable-wrapper"
 					>
-						<FoldableCard
-							onOpen={ this.trackOpenCard }
-							header={ toggle }
-						>
+						<FoldableCard onOpen={ this.trackOpenCard } header={ toggle }>
 							<SettingsGroup
 								hasChild
 								module={ this.props.getModule( 'protect' ) }
@@ -175,7 +172,7 @@ export const Protect = withModuleSettingsFormHelpers(
 						</FoldableCard>
 					</SettingsGroup>
 
-					{ ! this.props.hasConnectedOwner && (
+					{ ! this.props.hasConnectedOwner && ! this.props.isOfflineMode && (
 						<ConnectUserBar
 							feature="protect"
 							featureLabel={ __( 'Protect', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -126,7 +126,7 @@ export const SSO = withModuleSettingsFormHelpers(
 						</FormFieldset>
 					</SettingsGroup>
 
-					{ ! this.props.hasConnectedOwner && (
+					{ ! this.props.hasConnectedOwner && ! this.props.isOfflineMode && (
 						<ConnectUserBar
 							feature="sso"
 							featureLabel={ __( 'Secure Sign-On', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -28,6 +28,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 		render() {
 			const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'publicize' ),
 				isLinked = this.props.isLinked,
+				isOfflineMode = this.props.isOfflineMode,
 				connectUrl = this.props.connectUrl,
 				siteRawUrl = this.props.siteRawUrl,
 				isActive = this.props.getOptionValue( 'publicize' ),
@@ -104,7 +105,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 						</SettingsGroup>
 					) }
 
-					{ ! this.props.isLinked && (
+					{ ! isLinked && ! isOfflineMode && (
 						<ConnectUserBar
 							feature="publicize"
 							featureLabel={ __( 'Publicize', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
@@ -110,7 +110,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 						</ModuleToggle>
 					</SettingsGroup>
 
-					{ ! this.props.isLinked && (
+					{ ! isLinked && ! isOfflineMode && (
 						<ConnectUserBar
 							feature="sharedaddy"
 							featureLabel={ __( 'Sharing Buttons', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -23,7 +23,9 @@ export const SEO = withModuleSettingsFormHelpers(
 		};
 
 		render() {
-			const isActive = this.props.getOptionValue( 'seo-tools' );
+			const hasConnectedOwner = this.props.hasConnectedOwner,
+				isActive = this.props.getOptionValue( 'seo-tools' ),
+				isOfflineMode = this.props.isOfflineMode;
 
 			return (
 				<SettingsCard
@@ -60,7 +62,7 @@ export const SEO = withModuleSettingsFormHelpers(
 							{ __( 'Customize your SEO settings', 'jetpack' ) }
 						</ModuleToggle>
 					</SettingsGroup>
-					{ isActive && ! this.props.isOfflineMode && (
+					{ isActive && ! isOfflineMode && (
 						<Card
 							compact
 							className="jp-settings-card__configure-link"
@@ -71,7 +73,7 @@ export const SEO = withModuleSettingsFormHelpers(
 						</Card>
 					) }
 
-					{ ! this.props.hasConnectedOwner && (
+					{ ! hasConnectedOwner && ! isOfflineMode && (
 						<ConnectUserBar
 							feature="monitor"
 							featureLabel={ __( 'SEO', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -15,7 +15,6 @@ import { withModuleSettingsFormHelpers } from 'components/module-settings/with-m
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { ModuleToggle } from 'components/module-toggle';
-import ConnectUserBar from 'components/connect-user-bar';
 import { FormLabel, FormTextarea, FormFieldset } from 'components/forms';
 import FoldableCard from 'components/foldable-card';
 import CustomSeoTitles from './seo/custom-seo-titles.jsx';
@@ -83,15 +82,14 @@ export const SEO = withModuleSettingsFormHelpers(
 		};
 
 		render() {
-			const hasConnectedOwner = this.props.hasConnectedOwner,
-				isOfflineMode = this.props.isOfflineMode;
+			const isOfflineMode = this.props.isOfflineMode,
+				seo = this.props.getModule( 'seo-tools' ),
+				isSeoActive = this.props.getOptionValue( seo.module ),
+				customSeoTitles = this.props.getOptionValue( 'advanced_seo_title_formats' ),
+				frontPageMetaDescription = this.props.getOptionValue(
+					'advanced_seo_front_page_description'
+				);
 
-			const seo = this.props.getModule( 'seo-tools' );
-			const isSeoActive = this.props.getOptionValue( seo.module );
-			const frontPageMetaDescription = this.props.getOptionValue(
-				'advanced_seo_front_page_description'
-			);
-			const customSeoTitles = this.props.getOptionValue( 'advanced_seo_title_formats' );
 			const siteData = {
 				title: this.props.siteData.name || '',
 				tagline: this.props.siteData.description || '',
@@ -110,7 +108,7 @@ export const SEO = withModuleSettingsFormHelpers(
 				}
 				return acc;
 			}, [] );
-			const hasConflictingSeoPlugin = conflictingSeoPlugins.length > 0 ? true : false;
+			const hasConflictingSeoPlugin = conflictingSeoPlugins.length > 0;
 
 			return (
 				<SettingsCard
@@ -123,7 +121,6 @@ export const SEO = withModuleSettingsFormHelpers(
 				>
 					<SettingsGroup
 						disableInOfflineMode
-						disableInUserlessMode
 						module={ { module: 'seo-tools' } }
 						support={ {
 							text: __(
@@ -267,14 +264,6 @@ export const SEO = withModuleSettingsFormHelpers(
 								</FoldableCard>
 							</div>
 						) }
-
-					{ ! hasConnectedOwner && ! isOfflineMode && (
-						<ConnectUserBar
-							feature="monitor"
-							featureLabel={ __( 'SEO', 'jetpack' ) }
-							text={ __( 'Sign in to optimize your site for search engines.', 'jetpack' ) }
-						/>
-					) }
 				</SettingsCard>
 			);
 		}

--- a/projects/plugins/jetpack/changelog/fix-userless-connect-bar-offline-mode
+++ b/projects/plugins/jetpack/changelog/fix-userless-connect-bar-offline-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Userless project: do not display connect bar on Offline sites.
+
+

--- a/projects/plugins/jetpack/modules/seo-tools.php
+++ b/projects/plugins/jetpack/modules/seo-tools.php
@@ -6,7 +6,7 @@
  * Recommendation Order: 15
  * First Introduced: 4.4
  * Requires Connection: Yes
- * Requires User Connection: Yes
+ * Requires User Connection: No
  * Auto Activate: No
  * Module Tags: Social, Appearance
  * Feature: Traffic


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
﻿
This PR is a follow-up of #18837 and #19300.

It introduces the following changes:

**The connect bar main message should be translatable.**

**The SEO module now works in userless mode.**

**The Protect card should still be a bit readable when in offline mode.**

In bc422ac3f771e80a36ef47ef73d7681878411979, we wrapped the foldable card into a SettingsGroup component that already handles the display of the group when in offline mode. We consequently do not need to handle it again in the foldable card.

**Before**

<img width="1200" alt="Screenshot 2021-03-26 at 18 06 09" src="https://user-images.githubusercontent.com/426388/112670367-1e85f700-8e61-11eb-960d-ec3e1765ef78.png">


**After**

<img width="1189" alt="Screenshot 2021-03-26 at 18 06 57" src="https://user-images.githubusercontent.com/426388/112670388-22b21480-8e61-11eb-9477-1ff79f20a057.png">


**Let's not show the connect bar when in offline mode, since folks will not be able to connect their site to WordPress.com anyway.

**Before**

<img width="1075" alt="Screenshot 2021-03-26 at 18 24 02" src="https://user-images.githubusercontent.com/426388/112670409-2776c880-8e61-11eb-8659-7ddb924666c4.png">


**After**

<img width="1080" alt="Screenshot 2021-03-26 at 18 24 14" src="https://user-images.githubusercontent.com/426388/112670426-2d6ca980-8e61-11eb-808f-7f37bab0accb.png">

**Note**: a potential alternative would be to add the Offline check within the connect bar component itself. 

#### Jetpack product discussion

p1HpG7-ba8-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a brand new JN site running `master`.
* In the Jetpack constants page, enable Offline mode.
* If you then visit Jetpack > Settings, you should see the Userless card appear under some of the features, even though your site cannot be connected to WordPress.com.
* Switch to this branch.
* The userless connect bar prompt should disappear.
* In the Jetpack constants page, disable Offline mode and enable `JETPACK_NO_USER_TEST_MODE`.
* Disconnect from Jetpack, reconnect in userless mode.
* Go to "Settings -> Traffic -> Search engine optimization" and confirm that the module works in Userless mode (switch on/off and settings are available).