### PR TITLE
Search: Remove overlay trigger from Customizer

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-search-overlay-trigger-config
+++ b/projects/plugins/jetpack/changelog/remove-search-overlay-trigger-config
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: Remove overlay trigger from Customizer

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -171,7 +171,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 				'enableInfScroll' => get_option( $prefix . 'inf_scroll', '1' ) === '1',
 				'enableSort'      => get_option( $prefix . 'enable_sort', '1' ) === '1',
 				'highlightColor'  => get_option( $prefix . 'highlight_color', '#FFC' ),
-				'overlayTrigger'  => get_option( $prefix . 'overlay_trigger', 'immediate' ),
 				'resultFormat'    => get_option( $prefix . 'result_format', Jetpack_Search_Options::RESULT_FORMAT_MINIMAL ),
 				'showPoweredBy'   => get_option( $prefix . 'show_powered_by', '1' ) === '1',
 			),

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -98,29 +98,6 @@ class Jetpack_Search_Customize {
 			)
 		);
 
-		$id = $setting_prefix . 'overlay_trigger';
-		$wp_customize->add_setting(
-			$id,
-			array(
-				'default'   => 'results',
-				'transport' => 'postMessage',
-				'type'      => 'option',
-			)
-		);
-		$wp_customize->add_control(
-			$id,
-			array(
-				'label'       => __( 'Search Input Overlay Trigger', 'jetpack' ),
-				'description' => __( 'Select when your overlay should appear.', 'jetpack' ),
-				'section'     => $section_id,
-				'type'        => 'select',
-				'choices'     => array(
-					'immediate' => __( 'Open when the user starts typing', 'jetpack' ),
-					'results'   => __( 'Open when results are available', 'jetpack' ),
-				),
-			)
-		);
-
 		$id = $setting_prefix . 'excluded_post_types';
 		$wp_customize->add_setting(
 			$id,

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -182,12 +182,7 @@ class SearchApp extends Component {
 		}
 
 		this.props.setSearchQuery( event.target.value );
-		if ( this.state.overlayOptions.overlayTrigger === 'immediate' ) {
-			this.showResults();
-		}
-		if ( this.state.overlayOptions.overlayTrigger === 'results' ) {
-			this.props.response?.results && this.showResults();
-		}
+		this.showResults();
 	}, 200 );
 
 	handleFilterInputClick = event => {
@@ -311,7 +306,6 @@ class SearchApp extends Component {
 					onChangeSearch={ this.props.setSearchQuery }
 					onChangeSort={ this.props.setSort }
 					onLoadNextPage={ this.loadNextPage }
-					overlayTrigger={ this.state.overlayOptions.overlayTrigger }
 					postTypes={ this.props.options.postTypes }
 					response={ this.props.response }
 					resultFormat={ resultFormat }

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/customize.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/customize.js
@@ -8,7 +8,6 @@ const SETTINGS_TO_STATE_MAP = new Map( [
 	[ 'jetpack_search_enable_sort', 'enableSort' ],
 	[ 'jetpack_search_highlight_color', 'highlightColor' ],
 	[ 'jetpack_search_inf_scroll', 'enableInfScroll' ],
-	[ 'jetpack_search_overlay_trigger', 'overlayTrigger' ],
 	[ 'jetpack_search_show_powered_by', 'showPoweredBy' ],
 	[ 'jetpack_search_result_format', 'resultFormat' ],
 ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Removes Overlay Trigger from the Customizer. Now defaults to opening the search modal upon detecting user input on a search input.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Navigate to the Jetpack Search section of the Customizer. Ensure that the configurable overlay trigger no longer exists.
* Navigate to `/` and perform a site search. Ensure it summons a search modal and shows results as expected.
* Navigate to `/?s=search` and ensure that it shows search results as expected.