### PR TITLE
Jetpack Admin: Fix fetching available modules on user-less mode

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-userless-get-available-modules
+++ b/projects/plugins/jetpack/changelog/fix-userless-get-available-modules
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Jetpack Admin: Check user connection constrains when fetching the available modules list.
+Jetpack Admin: Check user connection constraints when fetching the available modules list.

--- a/projects/plugins/jetpack/changelog/fix-userless-get-available-modules
+++ b/projects/plugins/jetpack/changelog/fix-userless-get-available-modules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Admin: Check user connection constrains when fetching the available modules list.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -246,15 +246,31 @@ class Jetpack_Admin {
 			return false;
 		}
 
+		/*
+		 * In Offline mode, modules that require a site or user
+		 * level connection should be unavailable.
+		 */
 		if ( ( new Status() )->is_offline_mode() ) {
-			return ! ( $module['requires_connection'] );
-		} else {
-			if ( ! Jetpack::is_connection_ready() ) {
-				return false;
-			}
-
-			return Jetpack_Plan::supports( $module['module'] );
+			return ! ( $module['requires_connection'] || $module['requires_user_connection'] );
 		}
+
+		/*
+		 * Jetpack not connected.
+		 */
+		if ( ! Jetpack::is_connection_ready() ) {
+			return false;
+		}
+
+		/*
+		 * Jetpack connected at a site level only. Make sure to make
+		 * modules that require a user connection unavailable.
+		 */
+		if ( ! Jetpack::connection()->has_connected_owner() && $module['requires_user_connection'] ) {
+			return false;
+		}
+
+		return Jetpack_Plan::supports( $module['module'] );
+
 	}
 
 	function handle_unrecognized_action( $action ) {


### PR DESCRIPTION
This PR fixes the list of available modules taking into account their user connection constraints.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack Admin: Updates the `get_available_modules` method to return `false` if the module requires a user connection and the site has no connected owner.
* Jetpack Admin: Updates the `get_available_modules` method to return `false` if the module requires a user connection and the site is in offline mode.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1191179647901802-as-1200123916753249/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
**Before**
- Start with a brand new JN site running master.
- In the Jetpack constants page, enable Userless mode.
- Connect the site ONLY at a site level (skip user auth)
- Go to `wp-admin/admin.php?page=jetpack_modules`
- The modules below (requiring user connection) will be displayed as available while they shouldn't:

1. Monitor
2. Notifications
3. Post by Email
4. Protect
5. Publicize
6. Sharing (sharedaddy)
7. Single Sign On
8. Subscriptions
9. WordPress.com Toolbar (masterbar)

**After**
- Switch to this branch
- Go to `wp-admin/admin.php?page=jetpack_modules`
- Verify the above modules are now displayed as NOT available.
- Verify consistency between UIs in Settings and the modules page.
- In the Jetpack constants page, enable Offline mode.
- Verify the above modules are still displayed as NOT available.
