### PR TITLE
Connection: fully disable Monitor and Protect on userless Dashboard

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/monitor.jsx
@@ -24,6 +24,7 @@ class DashMonitor extends Component {
 	static propTypes = {
 		isOfflineMode: PropTypes.bool.isRequired,
 		isModuleAvailable: PropTypes.bool.isRequired,
+		hasConnectedOwner: PropTypes.bool.isRequired,
 	};
 
 	activateAndTrack = () => {
@@ -48,7 +49,11 @@ class DashMonitor extends Component {
 			link: getRedirectUrl( 'jetpack-support-monitor' ),
 		};
 
-		if ( this.props.getOptionValue( 'monitor' ) ) {
+		if (
+			this.props.getOptionValue( 'monitor' ) &&
+			! this.props.isOfflineMode &&
+			this.props.hasConnectedOwner
+		) {
 			return (
 				<DashItem label={ labelName } module="monitor" support={ support } status="is-working">
 					<p className="jp-dash-item__description">
@@ -82,6 +87,7 @@ class DashMonitor extends Component {
 				module="monitor"
 				support={ support }
 				className="jp-dash-item__is-inactive"
+				noToggle={ ! this.props.hasConnectedOwner }
 			>
 				<p className="jp-dash-item__description">
 					{ this.props.isOfflineMode

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
@@ -89,6 +89,7 @@ class DashProtect extends Component {
 				module="protect"
 				support={ support }
 				className="jp-dash-item__is-inactive"
+				noToggle={ ! this.props.hasConnectedOwner }
 			>
 				<p className="jp-dash-item__description">
 					{ this.props.isOfflineMode && __( 'Unavailable in Offline Mode', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/README.md
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/README.md
@@ -22,3 +22,4 @@ This is the base component and acts as a wrapper for an At A Glance item's title
 #### Props
 - `label` - *optional* (string) Title of the dash item.
 - `status` - *optional* (string) Sets the status colors and icons of the item. Available arguments are `is-success`, `is-warning`, `is-error`, and `is-info`.
+- `noToggle` - *optional* (bool) If `true`, the component will not disable the enable/disable toggle.

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
@@ -36,6 +36,7 @@ export class DashItem extends Component {
 		isModule: PropTypes.bool,
 		support: PropTypes.object,
 		overrideContent: PropTypes.element,
+		noToggle: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -44,6 +45,7 @@ export class DashItem extends Component {
 		pro: false,
 		isModule: true,
 		support: { text: '', link: '' },
+		noToggle: false,
 	};
 
 	toggleModule = () => {
@@ -78,6 +80,7 @@ export class DashItem extends Component {
 					this.props.module
 				) &&
 					this.props.isOfflineMode ) ||
+				this.props.noToggle ||
 				// Avoid toggle for manage as it's no longer a module
 				'manage' === this.props.module ? (
 					''

--- a/projects/plugins/jetpack/changelog/fix-userless-monitor-protect
+++ b/projects/plugins/jetpack/changelog/fix-userless-monitor-protect
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: The fix is insignificant, and the bug was introduced in the same Jetpack release.
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- hide the "toggle" buttons for Monitor and Protect cards in userless mode
- disable Monitor card in Offline mode when the module is enabled

#### Jetpack product discussion
1191179647901802-as-1200123916753257

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Connect Jetpack in Userless Mode.
2. Go to Jetpack Dashboard and confirm that cards "Protect" and "Downtime monitoring" are asking you to connect the user.
3. Confirm that the enable/disable toggles do not show up on these cards.
4. Connect the user, confirm that the toggles do show up, try switching then on/off.
5. Activate both "Downtime monitoring" and "Protect".
6. Switch into the Offline mode (`define( 'JETPACK_DEV_DEBUG', true );`) and reload the Jetpack Dashboard.
7. Confirm that both of those cards say "Unavailable in Offline Mode."