### PR TITLE
Connection: fixing typo in the userless Protect card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
@@ -98,7 +98,7 @@ class DashProtect extends Component {
 						! this.props.hasConnectedOwner &&
 						createInterpolateElement(
 							__(
-								'<a>Connect your WordPress.com</a> to keep your site protected from malicious sign in attempts.',
+								'<a>Connect your WordPress.com</a> account to keep your site protected from malicious sign in attempts.',
 								'jetpack'
 							),
 							{

--- a/projects/plugins/jetpack/changelog/fix-userless-dashboard-copy
+++ b/projects/plugins/jetpack/changelog/fix-userless-dashboard-copy
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Insignificant typo fix.
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Fixing typo in the Dashboard "Protect" card in Userless mode.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Connect your site in Userless mode.
2. Go to Jetpack Dashboard and find the "Protect" card.
3. Confirm that it displays "Connect your WordPress.com **account** to keep..." instead of "Connect your WordPress.com to keep..."