### PR TITLE
Recommendations: Hide Monitoring setting on User-less mode

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -25,6 +25,7 @@ import {
 import { getRewindStatus } from 'state/rewind';
 import { getSetting } from 'state/settings';
 import { getSitePlan, hasActiveProductPurchase, hasActiveScanPurchase } from 'state/site';
+import { hasConnectedOwner } from 'state/connection';
 import { isPluginActive } from 'state/site/plugins';
 
 const mergeArrays = ( x, y ) => {
@@ -187,6 +188,8 @@ const isStepEligibleToShow = ( state, step ) => {
 			return true;
 		case 'woocommerce':
 			return getDataByKey( state, 'site-type-store' ) ? ! isFeatureActive( state, step ) : false;
+		case 'monitor':
+			return hasConnectedOwner( state ) && ! isFeatureActive( state, step );
 		default:
 			return ! isFeatureActive( state, step );
 	}
@@ -255,6 +258,8 @@ const isFeatureEligibleToShowInSummary = ( state, slug ) => {
 	switch ( slug ) {
 		case 'woocommerce':
 			return true === getDataByKey( state, 'site-type-store' );
+		case 'monitor':
+			return hasConnectedOwner( state );
 		default:
 			return true;
 	}

--- a/projects/plugins/jetpack/changelog/fix-recommendations-hide-monitor-on-userless
+++ b/projects/plugins/jetpack/changelog/fix-recommendations-hide-monitor-on-userless
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Recommendations: Hide Monitoring setting on User-less mode.


### PR DESCRIPTION
Jetpack Assistant (Recommendations) allows users to enable the Monitoring setting, however on user-less mode (no connected users) this setting is disabled and we only allow users to enable it after connecting their WPCOM account.
This PR fixes the above by hiding the Monitoring setup step on User-less mode.

#### Changes proposed in this Pull Request:
The following fixes to the recommendations' state are introduced:
- `isStepEligibleToShow`: Adds an extra check whether the site has a connected owned in order to hide it if not.
- `isFeatureEligibleToShowInSummary`: Adds an extra check whether the site has a connected owned in order to hide it if not.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-2EA-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
**Before**
* Set up a new JN site running the master branch.
* Enable user-less mode ( `Settings->Jetpack Constants` )
* Setup Jetpack without connecting your WPCOM account (aka skip auth)
* Run the Jetpack Assistant and verify that the Monitoring step is visible and you can enable the corresponding setting.

**After**
* Set up a new JN site running the current branch.
* Enable user-less mode ( `Settings->Jetpack Constants` )
* Setup Jetpack without connecting your WPCOM account (aka skip auth)
* Run the Jetpack Assistant and verify that the Monitoring step is NOT visible.
* Verify that after running the Assistant, the Monitoring step will NOT appear in the summary page as skipped.
* Connect a user and verify that the Monitoring step will appear in the summary page as skipped.