### PR TITLE
VideoPress: bring in sync with WordPress.com

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-221526-223544
+++ b/projects/plugins/jetpack/changelog/update-videopress-221526-223544
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: VideoPress: bring in sync with WordPress.com. No changes that would impact Jetpack users
+
+

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-gutenberg.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-gutenberg.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Block Editor functionality for VideoPress users.
  *
@@ -37,6 +37,11 @@ class VideoPress_Gutenberg {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'override_video_upload' ) );
 	}
 
+	/**
+	 * Get site's ID.
+	 *
+	 * @return int $blog_id Site ID.
+	 */
 	private static function get_blog_id() {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			return get_current_blog_id();

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -352,7 +352,6 @@
 	"projects/plugins/jetpack/modules/videopress/class.videopress-ajax.php",
 	"projects/plugins/jetpack/modules/videopress/class.videopress-cli.php",
 	"projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php",
-	"projects/plugins/jetpack/modules/videopress/class.videopress-gutenberg.php",
 	"projects/plugins/jetpack/modules/videopress/class.videopress-options.php",
 	"projects/plugins/jetpack/modules/videopress/class.videopress-player.php",
 	"projects/plugins/jetpack/modules/videopress/class.videopress-scheduler.php",


### PR DESCRIPTION


#### Changes proposed in this Pull Request:

This PR brings the file in sync with WordPress.com: it includes r221526-wpcom and r223544-wpcom.

I've also taken the opportunity to fix phpcs errors.

#### Jetpack product discussion

Internal references: 

- D57013-code
- D59423-code

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here, the changes should not impact Jetpack customers.
* You can try, on a site with a paid plan and the Video option added under Jetpack > Settings > Performance, to use the Video block in a new post.
* Make sure you can still upload videos and see the modified video block that allows you to upload and view Jetpack videos.
