### PR TITLE
Publicize: update Twitter text processing library

### DIFF
--- a/projects/plugins/jetpack/changelog/update-twitter-text-php-213
+++ b/projects/plugins/jetpack/changelog/update-twitter-text-php-213
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Publicize: update tTwitter text processing library to avoid errors when using PHP 8

--- a/projects/plugins/jetpack/changelog/update-twitter-text-php-213
+++ b/projects/plugins/jetpack/changelog/update-twitter-text-php-213
@@ -1,4 +1,4 @@
 Significance: patch
 Type: compat
 
-Publicize: update tTwitter text processing library to avoid errors when using PHP 8
+Publicize: update Twitter text processing library to avoid errors when using PHP 8

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -38,7 +38,7 @@
 		"automattic/jetpack-sync": "1.21.x-dev",
 		"automattic/jetpack-terms-of-service": "1.9.x-dev",
 		"automattic/jetpack-tracking": "1.13.x-dev",
-		"nojimage/twitter-text-php": "3.1.1"
+		"nojimage/twitter-text-php": "3.1.2"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "1.1.x-dev"

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b656d368481480076f12818f9bfa5e87",
+    "content-hash": "fd7fd2ab1230b7ec643fa1f6674b1130",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1381,16 +1381,16 @@
         },
         {
             "name": "nojimage/twitter-text-php",
-            "version": "v3.1.1",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nojimage/twitter-text-php.git",
-                "reference": "7f466b331cebfdd00e3568acaf45f2e90a39a320"
+                "reference": "979bcf6a92d543b61588c7c0c0a87d0eb473d8f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nojimage/twitter-text-php/zipball/7f466b331cebfdd00e3568acaf45f2e90a39a320",
-                "reference": "7f466b331cebfdd00e3568acaf45f2e90a39a320",
+                "url": "https://api.github.com/repos/nojimage/twitter-text-php/zipball/979bcf6a92d543b61588c7c0c0a87d0eb473d8f6",
+                "reference": "979bcf6a92d543b61588c7c0c0a87d0eb473d8f6",
                 "shasum": ""
             },
             "require": {
@@ -1445,9 +1445,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nojimage/twitter-text-php/issues",
-                "source": "https://github.com/nojimage/twitter-text-php/tree/v3.1.1"
+                "source": "https://github.com/nojimage/twitter-text-php/tree/v3.1.2"
             },
-            "time": "2020-09-30T13:30:59+00:00"
+            "time": "2021-03-18T11:38:53+00:00"
         }
     ],
     "packages-dev": [
@@ -1570,16 +1570,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.5",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79"
+                "reference": "35f039df40a3b335ebf310f244cb242b3a83ac8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
-                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
+                "url": "https://api.github.com/repos/symfony/console/zipball/35f039df40a3b335ebf310f244cb242b3a83ac8d",
+                "reference": "35f039df40a3b335ebf310f244cb242b3a83ac8d",
                 "shasum": ""
             },
             "require": {
@@ -1647,7 +1647,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.5"
+                "source": "https://github.com/symfony/console/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -1663,7 +1663,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-06T13:42:15+00:00"
+            "time": "2021-03-28T09:42:18+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2294,16 +2294,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.4",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "4e78d7d47061fa183639927ec40d607973699609"
+                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/4e78d7d47061fa183639927ec40d607973699609",
-                "reference": "4e78d7d47061fa183639927ec40d607973699609",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
+                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
                 "shasum": ""
             },
             "require": {
@@ -2357,7 +2357,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.4"
+                "source": "https://github.com/symfony/string/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -2373,7 +2373,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-16T10:20:28+00:00"
+            "time": "2021-03-17T17:12:15+00:00"
         },
         {
             "name": "wikimedia/at-ease",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The lib was updated to update a PHP 8 fix for a part of the lib we do not use in Jetpack.
I do not think it hurts to update in any case.
Related PR: https://github.com/nojimage/twitter-text-php/pull/39

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here. You could try to use Publicize, with a linked Twitter account, set your Publicize options to "Twitter Thread" in the block editor, and see if your post still gets split into multiple tweets.
