### PR TITLE
cli: Avoid yarn upgrade, always do yarn install

### DIFF
--- a/tools/cli/helpers/tasks/installProjectTask.js
+++ b/tools/cli/helpers/tasks/installProjectTask.js
@@ -18,6 +18,21 @@ import { chalkJetpackGreen } from '../styling';
 import { normalizeInstallArgv } from '../normalizeArgv';
 
 /**
+ * Test if a lockfile is checked in.
+ *
+ * @param {string} cwd - Path being processed.
+ * @param {string} lockFile - Lock file name.
+ * @returns {boolean} - Whether the lock file exists and is checked in.
+ */
+async function hasLockFile( cwd, lockFile ) {
+	if ( ! fs.existsSync( path.resolve( cwd, lockFile ) ) ) {
+		return false;
+	}
+	const { stdout } = await execa.command( `git ls-files ${ lockFile }`, { cwd: cwd } );
+	return !! stdout;
+}
+
+/**
  * Preps the task for an individual project.
  *
  * @param {object} argv - Argv object for an install command. Must contain project and root at least.
@@ -39,21 +54,26 @@ export default function installProjectTask( argv ) {
 	argv.project = argv.root ? 'Monorepo' : argv.project;
 
 	const command = async ( pkgMgr, verbose ) => {
-		// Determine whether 'install' or 'upgrade' is needed. Notes:
-		//  - composer accepts both "update" and "upgrade", while yarn only accepts "upgrade".
-		//  - composer accepts "install" with no lockfile, despite complaining that it wants "update" instead.
-		//  - yarn requires "install" with no lockfile, "upgrade" errors out.
-		let subcommand = 'install';
-		if ( fs.existsSync( path.resolve( cwd, `${ pkgMgr }.lock` ) ) ) {
-			const { stdout } = await execa.command( `git ls-files ${ pkgMgr }.lock`, { cwd: cwd } );
-			subcommand = stdout ? 'install' : 'upgrade';
-		}
+		// For composer, choose 'install' or 'update' depending on whether the lockfile is checked in.
+		// For yarn, always use 'install' ('upgrade' has weird behavior), removing any stale local lockfile first.
+		let subcommand;
 		let args = '';
-		if ( pkgMgr === 'yarn' ) {
+		if ( pkgMgr === 'composer' ) {
+			subcommand = ( await hasLockFile( cwd, 'composer.lock' ) ) ? 'install' : 'update';
+		} else if ( pkgMgr === 'yarn' ) {
+			subcommand = 'install';
+			if (
+				! ( await hasLockFile( cwd, 'yarn.lock' ) ) &&
+				fs.existsSync( path.resolve( cwd, 'yarn.lock' ) )
+			) {
+				fs.unlinkSync( path.resolve( cwd, 'yarn.lock' ) );
+			}
 			// Yarn's own cache access is not multi-process safe, and yarn isn't being developed anymore (they want
 			// to replace it with "berry" aka "yarn 2") so we'll have to go with the poor mutex workaround.
 			// See https://github.com/yarnpkg/yarn/issues/683
 			args += ` --mutex=file:${ yarnCacheFile }`;
+		} else {
+			throw new Error( `Unknown package manager ${ pkgMgr }` );
 		}
 		return verbose
 			? execa.commandSync( `${ pkgMgr } ${ subcommand } ${ args }`, { cwd: cwd, stdio: 'inherit' } )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Yarn's install versus upgrade is weird:

- If there's no lock file, upgrade fails.
- If there is a lock file but it's outdated with respect to
  package.json, upgrade fails while install updates it.
- If there is a lock file that is up to date, install uses it while
  upgrade updates it.

The best thing for the CLI to do seems to be to just use `yarn install`
always, deleting any non-checked-in lockfile first to avoid the second
case.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Pretty sure that's what was going on in p1617037783160300-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* First, `git checkout 19abfd97^` then do `yarn install --ignore-engines` in `projects/packages/lazy-images/` to get an outdated yarn.lock created there. Then check out this and do `jetpack install packages/lazy-images`.