### PR TITLE
Payments block: Fix broken Connect to Stripe button

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-payments-connect-to-stripe
+++ b/projects/plugins/jetpack/changelog/fix-payments-connect-to-stripe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Payments block: Fixed broken Connect to Stripe link.

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -489,7 +489,7 @@ export class MembershipsButtonEdit extends Component {
 				<ToolbarControls
 					autosaveAndRedirect={ this.props.autosaveAndRedirect }
 					connected={ connected !== API_STATE_NOTCONNECTED }
-					connectUrl={ connectURL }
+					connectURL={ connectURL }
 					hasUpgradeNudge={ this.hasUpgradeNudge }
 					shouldUpgrade={ this.state.shouldUpgrade }
 				/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When the Payments block controls were refactored out into a separate component, the `connectURL` was incorrectly passed as `connectUrl`, breaking the button. This PR correctly passes the prop.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this branch.
* Open a test site that has a premium plan, but does not have Stripe connected.
* Create a new post and add a Payments block.
* Click the "Connect Stripe" button in the block toolbar
* Verify that you are taken to the Stripe connection page.
