### PR TITLE
Search: Prevent user from excluding all post types

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-prevent-exclude-all-post-types
+++ b/projects/plugins/jetpack/changelog/fix-prevent-exclude-all-post-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: prevent user from excluding all post types

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -158,7 +158,7 @@ class Jetpack_Search_Customize {
 				$wp_customize,
 				$id,
 				array(
-					'description' => __( 'Choose post types to exclude from search results.', 'jetpack' ),
+					'description' => __( 'Choose post types to exclude from search results. For search to work properly, please leave at least one post type unchecked.', 'jetpack' ),
 					'label'       => __( 'Excluded Post Types', 'jetpack' ),
 					'section'     => $section_id,
 				)

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -158,7 +158,7 @@ class Jetpack_Search_Customize {
 				$wp_customize,
 				$id,
 				array(
-					'description' => __( 'Choose post types to exclude from search results. For search to work properly, please leave at least one post type unchecked.', 'jetpack' ),
+					'description' => __( 'Choose post types to exclude from search results. You must leave at least one post type unchecked.', 'jetpack' ),
 					'label'       => __( 'Excluded Post Types', 'jetpack' ),
 					'section'     => $section_id,
 				)

--- a/projects/plugins/jetpack/modules/search/customize-controls/class-excluded-post-types-control.js
+++ b/projects/plugins/jetpack/modules/search/customize-controls/class-excluded-post-types-control.js
@@ -1,20 +1,23 @@
 /* eslint-disable no-var */
 
-jQuery( document ).ready( function( $ ) {
+jQuery( document ).ready( function ( $ ) {
 	// Refresh our hidden field value if any checkboxes change
-	$( '.customize-control-excluded-post-type-checkbox' ).on( 'change', function() {
-		var $parent = $( this )
-			.parent()
-			.parent();
+	$( '.customize-control-excluded-post-type-checkbox' ).on( 'change', function () {
+		var $parent = $( this ).parent().parent();
 		var newValue = $parent
 			.find( '.customize-control-excluded-post-type-checkbox:checked' )
-			.map( function() {
+			.map( function () {
 				return $( this ).val();
 			} )
 			.toArray();
+		$parent.find( '.customize-control-excluded-post-types' ).val( newValue ).trigger( 'change' );
+
+		// Set the last unchecked checkbox disabled to prvevent user from excluding all post types
+		var excludedPostTypesCount = $parent.find(
+			'.customize-control-excluded-post-type-checkbox:not(:checked)'
+		).length;
 		$parent
-			.find( '.customize-control-excluded-post-types' )
-			.val( newValue )
-			.trigger( 'change' );
+			.find( '.customize-control-excluded-post-type-checkbox:not(:checked)' )
+			.prop( 'disabled', excludedPostTypesCount <= 1 );
 	} );
 } );

--- a/projects/plugins/jetpack/modules/search/customize-controls/class-excluded-post-types-control.php
+++ b/projects/plugins/jetpack/modules/search/customize-controls/class-excluded-post-types-control.php
@@ -105,6 +105,8 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 			/>
 		<?php
 
+		$is_only_one_unchecked = ( count( $post_types ) - 1 ) === count( $this->get_arrayed_value() );
+
 		foreach ( $post_types as $post_type ) {
 			$input_id = Jetpack_Search_Helpers::generate_post_type_customizer_id( $post_type );
 			?>
@@ -115,6 +117,7 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 					type="checkbox"
 					value="<?php echo esc_attr( $post_type->name ); ?>"
 					<?php checked( $this->is_checked( $post_type ) ); ?>
+					<?php disabled( ! $this->is_checked( $post_type ) && $is_only_one_unchecked ); ?>
 				/>
 				<label for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_html( $post_type->label ); ?></label>
 			</div>


### PR DESCRIPTION
Fixes #17124

#### Changes proposed in this Pull Request:
##### Prevent user from excluding all post types:
- When there is only one option unchecked, set the options as disabled and re-enable if there are more than two left.
- And add ‘At least one post type should be left unchecked…." to the description. Checked FG, I assumed the description would be translated before next release. 

##### Options considered
1. When there is only one options left, we set it disabled and re-enable if there are more than two left. And add ‘At least one post type should be left unchecked…’ to the description. This is the option proposed, as it interferes the user least and would still prevent the user from checking all the boxes. 
2. When the last option is selected, we show a message saying all post types excluded and the setting will not be respected. The do-not-respect-settings idea is not good, because if not respected whey it's there.
3. When user select the last option, we revert the selection and show a message saying that, ‘at least one option should be left unchecked…’. This option could be working, but just would uncheck user’s selection, could be frustrating for users sometimes.

#### Jetpack product discussion
p1617144549011100-slack-jetpack-search-backstage

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Go to customizer of a Jetpack Search enabled site, ensure when only one post type unchecked, the option is not selectable.
- Publish site and ensure the options stick

#### Gif
![Untitled](https://user-images.githubusercontent.com/1425433/113250484-132d4280-931d-11eb-82a6-dd2d2c33d3b3.gif)

