### PR TITLE
Readme: update link to changelog

### DIFF
--- a/projects/plugins/jetpack/changelog/update-changelog-link
+++ b/projects/plugins/jetpack/changelog/update-changelog-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Readme: update link to changelog file. No changelog entry necessary.
+
+

--- a/projects/plugins/jetpack/changelog/update-changelog-link
+++ b/projects/plugins/jetpack/changelog/update-changelog-link
@@ -1,5 +1,4 @@
 Significance: patch
 Type: other
-Comment: Readme: update link to changelog file. No changelog entry necessary.
 
-
+Readme: update link to changelog file. No changelog entry necessary.

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -290,4 +290,4 @@ Our Cookie and Consent Banner can help you comply with GDPR. The European Unionâ
 
 --------
 
-[See the previous changelogs here](https://raw.githubusercontent.com/Automattic/jetpack/master/projects/plugins/jetpack/changelog.txt)
+[See the previous changelogs here](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/CHANGELOG.md#changelog)


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
We've now switched to a markdown file, so we can display the file with its Mardkdown preview instead of linking to a non-existing file.
I've opted to link to the Changelog anchor, so folks do not get to see the GitHub UI as much.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Check if the link works.
