### PR TITLE
Gardening Action: add Notify Editorial task

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -79,3 +79,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
           slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
+          slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -13,6 +13,7 @@ Here is the current list of tasks handled by this action:
 - Clean Labels (`cleanLabels`): Removes Status labels once a PR has been merged.
 - WordPress.com Commit Reminder (`wpcomCommitReminder`): Posts a comment on merged PRs to remind Automatticians to commit the matching WordPress.com change.
 - Notify Design (`notifyDesign`): Sends a Slack Notification to the Design team to request feedback, based on labels applied to a PR.
+- Notify Editorial (`notifyEditorial`): Sends a Slack Notification to the Editorial team to request feedback, based on labels applied to a PR.
 
 Some of the tasks are may not satisfy your needs. If that's the case, you can use the `tasks` option to limit the action to the list of tasks you need in your repo. See the example below to find out more.
 
@@ -63,12 +64,13 @@ jobs:
 
 ### Inputs
 
-The action relies on 4 parameters. 
+The action relies on the following parameters. 
 
 - `github_token` is a GitHub Access Token used to access GitHub's API. The user account associated with the token is the one that will be seen as posting the checkDescription comment, adding and removing labels, and so on. If omitted, the standard token for the github-actions bot will be used.
 - `tasks` allows for running selected tasks instead of the full suite. The value is a comma-separated list of task identifiers. You can find the list of the different tasks (and what event it's attached to) in `src/index.js`.
 - `slack_token` is the Auth token of a bot that is installed on your Slack workspace. The token should be stored in a [secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
 - `slack_design_channel` is the Slack public channel ID where messages for the design team will be posted. Again, the value should be stored in a secret.
+- `slack_editorial_channel` is the Slack public channel ID where messages for the Editorial team will be posted. Again, the value should be stored in a secret.
 
 To create a bot and get your `SLACK_TOKEN`, follow [the general instructions here](https://slack.com/intl/en-hu/help/articles/115005265703-Create-a-bot-for-your-workspace):
 

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -66,11 +66,11 @@ jobs:
 
 The action relies on the following parameters. 
 
-- `github_token` is a GitHub Access Token used to access GitHub's API. The user account associated with the token is the one that will be seen as posting the checkDescription comment, adding and removing labels, and so on. If omitted, the standard token for the github-actions bot will be used.
-- `tasks` allows for running selected tasks instead of the full suite. The value is a comma-separated list of task identifiers. You can find the list of the different tasks (and what event it's attached to) in `src/index.js`.
-- `slack_token` is the Auth token of a bot that is installed on your Slack workspace. The token should be stored in a [secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
-- `slack_design_channel` is the Slack public channel ID where messages for the design team will be posted. Again, the value should be stored in a secret.
-- `slack_editorial_channel` is the Slack public channel ID where messages for the Editorial team will be posted. Again, the value should be stored in a secret.
+- (Required) `github_token` is a GitHub Access Token used to access GitHub's API. The user account associated with the token is the one that will be seen as posting the checkDescription comment, adding and removing labels, and so on. If omitted, the standard token for the github-actions bot will be used.
+- (Optional) `tasks` allows for running selected tasks instead of the full suite. The value is a comma-separated list of task identifiers. You can find the list of the different tasks (and what event it's attached to) in `src/index.js`.
+- (Optional) `slack_token` is the Auth token of a bot that is installed on your Slack workspace. The token should be stored in a [secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+- (Optional) `slack_design_channel` is the Slack public channel ID where messages for the design team will be posted. Again, the value should be stored in a secret.
+- (Optional) `slack_editorial_channel` is the Slack public channel ID where messages for the Editorial team will be posted. Again, the value should be stored in a secret.
 
 To create a bot and get your `SLACK_TOKEN`, follow [the general instructions here](https://slack.com/intl/en-hu/help/articles/115005265703-Create-a-bot-for-your-workspace):
 

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -7,15 +7,15 @@ inputs:
     default: ${{ github.token }}
   slack_token:
     description: "Slack Bot access token"
-    required: true
+    required: false
     default: ""
   slack_design_channel:
     description: "Slack channel ID where messages for the Design team will be sent"
-    required: true
+    required: false
     default: ""
   slack_editorial_channel:
     description: "Slack channel ID where messages for the Editorial team will be sent"
-    required: true
+    required: false
     default: ""
   tasks:
     description: "Comma-separated selection of task names (function name, camelCase) this action should run. e.g. addLabels,cleanLabels"

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Slack channel ID where messages for the Design team will be sent"
     required: true
     default: ""
+  slack_editorial_channel:
+    description: "Slack channel ID where messages for the Editorial team will be sent"
+    required: true
+    default: ""
   tasks:
     description: "Comma-separated selection of task names (function name, camelCase) this action should run. e.g. addLabels,cleanLabels"
     required: false

--- a/projects/github-actions/repo-gardening/changelog/add-gardening-editorial-task
+++ b/projects/github-actions/repo-gardening/changelog/add-gardening-editorial-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a new task to notify Editorial team when we want their feedback.

--- a/projects/github-actions/repo-gardening/changelog/expand-gardening-clean-labels
+++ b/projects/github-actions/repo-gardening/changelog/expand-gardening-clean-labels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Expand list of labels to clean up after a PR has been merged.

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-required-parameters
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-required-parameters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Mark parameters that are not used by all tasks as optional.

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -14,6 +14,7 @@ const cleanLabels = require( './tasks/clean-labels' );
 const checkDescription = require( './tasks/check-description' );
 const wpcomCommitReminder = require( './tasks/wpcom-commit-reminder' );
 const notifyDesign = require( './tasks/notify-design' );
+const notifyEditorial = require( './tasks/notify-editorial' );
 const debug = require( './debug' );
 const ifNotFork = require( './if-not-fork' );
 const ifNotClosed = require( './if-not-closed' );
@@ -47,6 +48,11 @@ const automations = [
 		event: 'pull_request',
 		action: [ 'labeled' ],
 		task: ifNotClosed( notifyDesign ),
+	},
+	{
+		event: 'pull_request',
+		action: [ 'labeled' ],
+		task: ifNotClosed( notifyEditorial ),
 	},
 	{
 		event: 'push',

--- a/projects/github-actions/repo-gardening/src/tasks/clean-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/clean-labels/index.js
@@ -34,9 +34,14 @@ async function cleanLabels( payload, octokit ) {
 		'[Status] Needs Team Review',
 		'[Status] In Progress',
 		'[Status] Needs Author Reply',
+		'[Status] Needs Design',
 		'[Status] Needs Design Review',
+		'[Status] Design Input Requested',
 		'[Status] Needs i18n Review',
 		'[Status] String Freeze',
+		'[Status] Needs Copy',
+		'[Status] Needs Copy Review',
+		'[Status] Editorial Input Requested',
 	];
 
 	const labelsToRemoveFromPr = labelsOnPr.filter( label => labelsToRemove.includes( label ) );

--- a/projects/github-actions/repo-gardening/src/tasks/notify-editorial/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-editorial/index.js
@@ -1,0 +1,143 @@
+/**
+ * External dependencies
+ */
+const { getInput, setFailed } = require( '@actions/core' );
+
+/**
+ * Internal dependencies
+ */
+const debug = require( '../../debug' );
+const getLabels = require( '../../get-labels' );
+const sendSlackMessage = require( '../../send-slack-message' );
+
+/* global GitHub, WebhookPayloadPullRequest */
+
+/**
+ * Check for an Copy Review status label on a PR.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - PR number.
+ *
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasNeedsCopyReviewLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're only interested in the Needs Copy Review label.
+	return labels.includes( '[Status] Needs Copy Review' );
+}
+
+/**
+ * Check for a Needs Copy label on a PR.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - PR number.
+ *
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasNeedsCopyLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're only interested in the Needs Copy label.
+	return labels.includes( '[Status] Needs Copy' );
+}
+
+/**
+ * Check for an Editorial Input Requested label on a PR.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - PR number.
+ *
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasEditorialInputRequestedLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're only interested in the Editorial Input Requested label.
+	return labels.includes( '[Status] Editorial Input Requested' );
+}
+
+/**
+ * Send a Slack notification about a label to the Editorial team.
+ *
+ * @param {WebhookPayloadPullRequest} payload - Pull request event payload.
+ * @param {GitHub}                    octokit - Initialized Octokit REST client.
+ */
+async function notifyEditorial( payload, octokit ) {
+	const { number, repository } = payload;
+	const { owner, name: repo } = repository;
+	const ownerLogin = owner.login;
+
+	const slackToken = getInput( 'slack_token' );
+	if ( ! slackToken ) {
+		setFailed( `notify-editorial: Input slack_token is required but missing. Aborting.` );
+		return;
+	}
+
+	const channel = getInput( 'slack_editorial_channel' );
+	if ( ! channel ) {
+		setFailed(
+			`notify-editorial: Input slack_editorial_channel is required but missing. Aborting.`
+		);
+		return;
+	}
+
+	// Check if editorial input was already requested for that PR.
+	const hasBeenRequested = await hasEditorialInputRequestedLabel(
+		octokit,
+		ownerLogin,
+		repo,
+		number
+	);
+	if ( hasBeenRequested ) {
+		debug(
+			`notify-editorial: Editorial input was already requested for PR #${ number }. Aborting.`
+		);
+		return;
+	}
+
+	// Check for a Needs Copy Review label.
+	const isLabeledForCopy = await hasNeedsCopyLabel( octokit, ownerLogin, repo, number );
+	if ( isLabeledForCopy ) {
+		debug(
+			`notify-editorial: Found a Needs Copy label on PR #${ number }. Sending in Slack message.`
+		);
+		await sendSlackMessage(
+			`Someone would be interested in input from the Editorial team on this topic.`,
+			channel,
+			slackToken,
+			payload
+		);
+	}
+
+	// Check for a Needs Copy Review label.
+	const isLabeledForReview = await hasNeedsCopyReviewLabel( octokit, ownerLogin, repo, number );
+	if ( isLabeledForReview ) {
+		debug(
+			`notify-editorial: Found a Needs Copy Review label on PR #${ number }. Sending in Slack message.`
+		);
+		await sendSlackMessage(
+			`Someone is looking for a review from the Editorial team.`,
+			channel,
+			slackToken,
+			payload
+		);
+	}
+
+	if ( isLabeledForCopy || isLabeledForReview ) {
+		debug(
+			`notify-editorial: Adding a label to PR #${ number } to show that design input was requested.`
+		);
+		await octokit.issues.addLabels( {
+			owner: ownerLogin,
+			repo,
+			issue_number: number,
+			labels: [ '[Status] Editorial Input Requested' ],
+		} );
+	}
+}
+
+module.exports = notifyEditorial;

--- a/projects/github-actions/repo-gardening/src/tasks/notify-editorial/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-editorial/readme.md
@@ -1,0 +1,14 @@
+# Notify Editorial
+
+Send a Slack notification to the Editorial team when we need their input on a PR.
+
+This task responds to the following labels:
+
+- "[Status] Needs Copy Review"
+- "[Status] Needs Copy"
+
+When one of the labels above is added to a PR, a Slack message will be sent to channel of your choice.
+
+## Rationale
+
+Adding a label to a PR allows us to signify that we'd like input from our Editorial team on a project.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR adds in a few changes:

- Add a new Editorial task
    Just like the Needs Design task, we'll listen for labels and notify the
Editorial team accordingly.
    This is a feature that's already implemented in the Calypso repo. Let's standardize it.
- Expand list of labels to clean up after a PR has been merged
    It was missing the design and editorial review labels.
- Mark some parameters as optional
    Since they're not used in all tasks, they are only required when you use one of the tasks that relies on them. In this case, and if you miss the parameter, the action will fail.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* See that the comment below from the action still works.
* See that the labels added to this PR will be removed when we merge it.
* Check this message for an example of the task in use:
p1617197343068300-slack-C029XD8PN