### PR TITLE
github-actions: Enable autotagger for all actions repos

### DIFF
--- a/.github/files/gh-autotagger/workflows/autotagger.yml
+++ b/.github/files/gh-autotagger/workflows/autotagger.yml
@@ -19,7 +19,10 @@ jobs:
             export GIT_AUTHOR_EMAIL=matticbot@users.noreply.github.com
             export GIT_COMMITTER_NAME=matticbot
             export GIT_COMMITTER_EMAIL=matticbot@users.noreply.github.com
-            git remote set-url origin "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
             git tag "v$VER"
-            git push --tags
+            git push origin "v$VER"
+            if [[ -e composer.json ]] && jq -e '.extra.autotagger.major?' composer.json >/dev/null; then
+              git tag --force "v${VER%%.*}"
+              git push --force origin "v${VER%%.*}"
+            fi
           fi

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -105,7 +105,7 @@ We use `composer.json` to hold metadata about projects. Much of our generic tool
 * `.scripts.test-e2e`: If the package contains any E2E tests, this must run the necessary commands. See [E2E tests](#e2e-tests) for details.
 * `.scripts.test-js`: If the package contains any JavaScript tests, this must run the necessary commands. See [JavaScript tests](#javascript-tests) for details.
 * `.scripts.test-php`: If the package contains any PHPUnit tests, this must run the necessary commands. See [PHP tests](#php-tests) for details.
-* `.extra.autotagger`: Set true to enable automatic release-version tagging in the mirror repo. See [Mirror repositories > Autotagger](#autotagger) for details.
+* `.extra.autotagger`: Set truthy to enable automatic release-version tagging in the mirror repo. See [Mirror repositories > Autotagger](#autotagger) for details.
 * `.extra.dependencies`: This optional array specifies the "slugs" of any within-monorepo dependencies that can't otherwise be inferred. The "slug" consists of the two levels of directory under `projects/`, e.g. `plugins/jetpack` or `packages/lazy-images`. See [Testing](#testing) for details.
 * `.extra.mirror-repo`: This specifies the name of the GitHub mirror repo, i.e. the "Automattic/jetpack-_something_" in "https://github.com/Automattic/jetpack-_something_".
 * `.extra.release-branch-prefix`: Our mirroring and release tooling considers any branch named like "_prefix_/branch-_version_" to be a release branch, and this specifies which _prefix_ belongs to the project.
@@ -226,6 +226,8 @@ Most projects in the monorepo should have a mirror repository holding a built ve
 ### Autotagger
 
 If `.extra.autotagger` is set to a truthy value in the project's `composer.json`, a GitHub Action will be included in the mirror repo that will read the most recent version from the mirrored `CHANGELOG.md` in each push to master, and create the tag if that version has no prerelease or build suffix.
+
+If `.extra.autotagger` is set to an object with a truthy value for `major` (i.e. if `.extra.autotagger.major` is truthy), the GitHub Action will additionally create or update a major-version tag as is common for GitHub Action repositories.
 
 This is intended to work in combination with [Changelogger](#jetpack-changelogger): When any change files are present in the project, a `-alpha` version entry will be written to the changelog so the autotagging will not be triggered. To release a new version, you'd do the following:
 

--- a/projects/github-actions/pr-is-up-to-date/changelog/update-autotagger-for-actions
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-autotagger-for-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added autotagger action to simplify releases

--- a/projects/github-actions/pr-is-up-to-date/composer.json
+++ b/projects/github-actions/pr-is-up-to-date/composer.json
@@ -17,6 +17,9 @@
 		}
 	],
 	"extra": {
+		"autotagger": {
+			"major": true
+		},
 		"mirror-repo": "Automattic/action-pr-is-up-to-date",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/action-pr-is-up-to-date/compare/v${old}...v${new}"

--- a/projects/github-actions/push-to-mirrors/changelog/update-autotagger-for-actions
+++ b/projects/github-actions/push-to-mirrors/changelog/update-autotagger-for-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added autotagger action to simplify releases

--- a/projects/github-actions/push-to-mirrors/composer.json
+++ b/projects/github-actions/push-to-mirrors/composer.json
@@ -17,6 +17,9 @@
 		}
 	],
 	"extra": {
+		"autotagger": {
+			"major": true
+		},
 		"mirror-repo": "Automattic/action-push-to-mirrors",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/action-push-to-mirrors/compare/v${old}...v${new}"

--- a/projects/github-actions/repo-gardening/changelog/update-autotagger-for-actions
+++ b/projects/github-actions/repo-gardening/changelog/update-autotagger-for-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added autotagger action to simplify releases

--- a/projects/github-actions/repo-gardening/composer.json
+++ b/projects/github-actions/repo-gardening/composer.json
@@ -23,6 +23,9 @@
 		}
 	],
 	"extra": {
+		"autotagger": {
+			"major": true
+		},
 		"mirror-repo": "Automattic/action-repo-gardening",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/action-repo-gardening/compare/v${old}...v${new}"

--- a/projects/github-actions/required-review/changelog/update-autotagger-for-actions
+++ b/projects/github-actions/required-review/changelog/update-autotagger-for-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added autotagger action to simplify releases

--- a/projects/github-actions/required-review/composer.json
+++ b/projects/github-actions/required-review/composer.json
@@ -23,6 +23,9 @@
 		}
 	],
 	"extra": {
+		"autotagger": {
+			"major": true
+		},
 		"mirror-repo": "Automattic/action-required-review",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/action-required-review/compare/v${old}...v${new}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
And make the autotagger able to maintain the major version tag that's
described at https://docs.github.com/en/actions/creating-actions/about-actions#using-tags-for-release-management

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the Build step to see that the autotagger workflow is being added to the actions.
* Merge, then verify that when this is pushed to the mirrors that no tags are created (as this is not a release).
* Release an action (plus changelogger). See that the action gets both its "vX.Y.Z" and "vX" tags created/updated, while changelogger only gets "v1.1.2" (no "v1" tag).