### PR TITLE
CLI: Alpha sort project types during type prompt

### DIFF
--- a/tools/cli/helpers/projectHelpers.js
+++ b/tools/cli/helpers/projectHelpers.js
@@ -10,8 +10,8 @@ export const dirs = ( source, prefix = '' ) =>
 		.filter( dirent => dirent.isDirectory() )
 		.map( dirent => prefix + dirent.name );
 
-export const projectTypes = [ 'github-actions', 'packages', 'plugins', 'js-packages' ];
-// export const projectTypes = [ 'editor-extensions', 'github-actions', 'packages', 'plugins' ], // Swap out line above once there's editor-extensions in place.
+export const projectTypes = [ 'github-actions', 'js-packages', 'packages', 'plugins' ];
+// export const projectTypes = [ 'editor-extensions', 'js-packages', 'packages', 'plugins' ], // Swap out line above once there's editor-extensions in place.
 
 /**
  * Returns an array of all projects.

--- a/tools/cli/helpers/promptForProject.js
+++ b/tools/cli/helpers/promptForProject.js
@@ -63,7 +63,7 @@ export async function promptForType( options = { type: '' } ) {
 			type: 'list',
 			name: 'type',
 			message: 'What type of project are you working on today?',
-			choices: projectTypes,
+			choices: projectTypes.sort(),
 		} );
 	} else if ( ! projectTypes.includes( options.type ) ) {
 		return new Error( 'Must be an accepted project type.' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Ensures the type list is in alphabetical order.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the projectTypes array to alphabetical.
* Adds a `.sort()` to the promptForType function. Only adding it there since usually we don't care and avoid the time to sort.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack install` before and after this PR. See `js-packages` out of order before, and not after.
