### PR TITLE
Admin Page: Remove check for JSONP

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -165,8 +165,6 @@ abstract class Jetpack_Admin_Page {
 		return /** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
 			apply_filters( 'rest_enabled', true ) &&
 			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
-			apply_filters( 'rest_jsonp_enabled', true ) &&
-			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
 			apply_filters( 'rest_authentication_errors', true );
 	}
 

--- a/projects/plugins/jetpack/changelog/remove-jsonp-check
+++ b/projects/plugins/jetpack/changelog/remove-jsonp-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Admin Page: Do not show an error message with JSONP is disabled. The admin page does not use it.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

We don't use JSONP so no need to care about if it is enabled on a site or not.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* See above.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p3btAN-1o6-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add `add_filter( 'rest_jsonp_enabled', '__return_false' );` to a test site.
* See the wp-admin Jetpack dashboard not work.
* Apply this patch.
* See it work.
