### PR TITLE
wpcom-api: set post format to aside for dtp

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-yoavf-r223672-wpcom-1617271820
+++ b/projects/plugins/jetpack/changelog/fusion-sync-yoavf-r223672-wpcom-1617271820
@@ -1,0 +1,3 @@
+Significance: patch
+Type: compat
+Comment: Minor change for FB DTP post format. No need for a changelog entry.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -943,7 +943,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			$post['post_content'] = $map_block . $post['post_content'];
 		}
 
-		$post['post_format']  = 'aside';
+		$post['post_format'] = 'aside';
 
 		return $post;
 	}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -943,6 +943,8 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			$post['post_content'] = $map_block . $post['post_content'];
 		}
 
+		$post['post_format']  = 'aside';
+
 		return $post;
 	}
 }


### PR DESCRIPTION
Syncs r223672-wpcom 

#### Changes proposed in this Pull Request:
Minor change to post format for posts created through the wpcom-api under certain conditions.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Not really needed, but see D59622-code.
