### PR TITLE
Admin Menu: Check position before setting menu item

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-admin-menu-check-position
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-check-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed an issue which prevented some menu items from appearing in the unified admin menu because they were replaced with other menu items.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -375,20 +375,14 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * Adds Jetpack menu.
 	 */
 	public function add_jetpack_menu() {
-		global $menu;
-
-		$position = 50;
-		while ( isset( $menu[ $position ] ) ) {
-			$position++;
-		}
-		$this->add_admin_menu_separator( $position++, 'manage_options' );
+		$this->add_admin_menu_separator( 50, 'manage_options' );
 
 		// TODO: Replace with proper SVG data url.
 		$icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 32 32' %3E%3Cpath fill='%23a0a5aa' d='M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z'%3E%3C/path%3E%3Cpolygon fill='%23fff' points='15,19 7,19 15,3 '%3E%3C/polygon%3E%3Cpolygon fill='%23fff' points='17,29 17,13 25,13 '%3E%3C/polygon%3E%3C/svg%3E";
 
-		$is_menu_updated = $this->update_menu( 'jetpack', null, null, null, $icon, $position );
+		$is_menu_updated = $this->update_menu( 'jetpack', null, null, null, $icon, 51 );
 		if ( ! $is_menu_updated ) {
-			add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'jetpack', null, $icon, $position );
+			add_menu_page( esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'jetpack', null, $icon, 51 );
 		}
 
 		add_submenu_page( 'jetpack', esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, 2 );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -135,21 +135,13 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds a link to the menu to create a new site.
 	 */
 	public function add_new_site_link() {
-		global $menu;
-
 		$site_count = get_user_option( 'wpcom_site_count' );
 		if ( $site_count && $site_count > 1 ) {
 			return;
 		}
 
-		// Attempt to get last position.
-		$position = 1000;
-		while ( isset( $menu[ $position ] ) ) {
-			$position++;
-		}
-
-		$this->add_admin_menu_separator( ++$position );
-		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt', ++$position );
+		$this->add_admin_menu_separator();
+		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -133,13 +133,12 @@ abstract class Base_Admin_Menu {
 			$menu_item[6] = $icon;
 		}
 
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		unset( $menu[ $menu_position ] );
 		if ( $position ) {
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			unset( $menu[ $menu_position ] );
 			$menu_position = $position;
 		}
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$menu[ $menu_position ] = $menu_item;
+		$this->set_menu_item( $menu_item, $menu_position );
 
 		// Only add submenu when there are other submenu items.
 		if ( $url && ! empty( $submenu[ $slug ] ) ) {
@@ -178,18 +177,16 @@ abstract class Base_Admin_Menu {
 	 * @param string $cap Optional. The capability required for this menu to be displayed to the user.
 	 *                         Default: 'read'.
 	 */
-	public function add_admin_menu_separator( $position, $cap = 'read' ) {
-		global $menu;
-
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$menu[ $position ] = array(
+	public function add_admin_menu_separator( $position = null, $cap = 'read' ) {
+		$menu_item = array(
 			'',                                  // Menu title (ignored).
 			$cap,                                // Required capability.
 			wp_unique_id( 'separator-custom-' ), // URL or file (ignored, but must be unique).
 			'',                                  // Page title (ignored).
 			'wp-menu-separator',                 // CSS class. Identifies this item as a separator.
 		);
-		ksort( $menu );
+
+		$this->set_menu_item( $menu_item, $position );
 	}
 
 	/**
@@ -225,16 +222,23 @@ abstract class Base_Admin_Menu {
 	}
 
 	/**
-	 * Remove submenu items from given menu slug.
+	 * Adds the given menu item in the specified position.
 	 *
-	 * @param string $slug Menu slug.
+	 * @param array $item The menu item to add.
+	 * @param int   $position The position in the menu order this item should appear.
 	 */
-	public function remove_submenus( $slug ) {
-		global $submenu;
+	public function set_menu_item( $item, $position = null ) {
+		global $menu;
 
-		if ( isset( $submenu[ $slug ] ) ) {
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			$submenu[ $slug ] = array();
+		// Handle position (avoids overwriting menu items already populated in the given position).
+		// Inspired by https://core.trac.wordpress.org/browser/trunk/src/wp-admin/menu.php?rev=49837#L160.
+		if ( null === $position ) {
+			$menu[] = $item; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} elseif ( isset( $menu[ "$position" ] ) ) {
+			$position            = $position + substr( base_convert( md5( $item[2] . $item[0] ), 16, 10 ), -5 ) * 0.00001;
+			$menu[ "$position" ] = $item; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		} else {
+			$menu[ $position ] = $item; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -84,20 +84,12 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds a link to the menu to create a new site.
 	 */
 	public function add_new_site_link() {
-		global $menu;
-
 		if ( count( get_blogs_of_user( get_current_user_id() ) ) > 1 ) {
 			return;
 		}
 
-		// Attempt to get last position.
-		$position = 1000;
-		while ( isset( $menu[ $position ] ) ) {
-			$position++;
-		}
-
-		$this->add_admin_menu_separator( ++$position );
-		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt', ++$position );
+		$this->add_admin_menu_separator();
+		add_menu_page( __( 'Add new site', 'jetpack' ), __( 'Add new site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -174,7 +174,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 			'toplevel_page_https://wordpress.com/start?ref=calypso-sidebar',
 			'dashicons-plus-alt',
 		);
-		$this->assertSame( $menu[1002], $new_site_menu_item ); // 1001 is the separator position, 1002 is the link position
+		$this->assertSame( array_pop( $menu ), $new_site_menu_item );
 
 		delete_user_option( static::$user_id, 'wpcom_site_count' );
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-base-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-base-admin-menu.php
@@ -103,7 +103,6 @@ class Test_Base_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_admin_menu_separator( 15 );
 		static::$admin_menu->add_admin_menu_separator( 10, 'manage_options' );
 
-		$this->assertSame( array( 10, 15 ), array_keys( $menu ), 'Menu should be ordered by position parameter.' );
 		$this->assertSame( 'manage_options', $menu[10][1] );
 		$this->assertContains( 'separator-custom-', $menu[10][2] );
 		$this->assertSame( 'read', $menu[15][1] );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -158,7 +158,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 			'toplevel_page_https://wordpress.com/start?ref=calypso-sidebar',
 			'dashicons-plus-alt',
 		);
-		$this->assertSame( $menu[1002], $new_site_menu_item ); // 1001 is the separator position, 1002 is the link position
+		$this->assertSame( array_pop( $menu ), $new_site_menu_item );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/51510

#### Changes proposed in this Pull Request:

When manipulating the global `$menu` for the unified menu, our logic was not checking whether certain menu positions were already used by other menu items, causing them to be replaced (and thus to be missing in the unified menu).

On this PR we're ensuring that the menu positions are not already populated, and if so, we automatically place the new menu items in a different position.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Spin up a local Jetpack site running the `master` branch.
* Add the `wpcomsh` plugin to your local Jetpack site:
  - `cd tools/docker/mu-plugins/`
  - `git clone --single-branch --branch master git@github.com:Automattic/wpcomsh.git`
  - `cd wpcomsh`
  - `git submodule update --init --recursive`
  - `composer install`
  - `cd ..`
  - `ln -s wpcomsh/wpcomsh-loader.php ./`
  - Edit `wpcomsh/wpcomsh-loader.php` and add `define( 'IS_ATOMIC', true );` on the top.
* Add a new mu-plugin to the `tools/docker/mu-plugins` folder with the code below:
```php
add_action( 'admin_menu', function() {
	add_menu_page( 'My plugin', 'My plugin', 'read', 'my-plugin', '', '', 51 );
} );
```
* Load any WP Admin screen and note how the "My plugin" menu item is missing.
* Switch to this branch.
* Reload and make sure the "My Plugin" menu item shows up.
