### PR TITLE
Changelog: remove entries for feature that's not ready for launch

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -18,7 +18,6 @@
 - Jetpack Videos: improve the display of transcoding status for newly uploaded videos.
 - Podcast Player Block: improve fetching of the podcast description.
 - Syncrhonization: add new sync/health endpoint to allow update of the sync health options.
-- WordPress.com REST API: allow Facebook Metadata to be saved alongside posts created via the API.
 
 ### Improved compatibility
 - Auto-updates: respect auto-update constant/filters in plugin API endpoints.

--- a/projects/plugins/jetpack/changelog/update-changelog
+++ b/projects/plugins/jetpack/changelog/update-changelog
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This is the changelog.
+
+

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -254,7 +254,6 @@ Our Cookie and Consent Banner can help you comply with GDPR. The European Unionâ
 - Jetpack Videos: improve the display of transcoding status for newly uploaded videos.
 - Podcast Player Block: improve fetching of the podcast description.
 - Syncrhonization: add new sync/health endpoint to allow update of the sync health options.
-- WordPress.com REST API: allow Facebook Metadata to be saved alongside posts created via the API.
 
 #### Improved compatibility
 - Auto-updates: respect auto-update constant/filters in plugin API endpoints.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This faeture isn't ready for launch just yet, so let's not mention it in the changelog to avoid confusion.

﻿Related:
- #19378
- #19279
- #19233

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Does everything look okay?
