### PR TITLE
Search: Fix handling of Customizer controls using refresh

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-customizer-handle-refresh-transport
+++ b/projects/plugins/jetpack/changelog/fix-search-customizer-handle-refresh-transport
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Search: Fix handling of Customizer controls using refresh

--- a/projects/plugins/jetpack/modules/search/customize-controls/customize-controls.js
+++ b/projects/plugins/jetpack/modules/search/customize-controls/customize-controls.js
@@ -14,15 +14,12 @@ function postSectionMessage( expanded ) {
  * Adds functionality for Jetpack Search section detection in the Customizer.
  */
 function init() {
-	var firstInitialization = true; // eslint-disable-line no-var
-
 	window.wp.customize.bind( 'ready', function () {
 		// window.wp.customize.previewer will emit 'ready' multiple times, not just during initialization.
 		window.wp.customize.previewer.bind( 'ready', function () {
-			// Upon first initialization, open/close the modal if the Jetpack Search section is open/closed.
-			firstInitialization &&
+			window.wp.customize.previewer.loading.done( function () {
 				postSectionMessage( window.wp.customize.section( 'jetpack_search' ).expanded() );
-			firstInitialization = false;
+			} );
 
 			// If the Jetpack Search section is opened/closed, emit a message to open/close the modal.
 			window.wp.customize.section( 'jetpack_search' ).expanded.bind( function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
> Reported: Switching the search results sort order in the customizer for Instant Search reloads the full page and does not bring up the instant search overlay. (@atanas-dev)

Adds a listener to the `customizer.previewer.loading` function for a more reliable way of checking if the user has the Jetpack Search section expanded.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Navigate to the customizer and open the Jetpack Search section.
* Ensure that the search modal is summoned.
* Change a setting that forces a preview to reload, such as the `Default Sort` control.
* Ensure that the preview reloads and opens the search modal when complete.
* Navigate out of the Jetpack Search section of the customizer.
* Enter a query into a search input in the preview. Ensure that it opens the search modal as expected.
