### PR TITLE
SEO: add additional save buttons to card section

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -20,6 +20,7 @@ import FoldableCard from 'components/foldable-card';
 import CustomSeoTitles from './seo/custom-seo-titles.jsx';
 import SimpleNotice from 'components/notice';
 import { isFetchingPluginsData, isPluginActive } from 'state/site/plugins';
+import Button from 'components/button';
 
 export const conflictingSeoPluginsList = [
 	{
@@ -79,6 +80,17 @@ export const SEO = withModuleSettingsFormHelpers(
 
 		updateCustomSeoTitleInputState = newCustomSeoTitles => {
 			this.props.updateFormStateOptionValue( 'advanced_seo_title_formats', newCustomSeoTitles );
+		};
+
+		saveButton = props => {
+			const isSaving = this.props.isSavingAnyOption( this.constants.moduleOptionsArray );
+			return (
+				<Button primary compact type="submit" disabled={ isSaving || ! props.isDirty() }>
+					{ isSaving
+						? _x( 'Saving…', 'Button caption', 'jetpack' )
+						: _x( 'Save settings', 'Button caption', 'jetpack' ) }
+				</Button>
+			);
 		};
 
 		render() {
@@ -185,6 +197,11 @@ export const SEO = withModuleSettingsFormHelpers(
 												siteData={ siteData }
 											/>
 										</FormFieldset>
+										{
+											<div className={ 'jp-seo-custom-titles-save-button' }>
+												{ this.saveButton( this.props ) }
+											</div>
+										}
 									</SettingsGroup>
 								</FoldableCard>
 								<FoldableCard
@@ -193,7 +210,7 @@ export const SEO = withModuleSettingsFormHelpers(
 									className="jp-seo-front-page-description-card"
 								>
 									<SettingsGroup>
-										<p>
+										<p style={ { clear: 'both' } }>
 											{ __(
 												'Craft a description of your Website: up to 160 characters that will be used in search engine results for your front page, and when your website is shared on social media sites.',
 												'jetpack'
@@ -226,6 +243,11 @@ export const SEO = withModuleSettingsFormHelpers(
 												) }
 											</div>
 										</div>
+										{
+											<div className={ 'jp-seo-front-page-description-save-button' }>
+												{ this.saveButton( this.props ) }
+											</div>
+										}
 									</SettingsGroup>
 								</FoldableCard>
 								<FoldableCard

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -116,6 +116,11 @@
 	&-count {
 		padding: 0 0 0.25rem 0.25rem;
 	}
+
+	&-save-button {
+		float: right;
+		margin-top: 0.75rem;
+	}
 }
 
 .jp-seo-social-previews {
@@ -175,5 +180,10 @@
 	&-input-preview {
 		margin-top: 0.25rem;
 		font-style: italic;
+	}
+
+	&-save-button {
+		float: right;
+		margin-top: 0.75rem;
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-seo-tools-save-buttons
+++ b/projects/plugins/jetpack/changelog/update-seo-tools-save-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add additional save buttons for SEO tools in wp-admin since the card section can get long to scroll back to the top on.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In WP Admin the custom SEO card can get long vertically when the
different sections get expanded. Adding additional save buttons to the
other two sections will make it so the user doesn't have to scroll far
back to the top of the SEO card to save.

Fixes: #19403

#### Jetpack product discussion

Internal: p8oabR-DS-p2#comment-5199

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* With changes pulled down, in WP Admin head to `/wp-admin/admin.php?page=jetpack#/traffic`
* Make sure the additional save buttons under the custom title structures and custom meta description work.

![Demo 2021-04-02 at 16:11:55](https://user-images.githubusercontent.com/15803018/113457869-319f4680-93ce-11eb-829d-072469f48103.png)
