### PR TITLE
wpcom-api: update DTP allowed metadata 

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-yoavf-D59714-code-1617527
+++ b/projects/plugins/jetpack/changelog/fusion-sync-yoavf-D59714-code-1617527
@@ -1,0 +1,3 @@
+Significance: patch
+Type: compat
+Comment: Minor change for FB DTP allowed metadata. No need for a changelog entry.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -908,7 +908,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 	 * @return array
 	 */
 	public function dtp_fb_allowed_metadata( $keys ) {
-		return array_merge( $keys, array( '_dtp_fb', '_dtp_fb_geo_points' ) );
+		return array_merge( $keys, array( '_dtp_fb', '_dtp_fb_geo_points', '_dtp_fb_post_link' ) );
 	}
 
 	/**


### PR DESCRIPTION
Syncs D59714-code / r223768-wpcom

#### Changes proposed in this Pull Request:
Minor change to allowed metadata keys for DTP posts.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
See D59714 for integration tests.