### PR TITLE
E2E tests: Build Jetpack plugin using Jetpack CLI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -81,8 +81,9 @@ jobs:
         jq --version
 
     - name: Build Production Jetpack
-      working-directory: projects/plugins/jetpack
-      run: yarn build-production-concurrently
+      run: |
+        yarn install
+        ./node_modules/.bin/jetpack build plugins/jetpack -v --production
 
     - name: Set up environment
       working-directory: projects/plugins/jetpack/tests/e2e

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Build Production Jetpack
       run: |
         yarn install
-        ./node_modules/.bin/jetpack build plugins/jetpack -v --production
+        yarn jetpack build plugins/jetpack -v --production
 
     - name: Set up environment
       working-directory: projects/plugins/jetpack/tests/e2e

--- a/projects/plugins/jetpack/changelog/e2e-ci-build-jetpack-using-cli
+++ b/projects/plugins/jetpack/changelog/e2e-ci-build-jetpack-using-cli
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Change the command to build Jetpack in E2E tests Github action workflow


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Use Jetpack CLI to build Jetpack in E2E tests Github actions workflow

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI happy