### PR TITLE
Nav unification - hide submenu items instead of removing them

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-refactor-submenu-replace
+++ b/projects/plugins/jetpack/changelog/fix-refactor-submenu-replace
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Refactored the menu and submenu items replacement for nav unification

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -134,7 +134,7 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		if ( ! $menu_exists ) {
 			// Remove the submenu auto-created by Core.
-			remove_submenu_page( 'paid-upgrades.php', 'paid-upgrades.php' );
+			$this->hide_submenu_page( 'paid-upgrades.php', 'paid-upgrades.php' );
 		}
 	}
 
@@ -165,7 +165,7 @@ class Admin_Menu extends Base_Admin_Menu {
 			return;
 		}
 
-		remove_submenu_page( 'upload.php', 'media-new.php' );
+		$this->hide_submenu_page( 'upload.php', 'media-new.php' );
 
 		$this->update_menu( 'upload.php', 'https://wordpress.com/media/' . $this->domain );
 	}
@@ -282,8 +282,8 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		$this->update_submenus( 'themes.php', $submenus_to_update );
 
-		remove_submenu_page( 'themes.php', 'custom-header' );
-		remove_submenu_page( 'themes.php', 'custom-background' );
+		$this->hide_submenu_page( 'themes.php', 'custom-header' );
+		$this->hide_submenu_page( 'themes.php', 'custom-background' );
 
 		return $customize_url;
 	}
@@ -298,8 +298,8 @@ class Admin_Menu extends Base_Admin_Menu {
 			return;
 		}
 
-		remove_submenu_page( 'plugins.php', 'plugin-install.php' );
-		remove_submenu_page( 'plugins.php', 'plugin-editor.php' );
+		$this->hide_submenu_page( 'plugins.php', 'plugin-install.php' );
+		$this->hide_submenu_page( 'plugins.php', 'plugin-editor.php' );
 
 		$this->update_menu( 'plugins.php', 'https://wordpress.com/plugins/' . $this->domain );
 	}
@@ -350,8 +350,8 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 		$this->update_submenus( 'tools.php', $submenus_to_update );
 
-		remove_submenu_page( 'tools.php', 'tools.php' );
-		remove_submenu_page( 'tools.php', 'delete-blog' );
+		$this->hide_submenu_page( 'tools.php', 'tools.php' );
+		$this->hide_submenu_page( 'tools.php', 'delete-blog' );
 
 		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
 		add_submenu_page( 'tools.php', esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
@@ -369,8 +369,8 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		$this->update_submenus( 'options-general.php', array( 'options-general.php' => 'https://wordpress.com/settings/general/' . $this->domain ) );
 
-		remove_submenu_page( 'options-general.php', 'options-discussion.php' );
-		remove_submenu_page( 'options-general.php', 'options-writing.php' );
+		$this->hide_submenu_page( 'options-general.php', 'options-discussion.php' );
+		$this->hide_submenu_page( 'options-general.php', 'options-writing.php' );
 	}
 
 	/**
@@ -392,13 +392,13 @@ class Admin_Menu extends Base_Admin_Menu {
 		/* translators: Jetpack sidebar menu item. */
 		add_submenu_page( 'jetpack', esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'read', 'https://wordpress.com/jetpack-search/' . $this->domain, null, 4 );
 
-		remove_submenu_page( 'jetpack', 'stats' );
-		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
-		remove_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
+		$this->hide_submenu_page( 'jetpack', 'stats' );
+		$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
+		$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
 
 		if ( ! $is_menu_updated ) {
 			// Remove the submenu auto-created by Core.
-			remove_submenu_page( 'jetpack', 'jetpack' );
+			$this->hide_submenu_page( 'jetpack', 'jetpack' );
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -35,6 +35,13 @@ abstract class Base_Admin_Menu {
 	protected $domain;
 
 	/**
+	 * The CSS classes used to hide the submenu items in navigation.
+	 *
+	 * @var string
+	 */
+	const HIDE_CSS_CLASS = 'hide-if-js hide-if-no-js';
+
+	/**
 	 * Base_Admin_Menu constructor.
 	 */
 	protected function __construct() {
@@ -154,7 +161,7 @@ abstract class Base_Admin_Menu {
 	/**
 	 * Updates the submenus of the given menu slug.
 	 *
-	 * It hides the menu by adding the hide-if-js css class and duplicates the submenu with the new slug.
+	 * It hides the menu by adding the `hide-if-js hide-if-no-js` css classes and duplicates the submenu with the new slug.
 	 *
 	 * @param string $slug Menu slug.
 	 * @param array  $submenus_to_update Array of new submenu slugs.
@@ -175,10 +182,7 @@ abstract class Base_Admin_Menu {
 				continue;
 			}
 
-			$css_classes = empty( $item[4] ) ? 'hide-if-js hide-if-no-js' : $item[4] . ' hide-if-js hide-if-no-js';
-
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			$submenu [ $slug ][ $index ][4] = $css_classes;
+			$this->hide_submenu_element( $index, $slug, $item );
 		}
 
 		$submenu_items = array_values( $submenu[ $slug ] );
@@ -289,15 +293,32 @@ abstract class Base_Admin_Menu {
 		}
 
 		foreach ( $submenu[ $menu_slug ] as $i => $item ) {
-			if ( $submenu_slug === $item[2] ) {
-				$css_classes = isset( $item[4] ) ? $item[4] . '  hide-if-js hide-if-no-js' : 'hide-if-js hide-if-no-js';
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$submenu[ $menu_slug ][ $i ][4] = $css_classes;
-				return $item;
+			if ( $submenu_slug !== $item[2] ) {
+				continue;
 			}
+
+			$this->hide_submenu_element( $i, $menu_slug, $item );
+
+			return $item;
 		}
 
 		return false;
+	}
+
+	/**
+	 * Apply the hide-if-js and hide-if-no-js CSS classes to a submenu item.
+	 *
+	 * @param int    $index The position of a submenu item in the submenu array.
+	 * @param string $parent_slug The parent slug.
+	 * @param array  $item The submenu item.
+	 */
+	public function hide_submenu_element( $index, $parent_slug, $item ) {
+		global $submenu;
+
+		$css_classes = empty( $item[4] ) ? self::HIDE_CSS_CLASS : $item[4] . ' ' . self::HIDE_CSS_CLASS;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$submenu [ $parent_slug ][ $index ][4] = $css_classes;
 	}
 
 	/**
@@ -310,7 +331,7 @@ abstract class Base_Admin_Menu {
 		$visible_items = array_filter(
 			$submenu_items,
 			static function ( $item ) {
-				return empty( $item[4] ) || strpos( $item[4], 'hide-if-js hide-if-no-js' ) === false;
+				return empty( $item[4] ) || strpos( $item[4], self::HIDE_CSS_CLASS ) === false;
 			}
 		);
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -176,7 +176,7 @@ abstract class Base_Admin_Menu {
 		// This is needed for cases when the submenus to update have the same new slug.
 		$submenus_to_update = array_filter(
 			$submenus_to_update,
-			function ( $item, $old_slug ) {
+			static function ( $item, $old_slug ) {
 				return $item !== $old_slug;
 			},
 			ARRAY_FILTER_USE_BOTH

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -173,6 +173,15 @@ abstract class Base_Admin_Menu {
 			return;
 		}
 
+		// This is needed for cases when the submenus to update have the same new slug.
+		$submenus_to_update = array_filter(
+			$submenus_to_update,
+			function ( $item, $old_slug ) {
+				return $item !== $old_slug;
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+
 		/**
 		 * Iterate over all submenu items and add the hide the submenus with CSS classes.
 		 * This is done separately of the second foreach because the position of the submenu might change.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -39,7 +39,7 @@ abstract class Base_Admin_Menu {
 	 *
 	 * @var string
 	 */
-	const HIDE_CSS_CLASS = 'hide-if-js hide-if-no-js';
+	const HIDE_CSS_CLASS = 'hide-if-js';
 
 	/**
 	 * Base_Admin_Menu constructor.
@@ -161,7 +161,7 @@ abstract class Base_Admin_Menu {
 	/**
 	 * Updates the submenus of the given menu slug.
 	 *
-	 * It hides the menu by adding the `hide-if-js hide-if-no-js` css classes and duplicates the submenu with the new slug.
+	 * It hides the menu by adding the `hide-if-js` css class and duplicates the submenu with the new slug.
 	 *
 	 * @param string $slug Menu slug.
 	 * @param array  $submenus_to_update Array of new submenu slugs.
@@ -315,7 +315,7 @@ abstract class Base_Admin_Menu {
 	}
 
 	/**
-	 * Apply the hide-if-js and hide-if-no-js CSS classes to a submenu item.
+	 * Apply the hide-if-js CSS class to a submenu item.
 	 *
 	 * @param int    $index The position of a submenu item in the submenu array.
 	 * @param string $parent_slug The parent slug.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -228,7 +228,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		add_submenu_page( 'tools.php', esc_attr__( 'Export', 'jetpack' ), __( 'Export', 'jetpack' ), 'export', 'export.php' );
 
 		// Remove the submenu auto-created by Core.
-		remove_submenu_page( 'tools.php', 'tools.php' );
+		$this->hide_submenu_page( 'tools.php', 'tools.php' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -198,7 +198,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) {
 		$customize_url = parent::add_appearance_menu( $wp_admin_themes, $wp_admin_customize );
 
-		remove_submenu_page( 'themes.php', 'theme-editor.php' );
+		$this->hide_submenu_page( 'themes.php', 'theme-editor.php' );
 
 		$user_can_customize = current_user_can( 'customize' );
 
@@ -255,7 +255,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
 		// Replace sharing menu if it exists. See Publicize_UI::sharing_menu.
-		if ( remove_submenu_page( 'options-general.php', 'sharing' ) ) {
+		if ( $this->hide_submenu_page( 'options-general.php', 'sharing' ) ) {
 			add_submenu_page( 'options-general.php', esc_attr__( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/sharing-buttons/' . $this->domain, null, 30 );
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -194,11 +194,12 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_media_menu
 	 */
 	public function test_add_media_menu() {
-		global $menu;
+		global $menu, $submenu;
 
 		static::$admin_menu->add_media_menu();
 
 		$this->assertSame( 'https://wordpress.com/media/' . static::$domain, $menu[10][2] );
+		$this->assertFalse( static::$admin_menu->has_visible_items( $submenu['upload.php'] ) );
 	}
 
 	/**
@@ -254,11 +255,12 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_comments_menu
 	 */
 	public function test_add_comments_menu() {
-		global $menu;
+		global $menu, $submenu;
 
 		static::$admin_menu->add_comments_menu();
 
 		$this->assertSame( 'https://wordpress.com/comments/all/' . static::$domain, $menu[25][2] );
+		$this->assertFalse( self::$admin_menu->has_visible_items( $submenu['edit-comments.php'] ) );
 	}
 
 	/**
@@ -288,6 +290,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_plugins_menu();
 
 		$this->assertSame( 'https://wordpress.com/plugins/' . static::$domain, $menu[65][2] );
+		$this->assertFalse( self::$admin_menu->has_visible_items( $submenu['plugins.php'] ) );
 
 		// Reset.
 		$menu    = static::$menu_data;

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Dashboard_Customizations\Admin_Menu;
+use Automattic\Jetpack\Dashboard_Customizations\Base_Admin_Menu;
 use Automattic\Jetpack\Status;
 
 require_jetpack_file( 'modules/masterbar/admin-menu/class-admin-menu.php' );
@@ -143,7 +144,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_my_home_menu();
 
 		$this->assertSame( 'https://wordpress.com/home/' . static::$domain, $menu[2][2] );
-		$this->assertSame( 'hide-if-js hide-if-no-js', $submenu['index.php'][0][4] );
+		$this->assertSame( Base_Admin_Menu::HIDE_CSS_CLASS, $submenu['index.php'][0][4] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -334,6 +334,8 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		$menu    = static::$menu_data;
 		$submenu = static::$submenu_data;
 
+		// On multisite the administrator is not allowed to create users.
+		grant_super_admin( self::$user_id );
 		static::$admin_menu->add_users_menu();
 
 		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -141,8 +141,9 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		);
 
 		static::$admin_menu->add_my_home_menu();
+
 		$this->assertSame( 'https://wordpress.com/home/' . static::$domain, $menu[2][2] );
-		$this->assertEmpty( $submenu['index.php'] );
+		$this->assertSame( 'hide-if-js hide-if-no-js', $submenu['index.php'][0][4] );
 	}
 
 	/**
@@ -168,8 +169,8 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_upgrades_menu();
 
-		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, array_shift( $submenu['paid-upgrades.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, array_shift( $submenu['paid-upgrades.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, $submenu['paid-upgrades.php'][1][2] );
+		$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
 	}
 
 	/**
@@ -182,8 +183,8 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_posts_menu();
 
-		$this->assertSame( 'https://wordpress.com/posts/' . static::$domain, array_shift( $submenu['edit.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/post/' . static::$domain, array_shift( $submenu['edit.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/posts/' . static::$domain, $submenu['edit.php'][0][2] );
+		$this->assertSame( 'https://wordpress.com/post/' . static::$domain, $submenu['edit.php'][1][2] );
 	}
 
 	/**
@@ -192,12 +193,11 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_media_menu
 	 */
 	public function test_add_media_menu() {
-		global $menu, $submenu;
+		global $menu;
 
 		static::$admin_menu->add_media_menu();
 
 		$this->assertSame( 'https://wordpress.com/media/' . static::$domain, $menu[10][2] );
-		$this->assertEmpty( $submenu['upload.php'] );
 	}
 
 	/**
@@ -210,8 +210,8 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_page_menu();
 
-		$this->assertSame( 'https://wordpress.com/pages/' . static::$domain, array_shift( $submenu['edit.php?post_type=page'] )[2] );
-		$this->assertSame( 'https://wordpress.com/page/' . static::$domain, array_shift( $submenu['edit.php?post_type=page'] )[2] );
+		$this->assertSame( 'https://wordpress.com/pages/' . static::$domain, $submenu['edit.php?post_type=page'][0][2] );
+		$this->assertSame( 'https://wordpress.com/page/' . static::$domain, $submenu['edit.php?post_type=page'][1][2] );
 	}
 
 	/**
@@ -253,12 +253,11 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::add_comments_menu
 	 */
 	public function test_add_comments_menu() {
-		global $menu, $submenu;
+		global $menu;
 
 		static::$admin_menu->add_comments_menu();
 
 		$this->assertSame( 'https://wordpress.com/comments/all/' . static::$domain, $menu[25][2] );
-		$this->assertEmpty( $submenu['edit-comments.php'] );
 	}
 
 	/**
@@ -288,7 +287,6 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_plugins_menu();
 
 		$this->assertSame( 'https://wordpress.com/plugins/' . static::$domain, $menu[65][2] );
-		$this->assertEmpty( $submenu['plugins.php'] );
 
 		// Reset.
 		$menu    = static::$menu_data;
@@ -328,8 +326,8 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_users_menu();
 
-		$this->assertSame( 'https://wordpress.com/me', array_shift( $submenu['profile.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/me/account', array_shift( $submenu['profile.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/me', $submenu['profile.php'][0][2] );
+		$this->assertSame( 'https://wordpress.com/me/account', $submenu['profile.php'][2][2] );
 
 		// Reset.
 		wp_set_current_user( static::$user_id );
@@ -338,10 +336,10 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_users_menu();
 
-		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, array_shift( $submenu['users.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/people/new/' . static::$domain, array_shift( $submenu['users.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/me', array_shift( $submenu['users.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/me/account', array_shift( $submenu['users.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );
+		$this->assertSame( 'https://wordpress.com/people/new/' . static::$domain, $submenu['users.php'][1][2] );
+		$this->assertSame( 'https://wordpress.com/me', $submenu['users.php'][2][2] );
+		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][6][2] );
 	}
 
 	/**
@@ -354,10 +352,10 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_tools_menu();
 
-		$this->assertSame( 'https://wordpress.com/marketing/tools/' . static::$domain, array_shift( $submenu['tools.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/earn/' . static::$domain, array_shift( $submenu['tools.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/import/' . static::$domain, array_shift( $submenu['tools.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/export/' . static::$domain, array_shift( $submenu['tools.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/marketing/tools/' . static::$domain, $submenu['tools.php'][0][2] );
+		$this->assertSame( 'https://wordpress.com/earn/' . static::$domain, $submenu['tools.php'][1][2] );
+		$this->assertSame( 'https://wordpress.com/import/' . static::$domain, $submenu['tools.php'][3][2] );
+		$this->assertSame( 'https://wordpress.com/export/' . static::$domain, $submenu['tools.php'][4][2] );
 	}
 
 	/**
@@ -378,14 +376,14 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 *
 	 * @covers ::add_jetpack_menu
 	 */
-	public function add_jetpack_menu() {
+	public function test_add_jetpack_menu() {
 		global $submenu;
 
 		static::$admin_menu->add_jetpack_menu();
 
-		$this->assertSame( 'https://wordpress.com/activity-log/' . static::$domain, $submenu['jetpack'][2][2] );
-		$this->assertSame( 'https://wordpress.com/backup/' . static::$domain, $submenu['jetpack'][3][2] );
-		$this->assertSame( 'https://wordpress.com/jetpack-search/' . static::$domain, $submenu['jetpack'][4][2] );
+		$this->assertSame( 'https://wordpress.com/activity-log/' . static::$domain, $submenu['jetpack'][3][2] );
+		$this->assertSame( 'https://wordpress.com/backup/' . static::$domain, $submenu['jetpack'][4][2] );
+		$this->assertSame( 'https://wordpress.com/jetpack-search/' . static::$domain, $submenu['jetpack'][5][2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -342,10 +342,10 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		if ( current_user_can( 'install_themes' ) ) {
 			$this->assertSame( 'theme-install.php', $submenu['themes.php'][1][2] );
 			// Check Customize menu always links to WP Admin.
-			$this->assertSame( 'customize.php?return', $submenu['themes.php'][2][2] );
+			$this->assertSame( 'customize.php?return', $submenu['themes.php'][3][2] );
 		} else {
 			// Check Customize menu always links to WP Admin.
-			$this->assertSame( 'customize.php?return', $submenu['themes.php'][6][2] );
+			$this->assertSame( 'customize.php?return', $submenu['themes.php'][2][2] );
 		}
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -286,7 +286,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_tools_menu();
 
 		// Check Export menu item always links to WP Admin.
-		$this->assertSame( 'export.php', $submenu['tools.php'][3][2] );
+		$this->assertSame( 'export.php', $submenu['tools.php'][5][2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -99,7 +99,7 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_jetpack_menu();
 
-		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][2][2] );
+		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][3][2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -279,7 +279,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_tools_menu( false, true );
 
 		// Check Export menu item always links to Calypso.
-		$this->assertSame( 'https://wordpress.com/export/' . static::$domain, $submenu['tools.php'][3][2] );
+		$this->assertSame( 'https://wordpress.com/export/' . static::$domain, $submenu['tools.php'][4][2] );
 	}
 
 	/**
@@ -293,7 +293,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_options_menu();
 
 		$this->assertSame( 'https://wordpress.com/hosting-config/' . static::$domain, $submenu['options-general.php'][6][2] );
-		$this->assertSame( 'https://wordpress.com/marketing/sharing-buttons/' . static::$domain, $submenu['options-general.php'][8][2] );
+		$this->assertSame( 'https://wordpress.com/marketing/sharing-buttons/' . static::$domain, $submenu['options-general.php'][11][2] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/51459
Fixes https://github.com/Automattic/wp-calypso/issues/51381

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Instead of removing submenu items in order to not display them in the navigation, we can add ~~the `hide-if-no-js` and~~ `hide-if-js` CSS classes on the items we want to exclude from the navigation. 
- In wp-admin that would mean that html elements will still be present in the nav however, they'll not be displayed.
- On Calypso, since the submenu items are filtered on the back-end side, there shouldn't be any behaviour changes.

This was needed in order to keep compatibility with third-party plugins that depend on core submenu items to register hidden pages; one example of this is All in one SEO plugin, where in order to register a hidden page, a submenu item is added and then immediately removed: 
```   	
add_dashboard_page( '', '', 'fooo', 'foo', '' );
remove_submenu_page( 'index.php', 'foo' );
```
I'm not sure how common this snippet is in the plugin ecosystem, however this pattern was also found on several tutorials and therefore it's possible that other plugins might use the same approach.

#### Impact
It's important to note that, by using this approach, **all** wp-admin pages that have been removed (hidden) from the navigation will still be available by using directly the page URL. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Since the modification affects all menu and submenu items, we first need to check for any regressions.

_Simple_
- Apply D59781-code to your WP.com sandbox.
- Sandbox the API and a simple site.
- Go to https://wordpress.com and switch to the sandboxed site.
- Check the menu under different scenarios (Calypso, WP Admin, toggle on/off) and make sure there are no regressions.

_Atomic_
- Install Jetpack Beta on a Atomic site and switch to the branch of this PR.
- Go to https://wordpress.com and switch to the WoA site.
- Check the menu under different scenarios (Calypso, WP Admin, toggle on/off) and make sure there are no regressions.

_Jetpack_
- Spin up a Jetpack site running this branch.
- Spin up a local instance of Calypso with [this code](https://github.com/Automattic/wp-calypso/blob/46541a684523325e4efd293d0f8b7f2530f4e6f2/client/state/selectors/is-nav-unification-enabled.js#L27-L31) removed/commented out.
- Go to http://calypso.localhost:3000 and switch to the Jetpack site.
- Check the menu in Calypso only (since Nav Unification is disabled on WP Admin) and make sure there are no regressions (all menus should point to Calypso regardless of the toggle, except Feedback, Customize, Import, Export and WP Admin).

For #[51459](https://github.com/Automattic/wp-calypso/issues/51459):
- Go to you Atomic /Jetpack site
- Install All in One SEO plugin
- Make sure that wp-admin/index.php?page=aioseo-setup-wizard URL is not broken

For #[51381](https://github.com/Automattic/wp-calypso/issues/51381):
- Go to your Atomic/Jetpack site
- Check if the page is not broken: wp-admin/admin.php?page=stats
- Check in the wp-admin index that the Jetpack stats widget displays the stats. 