### PR TITLE
Avoid determine_current_user filter to enter an infinite loop

### DIFF
--- a/projects/packages/connection/changelog/fix-rest-authentication-infinite-loop
+++ b/projects/packages/connection/changelog/fix-rest-authentication-infinite-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid determine_current_user going through infinite loops


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes a very specific situation where the `determine_current_user` filter added by the connection package can produce an infinite loop. See p9o2xV-1kz-p2#comment-4415

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Avoid determine_current_user filter to enter an infinite loop

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9o2xV-1kz-p2#comment-4415

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up an ephemeral site with wpcomsh/Jetpack and jetpack-beta
* Connect Jetpack
* Break the Jetpack user token (see p9o2xV-1kz-p2#comment-4415 or use the [Debug helper plugin](https://github.com/Automattic/jetpack/tree/master/projects/plugins/debug-helper))
* Use the developer console to request WP REST API | wpcom/v2 | GET | /sites/$your-site-id/admin-menu.
* `tail -f /tmp/php-errors` on the ephemeral site should output an OOM error. The rest API response code should be 500
* Using jetpack beta, switch to this branch
* Make the request again and check that there's no OOM error and the REST response code is 400