### PR TITLE
Gardening Action: do not add the "Needs Author Reply" label if a PR is actively being worked on

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-check-progress-label
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-check-progress-label
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Description task: do not add the "Needs Author Reply" label if the PR is still being worked on (the "In Progress" label is in use).

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "1.1.0",
+	"version": "1.2.0-alpha",
 	"description": "Manage PR and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -74,6 +74,22 @@ async function hasNeedsReviewLabel( octokit, owner, repo, number ) {
 }
 
 /**
+ * Check for a "In Progress" status label on a PR.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - PR number.
+ *
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasProgressLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're really only interested in the In Progress label.
+	return !! labels.find( label => label.includes( '[Status] In Progress' ) );
+}
+
+/**
  * Build some info about a specific plugin's release dates.
  *
  * @param {string} plugin        - Plugin name.
@@ -450,11 +466,15 @@ async function updateLabels( payload, octokit ) {
 		} );
 	}
 
-	debug( `check-description: add Needs Author Reply label.` );
-	await octokit.issues.addLabels( {
-		...labelOpts,
-		labels: [ '[Status] Needs Author Reply' ],
-	} );
+	// Add the "Needs Author Reply" label, unless the author marked their PR as in progress.
+	const isInProgress = await hasProgressLabel( octokit, ownerLogin, repo, number );
+	if ( ! isInProgress ) {
+		debug( `check-description: add Needs Author Reply label.` );
+		await octokit.issues.addLabels( {
+			...labelOpts,
+			labels: [ '[Status] Needs Author Reply' ],
+		} );
+	}
 }
 
 /**

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -86,7 +86,7 @@ async function hasNeedsReviewLabel( octokit, owner, repo, number ) {
 async function hasProgressLabel( octokit, owner, repo, number ) {
 	const labels = await getLabels( octokit, owner, repo, number );
 	// We're really only interested in the In Progress label.
-	return !! labels.find( label => label.includes( '[Status] In Progress' ) );
+	return labels.includes( '[Status] In Progress' );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

If you are still working on your PR, you may make more changes that will appease the action that checks your PR description. It's consequently not useful to add the Needs Author Reply label if you're still not done with your work.

#### Does this pull request change what data or activity we track or use?

No

#### Jetpack product discussion

* See p1617721097468900-slack-CBG1CP4EN

#### Testing instructions:

* See the labels added by the action under this PR. I will purposefully leave the "Privacy" information out of my PR description, so the action will detect that something is failing. But I'll also add the "In Progress" label. It should not add a "Needs Author Reply" label in response.

![image](https://user-images.githubusercontent.com/426388/113759203-1b1e2580-9715-11eb-9851-3e87a24b55c8.png)


* I'll then edit things and mark the PR as ready for review.
