### PR TITLE
actions: Correctly supply git auth token

### DIFF
--- a/.github/files/renovate-helper.sh
+++ b/.github/files/renovate-helper.sh
@@ -33,7 +33,8 @@ cd $DIR
 
 echo "::group::Check out $HEAD_REF"
 git init -q .
-git remote add origin "https://${API_TOKEN_GITHUB}@github.com/${GITHUB_REPOSITORY}.git"
+git remote add origin "https://github.com/${GITHUB_REPOSITORY}"
+git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf "x-access-token:%s" "$API_TOKEN_GITHUB" | base64)"
 
 # Fetch commits to HEAD_REF since BASE_REF. Then fetch one more (the merge base).
 git fetch --no-tags --prune --shallow-exclude="$BASE_REF" origin "$HEAD_REF"

--- a/projects/github-actions/push-to-mirrors/changelog/fix-gh-actions-git-auth
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-gh-actions-git-auth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Correctly supply git auth token.

--- a/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
+++ b/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
@@ -76,7 +76,9 @@ while read -r GIT_SLUG; do
 	# Initialize the directory as a git repo, and set the remote
 	echo "::group::Fetching ${GIT_SLUG}"
 	git init -b "$BRANCH" .
-	git remote add origin "https://$API_TOKEN_GITHUB@github.com/${GIT_SLUG}.git"
+	git remote add origin "https://github.com/${GIT_SLUG}"
+	git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf "x-access-token:%s" "$API_TOKEN_GITHUB" | base64)"
+
 	FORCE_COMMIT=
 	if git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin "$BRANCH"; then
 		git reset --soft FETCH_HEAD


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Apparently GitHub sets up a generic auth token by default, and what we
were doing wasn't actually valid so it was falling back to that. This
should be the correct way to set it up.

This mostly doesn't matter, since either token is allowing access in
our current use cases. But it does prevent cancel-dups.yml from being
triggered from renovate-helper.sh and might break push-to-mirrors if
someone were to try using it to push to a private repo.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this. Then
    * Make sure the push-to-mirrors job still runs successfully.
    * Trigger renovate to rebase a PR that touches a project, and see if matticbot's push to add change files triggers jobs from cancel-dups.yml.