### PR TITLE
Retrieve invisible links when checking bookmarks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-show-links-manager-with-invisible-links
+++ b/projects/plugins/jetpack/changelog/update-show-links-manager-with-invisible-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+When we are retrieving links to see if the user has added any themselves to determine whether the Links Manager is in use (So we can hide it if it isn't). We are only retrieving visible links so if the user has added lots of invisible links we are incorrectly hiding the Links menu item. Here we are returning both visible and invisible links.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -81,9 +81,10 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		$link_manager_links = get_bookmarks(
 			array(
-				'orderby' => 'link_id',
-				'order'   => 'DESC',
-				'limit'   => $max_default_id,
+				'orderby'        => 'link_id',
+				'order'          => 'DESC',
+				'limit'          => 1,
+				'hide_invisible' => 0,
 			)
 		);
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -79,6 +79,7 @@ class Admin_Menu extends Base_Admin_Menu {
 		// See /wp-content/mu-plugins/wpcom-wp-install-defaults.php in WP.com.
 		$max_default_id = 10;
 
+		// We are only checking the latest entry link_id so are limiting the query to 1.
 		$link_manager_links = get_bookmarks(
 			array(
 				'orderby'        => 'link_id',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/51745

When we are retrieving links to see if the user has added any themselves to determine whether the Links Manager is in use (So we can hide it if it isn't). We are only retrieving visible links so if the user has added lots of invisible links we are incorrectly hiding the Links menu item.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Return both invisible and visible links.
* Limit the query to the latest item only rather than 10, as we are only checking that.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Simple**
* Apply this patch
* Remove all existing links from `/wp-admin/link-manager.php` and add a new link
* Link menu item should be visible.
* Edit your recently added link and make it private (Checkbox above the "Update Link" button).
* Link menu item should still be visible.
* Delete your recently added link.
* Link menu item should NOT be visible now.

**Atomic**

* Install Jetpack Beta plugin.
* Activate this branch.
* Remove all existing links from `/wp-admin/link-manager.php` and add a new link
* Link menu item should be visible.
* Edit your recently added link and make it private (Checkbox above the "Update Link" button).
* Link menu item should still be visible.
* Delete your recently added link.
* Link menu item should NOT be visible now.


