### PR TITLE
[RNMobile] Story block: attempt to assign videopress default thumbnail for mp4 videos

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/story/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/edit.native.js
@@ -177,6 +177,14 @@ const StoryEdit = ( { attributes, isSelected, clientId, setAttributes, onFocus }
 		}
 	}
 
+	function getVideoPressThumbnailUrlIfVideo( url ) {
+		if ( url !== undefined && url.endsWith( '.mp4' ) ) {
+			return url.replace( '.mp4', '_std.original.jpg' );
+		} else {
+			return url;
+		}
+	}
+
 	const mediaPlaceholder = (
 		// TODO this we are wrapping in a pointerEvents=none because we don't want to
 		// trigger the ADD MEDIA bottom sheet just yet, but only give the placedholder the right appearance.
@@ -231,7 +239,7 @@ const StoryEdit = ( { attributes, isSelected, clientId, setAttributes, onFocus }
 										isUploadFailed={ isUploadFailed || isSaveFailed }
 										isUploadInProgress={ isUploadProgressing || isSaveProgressing }
 										retryMessage={ retryMessage }
-										url={ mediaFiles[ 0 ].url } // just select the first one // TODO see how to handle video
+										url={ getVideoPressThumbnailUrlIfVideo( mediaFiles[ 0 ].url ) } // just select the first one
 										style={ styles[ 'wp-story-image' ] }
 									/>
 								);

--- a/projects/plugins/jetpack/extensions/blocks/story/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/edit.native.js
@@ -180,9 +180,8 @@ const StoryEdit = ( { attributes, isSelected, clientId, setAttributes, onFocus }
 	function getVideoPressThumbnailUrlIfVideo( url ) {
 		if ( url !== undefined && url.endsWith( '.mp4' ) ) {
 			return url.replace( '.mp4', '_std.original.jpg' );
-		} else {
-			return url;
 		}
+		return url;
 	}
 
 	const mediaPlaceholder = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
This was inspired by how video thumbnails for VideoPress videos were being handled [for the Aztec Editor in WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/blob/0690fa69de58a085327ea0571fa116df6a0ebbab/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java#L421-L434).
This is a quick way to show the video poster when the first slide in a media collection in the Story block is a video hosted with VideoPress. If the poster exists, it will be shown. Otherwise the placeholder is shown, same as today. A more elegant solution would involve adding a `thumbnail`  attribute to the block and populate such attribute with the correct value as retrieved from the API, but it seems a different kind of effort that we decided to deprioritize for now.

So for example, if a Story block has its first slide with a video like this one here:
`https://testmzorz3.files.wordpress.com/2020/12/wp_story1607131946292_0.mp4`

The URL will be replaced with the following URL:
`https://testmzorz3.files.wordpress.com/2020/12/wp_story1607131946292_0_std.original.jpg`

#### Does this pull request change what data or activity we track or use?

N/A

#### Testing instructions:
1. Create a Story post on a  VideoPress activated site (jetpack or .com)
2. make the first Story slide be a video uploaded to the site's media section
3. after the video gets uploaded, we'll have to wait for it to get converted so you get choose a thumbnail out of a frame of it  on the web admin / calypso.

<img width="320" alt="Screen Shot 2021-04-08 at 17 11 54" src="https://user-images.githubusercontent.com/6597771/114051727-bb826000-9863-11eb-8637-254b047c3ed6.png">

5. set a thumbnail on it by editing the media item in the Media section of your site
6. now open the Post on WPAndroid with gutenberg enabled
7. observe the thumbnail loads as the block's image in mobile Gutenberg



