### PR TITLE
Recommendations (Jetpack Assistant): add e2e test to cover main flow

### DIFF
--- a/projects/plugins/jetpack/changelog/add-e2e-test-to-jetpack-assistant
+++ b/projects/plugins/jetpack/changelog/add-e2e-test-to-jetpack-assistant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add e2e test to cover Jetpack Assistant's (Recommendations) main flow

--- a/projects/plugins/jetpack/tests/e2e/.vscode/settings.json
+++ b/projects/plugins/jetpack/tests/e2e/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"editor.formatOnSave": true
-}

--- a/projects/plugins/jetpack/tests/e2e/.vscode/settings.json
+++ b/projects/plugins/jetpack/tests/e2e/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"editor.formatOnSave": true
+}

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/page-actions.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/page-actions.js
@@ -319,5 +319,17 @@ export default class PageActions {
 		await this.page.selectOption( selector, options );
 	}
 
+	/**
+	 * Returns whether an element with the given selector is checked.
+	 *
+	 * @param {string} selector
+	 * @param {number} timeout
+	 * @return {Promise<boolean>} true if element is checked, false otherwise
+	 */
+	async isElementChecked( selector, timeout = this.timeout ) {
+		logger.action( `Checking if element '${ selector }' is checked` );
+		return await this.page.isChecked( selector, { timeout } );
+	}
+
 	// endregion
 }

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
@@ -51,39 +51,51 @@ export default class RecommendationsPage extends WpPage {
 	}
 
 	async saveSiteTypeAndContinue() {
-		return await this.click( 'a.is-primary[href*="recommendations/monitor"]' );
+		return await this.click( 'a[href*="recommendations/monitor"] >> text="Continue"' );
 	}
 
 	async isEnableMonitoringButtonVisible() {
-		return await this.isElementVisible( 'a.is-primary[href*="recommendations/related-posts"]' );
+		return await this.isElementVisible(
+			'a[href*="recommendations/related-posts"] >> text="Enable Downtime Monitoring"'
+		);
 	}
 
 	async enableMonitoringAndContinue() {
-		return await this.click( 'a.is-primary[href*="recommendations/related-posts"]' );
+		return await this.click(
+			'a[href*="recommendations/related-posts"] >> text="Enable Downtime Monitoring"'
+		);
 	}
 
 	async isEnableRelatedPostsButtonVisible() {
-		return await this.isElementVisible( 'a.is-primary[href*="recommendations/creative-mail"]' );
+		return await this.isElementVisible(
+			'a[href*="recommendations/creative-mail"] >> text="Enable Related Posts"'
+		);
 	}
 
 	async enableRelatedPostsAndContinue() {
-		return await this.click( 'a.is-primary[href*="recommendations/creative-mail"]' );
+		return await this.click(
+			'a[href*="recommendations/creative-mail"] >> text="Enable Related Posts"'
+		);
 	}
 
 	async isInstallCreativeMailButtonVisible() {
-		return await this.isElementVisible( 'a.is-primary[href*="recommendations/site-accelerator"]' );
+		return await this.isElementVisible(
+			'a[href*="recommendations/site-accelerator"] >> text="Install Creative Mail"'
+		);
 	}
 
 	async skipCreativeMailAndContinue() {
-		return await this.click( 'a:not(.is-primary)[href*="recommendations/site-accelerator"]' );
+		return await this.click( 'a[href*="recommendations/site-accelerator"] >> text="Not now"' );
 	}
 
 	async isEnableSiteAcceleratorButtonVisible() {
-		return await this.isElementVisible( 'a.is-primary[href*="recommendations/summary"]' );
+		return await this.isElementVisible(
+			'a[href*="recommendations/summary"] >> text="Enable Site Accelerator"'
+		);
 	}
 
 	async skipSiteAcceleratorAndContinue() {
-		return await this.click( 'a:not(.is-primary)[href*="recommendations/summary"]' );
+		return await this.click( 'a[href*="recommendations/summary"] >> text="Not now"' );
 	}
 
 	async isSummaryContentVisible() {

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
@@ -103,19 +103,19 @@ export default class RecommendationsPage extends WpPage {
 	}
 
 	async isPersonalSiteTypeChecked() {
-		return await this.isElementVisible( `${ this.siteTypePersonalCheckboxSel }:checked` );
+		return await this.isElementChecked( this.siteTypePersonalCheckboxSel );
 	}
 
 	async isOtherSiteTypeChecked() {
-		return await this.isElementVisible( `${ this.siteTypeOtherCheckboxSel }:checked` );
+		return await this.isElementChecked( this.siteTypeOtherCheckboxSel );
 	}
 
 	async isBusinessTypeUnchecked() {
-		return await this.isElementVisible( `${ this.siteTypeBusinessCheckboxSel }:checked` );
+		return await this.isElementChecked( this.siteTypeBusinessCheckboxSel );
 	}
 
 	async isStoreTypeUnchecked() {
-		return await this.isElementVisible( `${ this.siteTypeStoreCheckboxSel }:checked` );
+		return await this.isElementChecked( this.siteTypeStoreCheckboxSel );
 	}
 
 	async saveSiteTypeAndContinue() {

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
@@ -24,7 +24,7 @@ export default class RecommendationsPage extends WpPage {
 		return await this.waitForElementToBeVisible( siteTypeQuestionsSelector );
 	}
 
-	async checkPersonaSiteType() {
+	async checkPersonalSiteType() {
 		const personalSiteTypeSelector = PERSONAL_CHECKBOX_SELECTOR;
 		return await this.click( personalSiteTypeSelector );
 	}

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
@@ -3,16 +3,87 @@
  */
 import WpPage from '../wp-page';
 
-const PERSONAL_CHECKBOX_SELECTOR = '.jp-checkbox-answer__container:nth-child(1) input';
-const BUSINESS_CHECKBOX_SELECTOR = '.jp-checkbox-answer__container:nth-child(2) input';
-const STORE_CHECKBOX_SELECTOR = '.jp-checkbox-answer__container:nth-child(3) input';
-const OTHER_CHECKBOX_SELECTOR = '.jp-checkbox-answer__container:nth-child(4) input';
-
 export default class RecommendationsPage extends WpPage {
 	constructor( page ) {
 		const url = `${ siteUrl }/wp-admin/admin.php?page=jetpack#/recommendations`;
 		super( page, { expectedSelectors: [ '[class^=jp-recommendations-]' ], url } );
 	}
+
+	// selectors section
+
+	get siteTypeCheckboxesSel() {
+		return '.jp-recommendations-question__site-type-checkboxes';
+	}
+
+	get siteTypePersonalCheckboxSel() {
+		return '.jp-checkbox-answer__container:nth-child(1) input';
+	}
+
+	get siteTypeBusinessCheckboxSel() {
+		return '.jp-checkbox-answer__container:nth-child(2) input';
+	}
+
+	get siteTypeOtherCheckboxSel() {
+		return '.jp-checkbox-answer__container:nth-child(4) input';
+	}
+
+	get siteTypeStoreCheckboxSel() {
+		return '.jp-checkbox-answer__container:nth-child(3) input';
+	}
+
+	get saveSiteTypeButtonSel() {
+		return 'a[href*="recommendations/monitor"] >> text="Continue"';
+	}
+
+	get enableMonitoringButtonSel() {
+		return 'a[href*="recommendations/related-posts"] >> text="Enable Downtime Monitoring"';
+	}
+
+	get enableRelatedPostsButtonSel() {
+		return 'a[href*="recommendations/creative-mail"] >> text="Enable Related Posts"';
+	}
+
+	get installCreativeMailButtonSel() {
+		return 'a[href*="recommendations/site-accelerator"] >> text="Install Creative Mail"';
+	}
+
+	get skipCreativeMailButtonSel() {
+		return 'a[href*="recommendations/site-accelerator"] >> text="Not now"';
+	}
+
+	get enableSiteAcceleratorButtonSel() {
+		return 'a[href*="recommendations/summary"] >> text="Enable Site Accelerator"';
+	}
+
+	get skipSiteAcceleratorButtonSel() {
+		return 'a[href*="recommendations/summary"] >> text="Not now"';
+	}
+
+	get summaryContentSel() {
+		return '.jp-recommendations-summary__content';
+	}
+
+	get summarySidebarSel() {
+		return '.jp-recommendations-summary__sidebar';
+	}
+
+	get monitoringFeatureEnabledSel() {
+		return '.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Downtime Monitoring"';
+	}
+
+	get relatedPostsFeatureEnabledSel() {
+		return '.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Related Posts"';
+	}
+
+	get creativeMailFeatureNotEnabledSel() {
+		return '.jp-recommendations-feature-summary:not(.is-feature-enabled) >> a >> text="Creative Mail"';
+	}
+
+	get siteAcceleratorFeatureNotEnabledSel() {
+		return '.jp-recommendations-feature-summary:not(.is-feature-enabled) >> a >> text="Site Accelerator"';
+	}
+
+	// end selectors section
 
 	isUrlInSyncWithStepName( stepName ) {
 		const url = this.page.url();
@@ -20,117 +91,90 @@ export default class RecommendationsPage extends WpPage {
 	}
 
 	async areSiteTypeQuestionsVisible() {
-		const siteTypeQuestionsSelector = '.jp-recommendations-question__site-type-checkboxes';
-		return await this.waitForElementToBeVisible( siteTypeQuestionsSelector );
+		return await this.waitForElementToBeVisible( this.siteTypeCheckboxesSel );
 	}
 
 	async checkPersonalSiteType() {
-		const personalSiteTypeSelector = PERSONAL_CHECKBOX_SELECTOR;
-		return await this.click( personalSiteTypeSelector );
+		return await this.click( this.siteTypePersonalCheckboxSel );
 	}
 
 	async checkOtherSiteType() {
-		const otherSiteTypeSelector = OTHER_CHECKBOX_SELECTOR;
-		return await this.click( otherSiteTypeSelector );
+		return await this.click( this.siteTypeOtherCheckboxSel );
 	}
 
 	async isPersonalSiteTypeChecked() {
-		return await this.isElementVisible( `${ PERSONAL_CHECKBOX_SELECTOR }:checked` );
+		return await this.isElementVisible( `${ this.siteTypePersonalCheckboxSel }:checked` );
 	}
 
 	async isOtherSiteTypeChecked() {
-		return await this.isElementVisible( `${ OTHER_CHECKBOX_SELECTOR }:checked` );
+		return await this.isElementVisible( `${ this.siteTypeOtherCheckboxSel }:checked` );
 	}
 
 	async isBusinessTypeUnchecked() {
-		return await this.isElementVisible( `${ BUSINESS_CHECKBOX_SELECTOR }:checked` );
+		return await this.isElementVisible( `${ this.siteTypeBusinessCheckboxSel }:checked` );
 	}
 
 	async isStoreTypeUnchecked() {
-		return await this.isElementVisible( `${ STORE_CHECKBOX_SELECTOR }:checked` );
+		return await this.isElementVisible( `${ this.siteTypeStoreCheckboxSel }:checked` );
 	}
 
 	async saveSiteTypeAndContinue() {
-		return await this.click( 'a[href*="recommendations/monitor"] >> text="Continue"' );
+		return await this.click( this.saveSiteTypeButtonSel );
 	}
 
 	async isEnableMonitoringButtonVisible() {
-		return await this.isElementVisible(
-			'a[href*="recommendations/related-posts"] >> text="Enable Downtime Monitoring"'
-		);
+		return await this.isElementVisible( this.enableMonitoringButtonSel );
 	}
 
 	async enableMonitoringAndContinue() {
-		return await this.click(
-			'a[href*="recommendations/related-posts"] >> text="Enable Downtime Monitoring"'
-		);
+		return await this.click( this.enableMonitoringButtonSel );
 	}
 
 	async isEnableRelatedPostsButtonVisible() {
-		return await this.isElementVisible(
-			'a[href*="recommendations/creative-mail"] >> text="Enable Related Posts"'
-		);
+		return await this.isElementVisible( this.enableRelatedPostsButtonSel );
 	}
 
 	async enableRelatedPostsAndContinue() {
-		return await this.click(
-			'a[href*="recommendations/creative-mail"] >> text="Enable Related Posts"'
-		);
+		return await this.click( this.enableRelatedPostsButtonSel );
 	}
 
 	async isInstallCreativeMailButtonVisible() {
-		return await this.isElementVisible(
-			'a[href*="recommendations/site-accelerator"] >> text="Install Creative Mail"'
-		);
+		return await this.isElementVisible( this.installCreativeMailButtonSel );
 	}
 
 	async skipCreativeMailAndContinue() {
-		return await this.click( 'a[href*="recommendations/site-accelerator"] >> text="Not now"' );
+		return await this.click( this.skipCreativeMailButtonSel );
 	}
 
 	async isEnableSiteAcceleratorButtonVisible() {
-		return await this.isElementVisible(
-			'a[href*="recommendations/summary"] >> text="Enable Site Accelerator"'
-		);
+		return await this.isElementVisible( this.enableSiteAcceleratorButtonSel );
 	}
 
 	async skipSiteAcceleratorAndContinue() {
-		return await this.click( 'a[href*="recommendations/summary"] >> text="Not now"' );
+		return await this.click( this.skipSiteAcceleratorButtonSel );
 	}
 
 	async isSummaryContentVisible() {
-		return await this.isElementVisible( '.jp-recommendations-summary__content' );
+		return await this.isElementVisible( this.summaryContentSel );
 	}
 
 	async isSummarySidebarVisible() {
-		return await this.isElementVisible( '.jp-recommendations-summary__sidebar' );
+		return await this.isElementVisible( this.summarySidebarSel );
 	}
 
 	async isMonitoringFeatureEnabled() {
-		const monitorFeatureEnabledSelector =
-			'.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Downtime Monitoring"';
-
-		return await this.isElementVisible( monitorFeatureEnabledSelector );
+		return await this.isElementVisible( this.monitoringFeatureEnabledSel );
 	}
 
 	async isRelatedPostsFeatureEnabled() {
-		const relatedPostsFeatureEnabledSelector =
-			'.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Related Posts"';
-
-		return await this.isElementVisible( relatedPostsFeatureEnabledSelector );
+		return await this.isElementVisible( this.relatedPostsFeatureEnabledSel );
 	}
 
 	async isCreativeMailFeatureEnabled() {
-		const creativeMailFeatureEnabledSelector =
-			'.jp-recommendations-feature-summary:not(.is-feature-enabled) >> a >> text="Creative Mail"';
-
-		return await this.isElementVisible( creativeMailFeatureEnabledSelector );
+		return await this.isElementVisible( this.creativeMailFeatureNotEnabledSel );
 	}
 
 	async isSiteAcceleratorFeatureEnabled() {
-		const siteAcceleratorFeatureEnabledSelector =
-			'.jp-recommendations-feature-summary:not(.is-feature-enabled) >> a >> text="Site Accelerator"';
-
-		return await this.isElementVisible( siteAcceleratorFeatureEnabledSelector );
+		return await this.isElementVisible( this.siteAcceleratorFeatureNotEnabledSel );
 	}
 }

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
@@ -1,0 +1,124 @@
+/**
+ * Internal dependencies
+ */
+import WpPage from '../wp-page';
+
+const PERSONAL_CHECKBOX_SELECTOR = '.jp-checkbox-answer__container:nth-child(1) input';
+const BUSINESS_CHECKBOX_SELECTOR = '.jp-checkbox-answer__container:nth-child(2) input';
+const STORE_CHECKBOX_SELECTOR = '.jp-checkbox-answer__container:nth-child(3) input';
+const OTHER_CHECKBOX_SELECTOR = '.jp-checkbox-answer__container:nth-child(4) input';
+
+export default class RecommendationsPage extends WpPage {
+	constructor( page ) {
+		const url = `${ siteUrl }/wp-admin/admin.php?page=jetpack#/recommendations`;
+		super( page, { expectedSelectors: [ '[class^=jp-recommendations-]' ], url } );
+	}
+
+	isUrlInSyncWithStepName( stepName ) {
+		const url = this.page.url();
+		return url.includes( stepName );
+	}
+
+	async areSiteTypeQuestionsVisible() {
+		const siteTypeQuestionsSelector = '.jp-recommendations-question__site-type-checkboxes';
+		return await this.waitForElementToBeVisible( siteTypeQuestionsSelector );
+	}
+
+	async checkPersonaSiteType() {
+		const personalSiteTypeSelector = PERSONAL_CHECKBOX_SELECTOR;
+		return await this.click( personalSiteTypeSelector );
+	}
+
+	async checkOtherSiteType() {
+		const otherSiteTypeSelector = OTHER_CHECKBOX_SELECTOR;
+		return await this.click( otherSiteTypeSelector );
+	}
+
+	async isPersonalSiteTypeChecked() {
+		return await this.isElementVisible( `${ PERSONAL_CHECKBOX_SELECTOR }:checked` );
+	}
+
+	async isOtherSiteTypeChecked() {
+		return await this.isElementVisible( `${ OTHER_CHECKBOX_SELECTOR }:checked` );
+	}
+
+	async isBusinessTypeUnchecked() {
+		return await this.isElementVisible( `${ BUSINESS_CHECKBOX_SELECTOR }:checked` );
+	}
+
+	async isStoreTypeUnchecked() {
+		return await this.isElementVisible( `${ STORE_CHECKBOX_SELECTOR }:checked` );
+	}
+
+	async saveSiteTypeAndContinue() {
+		return await this.click( 'a.is-primary[href*="recommendations/monitor"]' );
+	}
+
+	async isEnableMonitoringButtonVisible() {
+		return await this.isElementVisible( 'a.is-primary[href*="recommendations/related-posts"]' );
+	}
+
+	async enableMonitoringAndContinue() {
+		return await this.click( 'a.is-primary[href*="recommendations/related-posts"]' );
+	}
+
+	async isEnableRelatedPostsButtonVisible() {
+		return await this.isElementVisible( 'a.is-primary[href*="recommendations/creative-mail"]' );
+	}
+
+	async enableRelatedPostsAndContinue() {
+		return await this.click( 'a.is-primary[href*="recommendations/creative-mail"]' );
+	}
+
+	async isInstallCreativeMailButtonVisible() {
+		return await this.isElementVisible( 'a.is-primary[href*="recommendations/site-accelerator"]' );
+	}
+
+	async skipCreativeMailAndContinue() {
+		return await this.click( 'a:not(.is-primary)[href*="recommendations/site-accelerator"]' );
+	}
+
+	async isEnableSiteAcceleratorButtonVisible() {
+		return await this.isElementVisible( 'a.is-primary[href*="recommendations/summary"]' );
+	}
+
+	async skipSiteAcceleratorAndContinue() {
+		return await this.click( 'a:not(.is-primary)[href*="recommendations/summary"]' );
+	}
+
+	async isSummaryContentVisible() {
+		return await this.isElementVisible( '.jp-recommendations-summary__content' );
+	}
+
+	async isSummarySidebarVisible() {
+		return await this.isElementVisible( '.jp-recommendations-summary__sidebar' );
+	}
+
+	async isMonitoringFeatureEnabled() {
+		const monitorFeatureEnabledSelector =
+			'.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Downtime Monitoring"';
+
+		return await this.isElementVisible( monitorFeatureEnabledSelector );
+	}
+
+	async isRelatedPostsFeatureEnabled() {
+		const relatedPostsFeatureEnabledSelector =
+			'.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Related Posts"';
+
+		return await this.isElementVisible( relatedPostsFeatureEnabledSelector );
+	}
+
+	async isCreativeMailFeatureEnabled() {
+		const creativeMailFeatureEnabledSelector =
+			'.jp-recommendations-feature-summary:not(.is-feature-enabled) >> a >> text="Creative Mail"';
+
+		return await this.isElementVisible( creativeMailFeatureEnabledSelector );
+	}
+
+	async isSiteAcceleratorFeatureEnabled() {
+		const siteAcceleratorFeatureEnabledSelector =
+			'.jp-recommendations-feature-summary:not(.is-feature-enabled) >> a >> text="Site Accelerator"';
+
+		return await this.isElementVisible( siteAcceleratorFeatureEnabledSelector );
+	}
+}

--- a/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
@@ -32,6 +32,8 @@ describe( 'Jetpack Recommendations', () => {
 
 		await step( 'Save answers and continue to the Monitor step', async () => {
 			await recommendationsPage.saveSiteTypeAndContinue();
+			await recommendationsPage.reload();
+			await recommendationsPage.waitForNetworkIdle();
 			const isMonitorStep = await recommendationsPage.isEnableMonitoringButtonVisible();
 			expect( isMonitorStep ).toBeTruthy();
 			expect( recommendationsPage.isUrlInSyncWithStepName( 'monitor' ) ).toBeTruthy();
@@ -39,6 +41,8 @@ describe( 'Jetpack Recommendations', () => {
 
 		await step( 'Enable Monitoring and continue to Related Post step', async () => {
 			await recommendationsPage.enableMonitoringAndContinue();
+			await recommendationsPage.reload();
+			await recommendationsPage.waitForNetworkIdle();
 			const isRelatedPostsStep = await recommendationsPage.isEnableRelatedPostsButtonVisible();
 			expect( isRelatedPostsStep ).toBeTruthy();
 			expect( recommendationsPage.isUrlInSyncWithStepName( 'related-posts' ) ).toBeTruthy();
@@ -46,6 +50,8 @@ describe( 'Jetpack Recommendations', () => {
 
 		await step( 'Enable Related Posts and continue to Creative Mail step', async () => {
 			await recommendationsPage.enableRelatedPostsAndContinue();
+			await recommendationsPage.reload();
+			await recommendationsPage.waitForNetworkIdle();
 			const isCreativeMailStep = await recommendationsPage.isInstallCreativeMailButtonVisible();
 			expect( isCreativeMailStep ).toBeTruthy();
 			expect( recommendationsPage.isUrlInSyncWithStepName( 'creative-mail' ) ).toBeTruthy();
@@ -53,6 +59,8 @@ describe( 'Jetpack Recommendations', () => {
 
 		await step( 'Skip Creative Mail and continue to Site Accelerator', async () => {
 			await recommendationsPage.skipCreativeMailAndContinue();
+			await recommendationsPage.reload();
+			await recommendationsPage.waitForNetworkIdle();
 			const isSiteAcceleratorStep = await recommendationsPage.isEnableSiteAcceleratorButtonVisible();
 			expect( isSiteAcceleratorStep ).toBeTruthy();
 			expect( recommendationsPage.isUrlInSyncWithStepName( 'site-accelerator' ) ).toBeTruthy();
@@ -60,7 +68,6 @@ describe( 'Jetpack Recommendations', () => {
 
 		await step( 'Skip Site Accelerator and continue to Summary', async () => {
 			await recommendationsPage.skipSiteAcceleratorAndContinue();
-			await recommendationsPage.reload();
 			await recommendationsPage.reload();
 			await recommendationsPage.waitForNetworkIdle();
 			const isSummaryContent = await recommendationsPage.isSummaryContentVisible();

--- a/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
@@ -1,0 +1,84 @@
+/**
+ * Internal dependencies
+ */
+import { step } from '../lib/env/test-setup';
+import RecommendationsPage from '../lib/pages/wp-admin/recommendations';
+
+describe( 'Jetpack Recommendations', () => {
+	it( 'Steps', async () => {
+		const recommendationsPage = await RecommendationsPage.visit( page );
+
+		await step( 'Navigate to the Recommendations module', async () => {
+			const isPageVisible = await recommendationsPage.areSiteTypeQuestionsVisible();
+			expect( isPageVisible ).toBeTruthy();
+			expect( recommendationsPage.isUrlInSyncWithStepName( 'site-type' ) ).toBeTruthy();
+		} );
+
+		await step( 'Check Personal and Other checkboxes', async () => {
+			await recommendationsPage.checkPersonaSiteType();
+			await recommendationsPage.checkOtherSiteType();
+
+			const isPersonalAndOtherChecked =
+				( await recommendationsPage.isPersonalSiteTypeChecked() ) &&
+				( await recommendationsPage.isOtherSiteTypeChecked() );
+
+			const isBusinessAndStoreChecked =
+				( await recommendationsPage.isBusinessTypeUnchecked() ) &&
+				( await recommendationsPage.isStoreTypeUnchecked() );
+
+			expect( isPersonalAndOtherChecked ).toBeTruthy();
+			expect( isBusinessAndStoreChecked ).toBeFalsy();
+		} );
+
+		await step( 'Save answers and continue to the Monitor step', async () => {
+			await recommendationsPage.saveSiteTypeAndContinue();
+			const isMonitorStep = await recommendationsPage.isEnableMonitoringButtonVisible();
+			expect( isMonitorStep ).toBeTruthy();
+			expect( recommendationsPage.isUrlInSyncWithStepName( 'monitor' ) ).toBeTruthy();
+		} );
+
+		await step( 'Enable Monitoring and continue to Related Post step', async () => {
+			await recommendationsPage.enableMonitoringAndContinue();
+			const isRelatedPostsStep = await recommendationsPage.isEnableRelatedPostsButtonVisible();
+			expect( isRelatedPostsStep ).toBeTruthy();
+			expect( recommendationsPage.isUrlInSyncWithStepName( 'related-posts' ) ).toBeTruthy();
+		} );
+
+		await step( 'Enable Related Posts and continue to Creative Mail step', async () => {
+			await recommendationsPage.enableRelatedPostsAndContinue();
+			const isCreativeMailStep = await recommendationsPage.isInstallCreativeMailButtonVisible();
+			expect( isCreativeMailStep ).toBeTruthy();
+			expect( recommendationsPage.isUrlInSyncWithStepName( 'creative-mail' ) ).toBeTruthy();
+		} );
+
+		await step( 'Skip Creative Mail and continue to Site Accelerator', async () => {
+			await recommendationsPage.skipCreativeMailAndContinue();
+			const isSiteAcceleratorStep = await recommendationsPage.isEnableSiteAcceleratorButtonVisible();
+			expect( isSiteAcceleratorStep ).toBeTruthy();
+			expect( recommendationsPage.isUrlInSyncWithStepName( 'site-accelerator' ) ).toBeTruthy();
+		} );
+
+		await step( 'Skip Site Accelerator and continue to Summary', async () => {
+			await recommendationsPage.skipSiteAcceleratorAndContinue();
+			await recommendationsPage.reload();
+			await recommendationsPage.reload();
+			await recommendationsPage.waitForNetworkIdle();
+			const isSummaryContent = await recommendationsPage.isSummaryContentVisible();
+			const isSummarySidebar = await recommendationsPage.isSummarySidebarVisible();
+			expect( isSummaryContent && isSummarySidebar ).toBeTruthy();
+			expect( recommendationsPage.isUrlInSyncWithStepName( 'summary' ) ).toBeTruthy();
+		} );
+
+		await step( 'Verify Monitoring and Related Posts are enabled', async () => {
+			const isMonitoringFeatureEnabled = await recommendationsPage.isMonitoringFeatureEnabled();
+			const isRelatedPostsFeatureEnabled = await recommendationsPage.isRelatedPostsFeatureEnabled();
+			expect( isMonitoringFeatureEnabled && isRelatedPostsFeatureEnabled ).toBeTruthy();
+		} );
+
+		await step( 'Verify Creative Mail and Site Accelerator are disabled', async () => {
+			const isCreativeMailFeatureEnabled = await recommendationsPage.isCreativeMailFeatureEnabled();
+			const isSiteAcceleratorFeatureEnabled = await recommendationsPage.isSiteAcceleratorFeatureEnabled();
+			expect( isCreativeMailFeatureEnabled && isSiteAcceleratorFeatureEnabled ).toBeTruthy();
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
@@ -15,7 +15,7 @@ describe( 'Jetpack Recommendations', () => {
 		} );
 
 		await step( 'Check Personal and Other checkboxes', async () => {
-			await recommendationsPage.checkPersonaSiteType();
+			await recommendationsPage.checkPersonalSiteType();
 			await recommendationsPage.checkOtherSiteType();
 
 			const isPersonalAndOtherChecked =

--- a/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
@@ -4,8 +4,8 @@
 import { step } from '../lib/env/test-setup';
 import RecommendationsPage from '../lib/pages/wp-admin/recommendations';
 
-describe( 'Jetpack Recommendations', () => {
-	it( 'Steps', async () => {
+describe( 'Recommendations (Jetpack Assistant)', () => {
+	it( 'Recommendations (Jetpack Assistant)', async () => {
 		const recommendationsPage = await RecommendationsPage.visit( page );
 
 		await step( 'Navigate to the Recommendations module', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related to 1200070516266605-as-1200070517042904

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add an e2e that covers the main flow of the Recommendations module (Jetpack Assistant). Specifically, it does the following: makes sure all steps are presented to the user, enables Downtime Monitoring and Related Posts, and makes sure that the Summary reflects the previous selection.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This doesn't bring changes to the product, it only adds unit tests to the Recommendations module.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. It doesn't change what data or activity we track or use.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review: make sure the test is readable and that its assertions make sense.

* `cd` into `jetpack/projects/plugins/jetpack/tests/e2e`.
* Run `yarn test-e2e ./specs/recommendations.test.js` to run the test in headless mode or `HEADLESS=false yarn test-e2e ./specs/recommendations.test.js` if you want to see it in action.
* Make sure the test pass. You should see an output like this:

```
2021-04-07 17:36:03 info: TEST PASSED: Jetpack Recommendations - Steps
 PASS  specs/recommendations.test.js (104.614 s)
  Jetpack Recommendations
    ✓ Steps (14646 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        104.888 s, estimated 112 s
Ran all test suites matching /.\/specs\/recommendations.test.js/i.
```