### PR TITLE
Jetpack Assistant (Recommendations): track the product slug of the product being upsold

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/product-card-upsell/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/product-card-upsell/index.jsx
@@ -30,20 +30,23 @@ const ProductCardUpsell = props => {
 		features,
 		header,
 		price,
+		product_slug,
 		title,
 	} = upsell;
 
 	useEffect( () => {
 		analytics.tracks.recordEvent( 'jetpack_recommendations_summary_sidebar_display', {
 			type: 'upsell_with_price',
+			product_slug,
 		} );
-	}, [] );
+	}, [ product_slug ] );
 
 	const onUpsellClick = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_recommendations_summary_sidebar_click', {
 			type: 'upsell_with_price',
+			product_slug,
 		} );
-	}, [] );
+	}, [ product_slug ] );
 
 	const currencyObject = getCurrencyObject( price, currency_code );
 

--- a/projects/plugins/jetpack/changelog/add-product-slug-jetpack-assistant-event
+++ b/projects/plugins/jetpack/changelog/add-product-slug-jetpack-assistant-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack Assistant: Add the product slug to the events dispatched when users see and click the product being upsold


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related to 1200070516266605-as-1200070517042933

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add the product slug to the events dispatched when users see and click the product being upsold. These events are `jetpack_recommendations_summary_sidebar_display` and `jetpack_recommendations_summary_sidebar_click`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* This PR doesn't change the UX in any way, it only adds more information to the events we already track.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

* Yes. This PR adds the product slug to the information we already track about the `jetpack_recommendations_summary_sidebar_display` and `jetpack_recommendations_summary_sidebar_click` events.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D59927-code to your WP.com sandbox.
* Select a Jetpack site that doesn't have any paid plan.
* Configure `JETPACK__SANDBOX_DOMAIN` to make your Jetpack site send its request to your WP.com sandbox rather than to WordPress.coms.
* On your wp-admin, go through the Recommendation module (Jetpack Assistant) and skip all features (it doesn't matter what you enable or skip).
* Make sure that you see Jetpack Backup Daily on the right of the screen.
* Open the Network tab of your browser.
* Refresh the page.
* Verify that the `jetpack_recommendations_summary_sidebar_display` event was dispatched and that it includes the `product_slug` property.
* Click the Jetpack Backup Daily upgrade button.
* Verify that the `jetpack_recommendations_summary_sidebar_click` event was dispatched and that it includes the `product_slug` property.