### PR TITLE
Search: Fix race condition for API responses

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-api-race-condition
+++ b/projects/plugins/jetpack/changelog/fix-search-api-race-condition
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Search: Fix race condition for API responses

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -59,9 +59,13 @@ class SearchApp extends Component {
 	}
 
 	componentDidMount() {
+		// Do not flush this debounced invocation.
+		// By debouncing this upon mounting, we avoid making unnecessary requests.
+		//
+		// E.g. Given `/?s=apple`, the search app will mount with search query "" and invoke getResults.
+		//      Once our Redux effects have executed, the search query will be updated to "apple" and
+		//      getResults will be invoked once more.
 		this.getResults();
-		this.getResults.flush();
-
 		this.addEventListeners();
 		this.disableAutocompletion();
 

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -59,7 +59,6 @@ class SearchApp extends Component {
 	}
 
 	componentDidMount() {
-		// Do not flush this debounced invocation.
 		// By debouncing this upon mounting, we avoid making unnecessary requests.
 		//
 		// E.g. Given `/?s=apple`, the search app will mount with search query "" and invoke getResults.

--- a/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
@@ -18,14 +18,16 @@ export function makeSearchRequest( options ) {
  * @param {object} params - Input parameters.
  * @param {object} params.options - Action options that generated this API response.
  * @param {object} params.response - API response.
+ * @param {object} params._id - Sequential ID used to determine recency of the response.
  *
  * @returns {object} Action object.
  */
-export function recordSuccessfulSearchRequest( { options, response } ) {
+export function recordSuccessfulSearchRequest( { options, response, _id } ) {
 	return {
 		type: 'RECORD_SUCCESSFUL_SEARCH_REQUEST',
 		options,
 		response,
+		_id,
 	};
 }
 

--- a/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
@@ -18,16 +18,16 @@ export function makeSearchRequest( options ) {
  * @param {object} params - Input parameters.
  * @param {object} params.options - Action options that generated this API response.
  * @param {object} params.response - API response.
- * @param {object} params._id - Sequential ID used to determine recency of the response.
+ * @param {object} params.responseId - Sequential ID used to determine recency of the response.
  *
  * @returns {object} Action object.
  */
-export function recordSuccessfulSearchRequest( { options, response, _id } ) {
+export function recordSuccessfulSearchRequest( { options, response, responseId } ) {
 	return {
 		type: 'RECORD_SUCCESSFUL_SEARCH_REQUEST',
 		options,
 		response,
-		_id,
+		responseId,
 	};
 }
 

--- a/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/actions.js
@@ -18,16 +18,14 @@ export function makeSearchRequest( options ) {
  * @param {object} params - Input parameters.
  * @param {object} params.options - Action options that generated this API response.
  * @param {object} params.response - API response.
- * @param {object} params.responseId - Sequential ID used to determine recency of the response.
  *
  * @returns {object} Action object.
  */
-export function recordSuccessfulSearchRequest( { options, response, responseId } ) {
+export function recordSuccessfulSearchRequest( { options, response } ) {
 	return {
 		type: 'RECORD_SUCCESSFUL_SEARCH_REQUEST',
 		options,
 		response,
-		responseId,
 	};
 }
 

--- a/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
@@ -14,6 +14,8 @@ import {
 	setSort,
 } from './actions';
 
+let RESPONSE_ID = 0;
+
 /**
  * Effect handler which will fetch search results from the API.
  *
@@ -28,7 +30,10 @@ function makeSearchAPIRequest( action, store ) {
 				return;
 			}
 
-			store.dispatch( recordSuccessfulSearchRequest( { options: action.options, response } ) );
+			store.dispatch(
+				recordSuccessfulSearchRequest( { options: action.options, response, _id: RESPONSE_ID } )
+			);
+			RESPONSE_ID++;
 		} )
 		.catch( error => {
 			// eslint-disable-next-line no-console

--- a/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
@@ -14,7 +14,7 @@ import {
 	setSort,
 } from './actions';
 
-let responseCounter = 0;
+let requestCounter = 0;
 
 /**
  * Effect handler which will fetch search results from the API.
@@ -23,21 +23,15 @@ let responseCounter = 0;
  * @param {object} store -  Store instance.
  */
 function makeSearchAPIRequest( action, store ) {
-	search( action.options )
+	requestCounter++;
+	search( action.options, requestCounter )
 		.then( response => {
 			if ( response === null ) {
 				// Request has been cancelled by a more recent request.
 				return;
 			}
 
-			store.dispatch(
-				recordSuccessfulSearchRequest( {
-					options: action.options,
-					response,
-					responseId: responseCounter,
-				} )
-			);
-			responseCounter++;
+			store.dispatch( recordSuccessfulSearchRequest( { options: action.options, response } ) );
 		} )
 		.catch( error => {
 			// eslint-disable-next-line no-console

--- a/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/effects.js
@@ -14,7 +14,7 @@ import {
 	setSort,
 } from './actions';
 
-let RESPONSE_ID = 0;
+let responseCounter = 0;
 
 /**
  * Effect handler which will fetch search results from the API.
@@ -31,9 +31,13 @@ function makeSearchAPIRequest( action, store ) {
 			}
 
 			store.dispatch(
-				recordSuccessfulSearchRequest( { options: action.options, response, _id: RESPONSE_ID } )
+				recordSuccessfulSearchRequest( {
+					options: action.options,
+					response,
+					responseId: responseCounter,
+				} )
 			);
-			RESPONSE_ID++;
+			responseCounter++;
 		} )
 		.catch( error => {
 			// eslint-disable-next-line no-console

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/api.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/api.js
@@ -49,7 +49,12 @@ export function isLoading( state = false, action ) {
 export function response( state = {}, action ) {
 	switch ( action.type ) {
 		case 'RECORD_SUCCESSFUL_SEARCH_REQUEST': {
-			const newState = { ...action.response };
+			// A more recent response has already been saved.
+			if ( '_id' in state && state._id >= action._id ) {
+				return state;
+			}
+
+			const newState = { ...action.response, _id: action._id };
 			// For paginated results, merge previous search results with new search results.
 			if ( action.options.pageHandle ) {
 				newState.aggregations = {

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/api.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/api.js
@@ -50,11 +50,15 @@ export function response( state = {}, action ) {
 	switch ( action.type ) {
 		case 'RECORD_SUCCESSFUL_SEARCH_REQUEST': {
 			// A more recent response has already been saved.
-			if ( 'id' in state && state.id > action.responseId ) {
+			if (
+				'requestId' in state &&
+				'requestId' in action.response &&
+				state.requestId > action.response.requestId
+			) {
 				return state;
 			}
 
-			const newState = { ...action.response, id: action.responseId };
+			const newState = { ...action.response };
 			// For paginated results, merge previous search results with new search results.
 			if ( action.options.pageHandle ) {
 				newState.aggregations = {

--- a/projects/plugins/jetpack/modules/search/instant-search/store/reducer/api.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/reducer/api.js
@@ -50,11 +50,11 @@ export function response( state = {}, action ) {
 	switch ( action.type ) {
 		case 'RECORD_SUCCESSFUL_SEARCH_REQUEST': {
 			// A more recent response has already been saved.
-			if ( '_id' in state && state._id >= action._id ) {
+			if ( 'id' in state && state.id > action.responseId ) {
 				return state;
 			}
 
-			const newState = { ...action.response, _id: action._id };
+			const newState = { ...action.response, id: action.responseId };
 			// For paginated results, merge previous search results with new search results.
 			if ( action.options.pageHandle ) {
 				newState.aggregations = {

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -145,16 +145,15 @@ describe( 'response Reducer', () => {
 	} );
 	test( 'ignores responses older than the current response', () => {
 		const initialState = {
-			id: 1,
+			requestId: 1,
 			aggregations: { taxonomy_1: { buckets: [] } },
 			results: [ { id: 2, result_type: 'page' } ],
 		};
 		const state = response(
 			initialState,
 			recordSuccessfulSearchRequest( {
-				responseId: 0,
 				options: actionOptions,
-				response: actionResponse,
+				response: { ...actionResponse, requestId: 0 },
 			} )
 		);
 		expect( state ).toEqual( initialState );

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -143,6 +143,22 @@ describe( 'response Reducer', () => {
 			results: [ { id: 2, result_type: 'page' } ],
 		} );
 	} );
+	test( 'ignores responses older than the current response', () => {
+		const initialState = {
+			_id: 1,
+			aggregations: { taxonomy_1: { buckets: [] } },
+			results: [ { id: 2, result_type: 'page' } ],
+		};
+		const state = response(
+			initialState,
+			recordSuccessfulSearchRequest( {
+				_id: 0,
+				options: actionOptions,
+				response: actionResponse,
+			} )
+		);
+		expect( state ).toEqual( initialState );
+	} );
 } );
 
 describe( 'searchQuery Reducer', () => {

--- a/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/store/test/reducer.test.js
@@ -145,14 +145,14 @@ describe( 'response Reducer', () => {
 	} );
 	test( 'ignores responses older than the current response', () => {
 		const initialState = {
-			_id: 1,
+			id: 1,
 			aggregations: { taxonomy_1: { buckets: [] } },
 			results: [ { id: 2, result_type: 'page' } ],
 		};
 		const state = response(
 			initialState,
 			recordSuccessfulSearchRequest( {
-				_id: 0,
+				responseId: 0,
 				options: actionOptions,
 				response: actionResponse,
 			} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Currently, it's possible for stale API responses to overwrite newer API responses. As a fix, this PR makes two changes:

1) Attaches a client-generated sequential ID to each API response to determine whether or not to evict the existing response stored in the Redux store.
2) Prevents the `getResults` denounce from being flushed upon SearchApp mounting.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Directly navigate to a search page (e.g. `?s=apples`).
* Ensure that only one search API response is recorded in the browser network console.
* Ensure that an older API response never overwrites a newer API response; this might be hard to reproduce. To make this easier, you can apply [this patch](https://gist.github.com/jsnmoon/3ac884d0c27c2dcb7ec79f21e46b017e) to add some randomized delay to each API response. 