### PR TITLE
Search: Enable link filtering on built-in WP taxonomies

### DIFF
--- a/projects/plugins/jetpack/changelog/update-search-custom-filter-link-and-built-in-taxonomies
+++ b/projects/plugins/jetpack/changelog/update-search-custom-filter-link-and-built-in-taxonomies
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Search: Enable link filtering on built-in WP taxonomies

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.jsx
@@ -18,6 +18,7 @@ import './search-filters.scss';
 class SearchFilters extends Component {
 	static defaultProps = {
 		showClearFiltersButton: true,
+		showTitle: true,
 	};
 
 	onChangeFilter = ( filterName, filterValue ) => {
@@ -62,7 +63,9 @@ class SearchFilters extends Component {
 		const aggregations = this.props.results?.aggregations;
 		return (
 			<div className="jetpack-instant-search__search-filters">
-				<div className="jetpack-instant-search__search-filters-title">Filter options</div>
+				{ this.props.showTitle && (
+					<div className="jetpack-instant-search__search-filters-title">Filter options</div>
+				) }
 				{ this.props.showClearFiltersButton && this.hasActiveFilters() && (
 					<a
 						class="jetpack-instant-search__clear-filters-link"

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.jsx
@@ -64,7 +64,9 @@ class SearchFilters extends Component {
 		return (
 			<div className="jetpack-instant-search__search-filters">
 				{ this.props.showTitle && (
-					<div className="jetpack-instant-search__search-filters-title">Filter options</div>
+					<div className="jetpack-instant-search__search-filters-title">
+						{ __( 'Filter options', 'jetpack' ) }
+					</div>
 				) }
 				{ this.props.showClearFiltersButton && this.hasActiveFilters() && (
 					<a

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
@@ -16,8 +16,6 @@
 }
 
 .jetpack-instant-search__clear-filters-link {
-	display: block;
-	margin-bottom: 1em;
 	position: absolute;
 	right: 0;
 	top: 0;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/sidebar.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/sidebar.jsx
@@ -44,6 +44,7 @@ const Sidebar = props => {
 							postTypes={ props.postTypes }
 							results={ props.response }
 							showClearFiltersButton={ ! hasFiltersSelectedOutsideOverlay && index === 0 }
+							showTitle={ ! hasFiltersSelectedOutsideOverlay && index === 0 }
 							widget={ widget }
 						/>
 					</div>,

--- a/projects/plugins/jetpack/modules/search/instant-search/components/sidebar.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/sidebar.jsx
@@ -15,22 +15,21 @@ import JetpackColophon from './jetpack-colophon';
 import './sidebar.scss';
 
 const Sidebar = props => {
-	const hasFiltersSelectedOutsideOverlay = props.widgetOutsideOverlay.filters?.length > 0;
 	return (
 		<div className="jetpack-instant-search__sidebar">
-			{ hasFiltersSelectedOutsideOverlay && (
-				<SearchFilters
-					filters={ props.filters }
-					loading={ props.isLoading }
-					locale={ props.locale }
-					postTypes={ props.postTypes }
-					results={ props.response }
-					showClearFiltersButton={ hasFiltersSelectedOutsideOverlay }
-					widget={ props.widgetOutsideOverlay }
-				/>
-			) }
+			{ /* If widgetOutsideOverlay doesn't contain any filters,
+			     this component will just show the title and clear filters button. */ }
+			<SearchFilters
+				filters={ props.filters }
+				loading={ props.isLoading }
+				locale={ props.locale }
+				postTypes={ props.postTypes }
+				results={ props.response }
+				showClearFiltersButton={ true }
+				widget={ props.widgetOutsideOverlay }
+			/>
 			<WidgetAreaContainer />
-			{ props.widgets.map( ( widget, index ) => {
+			{ props.widgets.map( widget => {
 				// Creates portals to elements moved into the WidgetAreaContainer.
 				return createPortal(
 					<div
@@ -43,8 +42,8 @@ const Sidebar = props => {
 							locale={ props.locale }
 							postTypes={ props.postTypes }
 							results={ props.response }
-							showClearFiltersButton={ ! hasFiltersSelectedOutsideOverlay && index === 0 }
-							showTitle={ ! hasFiltersSelectedOutsideOverlay && index === 0 }
+							showClearFiltersButton={ false }
+							showTitle={ false }
 							widget={ widget }
 						/>
 					</div>,

--- a/projects/plugins/jetpack/modules/search/instant-search/components/sidebar.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/sidebar.scss
@@ -1,10 +1,12 @@
 @import '../lib/styles/_helper.scss';
 
 .jetpack-instant-search__sidebar {
+	padding-top: 14px;
+
 	.jetpack-instant-search__widget-area {
 		> .widget {
 			border: none;
-			padding: 14px 0 0 0;
+			padding: 0;
 			margin: 0;
 			background: none;
 

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/filters.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/filters.js
@@ -5,9 +5,13 @@ import { SERVER_OBJECT_NAME } from './constants';
 
 // NOTE: This list is missing custom taxonomy names.
 //       getFilterKeys must be used to get the conclusive list of valid filter keys.
-const FILTER_KEYS = Object.freeze( [
+export const FILTER_KEYS = Object.freeze( [
 	// Post types
 	'post_types',
+	// Built-in taxonomies
+	'category',
+	'post_format',
+	'post_tag',
 	// Date filters
 	'month_post_date',
 	'month_post_date_gmt',

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/test/filters.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/test/filters.test.js
@@ -5,6 +5,7 @@
  * Internal dependencies
  */
 import {
+	FILTER_KEYS,
 	getFilterKeys,
 	getSelectableFilterKeys,
 	getUnselectableFilterKeys,
@@ -12,31 +13,25 @@ import {
 } from '../filters';
 
 describe( 'getFilterKeys', () => {
-	const DEFAULT_KEYS = [
-		'post_types',
-		'month_post_date',
-		'month_post_date_gmt',
-		'month_post_modified',
-		'month_post_modified_gmt',
-		'year_post_date',
-		'year_post_date_gmt',
-		'year_post_modified',
-		'year_post_modified_gmt',
-	];
 	test( 'defaults to a fixed array when parameters are null-ish', () => {
-		expect( getFilterKeys( null, undefined ) ).toEqual( DEFAULT_KEYS );
+		expect( getFilterKeys( null, undefined ) ).toEqual( FILTER_KEYS );
 	} );
 
 	test( 'includes taxonomies from widget configurations without duplicates', () => {
 		const widgets = [
 			{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
+			{ filters: [ { type: 'taxonomy', taxonomy: 'subject' } ] },
 			{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
+			{ filters: [ { type: 'taxonomy', taxonomy: 'subject' } ] },
 			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
 			{ filters: [ { type: 'post_type' } ] },
 		];
 		const widgetsOutsideOverlay = [ { filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] } ];
 		expect( getFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [
 			'post_types',
+			'category',
+			'post_format',
+			'post_tag',
 			'month_post_date',
 			'month_post_date_gmt',
 			'month_post_modified',
@@ -45,8 +40,7 @@ describe( 'getFilterKeys', () => {
 			'year_post_date_gmt',
 			'year_post_modified',
 			'year_post_modified_gmt',
-			'category',
-			'post_tag',
+			'subject',
 		] );
 	} );
 } );
@@ -86,6 +80,8 @@ describe( 'getUnselectableFilterKeys', () => {
 			{ filters: [ { type: 'post_type' } ] },
 		];
 		expect( getUnselectableFilterKeys( widgets ) ).toEqual( [
+			'category',
+			'post_format',
 			'month_post_date',
 			'month_post_date_gmt',
 			'month_post_modified',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Enables [link filtering](https://jetpack.com/support/search/install-search-on-your-site/#add-overlay-link) on built-in WordPress taxonomies without requiring such taxonomies to be included as filters in Jetpack Search widgets.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* On a page/post, add the following HTML snippet:
```html
<a href="#" class="jetpack-search-filter__link" data-filter-type="taxonomy" data-taxonomy="post_tag" data-val="audio">Open search modal with "audio" tag filter enabled.</a>

<a href="#" class="jetpack-search-filter__link" data-filter-type="taxonomy" data-taxonomy="category" data-val="performance" >Open search modal with "performance" category filter enabled.</a>
```
* Ensure that clicking on these links open the search modal with the appropriate filters enabled.
