### PR TITLE
Cover block: fix paid-block-media-placeholder interference with flex positioning

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-cover-block-paid-block-media-placeholder-flex-child
+++ b/projects/plugins/jetpack/changelog/fix-cover-block-paid-block-media-placeholder-flex-child
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Cover block: fix paid-block-media-placeholder interference with flex positioning

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
@@ -117,6 +117,16 @@ $icon-background-color: #fff;
 // Media Placeholder
 .paid-block-media-placeholder {
 	width: 100%;
+
+	// Remove paid-block-media-placeholder from being a flexbox child
+	// when the cover block has a background set
+	.wp-block-cover &:not( :only-child ) {
+		position: absolute;
+		top: 0;
+		right: 0;
+		left: 0;
+		bottom: 0;
+	}
 }
 
 // core/cover set padding 0 with !important.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related to #19488

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a CSS rule to "remove" the `paid-block-media-placeholder` element from the flexbox layout in the cover block, when the cover block has a background set

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Initial report: p1617898513140100-slack-CBTN58FTJ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply D59965-code to your sandbox
2. Open the block editor on a site that is added to your sandbox
3. Add a cover block
    - [ ] Before adding an image or picking a background color, make sure that the cover block looks like the version currently in production ![Screenshot 2021-04-09 at 14 18 07](https://user-images.githubusercontent.com/1083581/114178749-69fad380-993e-11eb-9e25-b63c8b730186.png)
4. Pick a background color or select a background image/video from the gallery
5. Add a paragraph into the cover block and play with the cover block settings to change the position of its content
    - [ ] The content should align within the cover block as expected
6. With the cover block selected, drag a new image over the block
    - [ ] The cover block should react to the dragging, and turn into a drop target ![Screenshot 2021-04-09 at 14 23 52](https://user-images.githubusercontent.com/1083581/114179399-379da600-993f-11eb-9f22-47212356502e.png)


#### Screen recordings:

**Before**

https://user-images.githubusercontent.com/1083581/114181127-6452bd00-9941-11eb-8797-3e544ffadc31.mp4


**After**

https://user-images.githubusercontent.com/1083581/114181138-67e64400-9941-11eb-87f8-7fbb7464e5b8.mp4
