### PR TITLE
E2E tests: Publish test results to Testspace

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -112,3 +112,12 @@ jobs:
       with:
         name: test-output-${{ matrix.gutenberg }}
         path: projects/plugins/jetpack/tests/e2e/output
+
+    - uses: testspace-com/setup-testspace@v1
+      with:
+        domain: ${{github.repository_owner}}
+    - name: Publish to Testspace
+      working-directory: projects/plugins/jetpack/tests/e2e
+      run: |
+        testspace output/reports/junit-*.xml
+      if: always()


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Publish E2E tests results to Testspace: https://automattic.testspace.com/projects/66340

#### Jetpack product discussion
p9dueE-2ID-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* After E2E tests complete in CI the results should be published in Testspace
