### PR TITLE
Search: add woocommerce_currency to sync

### DIFF
--- a/projects/packages/sync/changelog/add-woocommerce-currency-to-sync
+++ b/projects/packages/sync/changelog/add-woocommerce-currency-to-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add woocommerce_currency to the synced blog options

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -155,6 +155,7 @@ class Defaults {
 		'uploads_use_yearmonth_folders',
 		'users_can_register',
 		'verification_services_codes',
+		'woocommerce_currency',
 		'wordads_second_belowpost',
 		'wordads_display_front_page',
 		'wordads_display_post',

--- a/projects/plugins/jetpack/changelog/add-woocommerce-currency-to-sync
+++ b/projects/plugins/jetpack/changelog/add-woocommerce-currency-to-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add woocommerce_currency to the synced blog options

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -193,6 +193,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'mailserver_port'                              => 1,
 			'wp_page_for_privacy_policy'                   => false,
 			'enable_header_ad'                             => '1',
+			'woocommerce_currency'                         => 'JPY',
 			'wordads_second_belowpost'                     => '1',
 			'wordads_display_front_page'                   => '1',
 			'wordads_display_post'                         => '1',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The blog option `woocommerce_currency` is required in the Jetpack cache blog. We use it during Elasticsearch indexing to select the currency correctly for the Jetpack Search API. 

Related: https://github.com/Automattic/jetpack/issues/19500.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Make sure the sync options tests pass.
