### PR TITLE
Sharing: avoid broken sharing icons when using IE11 and legacy AMP theme

### DIFF
--- a/projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php
+++ b/projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php
@@ -426,18 +426,21 @@ class Jetpack_AMP_Support {
 	 */
 	public static function amp_reader_sharing_css() {
 		// If sharing is not enabled, we should not proceed to render the CSS.
-		if ( ! defined( 'JETPACK_SOCIAL_LOGOS_DIR' ) || ! defined( 'WP_SHARING_PLUGIN_DIR' ) ) {
+		if ( ! defined( 'JETPACK_SOCIAL_LOGOS_DIR' ) | ! defined( 'JETPACK_SOCIAL_LOGOS_URL' ) || ! defined( 'WP_SHARING_PLUGIN_DIR' ) ) {
 			return;
 		}
 
 		/*
 		 * We'll need to output the full contents of the 2 files
 		 * in the head on AMP views. We can't rely on regular enqueues here.
+		 * @todo As of AMP plugin v1.5, you can actually rely on regular enqueues thanks to https://github.com/ampproject/amp-wp/pull/4299. Once WPCOM upgrades AMP, then this method can be eliminated.
 		 *
 		 * phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		 * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		 */
-		echo file_get_contents( JETPACK_SOCIAL_LOGOS_DIR . 'social-logos.css' );
+		$css = file_get_contents( JETPACK_SOCIAL_LOGOS_DIR . 'social-logos.css' );
+		$css = preg_replace( '#(?<=url\(")(?=social-logos\.)#', JETPACK_SOCIAL_LOGOS_URL, $css ); // Make sure font files get their absolute paths.
+		echo $css;
 		echo file_get_contents( WP_SHARING_PLUGIN_DIR . 'amp-sharing.css' );
 
 		/*

--- a/projects/plugins/jetpack/changelog/fix-amp-legacy-reader-social-logos-css-import
+++ b/projects/plugins/jetpack/changelog/fix-amp-legacy-reader-social-logos-css-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Sharing: avoid broken sharing icons when using IE11 and the legacy AMP  plugin's theme.


### PR DESCRIPTION
Originally reported at https://github.com/ampproject/amp-wp/issues/5693. Users of the AMP plugin were getting access logs saying things like:

```
2021/04/12 06:30:26 [error] 9853#9853: *348118 open() "/var/www/sample/amp/social-logos.eot" failed (2: No such file or directory), client: 221.103.224.207, server: s01, request: "GET /sample/amp/social-logos.eot?5d3b4da4f6c2460dd842dbf9e0992ea6 HTTP/2.0", host: "example.org", referrer: "https://example.org/sample/amp/"
```

This issue wouldn't show up for modern browsers which support `data:` URLs, but for browsers that only support EOT or TTF font formats, the issue is that the CSS file uses a relative path for these font files:

https://github.com/Automattic/jetpack/blob/99ea6be4a3d54af93483c4373f6080192c9f05d1/projects/plugins/jetpack/_inc/social-logos/social-logos.css#L13-L16

So then when it was getting inlined for the Legacy AMP Reader template:

https://github.com/Automattic/jetpack/blob/99ea6be4a3d54af93483c4373f6080192c9f05d1/projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php#L440-L441

The browser had had to assume the font icons were relative to the current URL being viewed. So if the user was at `https://example.org/sample/amp/` then the browser would assume that `social-logos.eot` was located at `https://example.org/sample/amp/social-logos.eot`.

This fixes that problem by injecting the absolute URL for the fonts when inlining the stylesheet. For such browsers not supporting `data:` URLs, the effect is as follows:

Before | After
--------|------
<img width="136" alt="Screen Shot 2021-04-11 at 22 06 38" src="https://user-images.githubusercontent.com/134745/114343961-d4b13800-9b13-11eb-9dbd-8804cb92f1dd.png"> | <img width="128" alt="Screen Shot 2021-04-11 at 22 06 53" src="https://user-images.githubusercontent.com/134745/114343963-d549ce80-9b13-11eb-8b7a-0caeb819a334.png">


Note that once the AMP plugin is upgraded to v1.5+ on WordPress.com, this logic will no longer be needed because as of https://github.com/ampproject/amp-wp/pull/4299 you can now enqueue stylesheets normally on the Legacy AMP Reader templates.

#### Changes proposed in this Pull Request:

* Fix inlining of social-logos.css on the AMP Legacy Reader template by providing the absolute URL paths to the font files.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Activate AMP in Reader mode and select the AMP Legacy theme.
2. Enable sharing.
3. View an AMP page in IE11.
