### PR TITLE
Mailchimp Block: Fix UX for non-connected users.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mailchimp-block-secondary-user
+++ b/projects/plugins/jetpack/changelog/fix-mailchimp-block-secondary-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Mailchimp Block: Fix UX for non-connected users.

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
@@ -113,7 +113,7 @@ const InstagramGalleryEdit = props => {
 
 	const renderPlaceholderInstructions = () => {
 		if ( ! currentUserConnected ) {
-			return __( "First, you'll need to connect to WordPress.com.", 'jetpack' );
+			return __( "First, you'll need to connect your WordPress.com account.", 'jetpack' );
 		}
 		if ( ! isRequestingUserConnections && ! userConnections.length ) {
 			return __( 'Connect to Instagram to start sharing your images.', 'jetpack' );
@@ -179,7 +179,7 @@ const InstagramGalleryEdit = props => {
 						<Button
 							disabled={ isRequestingWpcomConnectUrl || ! wpcomConnectUrl }
 							href={ wpcomConnectUrl }
-							isPrimary
+							isSecondary
 						>
 							{ __( 'Connect to WordPress.com', 'jetpack' ) }
 						</Button>

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/use-connect-instagram.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/use-connect-instagram.js
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { NEW_INSTAGRAM_CONNECTION } from './constants';
+import isCurrentUserConnected from '../../shared/is-current-user-connected';
 
 export default function useConnectInstagram( {
 	accessToken,
@@ -27,9 +28,10 @@ export default function useConnectInstagram( {
 	const [ isConnecting, setIsConnecting ] = useState( false );
 	const [ isRequestingUserConnections, setIsRequestingConnections ] = useState( false );
 	const [ userConnections, setUserConnections ] = useState( [] );
+	const currentUserConnected = isCurrentUserConnected();
 
 	useEffect( () => {
-		if ( accessToken ) {
+		if ( accessToken || ! currentUserConnected ) {
 			return;
 		}
 
@@ -43,7 +45,7 @@ export default function useConnectInstagram( {
 				setIsRequestingConnections( false );
 				setUserConnections( [] );
 			} );
-	}, [ accessToken ] );
+	}, [ accessToken, currentUserConnected ] );
 
 	useEffect( () => {
 		if (

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
@@ -14,6 +14,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 /**
  * Internal dependencies
  */
+import { JETPACK_DATA_PATH } from '../../../shared/get-jetpack-data';
 import MailchimpSubscribeEdit from '../edit';
 import { settings } from '../../button';
 import { registerBlocks } from '../../../shared/test/block-fixtures';
@@ -92,12 +93,12 @@ describe( 'Mailchimp block edit component', () => {
 		};
 		render( <MailchimpSubscribeEdit { ...defaultProps } /> );
 		expect( window.fetch ).toHaveBeenCalledWith(
-			'/jetpack/v4/connection/url',
+			expect.stringContaining( '/jetpack/v4/connection/url?from=jetpack-block-editor&redirect=' ),
 			expect.anything()
 		);
 	} );
 
-	test( 'fetches mailchimp connect url mount if current user is connected', async () => {
+	test( 'fetches mailchimp connect url on mount if current user is connected', async () => {
 		render( <MailchimpSubscribeEdit { ...defaultProps } /> );
 		expect( window.fetch ).toHaveBeenCalledWith(
 			'/wpcom/v2/mailchimp?_locale=user',

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
@@ -77,9 +77,27 @@ describe( 'Mailchimp block edit component', () => {
 
 	beforeEach( () => {
 		setAttributes.mockClear();
+		window[ JETPACK_DATA_PATH ] = {
+			jetpack: {
+				is_current_user_connected: true,
+			},
+		};
 	} );
 
-	test( 'calls api on mount', async () => {
+	test( 'fetches user auth url on mount if current user is not connected', async () => {
+		window[ JETPACK_DATA_PATH ] = {
+			jetpack: {
+				is_current_user_connected: false,
+			},
+		};
+		render( <MailchimpSubscribeEdit { ...defaultProps } /> );
+		expect( window.fetch ).toHaveBeenCalledWith(
+			'/jetpack/v4/connection/url',
+			expect.anything()
+		);
+	} );
+
+	test( 'fetches mailchimp connect url mount if current user is connected', async () => {
 		render( <MailchimpSubscribeEdit { ...defaultProps } /> );
 		expect( window.fetch ).toHaveBeenCalledWith(
 			'/wpcom/v2/mailchimp?_locale=user',


### PR DESCRIPTION
This PR fixes the Mailchimp block UX for non-connected users, aka users that have not connected their WPCOM account.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Redirects the user to connect their WPCOM account when setting up the Mailchimp block
* Updates the Mailchimp block's UI to represent the above
* (Bonus) Fixes an error in the Instagram Gallery block (500 status code) when trying to fetch the instagram connections for a user that has not connected their WPCOM account.
* (Bonus) Fixes the UI in the Instagram Gallery block account connection button

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1191179647901802-as-1200141581897648/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
**Before**
* Connect Jetpack
* Add a secondary user but don't connect them to WPCOM
* Make sure you are logged in to WPCOM
* As the above user try to add the Mailchimp block in a post
* When clicking on the "Setup Mailchimp form" button on the Mailchimp block a blank page appears
* When adding the Instagram Gallery block in your post, notice a 500 http error in your browser's console

**After**
* Connect Jetpack
* Add a secondary user but don't connect them to WPCOM
* Make sure you are logged in to WPCOM
* As the above user try to add the Mailchimp block in a post
* Note the UI is changed and instead of the Setup Mailchimp form" button, you should see a "Connect to WordPress.com" button
* Connect your account and verify that the "Setup Mailchimp form" button appears now while the rest flow is unchanged.
* When adding the Instagram Gallery block in your post, the 500 http error no longer shows
* Repeat the whole flow but this time without being logged in to WPCOM