### PR TITLE
Connection: avoid accidental options removal in nonce cleanup

### DIFF
--- a/projects/packages/connection/changelog/fix-nonce-cleanup-zero
+++ b/projects/packages/connection/changelog/fix-nonce-cleanup-zero
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: nonce cleanup safeguard against accidental option removal.

--- a/projects/packages/connection/src/class-nonce-handler.php
+++ b/projects/packages/connection/src/class-nonce-handler.php
@@ -190,9 +190,12 @@ class Nonce_Handler {
 
 		$ids_fill = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
 
+		$args   = $ids;
+		$args[] = 'jetpack_nonce_%';
+
 		// The Code Sniffer is unable to understand what's going on...
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-		return $wpdb->query( $wpdb->prepare( "DELETE FROM `{$wpdb->options}` WHERE `option_id` IN ( {$ids_fill} ) AND option_name LIKE %s", $ids, 'jetpack_nonce_%' ) );
+		return $wpdb->query( $wpdb->prepare( "DELETE FROM `{$wpdb->options}` WHERE `option_id` IN ( {$ids_fill} ) AND option_name LIKE %s", $args ) );
 	}
 
 	/**

--- a/projects/packages/connection/src/class-nonce-handler.php
+++ b/projects/packages/connection/src/class-nonce-handler.php
@@ -181,6 +181,7 @@ class Nonce_Handler {
 			return false;
 		}
 
+		// Removing zeroes in case AUTO_INCREMENT of the options table is broken, and all ID's are zeroes.
 		$ids = array_filter( $ids );
 
 		if ( ! count( $ids ) ) {

--- a/projects/packages/connection/src/class-nonce-handler.php
+++ b/projects/packages/connection/src/class-nonce-handler.php
@@ -176,16 +176,23 @@ class Nonce_Handler {
 			)
 		);
 
-		if ( ! is_array( $ids ) || ! count( $ids ) ) {
-			// There's either nothing to remove, or there's an error and we can't proceed.
+		if ( ! is_array( $ids ) ) {
+			// There's an error and we can't proceed.
+			return false;
+		}
+
+		$ids = array_filter( $ids );
+
+		if ( ! count( $ids ) ) {
+			// There's nothing to remove.
 			return false;
 		}
 
 		$ids_fill = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
 
 		// The Code Sniffer is unable to understand what's going on...
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-		return $wpdb->query( $wpdb->prepare( "DELETE FROM `{$wpdb->options}` WHERE `option_id` IN ( {$ids_fill} )", $ids ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		return $wpdb->query( $wpdb->prepare( "DELETE FROM `{$wpdb->options}` WHERE `option_id` IN ( {$ids_fill} ) AND option_name LIKE %s", $ids, 'jetpack_nonce_%' ) );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test-class-nonce-handler.php
+++ b/projects/packages/connection/tests/php/test-class-nonce-handler.php
@@ -127,7 +127,7 @@ class Test_Nonce_Handler extends TestCase {
 				global $wpdb;
 
 				$query_filter_delete_run = true;
-				self::assertEquals( "DELETE FROM `{$wpdb->options}` WHERE `option_id` IN ( " . implode( ', ', $nonce_ids ) . ' )', $query );
+				self::assertStringStartsWith( "DELETE FROM `{$wpdb->options}` WHERE `option_id` IN ( " . implode( ', ', $nonce_ids ) . " ) AND option_name LIKE 'jetpack_nonce_", $query );
 			}
 
 			return $result;


### PR DESCRIPTION
If the options table has `AUTO_INCREMENT` broken and all option ID's are `0`, the nonce cleanup component will remove all options.
This PR adds additional checks to prevent this from happening.

#### Changes proposed in this Pull Request:
* Add safeguard against accidental option removal

#### Jetpack product discussion
p1617989003132300-slack-CBG1CP4EN
p1618002840155900-slack-CBG1CP4EN
3892136-zen
3901396-zen

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Setup a new JN site with Jetpack Beta and Jetpack Debug plugin. Install and active the "WP Crontrol" plugin.
2. Activate "Mocker" in the Jetpack Debug and create a bunch of nonces.
3. Go to the database and see how many options you have now: `select count(*) from wp_options;`
4. Go to "Tools -> Cron Events", find event `jetpack_clean_nonces` and run it.
5. Run the count query again and make sure that the nonces got removed: `select count(*) from wp_options;`
6. Go back to the "Mocker" and create another bunch of nonces. Count how many options you have now: `select count(*) from wp_options;`
7. Run the following queries to reset the `option_id` values:
```
ALTER TABLE wp_options DROP COLUMN option_id;
ALTER TABLE wp_options ADD COLUMN option_id bigint(20) unsigned NOT NULL DEFAULT 0 FIRST;
```
Confirm that all the option_id's were set to `0`: `select count(*) from wp_options where option_id > 0;` should find no entries.
8. Go to "Tools -> Cron Events" and run the event `jetpack_clean_nonces`.
9. Count how many options you have left. No options should've got removed because of the invalid ID's.