### PR TITLE
Revert "Search: add woocommerce_currency to sync"

### DIFF
--- a/projects/packages/sync/changelog/add-woocommerce-currency-to-sync
+++ b/projects/packages/sync/changelog/add-woocommerce-currency-to-sync
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add woocommerce_currency to the synced blog options

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -155,7 +155,6 @@ class Defaults {
 		'uploads_use_yearmonth_folders',
 		'users_can_register',
 		'verification_services_codes',
-		'woocommerce_currency',
 		'wordads_second_belowpost',
 		'wordads_display_front_page',
 		'wordads_display_post',

--- a/projects/plugins/jetpack/changelog/add-woocommerce-currency-to-sync
+++ b/projects/plugins/jetpack/changelog/add-woocommerce-currency-to-sync
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add woocommerce_currency to the synced blog options

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -193,7 +193,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'mailserver_port'                              => 1,
 			'wp_page_for_privacy_policy'                   => false,
 			'enable_header_ad'                             => '1',
-			'woocommerce_currency'                         => 'JPY',
 			'wordads_second_belowpost'                     => '1',
 			'wordads_display_front_page'                   => '1',
 			'wordads_display_post'                         => '1',


### PR DESCRIPTION
Reverts Automattic/jetpack#19501.

@westi advised in https://github.com/Automattic/jetpack/pull/19501/#issuecomment-818401640 that the `woocommerce_currency` option is already synced. 

It goes into the "no_autoload" options table rather than the main options table, and therefore needs to be retrieved in a slightly different way.

We no longer need to add `woocommerce_currency` to the main sync allow list.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Make sure the sync options tests pass.
