### PR TITLE
Define site icon CSS height and width inline

### DIFF
--- a/projects/plugins/jetpack/changelog/update-inline-css-site-icon
+++ b/projects/plugins/jetpack/changelog/update-inline-css-site-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add inline styles to dashboard header for site icon when nav unification is enabled to prevent site icon images overlaying the users interface making it unusable when nav unification styles are prevented from loading.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -67,16 +67,17 @@
 	padding: 10px 0 10px 8px;
 }
 
+/**
+ * Site icon inline-styles for height and width are defined in set_site_icon_inline_styles
+ */
 #adminmenu .toplevel_page_site-card .wp-menu-image {
 	background-image: none;
 	background-position: center;
 	background-repeat: no-repeat;
 	background-size: 18px 18px;
-	height: 32px;
 	transform: translateZ(0);
 	transition-property: background-image,background-color;
 	transition-duration: .2s;
-	width: 32px;
 }
 
 #adminmenu .toplevel_page_site-card .wp-menu-image img {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -80,11 +80,6 @@
 	transition-duration: .2s;
 }
 
-#adminmenu .toplevel_page_site-card .wp-menu-image img {
-	height: auto;
-	max-width: 100%;
-}
-
 #adminmenu a.toplevel_page_site-card:hover,
 #adminmenu li.toplevel_page_site-card:hover {
 	background-color: inherit;
@@ -96,7 +91,6 @@
 
 #adminmenu .toplevel_page_site-card.has-site-icon img {
 	padding: 0;
-	max-width: 100%;
 }
 
 #adminmenu .toplevel_page_site-card:hover div.wp-menu-image,

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -229,7 +229,8 @@ abstract class Base_Admin_Menu {
 	 */
 	public function set_site_icon_inline_styles() {
 		echo '<style>
-			#adminmenu .toplevel_page_site-card .wp-menu-image {
+			#adminmenu .toplevel_page_site-card .wp-menu-image,
+			#adminmenu .toplevel_page_site-card .wp-menu-image img {
 				height: 32px;
 				width: 32px;
 			}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -42,6 +42,7 @@ abstract class Base_Admin_Menu {
 		add_action( 'admin_menu', array( $this, 'reregister_menu_items' ), 99998 );
 		add_filter( 'admin_menu', array( $this, 'override_svg_icons' ), 99999 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_head', array( $this, 'set_site_icon_inline_styles' ) );
 		add_filter( 'rest_request_before_callbacks', array( $this, 'rest_api_init' ), 11 );
 
 		$this->domain = ( new Status() )->get_site_suffix();
@@ -220,6 +221,19 @@ abstract class Base_Admin_Menu {
 			JETPACK__VERSION,
 			true
 		);
+	}
+
+	/**
+	 * Injects inline-styles for site icon for when third-party plugins remove enqueued stylesheets.
+	 * Unable to use wp_add_inline_style as plugins remove styles from all non-standard handles
+	 */
+	public function set_site_icon_inline_styles() {
+		echo '<style>
+			#adminmenu .toplevel_page_site-card .wp-menu-image {
+				height: 32px;
+				width: 32px;
+			}
+		</style>';
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/51893

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add inline styles to dashboard header for site icon when nav unification is enabled
* Unable to use `wp_add_inline_style` because non-core handles get removed by third-party plugins (Gravity forms)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:

* Go to https://github.com/Automattic/wp-calypso/issues/51893 and follow the steps to replicate the issue
* For Atomic: Install Jetpack Beta and activate this branch. Attempt to replicate again
* For Simple: Apply patch `D60088` to your Sandbox and ensure you've sandboxed your site. Attempt to replicate again
