### PR TITLE
Saves sidebar expanded state from WP Admin to WPCOM calypso_preferences in real-time.

### DIFF
--- a/projects/plugins/jetpack/changelog/Sync sidebar collapsed state with wpcom
+++ b/projects/plugins/jetpack/changelog/Sync sidebar collapsed state with wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Sync sidebar collapsed state with wpcom.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -1,3 +1,5 @@
+/* global ajaxurl */
+
 ( function () {
 	function init() {
 		var adminbar = document.querySelector( '#wpadminbar' );
@@ -60,7 +62,7 @@
 
 	function saveSidebarIsExpanded( expanded ) {
 		var xhr = new XMLHttpRequest();
-		xhr.open( 'POST', '/wp-admin/admin-ajax.php', true );
+		xhr.open( 'POST', ajaxurl, true );
 		xhr.setRequestHeader( 'X-Requested-With', 'XMLHttpRequest' );
 		xhr.setRequestHeader( 'Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8' );
 		xhr.withCredentials = true;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -2,6 +2,7 @@
 	function init() {
 		var adminbar = document.querySelector( '#wpadminbar' );
 		var wpwrap = document.querySelector( '#wpwrap' );
+		var adminMenu = document.querySelector( '#adminmenu' );
 
 		if ( ! adminbar ) {
 			return;
@@ -40,6 +41,28 @@
 				}
 			} );
 		}
+
+		var collapseButton = adminMenu.querySelector( '#collapse-button' );
+		// Nav-Unification feature:
+		// Saves the sidebar state in server when "Collapse menu" is clicked.
+		// This is needed so that we update WPCOM for this preference in real-time.
+		if ( collapseButton ) {
+			collapseButton.addEventListener( 'click', function ( event ) {
+				// Let's the core event listener be triggered first.
+				setTimeout( function () {
+					saveSidebarIsExpanded( event.target.parentNode.ariaExpanded );
+				}, 50 );
+			} );
+		}
+	}
+
+	function saveSidebarIsExpanded( expanded ) {
+		var xhr = new XMLHttpRequest();
+		xhr.open( 'POST', '/wp-admin/admin-ajax.php', true );
+		xhr.setRequestHeader( 'X-Requested-With', 'XMLHttpRequest' );
+		xhr.setRequestHeader( 'Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8' );
+		xhr.withCredentials = true;
+		xhr.send( 'action=sidebar_state&expanded=' + expanded );
 	}
 
 	if ( document.readyState === 'loading' ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -42,17 +42,19 @@
 			} );
 		}
 
-		var collapseButton = adminMenu.querySelector( '#collapse-button' );
-		// Nav-Unification feature:
-		// Saves the sidebar state in server when "Collapse menu" is clicked.
-		// This is needed so that we update WPCOM for this preference in real-time.
-		if ( collapseButton ) {
-			collapseButton.addEventListener( 'click', function ( event ) {
-				// Let's the core event listener be triggered first.
-				setTimeout( function () {
-					saveSidebarIsExpanded( event.target.parentNode.ariaExpanded );
-				}, 50 );
-			} );
+		if ( adminMenu ) {
+			var collapseButton = adminMenu.querySelector( '#collapse-button' );
+			// Nav-Unification feature:
+			// Saves the sidebar state in server when "Collapse menu" is clicked.
+			// This is needed so that we update WPCOM for this preference in real-time.
+			if ( collapseButton ) {
+				collapseButton.addEventListener( 'click', function ( event ) {
+					// Let's the core event listener be triggered first.
+					setTimeout( function () {
+						saveSidebarIsExpanded( event.target.parentNode.ariaExpanded );
+					}, 50 );
+				} );
+			}
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -296,7 +296,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			'wpcom'
 		);
 
-		die();
+		wp_die();
 	}
 }
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -7,6 +7,9 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
+use Automattic\Jetpack\Connection\Client;
+use Jetpack_Options;
+
 require_once __DIR__ . '/class-admin-menu.php';
 
 /**
@@ -22,6 +25,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
+		add_action( 'wp_ajax_sidebar_state', array( $this, 'ajax_sidebar_state' ) );
 
 		add_action(
 			'admin_menu',
@@ -277,4 +281,24 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		remove_menu_page( 'gutenberg' );
 		parent::add_gutenberg_menus( $wp_admin );
 	}
+
+	/**
+	 * Saves the sidebar state ( expanded / collapsed ) via an ajax request.
+	 */
+	public function ajax_sidebar_state() {
+		$expanded = filter_var( $_REQUEST['expanded'], FILTER_VALIDATE_BOOLEAN ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$blog_id  = Jetpack_Options::get_option( 'id' );
+		Client::wpcom_json_api_request_as_user(
+			'/sites/' . $blog_id . '/update-calypso-preferences',
+			'2',
+			array(
+				'method' => 'POST',
+			),
+			(object) array( 'calypso_preferences' => (object) array( 'sidebarCollapsed' => ! $expanded ) ),
+			'wpcom'
+		);
+
+		die();
+	}
 }
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
 use Automattic\Jetpack\Connection\Client;
-use Jetpack_Options;
 
 require_once __DIR__ . '/class-admin-menu.php';
 
@@ -287,9 +286,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function ajax_sidebar_state() {
 		$expanded = filter_var( $_REQUEST['expanded'], FILTER_VALIDATE_BOOLEAN ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$blog_id  = Jetpack_Options::get_option( 'id' );
 		Client::wpcom_json_api_request_as_user(
-			'/sites/' . $blog_id . '/update-calypso-preferences',
+			'/me/preferences',
 			'2',
 			array(
 				'method' => 'POST',

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -15,6 +15,14 @@ require_once __DIR__ . '/class-admin-menu.php';
  * Class WPcom_Admin_Menu.
  */
 class WPcom_Admin_Menu extends Admin_Menu {
+	/**
+	 * WPcom_Admin_Menu constructor.
+	 */
+	protected function __construct() {
+		parent::__construct();
+
+		add_action( 'wp_ajax_sidebar_state', array( $this, 'ajax_sidebar_state' ) );
+	}
 
 	/**
 	 * Sets up class properties for REST API requests.
@@ -308,5 +316,29 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		// Plugins on Simple sites are always managed on Calypso.
 		parent::add_plugins_menu( false );
+	}
+
+	/**
+	 * Saves the sidebar state ( expanded / collapsed ) via an ajax request.
+	 */
+	public function ajax_sidebar_state() {
+		$expanded    = filter_var( $_REQUEST['expanded'], FILTER_VALIDATE_BOOLEAN ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$user_id     = get_current_user_id();
+		$preferences = get_user_attribute( $user_id, 'calypso_preferences' );
+		if ( empty( $preferences ) ) {
+			$preferences = array();
+		}
+
+		$value = array_merge( (array) $preferences, array( 'sidebarCollapsed' => ! $expanded ) );
+		$value = array_filter(
+			$value,
+			function ( $preference ) {
+				return null !== $preference;
+			}
+		);
+
+		update_user_attribute( $user_id, 'calypso_preferences', $value );
+
+		die();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -22,6 +22,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::__construct();
 
 		add_action( 'wp_ajax_sidebar_state', array( $this, 'ajax_sidebar_state' ) );
+		add_action( 'admin_init', array( $this, 'sync_sidebar_collapsed_state' ) );
 	}
 
 	/**
@@ -340,5 +341,13 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		update_user_attribute( $user_id, 'calypso_preferences', $value );
 
 		die();
+	}
+
+	/**
+	 * Syncs the sidebar collapsed state from Calypso Preferences.
+	 */
+	public function sync_sidebar_collapsed_state() {
+		$sidebar_collapsed = get_user_attribute( get_current_user_id(), 'calypso_preferences' )['sidebarCollapsed'];
+		set_user_setting( 'mfold', $sidebar_collapsed ? 'f' : 'o' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/46645
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The way that WP Admin works makes it difficult to retrieve the **updated** sidebar state.

**How it currently works?**
1. User visits `/wp-admin`
2. User clicks "Collapse Menu"
3. A cookie is added / updated `wp-settings-USERID`
4. User refreshes the page, `wp_user_settings()` runs and saves the cookie values to DB

In order to update the value in real time, I added an `eventListener` to the `Collapse menu` button. The first idea was to make a direct request to `https://public-api.wordpress.com/rest/v1.1/me/preferences` and update the `sidebarCollapsed` key of `calypso_preferences`. This wasn't fruitful, especially from Atomic sites due to authorization issues. In this pull request I am doing a `admin-ajax.php` request to the backend which in turn handles the updated state.

**On Simple SItes**
We can directly `update_user_attribute( $user_id, 'calypso_preferences', $value );` https://github.com/Automattic/jetpack/pull/19520/files#diff-92d4f67830b8fe2c5696cbff0470d4f9d34bcba7f9d5bd9a130e87ff1f39765eR341

**On Atomic Sites**
I had to implement a new `wpcom/v2` [endpoint](D60092-code) to be used in conjunction with `wpcom_json_api_request_as_user` https://github.com/Automattic/jetpack/blob/091be98ebc942395a830965d28efabafb46c190b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php (Related convos: p1618304805221500-slack-CBG1CP4EN p1618255652008700-slack-C03DY3RJ5)  

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Simple Sites
* Apply D60094-code
* Open the Dev Tools
* Go to your sandbox site and click "Collapse Menu"
* Go to `https://wordpress.com/me/account`
* Inspect the request to `https://public-api.wordpress.com/rest/v1.1/me/preferences` the response should include `sidebarCollapsed: true`

### Atomic Sites
* Apply this branch to your local Jetpack "Atomic" site
* Apply D60092-code
* In `tools/docker/wordpress/wp-config.php` add `define( 'JETPACK__SANDBOX_DOMAIN','[YOUR_SANDBOX_DOMAIN' );`
* In your sandbox `sudo global-http enable`, so that request from Jetpack are accepted.
* Click "Collapse Menu"
* * Go to `https://wordpress.com/me/account`
* Inspect the request to `https://public-api.wordpress.com/rest/v1.1/me/preferences` the response should include `sidebarCollapsed: true