### PR TITLE
Site Editor Compatibility: Fix layout of latest instagram posts cross browser

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-latest-instagram-posts-layout
+++ b/projects/plugins/jetpack/changelog/fix-latest-instagram-posts-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Prevents incorrect image sizing within the site editor for the latest instagram posts block.

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
@@ -74,7 +74,11 @@ const InstagramGalleryEdit = props => {
 		`wp-block-jetpack-instagram-gallery__grid-columns-${ columns }`,
 		{ 'is-stacked-on-mobile': isStackedOnMobile }
 	);
-	const gridStyle = { gridGap: spacing };
+	const gridStyle = {
+		gridGap: spacing,
+		// Used to only apply padding when stacked in mobile viewport.
+		[ `--latest-instagram-posts-spacing` ]: spacing ? `${ spacing }px` : undefined,
+	};
 	const photoStyle = { padding: spacing }; // Needed so the updates to the grid gap render when changed.
 
 	const shouldRenderSidebarNotice = () =>

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
@@ -75,7 +75,7 @@ const InstagramGalleryEdit = props => {
 		{ 'is-stacked-on-mobile': isStackedOnMobile }
 	);
 	const gridStyle = { gridGap: spacing };
-	const photoStyle = { padding: spacing };
+	const photoStyle = { padding: spacing }; // Needed so the updates to the grid gap render when changed.
 
 	const shouldRenderSidebarNotice = () =>
 		showSidebar && ! showLoadingSpinner && images.length < count;
@@ -88,6 +88,7 @@ const InstagramGalleryEdit = props => {
 					alt={ image.title || image.url }
 					src={ image.url }
 					attributes={ attributes }
+					spacing={ spacing }
 				/>
 			);
 		}

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/editor.scss
@@ -98,3 +98,13 @@
 		flex-direction: column;
 	}
 }
+
+@supports ( display: grid ) {
+	@media ( max-width: $break-small ) {
+		.wp-block-jetpack-instagram-gallery__grid.is-stacked-on-mobile {
+			.wp-block-jetpack-instagram-gallery__placeholder {
+				margin: 0 !important;
+			}
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/editor.scss
@@ -81,11 +81,20 @@
 
 @supports ( object-fit: cover ) {
 	.wp-block-jetpack-instagram-gallery__placeholder.is-loaded {
-		height: 100%;
+		display: flex;
 		flex-direction: column;
+		flex-grow: 1;
 		img {
 			height: auto;
 			object-fit: cover;
+			flex-grow: 1;
 		}
+	}
+}
+
+.wp-block-jetpack-instagram-gallery__grid {
+	.wp-block-jetpack-instagram-gallery__grid-post {
+		display: flex;
+		flex-direction: column;
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/editor.scss
@@ -38,7 +38,7 @@
 	animation-timing-function: ease-out, ease-out;
 	animation-iteration-count: 1, infinite;
 	background-color: #a7a79f;
-	display: block;
+	display: flex;
 	opacity: 1;
 
 	&.is-loaded {
@@ -82,8 +82,9 @@
 @supports ( object-fit: cover ) {
 	.wp-block-jetpack-instagram-gallery__placeholder.is-loaded {
 		height: 100%;
+		flex-direction: column;
 		img {
-			height: 100%;
+			height: auto;
 			object-fit: cover;
 		}
 	}

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/image-transition.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/image-transition.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { useEffect, useState, useRef } from '@wordpress/element';
 
-export default function ImageTransition( { src, alt } ) {
+export default function ImageTransition( { src, alt, spacing } ) {
 	const [ loaded, setLoaded ] = useState( false );
 	const [ containerHeight, setContainerHeight ] = useState( 'auto' );
 
@@ -33,10 +33,19 @@ export default function ImageTransition( { src, alt } ) {
 		}
 	}, [ src ] );
 
+	// The following offset is required to counter the padding needed on the
+	// parent elements so that resizing the grid gap spacing in the editor works
+	// across browsers and between FSE and post editor.
+	// Negative margin used as `padding: 0 !important` prevents redraw in Safari.
+	const containerOffset = spacing * -1;
+
 	const containerClasses = classnames( 'wp-block-jetpack-instagram-gallery__placeholder', {
 		'is-loaded': loaded,
 	} );
-	const containerStyles = loaded ? {} : { height: containerHeight };
+	const containerStyles = loaded ? { margin: containerOffset } : {
+		margin: containerOffset,
+		height: containerHeight,
+	};
 	const imageClasses = classnames( { 'is-loaded': loaded } );
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -61,7 +61,10 @@ function render_block( $attributes, $content ) { // phpcs:ignore VariableAnalysi
 		)
 	);
 
-	$grid_style = sprintf( 'grid-gap: %spx; --latest-instagram-posts-spacing: %spx;', $spacing, $spacing );
+	$grid_style = sprintf(
+		'grid-gap: %1$spx; --latest-instagram-posts-spacing: %1$spx;',
+		$spacing
+	);
 
 	if ( ! class_exists( 'Jetpack_Instagram_Gallery_Helper' ) ) {
 		\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -62,7 +62,6 @@ function render_block( $attributes, $content ) { // phpcs:ignore VariableAnalysi
 	);
 
 	$grid_style  = 'grid-gap: ' . $spacing . 'px;';
-	$photo_style = 'padding: ' . $spacing . 'px;';
 
 	if ( ! class_exists( 'Jetpack_Instagram_Gallery_Helper' ) ) {
 		\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );
@@ -109,7 +108,6 @@ function render_block( $attributes, $content ) { // phpcs:ignore VariableAnalysi
 				class="wp-block-jetpack-instagram-gallery__grid-post"
 				href="<?php echo esc_url( $image->link ); ?>"
 				rel="noopener noreferrer"
-				style="<?php echo esc_attr( $photo_style ); ?>"
 				target="_blank"
 			>
 				<img

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -61,7 +61,7 @@ function render_block( $attributes, $content ) { // phpcs:ignore VariableAnalysi
 		)
 	);
 
-	$grid_style  = 'grid-gap: ' . $spacing . 'px;';
+	$grid_style = 'grid-gap: ' . $spacing . 'px;';
 
 	if ( ! class_exists( 'Jetpack_Instagram_Gallery_Helper' ) ) {
 		\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -61,7 +61,7 @@ function render_block( $attributes, $content ) { // phpcs:ignore VariableAnalysi
 		)
 	);
 
-	$grid_style = 'grid-gap: ' . $spacing . 'px;';
+	$grid_style = sprintf( 'grid-gap: %spx; --latest-instagram-posts-spacing: %spx;', $spacing, $spacing );
 
 	if ( ! class_exists( 'Jetpack_Instagram_Gallery_Helper' ) ) {
 		\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/view.scss
@@ -41,6 +41,9 @@
 		@media ( max-width: $break-small ) {
 			&.is-stacked-on-mobile {
 				display: block;
+				.wp-block-jetpack-instagram-gallery__grid-post {
+					padding: var( --latest-instagram-posts-spacing );
+				}
 			}
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/view.scss
@@ -42,17 +42,6 @@
 			&.is-stacked-on-mobile {
 				display: block;
 			}
-			&:not( .is-stacked-on-mobile ) {
-				.wp-block-jetpack-instagram-gallery__grid-post {
-					padding: 0 !important; // Overrides the block style
-				}
-			}
-		}
-
-		@media ( min-width: $break-small ) {
-			.wp-block-jetpack-instagram-gallery__grid-post {
-				padding: 0 !important; // Overrides the block style
-			}
 		}
 
 		.wp-block-jetpack-instagram-gallery__grid-post {


### PR DESCRIPTION
Fixes #19466

#### Changes proposed in this Pull Request:
* Updates the latest instagram posts' styles to prevent the images stretching out to 100% height with the FSE

#### Does this pull request change what data or activity we track or use?
No change.

#### Testing instructions:
1. With the Gutenberg plugin active (>=10.4.0-rc1), activate a block-ready theme (like tt1-blocks)
2. In the site editor, insert an Instagram Latest Posts block into the Footer template part
3. Connect an account, and note that the images are loaded much too tall vertically
4. Checkout this PR, rebuild, then reload the site editor
5. The images should now be the expected square layout
6. Confirm the latest instagram posts block still displays correctly in the normal post editor and on the frontend
7. Test across different browsers. Especially Safari as it behaves slightly differently in terms of calculating dimensions of flex/grid layouts.

#### Screenshots

| Before | After |
|---|---|
| <img width="1345" alt="Screen Shot 2021-04-14 at 12 46 52 pm" src="https://user-images.githubusercontent.com/60436221/114648110-9a1cea80-9d21-11eb-8bea-ac3350453e62.png"> | <img width="1392" alt="Screen Shot 2021-04-14 at 12 49 12 pm" src="https://user-images.githubusercontent.com/60436221/114648119-9f7a3500-9d21-11eb-8d90-4a5ea5698e92.png"> |
