### PR TITLE
Update/compare block for fse

### DIFF
--- a/projects/plugins/jetpack/changelog/2021-04-14-21-46-59-158359
+++ b/projects/plugins/jetpack/changelog/2021-04-14-21-46-59-158359
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Some minor js updates to make image compare block compatible with site editor
+
+

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/edit.js
@@ -4,7 +4,7 @@
 import { InspectorControls, RichText } from '@wordpress/block-editor';
 import { Placeholder } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
-import { useLayoutEffect } from '@wordpress/element';
+import { useLayoutEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -25,6 +25,7 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 	// Check for useResizeObserver, not available in older Gutenberg.
 	let resizeListener = null;
 	let sizes = null;
+	const juxtaposeRef = useRef();
 	if ( useResizeObserver ) {
 		// Let's look for resize so we can trigger the thing.
 		[ resizeListener, sizes ] = useResizeObserver();
@@ -56,7 +57,7 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 	// Watching for changes to key variables to trigger scan.
 	useLayoutEffect( () => {
 		if ( imageBefore.url && imageAfter.url && typeof juxtapose !== 'undefined' ) {
-			juxtapose.scanPage();
+			juxtapose.scanPage( juxtaposeRef );
 		}
 	}, [ imageBefore, imageAfter, orientation ] );
 
@@ -66,7 +67,7 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 			<InspectorControls key="controls">
 				<ImageCompareControls { ...{ attributes, setAttributes } } />
 			</InspectorControls>
-			<div className={ classes } data-mode={ orientation || 'horizontal' }>
+			<div ref={ juxtaposeRef } className={ classes } data-mode={ orientation || 'horizontal' }>
 				<Placeholder label={ null }>
 					<div className="image-compare__image-before">
 						<ImgUpload

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/edit.js
@@ -57,7 +57,7 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 	// Watching for changes to key variables to trigger scan.
 	useLayoutEffect( () => {
 		if ( imageBefore.url && imageAfter.url && typeof juxtapose !== 'undefined' ) {
-			juxtapose.scanPage( juxtaposeRef );
+			juxtapose.makeSlider( juxtaposeRef?.current );
 		}
 	}, [ imageBefore, imageAfter, orientation ] );
 

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/editor.scss
@@ -3,6 +3,9 @@
 .wp-block-jetpack-image-compare {
 	margin-left: 0;
 	margin-right: 0;
+	img {
+		max-width: 100%;
+	}
 }
 
 // The positioning in the editor crops the selection focus. This accounts for that.

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/editor.scss
@@ -3,13 +3,16 @@
 .wp-block-jetpack-image-compare {
 	margin-left: 0;
 	margin-right: 0;
+	height: auto;
+	min-height: 100%;
+	width: 100%;
 }
 
 // The positioning in the editor crops the selection focus. This accounts for that.
 .jx-slider.jx-slider {
 	top: 1px;
 	left: 1px;
-	width: calc(100% - 2px);
+	width: calc( 100% - 2px );
 }
 
 .image-compare__placeholder > .components-placeholder {
@@ -61,7 +64,7 @@
 }
 
 // Disable the juxtaposition effect until the block itself is selected.
-[data-type="jetpack/image-compare"]:not(.is-selected) .image-compare__comparison {
+[data-type='jetpack/image-compare']:not( .is-selected ) .image-compare__comparison {
 	pointer-events: none;
 }
 
@@ -84,7 +87,7 @@
 	}
 
 	&::before {
-		content: "";
+		content: '';
 		display: block;
 		position: absolute;
 		z-index: 2;

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/editor.scss
@@ -3,9 +3,6 @@
 .wp-block-jetpack-image-compare {
 	margin-left: 0;
 	margin-right: 0;
-	height: auto;
-	min-height: 100%;
-	width: 100%;
 }
 
 // The positioning in the editor crops the selection focus. This accounts for that.

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
@@ -328,7 +328,7 @@ domReady( function () {
 				this.wrapper.appendChild( this.slider );
 				// Need to get the nearest parent document to calculate scrolltop
 				// in case the block is in an iframe.
-				this.sliderParentDocument = this.wrapper.closest( 'html' ).parentNode;
+				this.sliderParentDocument = this.wrapper.ownerDocument;
 				if ( this.options.mode !== 'horizontal' ) {
 					addClass( this.slider, this.options.mode );
 				}

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
@@ -155,8 +155,9 @@ domReady( function () {
 		return ! ( x === 'false' || x === '' );
 	}
 
-	function JXSlider( selector, images, options ) {
+	function JXSlider( selector, images, options, element ) {
 		this.selector = selector;
+		this.element = element;
 
 		let i;
 		this.options = {
@@ -308,8 +309,9 @@ domReady( function () {
 				this.imgAfter &&
 				this.imgAfter.loaded === true
 			) {
-				this.wrapper = document.querySelector( this.selector );
-				if ( ! this.wrapper ) {
+				this.wrapper = this.element ? this.element : document.querySelector( this.selector );
+
+				if ( ! this.wrapper || this.wrapper.querySelector( '.jx-slider' ) ) {
 					return;
 				}
 				addClass( this.wrapper, 'juxtapose' );
@@ -474,7 +476,7 @@ domReady( function () {
 	Given an element that is configured with the proper data elements, make a slider out of it.
 	Normally this will just be used by scanPage.
 	*/
-	juxtapose.makeSlider = function ( element, idx ) {
+	juxtapose.makeSlider = function ( element, idx, singleElement ) {
 		if ( typeof idx === 'undefined' ) {
 			idx = juxtapose.sliders.length; // not super threadsafe...
 		}
@@ -531,15 +533,20 @@ domReady( function () {
 					alt: images[ 1 ].alt,
 				},
 			],
-			options
+			options,
+			singleElement ? element : undefined
 		);
 	};
 
 	// Scan page and add juxtapose sliders.
-	juxtapose.scanPage = function () {
-		const elements = document.querySelectorAll( '.juxtapose' );
-		for ( let i = 0; i < elements.length; i++ ) {
-			juxtapose.makeSlider( elements[ i ], i );
+	juxtapose.scanPage = function ( ref ) {
+		if ( ref?.current ) {
+			juxtapose.makeSlider( ref.current, 0, true );
+		} else {
+			const elements = document.querySelectorAll( '.juxtapose' );
+			for ( let i = 0; i < elements.length; i++ ) {
+				juxtapose.makeSlider( elements[ i ], i );
+			}
 		}
 	};
 

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
@@ -155,8 +155,7 @@ domReady( function () {
 		return ! ( x === 'false' || x === '' );
 	}
 
-	function JXSlider( selector, images, options, element ) {
-		this.selector = selector;
+	function JXSlider( element, images, options ) {
 		this.element = element;
 
 		let i;
@@ -309,7 +308,7 @@ domReady( function () {
 				this.imgAfter &&
 				this.imgAfter.loaded === true
 			) {
-				this.wrapper = this.element ? this.element : document.querySelector( this.selector );
+				this.wrapper = this.element;
 
 				if ( ! this.wrapper || this.wrapper.querySelector( '.jx-slider' ) ) {
 					return;
@@ -476,7 +475,7 @@ domReady( function () {
 	Given an element that is configured with the proper data elements, make a slider out of it.
 	Normally this will just be used by scanPage.
 	*/
-	juxtapose.makeSlider = function ( element, idx, singleElement ) {
+	juxtapose.makeSlider = function ( element, idx ) {
 		if ( typeof idx === 'undefined' ) {
 			idx = juxtapose.sliders.length; // not super threadsafe...
 		}
@@ -511,16 +510,14 @@ domReady( function () {
 		const specificClass = 'juxtapose-' + idx;
 		addClass( element, specificClass );
 
-		const selector = '.' + specificClass;
-
 		if ( w.innerHTML ) {
 			w.innerHTML = '';
 		} else {
 			w.innerText = '';
 		}
 
-		const slider = new juxtapose.JXSlider(
-			selector,
+		return new juxtapose.JXSlider(
+			element,
 			[
 				{
 					src: images[ 0 ].src,
@@ -533,20 +530,15 @@ domReady( function () {
 					alt: images[ 1 ].alt,
 				},
 			],
-			options,
-			singleElement ? element : undefined
+			options
 		);
 	};
 
 	// Scan page and add juxtapose sliders.
-	juxtapose.scanPage = function ( ref ) {
-		if ( ref?.current ) {
-			juxtapose.makeSlider( ref.current, 0, true );
-		} else {
-			const elements = document.querySelectorAll( '.juxtapose' );
-			for ( let i = 0; i < elements.length; i++ ) {
-				juxtapose.makeSlider( elements[ i ], i );
-			}
+	juxtapose.scanPage = function () {
+		const elements = document.querySelectorAll( '.juxtapose' );
+		for ( let i = 0; i < elements.length; i++ ) {
+			juxtapose.makeSlider( elements[ i ], i );
 		}
 	};
 

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
@@ -124,15 +124,21 @@ domReady( function () {
 		return leftPercent;
 	}
 
-	function getTopPercent( slider, input ) {
+	function getTopPercent( slider, input, sliderParentDocument ) {
 		let topPercent;
 		if ( typeof input === 'string' || typeof input === 'number' ) {
 			topPercent = parseInt( input, 10 );
 		} else {
 			const sliderRect = slider.getBoundingClientRect();
 			const offset = {
-				top: sliderRect.top + document.body.scrollTop + document.documentElement.scrollTop,
-				left: sliderRect.left + document.body.scrollLeft + document.documentElement.scrollLeft,
+				top:
+					sliderRect.top +
+					sliderParentDocument.body.scrollTop +
+					sliderParentDocument.documentElement.scrollTop,
+				left:
+					sliderRect.left +
+					sliderParentDocument.body.scrollLeft +
+					sliderParentDocument.documentElement.scrollLeft,
 			};
 			const width = slider.offsetHeight;
 			const pageY = getPageY( input );
@@ -188,9 +194,8 @@ domReady( function () {
 	JXSlider.prototype = {
 		updateSlider: function ( input, animate ) {
 			let leftPercent;
-
 			if ( this.options.mode === 'vertical' ) {
-				leftPercent = getTopPercent( this.slider, input );
+				leftPercent = getTopPercent( this.slider, input, this.sliderParentDocument );
 			} else {
 				leftPercent = getLeftPercent( this.slider, input );
 			}
@@ -321,7 +326,9 @@ domReady( function () {
 				this.slider = document.createElement( 'div' );
 				this.slider.className = 'jx-slider';
 				this.wrapper.appendChild( this.slider );
-
+				// Need to get the nearest parent document to calculate scrolltop
+				// in case the block is in an iframe.
+				this.sliderParentDocument = this.wrapper.closest( 'html' ).parentNode;
 				if ( this.options.mode !== 'horizontal' ) {
 					addClass( this.slider, this.options.mode );
 				}

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/view.js
@@ -272,8 +272,8 @@ domReady( function () {
 		},
 
 		setWrapperDimensions: function () {
-			const wrapperWidth = getComputedWidthAndHeight( this.wrapper ).width;
-			const wrapperHeight = getComputedWidthAndHeight( this.wrapper ).height;
+			const wrapperWidth = getComputedWidthAndHeight( this.wrapper.parentNode ).width;
+			const wrapperHeight = getComputedWidthAndHeight( this.wrapper.parentNode ).height;
 			let dims = this.calculateDims( wrapperWidth, wrapperHeight );
 			// if window is in iframe, make sure images don't overflow boundaries
 			if ( window.location !== window.parent.location && ! this.options.makeResponsive ) {

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -108,7 +108,6 @@
 	"projects/plugins/jetpack/extensions/blocks/eventbrite/utils.js",
 	"projects/plugins/jetpack/extensions/blocks/image-compare/edit.js",
 	"projects/plugins/jetpack/extensions/blocks/image-compare/use-debounce.js",
-	"projects/plugins/jetpack/extensions/blocks/image-compare/view.js",
 	"projects/plugins/jetpack/extensions/blocks/opentable/edit.js",
 	"projects/plugins/jetpack/extensions/blocks/opentable/index.js",
 	"projects/plugins/jetpack/extensions/blocks/opentable/restaurant-picker.js",


### PR DESCRIPTION
Fixes #19465

#### Changes proposed in this Pull Request:
* Pass element reference to image compare script when in editor instead of walking dom to find the element. This allows the block to still work when in FSE editor iframe


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Check out this PR and run in local env with gutenberg trunk and FSE compat them
* Add Image Compare block in post and in site editor and make sure everything works as expected including in front end

Before:
<img src="https://user-images.githubusercontent.com/3629020/114783908-88455100-9dce-11eb-9e5f-9bbd81c59440.gif" alt="teeth-before" width="300px">

After:
<img src="https://user-images.githubusercontent.com/3629020/114783921-8b404180-9dce-11eb-938d-62f8183d6dde.gif" alt="teeth" width="300px">
