### PR TITLE
Fix using xdebug from docker container

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -22,7 +22,6 @@ RUN \
 		mysql-client \
 		nano \
 		php-apcu \
-		php-xdebug \
 		php7.4 \
 		php7.4-bcmath \
 		php7.4-cli \
@@ -37,6 +36,7 @@ RUN \
 		php7.4-pgsql \
 		php7.4-soap \
 		php7.4-sqlite3 \
+		php7.4-xdebug \
 		php7.4-xml \
 		php7.4-xsl \
 		php7.4-zip \

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -458,7 +458,7 @@ You’ll need to install the [php-debug](https://atom.io/packages/php-debug) pac
 
 1. Configure php-debug:
 
-	1. To listen on all addresses (**Server Address**: `0.0.0.0`)
+	1. To listen on all addresses (**Server Address**: `0.0.0.0` and **Port**: `9003`)
 	    ![Screenshot showing "Server Address" input](https://user-images.githubusercontent.com/746152/37093338-c381757e-21ed-11e8-92cd-5b947a2d35ba.png)
 
 	2. To map your current Jetpack directory to the docker file system path (**Path Maps** to `/var/www/html/wp-content/plugins/jetpack;/local-path-in-your-computer/jetpack`)
@@ -483,7 +483,7 @@ You’ll need to install the [php-debug](https://atom.io/packages/php-debug) pac
 
 	![Screenshot showing debugger console](https://user-images.githubusercontent.com/746152/37092608-3f649e26-21eb-11e8-87b8-02a8ae7e9a98.png)
 
-	* This window will read `Listening on address port 0.0.0.0:9000` until you go to the WordPress site and refresh to make a new request. Then this window will read: `Connected` for a short time until the request ends. Note that it will also remain as such if you had added a break point and the code flow has stopped:
+	* This window will read `Listening on address port 0.0.0.0:9003` until you go to the WordPress site and refresh to make a new request. Then this window will read: `Connected` for a short time until the request ends. Note that it will also remain as such if you had added a break point and the code flow has stopped:
 
 	![Screenshot showing "connected"](https://user-images.githubusercontent.com/746152/37092711-9d8d1fb4-21eb-11e8-93f6-dd1edf89e6fa.png)
 
@@ -536,39 +536,31 @@ In the debug panel in VSCode, select Add Configuration. Since you have PHP Debug
 You will need to supply a pathMappings value to the `launch.json` configuration. This value connects the debugger to the volume in Docker with the Jetpack code. Your `launch.json` file should have this configuration when you're done.
 
 ```json
-	{
-		"version": "0.2.0",
-		"configurations": [
-			{
-				"name": "Listen for XDebug",
-				"type": "php",
-				"request": "launch",
-				"port": 9000,
-				"pathMappings": {
-					"/var/www/html/wp-content/plugins/jetpack": "${workspaceRoot}"
-				}
-			},
-			{
-				"name": "Launch currently open script",
-				"type": "php",
-				"request": "launch",
-				"program": "${file}",
-				"cwd": "${fileDirname}",
-				"port": 9000
-			}
-		]
-	}
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/usr/local/src/jetpack-monorepo": "${workspaceRoot}"
+            }
+        },
+        {
+            "name": "Launch currently open script",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 9003
+        }
+    ]
+}
 ```
 
-You'll need to set up the `XDEBUG_CONFIG` environment variable to enable remote debugging, and set the address and the port that the PHP Xdebug extension will use to connect to the debugger running in VSCode. Add the variable to your `.env` file.
-
-`XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000 remote_enable=1`
-
-You [will also have to configure the IDE key](https://github.com/mac-cain13/xdebug-helper-for-chrome/issues/89) for the Chrome/ Mozilla extension. In your `php.ini` file (you'll find that file at `tools/docker/config/php.ini` in the Docker environment), add:
-
-`xdebug.idekey = VSCODE`
-
-Now, in your browser's Xdebug Helper preferences, look for the IDE Key setting:
+In your browser's Xdebug Helper preferences, look for the IDE Key setting:
 
 1. Select 'Other'
 2. Add `VSCODE` as the key.

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -442,55 +442,6 @@ You’ll likely need to install a browser extension like the following:
 * [The easiest Xdebug](https://addons.mozilla.org/en-US/firefox/addon/the-easiest-xdebug/) for Mozilla Firefox
 * [Xdebug Helper](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc) for Google Chrome
 
-#### Remote debugging with Atom editor
-
-![Screenshot showing Atom editor with Xdebug](https://user-images.githubusercontent.com/746152/37091829-573605f6-21e8-11e8-9f16-3908854fd7d6.png)
-
-You’ll need to install the [php-debug](https://atom.io/packages/php-debug) package for Atom. Features of this package include:
-* Add Breakpoints
-* Step through debugging (Over, In, Out)
-* Stack and Context views
-* Add watch points to inspect current values of variables
-
-##### Configuring Atom editor
-
-1. Install [php-debug](https://atom.io/packages/php-debug) package for your Atom editor.
-
-1. Configure php-debug:
-
-	1. To listen on all addresses (**Server Address**: `0.0.0.0` and **Port**: `9003`)
-	    ![Screenshot showing "Server Address" input](https://user-images.githubusercontent.com/746152/37093338-c381757e-21ed-11e8-92cd-5b947a2d35ba.png)
-
-	2. To map your current Jetpack directory to the docker file system path (**Path Maps** to `/var/www/html/wp-content/plugins/jetpack;/local-path-in-your-computer/jetpack`)
-
-		![Screenshot showing "Path Maps" input](https://user-images.githubusercontent.com/746152/37150779-c891a7f4-22b1-11e8-9293-f34679df82f5.png)
-
-1. Make sure you installed the Chrome extension on your browser and configure it to send the IDE Key `xdebug-atom`
-
-	* In the case of the **Xdebug Helper** extension, you get to set this by right-clicking (secondary click) on the extensions’ icon and clicking **Options**:
-
-		![Screenshot showing Xdebug helper menu](https://user-images.githubusercontent.com/746152/37093557-82b766a6-21ee-11e8-8c0f-93f7ae72b9dc.png)
-
-	* Set the IDE key field to `Other`, enter `xdebug-atom` in the text field, and press Save.
-
-		![Screenshot showing IDE Key](https://user-images.githubusercontent.com/746152/37178231-ac46f92e-2300-11e8-88ec-31434a3d8fc7.png)
-
-1. Going back to Atom, proceed to toggle debugging on from the **Package** Menu item:
-
-	![Screenshot showing Package menu items](https://user-images.githubusercontent.com/746152/37092536-08f8e4fa-21eb-11e8-8f5c-bcf70029612b.png)
-
-	* Expect to see the debugger console window opening:
-
-	![Screenshot showing debugger console](https://user-images.githubusercontent.com/746152/37092608-3f649e26-21eb-11e8-87b8-02a8ae7e9a98.png)
-
-	* This window will read `Listening on address port 0.0.0.0:9003` until you go to the WordPress site and refresh to make a new request. Then this window will read: `Connected` for a short time until the request ends. Note that it will also remain as such if you had added a break point and the code flow has stopped:
-
-	![Screenshot showing "connected"](https://user-images.githubusercontent.com/746152/37092711-9d8d1fb4-21eb-11e8-93f6-dd1edf89e6fa.png)
-
-1. You should be able to set breakpoints now:
-
-	![Screen animation showing setting a breakpoint](https://user-images.githubusercontent.com/746152/37093212-591fe7d8-21ed-11e8-8352-47839ce58964.gif)
-
 #### Remote debugging with PhpStorm editor
 
 Below are instructions for starting a debug session in PhpStorm that will listen to activity on your Jetpack docker.

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -464,7 +464,7 @@ Below are instructions for starting a debug session in PhpStorm that will listen
 
 1. In the server configuration window, check the 'Use path mappings' check box.
 
-1. In the server configuration window, map the root folder to '/usr/local/src/jetpack-monorepo'
+1. In the server configuration window, map the root folder to '/usr/local/src/jetpack-monorepo' and 'tools/docker/wordpress' to '/var/www/html'.
 
 1. In the server configuration window, click 'Apply' then 'Ok'.
 
@@ -496,7 +496,8 @@ You will need to supply a pathMappings value to the `launch.json` configuration.
             "request": "launch",
             "port": 9003,
             "pathMappings": {
-                "/usr/local/src/jetpack-monorepo": "${workspaceRoot}"
+                "/usr/local/src/jetpack-monorepo": "${workspaceRoot}",
+                "/var/www/html": "${workspaceRoot}/tools/docker/wordpress",
             }
         },
         {

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -513,7 +513,7 @@ Below are instructions for starting a debug session in PhpStorm that will listen
 
 1. In the server configuration window, check the 'Use path mappings' check box.
 
-1. In the server configuration window, map the main Jetpack folder to '/var/www/html/wp-content/plugins/jetpack' and map '/tools/docker/wordpress' to '/var/www/html'
+1. In the server configuration window, map the root folder to '/usr/local/src/jetpack-monorepo'
 
 1. In the server configuration window, click 'Apply' then 'Ok'.
 

--- a/tools/docker/config/php.ini
+++ b/tools/docker/config/php.ini
@@ -1,3 +1,4 @@
+[PHP]
 short_open_tag = Off
 session.auto_start = Off
 file_uploads = On
@@ -8,9 +9,9 @@ display_errors = On
 error_reporting = E_ALL
 error_log = /var/log/php/errors.log
 sendmail_path = /usr/sbin/ssmtp -t
-xdebug.remote_enable = On
-xdebug.remote_host = docker.for.mac.localhost
-xdebug.remote_handler = dbgp
-xdebug.profiler_enable = Off;
-xdebug.profiler_enable_trigger = On;
-xdebug.profiler_output_dir = "/var/www/html"
+
+[XDebug]
+xdebug.mode = debug
+xdebug.client_host = host.docker.internal
+xdebug.client_port = 9003
+xdebug.log = /var/log/php/xdebug_remote.log

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     depends_on:
       - db
       - maildev
-    build: .
+    image: automattic/jetpack-wordpress-dev:latest
     volumes:
       ## WordPress and its plugins and themes should be defined in docker/compose-volumes.yml{.sample}, not here!
       ## That avoids having to define them both here and in the "sftp" service.

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     depends_on:
       - db
       - maildev
-    image: automattic/jetpack-wordpress-dev:latest
+    build: .
     volumes:
       ## WordPress and its plugins and themes should be defined in docker/compose-volumes.yml{.sample}, not here!
       ## That avoids having to define them both here and in the "sftp" service.


### PR DESCRIPTION
This PR fixes remote debugging using Xdebug from the docker container and addresses https://github.com/Automattic/jetpack/issues/19427


### Changes proposed in this Pull Request:

The command `apt-get install php-xdebug` in `Dockerfile` was installing an xdebug version for php 8, apache is using php 7.4 so xdebug was not available for remote debugging the wordpress install.
Switching to the `php7.4-xdebug` package fixes it.

Before (php cli has the same config as apache):
```
⋊> docker exec -it jetpack_wordpress bash
root@a84e9975cdba:/var/www/html# php -v
PHP 7.4.16 (cli) (built: Mar  5 2021 07:54:02) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.16, Copyright (c), by Zend Technologies
```

After:
```
⋊> docker exec -it jetpack_wordpress bash
root@f2ba6410d75b:/var/www/html# php -v
PHP 7.4.16 (cli) (built: Mar  5 2021 07:54:02) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.16, Copyright (c), by Zend Technologies
    with Xdebug v3.0.3, Copyright (c) 2002-2021, by Derick Rethans
```

We also updated the xdebug configuration in `tools/docker/config/php.ini` as we're now using xdebug 3 which has renamed a bunch of settings (see https://xdebug.org/docs/upgrade_guide)

#### Does this pull request change what data or activity we track or use?

No

### Testing instructions:
- Checkout this branch
- `yarn docker:up`
- Set up your IDE to listen to xdebug sessions on port 9003 (default xdebug 3 port)
- Set a breakpoint in index.php, load http://localhost and notice that your IDE enters debug mode.


### TODO:
- [x] Update documentation
- [x] Discuss replacing `image: automattic/jetpack-wordpress-dev:latest` with `build: .` in `docker-compose.yml`