### PR TITLE
Publish to Testspace even if previous steps failed

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -124,6 +124,7 @@ jobs:
     - uses: testspace-com/setup-testspace@v1
       with:
         domain: ${{github.repository_owner}}
+      if: always()
     - name: Publish to Testspace
       working-directory: projects/plugins/jetpack/tests/e2e
       run: |

--- a/projects/plugins/jetpack/changelog/fix-testspace-publish-if-failure
+++ b/projects/plugins/jetpack/changelog/fix-testspace-publish-if-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

If the previous steps in actions failed the Testspace setup step was skipped leading to test failures not being published. This PR fixes that.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI happy
* Test results published to Testspace (even on failure - see [this run](https://github.com/Automattic/jetpack/pull/19534/checks?check_run_id=2343954746) )
