### PR TITLE
Recommendations (Jetpack Assistant): make element selectors more robust

### DIFF
--- a/projects/plugins/jetpack/changelog/add-recommendations-e2e-improvements
+++ b/projects/plugins/jetpack/changelog/add-recommendations-e2e-improvements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Replace fragile element selectors with a more robust version of themselves

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/recommendations.js
@@ -16,19 +16,19 @@ export default class RecommendationsPage extends WpPage {
 	}
 
 	get siteTypePersonalCheckboxSel() {
-		return '.jp-checkbox-answer__container:nth-child(1) input';
+		return '.jp-checkbox-answer__container input#site-type-personal';
 	}
 
 	get siteTypeBusinessCheckboxSel() {
-		return '.jp-checkbox-answer__container:nth-child(2) input';
-	}
-
-	get siteTypeOtherCheckboxSel() {
-		return '.jp-checkbox-answer__container:nth-child(4) input';
+		return '.jp-checkbox-answer__container input#site-type-business';
 	}
 
 	get siteTypeStoreCheckboxSel() {
-		return '.jp-checkbox-answer__container:nth-child(3) input';
+		return '.jp-checkbox-answer__container input#site-type-store';
+	}
+
+	get siteTypeOtherCheckboxSel() {
+		return '.jp-checkbox-answer__container input#site-type-other';
 	}
 
 	get saveSiteTypeButtonSel() {

--- a/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
@@ -6,9 +6,10 @@ import RecommendationsPage from '../lib/pages/wp-admin/recommendations';
 
 describe( 'Recommendations (Jetpack Assistant)', () => {
 	it( 'Recommendations (Jetpack Assistant)', async () => {
-		const recommendationsPage = await RecommendationsPage.visit( page );
+		let recommendationsPage;
 
 		await step( 'Navigate to the Recommendations module', async () => {
+			recommendationsPage = await RecommendationsPage.visit( page );
 			const isPageVisible = await recommendationsPage.areSiteTypeQuestionsVisible();
 			expect( isPageVisible ).toBeTruthy();
 			expect( recommendationsPage.isUrlInSyncWithStepName( 'site-type' ) ).toBeTruthy();

--- a/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/recommendations.test.js
@@ -18,17 +18,10 @@ describe( 'Recommendations (Jetpack Assistant)', () => {
 		await step( 'Check Personal and Other checkboxes', async () => {
 			await recommendationsPage.checkPersonalSiteType();
 			await recommendationsPage.checkOtherSiteType();
-
-			const isPersonalAndOtherChecked =
-				( await recommendationsPage.isPersonalSiteTypeChecked() ) &&
-				( await recommendationsPage.isOtherSiteTypeChecked() );
-
-			const isBusinessAndStoreChecked =
-				( await recommendationsPage.isBusinessTypeUnchecked() ) &&
-				( await recommendationsPage.isStoreTypeUnchecked() );
-
-			expect( isPersonalAndOtherChecked ).toBeTruthy();
-			expect( isBusinessAndStoreChecked ).toBeFalsy();
+			expect( await recommendationsPage.isPersonalSiteTypeChecked() ).toBeTruthy();
+			expect( await recommendationsPage.isOtherSiteTypeChecked() ).toBeTruthy();
+			expect( await recommendationsPage.isBusinessTypeUnchecked() ).toBeFalsy();
+			expect( await recommendationsPage.isStoreTypeUnchecked() ).toBeFalsy();
 		} );
 
 		await step( 'Save answers and continue to the Monitor step', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Follow-up of #19460.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Target input elements by their ID and remove `:nth-child` from selectors.
* Simplify assertion statements.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

This doesn't bring changes to the product, it only enhances the Recommendations module's e2e test.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No. It doesn't change what data or activity we track or use.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review: make sure the changes improve readability and robustness.
* `cd` into `jetpack/projects/plugins/jetpack/tests/e2e`.
* Run `yarn test-e2e ./specs/recommendations.test.js` to run the test in headless mode or `HEADLESS=false yarn test-e2e ./specs/recommendations.test.js` if you want to see it in action.
* Make sure the test pass. You should see an output like this:
```
2021-04-07 17:36:03 info: TEST PASSED: Jetpack Recommendations - Steps
 PASS  specs/recommendations.test.js (104.614 s)
  Jetpack Recommendations
    ✓ Steps (14646 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        104.888 s, estimated 112 s
Ran all test suites matching /.\/specs\/recommendations.test.js/i.
```