### PR TITLE
Connection: moving the registration REST endpoint to the package

### DIFF
--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -9,6 +9,7 @@
 		"automattic/jetpack-options": "^1.11",
 		"automattic/jetpack-roles": "^1.4",
 		"automattic/jetpack-status": "^1.7",
+		"automattic/jetpack-terms-of-service": "^1.9",
 		"automattic/jetpack-tracking": "^1.13"
 	},
 	"require-dev": {

--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -326,7 +326,7 @@ class Jetpack_XMLRPC_Server {
 
 			// This code mostly copied from Jetpack::admin_page_load.
 			Jetpack::maybe_set_version_option();
-			$registered = Jetpack::try_registration();
+			$registered = $this->connection->try_registration();
 			if ( is_wp_error( $registered ) ) {
 				return $this->error( $registered, 'remote_register' );
 			} elseif ( ! $registered ) {

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -112,6 +112,17 @@ class REST_Connector {
 				'permission_callback' => __CLASS__ . '::jetpack_reconnect_permission_check',
 			)
 		);
+
+		// Register the site (get `blog_token`).
+		register_rest_route(
+			'jetpack/v4',
+			'/connection/register',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'connection_register' ),
+				'permission_callback' => __CLASS__ . '::jetpack_register_permission_check',
+			)
+		);
 	}
 
 	/**
@@ -363,6 +374,56 @@ class REST_Connector {
 		}
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Verify that user is allowed to connect Jetpack.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @return bool|WP_Error Whether user has the capability 'jetpack_connect'.
+	 */
+	public static function jetpack_register_permission_check() {
+		if ( current_user_can( 'jetpack_connect' ) ) {
+			return true;
+		}
+
+		return new WP_Error( 'invalid_user_permission_jetpack_connect', self::get_user_permissions_error_msg(), array( 'status' => rest_authorization_required_code() ) );
+	}
+
+	/**
+	 * The endpoint tried to partially or fully reconnect the website to WP.com.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @param \WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function connection_register( $request ) {
+		if ( ! wp_verify_nonce( $request->get_param( 'registration_nonce' ), 'jetpack-registration-nonce' ) ) {
+			return new WP_Error( 'invalid_nonce', __( 'Unable to verify your request.', 'jetpack' ), array( 'status' => 403 ) );
+		}
+
+		$result = $this->connection->try_registration();
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( class_exists( 'Jetpack' ) ) {
+			$authorize_url = \Jetpack::build_authorize_url( false, true );
+		} else {
+			add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
+			$authorize_url = $this->connection->get_authorization_url();
+			remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
+		}
+
+		return rest_ensure_response(
+			array(
+				'authorizeUrl' => $authorize_url,
+			)
+		);
 	}
 
 }

--- a/projects/packages/connection/src/class-utils.php
+++ b/projects/packages/connection/src/class-utils.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use Automattic\Jetpack\Tracking;
+
 /**
  * Provides utility methods for the Connection package.
  */
@@ -73,6 +75,25 @@ class Utils {
 			array( __CLASS__, 'jetpack_api_constant_filter' ),
 			10,
 			2
+		);
+	}
+
+	/**
+	 * Filters the registration request body to include tracking properties.
+	 *
+	 * @param array $properties Already prepared tracking properties.
+	 * @return array amended properties.
+	 */
+	public static function filter_register_request_body( $properties ) {
+		$tracking        = new Tracking();
+		$tracks_identity = $tracking->tracks_get_identity( get_current_user_id() );
+
+		return array_merge(
+			$properties,
+			array(
+				'_ui' => $tracks_identity['_ui'],
+				'_ut' => $tracks_identity['_ut'],
+			)
 		);
 	}
 }

--- a/projects/plugins/debug-helper/modules/class-rest-api-tester.php
+++ b/projects/plugins/debug-helper/modules/class-rest-api-tester.php
@@ -115,6 +115,7 @@ class REST_API_Tester {
 				</div>
 
 				<div class="api-tester-block align-right">
+					<sub>Registration Nonce: <?php echo esc_html( wp_create_nonce( 'jetpack-registration-nonce' ) ); ?></sub>&nbsp;
 					<button type="submit" class="button-right" id="api-tester-submit">Send</button>
 				</div>
 

--- a/projects/plugins/jetpack/_inc/class.jetpack-provision.php
+++ b/projects/plugins/jetpack/_inc/class.jetpack-provision.php
@@ -52,7 +52,7 @@ class Jetpack_Provision { //phpcs:ignore
 		if ( ! Jetpack::connection()->is_connected() || ( isset( $named_args['force_register'] ) && (int) $named_args['force_register'] ) ) {
 			// This code mostly copied from Jetpack::admin_page_load.
 			Jetpack::maybe_set_version_option();
-			$registered = Jetpack::try_registration();
+			$registered = Jetpack::connection()->try_registration();
 			if ( is_wp_error( $registered ) ) {
 				return $registered;
 			} elseif ( ! $registered ) {

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -194,20 +194,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			)
 		);
 
-		// Start the connection process by registering the site on WordPress.com servers.
-		register_rest_route(
-			'jetpack/v4',
-			'/connection/register',
-			array(
-				'methods'             => WP_REST_Server::EDITABLE,
-				'callback'            => __CLASS__ . '::register_site',
-				'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
-				'args'                => array(
-					'registration_nonce' => array( 'type' => 'string' ),
-				),
-			)
-		);
-
 		// Set the connection owner
 		register_rest_route(
 			'jetpack/v4',
@@ -1805,19 +1791,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Registers the Jetpack site
 	 *
-	 * @uses Jetpack::try_registration();
-	 * @since 7.7.0
+	 * @deprecated since Jetpack 9.7.0
+	 * @see Automattic\Jetpack\Connection\REST_Connector::connection_register()
 	 *
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return bool|WP_Error True if Jetpack successfully registered
 	 */
 	public static function register_site( $request ) {
+		_deprecated_function( __METHOD__, 'jetpack-8.8.0', '\Automattic\Jetpack\Connection\REST_Connector::connection_register' );
+
 		if ( ! wp_verify_nonce( $request->get_param( 'registration_nonce' ), 'jetpack-registration-nonce' ) ) {
 			return new WP_Error( 'invalid_nonce', __( 'Unable to verify your request.', 'jetpack' ), array( 'status' => 403 ) );
 		}
 
-		$response = Jetpack::try_registration();
+		$response = Jetpack::connection()->try_registration();
 
 		if ( is_wp_error( $response ) ) {
 			return $response;

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Connection\Secrets;
 use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Connection\Webhooks as Connection_Webhooks;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
@@ -810,6 +811,9 @@ class Jetpack {
 
 		// Make resources use static domain when possible.
 		add_filter( 'jetpack_static_url', array( 'Automattic\\Jetpack\\Assets', 'staticize_subdomain' ) );
+
+		// Validate the domain names in Jetpack development versions.
+		add_action( 'jetpack_pre_register', array( get_called_class(), 'registration_check_domains' ) );
 	}
 
 	/**
@@ -3500,15 +3504,27 @@ p {
 
 	/**
 	 * Attempts Jetpack registration.  If it fail, a state flag is set: @see ::admin_page_load()
+	 *
+	 * @deprecated since Jetpack 9.7.0
+	 * @see Automattic\Jetpack\Connection\Manager::try_registration()
+	 *
+	 * @return bool|WP_Error
 	 */
 	public static function try_registration() {
-		$terms_of_service = new Terms_Of_Service();
-		// The user has agreed to the TOS at some point by now.
-		$terms_of_service->agree();
+		_deprecated_function( __METHOD__, 'jetpack-9.7', 'Automattic\\Jetpack\\Connection\\Manager::try_registration' );
+		return static::connection()->try_registration();
+	}
 
-		// Let's get some testing in beta versions and such.
-		if ( self::is_development_version() && defined( 'PHP_URL_HOST' ) ) {
-			// Before attempting to connect, let's make sure that the domains are viable.
+	/**
+	 * Checking the domain names in beta versions.
+	 * If this is a development version, before attempting to connect, let's make sure that the domains are viable.
+	 *
+	 * @param null|\WP_Error $error The domain validation error, or `null` if everything's fine.
+	 *
+	 * @return null|\WP_Error The domain validation error, or `null` if everything's fine.
+	 */
+	public static function registration_check_domains( $error ) {
+		if ( static::is_development_version() && defined( 'PHP_URL_HOST' ) ) {
 			$domains_to_check = array_unique(
 				array(
 					'siteurl' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
@@ -3516,21 +3532,14 @@ p {
 				)
 			);
 			foreach ( $domains_to_check as $domain ) {
-				$result = self::connection()->is_usable_domain( $domain );
+				$result = static::connection()->is_usable_domain( $domain );
 				if ( is_wp_error( $result ) ) {
 					return $result;
 				}
 			}
 		}
 
-		$result = self::register();
-
-		// If there was an error with registration and the site was not registered, record this so we can show a message.
-		if ( ! $result || is_wp_error( $result ) ) {
-			return $result;
-		} else {
-			return true;
-		}
+		return $error;
 	}
 
 	/**
@@ -4371,7 +4380,7 @@ p {
 					check_admin_referer( 'jetpack-register' );
 					self::log( 'register' );
 					self::maybe_set_version_option();
-					$registered = self::try_registration();
+					$registered = static::connection()->try_registration();
 					if ( is_wp_error( $registered ) ) {
 						$error = $registered->get_error_code();
 						self::state( 'error', $error );
@@ -5492,43 +5501,28 @@ endif;
 	}
 
 	/**
+	 * @deprecated since Jetpack 9.7.0
+	 * @see Automattic\Jetpack\Connection\Manager::try_registration()
+	 *
 	 * @return bool|WP_Error
 	 */
 	public static function register() {
-		$tracking = new Tracking();
-		$tracking->record_user_event( 'jpc_register_begin' );
-
-		add_filter( 'jetpack_register_request_body', array( __CLASS__, 'filter_register_request_body' ) );
-
-		$connection   = self::connection();
-		$registration = $connection->register();
-
-		remove_filter( 'jetpack_register_request_body', array( __CLASS__, 'filter_register_request_body' ) );
-
-		if ( ! $registration || is_wp_error( $registration ) ) {
-			return $registration;
-		}
-
-		return true;
+		_deprecated_function( __METHOD__, 'jetpack-9.7', 'Automattic\\Jetpack\\Connection\\Manager::try_registration' );
+		return static::connection()->try_registration( false );
 	}
 
 	/**
 	 * Filters the registration request body to include tracking properties.
 	 *
+	 * @deprecated since Jetpack 9.7.0
+	 * @see Automattic\Jetpack\Connection\Utils::filter_register_request_body()
+	 *
 	 * @param array $properties
 	 * @return array amended properties.
 	 */
 	public static function filter_register_request_body( $properties ) {
-		$tracking        = new Tracking();
-		$tracks_identity = $tracking->tracks_get_identity( get_current_user_id() );
-
-		return array_merge(
-			$properties,
-			array(
-				'_ui' => $tracks_identity['_ui'],
-				'_ut' => $tracks_identity['_ut'],
-			)
-		);
+		_deprecated_function( __METHOD__, 'jetpack-9.7', 'Automattic\\Jetpack\\Connection\\Utils::filter_register_request_body' );
+		return Connection_Utils::filter_register_request_body( $properties );
 	}
 
 	/**


### PR DESCRIPTION
The REST endpoint `connection/register` is deeply embodied into the Jetpack plugin.
This PR extracts the endpoint and some functions it depends on into the Connection package, making them available for other plugins using the package.

#### Changes proposed in this Pull Request:
* Moving the `connection/register` endpoint into the Connection package
* Moving some methods it depends on from the `Jetpack` class into the package

#### Jetpack product discussion
Required for #19422.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
TBD.