### PR TITLE
Remove Sharing submenu option from settings menu

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-sharing-submenu
+++ b/projects/plugins/jetpack/changelog/remove-sharing-submenu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Nav Unification: Remove Sharing submenu option from settings menu for wpcom sites.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -263,10 +263,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
-		// Replace sharing menu if it exists. See Publicize_UI::sharing_menu.
-		if ( $this->hide_submenu_page( 'options-general.php', 'sharing' ) ) {
-			add_submenu_page( 'options-general.php', esc_attr__( 'Sharing Settings', 'jetpack' ), __( 'Sharing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/sharing-buttons/' . $this->domain, null, 30 );
-		}
+		$this->hide_submenu_page( 'options-general.php', 'sharing' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -293,7 +293,6 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_options_menu();
 
 		$this->assertSame( 'https://wordpress.com/hosting-config/' . static::$domain, $submenu['options-general.php'][6][2] );
-		$this->assertSame( 'https://wordpress.com/marketing/sharing-buttons/' . static::$domain, $submenu['options-general.php'][11][2] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/49689


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This diff updates the Calypso wpcom Settings submenu to not include "Sharing" as an option, since this links to a page which is actually under the Tools menu (Tools->Marketing->Sharing Buttons).

(This fix was originally submitted as a wpcom diff at D59878-code, and it doesn't seem to relate directly to Jetpack behavior as standalone Jetpack sites don't seem to have this menu item anyway, but since the file exists as a Jetpack file as well, it seems like this is something that should be processed by Fusion. Please let me know if this is not the case and I can return to the original diff!)


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out wpcom Fusion-generated diff to your sandbox and make sure you have the API sandboxed.
* Open Calypso admin for a simple site.
* Verify that the Settings menu does not have a "Sharing" submenu item (either in the hover flyout menu or the dropdown when on a settings page).

![image](https://user-images.githubusercontent.com/13437011/114754855-a81d3c00-9d1e-11eb-87cb-ee3fd6f7cf9c.png)

![image](https://user-images.githubusercontent.com/13437011/114754916-b408fe00-9d1e-11eb-9f04-3f5b8395dad3.png)

Also verify that a standalone Jetpack site, while not having changed behavior, displays no errors with this PR checked out.
