### PR TITLE
Photon: Cast dimensions to int when comparing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-photon-size-comparison
+++ b/projects/plugins/jetpack/changelog/fix-photon-size-comparison
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Photon: correct image URLs in srcset in certain cases.

--- a/projects/plugins/jetpack/class.photon.php
+++ b/projects/plugins/jetpack/class.photon.php
@@ -751,8 +751,8 @@ class Jetpack_Photon {
 				}
 
 				if ( isset( $image_meta['width'], $image_meta['height'] ) ) {
-					$image_args['width']  = $image_meta['width'];
-					$image_args['height'] = $image_meta['height'];
+					$image_args['width']  = (int) $image_meta['width'];
+					$image_args['height'] = (int) $image_meta['height'];
 
 					list( $image_args['width'], $image_args['height'] ) = image_constrain_size_for_editor( $image_args['width'], $image_args['height'], $size, 'display' );
 					$has_size_meta                                      = true;
@@ -922,7 +922,7 @@ class Jetpack_Photon {
 
 			$args = array();
 			if ( 'w' === $source['descriptor'] ) {
-				if ( $height && ( $source['value'] === $width ) ) {
+				if ( $height && ( (int) $source['value'] === $width ) ) {
 					$args['resize'] = $width . ',' . $height;
 				} else {
 					$args['w'] = $source['value'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
WordPress is not particularly type-safe. In 3908038-zen I ran into a
situation where a site had the width and height metadata in 'sizes'
stored as strings rather than integers. WP was passing those strings
through in the srcset data, and since #16588 made a bunch of comparisons
strict Photon wasn't matching them anymore.

So add some casts to fix that.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have an image attachment on a post that has the `width` and `height` values in `sizes` as strings rather than integers.
    * I don't know how you might do this normally, I just did an UPDATE on the row in wp_postmeta to reproduce it.
* Activate Photon.
* Look at the `srcset` attribute on the `<img>` tag. The Photonized URLs should be like `resize=300%2C200`, not `w=300`.