### PR TITLE
Slideshow: Fix height of Upload button for FSE compatibility

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-upload-button-height-for-fse
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-upload-button-height-for-fse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Slideshow Block: Fix height of Upload Image button for compatibility with site editor.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/editor.scss
@@ -7,7 +7,6 @@
 	.components-form-file-upload,
 	.components-button.wp-block-jetpack-slideshow__add-item-button {
 		width: 100%;
-		height: 100%;
 	}
 
 	.components-button.wp-block-jetpack-slideshow__add-item-button {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #19487

Updates the CSS for the editor view of the Slideshow block so that it displays correctly in the FSE site editor. It does this by removing an unnecessary `height: 100%` rule which has no effect in the post editor, but which causes the button to be very large in FSE.

When testing, I checked the appearance of the block in both FSE _and_ the post editor across a number of themes to verify that there are no regressions from removing the rule. (Twenty Twenty, Twenty Twenty One, Varia, Blank Canvas, Seedlet).

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes unnecessary `height: 100%` from the Upload image button in the Slideshow's editor UI

#### Screenshots

| Before      | After |
| ----------- | ----------- |
| <img width="273" alt="Screen Shot 2021-04-14 at 2 57 13 PM" src="https://user-images.githubusercontent.com/63313398/114785563-bc1e6900-9d31-11eb-885e-07ee850dd132.png"> | <img width="407" alt="Screen Shot 2021-04-14 at 2 54 31 PM" src="https://user-images.githubusercontent.com/63313398/114785445-8f6a5180-9d31-11eb-8291-6353a34918c7.png"> |

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to an FSE site and view in the site-editor ( `/wp-admin/admin.php? page=gutenberg-edit-site`)
* Insert a Slideshow block
* Inspect the block and verify that the Upload Image button matches screenshots
* Open a post in the standard post editor, insert the Slideshow block, and verify that the button looks the same
* Try changing to a few different themes and verifying that there are no regressions/the UI looks the same.
