### PR TITLE
Search: use the posts_per_page value from query

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search_posts_per_page
+++ b/projects/plugins/jetpack/changelog/fix-search_posts_per_page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: Set the number of returned posts using the query's posts_per_page value.

--- a/projects/plugins/jetpack/modules/search/class.jetpack-search.php
+++ b/projects/plugins/jetpack/modules/search/class.jetpack-search.php
@@ -552,6 +552,7 @@ class Jetpack_Search {
 			'post_type'           => 'any',
 			'ignore_sticky_posts' => true,
 			'suppress_filters'    => true,
+			'posts_per_page'      => $query->get( 'posts_per_page' ),
 		);
 
 		$posts_query = new WP_Query( $args );


### PR DESCRIPTION
Fixes #19547

#### Changes proposed in this Pull Request:
Currently, the `filter__posts_pre_query` method uses the `posts_per_page` option value to determine the number of posts to return. Instead, it should use the `posts_per_page` value from the input `$query` to determine the number of posts to return. This will allow sites to use the `pre_get_posts` filter to adjust the number of returned posts.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Start with a site with a lot of content.
2. Install, activate, and connect Jetpack.
3. Add the Jetpack Search product to the site.
4. Navigate to Jetpack -> Settings -> Performance and disable "Enable instant search experience".
5. Add a code snippet which uses the `pre_get_posts` filter to adjust the number of search results displayed per page to a value greater than the default value of 10. For example:

```
add_filter( 'pre_get_posts', 'adjust_posts_per_page', 1, 2 );
function adjust_posts_per_page( $query ) {
	if ($query->is_main_query() && $query->is_search() ) {
		$query->set('posts_per_page', 20);
	}

	return $query;
}
```

6. Navigate to your site and perform a search that returns more than 10 results. The correct number of results per page should be displayed (20 if testing with the snippet above).
