### PR TITLE
Gardening: also run from forks for pull_request_target event

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -29,7 +29,7 @@ jobs:
   repo-gardening:
     name: "Manage labels and assignees"
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     timeout-minutes: 10  # 2021-03-12: Successful runs seem to take a few seconds, but can sometimes take a lot longer since we wait for previous runs to complete.
     steps:
       - name: Checkout


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
﻿
Follow-up from #19382.

We need to allow the action to run from forks for pull_request_target events, so we can add labels to PRs created by external contributors.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* See how the action was skipped in #19553: https://github.com/Automattic/jetpack/actions/runs/754757429
* For my next test PR (once this is merged), it should run.
