### PR TITLE
POC: Jetpack connection - consider whether the user has an associated wpcom account. No iframes.

### DIFF
--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -949,6 +949,8 @@ class Manager {
 			$jetpack_public = false;
 		}
 
+		error_log( print_r( $registration_details, 1 ) );
+
 		\Jetpack_Options::update_options(
 			array(
 				'id'     => (int) $registration_details->jetpack_id,
@@ -957,6 +959,10 @@ class Manager {
 		);
 
 		$this->get_tokens()->update_blog_token( (string) $registration_details->jetpack_secret );
+
+		if ( $registration_details->has_wpcom_account ) {
+			add_filter( 'jetpack_auth_user_has_wpcom_account', '__return_true' );
+		}
 
 		/**
 		 * Fires when a site is registered on WordPress.com.
@@ -1552,6 +1558,8 @@ class Manager {
 		 */
 		$auth_type = apply_filters( 'jetpack_auth_type', 'calypso' );
 
+		$has_wpcom_account = apply_filters( 'jetpack_auth_user_has_wpcom_account', false );
+
 		/**
 		 * Filters the user connection request data for additional property addition.
 		 *
@@ -1587,6 +1595,7 @@ class Manager {
 				'site_icon'     => get_site_icon_url(),
 				'site_lang'     => get_locale(),
 				'site_created'  => $this->get_assumed_site_creation_date(),
+				'has_wpcom_account' => $has_wpcom_account,
 			)
 		);
 

--- a/projects/plugins/jetpack/_inc/connect-button.js
+++ b/projects/plugins/jetpack/_inc/connect-button.js
@@ -38,20 +38,18 @@ jQuery( document ).ready( function ( $ ) {
 			}
 
 			if ( ! jetpackConnectButton.isRegistering ) {
-				if ( 'original' === jpConnect.forceVariation ) {
-					// Forcing original connection flow, `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME = true`
-					// or we're dealing with Safari which has issues with handling 3rd party cookies.
-					jetpackConnectButton.handleOriginalFlow();
-				} else {
-					// Default in-place connection flow.
-					jetpackConnectButton.handleConnectInPlaceFlow();
-				}
+				// if ( 'original' === jpConnect.forceVariation ) {
+				// 	// Forcing original connection flow, `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME = true`
+				// 	// or we're dealing with Safari which has issues with handling 3rd party cookies.
+				// 	jetpackConnectButton.handleOriginalFlow();
+				// } else {
+				// 	// Default in-place connection flow.
+				// 	jetpackConnectButton.handleConnectInPlaceFlow();
+				// }
+				jetpackConnectButton.handleRegistration();
 			}
 		},
-		handleOriginalFlow: function () {
-			window.location = connectButton.attr( 'href' );
-		},
-		handleConnectInPlaceFlow: function () {
+		handleRegistration: function () {
 			// Alternative connection buttons should redirect to the main one for the "connect in place" flow.
 			if ( connectButton.hasClass( 'jp-banner__alt-connect-button' ) ) {
 				// Make sure we don't lose the `from` parameter, if set.
@@ -81,8 +79,31 @@ jQuery( document ).ready( function ( $ ) {
 					_wpnonce: jpConnect.apiNonce,
 				},
 				error: jetpackConnectButton.handleConnectionError,
-				success: jetpackConnectButton.handleConnectionSuccess,
+				success: function ( data ) {
+					// eslint-disable-next-line
+					console.log( data );
+					if ( data.hasWpcomAccount ) {
+						if (
+							confirm( 'Hey! Looks like you have a wpcom account. Connect with it?' ) === true
+						) {
+							window.location = data.authorizeUrl;
+						} else {
+							alert( 'Cool! No worries, continue user-less.' );
+							window.location.reload();
+						}
+					} else {
+						if ( confirm( 'Wanna create a wpcom account to do more cool stuff?' ) === true ) {
+							window.location = data.authorizeUrl;
+						} else {
+							alert( 'Cool! No worries, continue user-less.' );
+							window.location.reload();
+						}
+					}
+				},
 			} );
+		},
+		handleOriginalFlow: function () {
+			window.location = connectButton.attr( 'href' );
 		},
 		triggerLoadingState: function () {
 			var loadingText = $( '<span>' )

--- a/projects/plugins/jetpack/_inc/jetpack-server-sandbox.php
+++ b/projects/plugins/jetpack/_inc/jetpack-server-sandbox.php
@@ -55,7 +55,7 @@ function jetpack_server_sandbox( &$url, &$headers ) {
 	if ( $request_parameters['host'] ) {
 		$headers['Host'] = $request_parameters['host'];
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			error_log( sprintf( "SANDBOXING via '%s': '%s'", JETPACK__SANDBOX_DOMAIN, $original_url ) );
+//			error_log( sprintf( "SANDBOXING via '%s': '%s'", JETPACK__SANDBOX_DOMAIN, $original_url ) );
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -1753,9 +1753,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return $response;
 		}
 
+		$auth_url = Jetpack::build_authorize_url( false, false );
+		$auth_url_params = parse_url( $auth_url, PHP_URL_QUERY );
+		parse_str( $auth_url_params, $auth_params );
+		$has_wpcom_account = isset( $auth_params['has_wpcom_account'] ) && $auth_params['has_wpcom_account'];
 		return rest_ensure_response(
 			array(
-				'authorizeUrl' => Jetpack::build_authorize_url( false, true ),
+				'authorizeUrl' => $auth_url,
+				'hasWpcomAccount' => $has_wpcom_account,
 			)
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This is a proof of concept. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Adds data to the /connection/register endpoint that informs the connect-button.js whether or not the email has an associated wpcom user account. 
- Bypasses all in-place flow logic in the connect-button.js
- Shows conditional messaging based on has_wpcom_account. 

The alert() and confirm() are here to represent how easily we can manipulate the connect UX within the plugin, based on the register response. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-bJT-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Apply D60324-code to your wpcom sandbox 
- Sandbox your Jetpack connection 
- "Set up Jetpack" from the main Jetpack dashboard
- You should see js `confirm` pop up with contextual info 
- Clicking ok will continue to the Calypso user auth
- Clicking cancel will reload the page