### PR TITLE
Site Editor Compatibility: Add fix for ExternalLink CSS in site editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-external-link-component-rendering-in-the-site-editor
+++ b/projects/plugins/jetpack/changelog/fix-external-link-component-rendering-in-the-site-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Site Editor Compatibility: Provide CSS styles for ExternalLink component to workaround site editor styling issue in Gutenberg.

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -9,6 +9,7 @@ import './shared/external-media';
 import './extended-blocks/core-embed';
 import './extended-blocks/paid-blocks';
 import './shared/styles/slideshow-fix.scss';
+import './shared/styles/external-link-fix.scss';
 
 // Register media source store to the centralized data registry.
 import './store/media-source';

--- a/projects/plugins/jetpack/extensions/shared/styles/external-link-fix.scss
+++ b/projects/plugins/jetpack/extensions/shared/styles/external-link-fix.scss
@@ -1,0 +1,13 @@
+// This adds CSS styling for the ExternalLink component, so that
+// it receives styles when used in the Site Editor. Many Jetpack
+// blocks use this component in the placeholder state, so this ensures
+// support in the Site Editor until a fix lands in Gutenberg.
+// See: https://github.com/WordPress/gutenberg/issues/30553
+
+.components-external-link__icon {
+	width: 1.4em;
+	height: 1.4em;
+	margin: -0.2em 0.1em 0;
+	vertical-align: middle;
+	fill: currentColor;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

In many Jetpack blocks, we use Gutenberg's `ExternalLink` component within the placeholder UI. In the FSE site editor, there is [an outstanding issue](https://github.com/WordPress/gutenberg/issues/30553) that styles in Gutenberg that are generated via Emotion's CSS-in-JS are not copied into the site editor iframe. This results in components like `ExternalLink` rendering in the editor canvas without their styles. While a long-term fix is on the horizon in Gutenberg with a new approach to styles, in the shorter term, to ensure Jetpack blocks behave nicely in the site editor, this change proposes that we add in CSS to the editor CSS that specifically targets this component, and adds in the CSS equivalent of the component's JS-based styling. For reference the styles used by this component can be found [here](https://github.com/andrewserong/gutenberg/blob/2a95a3d804b9e6d8a26c7aff189edb7c0414ff07/packages/components/src/external-link/styles/external-link-styles.js#L11-L11) in Gutenberg.

Related to https://github.com/Automattic/jetpack/issues/19504

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add CSS styles for the `ExternalLink` component so that they're loaded within the site editor, to fix styling issues with the placeholder state for Jetpack blocks
* This change is applied generally as opposed to within each affected block, so that it's easier to remove when a fix eventually lands in Gutenberg

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/19504

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Screenshots

Note the size difference of the ExternalLink icon in the below screenshots:

| Before (Google Calendar) | After (Google Calendar) | 
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/115195738-75b27b00-a132-11eb-8bfb-58b11a6dbae3.png) | ![image](https://user-images.githubusercontent.com/14988353/115195985-bf9b6100-a132-11eb-9935-2a0ffde112c3.png) |
| Before (Calendly) | After (Calendly) |
| ![image](https://user-images.githubusercontent.com/14988353/115195851-9975c100-a132-11eb-87c2-04777fd29bfb.png) | ![image](https://user-images.githubusercontent.com/14988353/115195896-a5618300-a132-11eb-9737-c563fd935746.png) |

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

A question: does this approach — adding a fairly global fix, seem reasonable? I thought it'd be preferable to adding the same block of CSS to every Jetpack block that uses the `ExternalLink` component (and it also means that anyone working on an individual block doesn't need to think about it). If it _does_ feel too global, I can go in and add it separately to each affected block.

* With the Gutenberg plugin active (>=10.4.0-rc1), activate a block-ready theme (like tt1-blocks)
* In the site editor (e.g. `/wp-admin/admin.php?page=gutenberg-edit-site`) add a block that includes the `ExternalLink` component in its placeholder state (e.g. Calendly or Google Calendar)
* Note that the ExternalLink icon is too large and offset too high vertically
* Apply this change to your test site or sandbox
* Reload the site editor, and check the placeholder state of these blocks — the ExternalLink icon should look appropriately sized and positioned
