### PR TITLE
Mailchimp Block: Fix styling issue with FSE

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mailchimp-styling-for-fse
+++ b/projects/plugins/jetpack/changelog/fix-mailchimp-styling-for-fse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Mailchimp block: add base styles to ensure compatibility with WordPress' Full Site Editing feature.

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
@@ -17,12 +17,6 @@
 		padding: 14px;
 	}
 
-	.components-button {
-		padding: 20px 30px;
-		border: inherit;
-		font: inherit;
-	}
-
 	.error,
 	.error:focus {
 		outline: 1px;

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
@@ -8,8 +8,19 @@
 		}
 	}
 
-	.wp-block-jetpack-button {
+	p {
 		margin-bottom: 1em;
+	}
+
+	input {
+		width: 100%;
+		padding: 14px;
+	}
+
+	.components-button {
+		padding: 20px 30px;
+		border: inherit;
+		font: inherit;
 	}
 
 	.error,

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
@@ -13,6 +13,7 @@
 	}
 
 	input {
+		box-sizing: border-box;
 		width: 100%;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
@@ -8,7 +8,7 @@
 		}
 	}
 
-	p {
+	.wp-block-jetpack-button, p {
 		margin-bottom: 1em;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
@@ -14,7 +14,6 @@
 
 	input {
 		width: 100%;
-		padding: 14px;
 	}
 
 	.error,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #19481

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix CSS issues with the mailchimp form using the site editor. This PR adds some new base styles for the form in the frontend, mainly adjusting the input width and margins/padding.
* Also fixes some CSS issues in TT1, including missing margin between form elements

**Notes**
* This PR relies on #19595 to fix the button styling. The PRs can be merged in either order, but if you want to see the button styled correctly you must apply this PR on top of that one.
* This PR does not fix the padding inside the email input; this is because it can't be done in a way that allows themes to override the padding for all input fields. TT1-blocks will need to update this style itself.
* This is not intended to necessarily match Twenty Twenty One theme styles, just to add some base styles to make the form look presentable on the frontend for now.

**Screenshots**

**Mailchimp block in the footer of a FSE site using TT1 blocks**
| Before | After |
| --- | --- |
| <img width="412" alt="Screen Shot 2021-04-19 at 10 09 08 AM" src="https://user-images.githubusercontent.com/63313398/115278577-762f1f80-a0fa-11eb-9179-5e88590e7a19.png">  |  <img width="445" alt="Screen Shot 2021-04-21 at 11 47 59 AM" src="https://user-images.githubusercontent.com/63313398/115605527-7add0a80-a297-11eb-8e16-f02f4443352b.png"> |

**Mailchimp block in the post content of a  site using TT1**
| Before | After |
| --- | --- |
| <img width="655" alt="Screen Shot 2021-04-19 at 10 09 44 AM" src="https://user-images.githubusercontent.com/63313398/115278639-8a731c80-a0fa-11eb-8323-0f6b89762388.png"> | <img width="666" alt="Screen Shot 2021-04-21 at 11 47 22 AM" src="https://user-images.githubusercontent.com/63313398/115605570-892b2680-a297-11eb-8946-64d5764b6894.png"> |


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Sync this PR; if you would like to see the final styling of the button, you should also apply the #19595 PR.

- Enable TT1 blocks theme.
- Insert a mailchimp block in the footer template in the site editor.
- Confirm that the mailchimp form fields display as expected in the editor.
- Confirm that the mailchimp form fields display as expected in the front end.
- Switch to a regular WP theme and insert a mailchimp form block in a post.
- Confirm that in this post the mailchimp form fields work expected in editor and front end.
