### PR TITLE
Nav Unification: Link to Calypso screens for Categories and Tags

### DIFF
--- a/projects/plugins/jetpack/changelog/update-taxonomy-nav-links
+++ b/projects/plugins/jetpack/changelog/update-taxonomy-nav-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Account for Categories and Tags in nav unification

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -163,8 +163,10 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 
 		$submenus_to_update = array(
-			'edit.php'     => 'https://wordpress.com/posts/' . $this->domain,
-			'post-new.php' => 'https://wordpress.com/post/' . $this->domain,
+			'edit.php'                        => 'https://wordpress.com/posts/' . $this->domain,
+			'post-new.php'                    => 'https://wordpress.com/post/' . $this->domain,
+			'edit-tags.php?taxonomy=category' => 'https://wordpress.com/settings/taxonomies/category/' . $this->domain,
+			'edit-tags.php?taxonomy=post_tag' => 'https://wordpress.com/settings/taxonomies/post_tag/' . $this->domain,
 		);
 		$this->update_submenus( 'edit.php', $submenus_to_update );
 	}


### PR DESCRIPTION
See Automattic/wp-calypso#50568

#### Changes proposed in this Pull Request:

* Categories and Tags menu items (under Posts) should link to Calypso screens when the Dashboard appearance toggle is **off** under Me -> Account Settings, and to `/wp-admin` when the toggle is on.
* The same menu items should link to `/wp-admin` screens when the Dashboard appearance toggle is **on** under Me -> Account Settings

<img width="292" alt="Screen Shot 2021-04-19 at 4 22 50 PM" src="https://user-images.githubusercontent.com/2124984/115298515-8dd2cc00-a12b-11eb-879d-67d1ef2b53f2.png">

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Apply D60379-code to your sandbox and sandbox the API
* Make sure the **Show advanced dashboard pages.** toggle is **off** under `/me/account`
* View your site's dashboard and click on Categories or Tags under Posts in the main navigation. You should be brought to `/settings/taxonomies/category/[site]` or `/settings/taxonomies/post_tag/[site]`
* Turn the **Show advanced dashboard pages.** setting **on** under `/me/account`
* Check your site's dashboard again. The Categories and Tags links under Posts should point to their respective screens in `/wp-admin` now.