### PR TITLE
JITM: set the JITM and cache filter defaults to true

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm_filters
+++ b/projects/packages/jitm/changelog/update-jitm_filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+JITM: set the default values of the jetpack_just_in_time_msgs and jetpack_just_in_time_msg_cache filters to true.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -55,9 +55,9 @@ class JITM {
 		 * @since 3.7.0
 		 * @since 5.4.0 Correct docblock to reflect default arg value
 		 *
-		 * @param bool false Whether to show just in time messages.
+		 * @param bool true Whether to show just in time messages.
 		 */
-		if ( ! apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
+		if ( ! apply_filters( 'jetpack_just_in_time_msgs', true ) ) {
 			return false;
 		}
 

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -19,7 +19,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '1.15.0';
+	const PACKAGE_VERSION = '1.15.1-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -391,7 +391,7 @@ class Post_Connection_JITM extends JITM {
 		$use_cache = false;
 
 		/** This filter is documented in class.jetpack.php */
-		if ( apply_filters( 'jetpack_just_in_time_msg_cache', false ) ) {
+		if ( apply_filters( 'jetpack_just_in_time_msg_cache', true ) ) {
 			$use_cache = true;
 		}
 

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -390,7 +390,13 @@ class Post_Connection_JITM extends JITM {
 		// If something is in the cache and it was put in the cache after the last sync we care about, use it.
 		$use_cache = false;
 
-		/** This filter is documented in class.jetpack.php */
+		/**
+		 * Filter to turn off jitm caching
+		 *
+		 * @since 5.4.0
+		 *
+		 * @param bool false Whether to cache just in time messages
+		 */
 		if ( apply_filters( 'jetpack_just_in_time_msg_cache', true ) ) {
 			$use_cache = true;
 		}

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -395,7 +395,7 @@ class Post_Connection_JITM extends JITM {
 		 *
 		 * @since 5.4.0
 		 *
-		 * @param bool false Whether to cache just in time messages
+		 * @param bool true Whether to cache just in time messages
 		 */
 		if ( apply_filters( 'jetpack_just_in_time_msg_cache', true ) ) {
 			$use_cache = true;

--- a/projects/packages/jitm/tests/php/test_JITM.php
+++ b/projects/packages/jitm/tests/php/test_JITM.php
@@ -36,23 +36,24 @@ class Test_Jetpack_JITM extends TestCase {
 		Monkey\tearDown();
 	}
 
-	public function test_jitm_disabled_by_default() {
+	public function test_jitm_enabled_by_default() {
 		Functions\expect( 'apply_filters' )
 			->once()
-			->with(	'jetpack_just_in_time_msgs', false );
-
-		$jitm = new JITM();
-		$this->assertFalse( $jitm->register() );
-	}
-
-	public function test_jitm_enabled_by_filter() {
-		Functions\expect( 'apply_filters' )
-			->once()
-			->with( 'jetpack_just_in_time_msgs', false )
+			->with(	'jetpack_just_in_time_msgs', true )
 			->andReturn( true );
 
 		$jitm = new JITM();
 		$this->assertTrue( $jitm->register() );
+	}
+
+	public function test_jitm_disabled_by_filter() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'jetpack_just_in_time_msgs', true )
+			->andReturn( false );
+
+		$jitm = new JITM();
+		$this->assertFalse( $jitm->register() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-jitm_filters
+++ b/projects/plugins/jetpack/changelog/update-jitm_filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+JITM: remove unnecessary add_filter calls for the JITM filters.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1094,11 +1094,7 @@ class Jetpack {
 
 	function jetpack_track_last_sync_callback( $params ) {
 		/**
-		 * Filter to turn off jitm caching
-		 *
-		 * @since 5.4.0
-		 *
-		 * @param bool false Whether to cache just in time messages
+		 * This filter is documented in the Automattic\Jetpack\JITMS\Post_Connection_JITM class.
 		 */
 		if ( ! apply_filters( 'jetpack_just_in_time_msg_cache', true ) ) {
 			return $params;

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -723,11 +723,6 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'filter_default_modules' ) );
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
-		// A filter to control all just in time messages
-		add_filter( 'jetpack_just_in_time_msgs', '__return_true', 9 );
-
-		add_filter( 'jetpack_just_in_time_msg_cache', '__return_true', 9 );
-
 		require_once JETPACK__PLUGIN_DIR . 'class-jetpack-pre-connection-jitms.php';
 		$jetpack_jitm_messages = ( new Jetpack_Pre_Connection_JITMs() );
 		add_filter( 'jetpack_pre_connection_jitms', array( $jetpack_jitm_messages, 'add_pre_connection_jitms' ) );
@@ -1105,7 +1100,7 @@ class Jetpack {
 		 *
 		 * @param bool false Whether to cache just in time messages
 		 */
-		if ( ! apply_filters( 'jetpack_just_in_time_msg_cache', false ) ) {
+		if ( ! apply_filters( 'jetpack_just_in_time_msg_cache', true ) ) {
 			return $params;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The `jetpack_just_in_time_msgs` filter is used to enable and disable the display of the JITMs. Let's set the default value to true. Currently, the plugin has to set the filter to true in order to display JITMs If a plugin has configured the JITM message package, it's safe to assume that the JITMs should be displayed.

Also, the `jetpack_just_in_time_msg_cache` filter is used to enable and disable the JITM cache. Let's set the default value to true.

These changes will make the JITM package easier to consume. Consumer plugins will no longer need to set these filters in order to display and cache JITMs.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
Verify that JITMs are still displayed:
1. Install this branch. Activate Jetpack and connect.
2. Navigate to the Jetpack dashboard. A JITM should display (assuming that you haven't previously dismissed the JITMs that display on the JP dashboard.).
