### PR TITLE
Calendly Block: Only use style classes when not in a placeholder state

### DIFF
--- a/projects/plugins/jetpack/changelog/update-calendly-placeholder-height
+++ b/projects/plugins/jetpack/changelog/update-calendly-placeholder-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Calendly Block: Remove excess height in the placeholder state in the editor UI.

--- a/projects/plugins/jetpack/extensions/blocks/calendly/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/edit.js
@@ -209,7 +209,10 @@ export function CalendlyEdit( props ) {
 		return blockEmbedding;
 	}
 
-	const classes = `${ className } calendly-style-${ style }`;
+	let classes = className;
+	if ( url && ! isEditingUrl ) {
+		classes += ` calendly-style-${ style }`;
+	}
 
 	return (
 		<div className={ classes }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related to https://github.com/Automattic/jetpack/issues/19504

I noticed while testing out the site editor in Gutenberg that the Calendly block adds the `.calendly-style-inline` class by default in the placeholder state. This style sets the iframe for the rendered Calendly block to be `630px` high, however when applied to the placeholder state, it results in a large amount of whitespace beneath the block, which looked off compared to similar blocks' placeholder states (e.g. the Google Calendar block).

This change only sets the classes in the editor when not in a placeholder state (there is a url, and it isn't being edited).

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Only add Calendly style classes when not in a placeholder state (note: for readability I used a simple if statement and concatenation instead of pulling in the classnames function, since we're only dealing with two class names here).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/115352712-081e5180-a1fb-11eb-8f6f-bdf054817166.png) | ![image](https://user-images.githubusercontent.com/14988353/115352795-1c624e80-a1fb-11eb-869b-a49b73d79423.png) |

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open up the post editor and go to add a Calendly block between a couple of paragraphs or other blocks
* Note the height of the placeholder state for the Calendly block
* Apply this change, and reload the editor
* Note that the Calendly block's placeholder state should no longer be taking up so much whitespace
* Enter a test Calendly url (e.g. https://calendly.com/andrew-serong/15min) and click embed
* The block should otherwise function the same in the editor and on the front end of the site, when using the Inline style (rendered within a 630px high iframe embed)
* With an FSE theme and Gutenberg plugin active, test in the site editor and on the front end of the site
