### PR TITLE
Adds the current plan inline with Upgrades menu.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -398,6 +398,19 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			$title = trim( str_replace( $matches[0], '', $title ) );
 		}
 
+		if ( false !== strpos( $title, 'inline-text' ) ) {
+			preg_match( '/<span class="inline-text">([A-Za-z0-9]+)<\/span>/', $title, $matches );
+
+			$text = $matches[1];
+			if ( $text ) {
+				// Keep the text in the item array.
+				$item['inlineText'] = $text;
+			}
+
+			// Finally remove the markup.
+			$title = trim( str_replace( $matches[0], '', $title ) );
+		}
+
 		// It's important we sanitize the title after parsing data to remove any unexpected markup but keep the content.
 		// We are also capilizing the first letter in case there was a counter (now parsed) in front of the title.
 		$item['title'] = ucfirst( wp_strip_all_tags( $title ) );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -153,18 +153,22 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			'title'      => 'Admin Menu',
 			'type'       => 'object',
 			'properties' => array(
-				'count'    => array(
+				'count'      => array(
 					'description' => 'Core/Plugin/Theme update count or unread comments count.',
 					'type'        => 'integer',
 				),
-				'icon'     => array(
+				'icon'       => array(
 					'description' => 'Menu item icon. Dashicon slug or base64-encoded SVG.',
 					'type'        => 'string',
 				),
-				'slug'     => array(
+				'inlineText' => array(
+					'description' => 'Additional text to be added inline with the menu title.',
+					'type'        => 'string',
+				),
+				'slug'       => array(
 					'type' => 'string',
 				),
-				'children' => array(
+				'children'   => array(
 					'items' => array(
 						'count'  => array(
 							'description' => 'Core/Plugin/Theme update count or unread comments count.',
@@ -190,14 +194,14 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 					),
 					'type'  => 'array',
 				),
-				'title'    => array(
+				'title'      => array(
 					'type' => 'string',
 				),
-				'type'     => array(
+				'type'       => array(
 					'enum' => array( 'separator', 'menu-item' ),
 					'type' => 'string',
 				),
-				'url'      => array(
+				'url'        => array(
 					'format' => 'uri',
 					'type'   => 'string',
 				),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -403,7 +403,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		}
 
 		if ( false !== strpos( $title, 'inline-text' ) ) {
-			preg_match( '/<span class="inline-text">([A-Za-z0-9]+)<\/span>/', $title, $matches );
+			preg_match( '/<span class="inline-text".+\s?>([A-Za-z0-9]+)<\/span>/', $title, $matches );
 
 			$text = $matches[1];
 			if ( $text ) {

--- a/projects/plugins/jetpack/changelog/Show current plan in sidebar
+++ b/projects/plugins/jetpack/changelog/Show current plan in sidebar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Show current WPCOM plan in sidebar menu item "Upgrades" when nav unification is enabled.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -170,11 +170,10 @@
 
 .inline-text {
 	position: absolute;
-	right: 0;
+	right: 20px;
 	top: 50%;
 	transform: translateY( -50% );
-	margin-right: 20px;
-	color: rgba(240,246,252,.7);
+	opacity: 0.8;
 }
 
 /**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -169,6 +169,7 @@
 }
 
 .inline-text {
+	display: block !important;
 	position: absolute;
 	right: 20px;
 	top: 50%;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -161,6 +161,19 @@
 }
 
 /**
+ * Upgrades with plan badge
+ */
+ #adminmenu .site__upgrades {
+	display: flex;
+	justify-content: space-between;
+}
+
+#adminmenu .site__upgrades .site__plan {
+	margin-right: 10px;
+	color: rgba(240,246,252,.7);
+}
+
+/**
  * Stats
  */
 [class*="toplevel_page_https://wordpress.com/stats/day"] .sidebar-unified__sparkline {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -161,13 +161,8 @@
 }
 
 /**
- * Upgrades with plan badge
+ * Inline text in a menu title
  */
- #adminmenu .site__upgrades {
-	display: flex;
-	justify-content: space-between;
-}
-
 .inline-text {
 	display: block !important;
 	position: absolute;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -168,8 +168,12 @@
 	justify-content: space-between;
 }
 
-#adminmenu .site__upgrades .site__plan {
-	margin-right: 10px;
+.inline-text {
+	position: absolute;
+	right: 0;
+	top: 50%;
+	transform: translateY( -50% );
+	margin-right: 20px;
 	color: rgba(240,246,252,.7);
 }
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -113,8 +113,10 @@ class Admin_Menu extends Base_Admin_Menu {
 
 	/**
 	 * Adds Upgrades menu.
+	 *
+	 * @param string $plan The current WPCOM plan of the blog.
 	 */
-	public function add_upgrades_menu() {
+	public function add_upgrades_menu( $plan ) {
 		global $menu;
 
 		$menu_exists = false;
@@ -126,7 +128,14 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 
 		if ( ! $menu_exists ) {
-			add_menu_page( __( 'Upgrades', 'jetpack' ), __( 'Upgrades', 'jetpack' ), 'manage_options', 'paid-upgrades.php', null, 'dashicons-cart', 4 );
+			$site_upgrades = '<span class="site__upgrades">%1$s<span class="site__plan">%2$s</span></span>';
+			$site_upgrades = sprintf(
+				$site_upgrades,
+				__( 'Upgrades', 'jetpack' ),
+				$plan
+			);
+
+			add_menu_page( __( 'Upgrades', 'jetpack' ), $site_upgrades, 'manage_options', 'paid-upgrades.php', null, 'dashicons-cart', 4 );
 		}
 
 		add_submenu_page( 'paid-upgrades.php', __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/my-plan/' . $this->domain, null, 5 );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -128,7 +128,7 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 
 		if ( ! $menu_exists ) {
-			$site_upgrades = '<span class="site__upgrades">%1$s<span class="site__plan">%2$s</span></span>';
+			$site_upgrades = '%1$s<span class="inline-text">%2$s</span>';
 			$site_upgrades = sprintf(
 				$site_upgrades,
 				__( 'Upgrades', 'jetpack' ),

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -116,7 +116,7 @@ class Admin_Menu extends Base_Admin_Menu {
 	 *
 	 * @param string $plan The current WPCOM plan of the blog.
 	 */
-	public function add_upgrades_menu( $plan ) {
+	public function add_upgrades_menu( $plan = null ) {
 		global $menu;
 
 		$menu_exists = false;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -129,7 +129,7 @@ class Admin_Menu extends Base_Admin_Menu {
 			add_menu_page( __( 'Upgrades', 'jetpack' ), __( 'Upgrades', 'jetpack' ), 'manage_options', 'paid-upgrades.php', null, 'dashicons-cart', 4 );
 		}
 
-		add_submenu_page( 'paid-upgrades.php', __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/' . $this->domain, null, 5 );
+		add_submenu_page( 'paid-upgrades.php', __( 'Plans', 'jetpack' ), __( 'Plans', 'jetpack' ), 'manage_options', 'https://wordpress.com/plans/my-plan/' . $this->domain, null, 5 );
 		add_submenu_page( 'paid-upgrades.php', __( 'Purchases', 'jetpack' ), __( 'Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 15 );
 
 		if ( ! $menu_exists ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -128,12 +128,17 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 
 		if ( ! $menu_exists ) {
-			$site_upgrades = '%1$s<span class="inline-text">%2$s</span>';
-			$site_upgrades = sprintf(
-				$site_upgrades,
-				__( 'Upgrades', 'jetpack' ),
-				$plan
-			);
+			if ( $plan ) {
+				// Add display:none as a default for cases when CSS is not loaded.
+				$site_upgrades = '%1$s<span class="inline-text" style="display:none">%2$s</span>';
+				$site_upgrades = sprintf(
+					$site_upgrades,
+					__( 'Upgrades', 'jetpack' ),
+					$plan
+				);
+			} else {
+				$site_upgrades = __( 'Upgrades', 'jetpack' );
+			}
 
 			add_menu_page( __( 'Upgrades', 'jetpack' ), $site_upgrades, 'manage_options', 'paid-upgrades.php', null, 'dashicons-cart', 4 );
 		}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -212,8 +212,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 	/**
 	 * Adds Upgrades menu.
+	 *
+	 * @param string $plan The current WPCOM plan of the blog.
 	 */
-	public function add_upgrades_menu() {
+	public function add_upgrades_menu( $plan = null ) {
 		$products = Jetpack_Plan::get();
 		$plan     = $products['product_name_short'];
 		parent::add_upgrades_menu( $plan );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -217,7 +217,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_upgrades_menu( $plan = null ) {
 		$products = Jetpack_Plan::get();
-		$plan     = $products['product_name_short'];
+		if ( array_key_exists( 'product_name_short', $products ) ) {
+			$plan = $products['product_name_short'];
+		}
 		parent::add_upgrades_menu( $plan );
 
 		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
 use Automattic\Jetpack\Connection\Client;
+use Jetpack_Plan;
 
 require_once __DIR__ . '/class-admin-menu.php';
 
@@ -213,7 +214,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds Upgrades menu.
 	 */
 	public function add_upgrades_menu() {
-		parent::add_upgrades_menu();
+		$products = Jetpack_Plan::get();
+		$plan     = $products['product_name_short'];
+		parent::add_upgrades_menu( $plan );
 
 		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -193,7 +193,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds Upgrades menu.
 	 */
 	public function add_upgrades_menu() {
-		parent::add_upgrades_menu();
+		$products = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
+		$plan     = $products['product_name_short'];
+		parent::add_upgrades_menu( $plan );
 
 		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -197,7 +197,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_upgrades_menu( $plan = null ) {
 		if ( class_exists( 'WPCOM_Store_API' ) ) {
 			$products = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
-			$plan     = $products['product_name_short'];
+			if ( array_key_exists( 'product_name_short', $products ) ) {
+				$plan = $products['product_name_short'];
+			}
 		}
 		parent::add_upgrades_menu( $plan );
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -191,8 +191,10 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 	/**
 	 * Adds Upgrades menu.
+	 *
+	 * @param string $plan The current WPCOM plan of the blog.
 	 */
-	public function add_upgrades_menu() {
+	public function add_upgrades_menu( $plan = null ) {
 		$products = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
 		$plan     = $products['product_name_short'];
 		parent::add_upgrades_menu( $plan );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -195,8 +195,10 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * @param string $plan The current WPCOM plan of the blog.
 	 */
 	public function add_upgrades_menu( $plan = null ) {
-		$products = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
-		$plan     = $products['product_name_short'];
+		if ( class_exists( 'WPCOM_Store_API' ) ) {
+			$products = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
+			$plan     = $products['product_name_short'];
+		}
 		parent::add_upgrades_menu( $plan );
 
 		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack' ), __( 'Domains', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 10 );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -168,9 +168,10 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_upgrades_menu() {
 		global $submenu;
 
-		static::$admin_menu->add_upgrades_menu();
+		static::$admin_menu->add_upgrades_menu( 'Test Plan' );
 
-		$this->assertSame( 'https://wordpress.com/plans/' . static::$domain, $submenu['paid-upgrades.php'][1][2] );
+		$this->assertSame( 'Upgrades<span class="inline-text">Test Plan</span>', $submenu['paid-upgrades.php'][0][0] );
+		$this->assertSame( 'https://wordpress.com/plans/my-plan/' . static::$domain, $submenu['paid-upgrades.php'][1][2] );
 		$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -170,7 +170,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_upgrades_menu( 'Test Plan' );
 
-		$this->assertSame( 'Upgrades<span class="inline-text">Test Plan</span>', $submenu['paid-upgrades.php'][0][0] );
+		$this->assertSame( 'Upgrades<span class="inline-text" style="display:none">Test Plan</span>', $submenu['paid-upgrades.php'][0][0] );
 		$this->assertSame( 'https://wordpress.com/plans/my-plan/' . static::$domain, $submenu['paid-upgrades.php'][1][2] );
 		$this->assertSame( 'https://wordpress.com/purchases/subscriptions/' . static::$domain, $submenu['paid-upgrades.php'][2][2] );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/49660

To Do

- [x] Inject HTML and style it
- [x] Find the correct plan for Simple sites
- [x] Find the correct plan for Atomic sites
- [x] Handle the api response in Calypso https://github.com/Automattic/wp-calypso/pull/52111
- [x] Style it in Calypso
- [x] Handle Color Scheme changes in text color
- [x] Tests

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the plan name in Upgrades menu title
* Supports passing inline text via the `admin-menu` api
* Defaults to `my-plan` for Plans submenu.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Please follow the instructions here https://github.com/Automattic/wp-calypso/pull/52111