### PR TITLE
Fixed array_filter warnings when the $submenu[ $slug ] is not set.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nav-unification-array-filter-warnings
+++ b/projects/plugins/jetpack/changelog/fix-nav-unification-array-filter-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Fixing a array_filter PHP warning that does not affect the current behaviour.
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -133,7 +133,7 @@ abstract class Base_Admin_Menu {
 		if ( $url ) {
 			$this->hide_submenu_page( $slug, $slug );
 
-			if ( ! $this->has_visible_items( $submenu[ $slug ] ) ) {
+			if ( ! isset( $submenu[ $slug ] ) || ! $this->has_visible_items( $submenu[ $slug ] ) ) {
 				$menu_item[2] = $url;
 			}
 		}
@@ -151,7 +151,7 @@ abstract class Base_Admin_Menu {
 		$this->set_menu_item( $menu_item, $menu_position );
 
 		// Only add submenu when there are other submenu items.
-		if ( $url && $this->has_visible_items( $submenu[ $slug ] ) ) {
+		if ( $url && isset( $submenu[ $slug ] ) && $this->has_visible_items( $submenu[ $slug ] ) ) {
 			add_submenu_page( $slug, $menu_item[3], $menu_item[0], $menu_item[1], $url, null, 0 );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes the array_filter warnings we are receiving when the $submenu[ $slug ] is not set. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adding isset() checks on $submenu[ $slug ] array making sure it exists.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Sandbox your wordpress.com environment
- Login with an Editor account on wordpress.com
- Make sure that no warnings are triggered on your sandbox by using `tail -f /tmp/php-errors`