### PR TITLE
Site Editor Compatibility: Podcast Player block issues in editor and front end views

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-site-editor-podcast-player-block
+++ b/projects/plugins/jetpack/changelog/fix-site-editor-podcast-player-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Ensure compatibility with the Site Editor by injecting required media assets into the Site Editor canvas, and loading frontend scripts onDomReady

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
@@ -95,7 +95,6 @@ const PodcastPlayerEdit = ( {
 
 	const playerId = `jetpack-podcast-player-block-${ instanceId }`;
 
-	const podCastPlayerRef = useRef();
 	const [ hasMigratedStyles, setHasMigratedStyles ] = useState( false );
 
 	// State.
@@ -169,15 +168,18 @@ const PodcastPlayerEdit = ( {
 
 	// The Podcast player audio element requires wpmedialement styles.
 	// These aren't available in the Site Editor context, so we have to copy them in.
-	useEffect( () => {
-		if ( ! hasMigratedStyles && podCastPlayerRef.current ) {
-			maybeCopyElementsToSiteEditorContext(
-				[ 'link#mediaelement-css', 'link#wp-mediaelement-css' ],
-				podCastPlayerRef.current
-			);
-			setHasMigratedStyles( true );
-		}
-	}, [ hasMigratedStyles ] );
+	const podCastPlayerRef = useCallback(
+		node => {
+			if ( node !== null && ! hasMigratedStyles ) {
+				maybeCopyElementsToSiteEditorContext(
+					[ 'link#mediaelement-css', 'link#wp-mediaelement-css' ],
+					node
+				);
+				setHasMigratedStyles( true );
+			}
+		},
+		[ hasMigratedStyles ]
+	);
 
 	// Load RSS feed initially and when the feed or selected episode changes.
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/edit.js
@@ -45,7 +45,7 @@ import { queueMusic } from './icons/';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import attributesValidation from './attributes';
 import PodcastPlayer from './components/podcast-player';
-import { makeCancellable } from './utils';
+import { makeCancellable, __maybeInjectStylesIntoSiteEditor } from './utils';
 import { fetchPodcastFeed } from './api';
 import { podcastPlayerReducer, actions } from './state';
 import { applyFallbackStyles } from '../../shared/apply-fallback-styles';
@@ -157,6 +157,7 @@ const PodcastPlayerEdit = ( {
 	);
 
 	useEffect( () => {
+		__maybeInjectStylesIntoSiteEditor();
 		return () => {
 			cancellableFetch?.current?.cancel?.();
 		};

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/utils.js
@@ -123,3 +123,26 @@ export const getColorsObject = memoize( generateColorsObject, config => {
 	// Cache key is a string with all arguments joined into one string.
 	return Object.values( config ).join();
 } );
+
+/**
+ * A temporary work-around to inject the styles we need for the media player into the site editor.
+ */
+export function __maybeInjectStylesIntoSiteEditor() {
+	// Check to see if we're in the site editor.
+	const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+
+	if ( iframe ) {
+		const mediaElementCSS = document.querySelector( 'link#mediaelement-css' );
+		const wpMediaElementCSS = document.querySelector( 'link#wp-mediaelement-css' );
+
+		if ( mediaElementCSS && ! iframe.contentDocument.querySelector( 'link#mediaelement-css' ) ) {
+			iframe.contentDocument.head.appendChild( mediaElementCSS.cloneNode() );
+			mediaElementCSS.remove();
+		}
+
+		if ( wpMediaElementCSS && ! iframe.contentDocument.querySelector( 'link#wp-mediaelement-css' ) ) {
+			iframe.contentDocument.head.appendChild( wpMediaElementCSS.cloneNode() );
+			wpMediaElementCSS.remove();
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/utils.js
@@ -123,26 +123,3 @@ export const getColorsObject = memoize( generateColorsObject, config => {
 	// Cache key is a string with all arguments joined into one string.
 	return Object.values( config ).join();
 } );
-
-/**
- * A temporary work-around to inject the styles we need for the media player into the site editor.
- */
-export function __maybeInjectStylesIntoSiteEditor() {
-	// Check to see if we're in the site editor.
-	const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
-
-	if ( iframe ) {
-		const mediaElementCSS = document.querySelector( 'link#mediaelement-css' );
-		const wpMediaElementCSS = document.querySelector( 'link#wp-mediaelement-css' );
-
-		if ( mediaElementCSS && ! iframe.contentDocument.querySelector( 'link#mediaelement-css' ) ) {
-			iframe.contentDocument.head.appendChild( mediaElementCSS.cloneNode() );
-			mediaElementCSS.remove();
-		}
-
-		if ( wpMediaElementCSS && ! iframe.contentDocument.querySelector( 'link#wp-mediaelement-css' ) ) {
-			iframe.contentDocument.head.appendChild( wpMediaElementCSS.cloneNode() );
-			wpMediaElementCSS.remove();
-		}
-	}
-}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/view.js
@@ -96,9 +96,11 @@ const initializeBlock = function ( id ) {
 	block.setAttribute( 'data-jetpack-block-initialized', 'true' );
 };
 
-document
-	.querySelectorAll( '.wp-block-jetpack-podcast-player:not([data-jetpack-block-initialized])' )
-	.forEach( player => {
-		player.classList.remove( 'is-default' );
-		initializeBlock( player.id );
-	} );
+document.addEventListener( 'DOMContentLoaded', () => {
+	document
+		.querySelectorAll( '.wp-block-jetpack-podcast-player:not([data-jetpack-block-initialized])' )
+		.forEach( player => {
+			player.classList.remove( 'is-default' );
+			initializeBlock( player.id );
+		} );
+} );

--- a/projects/plugins/jetpack/extensions/shared/block-editor-asset-loader.js
+++ b/projects/plugins/jetpack/extensions/shared/block-editor-asset-loader.js
@@ -13,15 +13,15 @@ export function getLoadContext( elementRef ) {
 }
 
 /**
- * Returns whether a given element is contained within an iframe.
- * Useful to check if a block sits inside the Site Editor.
+ * Returns whether a given element is contained within an Editor iframe.
+ * See: https://github.com/WordPress/gutenberg/blob/bee52e68292357011a799f067ad47aa1c1d710e1/packages/block-editor/src/components/iframe/index.js
  *
  * @param   {HTMLElement} elementRef - The element whose context we want to return.
- * @returns {boolean}                - Whether `elementRef` is contained within an iframe.
+ * @returns {boolean}                - Whether `elementRef` is contained within an Editor iframe.
  */
-export function isElementInIframe( elementRef ) {
+export function isElementInEditorIframe( elementRef ) {
 	const { currentWindow } = getLoadContext( elementRef );
-	return currentWindow.self !== currentWindow.top;
+	return currentWindow.name === 'editor-canvas' && currentWindow.self !== currentWindow.top;
 }
 
 /**
@@ -37,10 +37,18 @@ export function isElementInIframe( elementRef ) {
  * @param   {boolean}     shouldRemoveSource - Optional. Whether to remove the source element in the parent frame.
  * @returns {Array}                          - An array of successfully migrated selectors;
  */
-export function maybeCopyElementsToSiteEditorContext( elementSelectors, elementRef, shouldRemoveSource = false ) {
+export function maybeCopyElementsToSiteEditorContext(
+	elementSelectors,
+	elementRef,
+	shouldRemoveSource = false
+) {
 	// Check to see if we're in an iframe, e.g., the Site Editor.
 	// If not, do nothing.
-	if ( ! elementRef || ( ! elementSelectors && ! elementSelectors.length ) || ! isElementInIframe( elementRef ) ) {
+	if (
+		! elementRef ||
+		( ! elementSelectors && ! elementSelectors.length ) ||
+		! isElementInEditorIframe( elementRef )
+	) {
 		return;
 	}
 

--- a/projects/plugins/jetpack/extensions/shared/block-editor-asset-loader.js
+++ b/projects/plugins/jetpack/extensions/shared/block-editor-asset-loader.js
@@ -32,14 +32,15 @@ export function isElementInIframe( elementRef ) {
  * For use until Gutenberg offers a standardized way of including enqueued/3rd-party assets.
  * Target usage is the Podcast Playerblock: projects/plugins/jetpack/extensions/blocks/podcast-player/.
  *
- * @param   {Array}       elementSelectors - An array of selectors, e.g., [ '#conan', '#robocop' ]
- * @param   {HTMLElement} elementRef       - The current element.
- * @returns {Array}                        - An array of successfully migrated selectors;
+ * @param   {Array}       elementSelectors   - An array of selectors, e.g., [ '#conan', '#robocop' ]
+ * @param   {HTMLElement} elementRef         - The current element.
+ * @param   {boolean}     shouldRemoveSource - Optional. Whether to remove the source element in the parent frame.
+ * @returns {Array}                          - An array of successfully migrated selectors;
  */
-export function maybeCopyElementsToSiteEditorContext( elementSelectors = [], elementRef ) {
+export function maybeCopyElementsToSiteEditorContext( elementSelectors, elementRef, shouldRemoveSource = false ) {
 	// Check to see if we're in an iframe, e.g., the Site Editor.
 	// If not, do nothing.
-	if ( ! elementRef || ! elementSelectors.length || ! isElementInIframe( elementRef ) ) {
+	if ( ! elementRef || ( ! elementSelectors && ! elementSelectors.length ) || ! isElementInIframe( elementRef ) ) {
 		return;
 	}
 
@@ -53,7 +54,9 @@ export function maybeCopyElementsToSiteEditorContext( elementSelectors = [], ele
 			const isElementAlreadyPresentInCurrentWindow = !! currentDoc.querySelector( selector );
 			if ( parentElementToCopy && ! isElementAlreadyPresentInCurrentWindow ) {
 				currentDoc.head.appendChild( parentElementToCopy.cloneNode() );
-				parentElementToCopy.remove();
+				if ( shouldRemoveSource ) {
+					parentElementToCopy.remove();
+				}
 				return true;
 			}
 			return false;

--- a/projects/plugins/jetpack/extensions/shared/block-editor-asset-loader.js
+++ b/projects/plugins/jetpack/extensions/shared/block-editor-asset-loader.js
@@ -25,6 +25,20 @@ export function isElementInEditorIframe( elementRef ) {
 }
 
 /**
+ * Returns whether a iframe has domain access to its parent.
+ *
+ * @param   {HTMLElement} currentWindow - The window context for which we want to test access.
+ * @returns {boolean}                   - Whether we have access to the parent window.
+ */
+function canIframeAccessParentWindow( currentWindow ) {
+	try {
+		return !! currentWindow?.parent?.location.href;
+	} catch ( e ) {
+		return false;
+	}
+}
+
+/**
  * This function will check if the current element (e.g., a block) sits inside an Iframe (e.g., the Site Editor)
  * and tries to move elements from the parent window to the iframe.
  *
@@ -42,6 +56,7 @@ export function maybeCopyElementsToSiteEditorContext(
 	elementRef,
 	shouldRemoveSource = false
 ) {
+	let results = [];
 	// Check to see if we're in an iframe, e.g., the Site Editor.
 	// If not, do nothing.
 	if (
@@ -49,12 +64,16 @@ export function maybeCopyElementsToSiteEditorContext(
 		( ! elementSelectors && ! elementSelectors.length ) ||
 		! isElementInEditorIframe( elementRef )
 	) {
-		return;
+		return results;
 	}
 
 	const { currentDoc, currentWindow } = getLoadContext( elementRef );
+
+	if ( ! canIframeAccessParentWindow( currentWindow ) ) {
+		return results;
+	}
+
 	const parentDoc = currentWindow?.parent?.document;
-	let results = [];
 
 	if ( currentDoc && parentDoc ) {
 		results = elementSelectors.filter( selector => {

--- a/projects/plugins/jetpack/extensions/shared/block-editor-asset-loader.js
+++ b/projects/plugins/jetpack/extensions/shared/block-editor-asset-loader.js
@@ -1,0 +1,64 @@
+/**
+ * Returns the current document and window contexts for `elementRef`.
+ * Use to retrieve the correct context for elements that may be within an iframe.
+ *
+ * @param   {HTMLElement} elementRef - The element whose context we want to return.
+ * @returns {Object}                 - The current document (`currentDoc`) and window (`currentWindow`) contexts.
+ */
+export function getLoadContext( elementRef ) {
+	const currentDoc = elementRef.ownerDocument;
+	const currentWindow = currentDoc.defaultView || currentDoc.parentWindow;
+
+	return { currentDoc, currentWindow };
+}
+
+/**
+ * Returns whether a given element is contained within an iframe.
+ * Useful to check if a block sits inside the Site Editor.
+ *
+ * @param   {HTMLElement} elementRef - The element whose context we want to return.
+ * @returns {boolean}                - Whether `elementRef` is contained within an iframe.
+ */
+export function isElementInIframe( elementRef ) {
+	const { currentWindow } = getLoadContext( elementRef );
+	return currentWindow.self !== currentWindow.top;
+}
+
+/**
+ * This function will check if the current element (e.g., a block) sits inside an Iframe (e.g., the Site Editor)
+ * and tries to move elements from the parent window to the iframe.
+ *
+ * It's a temporary work-around to inject the styles we need for the media player into the site editor.
+ * For use until Gutenberg offers a standardized way of including enqueued/3rd-party assets.
+ * Target usage is the Podcast Playerblock: projects/plugins/jetpack/extensions/blocks/podcast-player/.
+ *
+ * @param   {Array}       elementSelectors - An array of selectors, e.g., [ '#conan', '#robocop' ]
+ * @param   {HTMLElement} elementRef       - The current element.
+ * @returns {Array}                        - An array of successfully migrated selectors;
+ */
+export function maybeCopyElementsToSiteEditorContext( elementSelectors = [], elementRef ) {
+	// Check to see if we're in an iframe, e.g., the Site Editor.
+	// If not, do nothing.
+	if ( ! elementRef || ! elementSelectors.length || ! isElementInIframe( elementRef ) ) {
+		return;
+	}
+
+	const { currentDoc, currentWindow } = getLoadContext( elementRef );
+	const parentDoc = currentWindow?.parent?.document;
+	let results = [];
+
+	if ( currentDoc && parentDoc ) {
+		results = elementSelectors.filter( selector => {
+			const parentElementToCopy = parentDoc.querySelector( selector );
+			const isElementAlreadyPresentInCurrentWindow = !! currentDoc.querySelector( selector );
+			if ( parentElementToCopy && ! isElementAlreadyPresentInCurrentWindow ) {
+				currentDoc.head.appendChild( parentElementToCopy.cloneNode() );
+				parentElementToCopy.remove();
+				return true;
+			}
+			return false;
+		} );
+
+		return results;
+	}
+}


### PR DESCRIPTION
This PR addresses Podcast Player block compatibility issues in the site editor, and on the frontend in block-based themes.

Fixes #19483

#### Changes proposed in this Pull Request:

1. Adds a check to see if the DOM is loaded before initializing the block on the frontend.
2. Adds a temporary workaround to inject required assets into the Site Editor iframe.

<img width="696" alt="Screen Shot 2021-04-21 at 3 13 14 pm" src="https://user-images.githubusercontent.com/6458278/115500421-96a2d980-a2b4-11eb-9679-3e9bf81b6601.png">

#### Jetpack product discussion
Related to Automattic/jetpack#19504

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Using a block-based theme, e.g., TT1 add a Podcast block to the site editor. Here's an RSS feed link: https://distributed.blog/category/podcast/feed/ 😄 
2. Once loaded, you should be able to interact with the player as expected.
3. Add another one.
4. Both should work 
5. Check that, for every podcast block you add, we're not duplicating the mediaelement-css assets.
6. Take a look at the frontend. The player(s) should both load.
7. Check a few other themes for regressions.
8. Sync the changes to WPCOM and ensure that both the block and site editors work as expected.