### PR TITLE
Fix "Add New Theme" menu item highlighted

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-add-new-theme-menu-highlighting
+++ b/projects/plugins/jetpack/changelog/fix-add-new-theme-menu-highlighting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Reassign $submenu_file value as null for theme-install.php so correct menu item Add New Theme is highlighted in admin menu.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -26,6 +26,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_scripts' ), 20 );
 		add_action( 'wp_ajax_sidebar_state', array( $this, 'ajax_sidebar_state' ) );
 
+		if ( ! $this->is_api_request ) {
+			add_filter( 'submenu_file', array( $this, 'override_the_theme_installer' ), 10, 2 );
+		}
+
 		add_action(
 			'admin_menu',
 			function () {
@@ -257,6 +261,21 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		parent::add_appearance_menu( $wp_admin_themes, true );
 
 		add_submenu_page( 'themes.php', esc_attr__( 'Add New Theme', 'jetpack' ), __( 'Add New Theme', 'jetpack' ), 'install_themes', 'theme-install.php', null, 1 );
+	}
+
+	/**
+	 * Override the global submenu_file for theme-install.php page so the WP Admin menu item gets highlighted correctly.
+	 *
+	 * @param string $submenu_file The current pages $submenu_file global variable value.
+	 * @return string | null
+	 */
+	public function override_the_theme_installer( $submenu_file ) {
+		global $pagenow;
+
+		if ( 'themes.php' === $submenu_file && 'theme-install.php' === $pagenow ) {
+			return null;
+		}
+		return $submenu_file;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/51349

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When going to the page `/wp-admin/theme-install.php` it will correctly highlight the menu item "Add New Theme" on Atomic sites.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack Beta and activate this branch on an Atomic site
* Go to Appearance > Add New Theme in the menu.
* Observe the menu item correctly highlighted as the current menu item you're on.

![Screenshot 2021-04-20 at 14 52 06](https://user-images.githubusercontent.com/8639742/115407509-fc755f80-a1e7-11eb-8fe2-caa16e8b1694.png)

