### PR TITLE
tests: Stop setting GITHUB_TOKEN when running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,6 @@ jobs:
       - name: Run project tests
         env:
           CHANGED: ${{ steps.changed.outputs.projects }}
-          GITHUB_TOKEN: secrets.API_TOKEN_GITHUB
         run: |
           EXIT=0
           mkdir artifacts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It's not even passing a token, it's passing the literal string
"secrets.API_TOKEN_GITHUB" due to incorrect syntax.

If it were passing a token, whatever tests were trying to use it would
probably fail on forked PRs. If we do wind up needing a token for tests,
we should try to use GH's own `secrets.GITHUB_TOKEN` (which will always
exist, but with read-only access for forked PRs) instead of matticbot's.

I see this was added during #18851, but it's not clear it was even being used there.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?