### PR TITLE
Carousel: use element ids in the for attributes of the label elements

### DIFF
--- a/projects/plugins/jetpack/changelog/2021-04-20-16-14-30-697350
+++ b/projects/plugins/jetpack/changelog/2021-04-20-16-14-30-697350
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Changes code that hasn't been released yet.
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -417,15 +417,15 @@ class Jetpack_Carousel {
 														</p>
 													<?php else : ?>
 														<fieldset>
-															<label for="email"><?php echo esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ); ?></label>
+															<label for="jp-carousel-comment-form-email-field"><?php echo esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ); ?></label>
 															<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
 														</fieldset>
 														<fieldset>
-															<label for="author"><?php echo esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ); ?></label>
+															<label for="jp-carousel-comment-form-author-field"><?php echo esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ); ?></label>
 															<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
 														</fieldset>
 														<fieldset>
-															<label for="url"><?php esc_html_e( 'Website', 'jetpack' ); ?></label>
+															<label for="jp-carousel-comment-form-url-field"><?php esc_html_e( 'Website', 'jetpack' ); ?></label>
 															<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" />
 														</fieldset>
 													<?php endif ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The `for` attribute of a `label` element should contain the id of the labeled element. (More info [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label).)
* The incorrect `for` attributes in the carousel comments cause accessibility errors in the [WAVE tool](https://wave.webaim.org/).
* Fix this by setting the `for` attributes in the carousel comment fields to the labeled elements' ids.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Reproduce the Form Label Accessibility Errors
1. Install, activate, and connect the master branch of Jetpack.
2. Navigate to Jetpack -> Settings -> Writing. Enable the `Display images in a full-screen carousel gallery` and `Show comments area in carousel` settings.
3. Create a post with an image gallery.
4. Navigate to the post and confirm that the carousel displays properly.
5. Test your site using the WAVE tool: https://wave.webaim.org/
6. In the WAVE tool, turn off styles and scroll down to the bottom of the page to see the carousel comments. You'll see some errors related to form labels.

#### Test This Branch
7. Apply this branch.
8. Navigate to the post with the gallery and confirm that the carousel displays properly.
9. Retest your site using the WAVE tool. 3 of the form label errors should be resolved. (The other errors will need to be addressed in other PRs.)