### PR TITLE
Simple site's export menu now follows the should_link_to_wp_admin() setting

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-import-export-inconsistency
+++ b/projects/plugins/jetpack/changelog/fix-import-export-inconsistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Calypso's Tool -> Export menu now honors the 'Show advanced dashboard pages' setting

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -245,8 +245,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		add_submenu_page( 'users.php', esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
 	}
 
-	// add_tools_menu() - Inherit from Admin_Menu base class.
-
 	/**
 	 * Adds Settings menu.
 	 *

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -245,16 +245,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		add_submenu_page( 'users.php', esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
 	}
 
-	/**
-	 * Adds Tools menu.
-	 *
-	 * @param bool $wp_admin_import Optional. Whether Import link should point to Calypso or wp-admin. Default false (Calypso).
-	 * @param bool $wp_admin_export Optional. Whether Export link should point to Calypso or wp-admin. Default false (Calypso).
-	 */
-	public function add_tools_menu( $wp_admin_import = false, $wp_admin_export = false ) {  // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Export on Simple sites is always handled on Calypso.
-		parent::add_tools_menu( $wp_admin_import, false );
-	}
+	// add_tools_menu() - Inherit from Admin_Menu base class.
 
 	/**
 	 * Adds Settings menu.

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -269,17 +269,29 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests add_tools_menu
+	 * Tests add_tools_menu - "Show Advanced Dashboard Pages" off
 	 *
 	 * @covers ::add_tools_menu
 	 */
 	public function test_add_tools_menu() {
 		global $submenu;
 
-		static::$admin_menu->add_tools_menu( false, true );
-
-		// Check Export menu item always links to Calypso.
+		static::$admin_menu->add_tools_menu( false, false );
+		$this->assertSame( 'https://wordpress.com/import/' . static::$domain, $submenu['tools.php'][3][2] );
 		$this->assertSame( 'https://wordpress.com/export/' . static::$domain, $submenu['tools.php'][4][2] );
+	}
+
+	/**
+	 * Tests add_tools_menu - "Show Advanced Dashboard Pages" on
+	 *
+	 * @covers ::add_tools_menu
+	 */
+	public function test_add_tools_menu_advanced() {
+		global $submenu;
+
+		static::$admin_menu->add_tools_menu( true, true );
+		$this->assertSame( 'import.php', $submenu['tools.php'][3][2] );
+		$this->assertSame( 'export.php', $submenu['tools.php'][4][2] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/51533

#### Changes proposed in this Pull Request:

Here is a summary of import/export links in Calypso, depending on the "Show advanced dashboard pages" setting on wordpress.com/me/account
```
simple | Advanced Dashboard OFF = 
  Import https://wordpress.com/import/simplesite
  Export https://wordpress.com/export/simplesite

simple | Advanced Dashboard ON = 
  Import https://simplesite/wp-admin/import.php?return=https%3A%2F%2Fwordpress.com%2Fhome%2Fsimplesite
  * Export https://wordpress.com/export/simplesite
  
atomic | Advanced Dashboard OFF =
  Import https://wordpress.com/import/atomicsite
  † Export https://atomicsite/wp-admin/export.php?return=https%3A%2F%2Fwordpress.com%2Fhome%2Fatomicsite
  
atomic | Advanced Dashboard ON =
  Import https://atomicsite/wp-admin/import.php?return=https%3A%2F%2Fwordpress.com%2Fhome%2Fatomicsite
  Export https://atomicsite/wp-admin/export.php?return=https%3A%2F%2Fwordpress.com%2Fhome%2Fatomicsite
 
 * = Should change to export.php for consistency.
 † = No change planned. Ideally, should change to calypso for consistency, but calypso export doesn't work on atomic sites.
```
The item marked with a * is being changed by this PR. It will now point to https://simplesite/wp-admin/export.php.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
no
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions (Calypso):
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply autogenerated patch to sandbox ( D60423-code )
* Visit calypso with public-api sandboxed
* Choose to manage a simple site
* Verify that the "Export" link links to `/wp-admin/export.php` when "Show advanced dashboard pages" setting is on, and links to calypso (`/export/sitename`) when the setting is off.
  * The setting can be found on `/me/account` on calypso

![2021-04-20_11-13](https://user-images.githubusercontent.com/937354/115429930-84983c80-a1c9-11eb-8c87-4c00d0296017.png)
^ The export link in question

#### Testing instructions (Wp-admin):
* Apply autogenerated patch to sandbox ( D60423-code )
* Visit `yoursite.word press.com/wp-admin` with `yoursite.word press.com` sandboxed
* Verify that the "Export" link links to `/wp-admin/export.php` when "Show advanced dashboard pages" setting is on, and links to calypso (`/export/sitename`) when the setting is off.
  * The setting can be found on `/me/account` on calypso


