### PR TITLE
Feature hints: handle multiple plugin response formats.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-plugin-search-error
+++ b/projects/plugins/jetpack/changelog/fix-plugin-search-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Feature Hints: avoid Fatal errors when other plugins filter the plugin list.

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -423,7 +423,21 @@ class Jetpack_Plugin_Search {
 	 * @return bool
 	 */
 	public function filter_cards( $plugin ) {
-		return ! in_array( $plugin['slug'], array( 'jetpack' ), true );
+		/*
+		 * $plugin is normally an array.
+		 * However, since the response data can be filtered,
+		 * we cannot fully trust its format.
+		 * Let's handle both arrays and objects, and bail if it's neither.
+		 */
+		if ( is_array( $plugin ) && ! empty( $plugin['slug'] ) ) {
+			$slug = $plugin['slug'];
+		} elseif ( is_object( $plugin ) && ! empty( $plugin->slug ) ) {
+			$slug = $plugin->slug;
+		} else {
+			return false;
+		}
+
+		return ! in_array( $slug, array( 'jetpack' ), true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #19576

#### Changes proposed in this Pull Request:

When we filter the list of plugins returned by the .org API, we assume a regular format (an object with arrays of information about each plugin).
However, other plugins and themes can also use the same `plugins_api_result` filter, with a lower priority, to change the response before we attempt to filter it.

Let's account for that and try to handle the different formats that may be offered to us.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I could not reproduce the exact error on my end, but we can check if the existing feature still works.

* On a site that's connected to WordPress.com, go to Plugins > Add New
* Search for Photon
* See that the Photon feature is highlighted as the first result, while the Jetpack plugin is not on the result list.
