### PR TITLE
Carousel: add label to carousel comment form textarea

### DIFF
--- a/projects/plugins/jetpack/changelog/2021-04-20-19-12-55-295671
+++ b/projects/plugins/jetpack/changelog/2021-04-20-19-12-55-295671
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Changes code that hasn't been released yet.
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -397,6 +397,7 @@ class Jetpack_Carousel {
 										</div>
 									<?php else : ?>
 										<form id="jp-carousel-comment-form">
+											<label for="jp-carousel-comment-form-comment-field" class="screen-reader-text"><?php echo esc_attr( $localize_strings['write_comment'] ); ?></label>
 											<textarea
 												name="comment"
 												class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add a label element for the carousel comment form textarea.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Reproduce the Form Label Accessibility Errors
1. Install, activate, and connect the master branch of Jetpack.
2. Navigate to Jetpack -> Settings -> Writing. Enable the `Display images in a full-screen carousel gallery` and `Show comments area in carousel` settings.
3. Create a post with an image gallery.
4. Navigate to the post and confirm that the carousel displays properly.
5. Test your site using the WAVE tool: https://wave.webaim.org/
6. In the WAVE tool, turn off styles and scroll down to the bottom of the page to see the carousel comments. You'll see an error related to form label for the carousel comment textarea element.

#### Test This Branch
7. Apply this branch.
8. Navigate to the post with the gallery and confirm that the carousel displays properly.
9. Retest your site using the WAVE tool. The form label errors should be resolved.
