### PR TITLE
At a glance: hide link to Scan from Atomic sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
@@ -259,7 +259,7 @@ class DashScan extends Component {
 	}
 
 	renderAction( url, message ) {
-		if ( ! this.props.isAtomicSite ) {
+		if ( this.props.isAtomicSite ) {
 			return null;
 		}
 

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
@@ -28,7 +28,7 @@ import {
 import { isOfflineMode } from 'state/connection';
 import DashItem from 'components/dash-item';
 import { get, isArray } from 'lodash';
-import { getUpgradeUrl, showBackups } from 'state/initial-state';
+import { getUpgradeUrl, isAtomicSite, showBackups } from 'state/initial-state';
 import JetpackBanner from 'components/jetpack-banner';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import {
@@ -67,19 +67,6 @@ const renderCard = props => (
 			<p className="jp-dash-item__description">{ props.content }</p>
 		) }
 	</DashItem>
-);
-
-const renderAction = ( url, message ) => (
-	<Card
-		compact
-		key="manage-scan"
-		className="jp-dash-item__manage-in-wpcom"
-		href={ url }
-		target="_blank"
-		rel="noopener noreferrer"
-	>
-		{ message }
-	</Card>
 );
 
 const renderActiveCard = message => {
@@ -271,6 +258,25 @@ class DashScan extends Component {
 		);
 	}
 
+	renderAction( url, message ) {
+		if ( ! this.props.isAtomicSite ) {
+			return null;
+		}
+
+		return (
+			<Card
+				compact
+				key="manage-scan"
+				className="jp-dash-item__manage-in-wpcom"
+				href={ url }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ message }
+			</Card>
+		);
+	}
+
 	renderThreatsFound( numberOfThreats, dashboardUrl ) {
 		return (
 			<>
@@ -290,7 +296,7 @@ class DashScan extends Component {
 						) }
 					</p>,
 				] ) }
-				{ renderAction( dashboardUrl, __( 'View security scan details', 'jetpack' ) ) }
+				{ this.renderAction( dashboardUrl, __( 'View security scan details', 'jetpack' ) ) }
 			</>
 		);
 	}
@@ -312,7 +318,7 @@ class DashScan extends Component {
 					{ renderActiveCard(
 						__( 'Please finish your setup by entering your server’s credentials.', 'jetpack' )
 					) }
-					{ renderAction(
+					{ this.renderAction(
 						getRedirectUrl( 'jetpack-scan-dash-credentials', { site: siteRawUrl } ),
 						__( 'Enter credentials', 'jetpack' )
 					) }
@@ -335,7 +341,7 @@ class DashScan extends Component {
 								'jetpack'
 							)
 						) }
-						{ renderAction(
+						{ this.renderAction(
 							getRedirectUrl( 'calypso-scanner', { site: siteRawUrl } ),
 							__( 'View security scan details', 'jetpack' )
 						) }
@@ -402,6 +408,7 @@ export default connect(
 		const sitePlan = getSitePlan( state );
 
 		return {
+			isAtomicSite: isAtomicSite( state ),
 			isOfflineMode: isOfflineMode( state ),
 			scanStatus: getScanStatus( state ),
 			fetchingScanStatus: isFetchingScanStatus( state ),

--- a/projects/plugins/jetpack/changelog/fix-at-a-glance-link-to-scan-atomic-sites
+++ b/projects/plugins/jetpack/changelog/fix-at-a-glance-link-to-scan-atomic-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Remove broken link to Scan details on Atomic sites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/48178

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hide link to Scan's section from Atomic sites. The Scan panel located at the `At a Glance` section contains a link to `wordpress.com/scan/:site` which leads users to a section that is not available to Atomic sites.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Read https://github.com/Automattic/wp-calypso/issues/48178 and 1164141197617539-as-1200221780317813.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

This PR does not change what data or activity we track or use.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Atomic site**
* Get an Atomic site.
* Activate the Jetpack Beta Tester plugin on the site.
* On the Jetpack Beta Tester plugin, activate this branch.
* Visit the site's wp-admin dashboard.
* Visit the At a glance section of the Jetpack plugin.
* Make sure that the Scan panel doesn't show any link to `wordpress.com/scan/:site` or any other link.

**Jetpack site**
* Get a Jetpack site.
* Purchase a Jetpack paid plan that includes Jetpack Scan.
* Activate the Jetpack Beta Tester plugin on the site.
* On the Jetpack Beta Tester plugin, activate this branch.
* Visit the site's wp-admin dashboard.
* Visit the At a glance section of the Jetpack plugin.
* Make sure that the Scan panel works as usual (there is an action link at the bottom).

**Demo – before**
![image](https://user-images.githubusercontent.com/3418513/115457775-4e73b080-a1fb-11eb-9000-6a53acb0814d.png)

**Demo – after**
![image](https://user-images.githubusercontent.com/3418513/115457566-18363100-a1fb-11eb-9a2a-3ee2ade7c373.png)
