### PR TITLE
docker: Add bin/jt to dockerignore

### DIFF
--- a/tools/docker/.dockerignore
+++ b/tools/docker/.dockerignore
@@ -1,3 +1,4 @@
+bin/jt/
 data
 wordpress
 wordpress-develop


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Ignores the JT installation directory.

Otherwise if JT is installed, Docker complains about unreadable files
there when doing `jetpack docker build-image` or the like.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Download the JT installer and run it per PCYsg-snO-p2. You don't need to actually sign up for JT.
* Try `yarn docker:build-image` or `jetpack docker build-image`.