### PR TITLE
JSON API: Add clear transient endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-clear-transient-endpoint
+++ b/projects/plugins/jetpack/changelog/add-clear-transient-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adds sites/site-id/clear/transient endpoint.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -153,6 +153,30 @@ class Jetpack_JSON_API_Sync_Modify_Health_Endpoint extends Jetpack_JSON_API_Sync
 }
 // phpcs:enable
 
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+/**
+ * POST /sites/%s/clear/transient
+ */
+class Jetpack_JSON_API_Sync_Clear_Transient_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
+	/**
+	 * Callback for clear/transient endpoint.
+	 *
+	 * @return array|WP_Error result of request.
+	 */
+	protected function result() {
+		$args = $this->input();
+
+		if ( $args['name'] ) {
+			return array(
+				'success' => delete_transient( $args['name'] ),
+			);
+		} else {
+			return new WP_Error( 'missing_transient', 'No transient provided.' );
+		}
+	}
+}
+// phpcs:enable
+
 // POST /sites/%s/sync/settings
 class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {

--- a/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -607,6 +607,28 @@ new Jetpack_JSON_API_Sync_Modify_Health_Endpoint(
 	)
 );
 
+// POST /sites/%s/clear/transient .
+new Jetpack_JSON_API_Sync_Clear_Transient_Endpoint(
+	array(
+		'description'             => 'Clear transient',
+		'method'                  => 'POST',
+		'group'                   => '__do_not_document',
+		'path'                    => '/sites/%s/clear/transient',
+		'stat'                    => 'clear-transient',
+		'allow_jetpack_site_auth' => true,
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'request_format'          => array(
+			'name' => '(string) Name of transient to clear',
+		),
+		'response_format'         => array(
+			'response' => '(bool) Whether transient was deleted',
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/clear/transient',
+	)
+);
+
 $sync_settings_response = array(
 	'dequeue_max_bytes'        => '(int|bool=false) Maximum bytes to read from queue in a single request',
 	'sync_wait_time'           => '(int|bool=false) Wait time between requests in seconds if sync threshold exceeded',

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-sync-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-sync-endpoints.php
@@ -175,7 +175,7 @@ class WP_Test_Jetpack_Sync_Json_Api_Endpoints extends WP_UnitTestCase {
 		);
 
 		// set input.
-		$endpoint->api->post_body    = '{}';
+		$endpoint->api->post_body    = '{ "name": "" }';
 		$endpoint->api->content_type = 'application/json';
 
 		$response = $endpoint->callback( 'clear/transient', $blog_id );

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-sync-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-sync-endpoints.php
@@ -110,4 +110,77 @@ class WP_Test_Jetpack_Sync_Json_Api_Endpoints extends WP_UnitTestCase {
 		// Verify WP_Error returned on invalid stati.
 		$this->assertInstanceOf( 'WP_Error', $response );
 	}
+
+	/**
+	 * Unit test for the `/sites/%s/clear/transient` endpoint with valid input.
+	 */
+	public function test_clear_transient() {
+		global $blog_id;
+
+		$endpoint = new Jetpack_JSON_API_Sync_Clear_Transient_Endpoint(
+			array(
+				'description'             => 'Clear transient',
+				'method'                  => 'POST',
+				'group'                   => '__do_not_document',
+				'path'                    => '/sites/%s/clear/transient',
+				'stat'                    => 'clear-transient',
+				'allow_jetpack_site_auth' => true,
+				'path_labels'             => array(
+					'$site' => '(int|string) The site ID, The site domain',
+				),
+				'request_format'          => array(
+					'name' => '(string) Name of transient to clear',
+				),
+				'response_format'         => array(
+					'response' => '(bool) Whether transient was deleted',
+				),
+				'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/clear/transient',
+			)
+		);
+
+		// set input.
+		$endpoint->api->post_body    = '{ "name": "jetpack_connected_user_data_1" }';
+		$endpoint->api->content_type = 'application/json';
+
+		$response = $endpoint->callback( 'clear/transient', $blog_id );
+
+		$this->assertEquals( 'in_sync', $response['success'] );
+	}
+
+	/**
+	 * Unit test for the `/sites/%s/clear/transient` endpoint with invalid input.
+	 */
+	public function test_clear_transient_error() {
+		global $blog_id;
+
+		$endpoint = new Jetpack_JSON_API_Sync_Clear_Transient_Endpoint(
+			array(
+				'description'             => 'Clear transient',
+				'method'                  => 'POST',
+				'group'                   => '__do_not_document',
+				'path'                    => '/sites/%s/clear/transient',
+				'stat'                    => 'clear-transient',
+				'allow_jetpack_site_auth' => true,
+				'path_labels'             => array(
+					'$site' => '(int|string) The site ID, The site domain',
+				),
+				'request_format'          => array(
+					'name' => '(string) Name of transient to clear',
+				),
+				'response_format'         => array(
+					'response' => '(bool) Whether transient was deleted',
+				),
+				'example_request'         => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/clear/transient',
+			)
+		);
+
+		// set input.
+		$endpoint->api->post_body    = '{}';
+		$endpoint->api->content_type = 'application/json';
+
+		$response = $endpoint->callback( 'clear/transient', $blog_id );
+
+		// Verify WP_Error returned if no transient name provided.
+		$this->assertInstanceOf( 'WP_Error', $response );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-sync-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-sync-endpoints.php
@@ -144,7 +144,7 @@ class WP_Test_Jetpack_Sync_Json_Api_Endpoints extends WP_UnitTestCase {
 
 		$response = $endpoint->callback( 'clear/transient', $blog_id );
 
-		$this->assertEquals( 'in_sync', $response['success'] );
+		$this->assertFalse( $response['success'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Part of a fix for https://github.com/Automattic/wp-calypso/issues/50312
* Adds an endpoint to clear a transient on a Jetpack site, so that we can clear `jetpack_connected_user_data_$user_id` when a user makes an account change (e.g. to color scheme or language) on WP.com

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1618495635435200/1618329458.321800-slack-CKZHG0QCR
p3hLNG-18q-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D60445-code and sandbox the API.
* Checkout this branch on a Jetpack-connected site.
* Check that you have a `jetpack_connected_user_data_1` transient on your Jetpack site, e.g. by running `wp transient get jetpack_connected_user_data_1` in wp-cli. You should see an array.
* [Ping the new endpoint](https://developer.wordpress.com/docs/api/console/) with `name: "jetpack_connected_user_data_1"` in the JSON body of the request.
Click the correct path in the dropdown:
<img width="649" alt="Screen Shot 2021-04-20 at 6 13 58 PM" src="https://user-images.githubusercontent.com/1689238/115470485-66036700-a204-11eb-91ca-ac24ec0f8355.png">
Fill in the transient name:
<img width="876" alt="Screen Shot 2021-04-20 at 6 14 24 PM" src="https://user-images.githubusercontent.com/1689238/115470491-6865c100-a204-11eb-922d-cc2d8a4f07b2.png">


* Check that the transient has been deleted on the Jetpack site: `Transient with key "jetpack_connected_user_data_1" is not set.`