### PR TITLE
Live Branches: show JN site options in details element

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.18
+// @version      1.19
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*
@@ -189,7 +189,11 @@
 		function appendHtml( el, contents ) {
 			const $el = $( el );
 			const liveBranches = $( '<div id="jetpack-live-branches" />' ).append(
-				`<h2>Jetpack Live Branches</h2> ${ contents }`
+				`<h2>Jetpack Live Branches</h2>
+				<details>
+					<summary>Expand for JN site options:</summary>
+					${ contents }
+				</details>`
 			);
 			$el.append( liveBranches );
 			$( 'body' ).on( 'change', $el.find( 'input[type=checkbox]' ), onInputChanged );

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -39,9 +39,9 @@
 			);
 		} else {
 			const contents = `
-			<h4>Settings</h4>
 			<details>
 				<summary>Expand for JN site options:</summary>
+				<h4>Settings</h4>
 				${ getOptionsList(
 					[
 						{

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -39,7 +39,9 @@
 			);
 		} else {
 			const contents = `
-				<h4>Settings</h4>
+			<h4>Settings</h4>
+			<details>
+				<summary>Expand for JN site options:</summary>
 				${ getOptionsList(
 					[
 						{
@@ -147,9 +149,10 @@
 					],
 					33
 				) }
-				<p>
-					<a id="jetpack-beta-branch-link" target="_blank" rel="nofollow noopener" href="#">…</a>
-				</p>
+			</details>
+			<p>
+				<a id="jetpack-beta-branch-link" target="_blank" rel="nofollow noopener" href="#">…</a>
+			</p>
 			`;
 			appendHtml( markdownBody, contents );
 			updateLink();
@@ -176,7 +179,7 @@
 
 		function getOptionsList( options, columnWidth ) {
 			return `
-				<ul style="list-style: none; padding-left: 0; display: flex; flex-wrap: wrap;">
+				<ul style="list-style: none; padding-left: 0; margin-top: 24px; display: flex; flex-wrap: wrap;">
 					${ options
 						.map( option => {
 							return getOption( option, columnWidth );
@@ -189,11 +192,7 @@
 		function appendHtml( el, contents ) {
 			const $el = $( el );
 			const liveBranches = $( '<div id="jetpack-live-branches" />' ).append(
-				`<h2>Jetpack Live Branches</h2>
-				<details>
-					<summary>Expand for JN site options:</summary>
-					${ contents }
-				</details>`
+				`<h2>Jetpack Live Branches</h2> ${ contents }`
 			);
 			$el.append( liveBranches );
 			$( 'body' ).on( 'change', $el.find( 'input[type=checkbox]' ), onInputChanged );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Nests the live branch JN site options under a `<details>` ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)) element to reduce noise when viewing PRs.
* Browser compat looks good: https://caniuse.com/details

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Install this updated userscript version in your userscript browser extension.
  * Raw install URL: https://github.com/Automattic/jetpack/raw/0d97153c47e8d15808bed843285f735458f9f6cc/tools/jetpack-live-branches/jetpack-live-branches.user.js
* Open a PR and observe that the live branch site options are nested under an accordion-like toggle.

#### GIF

![Apr-20-2021 16-42-09](https://user-images.githubusercontent.com/15803018/115472603-7234f780-a1f7-11eb-82b2-14e3078eaf6d.gif)

