### PR TITLE
Search: Fix pagination can load duplicated items under certain conditions

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-dup-items-in-pagination
+++ b/projects/plugins/jetpack/changelog/fix-dup-items-in-pagination
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fix pagination can reload existing items when several items have the same timestamp if sorting by date


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/19514

#### Changes proposed in this Pull Request:
Fix the bug: pagination can reload existing items when several items have the same timestamp if sort.

#### Jetpack product discussion


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- TBD