### PR TITLE
Jetpack Button Block: Ensure block enqueues core Button block styles as a dependency

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-button-block-to-enqueue-core-button-style
+++ b/projects/plugins/jetpack/changelog/update-jetpack-button-block-to-enqueue-core-button-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Site Editor Compatibility: Ensure Jetpack Button block always enqueues core Button block styles as a dependency.

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -39,9 +39,14 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function render_block( $attributes, $content ) {
 	$save_in_post_content = get_attribute( $attributes, 'saveInPostContent' );
 
-	if ( Blocks::is_amp_request() ) {
-		Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
+	// The Jetpack Button block depends on the core button block styles.
+	// The following ensures that those styles are enqueued when rendering this block.
+	$core_button = \WP_Block_Type_Registry::get_instance()->get_registered( 'core/button' );
+	if ( ! empty( $core_button->style ) ) {
+		wp_enqueue_style( $core_button->style );
 	}
+
+	Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
 
 	if ( $save_in_post_content || ! class_exists( 'DOMDocument' ) ) {
 		return $content;

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -42,7 +42,7 @@ function render_block( $attributes, $content ) {
 	// The Jetpack Button block depends on the core button block styles.
 	// The following ensures that those styles are enqueued when rendering this block.
 	$core_button = \WP_Block_Type_Registry::get_instance()->get_registered( 'core/button' );
-	if ( ! empty( $core_button->style ) ) {
+	if ( isset( $core_button ) && ! empty( $core_button->style ) ) {
 		wp_enqueue_style( $core_button->style );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -41,10 +41,8 @@ function render_block( $attributes, $content ) {
 
 	// The Jetpack Button block depends on the core button block styles.
 	// The following ensures that those styles are enqueued when rendering this block.
-	$core_button = \WP_Block_Type_Registry::get_instance()->get_registered( 'core/button' );
-	if ( isset( $core_button ) && ! empty( $core_button->style ) ) {
-		wp_enqueue_style( $core_button->style );
-	}
+	enqueue_existing_button_style_dependency( 'core/button' );
+	enqueue_existing_button_style_dependency( 'core/buttons' );
 
 	Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
 
@@ -226,5 +224,21 @@ function get_attribute( $attributes, $attribute_name ) {
 
 	if ( isset( $default_attributes[ $attribute_name ] ) ) {
 		return $default_attributes[ $attribute_name ];
+	}
+}
+
+/**
+ * Enqueue style for an existing block.
+ *
+ * The Jetpack Button block depends on styles from the core button block.
+ * In case that block is not already within the post content, we can use
+ * this function to ensure the block's style assets are enqueued.
+ *
+ * @param string $block_name Block type name including namespace.
+ */
+function enqueue_existing_button_style_dependency( $block_name ) {
+	$existing_block = \WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+	if ( isset( $existing_block ) && ! empty( $existing_block->style ) ) {
+		wp_enqueue_style( $existing_block->style );
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -2,10 +2,18 @@
 	display: inline-block;
 	margin: 0 auto;
 }
+
 .wp-block[data-align="center"] {
 	.wp-block-jetpack-button {
 		display: flex;
 		justify-content: center;
+	}
+}
+
+.wp-block[data-align="right"] {
+	.wp-block-jetpack-button {
+		display: flex;
+		justify-content: flex-end;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/button/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/view.scss
@@ -1,3 +1,7 @@
 .amp-wp-article .wp-block-jetpack-button {
 	color: #ffffff;
 }
+
+.wp-block-jetpack-button button {
+	border: inherit;
+}


### PR DESCRIPTION
As tracked in https://github.com/Automattic/jetpack/issues/19464 the Jetpack Button block depends on styles from the core Button block (via the class name `.wp-block-button__link`. In an FSE theme like TT1-blocks, no styles are provided to override the button block styling, so it becomes apparent that when no core Button block is inserted into a template part, then the Jetpack button block appears unstyled.

To address this, we can ensure that the core Button block styles are always enqueued when a Jetpack Button block is rendered on the server.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Possible fix for #19464 and related to https://github.com/Automattic/jetpack/issues/19504

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Always ensure the core Button Block styles are enqueued when rendering a Jetpack Button block
* Provide a default for the Button border (`inherit`), to avoid the browser default button border from being added

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/115515657-b5ab6680-a2c8-11eb-8bfc-ed6d65b5d162.png) | ![image](https://user-images.githubusercontent.com/14988353/115516188-379b8f80-a2c9-11eb-8617-30828536b333.png) |

Ensuring no regressions on a non-FSE site, checking that outline style and custom colours still works:

![image](https://user-images.githubusercontent.com/14988353/115516099-2488bf80-a2c9-11eb-914d-9c6b5515fc5e.png)


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In an FSE site with the TT1-blocks theme active, insert a block that uses the Jetpack Button block (e.g. Mailchimp or Contact Form) into a template part like the footer template part.
* Save the template.
* View the front end of the site — you should see the default styling of the Button block is applied to the Jetpack Button block
* On a non-FSE theme and site, using a Varia theme like Barnsbury, insert one of the blocks that uses the Jetpack Button block, and ensure that on the front end it still renders as you'd expect using the theme's styles for the button
