### PR TITLE
REST API: Add list modules v1.2 endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-rest-api-v12-list-modules-endpoint
+++ b/projects/plugins/jetpack/changelog/add-rest-api-v12-list-modules-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+REST API: Add list modules v1.2 endpoint

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-modules-list-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-modules-list-v1-2-endpoint.php
@@ -9,19 +9,28 @@ use Automattic\Jetpack\Status;
 /**
  * List modules v1.2 endpoint.
  */
-class Jetpack_JSON_API_Modules_List_V1_2_Endpoint extends Jetpack_JSON_API_Modules_List_Endpoint {
+class Jetpack_JSON_API_Modules_List_V1_2_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	/**
-	 * Override parent method to set the modules class property.
+	 * This endpoint allows authentication both via a blog and a user token.
+	 * If a user token is used, that user should have `jetpack_manage_modules` capability.
 	 *
-	 * @param  string $module The module slug.
-	 * @return bool true
+	 * @var array|string
 	 */
-	public function validate_input( $module ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	protected $needed_capabilities = 'jetpack_manage_modules';
+
+	/**
+	 * Fetch modules list.
+	 *
+	 * @return array An array of module objects.
+	 */
+	protected function result() {
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
+
 		$is_offline_mode = ( new Status() )->is_offline_mode();
 
 		$modules = Jetpack_Admin::init()->get_modules();
+
 		foreach ( $modules as $slug => $properties ) {
 			if ( $is_offline_mode ) {
 				$requires_connection      = isset( $modules[ $slug ]['requires_connection'] ) && $modules[ $slug ]['requires_connection'];
@@ -36,29 +45,6 @@ class Jetpack_JSON_API_Modules_List_V1_2_Endpoint extends Jetpack_JSON_API_Modul
 
 		$modules = Jetpack::get_translated_modules( $modules );
 
-		$this->modules = $modules;
-
-		return true;
-	}
-
-	/**
-	 * Format a list of modules for public display, using the supplied offset and limit args.
-	 *
-	 * @uses   WPCOM_JSON_API_Endpoint::query_args()
-	 * @return array         Public API modules objects
-	 */
-	protected function get_modules() {
-		$modules = array_values( $this->modules );
-		// do offset & limit - we've already returned a 400 error if they're bad numbers.
-		$args = $this->query_args();
-
-		if ( isset( $args['offset'] ) ) {
-			$modules = array_slice( $modules, (int) $args['offset'] );
-		}
-		if ( isset( $args['limit'] ) ) {
-			$modules = array_slice( $modules, 0, (int) $args['limit'] );
-		}
-
-		return $modules;
+		return array( 'modules' => $modules );
 	}
 }

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-modules-list-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-modules-list-v1-2-endpoint.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * List modules v1.2 endpoint.
+ *
+ *  @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Status;
+/**
+ * List modules v1.2 endpoint.
+ */
+class Jetpack_JSON_API_Modules_List_V1_2_Endpoint extends Jetpack_JSON_API_Modules_List_Endpoint {
+
+	/**
+	 * Override parent method to set the modules class property.
+	 *
+	 * @param  string $module The module slug.
+	 * @return bool true
+	 */
+	public function validate_input( $module ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
+		$is_offline_mode = ( new Status() )->is_offline_mode();
+
+		$modules = Jetpack_Admin::init()->get_modules();
+		foreach ( $modules as $slug => $properties ) {
+			if ( $is_offline_mode ) {
+				$requires_connection      = isset( $modules[ $slug ]['requires_connection'] ) && $modules[ $slug ]['requires_connection'];
+				$requires_user_connection = isset( $modules[ $slug ]['requires_user_connection'] ) && $modules[ $slug ]['requires_user_connection'];
+				if (
+					$requires_connection || $requires_user_connection
+				) {
+					$modules[ $slug ]['activated'] = false;
+				}
+			}
+		}
+
+		$modules = Jetpack::get_translated_modules( $modules );
+
+		$this->modules = $modules;
+
+		return true;
+	}
+
+	/**
+	 * Format a list of modules for public display, using the supplied offset and limit args.
+	 *
+	 * @uses   WPCOM_JSON_API_Endpoint::query_args()
+	 * @return array         Public API modules objects
+	 */
+	protected function get_modules() {
+		$modules = array_values( $this->modules );
+		// do offset & limit - we've already returned a 400 error if they're bad numbers.
+		$args = $this->query_args();
+
+		if ( isset( $args['offset'] ) ) {
+			$modules = array_slice( $modules, (int) $args['offset'] );
+		}
+		if ( isset( $args['limit'] ) ) {
+			$modules = array_slice( $modules, 0, (int) $args['limit'] );
+		}
+
+		return $modules;
+	}
+}

--- a/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -321,6 +321,8 @@ new Jetpack_JSON_API_Modules_List_Endpoint(
 		'method'                  => 'GET',
 		'path'                    => '/sites/%s/jetpack/modules',
 		'stat'                    => 'jetpack:modules',
+		'min_version'             => '1',
+		'max_version'             => '1.1',
 		'path_labels'             => array(
 			'$site' => '(int|string) The site ID, The site domain',
 		),
@@ -335,6 +337,31 @@ new Jetpack_JSON_API_Modules_List_Endpoint(
 			),
 		),
 		'example_request'         => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/jetpack/modules',
+	)
+);
+
+require_once $json_jetpack_endpoints_dir . 'class-jetpack-json-api-modules-list-v1-2-endpoint.php';
+
+new Jetpack_JSON_API_Modules_List_V1_2_Endpoint(
+	array(
+		'description'             => 'Get the list of available Jetpack modules on your site',
+		'method'                  => 'GET',
+		'path'                    => '/sites/%s/jetpack/modules',
+		'stat'                    => 'jetpack:modules',
+		'min_version'             => '1.2',
+		'path_labels'             => array(
+			'$site' => '(int|string) The site ID, The site domain',
+		),
+		'response_format'         => array(
+			'modules' => '(array) An array of module objects.',
+		),
+		'allow_jetpack_site_auth' => true,
+		'example_request_data'    => array(
+			'headers' => array(
+				'authorization' => 'Bearer YOUR_API_TOKEN',
+			),
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.2/sites/example.wordpress.org/jetpack/modules',
 	)
 );
 

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-modules-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-modules-endpoints.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Tests for the `sites/%s/jetpack/modules` endpoints.
+ *
+ * @package automattic/jetpack
+ */
+
+require_jetpack_file( 'class.json-api.php' );
+require_jetpack_file( 'class.json-api-endpoints.php' );
+
+/**
+ * Tests for the `sites/%s/jetpack/modules` endpoints.
+ */
+class WP_Test_Jetpack_Modules_Json_Api_Endpoints extends WP_UnitTestCase {
+	/**
+	 * Inserts globals needed to initialize the endpoint.
+	 */
+	private function set_globals() {
+		$_SERVER['REQUEST_METHOD'] = 'Get';
+		$_SERVER['HTTP_HOST']      = '127.0.0.1';
+		$_SERVER['REQUEST_URI']    = '/';
+	}
+
+	/**
+	 * Prepare the environment for the test.
+	 */
+	public function setUp() {
+		global $blog_id;
+
+		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
+			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
+		}
+
+		parent::setUp();
+
+		$this->set_globals();
+
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
+	}
+
+	/**
+	 * Unit test for the `v1.2/modules/%s` endpoint.
+	 */
+	public function test_get_modules_v1_2() {
+		global $blog_id;
+
+		$endpoint = new Jetpack_JSON_API_Modules_List_V1_2_Endpoint(
+			array(
+				'description'             => 'Get the list of available Jetpack modules on your site',
+				'method'                  => 'GET',
+				'path'                    => '/sites/%s/jetpack/modules',
+				'stat'                    => 'jetpack:modules',
+				'min_version'             => '1.2',
+				'path_labels'             => array(
+					'$site' => '(int|string) The site ID, The site domain',
+				),
+				'response_format'         => array(
+					'modules' => '(array) An array of module objects.',
+				),
+				'allow_jetpack_site_auth' => true,
+				'example_request_data'    => array(
+					'headers' => array(
+						'authorization' => 'Bearer YOUR_API_TOKEN',
+					),
+				),
+				'example_request'         => 'https://public-api.wordpress.com/rest/v1.2/sites/example.wordpress.org/jetpack/modules',
+			)
+		);
+
+		$response = $endpoint->callback( '', $blog_id );
+
+		$this->assertArrayHasKey( 'modules', $response );
+		$this->assertIsArray( $response['modules'] );
+
+		$module = array_pop( $response['modules'] );
+		$this->assertArrayHasKey( 'name', $module );
+		$this->assertArrayHasKey( 'description', $module );
+		$this->assertArrayHasKey( 'activated', $module );
+		$this->assertArrayHasKey( 'available', $module );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-modules-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-modules-endpoints.php
@@ -70,7 +70,7 @@ class WP_Test_Jetpack_Modules_Json_Api_Endpoints extends WP_UnitTestCase {
 		$response = $endpoint->callback( '', $blog_id );
 
 		$this->assertArrayHasKey( 'modules', $response );
-		$this->assertIsArray( $response['modules'] );
+		$this->assertTrue( is_array( $response['modules'] ) );
 
 		$module = array_pop( $response['modules'] );
 		$this->assertArrayHasKey( 'name', $module );


### PR DESCRIPTION
Introduces a new v1.2 endpoint for listing modules.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the min. max versions in the existing v1 modules list endpoint
* Adds a new v1.2 endpoint for listing modules that returns additional module info (same as `v4` endpoint excluding the `options` field)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-2Lm-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
D60475-code