### PR TITLE
Always use WP Admin for comments in Atomic sites.

### DIFF
--- a/projects/plugins/jetpack/changelog/Always use WP Admin for comments in Atomic sites.
+++ b/projects/plugins/jetpack/changelog/Always use WP Admin for comments in Atomic sites.
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Always use WP Admin for comments in Atomic sites.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -282,6 +282,13 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Always use WP Admin for comments.
+	 */
+	public function add_comments_menu() {
+		parent::add_comments_menu( true );
+	}
+
+	/**
 	 * Saves the sidebar state ( expanded / collapsed ) via an ajax request.
 	 */
 	public function ajax_sidebar_state() {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -283,8 +283,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 	/**
 	 * Always use WP Admin for comments.
+	 *
+	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
-	public function add_comments_menu() {
+	public function add_comments_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		parent::add_comments_menu( true );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/51429

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Always use WP Admin for comments in Atomic sites by not altering the Comments menu at all.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With `Show advanced dashboard pages.` off
* Load this branch in Jetpack Beta
* Click "Comments"
* You should be redirected to WP Admin
* Repeat with `Show advanced dashboard pages.` on (sanity check)
