### PR TITLE
Nav Unification: Fix Upgrades, Jetpack and Settings default menu slugs in WP-Admin

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -212,11 +212,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		global $submenu;
 
 		$current_user_can_access_menu = current_user_can( $menu_item[1] );
-		$has_first_menu_item          = isset( $submenu[ $menu_item[2] ][0] );
-		$menu_slug                    = $menu_item[2];
+		$submenu_items                = isset( $submenu[ $menu_item[2] ] ) ? array_values( $submenu[ $menu_item[2] ] ) : array();
+		$has_first_menu_item          = isset( $submenu_items[0] );
 
 		// Exclude unauthorized menu items when the user does not have access to the menu and the first submenu item.
-		if ( ! $current_user_can_access_menu && $has_first_menu_item && ! current_user_can( $submenu[ $menu_slug ][0][1] ) ) {
+		if ( ! $current_user_can_access_menu && $has_first_menu_item && ! current_user_can( $submenu_items[0][1] ) ) {
 			return array();
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -113,13 +113,6 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			if ( ! empty( $submenu[ $menu_item[2] ] ) ) {
 				$submenu_items = array_values( $submenu[ $menu_item[2] ] );
 
-				// If the user doesn't have the caps for the top level menu item, let's promote the first submenu item.
-				if ( empty( $item ) ) {
-					$menu_item[1] = $submenu_items[0][1]; // Capability.
-					$menu_item[2] = $submenu_items[0][2]; // Menu slug.
-					$item         = $this->prepare_menu_item( $menu_item );
-				}
-
 				// Add submenu items.
 				foreach ( $submenu_items as $submenu_item ) {
 					$submenu_item = $this->prepare_submenu_item( $submenu_item, $menu_item );
@@ -218,8 +211,17 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	private function prepare_menu_item( array $menu_item ) {
 		global $submenu;
 
-		// Exclude unauthorized menu items.
-		if ( ! current_user_can( $menu_item[1] ) ) {
+		$current_user_can_access_menu = current_user_can( $menu_item[1] );
+		$has_first_menu_item          = isset( $submenu[ $menu_item[2] ][0] );
+		$menu_slug                    = $menu_item[2];
+
+		// Exclude unauthorized menu items when the user does not have access to the menu and the first submenu item.
+		if ( ! $current_user_can_access_menu && $has_first_menu_item && ! current_user_can( $submenu[ $menu_slug ][0][1] ) ) {
+			return array();
+		}
+
+		// Exclude unauthorized menu items that don't have submenus.
+		if ( ! $current_user_can_access_menu && ! $has_first_menu_item ) {
 			return array();
 		}
 

--- a/projects/plugins/jetpack/changelog/fix-paid-upgrades-and-jetpack-menu-item
+++ b/projects/plugins/jetpack/changelog/fix-paid-upgrades-and-jetpack-menu-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed the Upgrades, Jetpack and Settings menu item slugs in WP-Admin

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -148,7 +148,8 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		if ( ! $menu_exists ) {
 			// Remove the submenu auto-created by Core.
-			$this->hide_submenu_page( 'paid-upgrades.php', 'paid-upgrades.php' );
+			// We remove it instead of hiding it because WP-Admin will see it as the first submenu item and therefore it acts as the menu's default URL.
+			remove_submenu_page( 'paid-upgrades.php', 'paid-upgrades.php' );
 		}
 	}
 
@@ -414,7 +415,7 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		if ( ! $is_menu_updated ) {
 			// Remove the submenu auto-created by Core.
-			$this->hide_submenu_page( 'jetpack', 'jetpack' );
+			remove_submenu_page( 'jetpack', 'jetpack' );
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -68,9 +68,6 @@ class Admin_Menu extends Base_Admin_Menu {
 			remove_menu_page( 'link-manager.php' );
 		}
 
-		$this->sort_hidden_submenus();
-		$this->hide_unauthorized_menus();
-
 		ksort( $GLOBALS['menu'] );
 	}
 
@@ -151,7 +148,6 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		if ( ! $menu_exists ) {
 			// Remove the submenu auto-created by Core.
-			// We remove it instead of hiding it because WP-Admin will see it as the first submenu item and therefore it acts as the menu's default URL.
 			$this->hide_submenu_page( 'paid-upgrades.php', 'paid-upgrades.php' );
 		}
 	}
@@ -419,7 +415,7 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
 
 		if ( ! $is_menu_updated ) {
-			// Remove the submenu auto-created by Core.
+			// Remove the submenu auto-created by Core just to be sure that there no issues on non-admin roles.
 			remove_submenu_page( 'jetpack', 'jetpack' );
 		}
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -68,6 +68,9 @@ class Admin_Menu extends Base_Admin_Menu {
 			remove_menu_page( 'link-manager.php' );
 		}
 
+		$this->hide_unauthorized_menus();
+		$this->sort_hidden_submenus();
+
 		ksort( $GLOBALS['menu'] );
 	}
 
@@ -149,7 +152,7 @@ class Admin_Menu extends Base_Admin_Menu {
 		if ( ! $menu_exists ) {
 			// Remove the submenu auto-created by Core.
 			// We remove it instead of hiding it because WP-Admin will see it as the first submenu item and therefore it acts as the menu's default URL.
-			remove_submenu_page( 'paid-upgrades.php', 'paid-upgrades.php' );
+			$this->hide_submenu_page( 'paid-upgrades.php', 'paid-upgrades.php' );
 		}
 	}
 
@@ -380,6 +383,8 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_options_menu( $wp_admin = false ) {
+		$this->hide_submenu_page( 'options-general.php', 'sharing' );
+
 		if ( $wp_admin ) {
 			return;
 		}
@@ -388,9 +393,6 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		$this->hide_submenu_page( 'options-general.php', 'options-discussion.php' );
 		$this->hide_submenu_page( 'options-general.php', 'options-writing.php' );
-
-		// We are safe to remove this page because it does not have any additional information and it's not a main page.
-		remove_submenu_page( 'options-general.php', 'sharing' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -388,6 +388,9 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		$this->hide_submenu_page( 'options-general.php', 'options-discussion.php' );
 		$this->hide_submenu_page( 'options-general.php', 'options-writing.php' );
+
+		// We are safe to remove this page because it does not have any additional information and it's not a main page.
+		remove_submenu_page( 'options-general.php', 'sharing' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -68,8 +68,8 @@ class Admin_Menu extends Base_Admin_Menu {
 			remove_menu_page( 'link-manager.php' );
 		}
 
-		$this->hide_unauthorized_menus();
 		$this->sort_hidden_submenus();
+		$this->hide_unauthorized_menus();
 
 		ksort( $GLOBALS['menu'] );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -484,18 +484,20 @@ abstract class Base_Admin_Menu {
 				continue;
 			}
 
-			// Hide the menu if it doesn't have any submenus visible.
-			if ( ! current_user_can( $menu_item[1] ) && ! $this->has_visible_items( $submenu[ $menu_item[2] ] ) ) {
+			// If the first submenu item is hidden then we should also hide the parent.
+			// Since the submenus are ordered by self::HIDE_CSS_CLASS (hidden submenus should be at the end of the array),
+			// we can say that if the first submenu is hidden then we should also hide the menu.
+			$first_submenu_item       = array_values( $submenu[ $menu_item[2] ] )[0];
+			$is_first_submenu_visible = $this->is_item_visible( $first_submenu_item );
+
+			// if the user does not have access to the menu and the first submenu is hidden, then hide the menu.
+			if ( ! current_user_can( $menu_item[1] ) && ! $is_first_submenu_visible ) {
 				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				$menu[ $menu_index ][4] = self::HIDE_CSS_CLASS;
 			}
 
-			// If the first submenu item is hidden then we should also hide the parent.
-			// Since the submenus are ordered by self::HIDE_CSS_CLASS, we can say that if the first submenu is
-			// hidden then we should also hide the menu.
-			$first_submenu_item = array_values( $submenu[ $menu_item[2] ] )[0];
-
-			if ( $menu_item[2] === $first_submenu_item[2] && ! $this->is_item_visible( $first_submenu_item ) ) {
+			// if the menu has the same slug as the first submenu then hide the submenu.
+			if ( $menu_item[2] === $first_submenu_item[2] && ! $is_first_submenu_visible ) {
 				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				$menu[ $menu_index ][4] = self::HIDE_CSS_CLASS;
 			}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -477,8 +477,25 @@ abstract class Base_Admin_Menu {
 		global $menu, $submenu;
 
 		foreach ( $menu as $menu_index => $menu_item ) {
+			$has_submenus = isset( $submenu[ $menu_item[2] ] );
+
+			// Skip if the menu doesn't have submenus.
+			if ( ! $has_submenus ) {
+				continue;
+			}
+
 			// Hide the menu if it doesn't have any submenus visible.
-			if ( ! current_user_can( $menu_item[1] ) && isset( $submenu[ $menu_item[2] ] ) && ! $this->has_visible_items( $submenu[ $menu_item[2] ] ) ) {
+			if ( ! current_user_can( $menu_item[1] ) && ! $this->has_visible_items( $submenu[ $menu_item[2] ] ) ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$menu[ $menu_index ][4] = self::HIDE_CSS_CLASS;
+			}
+
+			// If the first submenu item is hidden then we should also hide the parent.
+			// Since the submenus are ordered by self::HIDE_CSS_CLASS, we can say that if the first submenu is
+			// hidden then we should also hide the menu.
+			$first_submenu_item = array_values( $submenu[ $menu_item[2] ] )[0];
+
+			if ( $menu_item[2] === $first_submenu_item[2] && ! $this->is_item_visible( $first_submenu_item ) ) {
 				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				$menu[ $menu_index ][4] = self::HIDE_CSS_CLASS;
 			}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -23,6 +23,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		add_action( 'wp_ajax_sidebar_state', array( $this, 'ajax_sidebar_state' ) );
 		add_action( 'admin_init', array( $this, 'sync_sidebar_collapsed_state' ) );
+		add_action( 'admin_menu', array( $this, 'remove_submenus' ), 140 ); // After hookpress hook at 130.
 	}
 
 	/**
@@ -353,5 +354,40 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		$sidebar_collapsed = isset( $calypso_preferences['sidebarCollapsed'] ) ? $calypso_preferences['sidebarCollapsed'] : false;
 		set_user_setting( 'mfold', $sidebar_collapsed ? 'f' : 'o' );
+	}
+
+	/**
+	 * Removes unwanted submenu items.
+	 *
+	 * These submenus are added across wp-content and should be removed together with these function calls.
+	 */
+	public function remove_submenus() {
+		global $_registered_pages;
+
+		remove_submenu_page( 'index.php', 'akismet-stats' );
+		remove_submenu_page( 'index.php', 'my-comments' );
+		remove_submenu_page( 'index.php', 'stats' );
+		remove_submenu_page( 'index.php', 'subscriptions' );
+
+		/* @see https://github.com/Automattic/wp-calypso/issues/49210 */
+		remove_submenu_page( 'index.php', 'my-blogs' );
+		$_registered_pages['admin_page_my-blogs'] = true; // phpcs:ignore
+
+		remove_submenu_page( 'paid-upgrades.php', 'premium-themes' );
+		remove_submenu_page( 'paid-upgrades.php', 'domains' );
+		remove_submenu_page( 'paid-upgrades.php', 'my-upgrades' );
+		remove_submenu_page( 'paid-upgrades.php', 'billing-history' );
+
+		remove_submenu_page( 'themes.php', 'customize.php?autofocus[panel]=amp_panel&return=' . rawurlencode( admin_url() ) );
+
+		remove_submenu_page( 'users.php', 'wpcom-invite-users' ); // Wpcom_Invite_Users::action_admin_menu.
+
+		remove_submenu_page( 'options-general.php', 'adcontrol' );
+
+		// Remove menu item but continue allowing access.
+		foreach ( array( 'openidserver', 'webhooks' ) as $page_slug ) {
+			remove_submenu_page( 'options-general.php', $page_slug );
+			$_registered_pages[ 'admin_page_' . $page_slug ] = true; // phpcs:ignore
+		}
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -349,7 +349,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Syncs the sidebar collapsed state from Calypso Preferences.
 	 */
 	public function sync_sidebar_collapsed_state() {
-		$sidebar_collapsed = get_user_attribute( get_current_user_id(), 'calypso_preferences' )['sidebarCollapsed'];
+		$calypso_preferences = get_user_attribute( get_current_user_id(), 'calypso_preferences' );
+
+		$sidebar_collapsed = isset( $calypso_preferences['sidebarCollapsed'] ) ? $calypso_preferences['sidebarCollapsed'] : false;
 		set_user_setting( 'mfold', $sidebar_collapsed ? 'f' : 'o' );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -270,7 +270,8 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
 
-		$this->hide_submenu_page( 'options-general.php', 'sharing' );
+		// We are safe to remove this page because it does not have any additional information and it's not a main page.
+		remove_submenu_page( 'options-general.php', 'sharing' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -269,9 +269,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::add_options_menu( $wp_admin );
 
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
-
-		// We are safe to remove this page because it does not have any additional information and it's not a main page.
-		remove_submenu_page( 'options-general.php', 'sharing' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -253,6 +253,44 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	}
 
 	/**
+	 * Check if the menu URL is properly generated from the first submenu slug.
+	 */
+	public function test_if_the_first_submenu_url_is_used_for_menu_url() {
+		global $menu;
+
+		add_menu_page( '', __( 'Foo', 'jetpack' ), 'read', 'foo' );
+		$fnc = function () { }; /// needed for the slug to register as a page.
+		add_submenu_page( 'foo', 'title', 'title', 'read', 'sharing', $fnc, 0 );
+
+		$foo_item = array();
+
+		foreach ( $menu as $menu_item ) {
+			if ( 'foo' === $menu_item[2] ) {
+				$foo_item = $menu_item;
+				break;
+			}
+		}
+
+		$class = new ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
+
+		$prepare_menu_item = $class->getMethod( 'prepare_menu_item' );
+		$prepare_menu_item->setAccessible( true );
+
+		$expected = array(
+			'icon'  => 'dashicons-admin-generic',
+			'slug'  => 'foo',
+			'title' => 'Foo',
+			'type'  => 'menu-item',
+			'url'   => 'http://example.org/wp-admin/admin.php?page=sharing',
+		);
+
+		$this->assertSame(
+			$expected,
+			$prepare_menu_item->invokeArgs( new WPCOM_REST_API_V2_Endpoint_Admin_Menu(), array( $foo_item ) )
+		);
+	}
+
+	/**
 	 * Tests preparing a menu item icon.
 	 *
 	 * @param string $icon     Menu item icon as generated in wp-admin/menu.php.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -258,7 +258,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	public function test_if_the_first_submenu_url_is_used_for_menu_url() {
 		global $menu;
 
-		add_menu_page( '', __( 'Foo', 'jetpack' ), 'read', 'foo' );
+		add_menu_page( '', 'Foo', 'read', 'foo' );
 		$fnc = function () { }; /// needed for the slug to register as a page.
 		add_submenu_page( 'foo', 'title', 'title', 'read', 'sharing', $fnc, 0 );
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -418,4 +418,103 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		);
 		$this->assertSame( $menu[61], $fse_menu );
 	}
+
+	/**
+	 * Check if the hidden menus are at the end of the submenu.
+	 */
+	public function test_if_the_hidden_menus_are_at_the_end_of_submenu() {
+		global $submenu;
+
+		$submenu = array(
+			'options-general.php' => array(
+				array( '', 'read', 'test-slug', '', '' ),
+				array( '', 'read', 'test-slug', '', Base_Admin_Menu::HIDE_CSS_CLASS ),
+				array( '', 'read', 'test-slug', '', '' ),
+				array( '', 'read', 'test-slug', '' ),
+				array( '', 'read', 'test-slug', '', Base_Admin_Menu::HIDE_CSS_CLASS ),
+				array( '', 'read', 'test-slug', '', '' ),
+			),
+		);
+
+		static::$admin_menu->sort_hidden_submenus();
+		$this->assertNotEquals( Base_Admin_Menu::HIDE_CSS_CLASS, $submenu['options-general.php'][0][4] );
+		$this->assertNotEquals( Base_Admin_Menu::HIDE_CSS_CLASS, $submenu['options-general.php'][2][4] );
+
+		$this->assertEquals( $submenu['options-general.php'][3], array( '', 'read', 'test-slug', '' ) );
+
+		$this->assertNotEquals( Base_Admin_Menu::HIDE_CSS_CLASS, $submenu['options-general.php'][5][4] );
+
+		$this->assertEquals( Base_Admin_Menu::HIDE_CSS_CLASS, $submenu['options-general.php'][6][4] );
+		$this->assertEquals( Base_Admin_Menu::HIDE_CSS_CLASS, $submenu['options-general.php'][7][4] );
+
+		$submenu = self::$submenu_data;
+	}
+
+	/**
+	 * Check if the parent menu is hidden when the submenus are hidden.
+	 *
+	 * @dataProvider hide_menu_based_on_submenu_provider
+	 *
+	 * @param array $menu_items The mock menu array.
+	 * @param array $submenu_items The mock submenu array.
+	 * @param array $expected The expected result.
+	 */
+	public function test_if_it_hides_menu_based_on_submenu( $menu_items, $submenu_items, $expected ) {
+		global $submenu, $menu;
+
+		$menu    = $menu_items;
+		$submenu = $submenu_items;
+
+		static::$admin_menu->hide_parent_of_hidden_submenus();
+
+		$this->assertEquals( $expected, $menu[0] );
+
+		// reset the menu arrays.
+		$menu    = self::$menu_data;
+		$submenu = self::$submenu_data;
+	}
+
+	/**
+	 * The data provider for test_if_it_hides_menu_based_on_submenu.
+	 *
+	 * @return array
+	 */
+	public function hide_menu_based_on_submenu_provider() {
+		return array(
+			array(
+				array(
+					array( '', 'non-existing-capability', 'test-slug', '', '' ),
+				),
+				array(
+					'test-slug' => array(
+						array(
+							'test',
+							'',
+							'',
+							'',
+							Base_Admin_Menu::HIDE_CSS_CLASS,
+						),
+					),
+				),
+				array( '', 'non-existing-capability', 'test-slug', '', Base_Admin_Menu::HIDE_CSS_CLASS ),
+			),
+			array(
+				array(
+					array( '', 'read', 'test-slug', '', '' ),
+				),
+				array(
+					'test-slug' => array(
+						array(
+							'test',
+							'',
+							'test-slug',
+							'',
+							Base_Admin_Menu::HIDE_CSS_CLASS,
+						),
+					),
+				),
+				array( '', 'read', 'test-slug', '', Base_Admin_Menu::HIDE_CSS_CLASS ),
+			),
+		);
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -99,7 +99,7 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_jetpack_menu();
 
-		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][3][2] );
+		$this->assertSame( 'https://wordpress.com/scan/' . static::$domain, $submenu['jetpack'][2][2] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #19598 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- In case of `Upgrades` menu, we are safe to remove the default `paid-upgrades.php` submenu item that's generated by core.
- In case of Jetpack menu, for non-administrator roles, the first submenu item (and therefore the default slug of the menu) is the generated by the core's menu behaviour. In this case, when clicking on the menu item, the user will be redirected to a broken page. Just as in the case of `Upgrades`, the core submenu item can be removed.
- The Settings menu item will not appear for Editor roles because the only item displayed in there was `Sharing` which it should be hidden. As in the case of the other pages mentioned above, we are safe to remove this page since it does not contain additional functionality.
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

_Simple_
- Apply D60482-code to your WP.com sandbox.
- Apply also D60627-code to your WP.COM sandbox.
- Sandbox the API and a simple site.
- Go to https://wordpress.com and switch to the sandboxed site.

_Atomic_
- Install Jetpack Beta on a Atomic site and switch to the branch of this PR.
- Go to https://wordpress.com and switch to the WoA site.

Testing paid-upgrades.php:
 - Go to wp-admin dashboard (e.g. `site-name.wordpress.com/wp-admin/` and `site-name.wpcomstaging.com/wp-admin`)
 - Make sure that when clicking on `Upgrades` menu the page is not broken.
 
Testing Jetpack menu:
- Go to wp-admin dashboard with a non-administrator user
- Make sure that when clicking on the `Jetpack` menu the user is not redirected to a broken page.

Testing Settings menu:
- Go to Wordpress.com and login with an admin user.
- Go to wordpress.com and login with a `Editor` user
- Make sure that the `Settings` menu item is not displayed in the navigation

Testing Tools menu:
- Go to wordpress.com and login with a Contributor user
- Make sure that `Tools` menu is no longer displayed.