### PR TITLE
Licensing: Enable the connection banner when licenses stored

### DIFF
--- a/projects/plugins/jetpack/changelog/update-userless-license-aware-connection-banner
+++ b/projects/plugins/jetpack/changelog/update-userless-license-aware-connection-banner
@@ -1,4 +1,5 @@
 Significance: minor
 Type: enhancement
 
-Show the license-aware version of the connection banner when there is a userless connection established and there are stored licenses
+Show the license-aware version of the Connection banner when there is a userless connection established and there are stored licenses.
+Hide the Recommendations banner when the Connection banner is visible.

--- a/projects/plugins/jetpack/changelog/update-userless-license-aware-connection-banner
+++ b/projects/plugins/jetpack/changelog/update-userless-license-aware-connection-banner
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Show the license-aware version of the connection banner when there is a userless connection established and there are stored licenses

--- a/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
+++ b/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
@@ -40,9 +40,18 @@ class Jetpack_Recommendations_Banner {
 
 	/**
 	 * Initialize hooks to display the banner
+	 *
+	 * @since 9.7 Added the $current_screen parameter.
+	 *
+	 * @param \WP_Screen $current_screen Current WordPress screen.
 	 */
-	public function maybe_initialize_hooks() {
+	public function maybe_initialize_hooks( $current_screen ) {
 		if ( ! $this->can_be_displayed() ) {
+			return;
+		}
+
+		if ( Jetpack_Connection_Banner::can_be_displayed( $current_screen ) ) {
+			// We don't want to overcrowd the screen with both the Connection banner and the Recommendations banner.
 			return;
 		}
 

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3704,11 +3704,16 @@ p {
 			self::plugin_initialize();
 		}
 
-		$is_offline_mode = ( new Status() )->is_offline_mode();
-		if ( ! self::is_connection_ready() && ! $is_offline_mode ) {
+		$is_offline_mode              = ( new Status() )->is_offline_mode();
+		$fallback_no_verify_ssl_certs = Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' );
+		/** Already documented in automattic/jetpack-connection::src/class-client.php */
+		$client_verify_ssl_certs = apply_filters( 'jetpack_client_verify_ssl_certs', false );
+
+		if ( ! $is_offline_mode ) {
 			Jetpack_Connection_Banner::init();
-			/** Already documented in automattic/jetpack-connection::src/class-client.php */
-		} elseif ( ( false === Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' ) ) && ! apply_filters( 'jetpack_client_verify_ssl_certs', false ) ) {
+		}
+
+		if ( ( self::is_connection_ready() || $is_offline_mode ) && false === $fallback_no_verify_ssl_certs && ! $client_verify_ssl_certs ) {
 			// Upgrade: 1.1 -> 1.1.1
 			// Check and see if host can verify the Jetpack servers' SSL certificate
 			$args = array();


### PR DESCRIPTION
The connection banner should persist when there is a userless connection
established but there are stored licenses as this indicates there are
purchased products that require a connection owner and may not be provisioned yet.

#### Changes proposed in this Pull Request:

* Licensing: Enable the connection banner when there are stored licenses

#### Jetpack product discussion

p1618929257316300-slack-CQN0YDYM7

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

1. Start with a clean slate - no connection and no licenses stored in the `jetpack_licenses` option.
2. Confirm the normal connection banner shows up in wp-admin's Dashboard.
3. Run `yarn docker:wp option set jetpack_licenses '["foo"]' --format=json`.
4. Dashboard should now show the license-aware version of the connection banner.
5. Make sure `JETPACK_NO_USER_TEST_MODE` is enabled.
6. Establish a userless connection only - do not connect to your WPCOM account.
  If you're unsure on how to do this you can click on the green button in the CTA and navigate away without approving with your WPCOM account on the next page.
7. Dashboard should still show the license-aware connection banner.
8. Run `yarn docker:wp option set jetpack_licenses '[]' --format=json`.
9. Dashboard should no longer show any version of the connection banner.
10. Connect Jetpack with your WPCOM account.
11. Dashboard should continue to not show show any version of the connection banner.
12. Run `yarn docker:wp option set jetpack_licenses '["foo"]' --format=json` again.
13. Confirm Dashboard still shows no connection banner.

License-aware connection banner:
![Screenshot 2021-04-21 at 18 32 55](https://user-images.githubusercontent.com/22746396/115580701-04a8ca00-a2d0-11eb-9f16-bb17d898f999.png)