### PR TITLE
CLI: Refactor `jetpack changelog` tool

### DIFF
--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -192,6 +192,10 @@ async function changelogCommand( argv ) {
 		throw new Error( 'Unknown command' ); // Yargs should provide a helpful response before this, but to be safe.
 	}
 
+	if ( argv.cmd === 'version' ) {
+		throw new Error( 'Version not supported yet!' );
+	}
+
 	changelogArgs( argv );
 }
 

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -192,6 +192,7 @@ async function changelogCommand( argv ) {
 		throw new Error( 'Unknown command' ); // Yargs should provide a helpful response before this, but to be safe.
 	}
 
+	// @todo - add support for version, which will require a bit of tweaking since it has required arguments.
 	if ( argv.cmd === 'version' ) {
 		throw new Error( 'Version not supported yet!' );
 	}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR refactors the `jetpack changelog` tool to make things significantly cleaner and make further development easier. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Refactored using the "Sami method" which worked for the "Write" command: https://github.com/Automattic/jetpack/pull/19444

This PR makes "add", "write" and "validate" work the same way.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack changelog`
* Make sure all the commands continue to work properly.
* Passthroughs should work correctly as well, e.g:
	* `jetpack changelog add plugins/jetpack -s "patch" -t "bugfix" -e "testing changelog" -f "test"`
	* `jetpack changelog validate packages/abtest --no-verify`
	* `jetpack changelog write packages/abtest` 
* Error handling should largely be handled by the changelogger now, so incorrect or invalid commands should fail.
