### PR TITLE
Changes copy upon jetpack activation

### DIFF
--- a/projects/plugins/jetpack/_inc/connect-button.js
+++ b/projects/plugins/jetpack/_inc/connect-button.js
@@ -108,6 +108,8 @@ jQuery( document ).ready( function ( $ ) {
 			jetpackConnectIframe.on( 'load', function () {
 				jetpackConnectIframe.show();
 				$( '.jp-connect-full__button-container' ).hide();
+				$( '#jp-connect-full__step1-header' ).hide();
+				$( '#jp-connect-full__step2-header' ).show();
 			} );
 			jetpackConnectIframe.hide();
 			$( '.jp-connect-full__button-container' ).after( jetpackConnectIframe );

--- a/projects/plugins/jetpack/changelog/update-registration-copy
+++ b/projects/plugins/jetpack/changelog/update-registration-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Change copy on in-place connection title to match user-less behavior

--- a/projects/plugins/jetpack/class.jetpack-connection-banner.php
+++ b/projects/plugins/jetpack/class.jetpack-connection-banner.php
@@ -413,8 +413,12 @@ class Jetpack_Connection_Banner {
 
 				<?php endif; ?>
 
-				<div class="jp-connect-full__step-header">
+				<div id="jp-connect-full__step1-header" class="jp-connect-full__step-header">
 					<h2 class="jp-connect-full__step-header-title"><?php esc_html_e( 'Activate essential WordPress security and performance tools by setting up Jetpack', 'jetpack' ); ?></h2>
+				</div>
+
+				<div id="jp-connect-full__step2-header" class="jp-connect-full__step-header">
+					<h2 class="jp-connect-full__step-header-title"><?php esc_html_e( 'Jetpack is activated!', 'jetpack' ); ?><br /><?php esc_html_e( 'Unlock more amazing features by connecting a user account', 'jetpack' ); ?></h2>
 				</div>
 
 				<p class="jp-connect-full__tos-blurb">

--- a/projects/plugins/jetpack/scss/organisms/_banners.scss
+++ b/projects/plugins/jetpack/scss/organisms/_banners.scss
@@ -189,6 +189,10 @@
 	}
 }
 
+#jp-connect-full__step2-header {
+	display: none;
+}
+
 .jp-connect-full__tos-blurb {
 	font-size: $font-body-extra-small;
 	margin: 0 auto rem( 16px );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

NOTE: This PR assumes user-less connections are active for all users and should only be merged if and when we decide we are shipping it.

With user-less, when the users click on "Set up Jetpack" and see the in-place connection UI to authorize a user, the connection is already established.

This PR makes the title of this step more clear, to inform the user that Jetpack has been activated.

In our testings, some people reported confusion after bailing the connection flow and realizing Jetpack was connected even though they didn't make it to the end.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes the title of the in-place connection page after Jetpack is connected on a site level

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a new site with user-less testing mode
* Click "Set up Jetpack" either in the WP-admin dashboard or from the Jetpack Dashboard
* Make sure that, while the loader is being displayed in the page, that the title remains the same: "Activate essential WordPress security and performance tools by setting up Jetpack"
* When the loader disappears and the option to log in a user shows up, make sure the title of the page changed to "Jetpack is activated!<br>Unlock more amazing features by connecting a user account"

![Captura de Tela 2021-04-21 às 18 28 25](https://user-images.githubusercontent.com/971483/115626630-2906a580-a2d4-11eb-8e39-4eba56938611.png)


Repeat the flow above:
* in a window where you're logged in to WPCOM
* in a window you're not logged in to WPCOM
* in a window without support to 3rd party cookies

Note: For browsers without 3rd party cookies support (except Safari) there's a known issue in the experience, where the page loads and takes a while before redirecting to Calypso. This PR does not solve that, we just want to make sure things work.

Also, we might need to change the copy on the Calypso side.
