### PR TITLE
Theme Tools: Return early when there's no post context in jetpack_blog_display_custom_excerpt()

### DIFF
--- a/projects/plugins/jetpack/changelog/2021-04-23-01-04-14-716130
+++ b/projects/plugins/jetpack/changelog/2021-04-23-01-04-14-716130
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Avoid PHP Notices in jetpack_blog_display_custom_excerpt() when run outside of the loop / without post context.

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
@@ -87,7 +87,7 @@ function jetpack_the_content_to_the_excerpt( $content ) {
 	}
 	if ( empty( $excerpt ) ) {
 		return $content;
-        } else {
+	} else {
 		return $excerpt;
 	}
 }

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
@@ -33,6 +33,10 @@ if ( ! in_array( $blog_display, array( 'content', 'excerpt', 'mixed' ) ) ) {
  */
 function jetpack_blog_display_custom_excerpt( $content ) {
 	$post = get_post();
+	if ( empty( $post ) ) {
+		return $content;
+	}
+
 	if ( empty( $post->post_excerpt ) ) {
 		$text = strip_shortcodes( $post->post_content );
 		$text = str_replace( ']]>', ']]&gt;', $text );

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
@@ -39,7 +39,7 @@ function jetpack_blog_display_custom_excerpt( $content = '' ) {
 	if ( ! empty( $content ) ) {
 		_doing_it_wrong(
 			'jetpack_blog_display_custom_excerpt',
-			'You do not need to pass a $content parameter anymore.',
+			esc_html__( 'You do not need to pass a $content parameter anymore.', 'jetpack' ),
 			'jetpack-9.7.0'
 		);
 	}

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
@@ -30,8 +30,20 @@ if ( ! in_array( $blog_display, array( 'content', 'excerpt', 'mixed' ) ) ) {
 
 /**
  * Apply Content filters.
+ *
+ * @since 9.7.0 Deprecated $content parameter.
+ *
+ * @param string $content Post content. Deprecated.
  */
-function jetpack_blog_display_custom_excerpt() {
+function jetpack_blog_display_custom_excerpt( $content = '' ) {
+	if ( ! empty( $content ) ) {
+		_doing_it_wrong(
+			'jetpack_blog_display_custom_excerpt',
+			'You do not need to pass a $content parameter anymore.',
+			'jetpack-9.7.0'
+		);
+	}
+
 	$post = get_post();
 	if ( empty( $post ) ) {
 		return '';

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
@@ -31,10 +31,10 @@ if ( ! in_array( $blog_display, array( 'content', 'excerpt', 'mixed' ) ) ) {
 /**
  * Apply Content filters.
  */
-function jetpack_blog_display_custom_excerpt( $content ) {
+function jetpack_blog_display_custom_excerpt() {
 	$post = get_post();
 	if ( empty( $post ) ) {
-		return $content;
+		return '';
 	}
 
 	if ( empty( $post->post_excerpt ) ) {
@@ -80,12 +80,16 @@ function jetpack_blog_display_custom_excerpt( $content ) {
 function jetpack_the_content_to_the_excerpt( $content ) {
 	if ( ( is_home() || is_archive() ) && ! is_post_type_archive( array( 'jetpack-testimonial', 'jetpack-portfolio', 'product' ) ) ) {
 		if ( post_password_required() ) {
-			$content = sprintf( '<p>%s</p>', esc_html__( 'There is no excerpt because this is a protected post.', 'jetpack' ) );
+			$excerpt = sprintf( '<p>%s</p>', esc_html__( 'There is no excerpt because this is a protected post.', 'jetpack' ) );
 		} else {
-			$content = jetpack_blog_display_custom_excerpt( $content );
+			$excerpt = jetpack_blog_display_custom_excerpt();
 		}
 	}
-	return $content;
+	if ( empty( $excerpt ) ) {
+		return $content;
+        } else {
+		return $excerpt;
+	}
 }
 
 /**
@@ -122,7 +126,7 @@ function jetpack_the_content_customizer( $content ) {
 		if ( post_password_required() ) {
 			$excerpt = sprintf( '<p>%s</p>', esc_html__( 'There is no excerpt because this is a protected post.', 'jetpack' ) );
 		} else {
-			$excerpt = jetpack_blog_display_custom_excerpt( $content );
+			$excerpt = jetpack_blog_display_custom_excerpt();
 		}
 	}
 	if ( empty( $excerpt ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #19616

This seems odd, as the filter completely ignores the provided `$content` from the filter normally, so not sure if this is correct or not.. it seems that Jetpack should be using `$content` instead of `$post->post_excerpt` below in the if-else instead.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Returns early when no context is provided

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*  See Issue
