### PR TITLE
JITMs: update pre-connection messages for launch

### DIFF
--- a/projects/packages/jitm/changelog/update-pre-connection-jitms
+++ b/projects/packages/jitm/changelog/update-pre-connection-jitms
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Always display pre-connection JITMs, without the need to set a filter.

--- a/projects/packages/jitm/changelog/update-pre-connection-jitms-2
+++ b/projects/packages/jitm/changelog/update-pre-connection-jitms-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Avoid wrapping text in the main CTA button

--- a/projects/packages/jitm/src/class-pre-connection-jitm.php
+++ b/projects/packages/jitm/src/class-pre-connection-jitm.php
@@ -102,12 +102,6 @@ class Pre_Connection_JITM extends JITM {
 	 * @return array The JITMs to show, or an empty array if there is nothing to show
 	 */
 	public function get_messages( $message_path, $query, $full_jp_logo_exists ) {
-		/** This filter is documented in  class.jetpack-connection-banner.php */
-		if ( ! apply_filters( 'jetpack_pre_connection_prompt_helpers', false ) ) {
-			// If filter jetpack_pre_connection_prompt_helpers is not set, return an empty array.
-			return array();
-		}
-
 		if ( ! current_user_can( 'install_plugins' ) ) {
 			return array();
 		}

--- a/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
+++ b/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
@@ -75,6 +75,7 @@ $blue-medium-dark:       #2271b1;
 		font-size: 11px;
 		line-height: 1;
 		text-transform: uppercase;
+		white-space: nowrap;
 
 		&:disabled {
 			color: lighten( $gray, 30% );

--- a/projects/packages/jitm/tests/php/test_pre_connection_jitm.php
+++ b/projects/packages/jitm/tests/php/test_pre_connection_jitm.php
@@ -64,37 +64,9 @@ class Test_Pre_Connection_JITM extends TestCase {
 	}
 
 	/**
-	 * The pre-connection JITMs are disabled by default by the `jetpack_pre_connection_prompt_helpers` filter's default value.
-	 */
-	public function test_get_messages_prompt_helpers_default() {
-		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
-			->once()
-			->with( false );
-
-		Functions\expect( 'current_user_can' )
-			->atMost()
-			->once()
-			->andReturn( true );
-
-		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
-			->atMost()
-			->once()
-			->with( array() )
-			->andReturn( $this->test_jitms );
-
-		$this->assertEmpty( $this->jitm_instance->get_messages( '/wp:plugins:admin_notices/', '', false ) );
-	}
-
-	/**
 	 * The pre-connection JITMs are disabled when the current user does not have the 'install_plugins' capability.
 	 */
 	public function test_get_messages_user_cannot_install_plugins() {
-		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
-			->atMost()
-			->once()
-			->with( false )
-			->andReturns( true );
-
 		Functions\expect( 'current_user_can' )
 			->once()
 			->andReturn( false );
@@ -109,16 +81,10 @@ class Test_Pre_Connection_JITM extends TestCase {
 	}
 
 	/**
-	 * The pre-connection JITMs are empty by default. The default value of the 'jetpack_pre_connection_jitms' filter is 
+	 * The pre-connection JITMs are empty by default. The default value of the 'jetpack_pre_connection_jitms' filter is
 	 * an empty array.
 	 */
 	public function test_get_messages_jitms_filter_default() {
-		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
-			->atMost()
-			->once()
-			->with( false )
-			->andReturns( true );
-
 		Functions\expect( 'current_user_can' )
 			->atMost()
 			->once()
@@ -136,12 +102,6 @@ class Test_Pre_Connection_JITM extends TestCase {
 	 * returns anything other than an array.
 	 */
 	public function test_get_messages_filter_returns_string() {
-		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
-			->atMost()
-			->once()
-			->with( false )
-			->andReturns( true );
-
 		Functions\expect( 'current_user_can' )
 			->atMost()
 			->once()
@@ -159,7 +119,7 @@ class Test_Pre_Connection_JITM extends TestCase {
 	 * The pre-connection JITMs are added using the `jetpack_pre_connection_jitms` filter.
 	 */
 	public function test_get_messages_return_message() {
-		$this->set_prompt_helpers_and_user_cap_conditions();
+		$this->set_user_cap_conditions();
 
 		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
 			->once()
@@ -176,7 +136,7 @@ class Test_Pre_Connection_JITM extends TestCase {
 	 * tested path.
 	 */
 	public function test_get_messages_unmatched_message_path() {
-		$this->set_prompt_helpers_and_user_cap_conditions();
+		$this->set_user_cap_conditions();
 
 		Filters\expectApplied( 'jetpack_pre_connection_jitms' )
 			->once()
@@ -191,7 +151,7 @@ class Test_Pre_Connection_JITM extends TestCase {
 	 * missing the message_path key.
 	 */
 	public function test_get_messages_missing_key() {
-		$this->set_prompt_helpers_and_user_cap_conditions();
+		$this->set_user_cap_conditions();
 
 		unset( $this->test_jitms[0]['message_path'] );
 
@@ -207,7 +167,7 @@ class Test_Pre_Connection_JITM extends TestCase {
 	 * A pre-connection JITM is displayed if it has unexpected keys.
 	 */
 	public function test_get_messages_extra_key() {
-		$this->set_prompt_helpers_and_user_cap_conditions();
+		$this->set_user_cap_conditions();
 
 		$this->test_jitms[0]['extra_key'] = 'extra jitm key';
 
@@ -220,12 +180,7 @@ class Test_Pre_Connection_JITM extends TestCase {
 		$this->assertSame( $this->test_jitms[0]['id'], $messages[0]->id );
 	}
 
-	private function set_prompt_helpers_and_user_cap_conditions() {
-		Filters\expectApplied( 'jetpack_pre_connection_prompt_helpers' )
-			->once()
-			->with( false )
-			->andReturns( true );
-
+	private function set_user_cap_conditions() {
 		Functions\expect( 'current_user_can' )
 			->once()
 			->andReturn( true );

--- a/projects/plugins/jetpack/changelog/update-pre-connection-jitms
+++ b/projects/plugins/jetpack/changelog/update-pre-connection-jitms
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Pre-connection JITMs: update connection links to have from parameter.
+
+

--- a/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
+++ b/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
@@ -47,14 +47,13 @@ class Jetpack_Pre_Connection_JITMs {
 			/*
 			 * Add Connect URL to each message, with from including jitm id.
 			 */
-			$jetpack_setup_url = Jetpack::init()->build_connect_url(
-				true,
-				false,
-				sprintf( 'pre-connection-jitm-%s', $message['id'] )
+			$jetpack_setup_url               = $this->generate_admin_url(
+				array(
+					'page'    => 'jetpack',
+					'#/setup' => '',
+					'from'    => sprintf( 'pre-connection-jitm-%s', $message['id'] ),
+				)
 			);
-			// Add parameter to URL. Since we mention accepting ToS when clicking, no need to ask again on wpcom.
-			$jetpack_setup_url = add_query_arg( 'auth_approved', 'true', $jetpack_setup_url );
-
 			$messages[ $key ]['button_link'] = $jetpack_setup_url;
 
 			/*
@@ -67,6 +66,18 @@ class Jetpack_Pre_Connection_JITMs {
 		}
 
 		return $messages;
+	}
+
+	/**
+	 * Adds the input query arguments to the admin url.
+	 *
+	 * @param array $args The query arguments.
+	 *
+	 * @return string The admin url.
+	 */
+	private function generate_admin_url( $args ) {
+		$url = add_query_arg( $args, admin_url( 'admin.php' ) );
+		return $url;
 	}
 
 	/**

--- a/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
+++ b/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
@@ -49,9 +49,8 @@ class Jetpack_Pre_Connection_JITMs {
 			 */
 			$jetpack_setup_url               = $this->generate_admin_url(
 				array(
-					'page'    => 'jetpack',
-					'#/setup' => '',
-					'from'    => sprintf( 'pre-connection-jitm-%s', $message['id'] ),
+					'page' => 'jetpack#/setup',
+					'from' => sprintf( 'pre-connection-jitm-%s', $message['id'] ),
 				)
 			);
 			$messages[ $key ]['button_link'] = $jetpack_setup_url;

--- a/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
+++ b/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
@@ -5,6 +5,8 @@
  * @package jetpack
  */
 
+use Automattic\Jetpack\Redirect;
+
 /**
  * Jetpack's Pre-Connection JITMs. These can be displayed with the JITM package.
  */
@@ -16,20 +18,28 @@ class Jetpack_Pre_Connection_JITMs {
 	 * @return array An array containing the pre-connection JITM messages.
 	 */
 	private function get_raw_messages() {
+		$button_caption = __( 'Set up Jetpack', 'jetpack' );
+		/* Translators: placeholders are links. */
+		$media_description = __( 'Click on the <strong>Set up Jetpack</strong> button to agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com. You can then enable Site Accelerator, and start serving your images lightning fast, for free.', 'jetpack' );
+		/* Translators: placeholders are links. */
+		$widgets_description = __( 'Click on the <strong>Set up Jetpack</strong> button to agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com. You’ll then gain access to great additional widgets that display business contact info and maps, blog stats, and top posts', 'jetpack' );
+		/* Translators: placeholders are links. */
+		$posts_description = __( 'Click on the <strong>Set up Jetpack</strong> button to agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com, and we can start providing you in-depth states about your content and key visitors.', 'jetpack' );
+
 		$messages = array(
 			array(
 				'id'             => 'jpsetup-upload',
 				'message_path'   => '/wp:upload:admin_notices/',
 				'message'        => __( 'Do you want lightning-fast images?', 'jetpack' ),
-				'description'    => __( 'Set up Jetpack, enable Site Accelerator, and start serving your images lightning fast, for free.', 'jetpack' ),
-				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
+				'description'    => $this->generate_description_with_tos( $media_description ),
+				'button_caption' => $button_caption,
 			),
 			array(
 				'id'             => 'jpsetup-widgets',
 				'message_path'   => '/wp:widgets:admin_notices/',
 				'message'        => __( 'Looking for even more widgets?', 'jetpack' ),
-				'description'    => __( 'Set up Jetpack for great additional widgets that display business contact info and maps, blog stats, and top posts.', 'jetpack' ),
-				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
+				'description'    => $this->generate_description_with_tos( $widgets_description ),
+				'button_caption' => $button_caption,
 			),
 		);
 
@@ -38,8 +48,8 @@ class Jetpack_Pre_Connection_JITMs {
 				'id'             => 'jpsetup-posts',
 				'message_path'   => '/wp:edit-post:admin_notices/',
 				'message'        => __( 'Do you know which of these posts gets the most traffic?', 'jetpack' ),
-				'description'    => __( 'Set up Jetpack to get in-depth stats about your content and visitors.', 'jetpack' ),
-				'button_caption' => __( 'Set up Jetpack', 'jetpack' ),
+				'description'    => $this->generate_description_with_tos( $posts_description ),
+				'button_caption' => $button_caption,
 			);
 		}
 
@@ -54,17 +64,38 @@ class Jetpack_Pre_Connection_JITMs {
 				)
 			);
 			$messages[ $key ]['button_link'] = $jetpack_setup_url;
-
-			/*
-			 * Add ToS acceptance message to JITM description
-			 */
-			$messages[ $key ]['description'] .= sprintf(
-				'<br /><br />%s',
-				\jetpack_render_tos_blurb( false )
-			);
 		}
 
 		return $messages;
+	}
+
+	/**
+	 * Generate a description text with links to ToS documents.
+	 *
+	 * Those messages must mention the ToS agreement message,
+	 * but do not use the standard message defined in jetpack_render_tos_blurb.
+	 * Instead, they use their own custom messages.
+	 *
+	 * @param string $description Description string with placeholders.
+	 *
+	 * @return string
+	 */
+	private function generate_description_with_tos( $description ) {
+		return sprintf(
+			wp_kses(
+				$description,
+				array(
+					'a'      => array(
+						'href'   => array(),
+						'target' => array(),
+						'rel'    => array(),
+					),
+					'strong' => true,
+				)
+			),
+			esc_url( Redirect::get_url( 'wpcom-tos' ) ),
+			esc_url( Redirect::get_url( 'jetpack-support-what-data-does-jetpack-sync' ) )
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
+++ b/projects/plugins/jetpack/class-jetpack-pre-connection-jitms.php
@@ -20,11 +20,11 @@ class Jetpack_Pre_Connection_JITMs {
 	private function get_raw_messages() {
 		$button_caption = __( 'Set up Jetpack', 'jetpack' );
 		/* Translators: placeholders are links. */
-		$media_description = __( 'Click on the <strong>Set up Jetpack</strong> button to agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com. You can then enable Site Accelerator, and start serving your images lightning fast, for free.', 'jetpack' );
+		$media_description = __( 'Click on the <strong>Set up Jetpack</strong> button to agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com, and gain access to Site Accelerator.', 'jetpack' );
 		/* Translators: placeholders are links. */
-		$widgets_description = __( 'Click on the <strong>Set up Jetpack</strong> button to agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com. You’ll then gain access to great additional widgets that display business contact info and maps, blog stats, and top posts', 'jetpack' );
+		$widgets_description = __( 'Click on the <strong>Set up Jetpack</strong> button to agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com, and gain access to great additional widgets.', 'jetpack' );
 		/* Translators: placeholders are links. */
-		$posts_description = __( 'Click on the <strong>Set up Jetpack</strong> button to agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com, and we can start providing you in-depth states about your content and key visitors.', 'jetpack' );
+		$posts_description = __( 'Click on the <strong>Set up Jetpack</strong> button to agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com, and gain access to in-depth stats about your site.', 'jetpack' );
 
 		$messages = array(
 			array(

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -234,6 +234,8 @@ function jetpack_get_migration_data( $option_name ) {
 /**
  * Prints a TOS blurb used throughout the connection prompts.
  *
+ * Note: custom ToS messages are also defined in Jetpack_Pre_Connection_JITMs->get_raw_messages()
+ *
  * @since 5.3
  *
  * @echo string

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -235,12 +235,11 @@ function jetpack_get_migration_data( $option_name ) {
  * Prints a TOS blurb used throughout the connection prompts.
  *
  * @since 5.3
- * @since 9.7.0 Added new echo parameter.
  *
- * @param bool $echo Should we echo or return string. Default to true.
+ * @echo string
  */
-function jetpack_render_tos_blurb( $echo = true ) {
-	$tos_blurb = sprintf(
+function jetpack_render_tos_blurb() {
+	printf(
 		wp_kses(
 			/* Translators: placeholders are links. */
 			__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com.', 'jetpack' ),
@@ -256,12 +255,6 @@ function jetpack_render_tos_blurb( $echo = true ) {
 		esc_url( Redirect::get_url( 'wpcom-tos' ) ),
 		esc_url( Redirect::get_url( 'jetpack-support-what-data-does-jetpack-sync' ) )
 	);
-
-	if ( $echo ) {
-		echo $tos_blurb; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaping done above.
-	} else {
-		return $tos_blurb;
-	}
 }
 
 /**

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -235,11 +235,12 @@ function jetpack_get_migration_data( $option_name ) {
  * Prints a TOS blurb used throughout the connection prompts.
  *
  * @since 5.3
+ * @since 9.7.0 Added new echo parameter.
  *
- * @echo string
+ * @param bool $echo Should we echo or return string. Default to true.
  */
-function jetpack_render_tos_blurb() {
-	printf(
+function jetpack_render_tos_blurb( $echo = true ) {
+	$tos_blurb = sprintf(
 		wp_kses(
 			/* Translators: placeholders are links. */
 			__( 'By clicking the <strong>Set up Jetpack</strong> button, you agree to our <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and to <a href="%2$s" target="_blank" rel="noopener noreferrer">share details</a> with WordPress.com.', 'jetpack' ),
@@ -255,6 +256,12 @@ function jetpack_render_tos_blurb() {
 		esc_url( Redirect::get_url( 'wpcom-tos' ) ),
 		esc_url( Redirect::get_url( 'jetpack-support-what-data-does-jetpack-sync' ) )
 	);
+
+	if ( $echo ) {
+		echo $tos_blurb; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaping done above.
+	} else {
+		return $tos_blurb;
+	}
 }
 
 /**

--- a/projects/plugins/jetpack/tests/php/general/test-class-jetpack-pre-connection-jitms.php
+++ b/projects/plugins/jetpack/tests/php/general/test-class-jetpack-pre-connection-jitms.php
@@ -62,7 +62,7 @@ class WP_Test_Jetpack_Pre_Connection_JITMs extends TestCase {
 		$jitms    = new Jetpack_Pre_Connection_JITMs();
 		$messages = $jitms->add_pre_connection_jitms( array() );
 
-		$query = 'admin.php?page=jetpack&#/setup';
+		$query = 'admin.php?page=jetpack&#/setup&from=pre-connection-jitm-jpsetup-upload';
 
 		// Verify that the `jpsetup-upload` JITM is in the list of JITMs.
 		$index = array_search( 'jpsetup-upload', array_column( $messages, 'id' ), true );

--- a/projects/plugins/jetpack/tests/php/general/test-class-jetpack-pre-connection-jitms.php
+++ b/projects/plugins/jetpack/tests/php/general/test-class-jetpack-pre-connection-jitms.php
@@ -62,7 +62,7 @@ class WP_Test_Jetpack_Pre_Connection_JITMs extends TestCase {
 		$jitms    = new Jetpack_Pre_Connection_JITMs();
 		$messages = $jitms->add_pre_connection_jitms( array() );
 
-		$query = 'admin.php?page=jetpack&#/setup&from=pre-connection-jitm-jpsetup-upload';
+		$query = 'admin.php?page=jetpack#/setup&from=pre-connection-jitm-jpsetup-upload';
 
 		// Verify that the `jpsetup-upload` JITM is in the list of JITMs.
 		$index = array_search( 'jpsetup-upload', array_column( $messages, 'id' ), true );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR updates our pre-connection JITMs so they can be launched to all Jetpack sites. Until now, they were only available when setting a filter on your site

This PR:

﻿- removes that dependency to a filter to display the pre-connection messages.
- ~~updates the existing function used to display the ToS blurb, so that blurb can be used without echo'ing it right away.~~ Reverted that, we'll use custom ToS blurbs in those messages. See p1HpG7-bPy-p2#comment-46028
- updates the connection links in all pre-connection messages.

<img width="1259" alt="Screenshot 2021-04-23 at 18 09 40" src="https://user-images.githubusercontent.com/426388/115900342-1e791700-a460-11eb-85b3-26a242c93d17.png">
<img width="1259" alt="Screenshot 2021-04-23 at 18 09 34" src="https://user-images.githubusercontent.com/426388/115900350-2042da80-a460-11eb-806e-717ec26ac2cb.png">
<img width="1274" alt="Screenshot 2021-04-23 at 18 09 24" src="https://user-images.githubusercontent.com/426388/115900351-2042da80-a460-11eb-8e77-cbf5df8ee98e.png">


~~A by-product of this change is that clicking on the set-up button in those messages launches the old Calypso flow instead of the in-place flow.~~ I fixed that in 33b944bc71ff085e45f83f0590bb9288afe1e32a

#### Jetpack product discussion

* Internal reference: p1HpG7-bPy-p2

#### Does this pull request change what data or activity we track or use?

* It does add a from parameter to JITM buttons in those pre-connection messages, but that from parameter isn't communicated to WordPress.com until you click to connect.

#### Testing instructions:

* On a brand new site, go to the Media screen, or Appearance > Widgets, or the Posts screen if you've published 5 posts or more.
* You should see JITMs inviting you to connect your site to WordPress.com.
* If you connect, you should notice the name of the message in the `from` parameter of the `wpcom_jpc_authorize_begin` Tracks event that is logged a few minutes later.
