### PR TITLE
E2E tests: fix failing Pinterest test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-e2e-fix-pinterest-spec
+++ b/projects/plugins/jetpack/changelog/fix-e2e-fix-pinterest-spec
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: E2E tests: fixed failing Pinterest spec
+
+

--- a/projects/plugins/jetpack/tests/e2e/config/default.js
+++ b/projects/plugins/jetpack/tests/e2e/config/default.js
@@ -43,6 +43,11 @@ const config = {
 		url: 'https://github.com/Automattic/jetpack',
 		mainBranch: 'master',
 	},
+	blocks: {
+		pinterest: {
+			pinId: '689332286716774968',
+		},
+	},
 };
 
 module.exports = config;

--- a/projects/plugins/jetpack/tests/e2e/specs/free-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/free-blocks.test.js
@@ -8,6 +8,8 @@ import PinterestBlock from '../lib/pages/wp-admin/blocks/pinterest';
 import EventbriteBlock from '../lib/pages/wp-admin/blocks/eventbrite';
 import { step } from '../lib/env/test-setup';
 
+const config = require( 'config' );
+
 describe( 'Free blocks', () => {
 	let blockEditor;
 
@@ -21,7 +23,7 @@ describe( 'Free blocks', () => {
 	} );
 
 	it( 'Pinterest block', async () => {
-		const pinId = '180003316347175596';
+		const pinId = config.get( 'blocks.pinterest.pinId' );
 
 		await step( 'Can visit the block editor and add a Pinterest block', async () => {
 			const blockId = await blockEditor.insertBlock(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix for a failing Pinterest test. The pin used for testing no longer exists so I changed it. I also moved the pinId into config file for easier management.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* CI happy