### PR TITLE
Decode special chars in URLs for admin menu responses

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -376,7 +376,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			$url = admin_url( $url );
 		}
 
-		return esc_url_raw( $url );
+		return wp_specialchars_decode( esc_url_raw( $url ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -331,6 +331,9 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function prepare_menu_item_url( $url, $parent_slug = '' ) {
+		// Replace special characters with their correct entities e.g. &amp; to &.
+		$url = wp_specialchars_decode( $url );
+
 		// External URLS.
 		if ( preg_match( '/^https?:\/\//', $url ) ) {
 			// Allow URLs pointing to WordPress.com.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -331,21 +331,20 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function prepare_menu_item_url( $url, $parent_slug = '' ) {
-		// Replace special characters with their correct entities e.g. &amp; to &.
-		$url = wp_specialchars_decode( $url );
-
 		// External URLS.
 		if ( preg_match( '/^https?:\/\//', $url ) ) {
 			// Allow URLs pointing to WordPress.com.
 			if ( 0 === strpos( $url, 'https://wordpress.com/' ) ) {
 				// Calypso needs the domain removed so they're not interpreted as external links.
 				$url = str_replace( 'https://wordpress.com', '', $url );
-				return esc_url_raw( $url );
+				// Replace special characters with their correct entities e.g. &amp; to &.
+				return wp_specialchars_decode( esc_url_raw( $url ) );
 			}
 
 			// Allow URLs pointing to Jetpack.com.
 			if ( 0 === strpos( $url, 'https://jetpack.com/' ) ) {
-				return esc_url_raw( $url );
+				// Replace special characters with their correct entities e.g. &amp; to &.
+				return wp_specialchars_decode( esc_url_raw( $url ) );
 			}
 
 			// Disallow other external URLs.

--- a/projects/plugins/jetpack/changelog/update-admin-menu-api-special-characters-url
+++ b/projects/plugins/jetpack/changelog/update-admin-menu-api-special-characters-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Update prepare_menu_item_url in admin menu API to replace special characters in URLs with their HTML entities such as ampersand (e.g. convert &amp; to &).

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -397,7 +397,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				'https://jetpack.com/redirect/?source=calypso-backups&#038;site=example.org',
 				'jetpack',
 				null,
-				'https://jetpack.com/redirect/?source=calypso-backups&#038;site=example.org',
+				'https://jetpack.com/redirect/?source=calypso-backups&site=example.org',
 			),
 			// WooCommerce URLs.
 			array(

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -410,13 +410,13 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				'wc-admin&amp;path=/analytics/products',
 				'wc-admin&amp;path=/analytics/overview',
 				'__return_true',
-				admin_url( 'admin.php?page=wc-admin&amp;path=/analytics/products' ),
+				admin_url( 'admin.php?page=wc-admin&path=/analytics/products' ),
 			),
 			array(
 				'wc-admin&amp;path=customers',
 				'woocommerce',
 				'__return_true',
-				admin_url( 'admin.php?page=wc-admin&amp;path=customers' ),
+				admin_url( 'admin.php?page=wc-admin&path=customers' ),
 			),
 			// Disallowed URLs.
 			array(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/49309

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update `prepare_menu_item_url` method in admin menu API to replace special characters in URLs with their HTML entities such as ampersand (e.g. convert `&amp;` to `&`).

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Simple sites**

* Apply patch to Sandbox.
* Sandbox the public API.
* Enable the "Portfolio" menu item by going to Settings > General > Writing and toggling this on.
* Click Projects > Project Types and view the correct sub-menu being open.
* Try other menu items to check for regressions.


**Atomic sites**
* Install Jetpack Beta and activate this branch
* Enable the "Portfolio" menu item by going to Settings > General > Writing and toggling this on.
* Click Projects > Project Types and view the correct sub-menu being open.
* Try other menu items to check for regressions.