### PR TITLE
Jetpack Modules: Add explanation when a module is unavailable

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add_unavailable_reason_in_modules_list
+++ b/projects/plugins/jetpack/changelog/update-add_unavailable_reason_in_modules_list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Modules list: Add explanation when a module is unavailable.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -299,6 +299,27 @@ class Jetpack_Admin {
 			return 'Jetpack is not connected';
 		}
 
+		/**
+		 * We never want to show VaultPress as activatable through Jetpack so return an empty string.
+		 */
+		if ( 'vaultpress' === $module['module'] ) {
+			return '';
+		}
+
+		/*
+		 * WooCommerce Analytics should only be available
+		 * when running WooCommerce 3+
+		 */
+		if (
+			'woocommerce-analytics' === $module['module']
+			&& (
+					! class_exists( 'WooCommerce' )
+					|| version_compare( WC_VERSION, '3.0', '<' )
+				)
+			) {
+			return 'Requires WooCommerce 3+ plugin';
+		}
+
 		/*
 		 * In Offline mode, modules that require a site or user
 		 * level connection should be unavailable.
@@ -314,20 +335,6 @@ class Jetpack_Admin {
 		 */
 		if ( ! Jetpack::connection()->has_connected_owner() && $module['requires_user_connection'] ) {
 			return 'Requires a connected WordPress.com account';
-		}
-
-		/*
-		 * WooCommerce Analytics should only be available
-		 * when running WooCommerce 3+
-		 */
-		if (
-			'woocommerce-analytics' === $module['module']
-			&& (
-					! class_exists( 'WooCommerce' )
-					|| version_compare( WC_VERSION, '3.0', '<' )
-				)
-			) {
-			return 'Requires WooCommerce 3+ plugin';
 		}
 
 		/*

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -310,7 +310,7 @@ class Jetpack_Admin {
 					|| version_compare( WC_VERSION, '3.0', '<' )
 				)
 			) {
-			return 'Requires WooCommerce 3+ plugin';
+			return __( 'Requires WooCommerce 3+ plugin', 'jetpack' );
 		}
 
 		/*
@@ -319,7 +319,7 @@ class Jetpack_Admin {
 		 */
 		if ( ( new Status() )->is_offline_mode() ) {
 			if ( $module['requires_connection'] || $module['requires_user_connection'] ) {
-				return 'Offline mode';
+				return __( 'Offline mode', 'jetpack' );
 			}
 		}
 
@@ -327,21 +327,21 @@ class Jetpack_Admin {
 		 * Jetpack not connected.
 		 */
 		if ( ! Jetpack::is_connection_ready() ) {
-			return 'Jetpack is not connected';
+			return __( 'Jetpack is not connected', 'jetpack' );
 		}
 
 		/*
 		 * Jetpack connected at a site level only and module requires a user connection.
 		 */
 		if ( ! Jetpack::connection()->has_connected_owner() && $module['requires_user_connection'] ) {
-			return 'Requires a connected WordPress.com account';
+			return __( 'Requires a connected WordPress.com account', 'jetpack' );
 		}
 
 		/*
 		 * Plan restrictions.
 		 */
 		if ( ! Jetpack_Plan::supports( $module['module'] ) ) {
-			return 'Not supported by current plan';
+			return __( 'Not supported by current plan', 'jetpack' );
 		}
 
 		return '';

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -292,13 +292,6 @@ class Jetpack_Admin {
 			return false;
 		}
 
-		/*
-		 * Jetpack not connected.
-		 */
-		if ( ! Jetpack::is_connection_ready() ) {
-			return 'Jetpack is not connected';
-		}
-
 		/**
 		 * We never want to show VaultPress as activatable through Jetpack so return an empty string.
 		 */
@@ -328,6 +321,13 @@ class Jetpack_Admin {
 			if ( $module['requires_connection'] || $module['requires_user_connection'] ) {
 				return 'Offline mode';
 			}
+		}
+
+		/*
+		 * Jetpack not connected.
+		 */
+		if ( ! Jetpack::is_connection_ready() ) {
+			return 'Jetpack is not connected';
 		}
 
 		/*

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -141,7 +141,7 @@ class Jetpack_Admin {
 				$module_array['deactivate_nonce']   = wp_create_nonce( 'jetpack_deactivate-' . $module );
 				$module_array['activate_nonce']     = wp_create_nonce( 'jetpack_activate-' . $module );
 				$module_array['available']          = $is_available;
-				$module_array['unavailable_reason'] = $is_available ? '' : self::get_module_unavailable_reason( $module_array );
+				$module_array['unavailable_reason'] = $is_available ? false : self::get_module_unavailable_reason( $module_array );
 				$module_array['short_description']  = $short_desc_trunc;
 				$module_array['configure_url']      = Jetpack::module_configuration_url( $module );
 				$module_array['override']           = $overrides->get_module_override( $module );

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -114,6 +114,9 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 						<# } else if ( item.available && 'videopress' !== item.module ) { #>
 							<span class='activate'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=activate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.activate_nonce }}}"><?php _e( 'Activate', 'jetpack' ); ?></a></span>
 						<# } #>
+						<# if ( ! item.available ) { #>
+							<span class='unavailable_reason'>{{{ item.unavailable_reason }}}</span>
+						<# } #>
 						</div>
 					</td>
 				</tr>

--- a/projects/plugins/jetpack/scss/templates/_settings.scss
+++ b/projects/plugins/jetpack/scss/templates/_settings.scss
@@ -136,6 +136,10 @@
 					padding-left: 10px;
 					visibility: visible;
 				};
+
+				span.unavailable_reason {
+					color: #000;
+				}
 			}
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/test-get-modules.php
+++ b/projects/plugins/jetpack/tests/php/test-get-modules.php
@@ -187,8 +187,9 @@ class WP_Test_Get_Modules extends WP_UnitTestCase {
 		Jetpack_Options::update_option( 'blog_token', 'dummy.blogtoken' );
 		Jetpack_Options::update_option( 'id', '123' );
 
+		add_filter( 'jetpack_no_user_testing_mode', '__return_true' );
 		$this->assertSame( 'Requires a connected WordPress.com account', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
-
+		remove_filter( 'jetpack_no_user_testing_mode', '__return_true' );
 		// Mock a user connection.
 		$user = $this->factory->user->create_and_get(
 			array(

--- a/projects/plugins/jetpack/tests/php/test-get-modules.php
+++ b/projects/plugins/jetpack/tests/php/test-get-modules.php
@@ -206,6 +206,9 @@ class WP_Test_Get_Modules extends WP_UnitTestCase {
 
 		$dummy_module['module'] = 'woocommerce-analytics';
 		$this->assertSame( 'Requires WooCommerce 3+ plugin', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
+
+		$dummy_module['module'] = 'vaultpress';
+		$this->assertSame( '', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
 	}
 
 }

--- a/projects/plugins/jetpack/tests/php/test-get-modules.php
+++ b/projects/plugins/jetpack/tests/php/test-get-modules.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Test get_modules methods in Jetpack class
+ * Test module related methods in Jetpack and Jetpack_Admin class.
  *
  * @package jetpack
  */
 
 /**
- * Test get_modules
+ * Test module related methods in Jetpack and Jetpack_Admin class.
  */
 class WP_Test_Get_Modules extends WP_UnitTestCase {
 
@@ -163,6 +163,49 @@ class WP_Test_Get_Modules extends WP_UnitTestCase {
 				null,
 			),
 		);
+	}
+
+	/**
+	 * Test_get_module_unavailable_reason
+	 *
+	 * @covers Jetpack_Admin::get_module_unavailable_reason()
+	 */
+	public function test_get_module_unavailable_reason() {
+		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
+		// Inalid input.
+		$this->assertFalse( Jetpack_Admin::get_module_unavailable_reason( array() ) );
+
+		$dummy_module = array(
+			'module'                   => 'dummy',
+			'requires_connection'      => true,
+			'requires_user_connection' => true,
+		);
+
+		$this->assertSame( 'Jetpack is not connected', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
+
+		// Mock site connection.
+		Jetpack_Options::update_option( 'blog_token', 'dummy.blogtoken' );
+		Jetpack_Options::update_option( 'id', '123' );
+
+		$this->assertSame( 'Requires a connected WordPress.com account', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
+
+		// Mock a user connection.
+		$user = $this->factory->user->create_and_get(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		Jetpack_Options::update_option( 'master_user', $user->ID );
+		Jetpack_Options::update_option( 'user_tokens', array( $user->ID => "dummy.usertoken.$user->ID" ) );
+
+		$this->assertSame( 'Not supported by current plan', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
+
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+		$this->assertSame( 'Offline mode', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
+		remove_filter( 'jetpack_offline_mode', '__return_true' );
+
+		$dummy_module['module'] = 'woocommerce-analytics';
+		$this->assertSame( 'Requires WooCommerce 3+ plugin', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
 	}
 
 }


### PR DESCRIPTION
Display the reason a module is listed as unavailable in the modules list.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Jetpack_Admin: Introduces a `get_module_unavailable_reason` static method in `Jetpack_Admin`
- Jetpack_Admin: Updates the existing `get_modules` method by adding a `unavailable_reason` entry in each module array. If the module is available, this will be an empty value.
- 

**Notes**: Also affects the modules core `v4` [endpoint](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php#L195) that depends on the `get_modules` method but I think this is useful info to be included in our corresponding API response as well.

#### Jetpack product discussion
1191179647901802-as-1200216211144043/f

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Connect your site only at a site level (default in local env or by checking `JETPACK_NO_USER_TEST_MODE` in Settings->Jetpack Constants on a JN site)
* Go to `wp-admin/admin.php?page=jetpack_modules`
* Note the unavailable modules and verify the reason why they are unavailable is visible and makes sense.
* Test with offline mode as well
* Connect your WPCOM account and verify the modules listed as unavailable because of a missing user-connection are now available.
* Test offline mode once more