### PR TITLE
E2E tests: fixed incorrect event name logged for hook end

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-e2e-event-name-logging
+++ b/projects/plugins/jetpack/changelog/fix-e2e-event-name-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: E2E tests: fixed incorrect event name logged for hook end
+
+

--- a/projects/plugins/jetpack/tests/e2e/lib/env/playwright-environment.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/env/playwright-environment.js
@@ -43,10 +43,10 @@ class PlaywrightCustomEnvironment extends NodeEnvironment {
 	async handleTestEvent( event ) {
 		let eventName;
 
-		if ( event.test ) {
-			eventName = `${ event.test.parent.name } - ${ event.test.name }`;
-		} else if ( event.hook ) {
+		if ( event.hook ) {
 			eventName = `${ event.hook.type } - ${ event.hook.parent.name }`;
+		} else if ( event.test ) {
+			eventName = `${ event.test.parent.name } - ${ event.test.name }`;
 		} else {
 			eventName = event.name;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix for a logging issue.
When hooks that are part of a test suite end their name is incorrectly logged using test's name, instead of hook's name.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* CI happy
* Check log files info level for hooks start and end events are properly logged and their name match. 

Example:
``` 
2021-04-22 18:38:54 info: START: beforeAll - Jetpack pre-connection
2021-04-22 18:38:59 info: SUCCESS: beforeAll - Jetpack pre-connection
```
