### PR TITLE
JITM: Add unlinked in redirect url to indicate not-connected user

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm-redirect-unlinked
+++ b/projects/packages/jitm/changelog/update-jitm-redirect-unlinked
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+JITM: Update CTA redirect url with unlinked query arg to indicate current user is not connected.

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -479,6 +479,11 @@ class Post_Connection_JITM extends JITM {
 				$url_params['aff'] = $aff;
 			}
 
+			// Check if the current user has connected their WP.com account
+			// and if not add this information to the the array of URL parameters.
+			if ( ! ( new Manager() )->is_user_connected( $user->ID ) ) {
+				$url_params['unlinked'] = 1;
+			}
 			$envelope->url = add_query_arg( $url_params, 'https://jetpack.com/redirect/' );
 
 			$stats = new A8c_Mc_Stats();


### PR DESCRIPTION
The upsell JITMs redirect the users to landing pages from where they can select a product and immediately proceed to checkout.
Up to now, these JITMs where only displayed to connected users, but with user-less in mind we are going to show them to non-connected users as well.
This PR handles non-connected users being redirected by JITM CTAs by adding an `unlinked` query arg to the redirect url.
On the Calypso checkout page when the `unlinked` query arg is detected, users will be asked to connect their account first before proceeding to checkout, ensuring a non-breaking UX.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `Post_Connection_JITM` class: Checks if the current user has connected their WordPress.com account and adds the `unlinked` query arg in the redirect url if not.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1191179647901802-as-1200216211144035/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
D60580-code