### PR TITLE
API: Add delete transient wpcom/v2 endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
@@ -56,7 +56,7 @@ class WPCOM_REST_API_V2_Endpoint_Transient extends WP_REST_Controller {
 	public function delete_transient( \WP_REST_Request $request ) {
 		$transient_name = $request->get_param( 'name' );
 		if ( false !== strpos( $transient_name, 'jetpack_connected_user_data_' ) &&
-			wp_get_current_user()->ID === (int) substr( $transient_name, 28 ) ) {
+			get_current_user_id() === (int) substr( $transient_name, 28 ) ) {
 				return array(
 					'success' => delete_transient( $transient_name ),
 				);

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
@@ -24,17 +24,21 @@ class WPCOM_REST_API_V2_Endpoint_Transient extends WP_REST_Controller {
 	/**
 	 * Called automatically on `rest_api_init()`.
 	 *
-	 * /sites/$site/transients/$name/delete
+	 * /sites/<blog-id>/transients/$name/delete
 	 */
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<name>\w{1,172})/delete/',
+			'/' . $this->rest_base . '/(?P<name>\w{1,172})',
 			array(
 				array(
-					'methods'             => WP_REST_Server::EDITABLE,
+					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_transient' ),
 					'permission_callback' => 'is_user_logged_in',
+					'name'                => array(
+						'description' => __( 'The name of the transient to delete.', 'jetpack' ),
+						'type'        => 'string',
+					),
 				),
 			)
 		);
@@ -58,4 +62,5 @@ class WPCOM_REST_API_V2_Endpoint_Transient extends WP_REST_Controller {
 		}
 	}
 }
+
 wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Transient' );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * REST API endpoint for editing Jetpack Transients.
+ *
+ * @package automattic/jetpack
+ * @since 9.7.0
+ */
+
+/**
+ * Edit and delete transients.
+ *
+ * @since 9.7.0
+ */
+class WPCOM_REST_API_V2_Endpoint_Transient extends WP_REST_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'transients';
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Called automatically on `rest_api_init()`.
+	 *
+	 * /sites/$site/transients/$name/delete
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<name>\w{1,172})/delete/',
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'delete_transient' ),
+					'permission_callback' => 'is_user_logged_in',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Delete callback for transient.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return array|WP_Error
+	 */
+	public function delete_transient( \WP_REST_Request $request ) {
+		$name = rawurlencode( $request->get_param( 'name' ) );
+
+		if ( $name ) {
+			return array(
+				'success' => delete_transient( $name ),
+			);
+		} else {
+			return new WP_Error( 'missing_transient', 'No transient provided.' );
+		}
+	}
+}
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Transient' );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
@@ -60,7 +60,7 @@ class WPCOM_REST_API_V2_Endpoint_Transient extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check if a given request has read access.
+	 * Check if request has read access.
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-transient.php
@@ -51,12 +51,22 @@ class WPCOM_REST_API_V2_Endpoint_Transient extends WP_REST_Controller {
 	 * Delete transient callback.
 	 *
 	 * @param \WP_REST_Request $request Full details about the request.
-	 * @return array
+	 * @return array|WP_Error
 	 */
 	public function delete_transient( \WP_REST_Request $request ) {
-		return array(
-			'success' => delete_transient( $request->get_param( 'name' ) ),
-		);
+		$transient_name = $request->get_param( 'name' );
+		if ( false !== strpos( $transient_name, 'jetpack_connected_user_data_' ) &&
+			wp_get_current_user()->ID === (int) substr( $transient_name, 28 ) ) {
+				return array(
+					'success' => delete_transient( $transient_name ),
+				);
+		} else {
+			return new WP_Error(
+				'rest_cannot_delete',
+				__( 'Sorry, you are not allowed to delete this transient.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-wpcom-v2-delete-transient-endpoint
+++ b/projects/plugins/jetpack/changelog/add-wpcom-v2-delete-transient-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Add sites/site-id/transients/transient-name/delete endpoint.
+Add REST API v2 endpoint for editing transients.

--- a/projects/plugins/jetpack/changelog/add-wpcom-v2-delete-transient-endpoint
+++ b/projects/plugins/jetpack/changelog/add-wpcom-v2-delete-transient-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add sites/site-id/transients/transient-name/delete endpoint.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
@@ -24,7 +24,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient extends WP_Test_Jetpack_REST_
 	 *
 	 * @var string
 	 */
-	private $transient_name = 'jetpack_connected_user_data_1';
+	private static $transient_name;
 
 	/**
 	 * Value of test transient.
@@ -39,7 +39,8 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient extends WP_Test_Jetpack_REST_
 	 * @param WP_UnitTest_Factory $factory Fixture factory.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		static::$user_id = $factory->user->create( array( 'role' => 'editor' ) );
+		static::$user_id        = $factory->user->create( array( 'role' => 'editor' ) );
+		static::$transient_name = 'jetpack_connected_user_data_' . static::$user_id;
 	}
 
 	/**
@@ -49,7 +50,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient extends WP_Test_Jetpack_REST_
 		parent::setUp();
 
 		wp_set_current_user( static::$user_id );
-		set_transient( $this->transient_name, $this->transient_value );
+		set_transient( static::$transient_name, $this->transient_value );
 	}
 
 	/**
@@ -60,7 +61,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient extends WP_Test_Jetpack_REST_
 	public function test_delete_transient_permissions_check() {
 		wp_set_current_user( 0 );
 
-		$request  = wp_rest_request( Requests::DELETE, '/wpcom/v2/transients/' . $this->transient_name );
+		$request  = wp_rest_request( Requests::DELETE, '/wpcom/v2/transients/' . static::$transient_name );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
@@ -73,10 +74,10 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient extends WP_Test_Jetpack_REST_
 	 * @covers ::delete_transient
 	 */
 	public function test_delete_transient() {
-		$request  = wp_rest_request( Requests::DELETE, '/wpcom/v2/transients/' . $this->transient_name );
+		$request  = wp_rest_request( Requests::DELETE, '/wpcom/v2/transients/' . static::$transient_name );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( array( 'success' => true ), $response->get_data() );
-		$this->assertFalse( get_transient( $this->transient_name ) );
+		$this->assertFalse( get_transient( static::$transient_name ) );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
@@ -64,7 +64,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient extends WP_Test_Jetpack_REST_
 		$request  = wp_rest_request( Requests::DELETE, '/wpcom/v2/transients/' . static::$transient_name );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+		$this->assertErrorResponse( 'authorization_required', $response, 403 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
@@ -1,0 +1,82 @@
+<?php // phpcs:ignore
+/**
+ * Tests for /wpcom/v2/transients endpoints.
+ */
+
+require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+
+/**
+ * Class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient
+ *
+ * @coversDefaultClass WPCOM_REST_API_V2_Endpoint_Transient
+ */
+class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient extends WP_Test_Jetpack_REST_Testcase {
+
+	/**
+	 * Mock user ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id = 0;
+
+	/**
+	 * Name of test transient.
+	 *
+	 * @var string
+	 */
+	private $transient_name = 'jetpack_connected_user_data_1';
+
+	/**
+	 * Value of test transient.
+	 *
+	 * @var array
+	 */
+	private $transient_value = array( 'setting' => 'value' );
+
+	/**
+	 * Create shared database fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$user_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * Setup the environment for a test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( static::$user_id );
+		set_transient( $this->transient_name, $this->transient_value );
+	}
+
+	/**
+	 * Tests the permission check.
+	 *
+	 * @covers ::delete_transient_permissions_check
+	 */
+	public function test_delete_transient_permissions_check() {
+		wp_set_current_user( 0 );
+
+		$request  = wp_rest_request( Requests::DELETE, '/wpcom/v2/transients/' . $this->transient_name );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+	}
+
+	/**
+	 * Tests delete transient.
+	 *
+	 * @covers ::delete_transient_permissions_check
+	 * @covers ::delete_transient
+	 */
+	public function test_delete_transient() {
+		$request  = wp_rest_request( Requests::DELETE, '/wpcom/v2/transients/' . $this->transient_name );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( array( 'success' => true ), $response->get_data() );
+		$this->assertIsNotArray( get_transient( $this->transient_name ) );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-transient.php
@@ -77,6 +77,6 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Transient extends WP_Test_Jetpack_REST_
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( array( 'success' => true ), $response->get_data() );
-		$this->assertIsNotArray( get_transient( $this->transient_name ) );
+		$this->assertFalse( get_transient( $this->transient_name ) );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Part of a fix for https://github.com/Automattic/wp-calypso/issues/50312
* Adds an endpoint to delete a transient on a Jetpack site, so that we can clear `jetpack_connected_user_data_$user_id` when a user makes an account change (e.g. to color scheme or language) on WP.com

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1618495635435200/1618329458.321800-slack-CKZHG0QCR
p3hLNG-18q-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D60544-code and D60594-code and sandbox the API.
* Send a DELETE request to a Jetpack site via [the console](https://developer.wordpress.com/docs/api/console/): `https://public-api.wordpress.com/wpcom/v2/sites/{site slug or id}/transients/jetpack_connected_user_data_1`
* The response should be `success: true` or `success: false`