### PR TITLE
CLI: Add `version` to `jetpack changelog`

### DIFF
--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -281,7 +281,7 @@ async function changelogArgs( argv ) {
 			} else if ( argv.s || argv.t || argv.e ) {
 				console.error(
 					chalk.bgRed(
-						'Need to pass all arguments for non-interactive mode. Defaulting to interactive mode.'
+						'Need to pass all required arguments for non-interactive mode. Defaulting to interactive mode.'
 					)
 				);
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR adds the `version` command to the `jetpack changelog` tool.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p9dueE-2A1-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the `jetpack changelog` command and try the `version` command
* Passthroughs should work, ie, `jetpack changelog version plugins/jetpack next`
* Error handling should be handled by changelogger itself
* Make sure the existing commands, specifically add, continue to work normally.