### PR TITLE
Admin Menu: Fix invalid menu item ID attributes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-invalid-menu-id
+++ b/projects/plugins/jetpack/changelog/fix-invalid-menu-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sanitize the hookname used to generate menu item IDs

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -389,6 +389,9 @@ abstract class Base_Admin_Menu {
 
 		$svg_items = array();
 		foreach ( $menu as $idx => $menu_item ) {
+			// Menu items that don't have icons, for example separators, have less than 7
+			// elements, partly because the 7th is the icon. So, if we have less than 7,
+			// let's skip it.
 			if ( count( $menu_item ) < 7 ) {
 				continue;
 			}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -389,16 +389,21 @@ abstract class Base_Admin_Menu {
 
 		$svg_items = array();
 		foreach ( $menu as $idx => $menu_item ) {
-			if ( count( $menu_item ) > 6 && 0 === strpos( $menu_item[6], 'data:image/svg+xml' ) && 'site-card' !== $menu_item[3] ) {
-				$svg_items[] = array(
-					'icon' => $menu[ $idx ][6],
-					'id'   => $menu[ $idx ][5],
-				);
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$menu[ $idx ][6] = 'none';
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$menu[ $idx ][4] .= ' menu-svg-icon';
+			// If the hookname looks to contain a URL than sanitize it by remplacing invalid characters.
+			if ( false !== strpos( $menu_item[5], '://' ) ) {
+				$menu_item[5] = preg_replace( '![:/.]+!', '_', $menu_item[5] );
 			}
+
+			if ( count( $menu_item ) > 6 && 0 === strpos( $menu_item[6], 'data:image/svg+xml' ) && 'site-card' !== $menu_item[3] ) {
+				$svg_items[]   = array(
+					'icon' => $menu_item[6],
+					'id'   => $menu_item[5],
+				);
+				$menu_item[4] .= ' menu-svg-icon';
+				$menu_item[6]  = 'none';
+			}
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$menu[ $idx ] = $menu_item;
 		}
 		if ( count( $svg_items ) > 0 ) {
 			$styles = '.menu-svg-icon .wp-menu-image { background-repeat: no-repeat; background-position: center center } ';

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -393,7 +393,7 @@ abstract class Base_Admin_Menu {
 				continue;
 			}
 
-			// If the hookname looks to contain a URL than sanitize it by remplacing invalid characters.
+			// If the hookname contain a URL than sanitize it by replacing invalid characters.
 			if ( false !== strpos( $menu_item[5], '://' ) ) {
 				$menu_item[5] = preg_replace( '![:/.]+!', '_', $menu_item[5] );
 			}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -389,12 +389,16 @@ abstract class Base_Admin_Menu {
 
 		$svg_items = array();
 		foreach ( $menu as $idx => $menu_item ) {
+			if ( count( $menu_item ) < 7 ) {
+				continue;
+			}
+
 			// If the hookname looks to contain a URL than sanitize it by remplacing invalid characters.
 			if ( false !== strpos( $menu_item[5], '://' ) ) {
 				$menu_item[5] = preg_replace( '![:/.]+!', '_', $menu_item[5] );
 			}
 
-			if ( count( $menu_item ) > 6 && 0 === strpos( $menu_item[6], 'data:image/svg+xml' ) && 'site-card' !== $menu_item[3] ) {
+			if ( 0 === strpos( $menu_item[6], 'data:image/svg+xml' ) && 'site-card' !== $menu_item[3] ) {
 				$svg_items[]   = array(
 					'icon' => $menu_item[6],
 					'id'   => $menu_item[5],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Some menu items are pointing to full URLs. It turns out these have a
number of invalid characters that aren't getting stripped out by the
core WordPress functions. This meant that invalid ID attributes were
being set and that in turn broke the SVG styling introduced in #19364.

Fixes #19625

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR fixes the ID, by filtering out invalid characters, allowing the icon to be properly displayed.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:

* Using an Atomic site install Woocommerce
* Run the current master branch using the Jetpack Beta plugin
* Without Woocommerce activated, note that the icon is not displayed in the menu
* Swap to this branch and the icon should be displayed correctly.
