### PR TITLE
Mailchimp Block: Remove wrapper from rendered markup

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mailchimp-placeholder-state-in-fse
+++ b/projects/plugins/jetpack/changelog/fix-mailchimp-placeholder-state-in-fse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Mailchimp block: Remove placeholder wrapper div from server rendered markup to fix CSS issue when upgrade nudges are present on the front end.

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/mailchimp.php
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/mailchimp.php
@@ -64,94 +64,92 @@ function load_assets( $attr, $content ) {
 	?>
 
 	<div class="<?php echo esc_attr( $classes ); ?>" data-blog-id="<?php echo esc_attr( $blog_id ); ?>">
-		<div class="components-placeholder">
-			<form
-				aria-describedby="wp-block-jetpack-mailchimp_consent-text"
-				<?php if ( $is_amp_request ) : ?>
-					action-xhr="<?php echo esc_url( $amp_form_action ); ?>"
-					method="post"
-					id="mailchimp_form"
-					target="_top"
-					on="submit-success:AMP.setState( { mailing_list_status: 'subscribed', mailing_list_email: event.response.email } )"
-				<?php endif; ?>
-			>
-				<p>
-					<input
-						aria-label="<?php echo esc_attr( $values['emailPlaceholder'] ); ?>"
-						placeholder="<?php echo esc_attr( $values['emailPlaceholder'] ); ?>"
-						required
-						title="<?php echo esc_attr( $values['emailPlaceholder'] ); ?>"
-						type="email"
-						name="email"
-					/>
-				</p>
-				<?php foreach ( is_array( $values['interests'] ) ? $values['interests'] : array() as $interest ) : ?>
-					<input
-						name="interests[<?php echo esc_attr( $interest ); ?>]"
-						type="hidden"
-						class="mc-submit-param"
-						value="1"
-					/>
-				<?php endforeach; ?>
-				<?php
-				if (
-					! empty( $values['signupFieldTag'] )
-					&& ! empty( $values['signupFieldValue'] )
-					) :
-					?>
-					<input
-						name="merge_fields[<?php echo esc_attr( $values['signupFieldTag'] ); ?>]"
-						type="hidden"
-						class="mc-submit-param"
-						value="<?php echo esc_attr( $values['signupFieldValue'] ); ?>"
-					/>
-				<?php endif; ?>
-				<?php echo render_button( $attr, $content ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				<p id="wp-block-jetpack-mailchimp_consent-text">
-					<?php echo wp_kses_post( $values['consentText'] ); ?>
-				</p>
+		<form
+			aria-describedby="wp-block-jetpack-mailchimp_consent-text"
+			<?php if ( $is_amp_request ) : ?>
+				action-xhr="<?php echo esc_url( $amp_form_action ); ?>"
+				method="post"
+				id="mailchimp_form"
+				target="_top"
+				on="submit-success:AMP.setState( { mailing_list_status: 'subscribed', mailing_list_email: event.response.email } )"
+			<?php endif; ?>
+		>
+			<p>
+				<input
+					aria-label="<?php echo esc_attr( $values['emailPlaceholder'] ); ?>"
+					placeholder="<?php echo esc_attr( $values['emailPlaceholder'] ); ?>"
+					required
+					title="<?php echo esc_attr( $values['emailPlaceholder'] ); ?>"
+					type="email"
+					name="email"
+				/>
+			</p>
+			<?php foreach ( is_array( $values['interests'] ) ? $values['interests'] : array() as $interest ) : ?>
+				<input
+					name="interests[<?php echo esc_attr( $interest ); ?>]"
+					type="hidden"
+					class="mc-submit-param"
+					value="1"
+				/>
+			<?php endforeach; ?>
+			<?php
+			if (
+				! empty( $values['signupFieldTag'] )
+				&& ! empty( $values['signupFieldValue'] )
+				) :
+				?>
+				<input
+					name="merge_fields[<?php echo esc_attr( $values['signupFieldTag'] ); ?>]"
+					type="hidden"
+					class="mc-submit-param"
+					value="<?php echo esc_attr( $values['signupFieldValue'] ); ?>"
+				/>
+			<?php endif; ?>
+			<?php echo render_button( $attr, $content ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<p id="wp-block-jetpack-mailchimp_consent-text">
+				<?php echo wp_kses_post( $values['consentText'] ); ?>
+			</p>
 
-				<?php if ( $is_amp_request ) : ?>
+			<?php if ( $is_amp_request ) : ?>
 
-					<div submit-success>
-						<template type="amp-mustache">
-							<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_success wp-block-jetpack-mailchimp__is-amp">
-								<?php echo esc_html( $values['successLabel'] ); ?>
-							</div>
-						</template>
-					</div>
-					<div submit-error>
-						<template type="amp-mustache">
-							<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_error wp-block-jetpack-mailchimp__is-amp">
-								<?php echo esc_html( $values['errorLabel'] ); ?>
-							</div>
-						</template>
-					</div>
-					<div submitting>
-						<template type="amp-mustache">
-							<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_processing wp-block-jetpack-mailchimp__is-amp" role="status">
-								<?php echo esc_html( $values['processingLabel'] ); ?>
-							</div>
-						</template>
-					</div>
-
-				<?php endif; ?>
-
-			</form>
-			<?php if ( ! $is_amp_request ) : ?>
-
-				<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_processing" role="status">
-					<?php echo esc_html( $values['processingLabel'] ); ?>
+				<div submit-success>
+					<template type="amp-mustache">
+						<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_success wp-block-jetpack-mailchimp__is-amp">
+							<?php echo esc_html( $values['successLabel'] ); ?>
+						</div>
+					</template>
 				</div>
-				<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_success" role="status">
-					<?php echo esc_html( $values['successLabel'] ); ?>
+				<div submit-error>
+					<template type="amp-mustache">
+						<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_error wp-block-jetpack-mailchimp__is-amp">
+							<?php echo esc_html( $values['errorLabel'] ); ?>
+						</div>
+					</template>
 				</div>
-				<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_error" role="alert">
-					<?php echo esc_html( $values['errorLabel'] ); ?>
+				<div submitting>
+					<template type="amp-mustache">
+						<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_processing wp-block-jetpack-mailchimp__is-amp" role="status">
+							<?php echo esc_html( $values['processingLabel'] ); ?>
+						</div>
+					</template>
 				</div>
 
 			<?php endif; ?>
-		</div>
+
+		</form>
+		<?php if ( ! $is_amp_request ) : ?>
+
+			<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_processing" role="status">
+				<?php echo esc_html( $values['processingLabel'] ); ?>
+			</div>
+			<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_success" role="status">
+				<?php echo esc_html( $values['successLabel'] ); ?>
+			</div>
+			<div class="wp-block-jetpack-mailchimp_notification wp-block-jetpack-mailchimp_error" role="alert">
+				<?php echo esc_html( $values['errorLabel'] ); ?>
+			</div>
+
+		<?php endif; ?>
 	</div>
 	<?php
 	$html = ob_get_clean();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related to: https://github.com/Automattic/jetpack/pull/19566 and https://github.com/Automattic/jetpack/issues/19481

The Mailchimp block currently adds a div wrapper `<div class="components-placeholder">` in the server rendered view that appears to not be needed. This wrapper only exists in the editor UI during the loading state or when a Mailchimp connection has yet to be set up. When it exists in the server rendered view, it doesn't cause issues _most_ of the time. However, if any other code enqueues `wp-components`, then CSS that targets the `components-placeholder` class will be loaded, which then causes an issue rendering the block. An example is that the upgrade nudges rendered on the front end for logged in users enqueues `wp-components` [here](https://github.com/Automattic/jetpack/blob/83241dba4e7a4899332b86d40f73e8093c9e0079/projects/plugins/jetpack/_inc/lib/components.php#L24-L24).

The issue can be found if the following conditions are met:

1. Create a site or use a wpcom testing site that does not have a paid plan
2. Add a Mailchimp block
3. Add another block that requires a paid plan (e.g. the Calendly or Premium Content blocks)
4. Save the template part or page
5. View the front end of the site while logged in
6. You should see that there is an upgrade nudge rendered on the front end of the site, and that a white background and black border has been added to the Mailchimp block

I tested this within the site editor on a site running the TT1-blocks theme.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove the wrapper `<div class="components-placeholder">` from the server-rendered view of the Mailchimp block

***Note:*** The files changed view for this PR seems to be struggling a bit with the change here — the change is actually just removing the containing `div` and removing a level of indentation, but due to the kinds of markup removed, the algorithm to display the changes isn't having a good time displaying the change cleanly!

#### Screenshots

Note: these screenshots show the Mailchimp block rendered on the front end of a site while logged in and running the TT1-blocks theme. The styling issue to note here is the unintended white background and black border. The other issues (unstyled buttons) are being addressed separately. The upgrade nudge rendered beneath is for another block on the same page.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/115810022-857ed780-a430-11eb-8227-56ceadbb43a3.png) | ![image](https://user-images.githubusercontent.com/14988353/115810407-34231800-a431-11eb-901d-1d1a765acd38.png) |

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the above steps to test that you can replicate the issue on a wpcom site without a paid plan, running an FSE theme like TT1-blocks
* Apply this change, and verify that it fixes the issue while viewing the front end of the site while logged in
* Smoke test in a non-FSE site with existing Mailchimp block and a couple of themes to check that this doesn't introduce any regressions
