### PR TITLE
Connection Flow: add modal when dismissing connection banner

### DIFF
--- a/projects/plugins/jetpack/_inc/jetpack-connection-banner.js
+++ b/projects/plugins/jetpack/_inc/jetpack-connection-banner.js
@@ -8,28 +8,86 @@
 		fullScreenDismiss = $( '.jp-connect-full__dismiss, .jp-connect-full__dismiss-paragraph' ),
 		wpWelcomeNotice = $( '#welcome-panel' ),
 		connectionBanner = $( '#message' ),
-		connectionBannerDismiss = $( '.connection-banner-dismiss' );
+		connectionBannerDismiss = $( '.connection-banner-dismiss' ),
+		deactivateLinkElem = $( 'tr[data-slug=jetpack] > td.plugin-title > div > span.deactivate > a' );
 
 	// Move the banner below the WP Welcome notice on the dashboard
 	$( window ).on( 'load', function () {
 		wpWelcomeNotice.insertBefore( connectionBanner );
 	} );
 
-	// Dismiss the connection banner via AJAX
-	connectionBannerDismiss.on( 'click', function () {
-		$( connectionBanner ).hide();
+	var deactivateJetpackURL = deactivateLinkElem.attr( 'href' );
 
-		var data = {
-			action: 'jetpack_connection_banner',
-			nonce: jp_banner.connectionBannerNonce,
-			dismissBanner: true,
-		};
+	window.deactivateJetpack = function () {
+		window.location.href = deactivateJetpackURL;
+	};
 
-		$.post( jp_banner.ajax_url, data, function ( response ) {
-			if ( true !== response.success ) {
-				$( connectionBanner ).show();
+	var observer = new MutationObserver( function ( mutations ) {
+		mutations.forEach( function ( mutation ) {
+			if ( mutation.type === 'childList' ) {
+				mutation.addedNodes.forEach( function ( addedNode ) {
+					if ( 'TB_window' === addedNode.id ) {
+						// NodeList is static, we need to modify this in the DOM
+
+						$( '#TB_window' ).addClass( 'jetpack-disconnect-modal' );
+						deactivationModalCentralize();
+
+						$( '#TB_closeWindowButton, #TB_overlay' ).on( 'click', function ( e ) {
+							document.onkeyup = '';
+						} );
+
+						document.onkeyup = function ( e ) {
+							if ( e === null ) {
+								// ie
+								keycode = event.keyCode;
+							} else {
+								// mozilla
+								keycode = e.which;
+							}
+							if ( keycode == 27 ) {
+								// close
+								document.onkeyup = '';
+							}
+						};
+
+						observer.disconnect();
+					}
+				} );
 			}
 		} );
+	} );
+
+	window.deactivationModalCentralize = function () {
+		var modal = $( '#TB_window.jetpack-disconnect-modal' );
+		var top = $( window ).height() / 2 - $( modal ).height() / 2;
+		$( modal ).css( 'top', top + 'px' );
+	};
+
+	var body = $( 'body' )[ 0 ];
+
+	connectionBannerDismiss.attr(
+		'href',
+		'plugins.php#TB_inline?inlineId=jetpack_deactivation_dialog'
+	);
+	connectionBannerDismiss.attr( 'title', jp_banner.deactivate_title );
+	connectionBannerDismiss.addClass( 'thickbox' );
+
+	// Open dismiss deactivation dialog.
+	connectionBannerDismiss.on( 'click', function () {
+		observer.observe( body, { childList: true } );
+	} );
+
+	// Handle clicks inside the deactivation dialog.
+	$( '#jetpack_deactivation_dialog_content__button-cancel' ).on( 'click', function ( e ) {
+		tb_remove();
+		document.onkeyup = '';
+	} );
+
+	$( '#jetpack_deactivation_dialog_content__button-deactivate' ).on( 'click', function ( e ) {
+		e.preventDefault();
+
+		$( this ).prop( 'disabled', true );
+		deactivateJetpack();
 	} );
 
 	nav.on(

--- a/projects/plugins/jetpack/changelog/add-deactivation-dismiss-modal
+++ b/projects/plugins/jetpack/changelog/add-deactivation-dismiss-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Connection Banner: provide more helpful feedback when clicking the Dismiss icon.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This modifies the behaviour of the connection banner's dismiss button.
Instead of just dismissing and hiding the banner, we would like to deactivate the plugin entirely. If you do not intend on connecting your site to WordPress.com, there is no point in keeping the Jetpack plugin active.

This work is partially reusing elements of the deactivation modal introduced in #15858, in order to avoid duplicating code.

This is still a work in progress:

- [ ] I need to fix linting errors in the js
- [ ] Right now this only works from the plugins page. That's an issue since that banner also appears in the main dashboard. I'll explore using the `/wp/v2/plugins/jetpack/jetpack { status: "inactive" }` in a future commit to have a solution that doesn't rely on fetching the deactivation link from the page. ([Reference](https://make.wordpress.org/core/2020/07/16/new-and-modified-rest-api-endpoints-in-wordpress-5-5/))
- [ ] The modal's style is not perfect and still needs to be adjusted.

![image](https://user-images.githubusercontent.com/426388/115898991-83cc0880-a45e-11eb-839d-7ea044978d7c.png)


#### Jetpack product discussion
* ﻿Internal reference: p1HpG7-bPy-p2

#### Does this pull request change what data or activity we track or use?
* No
#### Testing instructions:
* On a brand new site, try clicking on the dismiss icon in the connection banner that appears in the plugins page and main dashboard page.
* Try deactivating the plugin from there, or cancelling your action.

