### PR TITLE
Record stat of the first time the site is registered

### DIFF
--- a/projects/packages/connection/changelog/add-track-unique-registrations
+++ b/projects/packages/connection/changelog/add-track-unique-registrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-heartbeat": "^1.3",
-		"automattic/jetpack-options": "^1.11",
+		"automattic/jetpack-options": "^1.12",
 		"automattic/jetpack-roles": "^1.4",
 		"automattic/jetpack-status": "^1.7",
 		"automattic/jetpack-terms-of-service": "^1.9",

--- a/projects/packages/heartbeat/changelog/add-track-unique-registrations
+++ b/projects/packages/heartbeat/changelog/add-track-unique-registrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/heartbeat/composer.json
+++ b/projects/packages/heartbeat/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-a8c-mc-stats": "^1.4",
-		"automattic/jetpack-options": "^1.11"
+		"automattic/jetpack-options": "^1.12"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^1.1"

--- a/projects/packages/jitm/changelog/add-track-unique-registrations
+++ b/projects/packages/jitm/changelog/add-track-unique-registrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-connection": "^1.26",
 		"automattic/jetpack-logo": "^1.5",
 		"automattic/jetpack-constants": "^1.6",
-		"automattic/jetpack-options": "^1.11",
+		"automattic/jetpack-options": "^1.12",
 		"automattic/jetpack-partner": "^1.4",
 		"automattic/jetpack-tracking": "^1.13",
 		"automattic/jetpack-redirect": "^1.5",

--- a/projects/packages/licensing/changelog/add-track-unique-registrations
+++ b/projects/packages/licensing/changelog/add-track-unique-registrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/licensing/composer.json
+++ b/projects/packages/licensing/composer.json
@@ -4,7 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-options": "^1.11",
+		"automattic/jetpack-options": "^1.12",
 		"automattic/jetpack-connection": "^1.26"
 	},
 	"require-dev": {

--- a/projects/packages/options/changelog/add-unique_registrations_stat
+++ b/projects/packages/options/changelog/add-unique_registrations_stat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added unique_registrations option

--- a/projects/packages/options/composer.json
+++ b/projects/packages/options/composer.json
@@ -33,7 +33,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-options/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.11.x-dev"
+			"dev-master": "1.12.x-dev"
 		}
 	}
 }

--- a/projects/packages/options/legacy/class-jetpack-options.php
+++ b/projects/packages/options/legacy/class-jetpack-options.php
@@ -59,6 +59,7 @@ class Jetpack_Options {
 					'site_icon_id',                // (int)    Attachment id of the site icon file
 					'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
 					'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
+					'unique_registrations',        // (integer) A counter of how many times the site was registered
 					'protect_whitelist',           // (array) IP Address for the Protect module to ignore
 					'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
 					'sync_health_status',          // (bool|array) An array of data relating to Jetpack's sync health.

--- a/projects/packages/sync/changelog/add-track-unique-registrations
+++ b/projects/packages/sync/changelog/add-track-unique-registrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -7,7 +7,7 @@
 		"automattic/jetpack-connection": "^1.26",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-heartbeat": "^1.3",
-		"automattic/jetpack-options": "^1.11",
+		"automattic/jetpack-options": "^1.12",
 		"automattic/jetpack-password-checker": "^0.1",
 		"automattic/jetpack-roles": "^1.4",
 		"automattic/jetpack-status": "^1.7"

--- a/projects/packages/terms-of-service/changelog/add-track-unique-registrations
+++ b/projects/packages/terms-of-service/changelog/add-track-unique-registrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/terms-of-service/composer.json
+++ b/projects/packages/terms-of-service/composer.json
@@ -4,7 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-options": "^1.11",
+		"automattic/jetpack-options": "^1.12",
 		"automattic/jetpack-status": "^1.7"
 	},
 	"require-dev": {

--- a/projects/packages/tracking/changelog/add-track-unique-registrations
+++ b/projects/packages/tracking/changelog/add-track-unique-registrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-assets": "^1.11",
-		"automattic/jetpack-options": "^1.11",
+		"automattic/jetpack-options": "^1.12",
 		"automattic/jetpack-status": "^1.7",
 		"automattic/jetpack-terms-of-service": "^1.9"
 	},

--- a/projects/plugins/jetpack/changelog/add-track-unique-registrations
+++ b/projects/plugins/jetpack/changelog/add-track-unique-registrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/add-unique_registrations_stat
+++ b/projects/plugins/jetpack/changelog/add-unique_registrations_stat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Record stat of the first time the site is registered

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -784,6 +784,7 @@ class Jetpack {
 
 		// After a successful connection.
 		add_action( 'jetpack_site_registered', array( $this, 'activate_default_modules_on_site_register' ) );
+		add_action( 'jetpack_site_registered', array( $this, 'handle_unique_registrations_stats' ) );
 
 		// Actions for Manager::authorize().
 		add_action( 'jetpack_authorize_starting', array( $this, 'authorize_starting' ) );
@@ -5025,6 +5026,25 @@ endif;
 		// Increment number of times connected.
 		$jetpack_unique_connection['connected'] += 1;
 		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
+	}
+
+	/**
+	 * This action fires when the site is registered (connected at a site level).
+	 */
+	public function handle_unique_registrations_stats() {
+		$jetpack_unique_registrations = Jetpack_Options::get_option( 'unique_registrations' );
+		// Checking if site has been registered previously before recording unique connection.
+		if ( ! $jetpack_unique_registrations ) {
+
+			$jetpack_unique_registrations = 0;
+
+			$this->stat( 'connections', 'unique-registrations' );
+			$this->do_stats( 'server_side' );
+		}
+
+		// Increment number of times connected.
+		$jetpack_unique_registrations ++;
+		Jetpack_Options::update_option( 'unique_registrations', $jetpack_unique_registrations );
 	}
 
 	/**

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -29,7 +29,7 @@
 		"automattic/jetpack-lazy-images": "1.4.x-dev",
 		"automattic/jetpack-licensing": "1.4.x-dev",
 		"automattic/jetpack-logo": "1.5.x-dev",
-		"automattic/jetpack-options": "1.11.x-dev",
+		"automattic/jetpack-options": "1.12.x-dev",
 		"automattic/jetpack-partner": "1.4.x-dev",
 		"automattic/jetpack-redirect": "1.5.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c752ebe82bfb0b89d7d2b6983d30012",
+    "content-hash": "217108c55dc268a76f3e732df0997972",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -400,12 +400,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "70c11d21cb75649592d93d4983dd211037b8a374"
+                "reference": "d7cab662ac8e0b19b03ada8faffb9e66e29dc4aa"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-heartbeat": "^1.3",
-                "automattic/jetpack-options": "^1.11",
+                "automattic/jetpack-options": "^1.12",
                 "automattic/jetpack-roles": "^1.4",
                 "automattic/jetpack-status": "^1.7",
                 "automattic/jetpack-terms-of-service": "^1.9",
@@ -668,11 +668,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/heartbeat",
-                "reference": "845231d51560155d0d7dfa46a7f1cfee6b4205c6"
+                "reference": "2b0e92c11def6004d764882e4283639d6ead6fb2"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
-                "automattic/jetpack-options": "^1.11"
+                "automattic/jetpack-options": "^1.12"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^1.1"
@@ -708,7 +708,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "091d6d49cc584dfbbb9837dfb14b2e31ccdbf8da"
+                "reference": "203f01c76507bc8cc84136b91c0b42631bcaebbb"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -716,7 +716,7 @@
                 "automattic/jetpack-connection": "^1.26",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
-                "automattic/jetpack-options": "^1.11",
+                "automattic/jetpack-options": "^1.12",
                 "automattic/jetpack-partner": "^1.4",
                 "automattic/jetpack-redirect": "^1.5",
                 "automattic/jetpack-status": "^1.7",
@@ -848,11 +848,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "ff369c33c3f693a6d535e73419e387ffa7abaebc"
+                "reference": "6424bd5df4569afe195dc766a435ebef783dc05c"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.26",
-                "automattic/jetpack-options": "^1.11"
+                "automattic/jetpack-options": "^1.12"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^1.1",
@@ -956,7 +956,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/options",
-                "reference": "190e89f7bef74b65b4d239855ca9ad4a8be54fa1"
+                "reference": "e2e07a5dc2b92f2892f04581e75f0b0fb1846c3b"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -973,7 +973,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-options/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.12.x-dev"
                 }
             },
             "autoload": {
@@ -1257,13 +1257,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "8788c3d2249eb34ed46b16f0b36630be4614ae86"
+                "reference": "f6e40adeea72c074a20c7080b548581fff936700"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.26",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-heartbeat": "^1.3",
-                "automattic/jetpack-options": "^1.11",
+                "automattic/jetpack-options": "^1.12",
                 "automattic/jetpack-password-checker": "^0.1",
                 "automattic/jetpack-roles": "^1.4",
                 "automattic/jetpack-status": "^1.7"
@@ -1302,10 +1302,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/terms-of-service",
-                "reference": "13d86487653fb10218f2c745591703bbb1524354"
+                "reference": "76e0aa453a1a7f753c7b2bafb8a6779b0616e7e2"
             },
             "require": {
-                "automattic/jetpack-options": "^1.11",
+                "automattic/jetpack-options": "^1.12",
                 "automattic/jetpack-status": "^1.7"
             },
             "require-dev": {
@@ -1357,11 +1357,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "13d2ecca0fa07b4521f0b7a7690f9f6c47dd7010"
+                "reference": "baf3bbc9d279897e709d19cecb904d6082cbf5ee"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
-                "automattic/jetpack-options": "^1.11",
+                "automattic/jetpack-options": "^1.12",
                 "automattic/jetpack-status": "^1.7",
                 "automattic/jetpack-terms-of-service": "^1.9"
             },


### PR DESCRIPTION
-- New rebased version of https://github.com/Automattic/jetpack/pull/19213 --

Under the `jetpack-connections` MC Stat there's an entry for `unique-connection`, that is bumped everytime a site connects for the first time.

This is triggered only after the user authorization. 

This PR adds a new similar metric for `unique-registrations` that is triggered upon site registration and will therefore count sites with a user-less connection.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds unique-registrations MC Stats

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1191179647901802-as-1199552431277341

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, we now anonymously track the first time a site was registered under `jetpack-connections/unique-registrations` MC Stat

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* Visit MC Stat `jetpack-connections/unique-registrations` and look at the count
* Make sure this option does not exist: `wp jetpack options get unique_registrations`
* If your site is connected, disconnect
* Click Set Up Jetpack, don't connect the user
* Make sure the option value is `1`: `wp jetpack options get unique_registrations`
* Visit MC Stat `jetpack-connections/unique-registrations` and see the count was bumped
* Refresh the page, you will be asked to Set up again. Set up!
* Make sure the option value is `2`: `wp jetpack options get unique_registrations`
* * Visit MC Stat `jetpack-connections/unique-registrations` and make sure the count was NOT bumped
