### PR TITLE
External Media: don't show duplicate buttons for post thumbnails

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-remove-replace-button
+++ b/projects/plugins/jetpack/changelog/fix-remove-replace-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Media Buttons: don't show duplicate buttons when a featured image is selected

--- a/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
+++ b/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
@@ -413,5 +413,6 @@ $grid-size: 8px;
 .editor-post-featured-image {
 	.components-dropdown .jetpack-external-media-button-menu {
 		margin-right: 8px;
+		margin-bottom: 1em;
 	}
 }

--- a/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
+++ b/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
@@ -416,3 +416,8 @@ $grid-size: 8px;
 		margin-bottom: 1em;
 	}
 }
+
+// Override DropDown component styles when warpping the "Set featured image" button.
+.editor-post-featured-image .components-dropdown {
+	display: initial;
+}

--- a/projects/plugins/jetpack/extensions/shared/external-media/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/index.js
@@ -50,6 +50,12 @@ if ( isCurrentUserConnected() && 'function' === typeof useBlockEditContext ) {
 			const { name } = useBlockEditContext();
 			let { render } = props;
 
+			// Featured Image gets rendered twice in the Post sidebar when an image is selected.
+			// We only want the first of the two, which conveniently has a value prop
+			if ( isFeaturedImage( props ) && props.value === undefined ) {
+				return <></>;
+			}
+
 			if ( isAllowedBlock( name, render ) || isFeaturedImage( props ) ) {
 				const { allowedTypes, gallery = false, value = [] } = props;
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/index.js
@@ -41,6 +41,7 @@ function MediaButton( props ) {
 				setSelectedSource={ setSelectedSource }
 				isReplace={ isReplaceMenu( mediaProps ) }
 				isFeatured={ isFeaturedImage( mediaProps ) }
+				hasImage={ mediaProps.value > 0 }
 			/>
 
 			{ ExternalLibrary && <ExternalLibrary onClose={ closeLibrary } { ...mediaProps } /> }

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
@@ -14,8 +14,8 @@ function MediaButtonMenu( props ) {
 	const { mediaProps, open, setSelectedSource, isFeatured, isReplace, hasImage } = props;
 	const originalComponent = mediaProps.render;
 	let isPrimary = isFeatured;
+	let isSecondary = false;
 	let isTertiary = ! isFeatured;
-	const extraProps = {};
 
 	if ( isReplace ) {
 		return (
@@ -41,7 +41,7 @@ function MediaButtonMenu( props ) {
 		label = __( 'Replace Image', 'jetpack' );
 		isPrimary = false;
 		isTertiary = false;
-		extraProps.isSecondary = true;
+		isSecondary = true;
 	}
 
 	return (
@@ -58,13 +58,13 @@ function MediaButtonMenu( props ) {
 						originalComponent( { open: onToggle } )
 					) : (
 						<Button
-							isTertiary={ isTertiary }
 							isPrimary={ isPrimary }
+							isSecondary={ isSecondary }
+							isTertiary={ isTertiary }
 							className="jetpack-external-media-button-menu"
 							aria-haspopup="true"
 							aria-expanded={ isOpen }
 							onClick={ onToggle }
-							{ ...extraProps }
 						>
 							{ label }
 						</Button>

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
@@ -11,9 +11,8 @@ import { media } from '@wordpress/icons';
 import MediaSources from './media-sources';
 
 function MediaButtonMenu( props ) {
-	const { mediaProps, open, setSelectedSource, isFeatured, isReplace } = props;
+	const { mediaProps, open, setSelectedSource, isFeatured, isReplace, hasImage } = props;
 	const originalComponent = mediaProps.render;
-	const featuredImageIsSelected = isFeatured && mediaProps.value > 0;
 	let isPrimary = isFeatured;
 	let isTertiary = ! isFeatured;
 	const extraProps = {};
@@ -38,7 +37,7 @@ function MediaButtonMenu( props ) {
 		label = __( 'Select Media', 'jetpack' );
 	}
 
-	if ( isFeatured && featuredImageIsSelected ) {
+	if ( isFeatured && hasImage ) {
 		label = __( 'Replace Image', 'jetpack' );
 		isPrimary = false;
 		isTertiary = false;
@@ -47,24 +46,30 @@ function MediaButtonMenu( props ) {
 
 	return (
 		<>
-			{ isFeatured && originalComponent( { open } ) }
+			{ isFeatured && hasImage && originalComponent( { open } ) }
 
 			<Dropdown
 				position="bottom right"
 				contentClassName="jetpack-external-media-button-menu__options"
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<Button
-						isTertiary={ isTertiary }
-						isPrimary={ isPrimary }
-						className="jetpack-external-media-button-menu"
-						aria-haspopup="true"
-						aria-expanded={ isOpen }
-						onClick={ onToggle }
-						{ ...extraProps }
-					>
-						{ label }
-					</Button>
-				) }
+				renderToggle={ ( { isOpen, onToggle } ) =>
+					// Featured image: when there's no image set, wrap the component, as it's already a (giant) button,
+					// there's no need to add a second button.
+					isFeatured && ! hasImage ? (
+						originalComponent( { open: onToggle } )
+					) : (
+						<Button
+							isTertiary={ isTertiary }
+							isPrimary={ isPrimary }
+							className="jetpack-external-media-button-menu"
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							onClick={ onToggle }
+							{ ...extraProps }
+						>
+							{ label }
+						</Button>
+					)
+				}
 				renderContent={ () => (
 					<NavigableMenu aria-label={ label }>
 						<MenuGroup>

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
@@ -13,10 +13,10 @@ import MediaSources from './media-sources';
 function MediaButtonMenu( props ) {
 	const { mediaProps, open, setSelectedSource, isFeatured, isReplace } = props;
 	const originalComponent = mediaProps.render;
-
-	if ( isFeatured && mediaProps.value === undefined ) {
-		return originalComponent( { open } );
-	}
+	const featuredImageIsSelected = isFeatured && mediaProps.value > 0;
+	let isPrimary = isFeatured;
+	let isTertiary = ! isFeatured;
+	const extraProps = {};
 
 	if ( isReplace ) {
 		return (
@@ -38,6 +38,13 @@ function MediaButtonMenu( props ) {
 		label = __( 'Select Media', 'jetpack' );
 	}
 
+	if ( isFeatured && featuredImageIsSelected ) {
+		label = __( 'Replace Image', 'jetpack' );
+		isPrimary = false;
+		isTertiary = false;
+		extraProps.isSecondary = true;
+	}
+
 	return (
 		<>
 			{ isFeatured && originalComponent( { open } ) }
@@ -47,12 +54,13 @@ function MediaButtonMenu( props ) {
 				contentClassName="jetpack-external-media-button-menu__options"
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
-						isTertiary={ ! isFeatured }
-						isPrimary={ isFeatured }
+						isTertiary={ isTertiary }
+						isPrimary={ isPrimary }
 						className="jetpack-external-media-button-menu"
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						onClick={ onToggle }
+						{ ...extraProps }
 					>
 						{ label }
 					</Button>

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
@@ -70,14 +70,20 @@ function MediaButtonMenu( props ) {
 						</Button>
 					)
 				}
-				renderContent={ () => (
+				renderContent={ ( { onClose } ) => (
 					<NavigableMenu aria-label={ label }>
 						<MenuGroup>
-							<MenuItem icon={ media } onClick={ open }>
+							<MenuItem
+								icon={ media }
+								onClick={ () => {
+									onClose();
+									open();
+								} }
+							>
 								{ __( 'Media Library', 'jetpack' ) }
 							</MenuItem>
 
-							<MediaSources open={ open } setSource={ setSelectedSource } />
+							<MediaSources open={ open } setSource={ setSelectedSource } onClick={ onClose } />
 						</MenuGroup>
 					</NavigableMenu>
 				) }

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-sources.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-sources.js
@@ -9,13 +9,20 @@ import { Fragment } from '@wordpress/element';
  */
 import { mediaSources } from '../sources';
 
-function MediaSources( { originalButton = null, open, setSource } ) {
+function MediaSources( { originalButton = null, onClick = () => {}, open, setSource } ) {
 	return (
 		<Fragment>
 			{ originalButton && originalButton( { open } ) }
 
 			{ mediaSources.map( ( { icon, id, label } ) => (
-				<MenuItem icon={ icon } key={ id } onClick={ () => setSource( id ) }>
+				<MenuItem
+					icon={ icon }
+					key={ id }
+					onClick={ () => {
+						onClick();
+						setSource( id );
+					} }
+				>
 					{ label }
 				</MenuItem>
 			) ) }


### PR DESCRIPTION
Previously, our "Select Image" button would still show alongside Core's "Replace Image" button. Now, Cores' button is not shown, and our button shows as "Replace Image" when an image has been selected.

Fixes #19555

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Post Thumbnail UI should no longer show duplicate buttons, and buttons shown are appropriate

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* apply soon-to-be-generated Diff to your WPCom sandbox
* Open an existing post (or create a new one)
* Open the "Featured Image" section in the Post sidebar
* No featured image selected should look like: 
 <img width="276" alt="Screen Shot 2021-04-23 at 15 46 43" src="https://user-images.githubusercontent.com/195089/115928076-2d090380-a44b-11eb-80d3-86f386c8726a.png">
* With a selected featured image: 
<img width="279" alt="Screen Shot 2021-04-23 at 15 44 55" src="https://user-images.githubusercontent.com/195089/115927934-e4514a80-a44a-11eb-9041-15cdf80f7c73.png">

Note that we use the Media Button in several locations throughout Gutenberg. These modifications should be isolated to featured image usage, but smoke testing other image-based blocks/settings since I can't find any tests for this.