### PR TITLE
Update Modal: use the wp-block-library styles

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-dialogue-modern/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-dialogue-modern/style.scss
@@ -68,7 +68,7 @@ body.jp-dialogue-modern-showing {
 		}
 	}
 
-	a {
+	a :not(.wp-block-button__link) {
 		text-decoration: underline;
 	}
 }

--- a/projects/plugins/jetpack/changelog/2021-04-23-21-16-10-453129
+++ b/projects/plugins/jetpack/changelog/2021-04-23-21-16-10-453129
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update Modal: use the wp-block-library styles

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3381,6 +3381,7 @@ p {
 	 */
 	public static function do_version_bump( $version, $old_version ) {
 		if ( $old_version ) { // For existing Jetpack installations.
+			add_action( 'admin_enqueue_scripts', __CLASS__ . '::enqueue_block_style' );
 
 			// If a front end page is visited after the update, the 'wp' action will fire.
 			add_action( 'wp', 'Jetpack::set_update_modal_display' );
@@ -3395,6 +3396,14 @@ p {
 	 */
 	public static function set_update_modal_display() {
 		self::state( 'display_update_modal', true );
+
+	}
+
+	/**
+	 * Enqueues the block library styles.
+	 */
+	public static function enqueue_block_style() {
+		wp_enqueue_style( 'wp-block-library' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3401,9 +3401,13 @@ p {
 
 	/**
 	 * Enqueues the block library styles.
+	 *
+	 * @param string $hook The current admin page.
 	 */
-	public static function enqueue_block_style() {
-		wp_enqueue_style( 'wp-block-library' );
+	public static function enqueue_block_style( $hook ) {
+		if ( 'toplevel_page_jetpack' === $hook ) {
+			wp_enqueue_style( 'wp-block-library' );
+		}
 	}
 
 	/**
@@ -3733,6 +3737,11 @@ p {
 		add_action( 'load-plugins.php', array( $this, 'intercept_plugin_error_scrape_init' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_menu_css' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'deactivate_dialog' ) );
+
+		if ( isset( $_COOKIE['jetpackState']['display_update_modal'] ) ) {
+			add_action( 'admin_enqueue_scripts', __CLASS__ . '::enqueue_block_style' );
+		}
+
 		add_filter( 'plugin_action_links_' . plugin_basename( JETPACK__PLUGIN_DIR . 'jetpack.php' ), array( $this, 'plugin_action_links' ) );
 
 		if ( self::is_connection_ready() || $is_offline_mode ) {


### PR DESCRIPTION
Fixes #18966

#### Changes proposed in this Pull Request:
* The update modal content could be generated using WordPress blocks, such as the Button block. Let's enqueue the `wp-block-library` style when the Jetpack version is bumped so that the modal can include properly styled blocks.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install and activate this branch.
2. Connect Jetpack.
3. Cause a version update. The update modal for version 8.4 includes a button, so update from 8.3 to 8.4:
     a. In the `jetpack.php` file, change the `JETPACK__VERSION` value to 8.3.
     b. Reload the site.
     c. In the `jetpack.php` file, change the `JETPACK__VERSION` value to 8.4.
4. Navigate to the Jetpack dashboard. You should see the 8.4 update modal, and a button should be displayed correctly at the bottom of the modal.
5. Repeat from step 3, this time navigating to other admin pages before navigating to the Jetpack dashboard.