### PR TITLE
Fixed Page Optimize plugin conflict for RTL stylesheets

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-page-optimize-conflict
+++ b/projects/plugins/jetpack/changelog/fix-page-optimize-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Fixed compatibility issue with Page Optimize plugin for RTL layouts for jetpack-admin-menu and colors stylesheets

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -277,7 +277,7 @@ abstract class Base_Admin_Menu {
 	 * https://core.trac.wordpress.org/ticket/53090
 	 */
 	public function configure_colors_for_rtl_stylesheets() {
-		wp_styles()->add_data( 'colors', 'rtl', $this->is_rtl() );
+		wp_style_add_data( 'colors', 'rtl', $this->is_rtl() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -273,9 +273,10 @@ abstract class Base_Admin_Menu {
 
 	/**
 	 * Mark the core colors stylesheets as RTL depending on the value from the environment.
+	 * This fixes a core issue where the extra RTL data is not added to the colors stylesheet.
+	 * https://core.trac.wordpress.org/ticket/53090
 	 */
 	public function configure_colors_for_rtl_stylesheets() {
-		// This also fixes the core issue.
 		wp_styles()->add_data( 'colors', 'rtl', $this->is_rtl() );
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -259,6 +259,9 @@ abstract class Base_Admin_Menu {
 			JETPACK__VERSION
 		);
 
+		wp_style_add_data( 'jetpack-admin-menu', 'rtl', $this->is_rtl() );
+		$this->configure_colors_for_rtl_stylesheets();
+
 		wp_enqueue_script(
 			'jetpack-admin-menu',
 			plugins_url( 'admin-menu.js', __FILE__ ),
@@ -266,6 +269,14 @@ abstract class Base_Admin_Menu {
 			JETPACK__VERSION,
 			true
 		);
+	}
+
+	/**
+	 * Mark the core colors stylesheets as RTL depending on the value from the environment.
+	 */
+	public function configure_colors_for_rtl_stylesheets() {
+		// This also fixes the core issue.
+		wp_styles()->add_data( 'colors', 'rtl', $this->is_rtl() );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #19340 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Added `rtl` extra data for `colors` and `jetpack-admin-menu` CSS handles. This in turn will make Page Optimize to ignore the stylesheets since the current implementation does not support RTL. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

_Simple_
- Apply D60626-code to your WP.com sandbox.
- Sandbox the API and a simple site.

_Atomic_
- Install Jetpack Beta on a Atomic site and switch to the branch of this PR.
- Go to https://wordpress.com and switch to the WoA site.

_Jetpack_
- Spin up a local environment and switch to this PR branch

To test this fix, on all environments, you'll need to:
- Have page optimize installed (except for Simple sites)
- Go to https://wordpress.com/me/account and change your language to an RTL language.
- Enable an RTL language on your site (Settings > General)
- Make sure that Page Optimize does not have `jetpack-admin-menu` and `colors` marked as excluded from CSS concatenation section.