### PR TITLE
Payments Block: Redirect back to editor after Stripe connection

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-payments-stripe-redirect
+++ b/projects/plugins/jetpack/changelog/fix-payments-stripe-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Payments Block: redirect back to block editor after Stripe connection.

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -26,6 +26,7 @@ import { applyFilters } from '@wordpress/hooks';
 import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
 import {
 	CURRENCY_OPTIONS,
+	getConnectUrl,
 	isPriceValid,
 	minimumTransactionAmountForCurrency,
 } from '../../shared/currencies';
@@ -489,7 +490,7 @@ export class MembershipsButtonEdit extends Component {
 				<ToolbarControls
 					autosaveAndRedirect={ this.props.autosaveAndRedirect }
 					connected={ connected !== API_STATE_NOTCONNECTED }
-					connectURL={ connectURL }
+					connectURL={ getConnectUrl( this.props.postId, connectURL ) }
 					hasUpgradeNudge={ this.hasUpgradeNudge }
 					shouldUpgrade={ this.state.shouldUpgrade }
 				/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
The Recurring Payments block was not correctly configuring the Stripe connectUrl to redirect back to the block editor after connection. As a result it falls back to redirecting you to the `earn/payments` settings page.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Refactors some logic which modifies the Stripe connection URL to redirect correctly out of the Premium Content block and into a shared function
* Updates the Recurring Payments block to use this function, and correctly redirect back to the block editor after Stripe connection

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You will need a test site with a premium plan and without a Stripe connection.

**Reproduce the bug**
* Open the block editor and insert a Payments block.
* Use the button in the block toolbar to Connect to Stripe.
* Follow prompts to connect to Stripe or skip connection if the store is sandboxed.
* Note that you are redirected to the `earn/payments` page instead of the post you were editing.

**Verify the fix**
* Disconnect your Stripe account from the `earn/payments` settings page (you may have to refresh a few times before the Disconnect button appears).
* Sync this changeset
* Open the block editor and insert a Payments block.
* Use the button in the block toolbar to Connect to Stripe.
* Follow prompts to connect/skip if sandboxed.
* Verify that you are redirected back to the post you were editing.

**Verify that Premium Content continues to work**
* Disconnect your Stripe account again.
* From the block editor, insert a Premium Content block.
* Use the button in the block toolbar to Connect to Stripe.
* Follow prompts to connect/skip if sandboxed.
* Verify that you are redirected back to the post you were editing.