### PR TITLE
Conversation: upload transcript file to the site media

### DIFF
--- a/projects/plugins/jetpack/changelog/update-conversation-upload-transcript-file
+++ b/projects/plugins/jetpack/changelog/update-conversation-upload-transcript-file
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Conversation: store the transcript file into the site media.

--- a/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/conversation/edit.js
@@ -13,6 +13,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { mediaUpload } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -125,9 +126,7 @@ function ConversationEdit( {
 		setIsProcessingFile( false );
 	}
 
-	function uploadTranscriptFile( event ) {
-		const transcriptFile = event.target.files?.[ 0 ];
-
+	function processTranscriptFile( transcriptFile ) {
 		// Check file exists.
 		if ( ! transcriptFile ) {
 			return showTranscriptProcessErrorMessage( __( 'Transcript file not found.', 'jetpack' ) );
@@ -176,6 +175,27 @@ function ConversationEdit( {
 			const dialogueBlocks = createBlocksFromInnerBlocksTemplate( dialogueBlocksTemplate );
 			insertBlocks( dialogueBlocks, 0, clientId );
 			setIsProcessingFile( false );
+		} );
+	}
+
+	function uploadTranscriptFile( event ) {
+		const transcriptFile = event.target.files?.[ 0 ];
+
+		mediaUpload( {
+			allowedTypes: [ 'text' ],
+			filesList: [ transcriptFile ],
+			onFileChange: uploadedFile => {
+				if (
+					! uploadedFile?.length ||
+					! uploadedFile[ 0 ] ||
+					! uploadedFile[ 0 ].guid // <- ensure file has been properly uploaded.
+				) {
+					return;
+				}
+
+				processTranscriptFile( transcriptFile );
+			},
+			onError: noticeOperations.createErrorNotice,
 		} );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

In this PR, the transcript file is uploaded to the site media, allowing to download of the original data when required.

Fixes #

#### Changes proposed in this Pull Request:

* conversation: store transcript file in the site media.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new Conversation Block
* Upload a transcript file
* Confirm the block content is parsed properly
* Check the file is in the site media
