### PR TITLE
Password checker: avoid checking in vendor directory

### DIFF
--- a/projects/packages/password-checker/.gitignore
+++ b/projects/packages/password-checker/.gitignore
@@ -1,1 +1,3 @@
 wordpress
+vendor
+composer.lock

--- a/projects/packages/password-checker/changelog/update-password-checker-gitignore
+++ b/projects/packages/password-checker/changelog/update-password-checker-gitignore
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid checking in vendor directory.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When releasing Jetpack 9.7 Beta earlier today, the Password Checker directory in my checked out copy of jetpack-production/branch-9.7 included the whole vendor directory for the password-checker package. We do not need it since those are only dev dependencies.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* I'm not sure how to best test this.
