### PR TITLE
build: Fix package ref updating

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -65,7 +65,11 @@ for SLUG in "${SLUGS[@]}"; do
 		echo "$JSON" > composer.json
 		if [[ -e "composer.lock" ]]; then
 			OLDLOCK=$(<composer.lock)
-			composer update --root-reqs --no-install
+			PACKAGES=()
+			mapfile -t PACKAGES < <( composer info --locked --name-only | sed -e 's/ *$//' | grep --fixed-strings --line-regexp --file=<( jq --argjson repo "$REPO" -rn '$repo.options.versions // {} | keys[]' ) )
+			if [[ ${#PACKAGES[@]} -gt 0 ]]; then
+				composer update --no-install "${PACKAGES[@]}"
+			fi
 		else
 			OLDLOCK=
 		fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We used `composer update --root-reqs` to try to update references to
monorepo packages to point to the built versions instead of the monorepo
versions.

But that fails to update any monorepo packages that are depended on
indirectly, like how plugins/jetpack depends on packages/sync which
depends on packages/password-checker but does not itself depend on
packages/password-checker.

This probably doesn't matter much, except for the case where we're
bundling the packages in the plugin. In that case we might get files
that aren't supposed to be included, or omit files that are.

So instead, explicitly update just the packages built from the monorepo.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#19666

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Revert #19666 and run a build. Does `vendor/automattic/jetpack-password-checker/vendor` still not exist in the Jetpack plugin?
