### PR TITLE
Personal settings link now includes site query param

### DIFF
--- a/projects/plugins/jetpack/changelog/update-personal-settings-link
+++ b/projects/plugins/jetpack/changelog/update-personal-settings-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+On WPCOM sites, the link in "Users -> Personal Settings" sidebar menu includes a "site" query parameter

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -247,13 +247,13 @@ class WPcom_Admin_Menu extends Admin_Menu {
 			$submenus_to_update = array(
 				'users.php'              => 'https://wordpress.com/people/team/' . $this->domain,
 				'grofiles-editor'        => 'https://wordpress.com/me',
-				'grofiles-user-settings' => 'https://wordpress.com/me/account',
+				'grofiles-user-settings' => 'https://wordpress.com/me/account/?site=' . $this->domain,
 			);
 			$this->update_submenus( 'users.php', $submenus_to_update );
 		} else {
 			$submenus_to_update = array(
 				'grofiles-editor'        => 'https://wordpress.com/me',
-				'grofiles-user-settings' => 'https://wordpress.com/me/account',
+				'grofiles-user-settings' => 'https://wordpress.com/me/account/?site=' . $this->domain,
 			);
 			$this->update_submenus( 'profile.php', $submenus_to_update );
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/50564

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* On WPCOM sites, the link in "Users -> Personal Settings" left handed menu is changed from `https://wordpress.com/me/account/` to `https://wordpress.com/me/account/?site=mysite.word press.com`

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
* Use a local copy of calypso with https://github.com/Automattic/wp-calypso/pull/52306 (branch `add/me-account-optionally-selects-site`) applied
* Apply the automatically generated wpcom patch related to this branch to your sandbox (D60700-code)
* Select a site on calypso different than your selected site
* Leave calypso for wp-admin [Click "Feedback" to land on edit.php]
* Returns to calypso from wp-admin by landing on the /me/account page [Click "Users" -> "Personal Settings"]
* On the calypso settings page, click on "My Sites" in the top left corner
* Before this patch: The selected site is lost [You are returned to your default site, not the selected one]
* After this patch: The selected site is retained [You are returned to the selected site]

