### PR TITLE
Search: Use Gutenberg prototype to customize settings

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/search-config/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/search-config/attributes.js
@@ -1,0 +1,3 @@
+export default {
+	// @TODO - Add block attributes here
+};

--- a/projects/plugins/jetpack/extensions/blocks/search-config/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/search-config/edit.js
@@ -50,7 +50,7 @@ export default function SearchConfigEdit( { className } ) {
 				<h3>{ __( 'Search Configurator 1000', 'jetpack' ) }</h3>
 				<SelectControl
 					disabled={ ! site }
-					label="Theme"
+					label={ __( 'Theme', 'jetpack' ) }
 					value={ theme }
 					options={ [
 						{ label: __( 'Light', 'jetpack' ), value: 'light' },
@@ -60,7 +60,7 @@ export default function SearchConfigEdit( { className } ) {
 				/>
 				<SelectControl
 					disabled={ ! site }
-					label="Result Format"
+					label={ __( 'Result Format', 'jetpack' ) }
 					value={ resultFormat }
 					options={ [
 						{ label: __( 'Minimal', 'jetpack' ), value: 'minimal' },
@@ -71,7 +71,7 @@ export default function SearchConfigEdit( { className } ) {
 				/>
 				<SelectControl
 					disabled={ ! site }
-					label="Sort"
+					label={ __( 'Sort', 'jetpack' ) }
 					value={ sort }
 					options={ [
 						{ label: __( 'Relevance (recommended)', 'jetpack' ), value: 'relevance' },
@@ -82,7 +82,7 @@ export default function SearchConfigEdit( { className } ) {
 				/>
 				<SelectControl
 					disabled={ ! site }
-					label="Overlay Trigger"
+					label={ __( 'Overlay Trigger', 'jetpack' ) }
 					value={ trigger }
 					options={ [
 						{ label: __( 'Open when the user starts typing', 'jetpack' ), value: 'immediate' },
@@ -95,19 +95,19 @@ export default function SearchConfigEdit( { className } ) {
 				<ToggleControl
 					checked={ sortEnabled }
 					disabled={ ! site }
-					label="Enable Sort"
+					label={ __( 'Enable Sort', 'jetpack' ) }
 					onChange={ setSortEnabled }
 				/>
 				<ToggleControl
 					checked={ infiniteScroll }
 					disabled={ ! site }
-					label="Enable Infinite Scroll"
+					label={ __( 'Enable Infinite Scroll', 'jetpack' ) }
 					onChange={ setInfiniteScroll }
 				/>
 				<ToggleControl
 					checked={ showLogo }
 					disabled={ ! site }
-					label="Show 'Powered by Jetpack'"
+					label={ __( "Show 'Powered by Jetpack'", 'jetpack' ) }
 					onChange={ setShowLogo }
 				/>
 			</Card>

--- a/projects/plugins/jetpack/extensions/blocks/search-config/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/search-config/edit.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Card, SelectControl, ToggleControl } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+export default function SearchConfigEdit( { className } ) {
+	/**
+	 * @returns {object} The UI displayed when user edits this block.
+	 */
+	const site = useSelect( select => select( 'core' ).getSite() );
+	const [ theme, setTheme ] = useEntityProp( 'root', 'site', 'jetpack_search_color_theme' );
+	const [ resultFormat, setResultFormat ] = useEntityProp(
+		'root',
+		'site',
+		'jetpack_search_result_format'
+	);
+	const [ sort, setSort ] = useEntityProp( 'root', 'site', 'jetpack_search_default_sort' );
+	const [ trigger, setTrigger ] = useEntityProp( 'root', 'site', 'jetpack_search_overlay_trigger' );
+	// TODO: Fix and re-enable.
+	// const [ color, setColor ] = useEntityProp( 'root', 'site', 'jetpack_search_highlight_color' );
+	const [ sortEnabled, setSortEnabled ] = useEntityProp(
+		'root',
+		'site',
+		'jetpack_search_enable_sort'
+	);
+	const [ infiniteScroll, setInfiniteScroll ] = useEntityProp(
+		'root',
+		'site',
+		'jetpack_search_inf_scroll'
+	);
+	const [ showLogo, setShowLogo ] = useEntityProp(
+		'root',
+		'site',
+		'jetpack_search_show_powered_by'
+	);
+
+	// TODO: Create control for jetpack_search_excluded_post_types.
+
+	return (
+		<div className={ className }>
+			<Card>
+				<h3>{ __( 'Search Configurator 1000', 'jetpack' ) }</h3>
+				<SelectControl
+					disabled={ ! site }
+					label="Theme"
+					value={ theme }
+					options={ [
+						{ label: __( 'Light', 'jetpack' ), value: 'light' },
+						{ label: __( 'Dark', 'jetpack' ), value: 'dark' },
+					] }
+					onChange={ setTheme }
+				/>
+				<SelectControl
+					disabled={ ! site }
+					label="Result Format"
+					value={ resultFormat }
+					options={ [
+						{ label: __( 'Minimal', 'jetpack' ), value: 'minimal' },
+						{ label: __( 'Expanded (shows images)', 'jetpack' ), value: 'expanded' },
+						{ label: __( 'Product (for WooCommerce stores)', 'jetpack' ), value: 'product' },
+					] }
+					onChange={ setResultFormat }
+				/>
+				<SelectControl
+					disabled={ ! site }
+					label="Sort"
+					value={ sort }
+					options={ [
+						{ label: __( 'Relevance (recommended)', 'jetpack' ), value: 'relevance' },
+						{ label: __( 'Newest first', 'jetpack' ), value: 'newest' },
+						{ label: __( 'Oldest first', 'jetpack' ), value: 'oldest' },
+					] }
+					onChange={ setSort }
+				/>
+				<SelectControl
+					disabled={ ! site }
+					label="Overlay Trigger"
+					value={ trigger }
+					options={ [
+						{ label: __( 'Open when the user starts typing', 'jetpack' ), value: 'immediate' },
+						{ label: __( 'Open when results are available', 'jetpack' ), value: 'results' },
+					] }
+					onChange={ setTrigger }
+				/>
+				{ /* TODO: Fix the ColorPicker implementation */ }
+				{ /* <ColorPicker color={ color } onChangeComplete={ value => setColor( value.hex ) } /> */ }
+				<ToggleControl
+					checked={ sortEnabled }
+					disabled={ ! site }
+					label="Enable Sort"
+					onChange={ setSortEnabled }
+				/>
+				<ToggleControl
+					checked={ infiniteScroll }
+					disabled={ ! site }
+					label="Enable Infinite Scroll"
+					onChange={ setInfiniteScroll }
+				/>
+				<ToggleControl
+					checked={ showLogo }
+					disabled={ ! site }
+					label="Show 'Powered by Jetpack'"
+					onChange={ setShowLogo }
+				/>
+			</Card>
+		</div>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/search-config/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/search-config/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from '../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/projects/plugins/jetpack/extensions/blocks/search-config/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/search-config/editor.scss
@@ -1,0 +1,5 @@
+/**
+ * Editor styles for Search-config
+ */
+
+.wp-block-jetpack-search-config { }

--- a/projects/plugins/jetpack/extensions/blocks/search-config/icon.js
+++ b/projects/plugins/jetpack/extensions/blocks/search-config/icon.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
+	<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
+	</SVG>
+);

--- a/projects/plugins/jetpack/extensions/blocks/search-config/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/search-config/index.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import edit from './edit';
+import icon from './icon';
+import { getIconColor } from '../../shared/block-icons';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
+
+export const name = 'search-config';
+export const title = __( 'Search Config', 'jetpack' );
+export const settings = {
+	title,
+	description: (
+		<Fragment>
+			<p>{ __( 'Search-config', 'jetpack' ) }</p>
+			<ExternalLink href="#">{ __( 'Learn more about Search-config', 'jetpack' ) }</ExternalLink>
+		</Fragment>
+	),
+	icon: {
+		src: icon,
+		foreground: getIconColor(),
+	},
+	category: 'jetpack',
+	keywords: [],
+	supports: {
+		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
+		align: false /* if set to true, the 'align' option below can be used*/,
+		// Pick which alignment options to display.
+		/*align: [ 'left', 'right', 'full' ],*/
+		// Support for wide alignment, that requires additional support in themes.
+		alignWide: true,
+		// When true, a new field in the block sidebar allows to define an id for the block and a button to copy the direct link.
+		anchor: false,
+		// When true, a new field in the block sidebar allows to define a custom className for the block’s wrapper.
+		customClassName: true,
+		// When false, Gutenberg won't add a class like .wp-block-your-block-name to the root element of your saved markup
+		className: true,
+		// Setting this to false suppress the ability to edit a block’s markup individually. We often set this to false in Jetpack blocks.
+		html: false,
+		// Passing false hides this block in Gutenberg's visual inserter.
+		/*inserter: true,*/
+		// When false, user will only be able to insert the block once per post.
+		multiple: true,
+		// When false, the block won't be available to be converted into a reusable block.
+		reusable: true,
+	},
+	edit,
+	/* @TODO Write the block editor output */
+	save: () => null,
+	attributes,
+	example: {
+		attributes: {
+			// @TODO: Add default values for block attributes, for generating the block preview.
+		},
+	},
+};

--- a/projects/plugins/jetpack/extensions/blocks/search-config/search-config.php
+++ b/projects/plugins/jetpack/extensions/blocks/search-config/search-config.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Search-config Block.
+ *
+ * @since 9.x
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Search_config;
+
+use Automattic\Jetpack\Blocks;
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'search-config';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	Blocks::jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Search-config block registration/dependency declaration.
+ *
+ * @return string
+ */
+function load_assets() {
+	/*
+	 * Enqueue necessary scripts and styles.
+	 */
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
+
+	return '';
+}

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -39,15 +39,8 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [
-		"amazon"
-	],
-	"experimental": [
-		"anchor-fm",
-		"premium-content",
-		"conversation",
-		"dialogue"
-	],
+	"beta": [ "amazon", "search-config" ],
+	"experimental": [ "anchor-fm", "premium-content", "conversation", "dialogue" ],
 	"no-post-editor": [
 		"business-hours",
 		"button",

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -21,6 +21,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	public function load_php() {
 		$this->base_load_php();
 
+		require_once __DIR__ . '/class-jetpack-search-settings.php';
+		new Jetpack_Search_Settings();
+
 		if ( class_exists( 'WP_Customize_Manager' ) ) {
 			require_once __DIR__ . '/class-jetpack-search-customize.php';
 			new Jetpack_Search_Customize();

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-settings.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-settings.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Jetpack Search Overlay Settings
+ *
+ * @package automattic/jetpack
+ */
+
+// Exit if file is accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once __DIR__ . '/class-jetpack-search-options.php';
+
+/**
+ * Class to initialize search settings on the site.
+ *
+ * @since 8.3.0
+ */
+class Jetpack_Search_Settings {
+
+	/**
+	 * Class initialization.
+	 *
+	 * @since 8.3.0
+	 */
+	public function __construct() {
+		add_action( 'admin_init', array( $this, 'settings_register' ) );
+		add_action( 'rest_api_init', array( $this, 'settings_register' ) );
+	}
+
+	/**
+	 * Register requisite settings.
+	 *
+	 * @since 9.x.x
+	 */
+	public function settings_register() {
+		// NOTE: This contains significant code duplication with class-jetpack-search-customize.
+		// TODO: Modularize these declarations into class-jetpack-search-options.
+		$setting_prefix = Jetpack_Search_Options::OPTION_PREFIX;
+		$settings       = array(
+			array( $setting_prefix . 'color_theme', 'string', 'light' ),
+			array( $setting_prefix . 'result_format', 'string', 'minimal' ),
+			array( $setting_prefix . 'default_sort', 'string', 'relevance' ),
+			array( $setting_prefix . 'overlay_trigger', 'string', 'results' ),
+			array( $setting_prefix . 'excluded_post_types', 'string', '' ),
+			array( $setting_prefix . 'highlight_color', 'string', '#FFC' ),
+			array( $setting_prefix . 'enable_sort', 'boolean', true ),
+			array( $setting_prefix . 'inf_scroll', 'boolean', true ),
+			array( $setting_prefix . 'show_powered_by', 'boolean', true ),
+		);
+		foreach ( $settings as $value ) {
+			register_setting(
+				'options',
+				$value[0],
+				array(
+					'default'      => $value[2],
+					'show_in_rest' => true,
+					'type'         => $value[1],
+				)
+			);
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Proof of concept. **Do not merge**!
* Adds a "Search Config" block that can be used to read/update Jetpack Search options.

#### Jetpack product discussion
pcNPJE-6f-p2.


#### Does this pull request change what data or activity we track or use?
None.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Ensure that you've enabled beta blocks using `define( 'JETPACK_BETA_BLOCKS', true );`.
* Open a page/post with the Gutenberg editor.
* Using the block selector, add the Search Config block.
* Ensure that the config block reads the existing Jetpack Search settings.
* Ensure that you can change the config block inputs once the settings have loaded.
* Ensure that you can save Jetpack Search setting changes by publishing the post.