### PR TITLE
[WIP] Try out adding a Likes button for full site editing

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/likes/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/likes/edit.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import '../../../modules/likes/style.css';
+
+const LikesEdit = props => {
+	const { className } = props;
+
+	const classes = `${ className } sharedaddy sd-block sd-like jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded`;
+
+	const onClick = event => {
+		event.preventDefault();
+	};
+
+	return (
+		<div className={ classes }>
+			<div class="sd-content wpl-likebox">
+				<div class="wpl-button like">
+					<a
+						href="#"
+						onClick={ onClick }
+						title={ __( 'Be the first to like this.', 'jetpack' ) }
+						class="like sd-button"
+						rel="nofollow"
+					>
+						<span>Like</span>
+					</a>
+				</div>
+
+				<div class="wpl-count sd-like-count">
+					<span class="wpl-count-text">{ __( 'Be the first to like this.', 'jetpack' ) }</span>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default LikesEdit;

--- a/projects/plugins/jetpack/extensions/blocks/likes/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/likes/editor.js
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
-import { name, settings } from '.';
+import { blockSettings, name, pluginSettings } from '.';
+import registerJetpackBlock from '../../shared/register-jetpack-block';
 import registerJetpackPlugin from '../../shared/register-jetpack-plugin';
 
-registerJetpackPlugin( name, settings );
+registerJetpackBlock( name, blockSettings );
+registerJetpackPlugin( name, pluginSettings );

--- a/projects/plugins/jetpack/extensions/blocks/likes/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/likes/editor.scss
@@ -1,0 +1,149 @@
+// These styles are copied from those distributed by https://widgets.wp.com/likes/style.css
+.wp-block-jetpack-likes {
+
+	.wpl-likebox, .wpl-follow a, .wpl-count a {
+		/* Webfonts aren't copied into the iframe, so fall back to sans-serifs
+		!important to override inline styles. Eventually this text should disappear. */
+		font-size: 11px !important;
+		font-family: "Open Sans", sans-serif !important;
+	}
+
+	.wpl-button {
+		min-width: 73px; /* Prevent avatars from jumping around when Like becomes Liked */
+	}
+
+	/* Like button, make sure it matches mu-plugins/post-flair/sharing/sharing.css, based on http://wordpress.com/i/buttons/ */
+	.wpl-button a {
+		text-decoration: none;
+		display: inline-block;
+		margin: 0 5px 3px 0;
+		font-size: 12px;
+		font-family: "Open Sans", sans-serif;
+		border-radius: 3px;
+		color: #777;
+		background: #f8f8f8;
+		border: 1px solid #cccccc;
+		box-shadow: 0 1px 0 rgba(0,0,0,.08);
+		text-shadow: none;
+		line-height: 23px;
+		padding: 1px 8px 0px 5px;
+	}
+	.wpl-button a:hover {
+		color: #555;
+		background: #fafafa;
+		border: 1px solid #999999;
+	}
+	.wpl-button a:active {
+		box-shadow: inset 0 1px 0 rgba(0,0,0,.16);
+	}
+	.wpl-button a:before {
+		display: inline-block;
+		position: relative;
+		width: 16px;
+		height: 16px;
+		text-align: center;
+		top: 3px;
+		margin-left: -1px;
+		margin-right: 1px;
+		content: '';
+		background-size: 16px 16px;
+	}
+	.wpl-button.like a:before {
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%232ba1cb' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E");
+	}
+	.wpl-button.liked a:before {
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='white' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E");
+	}
+	.wpl-button.reblog a:before {
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%232ba1cb' d='M22.086 9.914L20 7.828V18c0 1.105-.895 2-2 2h-7v-2h7V7.828l-2.086 2.086L14.5 8.5 19 4l4.5 4.5-1.414 1.414zM6 16.172V6h7V4H6c-1.105 0-2 .895-2 2v10.172l-2.086-2.086L.5 15.5 5 20l4.5-4.5-1.414-1.414L6 16.172z'/%3E%3C/g%3E%3C/svg%3E");
+	}
+	.rtl .wpl-button.like a:before,
+	.rtl .wpl-button.liked a:before {
+		margin-left: 1px;
+		margin-right: -1px;
+	}
+	.wpl-button.liked a {
+		background: #2ba1cb;
+		color: #fff;
+		box-shadow: inset 0 1px 0 rgba(0,0,0,.08);
+		border-color: #198fbb;
+	}
+	.wpl-button.liked a:before {
+		color: #fff;
+	}
+	.wpl-count {
+		clear: both;
+	}
+	.wpl-count-text {
+		line-height: 1.6;
+	}
+	.wpl-button {
+		float: left;
+	}
+	.rtl .wpl-button {
+		float: right;
+	}
+	.wpl-avatars {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		overflow: hidden;
+		height: 26px;
+	}
+	.wpl-avatars li {
+		margin: 0;
+		display: inline;
+	}
+	.wpl-avatars li a {
+		display: block;
+		float: left;
+		margin: 0 5px 3px 0;
+		border: none;
+	}
+	.rtl .wpl-avatars li a {
+		float: right;
+		margin: 0 0 3px 5px;
+	}
+	.wpl-avatars li a img {
+		width: 26px;
+		height: 26px;
+		padding: 0 !important;
+		border: none;
+	}
+	span.wpl-follow, span.wpl-comment {
+		margin-left: 5px;
+	}
+	a.comment-like-link:before {
+		color: #2EA2CC;
+		width: 16px;
+		height: 16px;
+		content: '';
+		display: inline-block;
+		position: relative;
+		top: 3px;
+		padding-right: 5px;
+		background-repeat: no-repeat;
+		background-size: 16px 16px;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%232EA2CC' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E");
+	}
+	a.comment-like-link:hover:before,
+	a.comment-liked:before,
+	div.comment-liked a.comment-like-link:before {
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%23f1831e' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E");
+	}
+	a.comment-liked:hover:before,
+	div.comment-liked a.comment-like-link:hover:before {
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='0' fill='none' width='24' height='24'/%3E%3Cg%3E%3Cpath fill='%23ff9a00' d='M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304'/%3E%3C/g%3E%3C/svg%3E");
+	}
+	a.comment-like-link {
+		color: #222;
+		font-size: 12px;
+		opacity: .8;
+		text-decoration: none;
+	}
+	a.comment-like-link.loading:before {
+		transition: opacity 2s;
+		opacity: 0;
+	}
+
+}

--- a/projects/plugins/jetpack/extensions/blocks/likes/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/likes/index.js
@@ -1,8 +1,33 @@
 /**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import LikesCheckbox from './likes-checkbox';
+import { DonationsIcon } from '../../shared/icons';
+import edit from './edit';
 
 export const name = 'likes';
 
-export const settings = { render: LikesCheckbox };
+export const pluginSettings = { render: LikesCheckbox };
+
+export const blockSettings = {
+	title: __( 'Likes', 'jetpack' ),
+	description: __( 'Display a like button on the post.', 'jetpack' ),
+	icon: DonationsIcon,
+	category: 'embed',
+	keywords: [
+		_x( 'like', 'block search term', 'jetpack' ),
+		_x( 'likes', 'block search term', 'jetpack' ),
+	],
+	supports: {
+		align: false,
+		html: false,
+	},
+	attributes: {},
+	edit,
+	save: () => null,
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related to: #19659

This is currently just a naive exploration into how a Likes button might work in full site editing. The primary idea is to have a server-rendered Likes button that the user can place wherever they like within a template part, instead of the Likes button being appended to the end of post content. This should enable a user to include the Likes button in a footer, or in a different position in relation to their post content, but otherwise adds no additional customisation.

Caveats:

* We currently can't provide any styling or customisation. It'd be great if we could provide center and right alignment and of course further down the line full styling control over the button
* It's quite clear that the Sharing buttons require the same treatment, otherwise they're stuck at the end of the post content, too

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Try adding a Likes block
* Try overriding the mechanism that inserts a Like button at the end of post content, and instead render the block wherever it occurs. Note: this approach still respects the checkbox to hide the Like button on an individual post.

#### Screenshots

##### Editor view

Note that we'd want a custom icon for this one, at the moment I've just stolen the love heart from the Donations block. It also needs some more explanatory text in the right-hand sidebar so people know what the block is and what it does.

![image](https://user-images.githubusercontent.com/14988353/116364419-85734300-a847-11eb-84eb-1318debdb5b7.png)

##### Front-end view on a post

Note that the Like button is correctly being rendered in the footer template part. However, the Sharing buttons are still being appended at the end of the post content — they'd want to get the same treatment.

![image](https://user-images.githubusercontent.com/14988353/116364547-a3d93e80-a847-11eb-9d6b-348f196181f3.png)

##### Front-end view of the home page of the site

Note that the homepage of the site correctly skips rendering the Like button as there is no post id in this context:

![image](https://user-images.githubusercontent.com/14988353/116364599-b6ec0e80-a847-11eb-8b3e-8132b18cf409.png)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/19659

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This is a slightly tricky one to test in wpcom, but to do so:
* I built and synced these changes to my sandbox
* Manually copied over the changes from `likes.php` to `jetpack-likes.php` in my sandbox, as it's in a different location. And it seemed to work okay.
