### PR TITLE
Standardize text prompting to connect/authenticate the user to wordpress.com

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -146,10 +146,7 @@ export class DashConnections extends Component {
 			cardContent = (
 				<div>
 					<div className="jp-connection-settings__info">
-						{ __(
-							'Connect your WordPress.com account to get the most out of Jetpack.',
-							'jetpack'
-						) }
+						{ __( 'Get the most out of Jetpack.', 'jetpack' ) }
 					</div>
 					<div className="jp-connection-settings__actions">{ maybeShowLinkUnlinkBtn }</div>
 				</div>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -147,7 +147,7 @@ export class DashConnections extends Component {
 				<div>
 					<div className="jp-connection-settings__info">
 						{ __(
-							'Link your account to WordPress.com to get the most out of Jetpack.',
+							'Connect your WordPress.com account to get the most out of Jetpack.',
 							'jetpack'
 						) }
 					</div>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -138,7 +138,7 @@ class DashStatsBottom extends Component {
 							connectUser={ true }
 							from="unlinked-user-connect"
 							connectLegend={ __(
-								'Connect your account to WordPress.com to view more stats',
+								'Connect your WordPress.com account to view more stats',
 								'jetpack'
 							) }
 						/>

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -121,7 +121,8 @@ export class ConnectButton extends React.Component {
 				href: connectUrl,
 				disabled: this.props.fetchingConnectUrl || this.props.isAuthorizing,
 			},
-			connectLegend = this.props.connectLegend || __( 'Link to WordPress.com', 'jetpack' );
+			connectLegend =
+				this.props.connectLegend || __( 'Connect your WordPress.com account', 'jetpack' );
 
 		// Secondary users in-place connection flow
 

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -104,7 +104,7 @@ export class ConnectButton extends React.Component {
 						onClick={ this.props.unlinkUser }
 						disabled={ this.props.isUnlinking }
 					>
-						{ this.props.connectLegend || __( 'Unlink me from WordPress.com', 'jetpack' ) }
+						{ this.props.connectLegend || __( 'Disconnect your WordPress.com account', 'jetpack' ) }
 					</a>
 				</div>
 			);

--- a/projects/plugins/jetpack/_inc/client/components/connect-user-bar/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-user-bar/index.jsx
@@ -44,7 +44,7 @@ const ConnectUserBar = props => {
 					<ConnectButton
 						connectUser={ true }
 						from="unlinked-user-connect"
-						connectLegend={ __( 'Connect my WordPress.com account', 'jetpack' ) }
+						connectLegend={ __( 'Connect your WordPress.com account', 'jetpack' ) }
 						customConnect={ customConnect }
 					/>
 				</div>

--- a/projects/plugins/jetpack/_inc/client/components/connect-user-bar/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/connect-user-bar/style.scss
@@ -28,6 +28,7 @@
 			line-height: 16px;
 			color: #0071A1;
 			text-align: center;
+			white-space: nowrap;
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
+++ b/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
@@ -150,10 +150,7 @@ class SubscriptionsComponent extends React.Component {
 					<ConnectUserBar
 						feature="subscriptions"
 						featureLabel={ __( 'Subscriptions', 'jetpack' ) }
-						text={ __(
-							'Connect your WordPress.com account to manage your subscriptions settings.',
-							'jetpack'
-						) }
+						text={ __( 'Connect to manage your subscriptions settings.', 'jetpack' ) }
 					/>
 				) }
 			</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
+++ b/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
@@ -150,7 +150,10 @@ class SubscriptionsComponent extends React.Component {
 					<ConnectUserBar
 						feature="subscriptions"
 						featureLabel={ __( 'Subscriptions', 'jetpack' ) }
-						text={ __( 'Sign in to manage your subscriptions settings.', 'jetpack' ) }
+						text={ __(
+							'Connect your WordPress.com account to manage your subscriptions settings.',
+							'jetpack'
+						) }
 					/>
 				) }
 			</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/searchable-modules/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/searchable-modules/index.jsx
@@ -120,7 +120,7 @@ class ActiveCard extends Component {
 					<ConnectUserBar
 						feature={ m.module }
 						featureLabel={ m.name }
-						text={ __( 'Sign in to configure.', 'jetpack' ) }
+						text={ __( 'Connect your WordPress.com account to configure.', 'jetpack' ) }
 					/>
 				) }
 			</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/searchable-modules/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/searchable-modules/index.jsx
@@ -120,7 +120,7 @@ class ActiveCard extends Component {
 					<ConnectUserBar
 						feature={ m.module }
 						featureLabel={ m.name }
-						text={ __( 'Connect your WordPress.com account to configure.', 'jetpack' ) }
+						text={ __( 'Connect to configure.', 'jetpack' ) }
 					/>
 				) }
 			</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/security/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/monitor.jsx
@@ -79,7 +79,10 @@ export const Monitor = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="monitor"
 							featureLabel={ __( 'Downtime Monitoring', 'jetpack' ) }
-							text={ __( 'Sign in to set up your status alerts.', 'jetpack' ) }
+							text={ __(
+								'Connect your WordPress.com account to set up your status alerts.',
+								'jetpack'
+							) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/security/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/monitor.jsx
@@ -79,10 +79,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="monitor"
 							featureLabel={ __( 'Downtime Monitoring', 'jetpack' ) }
-							text={ __(
-								'Connect your WordPress.com account to set up your status alerts.',
-								'jetpack'
-							) }
+							text={ __( 'Connect to set up your status alerts.', 'jetpack' ) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -176,7 +176,10 @@ export const Protect = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="protect"
 							featureLabel={ __( 'Protect', 'jetpack' ) }
-							text={ __( 'Sign in to set up brute force attack protection.', 'jetpack' ) }
+							text={ __(
+								'Connect your WordPress.com account to set up brute force attack protection.',
+								'jetpack'
+							) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -176,10 +176,7 @@ export const Protect = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="protect"
 							featureLabel={ __( 'Protect', 'jetpack' ) }
-							text={ __(
-								'Connect your WordPress.com account to set up brute force attack protection.',
-								'jetpack'
-							) }
+							text={ __( 'Connect to set up brute force attack protection.', 'jetpack' ) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -130,7 +130,10 @@ export const SSO = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="sso"
 							featureLabel={ __( 'Secure Sign-On', 'jetpack' ) }
-							text={ __( 'Sign in to enable WordPress.com Secure Sign-On.', 'jetpack' ) }
+							text={ __(
+								'Connect your WordPress.com account to enable WordPress.com Secure Sign-On.',
+								'jetpack'
+							) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -130,10 +130,7 @@ export const SSO = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="sso"
 							featureLabel={ __( 'Secure Sign-On', 'jetpack' ) }
-							text={ __(
-								'Connect your WordPress.com account to enable WordPress.com Secure Sign-On.',
-								'jetpack'
-							) }
+							text={ __( 'Connect to enable WordPress.com Secure Sign-On.', 'jetpack' ) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -109,7 +109,10 @@ export const Publicize = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="publicize"
 							featureLabel={ __( 'Publicize', 'jetpack' ) }
-							text={ __( 'Sign in to connect your social media accounts.', 'jetpack' ) }
+							text={ __(
+								'Connect your WordPress.com account to connect your social media accounts.',
+								'jetpack'
+							) }
 						/>
 					) }
 

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -109,10 +109,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="publicize"
 							featureLabel={ __( 'Publicize', 'jetpack' ) }
-							text={ __(
-								'Connect your WordPress.com account to connect your social media accounts.',
-								'jetpack'
-							) }
+							text={ __( 'Connect to add your social media accounts.', 'jetpack' ) }
 						/>
 					) }
 

--- a/projects/plugins/jetpack/_inc/client/writing/masterbar.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/masterbar.jsx
@@ -61,7 +61,10 @@ export const Masterbar = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="masterbar"
 							featureLabel={ __( 'WordPress.com Toolbar', 'jetpack' ) }
-							text={ __( 'Sign in to enable the WordPress.com toolbar.', 'jetpack' ) }
+							text={ __(
+								'Connect your WordPress.com account to enable the WordPress.com toolbar.',
+								'jetpack'
+							) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/writing/masterbar.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/masterbar.jsx
@@ -61,10 +61,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 						<ConnectUserBar
 							feature="masterbar"
 							featureLabel={ __( 'WordPress.com Toolbar', 'jetpack' ) }
-							text={ __(
-								'Connect your WordPress.com account to enable the WordPress.com toolbar.',
-								'jetpack'
-							) }
+							text={ __( 'Connect to enable the WordPress.com toolbar.', 'jetpack' ) }
 						/>
 					) }
 				</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
@@ -120,10 +120,7 @@ class PostByEmail extends React.Component {
 					<ConnectUserBar
 						feature="post-by-email"
 						featureLabel={ __( 'Post by Email', 'jetpack' ) }
-						text={ __(
-							'Connect your WordPress.com account to enable publishing via email.',
-							'jetpack'
-						) }
+						text={ __( 'Connect to enable publishing via email.', 'jetpack' ) }
 					/>
 				) }
 			</SettingsCard>

--- a/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
@@ -120,7 +120,10 @@ class PostByEmail extends React.Component {
 					<ConnectUserBar
 						feature="post-by-email"
 						featureLabel={ __( 'Post by Email', 'jetpack' ) }
-						text={ __( 'Sign in to enable publishing via email.', 'jetpack' ) }
+						text={ __(
+							'Connect your WordPress.com account to enable publishing via email.',
+							'jetpack'
+						) }
 					/>
 				) }
 			</SettingsCard>

--- a/projects/plugins/jetpack/changelog/update-standardize-user-connection-text
+++ b/projects/plugins/jetpack/changelog/update-standardize-user-connection-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Standardize wording for connecting the user.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Fixes inconsistent messaging to authenticate the user with WordPress.com

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Updates all copy to use the same messaging for connecting/authenticating the user with WordPress.com.

Before - Dashboard: 
![image](https://user-images.githubusercontent.com/7129409/116405040-37d1e880-a7fd-11eb-8e93-e0f66d3d085c.png)

After - Dashboard: 
![image](https://user-images.githubusercontent.com/7129409/116412167-6901e700-a804-11eb-9f37-6dcd61d02776.png)

Before - Stats dashboard button:
![image](https://user-images.githubusercontent.com/7129409/116405194-5e901f00-a7fd-11eb-8887-ebfe7af1b797.png)

After - Stats dashboard button:
![image](https://user-images.githubusercontent.com/7129409/116405279-7667a300-a7fd-11eb-8477-bdf8cd23d762.png)

Before - Settings card bar:
(This is just one - there are many settings bars that change in the PR, please look at the code changes)
![image](https://user-images.githubusercontent.com/7129409/116405342-8a130980-a7fd-11eb-9cbe-f1f522ffe32f.png)

After - Settings card bar: 
![image](https://user-images.githubusercontent.com/7129409/116408347-ad8b8380-a800-11eb-8a13-8ae9d253be15.png)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-bRQ-p2#comment-46172

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Set up Jetpack in site-only connection mode, and view the respective areas. Check for:
- Spacing
- Typos
- Wording 
