### PR TITLE
E2E: Check Mailchimp connection status 

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-fix-mailchimp-test
+++ b/projects/plugins/jetpack/changelog/e2e-fix-mailchimp-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+E2E tests: fix for failing test when Mailchimp is already set up

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/mailchimp.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/mailchimp.js
@@ -2,6 +2,7 @@ import LoginPage from '../../wpcom/login';
 import ConnectionsPage from '../../wpcom/connections';
 import logger from '../../../logger';
 import PageActions from '../../page-actions';
+import axios from 'axios';
 
 export default class MailchimpBlock extends PageActions {
 	constructor( blockId, page ) {
@@ -19,6 +20,22 @@ export default class MailchimpBlock extends PageActions {
 		return 'Mailchimp';
 	}
 
+	//region selectors
+
+	get setupFormBtnSel() {
+		return `${ this.blockSelector } a[href*='calypso-marketing-connections']`;
+	}
+
+	get recheckConnectionLnkSel() {
+		return `${ this.blockSelector } button.is-link`;
+	}
+
+	get joinBtnSel() {
+		return `${ this.blockSelector } div >> text="Join my email list"`;
+	}
+
+	//endregion
+
 	/**
 	 * Sets-up a mailchimp connection. Method expects to see a "Set up Mailchimp from" button in block editor.
 	 * - Starts by logging in to WPCOM account in page opened in new tab
@@ -29,49 +46,75 @@ export default class MailchimpBlock extends PageActions {
 	 *
 	 */
 	async connect( isLoggedIn = true ) {
-		const setupFormSelector = this.getSelector( "a[href*='calypso-marketing-connections']" );
-		const formSelector = await this.waitForElementToBeVisible( setupFormSelector );
-		const hrefProperty = await formSelector.getProperty( 'href' );
-		const connectionsUrl = await hrefProperty.jsonValue();
-		const wpComTab = await this.clickAndWaitForNewPage( setupFormSelector );
+		if ( await this.isMailchimpConnected() ) {
+			logger.info( `Mailchimp seems to be already connected` );
+		} else {
+			logger.step( `Connecting Mailchimp` );
 
-		if ( ! isLoggedIn ) {
-			await ( await LoginPage.init( wpComTab ) ).login( 'defaultUser' );
-		}
+			const formSelector = await this.waitForElementToBeVisible( this.setupFormBtnSel );
+			const hrefProperty = await formSelector.getProperty( 'href' );
+			const connectionsUrl = await hrefProperty.jsonValue();
+			const wpComTab = await this.clickAndWaitForNewPage( this.setupFormBtnSel );
 
-		// Hacky way to force-sync Publicize activation. The first attempt is always get redirected to stats page.
-		// TODO:
-		// explore a better way to sync the site. Maybe enable all the required modules as part of connection flow
-		// Or implement a way to trigger a sync manually.
-		let loaded = false;
-		let count = 0;
-		while ( ! loaded ) {
-			try {
-				count++;
-				await ConnectionsPage.init( wpComTab );
-				loaded = true;
-			} catch ( e ) {
-				logger.warn(
-					'ConnectionsPage is not available yet. Attempt: ' + count + ' URL: ' + connectionsUrl
-				);
-				await wpComTab.goto( connectionsUrl );
-				if ( count > 2 ) {
-					throw new Error( 'ConnectionsPage is not available after 3rd attempt' );
+			if ( ! isLoggedIn ) {
+				await ( await LoginPage.init( wpComTab ) ).login( 'defaultUser' );
+			}
+
+			// Hacky way to force-sync Publicize activation. The first attempt is always get redirected to stats page.
+			// TODO:
+			// explore a better way to sync the site. Maybe enable all the required modules as part of connection flow
+			// Or implement a way to trigger a sync manually.
+			let loaded = false;
+			let count = 0;
+			while ( ! loaded ) {
+				try {
+					count++;
+					await ConnectionsPage.init( wpComTab );
+					loaded = true;
+				} catch ( e ) {
+					logger.warn(
+						'ConnectionsPage is not available yet. Attempt: ' + count,
+						' URL: ' + connectionsUrl
+					);
+					await wpComTab.goto( connectionsUrl );
+					if ( count > 2 ) {
+						throw new Error( 'ConnectionsPage is not available after 3rd attempt' );
+					}
 				}
 			}
+
+			await wpComTab.reload( { waitUntil: 'domcontentloaded' } );
+
+			const wpComConnectionsPage = await ConnectionsPage.init( wpComTab );
+			await wpComConnectionsPage.selectMailchimpList();
+
+			await this.page.bringToFront();
+			await this.click( this.recheckConnectionLnkSel );
 		}
-		await wpComTab.reload( { waitUntil: 'domcontentloaded' } );
 
-		const wpComConnectionsPage = await ConnectionsPage.init( wpComTab );
-		await wpComConnectionsPage.selectMailchimpList();
-
-		await this.page.bringToFront();
-		const reCheckSelector = this.getSelector( 'button.is-link' );
-		await this.click( reCheckSelector );
+		await this.waitForElementToBeVisible( this.joinBtnSel );
 	}
 
-	getSelector( selector ) {
-		return `${ this.blockSelector } ${ selector }`;
+	/**
+	 * Determine if Mailchimp account is already set up
+	 * Calls rest_route=/wpcom/v2/mailchimp and checks response for connected status
+	 * "code":"connected" => Mailchimp was connected
+	 *
+	 * @return {Promise<boolean>} true is connected, false if not_connected status code is found or call fails for any reason
+	 */
+	async isMailchimpConnected() {
+		let connectionStatus = '';
+		try {
+			const url = `${ siteUrl }/index.php?rest_route=/wpcom/v2/mailchimp&_locale=user`;
+			const res = await axios.get( url );
+			logger.debug( JSON.stringify( res.data ) );
+			connectionStatus = res.data.code;
+		} catch ( error ) {
+			logger.error( error.message );
+		}
+
+		logger.debug( `Mailchimp connection status: ${ connectionStatus }` );
+		return connectionStatus === 'connected';
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix for cases when Mailchimp is already set up and the Mailchimp block test fails because it's expecting the setup button, but instead the join button is displayed.
This happens when running the Mailchimp test multiple times using the same site url.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* CI green
* Locally, start with a clean setup, then run the Mailchimp test multiple times without cleaning the env in between.
