### PR TITLE
Docker: Do not allow update/delete of Backups, Beta, etc

### DIFF
--- a/tools/docker/mu-plugins/01-monorepo.php
+++ b/tools/docker/mu-plugins/01-monorepo.php
@@ -1,0 +1,154 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Plugin Name: Monorepo Helper
+ * Description: A common place for monorepo things.
+ * Version: 1.0
+ * Author: Automattic
+ * Author URI: https://automattic.com/
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Jetpack\Docker\MuPlugin;
+
+/**
+ * Monorepo Tools.
+ */
+class Monorepo {
+	/**
+	 * Path to monorepo.
+	 *
+	 * @var string
+	 */
+	protected $monorepo;
+	/**
+	 * Path to monorepo plugins.
+	 *
+	 * @var string
+	 */
+	protected $plugins;
+	/**
+	 * Path to monorepo packages.
+	 *
+	 * @var string
+	 */
+	protected $packages;
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		$this->monorepo = '/usr/local/src/jetpack-monorepo/';
+		$this->plugins  = $this->monorepo . 'projects/plugins/';
+		$this->packages = $this->monorepo . 'projects/packages/';
+	}
+
+	/**
+	 * Property Getter
+	 *
+	 * @param string $var Property to get.
+	 *
+	 * @throws Exception If the requested property does not exist.
+	 */
+	public function get( $var ) {
+		if ( is_string( $var ) && isset( $this->$var ) ) {
+			return $this->$var;
+		}
+		throw new Exception( "Class property $var does not exist." );
+	}
+
+	/**
+	 * The same as Core's get_plugins, without forcing a passed value to be within the wp-content/plugins folder.
+	 *
+	 * @param string $plugin_folder Folder to find plugins within.
+	 */
+	private function get_plugins( $plugin_folder = '' ) {
+		$cache_plugins = wp_cache_get( 'monorepo_plugins', 'monorepo_plugins' ); // Updated cache values to not conflict.
+		if ( ! $cache_plugins ) {
+			$cache_plugins = array();
+		}
+
+		if ( isset( $cache_plugins[ $plugin_folder ] ) ) {
+			return $cache_plugins[ $plugin_folder ];
+		}
+
+			$wp_plugins  = array();
+			$plugin_root = WP_PLUGIN_DIR;
+		if ( ! empty( $plugin_folder ) ) {
+			$plugin_root = $plugin_folder; // This is what we changed, but it's dangerous. Thus a private function.
+		}
+
+			// Files in wp-content/plugins directory.
+			$plugins_dir  = @opendir( $plugin_root ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$plugin_files = array();
+
+		if ( $plugins_dir ) {
+			while ( ( $file = readdir( $plugins_dir ) ) !== false ) { // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+				if ( '.' === substr( $file, 0, 1 ) ) {
+					continue;
+				}
+
+				if ( is_dir( $plugin_root . '/' . $file ) ) {
+					$plugins_subdir = @opendir( $plugin_root . '/' . $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+					if ( $plugins_subdir ) {
+						while ( ( $subfile = readdir( $plugins_subdir ) ) !== false ) { // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+							if ( '.' === substr( $subfile, 0, 1 ) ) {
+								continue;
+							}
+
+							if ( '.php' === substr( $subfile, -4 ) ) {
+								$plugin_files[] = "$file/$subfile";
+							}
+						}
+
+						closedir( $plugins_subdir );
+					}
+				} else {
+					if ( '.php' === substr( $file, -4 ) ) {
+						$plugin_files[] = $file;
+					}
+				}
+			}
+
+			closedir( $plugins_dir );
+		}
+
+		if ( empty( $plugin_files ) ) {
+			return $wp_plugins;
+		}
+
+		foreach ( $plugin_files as $plugin_file ) {
+			if ( ! is_readable( "$plugin_root/$plugin_file" ) ) {
+				continue;
+			}
+
+			// Do not apply markup/translate as it will be cached.
+			$plugin_data = \get_plugin_data( "$plugin_root/$plugin_file", false, false );
+
+			if ( empty( $plugin_data['Name'] ) ) {
+				continue;
+			}
+
+			$wp_plugins[ plugin_basename( $plugin_file ) ] = $plugin_data;
+		}
+
+			uasort( $wp_plugins, '_sort_uname_callback' );
+
+			$cache_plugins[ $plugin_folder ] = $wp_plugins;
+			wp_cache_set( 'monorepo_plugins', $cache_plugins, 'monorepo_plugins' ); // Updated cache values to not conflict.
+
+			return $wp_plugins;
+
+	}
+
+	/**
+	 * Returns an array of monorepo plugins.
+	 *
+	 * @return array Array of monorepo plugins.
+	 */
+	public function plugins() {
+		return array_keys( $this->get_plugins( $this->plugins ) );
+	}
+}

--- a/tools/docker/mu-plugins/01-monorepo.php
+++ b/tools/docker/mu-plugins/01-monorepo.php
@@ -73,15 +73,15 @@ class Monorepo {
 			return $cache_plugins[ $plugin_folder ];
 		}
 
-			$wp_plugins  = array();
-			$plugin_root = WP_PLUGIN_DIR;
+		$wp_plugins  = array();
+		$plugin_root = WP_PLUGIN_DIR;
 		if ( ! empty( $plugin_folder ) ) {
 			$plugin_root = $plugin_folder; // This is what we changed, but it's dangerous. Thus a private function.
 		}
 
-			// Files in wp-content/plugins directory.
-			$plugins_dir  = @opendir( $plugin_root ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-			$plugin_files = array();
+		// Files in wp-content/plugins directory.
+		$plugins_dir  = @opendir( $plugin_root ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$plugin_files = array();
 
 		if ( $plugins_dir ) {
 			while ( ( $file = readdir( $plugins_dir ) ) !== false ) { // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
@@ -125,7 +125,7 @@ class Monorepo {
 			}
 
 			// Do not apply markup/translate as it will be cached.
-			$plugin_data = \get_plugin_data( "$plugin_root/$plugin_file", false, false );
+			$plugin_data = get_plugin_data( "$plugin_root/$plugin_file", false, false );
 
 			if ( empty( $plugin_data['Name'] ) ) {
 				continue;
@@ -134,13 +134,12 @@ class Monorepo {
 			$wp_plugins[ plugin_basename( $plugin_file ) ] = $plugin_data;
 		}
 
-			uasort( $wp_plugins, '_sort_uname_callback' );
+		uasort( $wp_plugins, '_sort_uname_callback' );
 
-			$cache_plugins[ $plugin_folder ] = $wp_plugins;
-			wp_cache_set( 'monorepo_plugins', $cache_plugins, 'monorepo_plugins' ); // Updated cache values to not conflict.
+		$cache_plugins[ $plugin_folder ] = $wp_plugins;
+		wp_cache_set( 'monorepo_plugins', $cache_plugins, 'monorepo_plugins' ); // Updated cache values to not conflict.
 
-			return $wp_plugins;
-
+		return $wp_plugins;
 	}
 
 	/**

--- a/tools/docker/mu-plugins/avoid-plugin-deletion.php
+++ b/tools/docker/mu-plugins/avoid-plugin-deletion.php
@@ -10,14 +10,7 @@
  * @package automattic/jetpack
  */
 
-// These are the plugins we don't want to update or delete.
-// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-$jetpack_docker_avoided_plugins = array(
-	'jetpack/jetpack.php',
-	'backup/jetpack-backup.php',
-	'beta/jetpack-beta.php',
-	'debug-helper/plugin.php',
-);
+use Jetpack\Docker\MuPlugin\Monorepo;
 
 /**
  * Remove the Delete link from your plugins list for important plugins
@@ -31,7 +24,7 @@ $jetpack_docker_avoided_plugins = array(
  * @return mixed
  */
 function jetpack_docker_disable_plugin_deletion_link( $actions, $plugin_file ) {
-	global $jetpack_docker_avoided_plugins;
+	$jetpack_docker_avoided_plugins = ( new Monorepo() )->plugins();
 	if (
 		array_key_exists( 'delete', $actions ) &&
 		in_array(
@@ -52,7 +45,7 @@ add_filter( 'plugin_action_links', 'jetpack_docker_disable_plugin_deletion_link'
  * @param string $plugin_file Path to the plugin file relative to the plugins directory.
  */
 function jetpack_docker_disable_delete_plugin( $plugin_file ) {
-	global $jetpack_docker_avoided_plugins;
+	$jetpack_docker_avoided_plugins = ( new Monorepo() )->plugins();
 	if ( in_array( $plugin_file, $jetpack_docker_avoided_plugins, true ) ) {
 		wp_die(
 			esc_html( 'Deleting plugin "' . $plugin_file . '" is disabled at mu-plugins/avoid-plugin-deletion.php' ),
@@ -68,7 +61,7 @@ add_action( 'delete_plugin', 'jetpack_docker_disable_delete_plugin', 10, 2 );
  * @param mixed $plugins Value of site transient.
  */
 function jetpack_docker_disable_plugin_update( $plugins ) {
-	global $jetpack_docker_avoided_plugins;
+	$jetpack_docker_avoided_plugins = ( new Monorepo() )->plugins();
 	if ( ! is_array( $jetpack_docker_avoided_plugins ) ) {
 		return $plugins;
 	}

--- a/tools/docker/mu-plugins/avoid-plugin-deletion.php
+++ b/tools/docker/mu-plugins/avoid-plugin-deletion.php
@@ -14,6 +14,9 @@
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 $jetpack_docker_avoided_plugins = array(
 	'jetpack/jetpack.php',
+	'backup/jetpack-backup.php',
+	'beta/jetpack-beta.php',
+	'debug-helper/plugin.php',
 );
 
 /**

--- a/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
+++ b/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
@@ -12,6 +12,8 @@
 
 namespace Jetpack\Docker\MuPlugin\FixMonorepoPluginsUrl;
 
+use Jetpack\Docker\MuPlugin\Monorepo;
+
 /**
  * Fix the plugins_url in the Docker dev environment.
  *
@@ -25,8 +27,7 @@ namespace Jetpack\Docker\MuPlugin\FixMonorepoPluginsUrl;
 function jetpack_docker_plugins_url( $url, $path, $plugin ) {
 	global $wp_plugin_paths;
 
-	$monorepo = '/usr/local/src/jetpack-monorepo/';
-	$packages = $monorepo . 'projects/packages/';
+	$packages = ( new Monorepo() )->get( 'packages' );
 
 	if ( strpos( $url, $packages ) !== false && strpos( $plugin, $packages ) === 0 ) {
 		// Look through available monorepo plugins until we find one with the plugin symlink.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Within our Docker setup, we load from the monorepo our plugins. We do not want WP to upgrade or delete these plugins else it overrides our local copies. This extends the existing prevention of that happening to Jetpack to the other monorepo plugins.

I'm not sure the best way to automate this to always cover all monorepo plugins, short of using how WP searches for plugins from the monorepo plugin directory and add those to the array. But, this at least prevents anyone from wrecking their local setup in the meantime.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds to the hardcoded list of monorepo plugins Backups, Beta, Debug Helper

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Before and after this PR, run Docker off master. See the upgrade prompt for Backups without patch.
*
