### PR TITLE
enable Plans tab to unliked users

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/navigation/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/navigation/index.jsx
@@ -71,9 +71,12 @@ export class Navigation extends React.Component {
 							{ _x( 'My Plan', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
-					{ ! this.props.isOfflineMode && this.props.isLinked && (
+					{ ! this.props.isOfflineMode && (
 						<NavItem
-							path={ getRedirectUrl( 'jetpack-plans', { site: this.props.siteUrl } ) }
+							path={ getRedirectUrl(
+								this.props.isLinked ? 'jetpack-plans' : 'jetpack-nav-site-only-plans',
+								{ site: this.props.siteUrl }
+							) }
 							onClick={ this.trackPlansClick }
 							selected={ this.props.location.pathname === '/plans' }
 						>

--- a/projects/plugins/jetpack/_inc/client/components/navigation/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/navigation/test/component.js
@@ -66,12 +66,12 @@ describe( 'Navigation', () => {
 
 		const wrapperManage = shallow( <Navigation { ...testProps } /> );
 
-		it( 'renders 1 NavItem component', () => {
-			expect( wrapperManage.find( 'NavItem' ) ).to.have.length( 1 );
+		it( 'renders 2 NavItem components', () => {
+			expect( wrapperManage.find( 'NavItem' ) ).to.have.length( 2 );
 		} );
 
-		it( 'renders At a Glance tab', () => {
-			expect( wrapperManage.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'At a Glance' );
+		it( 'renders At a Glance and Plans tabs', () => {
+			expect( wrapperManage.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'At a Glance,Plans' );
 		} );
 
 	} );

--- a/projects/plugins/jetpack/changelog/update-reactivate-plans
+++ b/projects/plugins/jetpack/changelog/update-reactivate-plans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enable the Plans tab for unlinked users


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Enables the Plans tab in Jetpack navigation menu for unliked users

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-2EQ-p2#comment-4986

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch and make sure to run `jetpack build plugins/jetpack`
* Connect your site only at a site level
* Visit the Jetpack Dashboard
* Make sure the "Plans" tab is visible
* Click the "Plans" tab
* choose a plan and click to buy it
* If logged out, log in
* Once you reach the checkout page, you can go back to your wp-admin
* Visit the Jetpack Dashboard and make sure your WPCOM user is linked to your site:

![Captura de Tela 2021-04-28 às 19 16 22](https://user-images.githubusercontent.com/971483/116481651-01768680-a85a-11eb-9734-2c1776f9a9ae.png)

Test the above flow in different conditions:
* already logged in to WPCOM in the same window
* Not logged in to WPCOM
* Also test the normal flow in a fully connected site

