### PR TITLE
Search: Fix modal intermittently scrolls to wrong position in Firefox

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-firefox-modal-position
+++ b/projects/plugins/jetpack/changelog/fix-firefox-modal-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: Fix modal intermittently scrolls to wrong position in Firefox

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -109,6 +109,13 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.addEventListener( 'click', this.handleFilterInputClick );
 		} );
+
+		// NOTE: Summoned overlay will not automatically be scrolled to the top
+		//       when used in conjuction with slideInUp animation.
+		// TODO: Figure out why this is happening, remove scrollOverlayToTop fn if possible.
+		document.querySelectorAll( `.${ OVERLAY_CLASS_NAME }` ).forEach( element => {
+			element.addEventListener( 'transitionend', this.scrollOverlayToTop );
+		} );
 	}
 
 	removeEventListeners() {
@@ -144,8 +151,11 @@ class SearchApp extends Component {
 		document.body.style.overflowY = null;
 	}
 
-	scrollOverlayToTop() {
-		const overlay = document.querySelector( `.${ OVERLAY_CLASS_NAME }` );
+	scrollOverlayToTop( event ) {
+		if ( event?.propertyName !== 'transform' ) {
+			return;
+		}
+		const overlay = event.target;
 		// NOTE: IE11 doesn't support scrollTo. Manually set overlay element's scrollTop.
 		if ( overlay.scrollTo ) {
 			overlay.scrollTo( 0, 0, { smooth: true } );
@@ -261,11 +271,6 @@ class SearchApp extends Component {
 		this.setState( { showResults }, () => {
 			if ( showResults ) {
 				this.preventBodyScroll();
-				// NOTE: Summoned overlay will not automatically be scrolled to the top
-				//       when used in conjuction with slideInUp animation.
-				//       10ms delay appears necessary within the Customizer
-				// TODO: Figure out why this is happening, remove scrollOverlayToTop fn if possible.
-				setTimeout( () => this.scrollOverlayToTop(), 10 );
 			} else {
 				// This codepath will only be executed in the Customizer.
 				this.restoreBodyScroll();

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -162,7 +162,8 @@ class SearchApp extends Component {
 		const overlay = event.target;
 		// NOTE: IE11 doesn't support scrollTo. Manually set overlay element's scrollTop.
 		if ( overlay.scrollTo ) {
-			overlay.scrollTo( 0, 0, { smooth: true } );
+			// @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
+			overlay.scrollTo( 0, 0 );
 		} else {
 			overlay.scrollTop = 0;
 		}

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -134,6 +134,10 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.removeEventListener( 'click', this.handleFilterInputClick );
 		} );
+
+		document.querySelectorAll( `.${ OVERLAY_CLASS_NAME }` ).forEach( element => {
+			element.removeEventListener( 'transitionend', this.scrollOverlayToTop );
+		} );
 	}
 
 	disableAutocompletion() {


### PR DESCRIPTION
Fixes #19480 

#### Changes proposed in this Pull Request:
The overlay will not automatically be scrolled to the top  when used in conjuction with slideInUp animation. A timeout to trigger `scrollOverlayToTop` was used to correct it, but under some circumstances in Firefox, the function is called before the animation, which makes the overlay still not scrolled to the top sometimes.

The PR changed the scroll trigger from timeout to listening to `transitionend` event, by which we could wait till the animation is complete and then we could scroll the overlay to the top.

The issue that the overlay is not scrolled to the top after animation is not in the scope of this pull request, and will need further investigation.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- In Firefox/Chrome/Safari/IE11/Edge, go to a page with search enabled and open the modal
- Ensure the search input of the overlay is visible without scrolling
![image](https://user-images.githubusercontent.com/1425433/116498124-1d7f3400-a8fd-11eb-8e7c-199b5472687d.png)
