### PR TITLE
E2E tests: Connection wait for loading timeout to 35 sec

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-connect-btn-timeout
+++ b/projects/plugins/jetpack/changelog/e2e-connect-btn-timeout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+E2E tests: Change the timeout to wait for loading animation in connection frame, before the approve button is displayed.

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/in-place-authorize.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/in-place-authorize.js
@@ -11,7 +11,7 @@ export default class InPlaceAuthorizeFrame extends WpPage {
 	static async init( page ) {
 		const loadingSelector = '.jp-connect-full__button-container-loading';
 		const thisPage = new this( page );
-		await thisPage.waitForElementToBeHidden( loadingSelector, 60000 );
+		await thisPage.waitForElementToBeHidden( loadingSelector, 35000 );
 		return thisPage;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
 
Change the timeout to wait for loading animation in connection frame, before the approve button is displayed. 

#### Jetpack product discussion

p1619699921405800/1619682720.387300-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* All E2E tests should pass