### PR TITLE
E2E Tests: Add Classic and Userless connection tests

### DIFF
--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/in-place-authorize.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/in-place-authorize.js
@@ -27,6 +27,13 @@ export default class InPlaceAuthorizeFrame extends WpPage {
 		return this.waitToDisappear();
 	}
 
+	async continueWithout() {
+		const continueSelector = '#jp-authenticate-no_user_test_mode a.jp-no-user-mode-button';
+		const iframe = await this.getFrame();
+		await iframe.click( continueSelector );
+		return this.waitToDisappear();
+	}
+
 	async waitToDisappear() {
 		return await this.waitForElementToBeHidden( this.selectors[ 0 ] );
 	}

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wpcom/me.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wpcom/me.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import WpPage from '../wp-page';
+import getRedirectUrl from '../../../../../_inc/client/lib/jp-redirect';
+
+export default class MePage extends WpPage {
+	constructor( page ) {
+		const expectedSelector = '#wpcom .is-section-me';
+		const url = getRedirectUrl( 'calypso-me' );
+		super( page, { expectedSelectors: [ expectedSelector ], url } );
+	}
+
+	async logOut() {
+		const logOutSelector = '.sidebar__me-signout button';
+
+		await this.click( logOutSelector );
+		await this.waitForElementToBeHidden( this.selectors[ 0 ] );
+	}
+}

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -18,6 +18,7 @@
 		"env-start": "./bin/env.sh start",
 		"env-reset": "./bin/env.sh reset",
 		"tunnel-on": "pm2 start bin/ecosystem.config.js && yarn pm2 logs --nostream --lines 4",
+		"tunnel-reset": "rm -rf config/tmp && yarn tunnel-on",
 		"tunnel-off": "pm2 delete bin/ecosystem.config.js && NODE_ENV=test node bin/tunnel.js off",
 		"pretest-e2e": "yarn clean",
 		"test-e2e": "NODE_CONFIG_DIR='./config' jest --config jest.config.js --runInBand --verbose --detectOpenHandles --json --outputFile=output/summary.json",

--- a/projects/plugins/jetpack/tests/e2e/specs/connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/connection.test.js
@@ -1,11 +1,16 @@
 import { step } from '../lib/env/test-setup';
-import { doInPlaceConnection } from '../lib/flows/jetpack-connect';
-import { execMultipleWpCommands, execWpCommand } from '../lib/utils-helper';
+import {
+	doInPlaceConnection,
+	doUserlessConnection,
+	loginToWpComIfNeeded,
+	loginToWpSite,
+	doClassicConnection,
+} from '../lib/flows/jetpack-connect';
+import { resetWordpressInstall, execShellCommand, resolveSiteUrl } from '../lib/utils-helper';
 import Sidebar from '../lib/pages/wp-admin/sidebar';
 import JetpackPage from '../lib/pages/wp-admin/jetpack';
-import path from 'path';
-import config from 'config';
 import DashboardPage from '../lib/pages/wp-admin/dashboard';
+import MePage from '../lib/pages/wpcom/me';
 
 // Disable pre-connect for this test suite
 process.env.SKIP_CONNECT = true;
@@ -15,33 +20,49 @@ process.env.SKIP_CONNECT = true;
  * @group connection
  */
 describe( 'Connection', () => {
-	beforeAll( async () => {
-		await execMultipleWpCommands(
-			'wp option delete e2e_jetpack_plan_data',
-			'wp option delete jetpack_active_plan',
-			'wp option delete jetpack_private_options',
-			'wp option delete jetpack_sync_error_idc'
-		);
-		await page.reload();
-		await page.reload();
-	} );
-
-	beforeEach( async () => {
-		await DashboardPage.visit( page );
-	} );
-
-	afterAll( async () => {
-		await execWpCommand(
-			`'wp option update jetpack_private_options --format=json < ${ path.resolve(
-				config.get( 'temp.jetpackPrivateOptions' )
-			) }'`
-		);
+	afterEach( async () => {
+		await execShellCommand( 'yarn tunnel-reset' );
+		global.siteUrl = resolveSiteUrl();
+		await resetWordpressInstall();
+		await loginToWpComIfNeeded( 'defaultUser', true );
+		await loginToWpSite( true );
 	} );
 
 	it( 'In-place', async () => {
 		await step( 'Can start in-place connection', async () => {
+			await DashboardPage.visit( page );
 			await ( await Sidebar.init( page ) ).selectJetpack();
 			await doInPlaceConnection();
+		} );
+
+		await step( 'Can assert that site is connected', async () => {
+			const jetpackPage = await JetpackPage.init( page );
+			expect( await jetpackPage.isConnected() ).toBeTruthy();
+		} );
+	} );
+
+	it( 'User-less', async () => {
+		await step( 'Can log out from WPCOM', async () => {
+			await ( await MePage.visit( page ) ).logOut();
+		} );
+
+		await step( 'Can start Userless connection', async () => {
+			await DashboardPage.visit( page );
+			await ( await Sidebar.init( page ) ).selectJetpack();
+			await doUserlessConnection();
+		} );
+
+		await step( 'Can assert that site is connected', async () => {
+			const jetpackPage = await JetpackPage.init( page );
+			expect( await jetpackPage.isConnected() ).toBeTruthy();
+		} );
+	} );
+
+	it( 'Classic', async () => {
+		await step( 'Can start classic connection', async () => {
+			await DashboardPage.visit( page );
+			await ( await Sidebar.init( page ) ).selectJetpack();
+			await doClassicConnection( true );
 		} );
 
 		await step( 'Can assert that site is connected', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add Userless connection test
* Add Classic connection test

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure CI is green
* Run tests locally: `yarn test-e2e specs/connection.test.js`
