### PR TITLE
Fix duplicate Publicize connection banner

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -29,7 +29,6 @@ export const Publicize = withModuleSettingsFormHelpers(
 			const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'publicize' ),
 				isLinked = this.props.isLinked,
 				isOfflineMode = this.props.isOfflineMode,
-				connectUrl = this.props.connectUrl,
 				siteRawUrl = this.props.siteRawUrl,
 				isActive = this.props.getOptionValue( 'publicize' ),
 				userCanManageModules = this.props.userCanManageModules;
@@ -39,27 +38,19 @@ export const Publicize = withModuleSettingsFormHelpers(
 					return;
 				}
 
-				return isLinked ? (
-					<Card
-						compact
-						className="jp-settings-card__configure-link"
-						onClick={ this.trackClickConfigure }
-						target="_blank"
-						rel="noopener noreferrer"
-						href={ getRedirectUrl( 'calypso-marketing-connections', { site: siteRawUrl } ) }
-					>
-						{ __( 'Connect your social media accounts', 'jetpack' ) }
-					</Card>
-				) : (
-					<Card
-						compact
-						className="jp-settings-card__configure-link"
-						target="_blank"
-						rel="noopener noreferrer"
-						href={ `${ connectUrl }&from=unlinked-user-connect-publicize` }
-					>
-						{ __( 'Create a Jetpack account to use this feature', 'jetpack' ) }
-					</Card>
+				return (
+					isLinked && (
+						<Card
+							compact
+							className="jp-settings-card__configure-link"
+							onClick={ this.trackClickConfigure }
+							target="_blank"
+							rel="noopener noreferrer"
+							href={ getRedirectUrl( 'calypso-marketing-connections', { site: siteRawUrl } ) }
+						>
+							{ __( 'Connect your social media accounts', 'jetpack' ) }
+						</Card>
+					)
 				);
 			};
 

--- a/projects/plugins/jetpack/changelog/fix-duplicate-publicize-connect-banner
+++ b/projects/plugins/jetpack/changelog/fix-duplicate-publicize-connect-banner
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Do not show multiple connection prompts in the Publicize settings card.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes an issue when we were showing two banners to connect the user in the Publicize settings card, as shown here: 
![image](https://user-images.githubusercontent.com/7129409/116604604-57036f80-a8fc-11eb-9a4a-29dca76ab7bb.png) 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Removes the legacy connection banner from the Publicize settings card. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Connect site-only mode
2. Enable Publicize from `/wp-admin/admin.php?page=jetpack_modules`
3. Navigate to `/wp-admin/admin.php?page=jetpack#/sharing`
4. Look at the Publicize card
5. It should only have one prompt to connect the user
6. Connect a user 
7. Make sure the existing prompt to "Connect your social media accounts" is still present, and works. 
