### PR TITLE
Hide protect card for non-admins in site-only connection

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -31,7 +31,7 @@ import {
 	userCanViewStats,
 	userIsSubscriber,
 } from 'state/initial-state';
-import { isOfflineMode } from 'state/connection';
+import { isOfflineMode, hasConnectedOwner } from 'state/connection';
 import { getModuleOverride } from 'state/modules';
 import { getScanStatus, isFetchingScanStatus } from 'state/scan';
 
@@ -163,10 +163,8 @@ class AtAGlance extends Component {
 			stats = <DashStats { ...settingsProps } { ...urls } />;
 		}
 
-		let protect = '';
-		if ( this.props.getOptionValue( 'protect' ) ) {
-			protect = <DashProtect { ...settingsProps } />;
-		}
+		const protect = <DashProtect { ...settingsProps } />;
+		const showSecurity = this.props.getOptionValue( 'protect' ) && this.props.hasConnectedOwner;
 
 		return this.props.userIsSubscriber ? (
 			<div>
@@ -176,11 +174,8 @@ class AtAGlance extends Component {
 		) : (
 			<div>
 				{ stats }
-				{
-					// Site Security
-					this.props.getOptionValue( 'protect' ) && securityHeader
-				}
-				{ protect }
+				{ showSecurity && securityHeader }
+				{ showSecurity && protect }
 				{ connections }
 			</div>
 		);
@@ -197,5 +192,6 @@ export default connect( state => {
 		multisite: isMultisite( state ),
 		scanStatus: getScanStatus( state ),
 		fetchingScanStatus: isFetchingScanStatus( state ),
+		hasConnectedOwner: hasConnectedOwner( state ),
 	};
 } )( withModuleSettingsFormHelpers( AtAGlance ) );

--- a/projects/plugins/jetpack/changelog/fix-protect-for-non-admins
+++ b/projects/plugins/jetpack/changelog/fix-protect-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Do not display Protect card for non-admin users while in site-only connection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes p9dueE-2EQ-p2#comment-5000

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* do not display the Protect card for non-admin users while there is not a connected owner - and thus Protect can not be activated

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-2EQ-p2#comment-5000

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open 2 windows of the site. One logged in as admin and another as an editor
* With the admin, connect only at a site level
* As an editor, visit the Dashboard and confirm Protect is not there
* As an admin, connect your user - make sure Protect is enabled
* As an editor, confirm Protect is present
* As an admin, deactivate Protect
* As an editor, confirm Protect is not present
* As an admin, re-activate Protect
* As an admin, Disconnect Jetpack and connect again only at a site level (protect will be kept marked as active)
* As an editor, confirm Protect is not there