### PR TITLE
Hide settings in site-only conn for non admin

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -68,11 +68,10 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 9.7.0 If Connection does not have an owner, restrict it to admins
 	 */
 	function jetpack_add_settings_sub_nav_item() {
-		if (
-			( ( new Status() )->is_offline_mode() || Jetpack::is_connection_ready() ) &&
-			current_user_can( 'edit_posts' ) &&
-			( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() || current_user_can( 'manage_options' ) )
-		) {
+		if ( ! ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! current_user_can( 'jetpack_connect' ) ) {
+			return;
+		}
+		if ( ( ( new Status() )->is_offline_mode() || Jetpack::is_connection_ready() ) && current_user_can( 'edit_posts' ) ) {
 			add_submenu_page( 'jetpack', __( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/settings', '__return_null' );
 		}
 	}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -65,9 +65,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * If user is allowed to see the Jetpack Admin, add Settings sub-link.
 	 *
 	 * @since 4.3.0
+	 * @since 9.7.0 If Connection does not have an owner, restrict it to admins
 	 */
 	function jetpack_add_settings_sub_nav_item() {
-		if ( ( ( new Status() )->is_offline_mode() || Jetpack::is_connection_ready() ) && current_user_can( 'edit_posts' ) ) {
+		if (
+			( ( new Status() )->is_offline_mode() || Jetpack::is_connection_ready() ) &&
+			current_user_can( 'edit_posts' ) &&
+			( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() || current_user_can( 'manage_options' ) )
+		) {
 			add_submenu_page( 'jetpack', __( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/settings', '__return_null' );
 		}
 	}

--- a/projects/plugins/jetpack/changelog/update-hide-settings-site-level-non-admin
+++ b/projects/plugins/jetpack/changelog/update-hide-settings-site-level-non-admin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Hide Settings page for non-admin users when in site-only connection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

When the site is at a site-only connection, non administrators are not able to link their accounts to WordPress.com to enable features that require a user connection.

Editors, for example, can access the Settings page only to see Post By Email and Publicize, however they will not be able to link their accounts until and admin has done this before and enabled those features.

This PR hides the Settings page for non-admin while the site doesn't have a full connection

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hides the Settings menu for non admin while in site-only connection

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1619720622439100-slack-CBG1CP4EN?thread_ts=1619718679.433500&cid=CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect at a site level only
* Check the Settings menu is available and working for admins
* Login as an editor and check the Settings menu is not available
* Complete the connection with a user
* Make sure Settings menu is working for both admins and editors