### PR TITLE
fix default iframe heigh

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/auth-iframe/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/auth-iframe/index.jsx
@@ -36,7 +36,7 @@ export class AuthIframe extends React.Component {
 
 	static defaultProps = {
 		title: __( 'Connect your WordPress.com account', 'jetpack' ),
-		height: '220',
+		height: '330',
 		width: '100%',
 		scrollToIframe: true,
 		onAuthorized: noop,

--- a/projects/plugins/jetpack/_inc/client/components/auth-iframe/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/auth-iframe/test/component.js
@@ -47,8 +47,8 @@ describe( 'AuthIframe', () => {
 			expect( wrapper.find( 'InPlaceConnection' ).props().width ).to.be.equal( '100%' );
 		} );
 
-		it( 'has 220 height', () => {
-			expect( wrapper.find( 'InPlaceConnection' ).props().height ).to.be.equal( '220' );
+		it( 'has 330 height', () => {
+			expect( wrapper.find( 'InPlaceConnection' ).props().height ).to.be.equal( '330' );
 		} );
 	} );
 

--- a/projects/plugins/jetpack/changelog/fix-iframe-heigh-on-dashboard
+++ b/projects/plugins/jetpack/changelog/fix-iframe-heigh-on-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Fix the height of the User Authentication Dialog on the dashboard


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes the layout of the connection iframe when the user is connecting via one of the buttons in the Jetpack Dashboard.

What really changed here is that we're now displaying the TOS agreement on this context, and we didn't before.

I'd love a confirmation if the fix is to really adjust the height or to remove the TOS.

Before (see the scrollbar):
![Captura de Tela 2021-04-29 às 15 51 46](https://user-images.githubusercontent.com/971483/116720999-34805d80-a9b3-11eb-924e-cf46629ec6c7.png)


After:
![Captura de Tela 2021-04-30 às 12 55 43](https://user-images.githubusercontent.com/971483/116721171-685b8300-a9b3-11eb-9f63-edaa2c5116be.png)


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix the height of the In-place Connection dialog on the Dashboard

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1619722373443900-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the iframe connection in every possible situation:
* Regular in-place connection flow while logged in to WPCOM
* Regular in-place connection flow while not logged in to WPCOM (option to skip user auth)
* Set up a site-only connection. Go to the Jetpack Dashboard and click in one of the "Connect your WordPress.com account" links -> Make sure the iframe looks good without any scrollbars

Test the Reconnection
* Set up a full connection
* Set up your site to an invalid sandbox
* Visit the Dashboard. You'll see a Connection Error notice and an invitation to Restore the connection
* (before clicking, remove the invalid sandbox)
* Click Restore connection and make sure the iframe looks good