### PR TITLE
JITM: Use the connection package instead of Jetpack to get auth URL.

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm_use_connection_auth_url
+++ b/projects/packages/jitm/changelog/update-jitm_use_connection_auth_url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+JITM: Use manager::get_authorization_url to obtain the authorization url in the user deletion notice.

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -285,7 +285,8 @@ class Post_Connection_JITM extends JITM {
 			<?php
 		} else {
 			echo '<p>' . esc_html__( 'Every Jetpack site needs at least one connected admin for the features to work properly. Please connect to your WordPress.com account via the button below. Once you connect, you may refresh this page to see an option to change the connection owner.', 'jetpack' ) . '</p>';
-			$connect_url = \Jetpack::init()->build_connect_url( false, false, 'delete_connection_owner_notice' );
+			$connect_url = $connection_manager->get_authorization_url();
+			$connect_url = add_query_arg( 'from', 'delete_connection_owner_notice', $connect_url );
 			echo "<a href='" . esc_url( $connect_url ) . "' target='_blank' rel='noopener noreferrer' class='button-primary'>" . esc_html__( 'Connect to WordPress.com', 'jetpack' ) . '</a>';
 		}
 


### PR DESCRIPTION
Fixes #19701

#### Changes proposed in this Pull Request:
* The user deletion notice currently uses the `Jetpack::build_connect_url` method to obtain the user authorization url. Let's use the `Manager::get_authorization_url` method instead, so that the JITM package doesn't depend on a Jetpack method.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. On Jetpack master, start with a site that's connected to WordPress.com account A with Admin A.
2. Create a new user, Admin B.
3. Log out of the site, and of WordPress.com Admin A.
4. Log in with WordPress.com account B and Admin B local user.
5. Go to the Users menu
6. Click on the delete action next to the Admin A user.
7. You'll be offered an option to connect your account to WordPress.com, and become the new connection owner.
8. Click on that button.
9. You should be able to successfully connect your account to WordPress.com with no errors.
