### PR TITLE
changelogger: Find base dir by looking for composer.json

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-changelogger-in-subdir
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/github-actions/pr-is-up-to-date/composer.json
+++ b/projects/github-actions/pr-is-up-to-date/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.1.x-dev"
+		"automattic/jetpack-changelogger": "1.2.x-dev"
 	},
 	"repositories": [
 		{

--- a/projects/github-actions/push-to-mirrors/changelog/fix-changelogger-in-subdir
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/github-actions/push-to-mirrors/composer.json
+++ b/projects/github-actions/push-to-mirrors/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.1.x-dev"
+		"automattic/jetpack-changelogger": "1.2.x-dev"
 	},
 	"repositories": [
 		{

--- a/projects/github-actions/repo-gardening/changelog/fix-changelogger-in-subdir
+++ b/projects/github-actions/repo-gardening/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/github-actions/repo-gardening/composer.json
+++ b/projects/github-actions/repo-gardening/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.1.x-dev"
+		"automattic/jetpack-changelogger": "1.2.x-dev"
 	},
 	"scripts": {
 		"build-development": [

--- a/projects/github-actions/required-review/changelog/fix-changelogger-in-subdir
+++ b/projects/github-actions/required-review/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/github-actions/required-review/composer.json
+++ b/projects/github-actions/required-review/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.1.x-dev"
+		"automattic/jetpack-changelogger": "1.2.x-dev"
 	},
 	"scripts": {
 		"build-development": [

--- a/projects/js-packages/connection/changelog/fix-changelogger-in-subdir
+++ b/projects/js-packages/connection/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/connection/composer.json
+++ b/projects/js-packages/connection/composer.json
@@ -3,7 +3,7 @@
 	"description": "Jetpack Connection Component.",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.1.x-dev"
+		"automattic/jetpack-changelogger": "1.2.x-dev"
 	},
 	"scripts": {
 		"test-js": [

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.1.0",
+	"version": "0.1.1-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/a8c-mc-stats/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/a8c-mc-stats/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/a8c-mc-stats/composer.json
+++ b/projects/packages/a8c-mc-stats/composer.json
@@ -6,7 +6,7 @@
 	"require": {},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/abtest/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/abtest/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/abtest/composer.json
+++ b/projects/packages/abtest/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"automattic/wordbless": "dev-master",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/analyzer/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/analyzer/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/analyzer/composer.json
+++ b/projects/packages/analyzer/composer.json
@@ -7,7 +7,7 @@
 		"nikic/php-parser": "^4.2"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/assets/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/assets/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/assets/composer.json
+++ b/projects/packages/assets/composer.json
@@ -9,7 +9,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/autoloader/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/autoloader/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/autoloader/composer.json
+++ b/projects/packages/autoloader/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/backup/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/backup/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"files": [

--- a/projects/packages/blocks/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/blocks/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/blocks/composer.json
+++ b/projects/packages/blocks/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"automattic/wordbless": "dev-master",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/changelogger/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/changelogger/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+If composer.json is not present in the current directory, check parents and ask if the parent should be used (like composer does).

--- a/projects/packages/changelogger/changelog/fix-changelogger-in-subdir-2
+++ b/projects/packages/changelogger/changelog/fix-changelogger-in-subdir-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Changelogger `Config::setOutput()` is no longer needed. Config will throw a ConfigException instead of printing an error.

--- a/projects/packages/changelogger/composer.json
+++ b/projects/packages/changelogger/composer.json
@@ -55,7 +55,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-master": "1.1.x-dev"
+			"dev-master": "1.2.x-dev"
 		},
 		"mirror-repo": "Automattic/jetpack-changelogger",
 		"version-constants": {

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -11,13 +11,14 @@ use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * User interface for the changelogger tool.
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '1.1.2';
+	const VERSION = '1.2.0-alpha';
 
 	/**
 	 * Constructor.
@@ -35,9 +36,46 @@ class Application extends SymfonyApplication {
 	 * @return int
 	 */
 	public function doRun( InputInterface $input, OutputInterface $output ) {
-		Config::setOutput( $output );
 		$output->getFormatter()->setStyle( 'warning', new OutputFormatterStyle( 'black', 'yellow' ) );
-		return parent::doRun( $input, $output );
+		$errout = is_callable( array( $output, 'getErrorOutput' ) ) ? $output->getErrorOutput() : $output;
+
+		// Try to find a composer.json, if COMPOSER isn't set.
+		if ( ! getenv( 'COMPOSER' ) ) {
+			$dir = getcwd();
+			$ok  = false;
+			do {
+				$composer = $dir . DIRECTORY_SEPARATOR . 'composer.json';
+				if ( file_exists( $composer ) ) {
+					$ok = true;
+					break;
+				}
+
+				$prev = $dir;
+				$dir  = dirname( $dir );
+			} while ( $prev !== $dir );
+
+			// If we found one in a parent directory, ask if it should be used.
+			if ( getcwd() !== $dir ) {
+				if ( ! $ok || ! $input->isInteractive() ) {
+					$errout->writeln( '<error>File composer.json is not found in ' . getcwd() . '.</>' );
+					$errout->writeln( '<error>Run changelogger from the appropriate directory, or set the environment variable COMPOSER to point to composer.json.</>' );
+					return -1;
+				}
+
+				$question = new ConfirmationQuestion( "<info>No composer.json in current directory, do you want to use the one at $composer? [Y/n]</> ", true );
+				if ( ! $this->getHelperSet()->get( 'question' )->ask( $input, $output, $question ) ) {
+					return -1;
+				}
+			}
+			Config::setComposerJsonPath( $composer );
+		}
+
+		try {
+			return parent::doRun( $input, $output );
+		} catch ( ConfigException $ex ) {
+			$errout->writeln( "<error>{$ex->getMessage()}</>" );
+			return -1;
+		}
 	}
 
 }

--- a/projects/packages/changelogger/src/ConfigException.php
+++ b/projects/packages/changelogger/src/ConfigException.php
@@ -1,0 +1,18 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * Exception class used for fatal configuration errors.
+ *
+ * @package automattic/jetpack-changelogger
+ */
+
+namespace Automattic\Jetpack\Changelogger;
+
+use RuntimeException;
+
+/**
+ * Exception class used for fatal configuration errors.
+ *
+ * @since 1.2.0
+ */
+class ConfigException extends RuntimeException {
+}

--- a/projects/packages/changelogger/tests/php/includes/src/CommandTestCase.php
+++ b/projects/packages/changelogger/tests/php/includes/src/CommandTestCase.php
@@ -8,8 +8,6 @@
 namespace Automattic\Jetpack\Changelogger\Tests;
 
 use Automattic\Jetpack\Changelogger\Application;
-use Automattic\Jetpack\Changelogger\Config;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -24,16 +22,6 @@ class CommandTestCase extends TestCase {
 	 * @return Command
 	 */
 	protected function getCommand( $name ) {
-		// `$command->configure()` is called by `->__construct()`, which may
-		// call Config, so we need Config to have an output set. Set one that
-		// asserts that nothing is output, we don't need to test Config failure
-		// cases here.
-		$output = $this->getMockBuilder( BufferedOutput::class )
-			->setMethods( array( 'doWrite' ) )
-			->getMock();
-		$output->expects( $this->never() )->method( 'doWrite' );
-		Config::setOutput( $output );
-
 		$app = new Application();
 		return $app->find( $name );
 	}

--- a/projects/packages/changelogger/tests/php/includes/src/TestCase.php
+++ b/projects/packages/changelogger/tests/php/includes/src/TestCase.php
@@ -128,7 +128,7 @@ class TestCase extends PHPUnit_TestCase {
 		$w->config = array();
 		$w->cache  = array();
 		$w->loaded = false;
-		$w->out    = null;
+		Config::setComposerJsonPath( null );
 	}
 
 }

--- a/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
@@ -5,10 +5,14 @@
  * @package automattic/jetpack-changelogger
  */
 
+// phpcs:disable WordPress.WP.AlternativeFunctions, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
+
 namespace Automattic\Jetpack\Changelogger\Tests;
 
 use Automattic\Jetpack\Changelogger\Application;
 use Automattic\Jetpack\Changelogger\Config;
+use Automattic\Jetpack\Changelogger\ConfigException;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Wikimedia\TestingAccessWrapper;
@@ -21,6 +25,16 @@ use Wikimedia\TestingAccessWrapper;
 class ApplicationTest extends TestCase {
 	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 	use \Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+
+	/**
+	 * Set up.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		$this->useTempDir();
+		file_put_contents( 'composer.json', "{}\n" );
+	}
 
 	/**
 	 * Test the application.
@@ -40,28 +54,184 @@ class ApplicationTest extends TestCase {
 	}
 
 	/**
-	 * Test the stuff done by doRun().
+	 * Run the application.
+	 *
+	 * @param callable $callback Command callback.
+	 * @param array    $options Options:
+	 *     - catch-exceptions: (bool) Whether the application should catch exceptions. Default false.
+	 *     - inputs: (array) Value to pass to $tester->setInputs().
+	 * @return ApplicationTester
 	 */
-	public function testDoRun() {
+	private function runApplication( $callback, array $options = array( 'interactive' => false ) ) {
 		$app = new Application();
 		$app->setAutoExit( false );
+		$app->setCatchExceptions( false );
 
-		$mock = $this->getMockBuilder( Command::class )
-			->setConstructorArgs( array( 'testDoRun' ) )
-			->setMethods( array( 'execute' ) )
-			->getMock();
-		$mock->expects( $this->once() )->method( 'execute' )->willReturnCallback(
+		if ( isset( $options['catch-exceptions'] ) ) {
+			$app->setCatchExceptions( $options['catch-exceptions'] );
+			unset( $options['catch-exceptions'] );
+		}
+
+		$command = new Command( 'testDoRun' );
+		$command->setCode( $callback );
+		$app->add( $command );
+
+		$tester = new ApplicationTester( $app );
+
+		$options['interactive'] = isset( $options['inputs'] );
+		if ( $options['interactive'] ) {
+			$tester->setInputs( $options['inputs'] );
+			unset( $options['inputs'] );
+		}
+
+		$options[] = 'decorated';
+		$tester->run( array( 'command' => 'testDoRun' ), $options );
+		return $tester;
+	}
+
+	/**
+	 * Basic test of doRun().
+	 */
+	public function testDoRun() {
+		$tester = $this->runApplication(
 			function ( $input, $output ) {
-				$this->assertSame( $output, TestingAccessWrapper::newFromClass( Config::class )->out );
+				$this->assertSame(
+					getcwd() . DIRECTORY_SEPARATOR . 'composer.json',
+					TestingAccessWrapper::newFromClass( Config::class )->composerJsonPath
+				);
 				$this->assertTrue( $output->getFormatter()->hasStyle( 'warning' ) );
 				return 42;
 			}
 		);
-		$app->add( $mock );
+		$this->assertSame( 42, $tester->getStatusCode() );
+		$this->assertSame( '', $tester->getDisplay() );
+	}
 
-		$tester = new ApplicationTester( $app );
-		$code   = $tester->run( array( 'command' => 'testDoRun' ), array( 'decorated' ) );
-		$this->assertSame( 42, $code );
+	/**
+	 * Test doRun(), command threw ConfigException.
+	 */
+	public function testDoRun_ConfigException() {
+		$tester = $this->runApplication(
+			function () {
+				throw new ConfigException( 'Test config exception' );
+			}
+		);
+		$this->assertSame( -1, $tester->getStatusCode() );
+		$this->assertSame( "Test config exception\n", $tester->getDisplay() );
+	}
+
+	/**
+	 * Test doRun(), command threw RuntimeException.
+	 */
+	public function testDoRun_RuntimeException() {
+		$tester = $this->runApplication(
+			function () {
+				throw new RuntimeException( 'Test runtime exception' );
+			},
+			array( 'catch-exceptions' => true )
+		);
+		$this->assertSame( 1, $tester->getStatusCode() );
+		$this->assertMatchesRegularExpression( '/In ApplicationTest.php line \d+:\n *\n  Test runtime exception *\n/', $tester->getDisplay() );
+	}
+
+	/**
+	 * Test of doRun() with COMPOSER set
+	 */
+	public function testDoRun_env() {
+		putenv( 'COMPOSER=composer.json' );
+		$tester = $this->runApplication(
+			function () {
+				$this->assertNull( TestingAccessWrapper::newFromClass( Config::class )->composerJsonPath );
+				return 42;
+			}
+		);
+		$this->assertSame( 42, $tester->getStatusCode() );
+		$this->assertSame( '', $tester->getDisplay() );
+	}
+
+	/**
+	 * Test of doRun() with no composer.json
+	 */
+	public function testDoRun_noComposerJson() {
+		unlink( 'composer.json' );
+
+		// Sanity check.
+		$dir = getcwd();
+		do {
+			if ( file_exists( "$dir/composer.json" ) ) {
+				$this->fail( 'Precondition failed: This test requires that no composer.json exist above the temporary directory ' . getcwd() . ", but $dir/composer.json exists." );
+			}
+			$prev = $dir;
+			$dir  = dirname( $dir );
+		} while ( $prev !== $dir );
+
+		$tester = $this->runApplication(
+			function () {
+				$this->fail( 'Command should not be called' );
+			}
+		);
+		$this->assertSame( -1, $tester->getStatusCode() );
+		$this->assertSame( 'File composer.json is not found in ' . getcwd() . ".\nRun changelogger from the appropriate directory, or set the environment variable COMPOSER to point to composer.json.\n", $tester->getDisplay() );
+	}
+
+	/**
+	 * Test doRun() in a subdirectory, non-interactive.
+	 */
+	public function testDoRun_subdir_noninteractive() {
+		$cwd = getcwd();
+		mkdir( 'foo' );
+		mkdir( 'foo/bar' );
+		chdir( 'foo/bar' );
+
+		$tester = $this->runApplication(
+			function () {
+				$this->fail( 'Command should not be called' );
+			}
+		);
+		$this->assertSame( -1, $tester->getStatusCode() );
+		$this->assertSame( "File composer.json is not found in $cwd/foo/bar.\nRun changelogger from the appropriate directory, or set the environment variable COMPOSER to point to composer.json.\n", $tester->getDisplay() );
+	}
+
+	/**
+	 * Test doRun() in a subdirectory, interactive, answer N.
+	 */
+	public function testDoRun_subdir_interactive_N() {
+		$cwd = getcwd();
+		mkdir( 'foo' );
+		mkdir( 'foo/bar' );
+		chdir( 'foo/bar' );
+
+		$tester = $this->runApplication(
+			function () {
+				$this->fail( 'Command should not be called' );
+			},
+			array( 'inputs' => array( 'N' ) )
+		);
+		$this->assertSame( -1, $tester->getStatusCode() );
+		$this->assertSame( "No composer.json in current directory, do you want to use the one at $cwd/composer.json? [Y/n] ", $tester->getDisplay() );
+	}
+
+	/**
+	 * Test doRun() in a subdirectory, interactive, answer Y.
+	 */
+	public function testDoRun_subdir_interactive_Y() {
+		$cwd = getcwd();
+		mkdir( 'foo' );
+		mkdir( 'foo/bar' );
+		chdir( 'foo/bar' );
+
+		$tester = $this->runApplication(
+			function () use ( $cwd ) {
+				$this->assertSame(
+					$cwd . DIRECTORY_SEPARATOR . 'composer.json',
+					TestingAccessWrapper::newFromClass( Config::class )->composerJsonPath
+				);
+				return 42;
+			},
+			array( 'inputs' => array( 'Y' ) )
+		);
+		$this->assertSame( 42, $tester->getStatusCode() );
+		$this->assertSame( "No composer.json in current directory, do you want to use the one at $cwd/composer.json? [Y/n] ", $tester->getDisplay() );
 	}
 
 }

--- a/projects/packages/changelogger/tests/php/tests/src/CommandLoaderTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/CommandLoaderTest.php
@@ -9,9 +9,7 @@ namespace Automattic\Jetpack\Changelogger\Tests;
 
 use Automattic\Jetpack\Changelogger\AddCommand;
 use Automattic\Jetpack\Changelogger\CommandLoader;
-use Automattic\Jetpack\Changelogger\Config;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
-use Symfony\Component\Console\Output\BufferedOutput;
 
 /**
  * Tests for the changelogger CommandLoader class.
@@ -34,9 +32,6 @@ class CommandLoaderTest extends TestCase {
 	 * Test `get()`.
 	 */
 	public function testGet() {
-		$out = new BufferedOutput();
-		Config::setOutput( $out );
-
 		$loader = new CommandLoader();
 		$this->assertInstanceOf( AddCommand::class, $loader->get( 'add' ) );
 	}

--- a/projects/packages/codesniffer/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/codesniffer/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -12,7 +12,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/compat/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/compat/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/compat/composer.json
+++ b/projects/packages/compat/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"files": [

--- a/projects/packages/config/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/config/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/config/composer.json
+++ b/projects/packages/config/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/connection-ui/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/connection-ui/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/composer.json
+++ b/projects/packages/connection-ui/composer.json
@@ -7,7 +7,7 @@
 		"automattic/jetpack-connection": "^1.26"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "1.0.2",
+	"version": "1.0.3-alpha",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-connection-ui",

--- a/projects/packages/connection/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/connection/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -16,7 +16,7 @@
 		"automattic/wordbless": "@dev",
 		"yoast/phpunit-polyfills": "0.2.0",
 		"brain/monkey": "2.6.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"files": [

--- a/projects/packages/constants/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/constants/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/constants/composer.json
+++ b/projects/packages/constants/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/device-detection/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/device-detection/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/device-detection/composer.json
+++ b/projects/packages/device-detection/composer.json
@@ -6,7 +6,7 @@
 	"require": {},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/error/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/error/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/error/composer.json
+++ b/projects/packages/error/composer.json
@@ -6,7 +6,7 @@
 	"require": {},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/heartbeat/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/heartbeat/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/heartbeat/composer.json
+++ b/projects/packages/heartbeat/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-options": "^1.12"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/jitm/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/jitm/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -19,7 +19,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/lazy-images/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/lazy-images/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/lazy-images/composer.json
+++ b/projects/packages/lazy-images/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"automattic/wordbless": "dev-master",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/licensing/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/licensing/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/licensing/composer.json
+++ b/projects/packages/licensing/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"automattic/wordbless": "@dev",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/logo/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/logo/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/logo/composer.json
+++ b/projects/packages/logo/composer.json
@@ -6,7 +6,7 @@
 	"require": {},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/options/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/options/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/options/composer.json
+++ b/projects/packages/options/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/partner/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/partner/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/partner/composer.json
+++ b/projects/packages/partner/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/password-checker/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/password-checker/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/password-checker/composer.json
+++ b/projects/packages/password-checker/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "^1.1",
+		"automattic/jetpack-changelogger": "^1.2",
 		"automattic/wordbless": "@dev",
 		"yoast/phpunit-polyfills": "0.2.0"
 	},

--- a/projects/packages/redirect/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/redirect/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/redirect/composer.json
+++ b/projects/packages/redirect/composer.json
@@ -9,7 +9,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/roles/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/roles/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/roles/composer.json
+++ b/projects/packages/roles/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/status/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/status/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -7,7 +7,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/sync/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/sync/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-status": "^1.7"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/terms-of-service/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/terms-of-service/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/terms-of-service/composer.json
+++ b/projects/packages/terms-of-service/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"brain/monkey": "2.6.0",
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/tracking/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/tracking/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -11,7 +11,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/plugins/backup/changelog/fix-changelogger-in-subdir
+++ b/projects/plugins/backup/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "0.2.0",
-		"automattic/jetpack-changelogger": "^1.1"
+		"automattic/jetpack-changelogger": "^1.2"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccbb101c434babb44c7709e3a30a7e21",
+    "content-hash": "e939766f168b774b55f1a75f375187cd",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -116,13 +116,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "e7f6bec617b4ff246ea975768814454f84d06f68"
+                "reference": "95ff0278a5308e68e73dd68d1af98251fbbdbb4e"
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "composer-plugin",
@@ -242,13 +242,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "28010fc1559669d9d68d60d650816620336227c3"
+                "reference": "dd91e224716bcf897d85664248574bf872a45de3"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.26"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1"
+                "automattic/jetpack-changelogger": "^1.2"
             },
             "type": "library",
             "extra": {
@@ -638,7 +638,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "bf07844a67872b3bb3c0b8c4524ef86bf28cc822"
+                "reference": "53fd89e7f369d1cb46106845aa91bac842cd70f9"
             },
             "require": {
                 "php": ">=5.6",
@@ -657,7 +657,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/beta/changelog/fix-changelogger-in-subdir
+++ b/projects/plugins/beta/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.1.x-dev"
+		"automattic/jetpack-changelogger": "1.2.x-dev"
 	},
 	"autoload": {},
 	"repositories": [

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "777b48e88f9391655babeda184b2e987",
+    "content-hash": "737e92054307a685117200e0512ed977",
     "packages": [],
     "packages-dev": [
         {
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "bf07844a67872b3bb3c0b8c4524ef86bf28cc822"
+                "reference": "53fd89e7f369d1cb46106845aa91bac842cd70f9"
             },
             "require": {
                 "php": ">=5.6",
@@ -32,7 +32,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/debug-helper/changelog/fix-changelogger-in-subdir
+++ b/projects/plugins/debug-helper/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/debug-helper/composer.json
+++ b/projects/plugins/debug-helper/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.1.x-dev"
+		"automattic/jetpack-changelogger": "1.2.x-dev"
 	},
 	"repositories": [
 		{

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d61b8c01d13effc96340b1a6b15bffac",
+    "content-hash": "c35865e84ac26d5f1b55ae5c4d90f78a",
     "packages": [],
     "packages-dev": [
         {
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "bf07844a67872b3bb3c0b8c4524ef86bf28cc822"
+                "reference": "53fd89e7f369d1cb46106845aa91bac842cd70f9"
             },
             "require": {
                 "php": ">=5.6",
@@ -32,7 +32,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {

--- a/projects/plugins/jetpack/changelog/fix-changelogger-in-subdir
+++ b/projects/plugins/jetpack/changelog/fix-changelogger-in-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -40,7 +40,7 @@
 		"nojimage/twitter-text-php": "3.1.2"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "1.1.x-dev"
+		"automattic/jetpack-changelogger": "1.2.x-dev"
 	},
 	"scripts": {
 		"build-production": [

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d00c766782fb762bd9e34ad25046493c",
+    "content-hash": "8365a724f4800144e131089d3839a394",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,10 +12,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "062647e2d8c16a57b42d15e7a588434df812ebd4"
+                "reference": "c922996fa6d50ef7288e3022c1531f20869aea86"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -62,14 +62,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/abtest",
-                "reference": "d35dc7ce5285bde3628ec9b23ec7dbdd536941fd"
+                "reference": "c8778de4ab88f6c93e9d9773ab06d16fe85b68bb"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.26",
                 "automattic/jetpack-error": "^1.3"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "automattic/wordbless": "dev-master",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -120,13 +120,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "512348462627a81b2afd303bebd898bc9b9061c2"
+                "reference": "bd0e49700afef81db5bd04e9c0948956e1d89262"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -174,13 +174,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "e7f6bec617b4ff246ea975768814454f84d06f68"
+                "reference": "95ff0278a5308e68e73dd68d1af98251fbbdbb4e"
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "composer-plugin",
@@ -232,10 +232,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "79e64001db892a79c582da72f2631b1de384ee5a"
+                "reference": "a55443b257f63b65ec6d05709e8286d0d73ade73"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1"
+                "automattic/jetpack-changelogger": "^1.2"
             },
             "type": "library",
             "extra": {
@@ -271,10 +271,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "da3a0fcda34764ea7718e32a1cd77fbd1eb72fcb"
+                "reference": "f42ad49cb879d8c07dd13f76cf69d0b55ddd23c6"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "automattic/wordbless": "dev-master",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -325,10 +325,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/compat",
-                "reference": "a595a5b2b1e9029cef40bbe2361bf8c08e88cd06"
+                "reference": "1de05abbe86ccbb89318bc5625c3c90d62f87420"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1"
+                "automattic/jetpack-changelogger": "^1.2"
             },
             "type": "library",
             "extra": {
@@ -364,10 +364,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "411c9d6164ddb4584d3511394fc12d501228367c"
+                "reference": "5cc8275ac867ff99e527da0df9e8f14ec53b11fd"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1"
+                "automattic/jetpack-changelogger": "^1.2"
             },
             "type": "library",
             "extra": {
@@ -400,7 +400,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d7cab662ac8e0b19b03ada8faffb9e66e29dc4aa"
+                "reference": "c3cf08a9502da00644b992f2913d3c7462168cd9"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6",
@@ -412,7 +412,7 @@
                 "automattic/jetpack-tracking": "^1.13"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "automattic/wordbless": "@dev",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
@@ -468,13 +468,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "28010fc1559669d9d68d60d650816620336227c3"
+                "reference": "dd91e224716bcf897d85664248574bf872a45de3"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.26"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1"
+                "automattic/jetpack-changelogger": "^1.2"
             },
             "type": "library",
             "extra": {
@@ -517,10 +517,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "d3058751e2d560e611b5ca636ffa6128797819d1"
+                "reference": "4af9f14f6a08c81318d4067b891ef610f343b963"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -568,10 +568,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "210f9c109c3d57a159957d605ef09cc0a5306b4a"
+                "reference": "68a5cff39e5295fecbc20d36812364fa38b9771c"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -618,10 +618,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/error",
-                "reference": "18fced584d5add2fd58186dcffd6a564cc300ab9"
+                "reference": "f64061cbe4bc67a078fd5d2ac00beceef4897aa3"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -668,14 +668,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/heartbeat",
-                "reference": "2b0e92c11def6004d764882e4283639d6ead6fb2"
+                "reference": "c054b09d4c4501623b04d93525b06b880f5a62c3"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
                 "automattic/jetpack-options": "^1.12"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1"
+                "automattic/jetpack-changelogger": "^1.2"
             },
             "type": "library",
             "extra": {
@@ -708,7 +708,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "1d45f73908ae3f50103273ddee5bbde046f7f451"
+                "reference": "bc4c7d3bc0875b78538db73f5b6288fde93ba25d"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -724,7 +724,7 @@
                 "automattic/jetpack-tracking": "^1.13"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -783,14 +783,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/lazy-images",
-                "reference": "99f4f188d2c7a61db313fda25773e1208624e243"
+                "reference": "de070d55407bbce5346035e8e6b4ef4a4b5b5f8f"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "automattic/wordbless": "dev-master",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -849,14 +849,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "6424bd5df4569afe195dc766a435ebef783dc05c"
+                "reference": "114417e5d4899f991c219e65e70a389fb32b6078"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.26",
                 "automattic/jetpack-options": "^1.12"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -907,10 +907,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "913c5fbef2a08a1d983c21e07fa6129990806232"
+                "reference": "fded849729d28f06f5db6c986fc64a17a320b213"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -957,13 +957,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/options",
-                "reference": "e2e07a5dc2b92f2892f04581e75f0b0fb1846c3b"
+                "reference": "f8cb7c3731146ebdb63f703b8674504dd2708c3e"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -997,10 +997,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "75cdebf78152e39bcc694e92ed99e37df7eb5097"
+                "reference": "a956480f55aee834af3d28dc7efbdaec16a6a07e"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1102,13 +1102,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "ac2f235fb9997be0b6c42244b43010c39473e623"
+                "reference": "3594a55fa382221dc688f7892c36c9d63f4fdd00"
             },
             "require": {
                 "automattic/jetpack-status": "^1.7"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1156,10 +1156,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "6ef2c32c8c82219f8d25359d33d7e330f5fad256"
+                "reference": "bde868c2636fca7fca76b29a7df23fcd437481fc"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1207,10 +1207,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "0cae4e732a782dbae92f37b94f782a4e7ec21484"
+                "reference": "ae573385f7a9623e68b979ba67c5ae7148a773b3"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1258,7 +1258,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f6e40adeea72c074a20c7080b548581fff936700"
+                "reference": "e0da54c067b68d46d8e4e75672f4d4aab23bc4b6"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.26",
@@ -1270,7 +1270,7 @@
                 "automattic/jetpack-status": "^1.7"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1"
+                "automattic/jetpack-changelogger": "^1.2"
             },
             "type": "library",
             "extra": {
@@ -1303,14 +1303,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/terms-of-service",
-                "reference": "76e0aa453a1a7f753c7b2bafb8a6779b0616e7e2"
+                "reference": "cef777fc474f8b4cc8f331daa255ddac9f30cf99"
             },
             "require": {
                 "automattic/jetpack-options": "^1.12",
                 "automattic/jetpack-status": "^1.7"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
@@ -1358,7 +1358,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "baf3bbc9d279897e709d19cecb904d6082cbf5ee"
+                "reference": "0b22d20d6bc3e8239a193e3195c7789e9c9bbcd7"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
@@ -1367,7 +1367,7 @@
                 "automattic/jetpack-terms-of-service": "^1.9"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/jetpack-changelogger": "^1.2",
                 "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "library",
@@ -1487,7 +1487,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "bf07844a67872b3bb3c0b8c4524ef86bf28cc822"
+                "reference": "53fd89e7f369d1cb46106845aa91bac842cd70f9"
             },
             "require": {
                 "php": ">=5.6",
@@ -1506,7 +1506,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 },
                 "mirror-repo": "Automattic/jetpack-changelogger",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Like composer itself does, look for composer.json in parent directories
if the current directory does not have one. If composer.json is found in
the parent, ask whether it should be used (and exit if the user answers
"no").

This also cleans up Config to no longer need an OutputInterface
injected, which I've never really liked but hadn't seen a way around it
before. Now the way around it is obvious.

Don't be afraid that this PR touches 93 files and every project, that's only because every project depends on changelogger so every project gets the dependency version updated and a changelog entry to note it.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1619786711497600-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Change to a subdirectory of a project (e.g. `projects/plugins/jetpack/tests/e2e`), then run changelogger out of vendor (e.g. `../../vendor/bin/changelogger add`).