### PR TITLE
JITM: move the last sync callback hook to the JITM package

### DIFF
--- a/projects/packages/jitm/changelog/update-move_jitm_sync_hook
+++ b/projects/packages/jitm/changelog/update-move_jitm_sync_hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+JITM: move sync updated option hook to the JITM package.

--- a/projects/plugins/jetpack/changelog/update-move_jitm_sync_hook
+++ b/projects/plugins/jetpack/changelog/update-move_jitm_sync_hook
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: JITM: move jetpack_track_last_sync_callback to JITM package.
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -767,11 +767,6 @@ class Jetpack {
 			add_action( 'wp_print_footer_scripts', array( $this, 'implode_frontend_css' ), -1 ); // Run first to trigger before `print_late_styles`
 		}
 
-		/**
-		 * These are sync actions that we need to keep track of for jitms
-		 */
-		add_filter( 'jetpack_sync_before_send_updated_option', array( $this, 'jetpack_track_last_sync_callback' ), 99 );
-
 		// Actually push the stats on shutdown.
 		if ( ! has_action( 'shutdown', array( $this, 'push_stats' ) ) ) {
 			add_action( 'shutdown', array( $this, 'push_stats' ) );
@@ -1092,23 +1087,17 @@ class Jetpack {
 		return $callables;
 	}
 
+	/**
+	 * Deprecated
+	 * Please use Automattic\Jetpack\JITMS\JITM::jetpack_track_last_sync_callback instead.
+	 *
+	 * @param array $params The action parameters.
+	 *
+	 * @deprecated since 9.8.
+	 */
 	function jetpack_track_last_sync_callback( $params ) {
-		/**
-		 * This filter is documented in the Automattic\Jetpack\JITMS\Post_Connection_JITM class.
-		 */
-		if ( ! apply_filters( 'jetpack_just_in_time_msg_cache', true ) ) {
-			return $params;
-		}
-
-		if ( is_array( $params ) && isset( $params[0] ) ) {
-			$option = $params[0];
-			if ( 'active_plugins' === $option ) {
-				// use the cache if we can, but not terribly important if it gets evicted
-				set_transient( 'jetpack_last_plugin_sync', time(), HOUR_IN_SECONDS );
-			}
-		}
-
-		return $params;
+		_deprecated_function( __METHOD__, 'jetpack-9.8', '\Automattic\Jetpack\JITMS\JITM->jetpack_track_last_sync_callback' );
+		return Automattic\Jetpack\JITMS\JITM::get_instance()->jetpack_track_last_sync_callback( $params );
 	}
 
 	function jetpack_connection_banner_callback() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The `jetpack_last_plugin_sync` transient value is used to determine if the JITM cache should be used. This transient is updated when the `jetpack_sync_before_send_updated_option` filter fires. Move the `jetpack_sync_before_send_updated_option` hook and the `jetpack_track_last_sync_callback` method from the Jetpack class to the JITM package. This will allow the JITM package to update the `jetpack_last_plugin_sync` transient value when the Jetpack plugin is not active.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install and activate this branch. Connect Jetpack.
2. Check the value of the `jetpack_last_plugin_sync` transient:
   `wp transient get jetpack_last_pluging_sync`
3. Activate a plugin.
4. Verify that the value of the `jetpack_last_plugin_sync` transient has changed.
