### PR TITLE
Protect: Resolve PHP notice for unknown var

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-protect-notice
+++ b/projects/plugins/jetpack/changelog/fix-protect-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Declares a var before use.
+
+

--- a/projects/plugins/jetpack/modules/protect.php
+++ b/projects/plugins/jetpack/modules/protect.php
@@ -379,9 +379,10 @@ class Jetpack_Protect_Module {
 	/**
 	 * Get all IP headers so that we can process on our server...
 	 *
-	 * @return string
+	 * @return array
 	 */
 	function get_headers() {
+		$output             = array();
 		$ip_related_headers = array (
 			'GD_PHP_HANDLER',
 			'HTTP_AKAMAI_ORIGIN_HOP',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes "Undefined variable: output in plugins/jetpack/modules/protect.php:411"

Pretty straight forward. If none of the headers are present, $output is never set. We need to set it to ensure it is there to return.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
no

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load JP in a setup without any of those headers, probably like PHP CLI or soemthing.
*
