### PR TITLE
Slideshow block: fix drag issue in firefox

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-firefox-slideshow-drag-bug
+++ b/projects/plugins/jetpack/changelog/fix-firefox-slideshow-drag-bug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Added addtional css to fix drag issue in firefox in slideshow block
+
+

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -57,6 +57,10 @@
 			margin: 0;
 			position: relative;
 			width: 100%;
+			.wp-block-jetpack-slideshow_image {
+				pointer-events: none;
+				user-select: none;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #19728

#### Changes proposed in this Pull Request:
* Adds some additional css to stop image hijacking drag event in firefox

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* In firefox add a slideshow block with images. In the front end notice how it is not possible to drag slides to move through slideshow if dragging directly over images
* Check out this PR and try again and it should now be possible to drag the images to move through slideshow

Before:
![before-drag](https://user-images.githubusercontent.com/3629020/117082396-450b4c00-ad96-11eb-938e-4da51c9a3c9e.gif)

After:
![after-drag](https://user-images.githubusercontent.com/3629020/117082404-4a689680-ad96-11eb-8abf-97bac5dea281.gif)

