### PR TITLE
Add Advanced General menu item

### DIFF
--- a/projects/plugins/jetpack/changelog/add-advanced-general-menu-item
+++ b/projects/plugins/jetpack/changelog/add-advanced-general-menu-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Adds Advanced General menu item when user has Advanced Dashboard toggle enabled so they can still access Calypso settings.

--- a/projects/plugins/jetpack/changelog/add-advanced-general-menu-item
+++ b/projects/plugins/jetpack/changelog/add-advanced-general-menu-item
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Adds Advanced General menu item when user has Advanced Dashboard toggle enabled so they can still access Calypso settings.
+Adds Advanced General menu item that points to WP Admin regardless of whether the Advanced Dashboard toggle is enabled or not.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -380,15 +380,15 @@ class Admin_Menu extends Base_Admin_Menu {
 	 */
 	public function add_options_menu( $wp_admin = false ) {
 		$this->hide_submenu_page( 'options-general.php', 'sharing' );
-
-		if ( $wp_admin ) {
-			return;
-		}
-
 		$this->update_submenus( 'options-general.php', array( 'options-general.php' => 'https://wordpress.com/settings/general/' . $this->domain ) );
 
-		$this->hide_submenu_page( 'options-general.php', 'options-discussion.php' );
-		$this->hide_submenu_page( 'options-general.php', 'options-writing.php' );
+		if ( $wp_admin ) {
+			// There is not complete feature parity between WP Admin and Calypso settings https://github.com/Automattic/wp-calypso/issues/51189.
+			add_submenu_page( 'options-general.php', esc_attr__( 'Advanced General', 'jetpack' ), __( 'Advanced General', 'jetpack' ), 'manage_options', 'options-general.php', null, 1 );
+		} else {
+			$this->hide_submenu_page( 'options-general.php', 'options-discussion.php' );
+			$this->hide_submenu_page( 'options-general.php', 'options-writing.php' );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -380,15 +380,17 @@ class Admin_Menu extends Base_Admin_Menu {
 	 */
 	public function add_options_menu( $wp_admin = false ) {
 		$this->hide_submenu_page( 'options-general.php', 'sharing' );
+
+		// There is not complete feature parity between WP Admin and Calypso settings https://github.com/Automattic/wp-calypso/issues/51189.
 		$this->update_submenus( 'options-general.php', array( 'options-general.php' => 'https://wordpress.com/settings/general/' . $this->domain ) );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Advanced General', 'jetpack' ), __( 'Advanced General', 'jetpack' ), 'manage_options', 'options-general.php', null, 1 );
 
 		if ( $wp_admin ) {
-			// There is not complete feature parity between WP Admin and Calypso settings https://github.com/Automattic/wp-calypso/issues/51189.
-			add_submenu_page( 'options-general.php', esc_attr__( 'Advanced General', 'jetpack' ), __( 'Advanced General', 'jetpack' ), 'manage_options', 'options-general.php', null, 1 );
-		} else {
-			$this->hide_submenu_page( 'options-general.php', 'options-discussion.php' );
-			$this->hide_submenu_page( 'options-general.php', 'options-writing.php' );
+			return;
 		}
+
+		$this->hide_submenu_page( 'options-general.php', 'options-discussion.php' );
+		$this->hide_submenu_page( 'options-general.php', 'options-writing.php' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -268,7 +268,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		// No need to add a menu linking to WP Admin if there is already one.
 		if ( ! $wp_admin ) {
-			add_submenu_page( 'options-general.php', esc_attr__( 'Advanced General', 'jetpack' ), __( 'Advanced General', 'jetpack' ), 'manage_options', 'options-general.php' );
 			add_submenu_page( 'options-general.php', esc_attr__( 'Advanced Writing', 'jetpack' ), __( 'Advanced Writing', 'jetpack' ), 'manage_options', 'options-writing.php' );
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -376,10 +376,12 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_options_menu();
 
 		$this->assertSame( 'https://wordpress.com/settings/general/' . static::$domain, array_shift( $submenu['options-general.php'] )[2] );
+		$this->assertSame( 'options-general.php', $submenu['options-general.php'][1][2] );
 	}
 
 	/**
 	 * Tests add_jetpack_menu
+	 * §
 	 *
 	 * @covers ::add_jetpack_menu
 	 */

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -309,7 +309,6 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_options_menu();
 		$this->assertSame( 'https://wordpress.com/hosting-config/' . static::$domain, $submenu['options-general.php'][6][2] );
 		$this->assertSame( 'options-writing.php', array_pop( $submenu['options-general.php'] )[2] );
-		$this->assertSame( 'options-general.php', array_pop( $submenu['options-general.php'] )[2] );
 
 		// Reset.
 		$menu    = static::$menu_data;
@@ -318,7 +317,6 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_options_menu( true );
 		$last_submenu = array_pop( $submenu['options-general.php'] );
 		$this->assertNotSame( 'options-writing.php', $last_submenu[2] );
-		$this->assertNotSame( 'options-general.php', $last_submenu[2] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/51189

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When the advanced dashboard toggle is enabled we need to add an "Advanced General" menu item so that Calypso settings are still accessible.
#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

**Simple Sites**

* Apply the WPCOM patch D61023-code to your Sandbox
* Check that Settings > Advanced General exists regardless of whether the "Advanced Dashboard" toggle is enabled or not and that it goes to WP Admin
* Check that Settings > General exists and goes to Calypso settings

**Atomic Sites**

* Install Jetpack Beta and activate this branch.
* Check that Settings > Advanced General exists regardless of whether the "Advanced Dashboard" toggle is enabled or not and that it goes to WP Admin
* Check that Settings > General exists and goes to Calypso settings
