### PR TITLE
If no Full Sync in process early return to minimize option writes

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-early-return-full-sync
+++ b/projects/packages/sync/changelog/fix-sync-early-return-full-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Performance : If no Full Sync is in process early return before we update options .

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -260,8 +260,15 @@ class Sender {
 		if ( ! $sync_module ) {
 			return;
 		}
+		// Full Sync Disabled.
 		if ( ! Settings::get_setting( 'full_sync_sender_enabled' ) ) {
 			return;
+		}
+
+		// Sync not started or Sync finished.
+		$status = $sync_module->get_status();
+		if ( false === $status['started'] || ( ! empty( $status['started'] ) && ! empty( $status['finished'] ) ) ) {
+			return false;
 		}
 
 		// Don't sync if request is marked as read only.

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -265,15 +265,15 @@ class Sender {
 			return;
 		}
 
+		// Don't sync if request is marked as read only.
+		if ( Constants::is_true( 'JETPACK_SYNC_READ_ONLY' ) ) {
+			return new \WP_Error( 'jetpack_sync_read_only' );
+		}
+
 		// Sync not started or Sync finished.
 		$status = $sync_module->get_status();
 		if ( false === $status['started'] || ( ! empty( $status['started'] ) && ! empty( $status['finished'] ) ) ) {
 			return false;
-		}
-
-		// Don't sync if request is marked as read only.
-		if ( Constants::is_true( 'JETPACK_SYNC_READ_ONLY' ) ) {
-			return new \WP_Error( 'jetpack_sync_read_only' );
 		}
 
 		$this->continue_full_sync_enqueue();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

When Sync is enabled on a site we add 2 hooks to the shutdown action to perform incremental sync and full sync processes. The do_full_sync hook was currently not checking if a Full Sync was running before updating options used to ensure a single process is running. As these hooks run for front end view we were adding unnecessary write operations. 

This updates the process to check the status and if no Full Sync is in progress we return instead of updating options.

Fixes #jpop-6590

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Increase performance by minimizing option writes from Full Sync.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
 No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There are several flows that should be tested manually and already have unit/integration tests.

1) Verify that incremental sync is not impacted. By performing site edits and verifying they synced (Debug Tool can give you sync queue info)
2) Trigger a Full Sync (Debug Tool) and verify it runs to completion.
3) After a Full Sync completes navigate the site, update content and verify we don't update the 'jetpack_next_sync_time_full-sync-enqueue' 
