### PR TITLE
Enable upgrade banner for WoA sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-simple-and-atomic-plan-parity
+++ b/projects/plugins/jetpack/changelog/update-simple-and-atomic-plan-parity
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Implement Atomic plans in the same way that Simpe sites
+Offer features depending on the current plan of the site rather on the current platform of the site.

--- a/projects/plugins/jetpack/changelog/update-simple-and-atomic-plan-parity
+++ b/projects/plugins/jetpack/changelog/update-simple-and-atomic-plan-parity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Implement Atomic plans in the same way that Simpe sites

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -7,8 +7,8 @@
  */
 
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
 

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1064,17 +1064,9 @@ class Jetpack_Gutenberg {
 				$features_data = Store_Product_List::get_site_specific_features_data();
 			} else {
 				// Atomic sites.
-				// Hit the WP COM API '/features' endpoint.
-				$response = Client::wpcom_json_api_request_as_blog(
-					sprintf( '/sites/%d/features', Jetpack_Options::get_option( 'id' ) ),
-					Client::WPCOM_JSON_API_VERSION
-				);
-	
-				if ( ! is_wp_error( $response ) ) {
-					$body = wp_remote_retrieve_body( $response );
-					if ( $body ) {
-						$features_data = json_decode( $body, true );
-					}
+				$option = get_option( 'jetpack_active_plan' );
+				if ( ! empty( $option ) && array_key_exists( 'features', $option ) ) {
+					$features_data = $option['features'];
 				}
 			}
 

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1054,7 +1054,7 @@ class Jetpack_Gutenberg {
 		$is_atomic_site = jetpack_is_atomic_site();
 
 		// Check feature availability for Simple and Atomic sites.
-		if ( $is_simple_site || $is_atomic_site  ) {
+		if ( $is_simple_site || $is_atomic_site ) {
 
 			// Simple sites.
 			if ( $is_simple_site ) {

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1070,7 +1070,7 @@ class Jetpack_Gutenberg {
 				}
 			}
 
-			$is_available  = in_array( $slug, $features_data['active'], true );
+			$is_available = in_array( $slug, $features_data['active'], true );
 			if ( ! empty( $features_data['available'][ $slug ] ) ) {
 				$plan = $features_data['available'][ $slug ][0];
 			}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1050,7 +1050,8 @@ class Jetpack_Gutenberg {
 		$plan         = '';
 		$slug         = self::remove_extension_prefix( $slug );
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		// Check feature availability for Simple and Atomic sites.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM || jetpack_is_atomic_site() ) {
 			// Hit the WP COM API '/features' endpoint.
 			$response = Client::wpcom_json_api_request_as_blog(
 				sprintf( '/sites/%d/features', Jetpack_Options::get_option( 'id' ) ),
@@ -1067,11 +1068,7 @@ class Jetpack_Gutenberg {
 					}
 				}
 			}
-		} elseif ( ! jetpack_is_atomic_site() ) {
-			/*
-			 * If it's Atomic then assume all features are available
-			 * otherwise check against the Jetpack plan.
-			 */
+		} else {
 			$is_available = Jetpack_Plan::supports( $slug );
 			$plan         = Jetpack_Plan::get_minimum_plan_for_feature( $slug );
 		}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -7,7 +7,6 @@
  */
 
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1069,7 +1069,7 @@ class Jetpack_Gutenberg {
 				}
 			}
 
-			$is_available = in_array( $slug, $features_data['active'], true );
+			$is_available = array_key_exists( 'active', $features_data ) && in_array( $slug, $features_data['active'], true );
 			if ( ! empty( $features_data['available'][ $slug ] ) ) {
 				$plan = $features_data['available'][ $slug ][0];
 			}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1069,7 +1069,7 @@ class Jetpack_Gutenberg {
 				}
 			}
 
-			$is_available = array_key_exists( 'active', $features_data ) && in_array( $slug, $features_data['active'], true );
+			$is_available = isset( $features_data['active'] ) && in_array( $slug, $features_data['active'], true );
 			if ( ! empty( $features_data['available'][ $slug ] ) ) {
 				$plan = $features_data['available'][ $slug ][0];
 			}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1064,7 +1064,7 @@ class Jetpack_Gutenberg {
 			} else {
 				// Atomic sites.
 				$option = get_option( 'jetpack_active_plan' );
-				if ( ! empty( $option ) && array_key_exists( 'features', $option ) ) {
+				if ( isset( $option['features'] ) ) {
 					$features_data = $option['features'];
 				}
 			}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1135,6 +1135,6 @@ class Jetpack_Gutenberg {
  *
  * More doc: https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/extensions#upgrades-for-blocks
  */
-if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+if ( jetpack_is_atomic_site() ) {
 	add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
 }

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1127,3 +1127,14 @@ class Jetpack_Gutenberg {
 		};
 	}
 }
+
+/*
+ * Enable upgrade nudge for Atomic sites.
+ * This feature is false as default,
+ * so let's enable it through this filter.
+ *
+ * More doc: https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/extensions#upgrades-for-blocks
+ */
+if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+	add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
+}

--- a/projects/plugins/jetpack/extensions/shared/plan-utils.js
+++ b/projects/plugins/jetpack/extensions/shared/plan-utils.js
@@ -33,7 +33,7 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 	// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't.
 	let planPathSlug = startsWith( planSlug, 'jetpack_' ) ? planSlug : get( plan, [ 'path_slug' ] );
 
-	// Overrites path to `business` for Atomic sites.
+	// Overwrites path to `business` for Atomic sites.
 	if ( isAtomicSite() ) {
 		planPathSlug = 'business';
 	}

--- a/projects/plugins/jetpack/extensions/shared/plan-utils.js
+++ b/projects/plugins/jetpack/extensions/shared/plan-utils.js
@@ -84,6 +84,7 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 	if ( isAtomicSite() ) {
 		return addQueryArgs( `https://wordpress.com/plans/${ getSiteFragment() }`, {
 			redirect_to,
+			customerType: 'business',
 		} );
 	}
 

--- a/projects/plugins/jetpack/extensions/shared/plan-utils.js
+++ b/projects/plugins/jetpack/extensions/shared/plan-utils.js
@@ -80,6 +80,13 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 					  );
 		  } )();
 
+	// Redirect to calypso plans page for WoC sites.
+	if ( isAtomicSite() ) {
+		return addQueryArgs( `https://wordpress.com/plans/${ getSiteFragment() }`, {
+			redirect_to,
+		} );
+	}
+
 	return (
 		planPathSlug &&
 		addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {

--- a/projects/plugins/jetpack/extensions/shared/plan-utils.js
+++ b/projects/plugins/jetpack/extensions/shared/plan-utils.js
@@ -31,12 +31,7 @@ import { requiresPaidPlan } from './register-jetpack-block';
  */
 export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 	// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't.
-	let planPathSlug = startsWith( planSlug, 'jetpack_' ) ? planSlug : get( plan, [ 'path_slug' ] );
-
-	// Overwrites path to `business` for Atomic sites.
-	if ( isAtomicSite() ) {
-		planPathSlug = 'business';
-	}
+	const planPathSlug = startsWith( planSlug, 'jetpack_' ) ? planSlug : get( plan, [ 'path_slug' ] );
 
 	// The full site editor has no set post type.
 	const redirect_to = ( undefined === postType

--- a/projects/plugins/jetpack/extensions/shared/plan-utils.js
+++ b/projects/plugins/jetpack/extensions/shared/plan-utils.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import getJetpackData from './get-jetpack-data';
-import { isSimpleSite } from './site-type-utils';
+import { isSimpleSite, isAtomicSite } from './site-type-utils';
 import getSiteFragment from './get-site-fragment';
 import getJetpackExtensionAvailability from './get-jetpack-extension-availability';
 import { requiresPaidPlan } from './register-jetpack-block';
@@ -31,7 +31,12 @@ import { requiresPaidPlan } from './register-jetpack-block';
  */
 export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 	// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't.
-	const planPathSlug = startsWith( planSlug, 'jetpack_' ) ? planSlug : get( plan, [ 'path_slug' ] );
+	let planPathSlug = startsWith( planSlug, 'jetpack_' ) ? planSlug : get( plan, [ 'path_slug' ] );
+
+	// Overrites path to `business` for Atomic sites.
+	if ( isAtomicSite() ) {
+		planPathSlug = 'business';
+	}
 
 	// The full site editor has no set post type.
 	const redirect_to = ( undefined === postType
@@ -50,10 +55,10 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 				);
 		  }
 		: () => {
-				// The editor for CPTs has an `edit/` route fragment prefixed
+				// The editor for CPTs has an `edit/` route fragment prefixed.
 				const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
 
-				// Post-checkout: redirect back here
+				// Post-checkout: redirect back here.
 				return isSimpleSite()
 					? addQueryArgs(
 							'/' +

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -197,8 +197,8 @@ require_once JETPACK__PLUGIN_DIR . 'load-jetpack.php';
  * More doc: https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/extensions#upgrades-for-blocks
  */
 if (
-	defined( 'IS_ATOMIC' ) && IS_ATOMIC ||  // <- WoA
-	defined( 'IS_PRESSABLE' ) && IS_PRESSABLE // <- Pressable
+	defined( 'IS_ATOMIC' ) && IS_ATOMIC ||
+	defined( 'IS_PRESSABLE' ) && IS_PRESSABLE
 ) {
 	add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
 }

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -196,9 +196,6 @@ require_once JETPACK__PLUGIN_DIR . 'load-jetpack.php';
  *
  * More doc: https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/extensions#upgrades-for-blocks
  */
-if (
-	defined( 'IS_ATOMIC' ) && IS_ATOMIC ||
-	defined( 'IS_PRESSABLE' ) && IS_PRESSABLE
-) {
+if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 	add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
 }

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -188,3 +188,13 @@ register_deactivation_hook( __FILE__, array( 'Jetpack', 'plugin_deactivation' ) 
 
 // Require everything else, that is not loaded via the autoloader.
 require_once JETPACK__PLUGIN_DIR . 'load-jetpack.php';
+
+/*
+ * Enable upgrade nudge for Atomic sites.
+ * This feature is false as default,
+ * so let's enable it through this filter.
+ *
+ * More doc: https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/extensions#upgrades-for-blocks
+ */
+
+add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -196,5 +196,9 @@ require_once JETPACK__PLUGIN_DIR . 'load-jetpack.php';
  *
  * More doc: https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/extensions#upgrades-for-blocks
  */
-
-add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
+if (
+	defined( 'IS_ATOMIC' ) && IS_ATOMIC ||  // <- WoA
+	defined( 'IS_PRESSABLE' ) && IS_PRESSABLE // <- Pressable
+) {
+	add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
+}

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -188,14 +188,3 @@ register_deactivation_hook( __FILE__, array( 'Jetpack', 'plugin_deactivation' ) 
 
 // Require everything else, that is not loaded via the autoloader.
 require_once JETPACK__PLUGIN_DIR . 'load-jetpack.php';
-
-/*
- * Enable upgrade nudge for Atomic sites.
- * This feature is false as default,
- * so let's enable it through this filter.
- *
- * More doc: https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/extensions#upgrades-for-blocks
- */
-if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-	add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/19498

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR adds the features availability logic according to the site plan for Atomic sites.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Simple sites

* Apply the patch
* Get sandboxed
* Start to edit a post
* Nothing should change here. For sites with a `free` plan and paid blocks, you should see the upgrade banner:

block | Free plan | Paid plan
------|------|------
Donations | ![image](https://user-images.githubusercontent.com/77539/117493917-00c0ad00-af4a-11eb-97cf-f72ebfd4d467.png) | ![image](https://user-images.githubusercontent.com/77539/117492769-74fa5100-af48-11eb-8e14-1aaa0a0e401b.png)
Payments | ![image](https://user-images.githubusercontent.com/77539/117494013-1df57b80-af4a-11eb-90df-ac3d2fc3b8ce.png) | ![image](https://user-images.githubusercontent.com/77539/117492928-aa9f3a00-af48-11eb-8dfe-ae40fb7831e3.png)
Calendly | ![image](https://user-images.githubusercontent.com/77539/117494045-2c439780-af4a-11eb-8035-cffa7b12500e.png) | ![image](https://user-images.githubusercontent.com/77539/117494173-5bf29f80-af4a-11eb-8871-678363917566.png)


### Atomic sites

* Get the Jetpack beta plugin
* Install and activate
* Switch the plugin to this `update/simple-and-atomic-plan-parity` branch
* Start to edit a post

~The~ Almost the same behavior that Simple sites: show upgrade banner for paid blocks when the site has a `free` plan, with the difference that the button link should lead to the plans page, instead of the checkout one.

* Confirm you see the **_Business sites and online stores_** as tab as default.

<img src="https://user-images.githubusercontent.com/77539/117971269-0b8b9100-b300-11eb-88e0-787dae3415a6.png" width="800px" />


### Jetpack sites

No upgrade banners at all. Some (paid for Simple and Atomic sites) blocks are available for Jetpack sites, such as `Calendly`, `Payments`, `Video`, etc. Other won't be, for instance `Donations` block.
