### PR TITLE
SEO: fix Calypso error when updating `seo_meta_description` option

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-legacy-seo-calypso-error
+++ b/projects/plugins/jetpack/changelog/fix-legacy-seo-calypso-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+For users that are able to update the `LEGACY_META_OPTION` option, avoid trying to update `TITLE_FORMATS_OPTION` which would display an 403 in Calypso.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -809,6 +809,9 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case Jetpack_SEO_Titles::TITLE_FORMATS_OPTION:
 					if ( ! Jetpack_SEO_Utils::is_enabled_jetpack_seo() ) {
+						if ( Jetpack_SEO_Utils::has_legacy_front_page_meta() ) {
+							break;
+						}
 						return new WP_Error( 'unauthorized', __( 'SEO tools are not enabled for this site.', 'jetpack' ), 403 );
 					}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Follow up to Automattic/jetpack/pull/19753
* For users that are able to update the `LEGACY_META_OPTION` option, this change will avoid trying to update `TITLE_FORMATS_OPTION` which would display a 403 in Calypso.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

* Will require a sandbox with these changes pulled down.
* On a sandboxed site with no paid plan, set the following option: `wp option add seo_meta_description 'Testing legacy front page meta description.' --url=__sandbox_url__`.
* This will allow the UI to show up for editing the front page meta at: `https://wordpress.com/marketing/traffic/__site_url__`
* You should now be able to update that description without seeing any errors in Calypso or your sandbox.
* Next, add a Business plan to the sandboxed site. And again update the front page description. This should produce no errors, and should delete the prior `seo_meta_description` option updating it to `advanced_seo_front_page_description`.
* Finally, on a WPorg JP (free or paid plan), make sure you are still able to set the front mage description as expected without error in Calypso.