### PR TITLE
Fix date used in Top Posts dashboar widget

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-top-posts-widget
+++ b/projects/plugins/jetpack/changelog/fix-top-posts-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes the date used to fetch the Top posts in the Top posts dashboard widget

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1258,7 +1258,7 @@ function stats_dashboard_widget_content() {
 
 	$post_ids = array();
 
-	$csv_end_date = gmdate( 'Y-m-d' );
+	$csv_end_date = current_time( 'Y-m-d' );
 	$csv_args     = array(
 		'top'    => "&limit=8&end=$csv_end_date",
 		'search' => "&limit=5&end=$csv_end_date",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 6571-gh-jpop-issues

## More about this bug.

Since this subject is often confusing, also for myself, I thought it was a good idea to write down the "whys" here as I have it fresh in my mind.

This line was recently changed in [this commit](https://github.com/Automattic/jetpack/pull/19310/files#diff-074ea7354745baca91015b568ed3398387def033002ec1304e16c2f2578c86feR1261). But the truth is that the bug was not introduced there, the code was already buggy before.

### Why we use `gmdate`

First let's understand why we avoid the use of `date` and favor `gmdate`.

Both functions do the same thing. The difference is that, under Linux/Apache servers, `date` takes the local timezone into account, while it does not under Windows servers. This could make our code have different result in different servers, and that's why we favor `gmdate` instead, so we know exactly what the result will be in any situation.

### And what if I want to take the local timezone into consideration

Then you need to make this explicitly. There are several approaches. 

WordPress has one function that gets the current datetime of the site in the correct way: `current_time`. It's easy to use this when we want the current date and time.

### The old and the new bug

BEFORE: This line used to read:

```PHP
$csv_end_date = date( 'Y-m-d', current_time( 'timestamp' ) );
```

There are 2 problems in the code above
1. `current_time` accepts a date format as an input. So it's not necessary to use `date` just to format it to `Y-m-d`. You can simply use `current_time( 'Y-m-d' )`
2. As we know, both `current_time` and `date` take timezone into consideration. What happens there is that we do the timezone transformation twice. So if a site is running in GMT-3, the end result would be GMT-6! This bug has been there for a while

AFTER: it looked like this

```PHP
$csv_end_date = gmdate( 'Y-m-d' );
```


THE FIX is as simple as:

```PHP
$csv_end_date = current_time( 'Y-m-d' );
```

In the code above we are getting the time and not considering the timezone. Which led to the bug reported in the issue that initiated this discussion. The user visited their dashboard late in the night, and as they were behind GMT, the site would try to fetch data from the next day.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix date used in Top Posts dashboar widget

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch in a Jetpack site
* Add a debug in the line changed and make sure the date returned matches the date in the timezone of the site, and not in UTC (tip, change the format to `'H:i'`
