### PR TITLE
Add attributes needed for hiding nested upgrade nudges

### DIFF
--- a/projects/packages/blocks/changelog/add-support-hiding-nested-nudges
+++ b/projects/packages/blocks/changelog/add-support-hiding-nested-nudges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds an attribute to paid blocks to support hiding nested upgrade nudges on the frontend.

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -63,6 +63,20 @@ class Blocks {
 		if ( ! self::is_standalone_block() ) {
 			// If the block is dynamic, and a Jetpack block, wrap the render_callback to check availability.
 			if ( ! empty( $args['plan_check'] ) ) {
+				// Set up attributes.
+				if ( ! isset( $args['attributes'] ) ) {
+					$args['attributes'] = array();
+				}
+				$args['attributes'] = array_merge(
+					$args['attributes'],
+					array(
+						// Indicates that this block should display an upgrade nudge on the frontend when applicable.
+						'shouldDisplayFrontendBanner' => array(
+							'type'    => 'boolean',
+							'default' => true,
+						),
+					)
+				);
 				if ( isset( $args['render_callback'] ) ) {
 					$args['render_callback'] = Jetpack_Gutenberg::get_render_callback_with_availability_check( $feature_name, $args['render_callback'] );
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of fix for 221-gh-Automattic/view-design
Related to #19407 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When a block is registered using jetpack_register_block and the plan_check attribute, we dynamically add a shouldDisplayFrontendBanner attribute used to indicate whether the nudge should be displayed on the frontend (true by default)
* By itself this change should have no effect, but it is necessary for #19407 which removes nested upgrade nudges.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync changes
* Insert a paid block into the editor and verify that there are no console errors
* Verify that in-editor upgrade nudges continue to work as normal
* Verify that frontend nudges continue to work as normal
