### PR TITLE
Search: don't open overlay when user is composing text using an input method editor (Chinese, Japanese, Korean and Indic languages)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-cjk-input
+++ b/projects/plugins/jetpack/changelog/fix-search-cjk-input
@@ -1,4 +1,4 @@
 Significance: minor
 Type: bugfix
 
-Search: don't open overlay when user is composing CJK input
+Search: don't open overlay when user is composing text using an input method editor (Chinese, Japanese, Korean and Indic languages)

--- a/projects/plugins/jetpack/changelog/fix-search-cjk-input
+++ b/projects/plugins/jetpack/changelog/fix-search-cjk-input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Search: don't open overlay when user is composing CJK input

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -103,7 +103,9 @@ class SearchApp extends Component {
 		// Add listeners for input and submit
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.addEventListener( 'submit', this.handleSubmit );
-			// keyup event is fired after compositionend, to avoid duplicating text.
+			// keydown handler is causing text duplication because it actively sets the search input
+			// value after system input method empty the input but before filling the input again.
+			// so changed to keyup event which is fired after compositionend when Enter is pressed.
 			input.addEventListener( 'keyup', this.handleKeyup );
 			input.addEventListener( 'input', this.handleInput );
 			input.addEventListener( 'compositionstart', this.handleCompositionStart );

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -99,6 +99,7 @@ class SearchApp extends Component {
 		// Add listeners for input and submit
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.addEventListener( 'submit', this.handleSubmit );
+			// keyup event is fired after compositionend, to avoid duplicating text.
 			input.addEventListener( 'keyup', this.handleKeyup );
 			input.addEventListener( 'input', this.handleInput );
 			input.addEventListener( 'compositionstart', this.handleCompositionStart );

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -127,7 +127,7 @@ class SearchApp extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.removeEventListener( 'submit', this.handleSubmit );
-			input.removeEventListener( 'keydown', this.handleKeydown );
+			input.removeEventListener( 'keyup', this.handleKeyup );
 			input.removeEventListener( 'input', this.handleInput );
 			input.removeEventListener( 'compositionstart', this.handleCompositionStart );
 			input.removeEventListener( 'compositionend', this.handleCompositionEnd );

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -51,6 +51,10 @@ class SearchApp extends Component {
 		super( ...arguments );
 		this.input = createRef();
 		this.state = {
+			// When typing in CJK, the following events fire in order:
+			// keydown, compositionstart, compositionupdate, input, keyup, keydown,compositionend, keyup
+			// We toggle isComposing on compositionstart and compositionend events.
+			// (CJK = Chinese, Japanese, Korean; see https://en.wikipedia.org/wiki/CJK_characters)
 			isComposing: false,
 			overlayOptions: { ...this.props.initialOverlayOptions },
 			showResults: !! this.props.initialShowResults, // initialShowResults can be undefined

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -99,7 +99,7 @@ class SearchApp extends Component {
 		// Add listeners for input and submit
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.addEventListener( 'submit', this.handleSubmit );
-			input.addEventListener( 'keydown', this.handleKeydown );
+			input.addEventListener( 'keyup', this.handleKeyup );
 			input.addEventListener( 'input', this.handleInput );
 			input.addEventListener( 'compositionstart', this.handleCompositionStart );
 			input.addEventListener( 'compositionend', this.handleCompositionEnd );
@@ -200,7 +200,7 @@ class SearchApp extends Component {
 		}
 	};
 
-	handleKeydown = event => {
+	handleKeyup = event => {
 		// If user presses enter, propagate the query value and immediately show the results.
 		if ( event.key === 'Enter' ) {
 			this.props.setSearchQuery( event.target.value );

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -51,6 +51,7 @@ class SearchApp extends Component {
 		super( ...arguments );
 		this.input = createRef();
 		this.state = {
+			isComposing: false,
 			overlayOptions: { ...this.props.initialOverlayOptions },
 			showResults: !! this.props.initialShowResults, // initialShowResults can be undefined
 		};
@@ -100,6 +101,8 @@ class SearchApp extends Component {
 			input.form.addEventListener( 'submit', this.handleSubmit );
 			input.addEventListener( 'keydown', this.handleKeydown );
 			input.addEventListener( 'input', this.handleInput );
+			input.addEventListener( 'compositionstart', this.handleCompositionStart );
+			input.addEventListener( 'compositionend', this.handleCompositionEnd );
 		} );
 
 		document.querySelectorAll( this.props.themeOptions.overlayTriggerSelector ).forEach( button => {
@@ -125,6 +128,8 @@ class SearchApp extends Component {
 			input.form.removeEventListener( 'submit', this.handleSubmit );
 			input.removeEventListener( 'keydown', this.handleKeydown );
 			input.removeEventListener( 'input', this.handleInput );
+			input.removeEventListener( 'compositionstart', this.handleCompositionStart );
+			input.removeEventListener( 'compositionend', this.handleCompositionEnd );
 		} );
 
 		document.querySelectorAll( this.props.themeOptions.overlayTriggerSelector ).forEach( button => {
@@ -210,6 +215,11 @@ class SearchApp extends Component {
 			return;
 		}
 
+		// Is the user still composing input with a CJK language?
+		if ( this.state.isComposing ) {
+			return;
+		}
+
 		if ( this.state.overlayOptions.overlayTrigger === 'submit' ) {
 			return;
 		}
@@ -224,6 +234,14 @@ class SearchApp extends Component {
 			this.props.response?.results && this.showResults();
 		}
 	}, 200 );
+
+	handleCompositionStart = () => {
+		this.setState( { isComposing: true } );
+	};
+
+	handleCompositionEnd = () => {
+		this.setState( { isComposing: false } );
+	};
 
 	handleFilterInputClick = event => {
 		event.preventDefault();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Partial fix for https://github.com/Automattic/jetpack/issues/18581.

#### Changes proposed in this Pull Request:
When composing text for CJK languages, users might need to enter several Latin letters for one CJK character - as the user starts to enter, the overlay pops up and breaks the input.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Visit a test site with a Jetpack Search plan.
2. Using an input language like Japanese - Hiragana, start typing a word in a search input. Ensure that you can complete the word without the overlay opening unexpectedly.

cc @kangzj 

<img width="437" alt="Screen Shot 2021-05-07 at 17 02 10" src="https://user-images.githubusercontent.com/17325/117400069-ff957d00-af55-11eb-9187-b8bb5bd9e9a2.png">
