### PR TITLE
Nav Unification: Update site redirect flag function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-nav-unification-redirect-flag
+++ b/projects/plugins/jetpack/changelog/update-nav-unification-redirect-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Update logic for showing a Redirect flag in the sidebar

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -122,7 +122,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 			);
 		}
 
-		if ( is_redirected_domain( $this->domain ) ) {
+		if ( is_simple_site_redirect( $this->domain ) ) {
 			$badge .= '<span class="site__badge site__badge-redirect">' . esc_html__( 'Redirect', 'jetpack' ) . '</span>';
 		}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -122,7 +122,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 			);
 		}
 
-		if ( is_simple_site_redirect( $this->domain ) ) {
+		if ( function_exists( 'is_simple_site_redirect' ) && is_simple_site_redirect( $this->domain ) ) {
 			$badge .= '<span class="site__badge site__badge-redirect">' . esc_html__( 'Redirect', 'jetpack' ) . '</span>';
 		}
 


### PR DESCRIPTION
Fixes Automattic/wp-calypso#51530

#### Changes proposed in this Pull Request:

* The `is_redirected_domain()` check is too broad for Site Redirect's purposes. We've introduced a new function to check specifically for Site Redirects in D60809-code, and this PR updates the check for the "Redirect" flag in the sidebar on the /wp-admin side.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Apply D60809-code and D61140-code to your sandbox
* Sandbox a test site with a custom domain mapped
* Go to your test site's `/wp-admin`; there should be no "Redirect" flag in the sidebar, as shown above
* Sandbox another site that uses a simple Site Redirect (set up at `/domains/add/site-redirect`)
* Ensure the "Redirect" flag is present in the sidebar as expected