### PR TITLE
WP.com Posts: Show thumbnail on the posts list screen

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,7 +43,8 @@
 				"automattic/jetpack-status",
 				"automattic/jetpack-sync",
 				"automattic/jetpack-terms-of-service",
-				"automattic/jetpack-tracking"
+				"automattic/jetpack-tracking",
+				"automattic/jetpack-wpcom-posts"
 			],
 			"enabled": false
 		},

--- a/projects/packages/wpcom-posts/.gitattributes
+++ b/projects/packages/wpcom-posts/.gitattributes
@@ -1,0 +1,13 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+package.json      export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+.gitignore        production-exclude
+changelog/**      production-exclude
+phpunit.xml.dist  production-exclude
+tests/**          production-exclude

--- a/projects/packages/wpcom-posts/.gitignore
+++ b/projects/packages/wpcom-posts/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/packages/wpcom-posts/.gitignore
+++ b/projects/packages/wpcom-posts/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 node_modules/
+wordpress/

--- a/projects/packages/wpcom-posts/CHANGELOG.md
+++ b/projects/packages/wpcom-posts/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/packages/wpcom-posts/README.md
+++ b/projects/packages/wpcom-posts/README.md
@@ -1,0 +1,20 @@
+# wpcom-posts
+
+Enhancements for the "Posts" screens on WordPress.com sites.
+
+## How to install wpcom-posts
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+wpcom-posts is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/packages/wpcom-posts/actions.php
+++ b/projects/packages/wpcom-posts/actions.php
@@ -5,15 +5,17 @@
  * @package automattic/jetpack-wpcom-posts
  */
 
-use Automattic\Jetpack\WPcom\Posts;
+namespace Automattic\Jetpack\WPcom\Posts;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
-add_action(
-	'init',
-	function () {
-		new Posts\Thumbnail();
-	}
-);
+/**
+ * Initializes the thumbnail enhancements.
+ */
+function setup_thumbnail() {
+	new Thumbnail();
+}
+
+add_action( 'init', __NAMESPACE__ . '\setup_thumbnail' );

--- a/projects/packages/wpcom-posts/actions.php
+++ b/projects/packages/wpcom-posts/actions.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Action Hooks for the WordPress.com's Posts enhancements.
+ *
+ * @package automattic/jetpack-wpcom-posts
+ */
+
+use Automattic\Jetpack\WPcom\Posts;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+add_action(
+	'init',
+	function () {
+		new Posts\Thumbnail();
+	}
+);

--- a/projects/packages/wpcom-posts/composer.json
+++ b/projects/packages/wpcom-posts/composer.json
@@ -1,0 +1,54 @@
+{
+	"name": "automattic/jetpack-wpcom-posts",
+	"description": "Enhancements for the \"Posts\" screens on WordPress.com sites.",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "0.2.0",
+		"automattic/jetpack-changelogger": "^1.1",
+		"automattic/wordbless": "dev-master"
+	},
+	"autoload": {
+		"files": [
+			"actions.php"
+		],
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"@composer install",
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		],
+		"test-coverage": [
+			"@composer install",
+			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+		],
+		"test-php": [
+			"@composer phpunit"
+		],
+		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-wpcom-posts",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-wpcom-posts/compare/v${old}...v${new}"
+		},
+		"branch-alias": {
+			"dev-master": "0.1.x-dev"
+		}
+	}
+}

--- a/projects/packages/wpcom-posts/composer.json
+++ b/projects/packages/wpcom-posts/composer.json
@@ -19,11 +19,11 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer install",
+			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer install",
+			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [
@@ -34,7 +34,7 @@
 	"repositories": [
 		{
 			"type": "path",
-			"url": "../../packages/*",
+			"url": "../*",
 			"options": {
 				"monorepo": true
 			}

--- a/projects/packages/wpcom-posts/license.txt
+++ b/projects/packages/wpcom-posts/license.txt
@@ -1,0 +1,14 @@
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA.

--- a/projects/packages/wpcom-posts/package.json
+++ b/projects/packages/wpcom-posts/package.json
@@ -1,0 +1,29 @@
+{
+	"private": true,
+	"description": "Enhancements for the \"Posts\" screens on WordPress.com sites.",
+	"homepage": "https://jetpack.com",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "echo 'Not implemented.",
+		"build-js": "echo 'Not implemented.",
+		"build-production": "echo 'Not implemented.",
+		"build-production-js": "echo 'Not implemented.",
+		"clean": "true",
+		"distclean": "rm -rf node_modules && yarn clean",
+		"install-if-deps-outdated": "yarn install --check-files --production=false --frozen-lockfile",
+		"validate-es5": "eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore"
+	},
+	"devDependencies": {},
+	"engines": {
+		"node": "^14.16.0",
+		"yarn": "^1.3.2"
+	}
+}

--- a/projects/packages/wpcom-posts/phpunit.xml.dist
+++ b/projects/packages/wpcom-posts/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<directory suffix=".php">.</directory>
+			<exclude>
+				<directory suffix=".php">tests</directory>
+				<directory suffix=".php">vendor</directory>
+				<directory suffix=".php">wordpress</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/projects/packages/wpcom-posts/phpunit.xml.dist
+++ b/projects/packages/wpcom-posts/phpunit.xml.dist
@@ -5,7 +5,7 @@
 		</testsuite>
 	</testsuites>
 	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="false">
+		<whitelist>
 			<directory suffix=".php">.</directory>
 			<exclude>
 				<directory suffix=".php">tests</directory>

--- a/projects/packages/wpcom-posts/src/class-thumbnail.php
+++ b/projects/packages/wpcom-posts/src/class-thumbnail.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Thumbnail enhancements for the "Posts" screens on WordPress.com sites.
+ *
+ * @package automattic/jetpack-wpcom-posts
+ */
+
+namespace Automattic\Jetpack\WPcom\Posts;
+
+/**
+ * Class Thumbnail.
+ */
+class Thumbnail {
+	/**
+	 * Thumbnail constructor.
+	 */
+	public function __construct() {
+		add_filter( 'manage_posts_columns', array( $this, 'add_posts_column_header' ) );
+		add_filter( 'manage_pages_columns', array( $this, 'add_posts_column_header' ) );
+		add_action( 'manage_posts_custom_column', array( $this, 'display_posts_column_content' ), 10, 2 );
+		add_action( 'manage_pages_custom_column', array( $this, 'display_posts_column_content' ), 10, 2 );
+		add_action( 'admin_print_styles-edit.php', array( $this, 'load_columns_css' ) );
+	}
+
+	/**
+	 * Adds a new column header for displaying the thumbnail of a post.
+	 *
+	 * @param array $columns An array of column names.
+	 * @return array An array of column names.
+	 */
+	public function add_posts_column_header( $columns ) {
+		// Place if before author.
+		$pos = array_search( 'author', array_keys( $columns ), true );
+		if ( ! is_int( $pos ) ) {
+			return $columns;
+		}
+		$chunks                 = array_chunk( $columns, $pos, true );
+		$chunks[0]['thumbnail'] = ''; // Deliberately empty.
+
+		return call_user_func_array( 'array_merge', $chunks );
+	}
+
+	/**
+	 * Displays the thumbnail content.
+	 *
+	 * @param string $column  The name of the column to display.
+	 * @param int    $post_id The current post ID.
+	 */
+	public function display_posts_column_content( $column, $post_id ) {
+		if ( 'thumbnail' !== $column ) {
+			return;
+		}
+
+		echo get_the_post_thumbnail( $post_id, array( 50, 50 ), array( 'style' => 'height: auto;' ) );
+	}
+
+	/**
+	 * Load CSS needed for the thumbnail column.
+	 */
+	public function load_columns_css() {
+		?>
+		<style type="text/css">
+			.fixed .column-thumbnail {
+				width: 5em;
+			}
+		</style>
+		<?php
+	}
+}

--- a/projects/packages/wpcom-posts/tests/php/bootstrap.php
+++ b/projects/packages/wpcom-posts/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/projects/packages/wpcom-posts/tests/php/bootstrap.php
+++ b/projects/packages/wpcom-posts/tests/php/bootstrap.php
@@ -9,3 +9,8 @@
  * Include the composer autoloader.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * Load WorDBless
+ */
+\WorDBless\Load::load();

--- a/projects/packages/wpcom-posts/tests/php/test-class-thumbnail.php
+++ b/projects/packages/wpcom-posts/tests/php/test-class-thumbnail.php
@@ -7,12 +7,12 @@
 
 namespace Automattic\Jetpack\WPcom\Posts;
 
-use PHPUnit\Framework\TestCase;
+use WorDBless\BaseTestCase;
 
 /**
  * Class Test_Thumbnail
  */
-class Test_Thumbnail extends TestCase {
+class Test_Thumbnail extends BaseTestCase {
 
 	/**
 	 * Checks that the thumbnail enhancements are initialized.

--- a/projects/packages/wpcom-posts/tests/php/test-class-thumbnail.php
+++ b/projects/packages/wpcom-posts/tests/php/test-class-thumbnail.php
@@ -13,13 +13,28 @@ use WorDBless\BaseTestCase;
  * Class Test_Thumbnail
  */
 class Test_Thumbnail extends BaseTestCase {
+	/**
+	 * Core class used to implement displaying posts in a list table.
+	 *
+	 * @var WP_Posts_List_Table
+	 */
+	protected $table;
 
 	/**
-	 * Checks that the thumbnail enhancements are initialized.
+	 * Setup runs before each test.
 	 *
-	 * @covers ::setup_thumbnail
+	 * @before
 	 */
-	public function test_setup_thumbnail() {
-		$this->assertEquals( 10, has_action( 'init', __NAMESPACE__ . '\setup_thumbnail' ) );
+	public function set_up() {
+		new Thumbnail();
+		$this->table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit-page' ) );
+	}
+
+	/**
+	 * Checks that a new column header for thumbnails is added to the posts list table.
+	 */
+	public function test_thumbnail_column_header() {
+		$columns = $this->table->get_columns();
+		$this->assertSame( '', $columns['thumbnail'] );
 	}
 }

--- a/projects/packages/wpcom-posts/tests/php/test-class-thumbnail.php
+++ b/projects/packages/wpcom-posts/tests/php/test-class-thumbnail.php
@@ -21,6 +21,13 @@ class Test_Thumbnail extends BaseTestCase {
 	protected $table;
 
 	/**
+	 * Test post.
+	 *
+	 * @var WP_Post
+	 */
+	protected $post;
+
+	/**
 	 * Setup runs before each test.
 	 *
 	 * @before
@@ -28,6 +35,30 @@ class Test_Thumbnail extends BaseTestCase {
 	public function set_up() {
 		new Thumbnail();
 		$this->table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit-page' ) );
+
+		$this->post = wp_insert_post(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'Post title',
+				'post_content' => 'Post content',
+				'post_excerpt' => 'Post excerpt',
+				'post_type'    => 'post',
+			)
+		);
+
+		add_filter( 'post_thumbnail_html', array( $this, 'mock_post_thumbnail_html' ), 10, 4 );
+	}
+
+	public function tear_down() {
+		remove_filter( 'post_thumbnail_html', array( $this, 'mock_post_thumbnail_html' ) );
+	}
+
+	public function mock_post_thumbnail_html( $html, $post_id, $size, $attr ) {
+		$width  = $size[0];
+		$height = $size[1];
+		$style  = $attr['style'];
+
+		return "My thumbnail of $width x $height with a $style style";
 	}
 
 	/**
@@ -36,5 +67,12 @@ class Test_Thumbnail extends BaseTestCase {
 	public function test_thumbnail_column_header() {
 		$columns = $this->table->get_columns();
 		$this->assertSame( '', $columns['thumbnail'] );
+	}
+
+	/**
+	 * Checks that the post thumbnail is displayed in the new column cell new.
+	 */
+	public function test_thumbnail_column_content() {
+		$this->table->column_default( 'thumbnail' );
 	}
 }

--- a/projects/packages/wpcom-posts/tests/php/test-class-thumbnail.php
+++ b/projects/packages/wpcom-posts/tests/php/test-class-thumbnail.php
@@ -1,0 +1,25 @@
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Test methods from Automattic\Jetpack\WPcom\Posts\Thumbnail
+ *
+ * @package automattic/jetpack-wpcom-posts
+ */
+
+namespace Automattic\Jetpack\WPcom\Posts;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Test_Thumbnail
+ */
+class Test_Thumbnail extends TestCase {
+
+	/**
+	 * Checks that the thumbnail enhancements are initialized.
+	 *
+	 * @covers ::setup_thumbnail
+	 */
+	public function test_setup_thumbnail() {
+		$this->assertEquals( 10, has_action( 'init', __NAMESPACE__ . '\setup_thumbnail' ) );
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Introduces a new `wpcom-posts` package which seeks to be home for all the enhancements to apply on the Posts and Pages screens for WordPress.com sites.
- This is part of a technical spike exploring how we can build a Composer package using the Jetpack monorepo which will be exclusively consumed by Simple and Atomic sites.
- For now, this package simply displays the post thumbnail in the posts/pages list table (helps fixing https://github.com/Automattic/wp-calypso/issues/51357). 

<img width="1256" alt="Screen Shot 2021-05-07 at 17 01 02" src="https://user-images.githubusercontent.com/1233880/117470427-14bedb80-af57-11eb-99e5-463b8e725200.png">

Remaining tasks:
- [x] Create package skeleton.
- [x] Implement logic for showing the thumbnail on a new column in the posts screen.
- [ ] Add unit tests.
- [ ] Create mirror repo.
- [ ] Publish first version of package.

#### Jetpack product discussion
pd2C0z-b-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Spin up a local Jetpack site.
- Add the new package to the Jetpack plugin: `cd projects/plugins/jetpack && composer require automattic/jetpack-wpcom-posts`.
- Go to Posts > All posts.
- Make sure the featured image of the posts is displayed in a new column.