### PR TITLE
Add query param to plans-prompt-url if site is non-https.

### DIFF
--- a/projects/plugins/jetpack/changelog/2021-05-07-14-34-28-905718
+++ b/projects/plugins/jetpack/changelog/2021-05-07-14-34-28-905718
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+After connection: Add query param indicating if site is non-https for use on the Plans selection page.

--- a/projects/plugins/jetpack/class.jetpack-connection-banner.php
+++ b/projects/plugins/jetpack/class.jetpack-connection-banner.php
@@ -231,11 +231,28 @@ class Jetpack_Connection_Banner {
 				'forceVariation'        => $force_variation,
 				'connectInPlaceUrl'     => Jetpack::admin_url( 'page=jetpack#/setup' ),
 				'dashboardUrl'          => Jetpack::admin_url( 'page=jetpack#/dashboard' ),
-				'plansPromptUrl'        => Redirect::get_url( 'jetpack-connect-plans' ),
+				'plansPromptUrl'        => self::get_plans_prompt_url(),
 				'identity'              => $identity,
 				'preFetchScript'        => plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ) . '?ver=' . JETPACK__VERSION,
 			)
 		);
+	}
+
+	/**
+	 * Gets the Jetpack Redirect url pointing to the Jetpack plans/pricing page.
+	 *
+	 * @since 9.8
+	 *
+	 * @return string
+	 */
+	public function get_plans_prompt_url() {
+		$query = array();
+		// If the site's wp-admin url is http only (not https), include a query param indicating this. `&query=https%3Doff`.
+		// The query param is used on the Calypso plans/pricing page to build the sites's wp-admin url when selecting the Jetapack "Free" plan.
+		if ( 'http://' === substr( get_site_url(), 0, 7 ) ) {
+			$query['query'] = 'https=off';
+		}
+		return Redirect::get_url( 'jetpack-connect-plans', $query );
 	}
 
 	/**


### PR DESCRIPTION
If the site's wp-admin url is http only (not https), this PR adds a query param to the plans-prompt-url indicating this. ie- `&query=https%3Doff`.
The query param is used on the Calypso plans/pricing page to redirect to the sites's wp-admin url after selecting the Jetpack "Free" plan.
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related to: https://github.com/Automattic/wp-calypso/issues/52394

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* If the site's wp-admin url is http only (not https), include a query param indicating this in the plans-prompt-url Jetpack Redirect.
* With the param included, the Jetpack Redirect url should look like this:
    * `https://jetpack.com/redirect?source=jetpack-connect-plans&site=[site]&query=https%3Doff`
    * Which points to --> `https://cloud.jetpack.com/pricing/?site=[site]&https=off`
    * ^^ this page utilizes the `&https=off` when building the wp-admin url in the "Jetpack Free" card button.


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Original report: p8oabR-F6-p2#comment-5251

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD - comming soon..
*
