### PR TITLE
Calendly block: fix "floating calendar" seen in P2

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-calendly-block-for-p2s
+++ b/projects/plugins/jetpack/changelog/fix-calendly-block-for-p2s
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Calendly block: add target existence check before running init scripts

--- a/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
@@ -171,6 +171,9 @@ function enqueue_calendly_js() {
 		'jetpack-calendly-external-js',
 		"function jetpackInitCalendly( url, elementId ) {
 			function initCalendlyWidget() {
+				if ( ! document.getElementById( elementId ) ) {
+					return;
+				}
 				Calendly.initInlineWidget({
 					url: url,
 					parentElement: document.getElementById( elementId ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

P2s have a compact view feature in which the post content is not rendered. This causes a weird behavior for P2s with posts containing Calendly blocks -- a floating calendar is seen around the footer area (see https://cloudup.com/c7yCvzNO_Ce). This is because the target element the widget script expects is not actually there.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add an existence check for the target element before running the widget init scripts.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Regression test: On non-P2 sites, make sure that the Calendly block still works as expected. 

P2 fix test: On top of the changes here, apply D61128-code to your sandbox, under `wp-content/themes/pub`. D61128 removes a temp workaround for this issue.
