### PR TITLE
WPCOM API: update settings endpoint to store unslashed values for date/time

### DIFF
--- a/projects/plugins/jetpack/changelog/changelog.md
+++ b/projects/plugins/jetpack/changelog/changelog.md
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+udpate the way we save the time and date format on the settings endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -555,6 +555,8 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			if ( ! is_array( $value ) ) {
 				$value = trim( $value );
 			}
+			// preserve the raw value before unslashing the value. The slashes need to be preserved for date and time formats.
+			$raw_value = $value;
 			$value = wp_unslash( $value );
 
 			switch ( $key ) {
@@ -752,8 +754,10 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'date_format':
 				case 'time_format':
 					// settings are stored as strings.
-					if ( update_option( $key, sanitize_text_field( $value ) ) ) {
-						$updated[ $key ] = $value;
+					// raw_value is used to help preserve any escaped characters that might exist in the formatted string.
+					$sanitized_value = sanitize_text_field( $raw_value );
+					if ( update_option( $key, $sanitized_value ) ) {
+						$updated[ $key ] = $sanitized_value;
 					}
 					break;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -557,7 +557,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			}
 			// preserve the raw value before unslashing the value. The slashes need to be preserved for date and time formats.
 			$raw_value = $value;
-			$value = wp_unslash( $value );
+			$value     = wp_unslash( $value );
 
 			switch ( $key ) {
 


### PR DESCRIPTION
See D61035-code

#### Changes proposed in this Pull Request:
*   This PR brings the changes from .com over to Jetpack and fixes the issue for Jetpack sites.

#### Testing instructions:
* Apply this PR to a jetpack site. 
* Change the date or time format setting in the mobile app to use a slash (for example j \d\e F, Y ) ( a character you want to escape) not that the slashes are not escaped but remain. Which produced the expected result. 

#### Does this pull request change what data or activity we track or use?
No

