### PR TITLE
Story Block: Use CSS scale3d() instead of scale()

### DIFF
--- a/projects/plugins/jetpack/changelog/story-block-fix-chrome-1px-border-on-preview
+++ b/projects/plugins/jetpack/changelog/story-block-fix-chrome-1px-border-on-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment: Story Block: Use CSS scale3d() instead of scale()

--- a/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
@@ -35,9 +35,9 @@
 
 	&:hover {
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-		transform: scale(1.03, 1.03);
+		transform: scale3d(1.03, 1.03, 1);
 		figure {
-			transform: scale(1.07, 1.07);
+			transform: scale3d(1.07, 1.07, 1);
 		}
 	}
 


### PR DESCRIPTION
Fixes a minor esthetic bug when displaying story previews on chrome.
Sometimes (usually when the image width is not divisible by 180px (the story preview width)), a story would display with a 1px black column on the right side of the image (can also happen at the bottom).

<img width="532" alt="Screenshot 2021-05-07 at 19 56 05" src="https://user-images.githubusercontent.com/230230/117489770-4ee7a780-af6e-11eb-95d2-3284ae72d9a8.png">

This PR attempts to fix it.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Try creating a story with a rather small image, the issue is also visible on video caption.
You can try this block story template which reproduces the bugs pretty consistently:
```
<!-- wp:jetpack/story {"mediaFiles":[{"alt":"","id":270,"link":"https://alexforcier.wpsandbox.me/small-mp4-2/","type":"file","caption":"","url":"https://videos.files.wordpress.com/VJndghBo/small.mp4","mime":"video/videopress","width":0,"height":0}]} -->
<div class="wp-block-jetpack-story wp-story"></div>
<!-- /wp:jetpack/story -->
```
* Test on chrome, try at different width, hover on the story etc, there should be not black lines on the side.
* Make sure there is no regression on mobile
