### PR TITLE
changelogger: Handle reused branches in non-interactive mode

### DIFF
--- a/.github/files/renovate-helper.sh
+++ b/.github/files/renovate-helper.sh
@@ -90,7 +90,7 @@ for DIR in $(git diff --name-only "$BASE_REF"..."$HEAD_REF" | sed -nE 's!^(proje
 	cd "$DIR"
 
 	ARGS=()
-	ARGS=( add --no-interaction --significance=patch )
+	ARGS=( add --no-interaction --filename-auto-suffix --significance=patch )
 	if [[ "$SLUG" == "plugins/jetpack" ]]; then
 		ARGS+=( --type=other )
 	else

--- a/projects/packages/changelogger/changelog/add-changelogger-filename-dups
+++ b/projects/packages/changelogger/changelog/add-changelogger-filename-dups
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+New option, `--filename-auto-suffix`, to ensure that a reused branch won't prevent entry creation in non-interactive mode.

--- a/projects/packages/changelogger/src/AddCommand.php
+++ b/projects/packages/changelogger/src/AddCommand.php
@@ -77,6 +77,7 @@ class AddCommand extends Command {
 
 		$this->setDescription( 'Adds a change file' )
 			->addOption( 'filename', 'f', InputOption::VALUE_REQUIRED, 'Name for the change file. If not provided, a default will be determined from the current timestamp or git branch name.' )
+			->addOption( 'filename-auto-suffix', null, InputOption::VALUE_NONE, 'If the specified file already exists in non-interactive mode, add a numeric suffix so the new entry can be created.' )
 			->addOption( 'significance', 's', InputOption::VALUE_REQUIRED, "Significance of the change, in the style of semantic versioning. One of the following:\n" . $joiner( self::$significances ) )
 			->addOption( 'type', 't', InputOption::VALUE_REQUIRED, Config::types() ? "Type of change. One of the following:\n" . $joiner( Config::types() ) : 'Normally this would be used to indicate the type of change, but this project does not use types. Do not use.' )
 			->addOption( 'comment', 'c', InputOption::VALUE_REQUIRED, 'Optional comment to include in the file.' )
@@ -190,6 +191,14 @@ EOF
 			} else {
 				if ( null === $input->getOption( 'filename' ) ) {
 					$output->writeln( "Using default filename \"$filename\".", OutputInterface::VERBOSITY_VERBOSE );
+				}
+				if ( file_exists( "$dir/$filename" ) && $input->getOption( 'filename-auto-suffix' ) ) {
+					$i = 2;
+					while ( file_exists( "$dir/$filename#$i" ) ) {
+						$i++;
+					}
+					$output->writeln( "File \"$filename\" already exists. Creating \"$filename#$i\" instead.", OutputInterface::VERBOSITY_VERBOSE );
+					$filename = "$filename#$i";
 				}
 				try {
 					$this->validateFilename( $filename );

--- a/projects/packages/changelogger/tests/php/tests/src/AddCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/AddCommandTest.php
@@ -96,6 +96,39 @@ class AddCommandTest extends CommandTestCase {
 	}
 
 	/**
+	 * Test the try-harder logic for making a filename.
+	 */
+	public function testExecute_autoSuffix() {
+		mkdir( 'changelog' );
+		$tester = $this->getTester( 'add' );
+
+		// Create all the files first.
+		for ( $i = 1; $i < 10; $i++ ) {
+			$code = $tester->execute(
+				array(
+					'--filename'             => 'testing',
+					'--filename-auto-suffix' => true,
+					'--significance'         => 'patch',
+					'--type'                 => 'fixed',
+					'--entry'                => "Testing $i.",
+				),
+				array( 'interactive' => false )
+			);
+			$this->assertSame( 0, $code );
+		}
+
+		// Then validate them all.
+		for ( $i = 1; $i < 10; $i++ ) {
+			$file = 1 === $i ? 'changelog/testing' : "changelog/testing#$i";
+			$this->assertFileExists( $file );
+			$this->assertSame(
+				"Significance: patch\nType: fixed\n\nTesting $i.\n",
+				file_get_contents( $file )
+			);
+		}
+	}
+
+	/**
 	 * Test the command.
 	 *
 	 * @dataProvider provideExecute


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
If changelogger is being used non-interactively, it may be that the
branch name is being reused and so the automatic filename would result
in an error.

Add a command line option that indicates that this is expected and a
numeric suffix should automatically be added to avoid an error.

We don't do this in interactive mode. When a human is using the tool,
they should be informed and allowed to choose an alternative file name.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge, then trigger renovate to run again on #19786. Or manually reproduce what's happening there that makes the "Amend renovate PR" job fail.