### PR TITLE
Ensure VideoPress mime-type is set when updating meta

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ensure-correct-mime-type-on-videopress-updates
+++ b/projects/plugins/jetpack/changelog/update-ensure-correct-mime-type-on-videopress-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Ensure video/videopress mime type is set on attachments when a videopress update xmlrpc call is received

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-xmlrpc.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-xmlrpc.php
@@ -113,7 +113,8 @@ class VideoPress_XMLRPC {
 			return false;
 		}
 
-		$attachment->guid = $info['original'];
+		$attachment->guid           = $info['original'];
+		$attachment->post_mime_type = 'video/videopress';
 
 		wp_update_post( $attachment );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This change fixes a case in the Atomic flow where attachments uploaded to a site before it goes atomic would be missing the VideoPress options in the media library video item. This is caused because the `post_mime_type` in wpcom is set to `video/quicktime` instead of `video/videopress` and that metadata is copied over as-is when the site is made Atomic. Other metadata is missing as well in this process, and calling the `jetpack.updateVideoPressMediaItem` xmlrpc function back-fills all of the required metadata except for the mime type, which is what this PR adds. Once this change is released it will allow the fix in D60437-code to set the values correctly on Atomic transfer and back-fill attachments for sites affected by this issue.

#### Changes proposed in this Pull Request:
* When video meta is updated by a wpcom xmlrpc call, ensure the `post_mime_type` is also set to the videopress mime type `video/videopress` to allow attachment checks to pass in the rest of the codebase and treat the attachment like a videopress file (for example: show appropriate options in media library). 


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Atomic discussion p9o2xV-1mi-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Note: There is no particular Jetpack-only issue being resolved here, so all we can do is test that VideoPress uploads continue to work as expected when the xmlrpc call is made (`jetpack.updateVideoPressMediaItem` gets called multiple times during the transcode process, once for each format being transcoded)

* Ensure you have a Jetpack plan that allows VideoPress uploads, and that Video Upgrade is enabled
* Upload a new video to the media library
* Once the video has completed uploading, Open the video in the Media Library and ensure the `File Type` is still `video/videopress` and that all videopress options are available in the side bar.