### PR TITLE
Remove post authorization from package

### DIFF
--- a/projects/packages/connection/changelog/update-remove_post_authorization_from_package
+++ b/projects/packages/connection/changelog/update-remove_post_authorization_from_package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove do_post_authorization routine and add a hook instead

--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -490,7 +490,12 @@ class Jetpack_XMLRPC_Server {
 
 		( new Tokens() )->update_user_token( $user->ID, sprintf( '%s.%d', $token, $user->ID ), true );
 
-		$this->do_post_authorization();
+		/**
+		 * Hook fired at the end of the jetpack.remoteConnect XML-RPC callback
+		 *
+		 * @since 9.8.0
+		 */
+		do_action( 'jetpack_remote_connect_end' );
 
 		return $this->connection->has_connected_owner();
 	}
@@ -778,20 +783,6 @@ class Jetpack_XMLRPC_Server {
 				'post_parent' => $parent_id,
 			)
 		);
-	}
-
-	/**
-	 * Handles authorization actions after connecting a site, such as enabling modules.
-	 *
-	 * This do_post_authorization() is used in this class, as opposed to calling
-	 * Jetpack::handle_post_authorization_actions() directly so that we can mock this method as necessary.
-	 *
-	 * @return void
-	 */
-	public function do_post_authorization() {
-		/** This filter is documented in class.jetpack-cli.php */
-		$enable_sso = apply_filters( 'jetpack_start_enable_sso', true );
-		Jetpack::handle_post_authorization_actions( $enable_sso, false, false );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test_jetpack_xmlrpc_server.php
+++ b/projects/packages/connection/tests/php/test_jetpack_xmlrpc_server.php
@@ -292,7 +292,7 @@ class Jetpack_XMLRPC_Server_Test extends BaseTestCase {
 			)
 		);
 
-		$server   = $this->get_mocked_xmlrpc_server();
+		$server   = new Jetpack_XMLRPC_Server();
 		$response = $server->remote_connect(
 			array(
 				'nonce'      => '1234',
@@ -322,7 +322,7 @@ class Jetpack_XMLRPC_Server_Test extends BaseTestCase {
 			)
 		);
 
-		$server   = $this->get_mocked_xmlrpc_server();
+		$server   = new Jetpack_XMLRPC_Server();
 		$response = $server->remote_connect(
 			array(
 				'nonce'      => '1234',
@@ -418,24 +418,4 @@ class Jetpack_XMLRPC_Server_Test extends BaseTestCase {
 		return $xml;
 	}
 
-	/**
-	 * Get a mocked XMLRPC server.
-	 *
-	 * @return Jetpack_XMLRPC_Server
-	 */
-	protected function get_mocked_xmlrpc_server() {
-		$server = $this->getMockBuilder( 'Jetpack_XMLRPC_Server' )
-			->setMethods(
-				array(
-					'do_post_authorization',
-				)
-			)
-			->getMock();
-
-		$server->expects( $this->any() )
-			->method( 'do_post_authorization' )
-			->will( $this->returnValue( true ) );
-
-		return $server;
-	}
 }

--- a/projects/plugins/jetpack/changelog/update-remove_post_authorization_from_package
+++ b/projects/plugins/jetpack/changelog/update-remove_post_authorization_from_package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Hook into the Connection package remote_connect to perform Jetpack specific routines

--- a/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
+++ b/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
@@ -21,6 +21,7 @@ class Jetpack_XMLRPC_Methods {
 	public static function init() {
 		add_filter( 'jetpack_xmlrpc_unauthenticated_methods', array( __CLASS__, 'xmlrpc_methods' ) );
 		add_filter( 'jetpack_xmlrpc_test_connection_response', array( __CLASS__, 'test_connection' ) );
+		add_action( 'jetpack_remote_connect_end', array( __CLASS__, 'remote_connect_end' ) );
 	}
 
 	/**
@@ -193,5 +194,17 @@ class Jetpack_XMLRPC_Methods {
 			(string) $nonce,
 			(string) $hmac,
 		);
+	}
+
+	/**
+	 * Hooks into the remote_connect XMLRPC endpoint and triggers Jetpack::handle_post_authorization_actions
+	 *
+	 * @since 9.8.0
+	 * @return void
+	 */
+	public static function remote_connect_end() {
+		/** This filter is documented in class.jetpack-cli.php */
+		$enable_sso = apply_filters( 'jetpack_start_enable_sso', true );
+		Jetpack::handle_post_authorization_actions( $enable_sso, false, false );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/test_class.jetpack-xmlrpc-server.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.jetpack-xmlrpc-server.php
@@ -103,4 +103,47 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Asserts that the jetpack_remote_connect_end is properly hooked
+	 */
+	public function test_remote_connect_hook() {
+
+		$xml = $this->getMockBuilder( 'Jetpack_IXR_Client' )
+			->setMethods(
+				array(
+					'query',
+					'isError',
+					'getResponse',
+				)
+			)
+			->getMock();
+
+		$xml->expects( $this->exactly( 1 ) )
+			->method( 'query' )
+			->will( $this->returnValue( 'sadlkjdasd.sadlikdj' ) );
+
+		$xml->expects( $this->exactly( 1 ) )
+			->method( 'isError' )
+			->will( $this->returnValue( empty( $error ) ? false : true ) );
+
+		$xml->expects( $this->exactly( 1 ) )
+			->method( 'getResponse' )
+			->will( $this->returnValue( 'asdadsasd' ) );
+
+		$server = new Jetpack_XMLRPC_Server();
+
+		$this->assertSame( 10, has_action( 'jetpack_remote_connect_end', array( 'Jetpack_XMLRPC_Methods', 'remote_connect_end' ) ), 'Action jetpack_remote_connect_end not hooked' );
+
+		$server->remote_connect(
+			array(
+				'nonce'      => '1234',
+				'local_user' => self::$xmlrpc_admin,
+			),
+			$xml
+		);
+
+		$this->assertSame( 1, did_action( 'jetpack_remote_connect_end' ), 'Action was not fired' );
+
+	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of the Package Independence effort, removes the routine that runs after `remote_connect` from the Connection package and use a hook in the plugin to do it instead

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the routine that runs after `remote_connect` from the Connection package and use a hook in the plugin to do it instead

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1199702491434901-as-1199702491434919

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Look at the code
* Tests are passing?
* Not sure how to test the real thing. Do you think that's enough?
* Do you think we should deprecate `do_post_authorization` method instead of deleting it? Nobody should be using it...