### PR TITLE
Instant Search: add 'open when user submits the form' overlay trigger

### DIFF
--- a/projects/plugins/jetpack/changelog/add-search-overlay-trigger-submit
+++ b/projects/plugins/jetpack/changelog/add-search-overlay-trigger-submit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Instant Search: add 'open when user submits the form' overlay trigger

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -139,8 +139,9 @@ class Jetpack_Search_Customize {
 				'section'     => $section_id,
 				'type'        => 'select',
 				'choices'     => array(
-					'immediate' => __( 'Open when the user starts typing', 'jetpack' ),
+					'immediate' => __( 'Open when user starts typing', 'jetpack' ),
 					'results'   => __( 'Open when results are available', 'jetpack' ),
+					'submit'    => __( 'Open when user submits the form', 'jetpack' ),
 				),
 			)
 		);

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -210,10 +210,16 @@ class SearchApp extends Component {
 			return;
 		}
 
+		if ( this.state.overlayOptions.overlayTrigger === 'submit' ) {
+			return;
+		}
+
 		this.props.setSearchQuery( event.target.value );
+
 		if ( this.state.overlayOptions.overlayTrigger === 'immediate' ) {
 			this.showResults();
 		}
+
 		if ( this.state.overlayOptions.overlayTrigger === 'results' ) {
 			this.props.response?.results && this.showResults();
 		}
@@ -291,6 +297,7 @@ class SearchApp extends Component {
 		if ( this.props.hasActiveQuery && ! this.state.showResults ) {
 			this.showResults();
 		}
+
 		if ( ! this.props.hasActiveQuery && isHistoryNav ) {
 			this.hideResults( isHistoryNav );
 		}


### PR DESCRIPTION
A possible alternative to https://github.com/Automattic/jetpack/pull/19325, which proposes removing the overlay trigger setting altogether.

There are three situations I know of where the existing overlay triggers provide a poor experience:
* Entering a first search character with an input method editor (IME) unexpectedly opens the modal during composition (working on this in https://github.com/Automattic/jetpack/pull/19771)
* Entering an accented character like é at the beginning of a search can unexpectedly open the modal with the wrong character (e)
* In general, the modal opening can feel jarring because there is no visual cue to indicate the modal is coming when you start typing.

If I installed Search on my own site, this is the way I'd want it to behave:
* Clicking a search button opens the modal
* Pressing enter in the input opens the modal
* Search results are only "instant" once the modal is open

This PR adds this as an overlay trigger option.

#### Changes proposed in this Pull Request:
* Add a new overlay trigger for Instant Search called "submit". This only opens the overlay when a user submits the search form or clicks a search button.

<img width="300" alt="Screen Shot 2021-05-10 at 15 34 00" src="https://user-images.githubusercontent.com/17325/117603204-a2443a80-b1a6-11eb-86b3-b97343ff32c6.png">

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On a test site with a Jetpack Search plan, go to the Customizer > Jetpack Search in wp-admin.
* Choose the overlay trigger "Open when user submits the form".
* Return to the front end of the site. Ensure that either clicking a search button or pressing enter in a search input display the search overlay/modal. Ensure that typing a search query alone does not trigger the overlay.
