### PR TITLE
SEO Tools: add SEOPress to the list of fellow SEO plugins

### DIFF
--- a/projects/plugins/jetpack/changelog/add-seopress-seo-tools-list
+++ b/projects/plugins/jetpack/changelog/add-seopress-seo-tools-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+SEO Tools: add SEOPress to the list of fellow SEO plugins.

--- a/projects/plugins/jetpack/modules/seo-tools.php
+++ b/projects/plugins/jetpack/modules/seo-tools.php
@@ -24,6 +24,8 @@ $jetpack_seo_conflicting_plugins = array(
 	'seo-by-rank-math/rank-math.php',
 	'autodescription/autodescription.php',
 	'slim-seo/slim-seo.php',
+	'wp-seopress/seopress.php',
+	'wp-seopress-pro/seopress-pro.php',
 );
 
 foreach ( $jetpack_seo_conflicting_plugins as $seo_plugin ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿Let's add SEOPress (both the free and paid versions)  to the list of fellow SEO plugins, that should stop our SEO tools from activating.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start on a connected Jetpack site.
* Under Jetpack > Settings > Traffic, enable SEO Tools.
* Customize some of the settings.
* Ensure the settings are visible on the frontend.
* Install and activate the SEOPress plugin.
* Verify that Jetpack's SEO customizations are no longer visible on the frontend.
