### PR TITLE
Add back build-jetpack-concurrently script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"build": "yarn install-if-deps-outdated && yarn clean && yarn build-php && yarn build-packages && yarn build-jetpack",
 		"build-concurrently": "yarn install-if-deps-outdated && yarn clean && yarn concurrently 'yarn build-php' 'yarn build-packages' 'yarn build-jetpack-concurrently'",
 		"build-jetpack": "cd projects/plugins/jetpack && yarn build",
-		"build-jetpack-backup": "cd projects/plugins/backup && yarn build",
+		"build-jetpack-concurrently": "cd projects/plugins/jetpack && yarn build-concurrently",
 		"build-packages": "echo 'Deprecated: Please use the command: jetpack build packages' && yarn jetpack build packages",
 		"build-php": "composer install --ignore-platform-reqs",
 		"build-production": "yarn distclean && yarn install --production=false && yarn build-production-php && yarn build-production-packages && yarn build-production-jetpack",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add back `build-jetpack-concurrently`, was accidentally removed in 3599b20dce6f556f78d6aa9509eb6913f40744bf
* Removes `build-jetpack-backup`

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

* Not much to test, the `build-concurrently` script should now run without error since `build-jetpack-concurrently` has been restored.