### PR TITLE
Docs: update changelogger mentions to use the CLI tool

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -267,9 +267,9 @@ The body is separated from the headers by a blank line, and is the text that act
 
 ### Using the Jetpack Changelogger
 
-The changelogger tool is dev-required by each project via Composer, and after `composer install` may be run to interactively add a change file using:
+The changelogger tool can be used via [Jetpack's CLI tool](#first-time). You may use the following command to generate changelog entries for each project that needs one:
 
-`vendor/bin/changelogger add`
+`jetpack changelog add`
 
 **Does it matter what the change file is named?** Starting the file name with `.` should not be used. Also consider avoiding names that have extensions like `.php` or `.js` to avoid confusing other tools.
 

--- a/projects/github-actions/repo-gardening/changelog/update-docs-changelogger-in-monorepo
+++ b/projects/github-actions/repo-gardening/changelog/update-docs-changelogger-in-monorepo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Check Description task: update changelogger instructions to recommend the use of the CLI tool.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -385,7 +385,7 @@ My PR adds *x* and *y*.
 			'`, `'
 		) }\`
 
-Go to that project and use \`vendor/bin/changelogger add\` to add a change file.
+Use [the Jetpack CLI tool](https://github.com/Automattic/jetpack/blob/master/docs/monorepo.md#first-time) to generate changelog entries by running the following command: \`jetpack changelog add\`.
 Guidelines: [/docs/writing-a-good-changelog-entry.md](https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md)
 `,
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Now that we have the CLI tool as a wrapper, let's encourage folks to use it:
- In the main docs
- In the comment from the GitHub action

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Check for typos.
