### PR TITLE
tools: Avoid `composer update --root-reqs` in more places

### DIFF
--- a/tools/check-composer-deps.sh
+++ b/tools/check-composer-deps.sh
@@ -127,7 +127,7 @@ for SLUG in "${SLUGS[@]}"; do
 			cd "$BASE/projects/$SLUG"
 			debug "Updating $SLUG composer.lock"
 			OLD="$(<composer.lock)"
-			composer update --root-reqs --quiet
+			"$BASE/tools/composer-update-monorepo.sh" --quiet "$SLUG"
 			if [[ "$OLD" != "$(<composer.lock)" ]] && ! $DIDCL; then
 				info "Creating changelog entry for $SLUG composer.lock update"
 				changelogger "$SLUG" '' 'Updated composer.lock.'

--- a/tools/composer-update-monorepo.sh
+++ b/tools/composer-update-monorepo.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+BASE=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+. "$BASE/tools/includes/check-osx-bash-version.sh"
+. "$BASE/tools/includes/chalk-lite.sh"
+
+function usage {
+	cat <<-EOH
+		usage: $0 [options] <dir>
+
+		Updates all monorepo packages for the project in the specified directory.
+		If \`--root-reqs\` is passed, also updates its root reqs.
+
+		Most options accepted by \`composer update\` are accepted to pass on
+		to composer while updating dependencies.
+	EOH
+	exit 1
+}
+
+function check_dir {
+	if [[ ! -z "$DIR" ]]; then
+		error "Only one directory may be specified."
+		return 1
+	elif [[ -d "$1" ]]; then
+		DIR="${1%/}"
+	elif [[ "$1" == "*/composer.json" && -f "$1" ]]; then # DWIM
+		DIR="$(dirname "$1")"
+	elif [[ "$1" == "*/composer.lock" && -f "$1" ]]; then # DWIM
+		DIR="$(dirname "$1")"
+	else
+		error "Directory $1 does not exist."
+		return 1
+	fi
+	if [[ ! -f "$DIR/composer.json" ]]; then
+		error "$DIR does not contain composer.json."
+		return 1
+	fi
+	if [[ ! -f "$DIR/composer.lock" ]]; then
+		error "$DIR does not contain composer.lock."
+		return 1
+	fi
+}
+
+COMPOSER_ARGS=()
+ROOT_REQS=false
+while [[ $# -gt 0 ]]; do
+	arg="$1"
+	shift
+	case $arg in
+		-h|--help)
+			usage
+			exit
+			;;
+		-V|--version|-d|--working-dir|--working-dir=*)
+			die "Cannot pass $arg on to composer."
+			;;
+		--root-reqs)
+			ROOT_REQS=true
+			;;
+		--)
+			while [[ $# -gt 0 ]]; do
+				check_dir "$1"
+				shift
+			done
+			;;
+		-*)
+			COMPOSER_ARGS+=( "$arg" )
+			;;
+		*)
+			check_dir "$arg"
+			;;
+	esac
+done
+if [[ -z "$DIR" ]]; then
+	usage
+fi
+
+TO_UPDATE=()
+mapfile -t TO_UPDATE < <(
+	(
+		composer info --working-dir="$DIR" --locked --name-only | sed -e 's/ *$//' | grep --fixed-strings --line-regexp --file=<( jq -r '.name' "$BASE"/projects/packages/*/composer.json )
+		if $ROOT_REQS; then
+			composer info --working-dir="$DIR" --locked --direct --name-only | sed -e 's/ *$//'
+		fi
+	) | sort -u
+)
+COMPOSER_ROOT_VERSION=dev-master composer update "${COMPOSER_ARGS[@]}" --working-dir="$DIR" -- "${TO_UPDATE[@]}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In tools/check-composer-deps.sh and the CI lockfile check, we were using
`composer update --root-reqs` to try to update monorepo packages in
composer.lock.

But that fails to update monorepo packages that are depended on
indirectly. What we need to do is pass the list of all monorepo packages
(and the root reqs) to `composer update` so it can update those and only
those.

Since the code to properly determine that list is somewhat complicated,
let's wrap it in a script.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1620666192013600-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a shallow clone of this PR: `git clone --branch=fix/composer-update-root-reqs --depth=1 git@github.com:Automattic/jetpack.git /tmp/jetpack`
* Change to the clone directory: `cd /tmp/jetpack`
* Bump the version number of packages/status: `composer config --working-dir=projects/packages/status extra.branch-alias.dev-master 1.8.x-dev`
* Run `.github/files/check-lock-files.sh`.
  * It should report a problem in plugins/backup and recommend running `tools/composer-update-monorepo.sh --root-reqs "projects/plugins/backup"`.
  * It should **not** fail with a "Your requirements could not be resolved to an installable set of packages" error.
* Run `tools/composer-update-monorepo.sh --root-reqs "projects/plugins/backup"` as recommended.
  * It should update `projects/plugins/backup/composer.lock` with the new version for packages/status.