### PR TITLE
Add and use filter to remote_register redirect uri

### DIFF
--- a/projects/packages/connection/changelog/update-filter_remote_register_redirect_uri
+++ b/projects/packages/connection/changelog/update-filter_remote_register_redirect_uri
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Package Independence: Add a filter to the remote_uri returned by remote_register XMLRPC method

--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -376,20 +376,14 @@ class Jetpack_XMLRPC_Server {
 
 		$site_icon = get_site_icon_url();
 
-		$auto_enable_sso = ( ! $this->connection->has_connected_owner() || Jetpack::is_module_active( 'sso' ) );
-
-		/** This filter is documented in class.jetpack-cli.php */
-		if ( apply_filters( 'jetpack_start_enable_sso', $auto_enable_sso ) ) {
-			$redirect_uri = add_query_arg(
-				array(
-					'action'      => 'jetpack-sso',
-					'redirect_to' => rawurlencode( admin_url() ),
-				),
-				wp_login_url() // TODO: come back to Jetpack dashboard?
-			);
-		} else {
-			$redirect_uri = admin_url();
-		}
+		/**
+		 * Filters the Redirect URI returned by the remote_register XMLRPC method
+		 *
+		 * @param string $redirect_uri The Redirect URI
+		 *
+		 * @since 9.8.0
+		 */
+		$redirect_uri = apply_filters( 'jetpack_xmlrpc_remote_register_redirect_uri', admin_url() );
 
 		// Generate secrets.
 		$roles   = new Roles();

--- a/projects/plugins/jetpack/changelog/update-filter_remote_register_redirect_uri
+++ b/projects/plugins/jetpack/changelog/update-filter_remote_register_redirect_uri
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Connection package independence: Filters the remote_register XMLRPC endpoint redirect URI

--- a/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
+++ b/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
@@ -24,7 +24,7 @@ class Jetpack_XMLRPC_Methods {
 		add_filter( 'jetpack_remote_xmlrpc_provision_response', array( __CLASS__, 'remote_provision_response' ), 10, 2 );
 		add_action( 'jetpack_xmlrpc_server_event', array( __CLASS__, 'jetpack_xmlrpc_server_event' ), 10, 4 );
 		add_action( 'jetpack_remote_connect_end', array( __CLASS__, 'remote_connect_end' ) );
-		add_action( 'jetpack_xmlrpc_remote_register_redirect_uri', array( __CLASS__, 'remote_register_redirect_uri' ) );
+		add_filter( 'jetpack_xmlrpc_remote_register_redirect_uri', array( __CLASS__, 'remote_register_redirect_uri' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
+++ b/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
@@ -22,6 +22,7 @@ class Jetpack_XMLRPC_Methods {
 		add_filter( 'jetpack_xmlrpc_unauthenticated_methods', array( __CLASS__, 'xmlrpc_methods' ) );
 		add_filter( 'jetpack_xmlrpc_test_connection_response', array( __CLASS__, 'test_connection' ) );
 		add_action( 'jetpack_remote_connect_end', array( __CLASS__, 'remote_connect_end' ) );
+		add_action( 'jetpack_xmlrpc_remote_register_redirect_uri', array( __CLASS__, 'remote_register_redirect_uri' ) );
 	}
 
 	/**
@@ -206,5 +207,30 @@ class Jetpack_XMLRPC_Methods {
 		/** This filter is documented in class.jetpack-cli.php */
 		$enable_sso = apply_filters( 'jetpack_start_enable_sso', true );
 		Jetpack::handle_post_authorization_actions( $enable_sso, false, false );
+	}
+
+	/**
+	 * Filters the Redirect URI returned by the remote_register XMLRPC method
+	 *
+	 * @since 9.8.0
+	 *
+	 * @param string $redirect_uri The Redirect URI.
+	 * @return string
+	 */
+	public static function remote_register_redirect_uri( $redirect_uri ) {
+		$auto_enable_sso = ( ! ( new Connection_Manager() )->has_connected_owner() || Jetpack::is_module_active( 'sso' ) );
+
+		/** This filter is documented in class.jetpack-cli.php */
+		if ( apply_filters( 'jetpack_start_enable_sso', $auto_enable_sso ) ) {
+			$redirect_uri = add_query_arg(
+				array(
+					'action'      => 'jetpack-sso',
+					'redirect_to' => rawurlencode( admin_url() ),
+				),
+				wp_login_url() // TODO: come back to Jetpack dashboard?
+			);
+		}
+
+		return $redirect_uri;
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/test_class.jetpack-xmlrpc-server.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.jetpack-xmlrpc-server.php
@@ -146,4 +146,38 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Tests if the remote_register redirect uri is being filtered
+	 */
+	public function test_remote_register_redirect_uri_filter() {
+		$request = array(
+			'local_user' => 1,
+		);
+
+		// The filter should modify the URI because there's no Connection owner.  (see conditions in Jetpack_XMLRPC_Methods::remote_register_redirect_uri).
+		$response     = ( new Jetpack_XMLRPC_Server() )->remote_provision( $request );
+		$expected_uri = Jetpack_XMLRPC_Methods::remote_register_redirect_uri( 'dummy' );
+
+		$this->assertNotSame( 'dummy', $expected_uri );
+		$this->assertSame( $expected_uri, $response['redirect_uri'] );
+	}
+
+	/**
+	 * Tests if the remote_register redirect uri is not being filtered when conditions do not apply
+	 */
+	public function test_remote_register_redirect_uri_filter_not_applied() {
+		$request = array(
+			'local_user' => 1,
+		);
+
+		( new Tokens() )->update_user_token( 1, 'asd.qwe.1', true );
+
+		// The filter should not modify the URI because there's a Connection owner and sso is not enabled. (see conditions in Jetpack_XMLRPC_Methods::remote_register_redirect_uri).
+		$response         = ( new Jetpack_XMLRPC_Server() )->remote_provision( $request );
+		$not_expected_uri = Jetpack_XMLRPC_Methods::remote_register_redirect_uri( 'dummy' );
+
+		$this->assertSame( 'dummy', $not_expected_uri );
+		$this->assertNotSame( $not_expected_uri, $response['redirect_uri'] );
+	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of the Connection Independece efforts.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a filter to the Remote URI returned by the remote_register XMLRPC method, and move the Jetpack specific modification into the plugin

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1199702491434901-as-1199702491434919

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Look at the code
* Check the tests are working as expected