### PR TITLE
Admin: ensure Jetpack settings can be accessed in Offline mode.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/masthead/header-nav.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/header-nav.jsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React, { useCallback } from 'react';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
+import {
+	getSiteConnectionStatus,
+	hasConnectedOwner as hasConnectedOwnerSelector,
+	isCurrentUserLinked as isCurrentUserLinkedSelector,
+	isSiteRegistered,
+} from 'state/connection';
+import { userCanEditPosts, userCanManageOptions } from 'state/initial-state';
+import { getActiveModules } from 'state/modules';
+
+const HeaderNavComponent = props => {
+	const {
+		activeModules,
+		canEditPosts,
+		canManageOptions,
+		hasConnectedOwner,
+		isCurrentUserLinked,
+		isSiteConnected,
+		location = { pathname: '' },
+		siteConnectionStatus,
+	} = props;
+
+	const { pathname } = location;
+
+	const isDashboardView =
+		[ '/', '/dashboard', '/my-plan', '/plans' ].includes( pathname ) ||
+		pathname.includes( '/recommendations' );
+	const isStatic = '' === pathname;
+
+	const onTrackDashClick = useCallback( () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'masthead',
+			path: 'nav_dashboard',
+		} );
+	}, [] );
+
+	const onTrackSettingsClick = useCallback( () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'masthead',
+			path: 'nav_settings',
+		} );
+	}, [] );
+
+	if ( isStatic ) {
+		return null;
+	}
+
+	if ( ! siteConnectionStatus ) {
+		return null;
+	}
+
+	/**
+	 * Determine whether a user can access the Jetpack Settings page.
+	 *
+	 * Rules are:
+	 * - We're not on the /setup page route
+	 * - user is allowed to see the Jetpack Admin
+	 * - site is connected or in offline mode
+	 * - non-admins only need access to the settings when there are modules they can manage.
+	 */
+	if ( pathname.startsWith( '/setup' ) ) {
+		return null;
+	}
+
+	if ( ! canEditPosts ) {
+		return null;
+	}
+
+	if ( siteConnectionStatus !== 'offline' && ! isSiteConnected ) {
+		return null;
+	}
+
+	if ( siteConnectionStatus !== 'offline' && ! canManageOptions ) {
+		if ( ! hasConnectedOwner ) {
+			return null;
+		}
+
+		if ( ! isCurrentUserLinked ) {
+			return null;
+		}
+
+		// Are there any modules accessible by non-admins active?
+		const activeNonAdminModules = activeModules.some( module =>
+			[ 'post-by-email', 'publicize' ].includes( module )
+		);
+
+		if ( ! activeNonAdminModules ) {
+			return null;
+		}
+	}
+
+	return (
+		<div className="jp-masthead__nav">
+			<ButtonGroup>
+				<Button
+					compact={ true }
+					href="#/dashboard"
+					primary={ isDashboardView && ! isStatic }
+					onClick={ onTrackDashClick }
+				>
+					{ __( 'Dashboard', 'jetpack' ) }
+				</Button>
+				<Button
+					compact={ true }
+					href="#/settings"
+					primary={ ! isDashboardView && ! isStatic }
+					onClick={ onTrackSettingsClick }
+				>
+					{ __( 'Settings', 'jetpack' ) }
+				</Button>
+			</ButtonGroup>
+		</div>
+	);
+};
+
+const HeaderNav = connect( state => {
+	return {
+		canEditPosts: userCanEditPosts( state ),
+		canManageOptions: userCanManageOptions( state ),
+		hasConnectedOwner: hasConnectedOwnerSelector( state ),
+		isCurrentUserLinked: isCurrentUserLinkedSelector( state ),
+		isSiteConnected: isSiteRegistered( state ),
+		activeModules: getActiveModules( state ),
+		siteConnectionStatus: getSiteConnectionStatus( state ),
+	};
+} )( HeaderNavComponent );
+
+export { HeaderNav };

--- a/projects/plugins/jetpack/_inc/client/components/masthead/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/index.jsx
@@ -3,44 +3,20 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import Button from 'components/button';
-import ButtonGroup from 'components/button-group';
+import { HeaderNav } from './header-nav';
 import {
 	getSiteConnectionStatus,
 	getSandboxDomain,
 	fetchSiteConnectionTest,
-	hasConnectedOwner as hasConnectedOwnerSelector,
-	isSiteRegistered,
 } from 'state/connection';
-import { getCurrentVersion, userCanEditPosts, userCanManageOptions } from 'state/initial-state';
 import JetpackLogo from '../jetpack-logo';
 
 export class Masthead extends React.Component {
-	static defaultProps = {
-		location: { pathname: '' },
-	};
-
-	trackDashClick = () => {
-		analytics.tracks.recordJetpackClick( {
-			target: 'masthead',
-			path: 'nav_dashboard',
-		} );
-	};
-
-	trackSettingsClick = () => {
-		analytics.tracks.recordJetpackClick( {
-			target: 'masthead',
-			path: 'nav_settings',
-		} );
-	};
-
 	trackLogoClick = () => {
 		analytics.tracks.recordJetpackClick( {
 			target: 'masthead',
@@ -53,15 +29,7 @@ export class Masthead extends React.Component {
 	};
 
 	render() {
-		const {
-			canEditPosts,
-			canManageOptions,
-			hasConnectedOwner,
-			isSiteConnected,
-			location: { pathname },
-			sandboxDomain,
-			siteConnectionStatus,
-		} = this.props;
+		const { sandboxDomain, siteConnectionStatus } = this.props;
 
 		const offlineNotice = siteConnectionStatus === 'offline' ? <code>Offline Mode</code> : '',
 			sandboxedBadge = sandboxDomain ? (
@@ -77,27 +45,7 @@ export class Masthead extends React.Component {
 				</code>
 			) : (
 				''
-			),
-			isDashboardView =
-				includes( [ '/', '/dashboard', '/my-plan', '/plans' ], pathname ) ||
-				pathname.includes( '/recommendations' ),
-			isStatic = '' === pathname;
-
-		/*
-		 * Determine whether a user can access the Jetpack Settings page.
-		 *
-		 * Rules are:
-		 * - We're not on the /setup page route
-		 * - user is allowed to see the Jetpack Admin
-		 * - site is connected or in offline mode
-		 * - if the site is connected but doesn't have a connected user, only show to admins.
-		 */
-		const canAccessSettings =
-			! pathname.startsWith( '/setup' ) &&
-			canEditPosts &&
-			( siteConnectionStatus === 'offline' ||
-				( isSiteConnected && hasConnectedOwner ) ||
-				( isSiteConnected && ! hasConnectedOwner && canManageOptions ) );
+			);
 
 		return (
 			<div className="jp-masthead">
@@ -109,30 +57,7 @@ export class Masthead extends React.Component {
 						{ offlineNotice }
 						{ sandboxedBadge }
 					</div>
-					{ canAccessSettings && (
-						<div className="jp-masthead__nav">
-							{ ! isStatic && siteConnectionStatus && (
-								<ButtonGroup>
-									<Button
-										compact={ true }
-										href="#/dashboard"
-										primary={ isDashboardView && ! isStatic }
-										onClick={ this.trackDashClick }
-									>
-										{ __( 'Dashboard', 'jetpack' ) }
-									</Button>
-									<Button
-										compact={ true }
-										href="#/settings"
-										primary={ ! isDashboardView && ! isStatic }
-										onClick={ this.trackSettingsClick }
-									>
-										{ __( 'Settings', 'jetpack' ) }
-									</Button>
-								</ButtonGroup>
-							) }
-						</div>
-					) }
+					<HeaderNav location={ this.props.location } />
 				</div>
 			</div>
 		);
@@ -142,11 +67,6 @@ export class Masthead extends React.Component {
 export default connect(
 	state => {
 		return {
-			canEditPosts: userCanEditPosts( state ),
-			canManageOptions: userCanManageOptions( state ),
-			currentVersion: getCurrentVersion( state ),
-			hasConnectedOwner: hasConnectedOwnerSelector( state ),
-			isSiteConnected: isSiteRegistered( state ),
 			sandboxDomain: getSandboxDomain( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 		};

--- a/projects/plugins/jetpack/_inc/client/state/modules/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/modules/reducer.js
@@ -196,6 +196,18 @@ export function getModules( state ) {
 }
 
 /**
+ * Returns an array of module slugs for all active modules on the site.
+ *
+ * @param  {object} state - Global state tree
+ * @returns {Array}         Array of module slugs.
+ */
+export function getActiveModules( state ) {
+	return Object.keys( state.jetpack.modules.items ).filter(
+		module_slug => state.jetpack.modules.items[ module_slug ].activated
+	);
+}
+
+/**
  * Returns a module object by its name as present in the state
  * @param  {Object} state Global state tree
  * @param  {String}  name module name

--- a/projects/plugins/jetpack/changelog/fix-settings-access-offline-mode
+++ b/projects/plugins/jetpack/changelog/fix-settings-access-offline-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: ensure that the Jetpack settings page can be accessed when using Jetpack's Offline mode.


### PR DESCRIPTION
Fixes #19814

#### Changes proposed in this Pull Request:

This is a follow-up from #19714.

This PR does 3 things:

1. It refactors / extracts the access check used to add the Settings submenu, so it's more readable now that we have multiple conditions.
2. It adds that submenu when folks use Offline mode.
3. It applies a similar logic (and refactors into its own component to help readability) to the navigation menu that is shown in the Jetpack dashboard pages.

![image](https://user-images.githubusercontent.com/426388/117810709-0840c880-b260-11eb-986f-acb36eb56565.png)

**Note**: there are a number of conditions here, I think I caught them all but would really appreciate if y'all could tell me if things are more readable / easier to understand with this new implementation. If that's only more readable for me, then that's not very useful :) 

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

1. Start with a fresh Jetpack site, not connected to WordPress.com.
1. You should not see the Settings submenu under the Jetpack menu.
1. Enable offline mode, either via the Constants menu page on JN, or via `define( 'JETPACK_DEV_DEBUG', true );` on your own dev env.
1. Now you should see both the Settings submenu, and when going to Jetpack > Dashboard, you should see the navigation menu at the top of the page.
1. Disable Offline mode.
1. Connect your site to WordPress.com, **but not your user**.
1. You should now see the submenu and the navigation menu.
1. Go to Users > Add New, and create a new Editor user.
1. In a new browser, log in with that editor.
1. You should not see the Settings submenu nor the navigation menu.
1. Back in your original browser, connect your user to your WordPress.com account.
1. You should now see the submenu and the navigation menu.
1. In the other browser, the editor user should still not see the nav menu.
1. Connect that editor user to its own WordPress.com account.
1. After connection, you should still not see the nav menu yet.
1. Back in your original browser with your admin menu, activate either Publicize or Post By Email.
1. In the editor's browser, you should now see the submenu and the navigation menu.
