### PR TITLE
CSS Tidy Fix broken linting ignore comment

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-css-tidy-linting-issue
+++ b/projects/plugins/jetpack/changelog/fix-css-tidy-linting-issue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor linting comment fix
+
+

--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -1624,7 +1624,7 @@ class Jetpack_Safe_CSS {
 		$csstidy->set_cfg( 'css_level', 'CSS3.0' );
 
 		// Turn off css shorthands when in block editor context as it breaks block validation.
-		if ( true === isset( $_REQUEST['_gutenberg_nonce'] ) && wp_verify_nonce( $_REQUEST['_gutenberg_nonce'], 'gutenberg_request' ) ) { // WordPress.Security.ValidatedSanitizedInput.InputNotSanitized.
+		if ( true === isset( $_REQUEST['_gutenberg_nonce'] ) && wp_verify_nonce( $_REQUEST['_gutenberg_nonce'], 'gutenberg_request' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			$csstidy->set_cfg( 'optimise_shorthands', 0 );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The linting ignore comment in #19738 was broken, which only came to light when trying to merge the related diff. This was fixed on the diff, so this PR backports the fix to the jetpack code.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
No testing needed as just a comment change
