### PR TITLE
Packages: release a new version of Blocks and Changelogger

### DIFF
--- a/projects/packages/blocks/CHANGELOG.md
+++ b/projects/packages/blocks/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2021-05-12
+### Added
+- Add helper method to determine if the current theme is an FSE/Site editor theme.
+- Adds an attribute to paid blocks to support hiding nested upgrade nudges on the frontend.
+
+### Changed
+- Updated package dependencies.
+
 ## [1.3.0] - 2021-03-22
 ### Added
 - Composer alias for dev-master, to improve dependencies
@@ -44,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Blocks: introduce new package for block management
 
+[1.4.0]: https://github.com/Automattic/jetpack-blocks/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/Automattic/jetpack-blocks/compare/v1.2.2...v1.3.0
 [1.2.2]: https://github.com/Automattic/jetpack-blocks/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Automattic/jetpack-blocks/compare/v1.2.0...v1.2.1

--- a/projects/packages/blocks/changelog/add-is-fse-theme-method
+++ b/projects/packages/blocks/changelog/add-is-fse-theme-method
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add helper method to determine if the current theme is an FSE/Site editor theme.

--- a/projects/packages/blocks/changelog/add-support-hiding-nested-nudges
+++ b/projects/packages/blocks/changelog/add-support-hiding-nested-nudges
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Adds an attribute to paid blocks to support hiding nested upgrade nudges on the frontend.

--- a/projects/packages/blocks/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/blocks/changelog/fix-changelogger-in-subdir
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2021-05-12
+### Added
+- New option, `--filename-auto-suffix`, to ensure that a reused branch won't prevent entry creation in non-interactive mode.
+
+### Deprecated
+- Changelogger `Config::setOutput()` is no longer needed. Config will throw a ConfigException instead of printing an error.
+
+### Fixed
+- If composer.json is not present in the current directory, check parents and ask if the parent should be used (like composer does).
+
 ## [1.1.2] - 2021-04-08
 ### Fixed
 - Don't insert extra newlines if a subsection has no non-empty entries.
@@ -26,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[1.2.0]: https://github.com/Automattic/jetpack-changelogger/compare/1.1.2...1.2.0
 [1.1.2]: https://github.com/Automattic/jetpack-changelogger/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/Automattic/jetpack-changelogger/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/Automattic/jetpack-changelogger/compare/1.0.0...1.1.0

--- a/projects/packages/changelogger/changelog/add-changelogger-filename-dups
+++ b/projects/packages/changelogger/changelog/add-changelogger-filename-dups
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-New option, `--filename-auto-suffix`, to ensure that a reused branch won't prevent entry creation in non-interactive mode.

--- a/projects/packages/changelogger/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/changelogger/changelog/fix-changelogger-in-subdir
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-If composer.json is not present in the current directory, check parents and ask if the parent should be used (like composer does).

--- a/projects/packages/changelogger/changelog/fix-changelogger-in-subdir-2
+++ b/projects/packages/changelogger/changelog/fix-changelogger-in-subdir-2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Changelogger `Config::setOutput()` is no longer needed. Config will throw a ConfigException instead of printing an error.

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '1.2.0-alpha';
+	const VERSION = '1.2.0';
 
 	/**
 	 * Constructor.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Let's release a new version of the Blocks package so we can benefit from changes that will be needed on WordPress.com.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Check for typos.
