### PR TITLE
Story Block: Fix video not loading on safari and Chrome iOS

### DIFF
--- a/projects/plugins/jetpack/changelog/story-block-fix-video-partial-content-ios
+++ b/projects/plugins/jetpack/changelog/story-block-fix-video-partial-content-ios
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Story Block: Fix video not loading on safari and Chrome iOS

--- a/projects/plugins/jetpack/extensions/blocks/story/player/lib/wait-media-ready.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/lib/wait-media-ready.js
@@ -18,7 +18,7 @@ export default async function waitMediaReady( mediaElement ) {
 			// In case the media has stopped loading, force a reload
 			if (
 				mediaElement.HAVE_NOTHING === mediaElement.readyState &&
-				mediaElement.networkState < mediaElement.NETWORK_LOADING
+				mediaElement.networkState !== mediaElement.NETWORK_LOADING
 			) {
 				mediaElement.load();
 			}

--- a/projects/plugins/jetpack/extensions/blocks/story/player/lib/wait-media-ready.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/lib/wait-media-ready.js
@@ -15,6 +15,13 @@ export default async function waitMediaReady( mediaElement ) {
 			mediaElement.addEventListener( 'canplaythrough', resolve, { once: true } );
 			// `canplaythrough` may not be triggered on firefox
 			mediaElement.addEventListener( 'load', resolve, { once: true } );
+			// In case the media has stopped loading, force a reload
+			if (
+				mediaElement.HAVE_NOTHING === mediaElement.readyState &&
+				mediaElement.networkState < mediaElement.NETWORK_LOADING
+			) {
+				mediaElement.load();
+			}
 		} );
 	}
 }


### PR DESCRIPTION
The [recent work on video loading](https://github.com/Automattic/jetpack/pull/17342) for the story block actually caused a regression on iOS. It seems videos sometimes do not load. In those cases, partial requests are failing and they're  not tried again (it's not clear why as it seems the server is configured correctly for handling partial requests and it's not a cross-origin issue either).

As a result the story appears to be constantly loading:

![IMG_6CFF3438769E-1](https://user-images.githubusercontent.com/230230/117962339-67b1dd80-b31f-11eb-95a0-9d11f723a965.jpeg)


#### Changes proposed in this Pull Request:
This change makes sure a failed media is retried.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Apply this patch on a public site
* Publish a story starting with a video
* Access it with an iOS device with either Safari or Chrome
* (Optional: try it on both an iphone and an ipad as safari doesn't have the same permission on each, for instance the fullscreen api is only enabled on ipad)
* Video should be loading on start
* Story should be playing fine
