### PR TITLE
CLI: Ensure extras section of composer exists for Changelog

### DIFF
--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -273,7 +273,6 @@ async function changelogAdd( argv ) {
 	if ( argv._[ 1 ] === 'add' && ! argv.project ) {
 		const needChangelog = await changedProjects();
 		const uniqueProjects = await checkSpecialProjects( needChangelog );
-
 		// If we don't detect any modified projects, shortcircuit to default changelogger.
 		if ( needChangelog.length === 0 && uniqueProjects.length === 0 ) {
 			changelogArgs( argv );
@@ -452,13 +451,17 @@ async function changedProjects() {
 	const projects = allProjects();
 	// Get all files that were worked with (created, deleted, modified, etc)
 	for ( const file of gitStatus.files ) {
-		gitFiles.push( file.path );
+		const parsedPath = file.path.split( '/' );
+		const project = `${ parsedPath[ 1 ] }/${ parsedPath[ 2 ] }`;
+		if ( ! gitFiles.includes( project ) ) {
+			gitFiles.push( project );
+		}
 	}
 
 	// See if any files modified match our project list.
 	for ( const proj of projects ) {
 		for ( const file of gitFiles ) {
-			if ( file.includes( proj ) && ! modifiedProjects.includes( proj ) ) {
+			if ( proj === file ) {
 				modifiedProjects.push( proj );
 			}
 		}

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -444,29 +444,18 @@ async function gitAdd( argv ) {
  * @returns {Array} modifiedProjects - projects that need a changelog.
  */
 async function changedProjects() {
-	const modifiedProjects = [];
-	const gitFiles = [];
+	const re = /^projects\/([^/]+\/[^/]+)\//;
+	const modifiedProjects = new Set();
 	const git = simpleGit();
 	const gitStatus = await git.status();
-	const projects = allProjects();
-	// Get all files that were worked with (created, deleted, modified, etc)
 	for ( const file of gitStatus.files ) {
-		const parsedPath = file.path.split( '/' );
-		const project = `${ parsedPath[ 1 ] }/${ parsedPath[ 2 ] }`;
-		if ( ! gitFiles.includes( project ) ) {
-			gitFiles.push( project );
+		const match = file.path.match( re );
+		if ( match ) {
+			modifiedProjects.add( match[ 1 ] );
 		}
 	}
 
-	// See if any files modified match our project list.
-	for ( const proj of projects ) {
-		for ( const file of gitFiles ) {
-			if ( proj === file ) {
-				modifiedProjects.push( proj );
-			}
-		}
-	}
-	return modifiedProjects;
+	return allProjects().filter( proj => modifiedProjects.has( proj ) );
 }
 
 /**

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -252,7 +252,11 @@ async function checkSpecialProjects( needChangelog ) {
 		const composerJSON = readComposerJson( proj );
 		// todo - handle duplicate special projects with the same type of requirements.
 		// todo - If we want to generate changelogger questions dynamically, we can push the entire composerJSON.extra.changelogger.types object.
-		if ( composerJSON.extra.changelogger && composerJSON.extra.changelogger.types ) {
+		if (
+			composerJSON.extra &&
+			composerJSON.extra.changelogger &&
+			composerJSON.extra.changelogger.types
+		) {
 			needChangelog.splice( needChangelog.indexOf( proj ), 1 );
 			specialProjects.push( proj );
 		}

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -444,7 +444,7 @@ async function gitAdd( argv ) {
  * @returns {Array} modifiedProjects - projects that need a changelog.
  */
 async function changedProjects() {
-	const re = /^projects\/([^/]+\/[^/]+)\//;
+	const re = /^projects\/([^/]+\/[^/]+)\//; // regex matches project file path, ie 'project/packages/connection/..'
 	const modifiedProjects = new Set();
 	const git = simpleGit();
 	const gitStatus = await git.status();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Ensures that composer.json has an extra section before reading it.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Modify files in js-packages/connection
* Run `jetpack changelog add`
* Before patch, see error. After patch, see it work.

The js-packages/connection does not (yet) have an extra section since the mirror repo does not yet exist.
