### PR TITLE
Search: ensure modal search input has no max-width

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-input-max-width
+++ b/projects/plugins/jetpack/changelog/fix-search-input-max-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Instant Search: ensure search input is the correct width if an input max-width has been specified in the theme

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-box.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-box.scss
@@ -20,6 +20,7 @@ input.jetpack-instant-search__box-input.search-field {
 	color: $color-text-light;
 	font-size: 18px;
 	height: 60px;
+	max-width: none;
 	line-height: 1;
 	margin: 0;
 	padding: 0 14px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
In the Instant Search modal's search input, override any max-width set in the theme.

I noticed on an existing site (https://sixcolors.com/?s=hello) using Jetpack Instant Search that the 'clear' button was shown in the centre of the search input:

<img width="1539" alt="Screen Shot 2021-05-13 at 16 43 35" src="https://user-images.githubusercontent.com/17325/118079716-c3a66000-b40c-11eb-8488-43e2334baa50.png">

This happened because the underlying theme had specified a max-width for all inputs:

<img width="366" alt="Screen Shot 2021-05-13 at 16 55 35" src="https://user-images.githubusercontent.com/17325/118079738-cef98b80-b40c-11eb-8d83-9ba424109d99.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
On a test site with Jetpack Instant Search enabled, add custom CSS to impose a max-width on all inputs:

```
input {
  max-width: 500px;
}
```

Perform a search to open the search modal. Ensure that the clear button is shown in the expected position (on the right).
