### PR TITLE
Admin Page: display Sharing as new default tab for non-admins

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/navigation-settings/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/navigation-settings/index.jsx
@@ -106,7 +106,7 @@ export const NavigationSettings = createReactClass( {
 	},
 
 	render: function () {
-		let navItems, sharingTab;
+		let navItems, sharingTab, writingTab;
 		if ( this.props.userCanManageModules ) {
 			navItems = (
 				<NavTabs selectedText={ this.props.routeName }>
@@ -192,6 +192,7 @@ export const NavigationSettings = createReactClass( {
 		} else if ( this.props.isSubscriber ) {
 			navItems = false;
 		} else {
+			// Show a sharing tab if the Publicize module is active and the user can publish.
 			if ( ! this.props.isModuleActivated( 'publicize' ) || ! this.props.userCanPublish ) {
 				sharingTab = '';
 			} else {
@@ -199,30 +200,34 @@ export const NavigationSettings = createReactClass( {
 					<NavItem
 						path="#sharing"
 						onClick={ this.handleClickForTracking( 'sharing' ) }
-						selected={ this.props.location.pathname === '/sharing' }
+						selected={
+							this.props.location.pathname === '/sharing' ||
+							this.props.location.pathname === '/settings'
+						}
 					>
 						{ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
 					</NavItem>
 				);
 			}
+
+			// Show a Writing tab if the Post By Email module is active and the user can publish.
+			if ( ! this.props.isModuleActivated( 'post-by-email' ) || ! this.props.userCanPublish ) {
+				writingTab = '';
+			} else {
+				writingTab = this.props.hasAnyOfTheseModules( [ 'post-by-email' ] ) && (
+					<NavItem
+						path="#writing"
+						onClick={ this.handleClickForTracking( 'writing' ) }
+						selected={ this.props.location.pathname === '/writing' }
+					>
+						{ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
+					</NavItem>
+				);
+			}
 			navItems = (
 				<NavTabs selectedText={ this.props.routeName }>
-					{ this.props.hasAnyOfTheseModules( [ 'post-by-email' ] ) && (
-						<NavItem
-							path="#writing"
-							onClick={ this.handleClickForTracking( 'writing' ) }
-							selected={
-								this.props.location.pathname === '/writing' ||
-								this.props.location.pathname === '/settings'
-							}
-						>
-							{ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
-						</NavItem>
-					) }
-					{
-						// Give only Publicize to non admin users
-						sharingTab
-					}
+					{ writingTab }
+					{ sharingTab }
 				</NavTabs>
 			);
 		}

--- a/projects/plugins/jetpack/_inc/client/components/navigation-settings/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/navigation-settings/test/component.js
@@ -11,8 +11,7 @@ import { shallow } from 'enzyme';
 import { NavigationSettings } from '../index';
 
 describe( 'NavigationSettings', () => {
-	let wrapper,
-		testProps;
+	let wrapper, testProps;
 
 	before( () => {
 		testProps = {
@@ -22,11 +21,11 @@ describe( 'NavigationSettings', () => {
 			userCanManageModules: false,
 			isSubscriber: true,
 			location: {
-				pathname: '/settings'
+				pathname: '/settings',
 			},
 			routeName: 'General',
 			history: {
-				listen: () => {}
+				listen: () => {},
 			},
 			isModuleActivated: () => true,
 			isSiteConnected: true,
@@ -34,8 +33,33 @@ describe( 'NavigationSettings', () => {
 			siteAdminUrl: 'https://example.org/wp-admin/',
 			searchForTerm: () => {},
 			isLinked: true,
-			moduleList: { sitemaps: true, carousel: true, 'custom-content-types': true, 'verification-tools': true, markdown: true, 'infinite-scroll': true, 'gravatar-hovercards': true, sharedaddy: true, sso: true, 'related-posts': true, monitor: true, vaultpress: true, stats: true, masterbar: true, 'google-analytics': true, 'seo-tools': true, wordads: true, videopress: true, subscriptions: true, comments: true, 'post-by-email': true, photon: true, publicize: true, likes: true },
-			isPluginActive: () => true
+			moduleList: {
+				sitemaps: true,
+				carousel: true,
+				'custom-content-types': true,
+				'verification-tools': true,
+				markdown: true,
+				'infinite-scroll': true,
+				'gravatar-hovercards': true,
+				sharedaddy: true,
+				sso: true,
+				'related-posts': true,
+				monitor: true,
+				vaultpress: true,
+				stats: true,
+				masterbar: true,
+				'google-analytics': true,
+				'seo-tools': true,
+				wordads: true,
+				videopress: true,
+				subscriptions: true,
+				comments: true,
+				'post-by-email': true,
+				photon: true,
+				publicize: true,
+				likes: true,
+			},
+			isPluginActive: () => true,
 		};
 
 		window.location.hash = '#settings';
@@ -65,11 +89,10 @@ describe( 'NavigationSettings', () => {
 	} );
 
 	describe( 'for Editor, Author and Contributor users', () => {
-
 		before( () => {
 			Object.assign( testProps, {
 				userCanManageModules: false,
-				isSubscriber: false
+				isSubscriber: false,
 			} );
 
 			wrapper = shallow( <NavigationSettings { ...testProps } /> );
@@ -91,7 +114,7 @@ describe( 'NavigationSettings', () => {
 				userCanManageModules: false,
 				isSubscriber: false,
 				userCanPublish: true,
-				isModuleActivated: m => 'sharedaddy' === m
+				isModuleActivated: m => 'sharedaddy' === m,
 			} );
 			expect(
 				shallow( <NavigationSettings { ...publicizeProps } /> )
@@ -103,9 +126,40 @@ describe( 'NavigationSettings', () => {
 			).to.be.true;
 		} );
 
-		it( 'has /writing as selected navigation item, accessing through /settings', () => {
-			expect( wrapper.find( 'NavItem' ).get( 0 ).props.selected ).to.be.true;
-			expect( wrapper.find( 'NavItem' ).get( 0 ).props.path ).to.equal( '#writing' );
+		it( 'show only Sharing if Post By Email is disabled', () => {
+			const pbeProps = Object.assign( {}, testProps, {
+				userCanManageModules: false,
+				isSubscriber: false,
+				userCanPublish: true,
+				isModuleActivated: m => 'post-by-email' === m,
+			} );
+			expect(
+				shallow( <NavigationSettings { ...pbeProps } /> )
+					.find( 'NavItem' )
+					.children()
+					.getElements()
+					.filter( item => 'string' === typeof item )
+					.every( item => [ 'Sharing' ].includes( item ) )
+			).to.be.true;
+		} );
+
+		it( 'has /sharing as selected navigation item, accessing through /settings, even when both PBE and Publicize are active', () => {
+			const allActivatedProps = Object.assign( {}, testProps, {
+				userCanManageModules: false,
+				isSubscriber: false,
+				userCanPublish: true,
+				isModuleActivated: m => true,
+			} );
+			expect(
+				shallow( <NavigationSettings { ...allActivatedProps } /> )
+					.find( 'NavItem' )
+					.get( 1 ).props.selected
+			).to.be.true;
+			expect(
+				shallow( <NavigationSettings { ...allActivatedProps } /> )
+					.find( 'NavItem' )
+					.get( 1 ).props.path
+			).to.equal( '#sharing' );
 		} );
 
 		it( 'does not display Search', () => {
@@ -117,7 +171,7 @@ describe( 'NavigationSettings', () => {
 				userCanManageModules: false,
 				isSubscriber: false,
 				isContributor: true,
-				isModuleActivated: m => 'sharedaddy' === m
+				isModuleActivated: m => 'sharedaddy' === m,
 			} );
 			expect(
 				shallow( <NavigationSettings { ...publicizeProps } /> )
@@ -136,10 +190,10 @@ describe( 'NavigationSettings', () => {
 					isSubscriber: false,
 					userCanPublish: true,
 					location: {
-						pathname: '/settings'
+						pathname: '/settings',
 					},
 					routeName: 'General',
-					isModuleActivated: m => 'publicize' === m
+					isModuleActivated: m => 'publicize' === m,
 				} );
 				it( 'show Sharing if user is linked', () => {
 					expect(
@@ -159,7 +213,7 @@ describe( 'NavigationSettings', () => {
 		before( () => {
 			Object.assign( testProps, {
 				userCanManageModules: true,
-				isSubscriber: false
+				isSubscriber: false,
 			} );
 
 			wrapper = shallow( <NavigationSettings { ...testProps } /> );
@@ -172,14 +226,8 @@ describe( 'NavigationSettings', () => {
 					.children()
 					.getElements()
 					.filter( item => 'string' === typeof item )
-					.every(
-						item => [
-							'Writing',
-							'Discussion',
-							'Traffic',
-							'Security',
-							'Sharing'
-						].includes( item )
+					.every( item =>
+						[ 'Writing', 'Discussion', 'Traffic', 'Security', 'Sharing' ].includes( item )
 					)
 			).to.be.true;
 		} );
@@ -212,13 +260,12 @@ describe( 'NavigationSettings', () => {
 					} );
 				} );
 			} );
-
 		} );
 
 		it( 'switches to Security when the tab is clicked', () => {
 			Object.assign( testProps, {
 				location: {
-					pathname: '/security'
+					pathname: '/security',
 				},
 				routeName: 'Security',
 			} );

--- a/projects/plugins/jetpack/changelog/update-settings-default-non-admin
+++ b/projects/plugins/jetpack/changelog/update-settings-default-non-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: display the Sharing settings tab when editors only need to customize Publicize settings for their own account.

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -63,7 +63,6 @@
 	"projects/plugins/jetpack/_inc/client/pro-status/index.jsx",
 	"projects/plugins/jetpack/_inc/client/rest-api/index.js",
 	"projects/plugins/jetpack/_inc/client/security/sso.jsx",
-	"projects/plugins/jetpack/_inc/client/settings/index.jsx",
 	"projects/plugins/jetpack/_inc/client/state/at-a-glance/reducer.js",
 	"projects/plugins/jetpack/_inc/client/state/connection/actions.js",
 	"projects/plugins/jetpack/_inc/client/state/connection/reducer.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is a bit of a follow-up to #19815. This PR changes the behaviour of the Settings screen for connected non-admins.

Non-admins currently need access to the Settings screen for 2 reasons:

- Publicize (Sharing tab)
- Post By Email (Writing tab)

Until now, we always defaulted to the Writing tab for connected non-admins. This has 2 problems:

1 - We did not check if the Post By Email module was actually enabled, so when the module was disabled editors loading the settings page would only see a Writing tab and its title, but no content.

![image](https://user-images.githubusercontent.com/426388/118120371-102f7280-b3f0-11eb-9cfc-f88746952572.png)


2 - Publicize is more popular than Post By Email today, so it's more likely that editors will be interested in the Publicize settings first, even if both PBE and Publicize are enabled.

![image](https://user-images.githubusercontent.com/426388/118120435-2ccbaa80-b3f0-11eb-90d5-368cbb7cdd73.png)

This PR changes that default behaviour, and introduces checks for the active modules to avoid displaying tabs when we do not need to.

Previous work on this: #13541
    
#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

While testing, you'll want to pay extra attention to:

1. The content inside the settings screen at `wp-admin/admin.php?page=jetpack#/settings`
2. The tabs available at the top of the page and whether they're properly marked as active.

![image](https://user-images.githubusercontent.com/426388/118120679-88963380-b3f0-11eb-800d-27d0bb087916.png)

* Start with a site that's connected to WordPress.com, and 2 users connected to WordPress.com; an admin and an editor.
* In browser A, log in as the admin.
* Start by disabling both the Publicize and Post By Email modules.
* In browser B, log in as the editor.
* You should not have access to the Jetpack > Settings screen at this point
* In browser A, enable the Publicize module.
* In browser B, you should have access to the Settings tab.
* Accessing it reveals the Publicize settings, whether when using the `jetpack#/settings` path or `jetpack#/sharing` path (both should work, try clicking on the tab at the top to check).
* In browser A, enable the Post By Email module.
* In browser B, reload `jetpack#/settings`.
* Both the Writing and Sharing tabs should be visible. The Sharing tab should be active by default. You should be able to access settings for both features.
* In browser A, disable the Publicize module.
* In browser B, reload `jetpack#/settings`
* Only the Writing tab should be visible, and the PBE settings should be displayed.
