### PR TITLE
E2E Tests: Unprettify `jq` output

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           MATRIX='[{"group":"pre-connection" },{"group":"connection" },{"group":"post-connection" }]'
           if [ ${{ github.event_name }} == schedule ]; then
-            MATRIX=$(echo $MATRIX | jq '. + [{"group": "gutenberg"}]')
+            MATRIX=$(echo $MATRIX | jq '. + [{"group": "gutenberg"}]' | jq -c .)
           fi
           echo $MATRIX
           echo "::set-output name=matrix::$MATRIX"


### PR DESCRIPTION
Apparently, scheduled runs weren't working at all. Pobably, GH Actions does not like when matrix defined in runtime is prettified: 
```
Error when evaluating 'strategy' for job 'e2e-tests'. (Line: 41, Col: 18): Error reading JArray from JsonReader. Path '', line 1, position 1.,(Line: 41, Col: 18): Unexpected value ''
```
https://github.com/Automattic/jetpack/actions/runs/838790992 


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Impossible to test. Just merge and wait for 12 hours :D  
*
