### PR TITLE
Sync: avoid PHP notices in some edge-cases

### DIFF
--- a/projects/packages/sync/changelog/fix-notice-sync-queue-buffer
+++ b/projects/packages/sync/changelog/fix-notice-sync-queue-buffer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Janitorial: avoid PHP notices in some edge-cases

--- a/projects/packages/sync/src/class-queue-buffer.php
+++ b/projects/packages/sync/src/class-queue-buffer.php
@@ -48,7 +48,7 @@ class Queue_Buffer {
 	 *
 	 * @access public
 	 *
-	 * @return array Sync items in the buffer.
+	 * @return bool|array Sync items in the buffer.
 	 */
 	public function get_items() {
 		return array_combine( $this->get_item_ids(), $this->get_item_values() );

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -404,6 +404,10 @@ class Sender {
 		$upload_size   = 0;
 		$items_to_send = array();
 		$items         = is_array( $buffer_or_items ) ? $buffer_or_items : $buffer_or_items->get_items();
+		if ( ! is_array( $items ) ) {
+			$items = array();
+		}
+
 		// Set up current screen to avoid errors rendering content.
 		require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
 		require_once ABSPATH . 'wp-admin/includes/screen.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
﻿
`array_combine()` can return false if the number of elements for each array isn't equal.

Let's take that into account to avoid PHP notices like this:

* File
/home/wordcamp/public_html/wp-content/plugins/jetpack/vendor/automattic/jetpack-sync/src/class-sender.php:422
* Stack Trace
shutdown_action_hook, do_action('shutdown'), WP_Hook->do_action, WP_Hook->apply_filters, Automattic\Jetpack\Sync\Sender->do_sync, Automattic\Jetpack\Sync\Sender->do_sync_and_set_delays, Automattic\Jetpack\Sync\Sender->do_sync_for_queue, Automattic\Jetpack\Sync\Sender->get_items_to_send, WordCamp\Error_Handling\handle_error, WordCamp\Error_Handling\send_error_to_slack


#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here, tests should still pass.

