### PR TITLE
Unify carousel JS between Jetpack and wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/update-unify-carousel-js
+++ b/projects/plugins/jetpack/changelog/update-unify-carousel-js
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Under the hood changes to unify carousel JS between wpcom and Jetpack.
+
+


### PR DESCRIPTION
This updates the Jetpack carousel JS to make it possible to have a single, unmodified JS codebase for the plugin. It shouldn't result in any user-visible changes for Jetpack or wpcom users.

Once Fusion generates a sync diff, I will commandeer it and update it to add the wpcom-specific code that enables this. A draft of that is available at D61295-code.

#### Changes proposed in this Pull Request:
* Unify carousel JS between Jetpack and wpcom

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Smoke-test the carousel and ensure that everything continues to work normally.
