### PR TITLE
Premium Content Block: Update to useBlockProps

### DIFF
--- a/projects/plugins/jetpack/changelog/update-premium-content-10-6
+++ b/projects/plugins/jetpack/changelog/update-premium-content-10-6
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Internal fix
+
+

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 // eslint-disable-next-line wpcalypso/import-docblock
-import { InnerBlocks, __experimentalBlock as Block } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -79,9 +79,12 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 		);
 	}, [ subscribeButton ] );
 
+	const blockProps = useBlockProps( {
+		className: 'wp-block-buttons',
+	} );
+
 	return (
-		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		<Block.div className="wp-block-buttons">
+		<div { ...blockProps }>
 			<InnerBlocks
 				allowedBlocks={ ALLOWED_BLOCKS }
 				template={ isPreview ? previewTemplate : template }
@@ -89,7 +92,7 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 				__experimentalLayout={ { type: 'default', alignments: [] } }
 				__experimentalMoverDirection="horizontal"
 			/>
-		</Block.div>
+		</div>
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
@@ -38,7 +38,7 @@ const settings = {
 				alignWide: false,
 				lightBlockWrapper: true,
 				inserter: false,
-			},			
+			},
 			save() {
 				return (
 					<div className="wp-block-buttons">

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
@@ -33,6 +33,12 @@ const settings = {
 	deprecated: [
 		{
 			attributes: {},
+			supports: {
+				align: true,
+				alignWide: false,
+				lightBlockWrapper: true,
+				inserter: false,
+			},			
 			save() {
 				return (
 					<div className="wp-block-buttons">

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { button as icon } from '@wordpress/icons';
-
+import { InnerBlocks } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
@@ -12,6 +12,7 @@ import save from './save';
 
 const name = 'premium-content/buttons';
 const settings = {
+	apiVersion: 2,
 	title: __( 'Premium Content buttons', 'jetpack' ),
 	description: __(
 		'Prompt Premium Content visitors to take action with a group of button-style links.',
@@ -29,6 +30,18 @@ const settings = {
 	edit,
 	save,
 	usesContext: [ 'premium-content/planId', 'premium-content/isPreview' ],
+	deprecated: [
+		{
+			attributes: {},
+			save() {
+				return (
+					<div className="wp-block-buttons">
+						<InnerBlocks.Content />
+					</div>
+				);
+			},
+		},
+	],
 };
 
 export { name, settings };

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/save.js
@@ -1,13 +1,15 @@
 /**
  * WordPress dependencies
  */
-// eslint-disable-next-line wpcalypso/import-docblock
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save() {
+	const blockProps = useBlockProps.save( {
+		className: 'wp-block-buttons',
+	} );
+
 	return (
-		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		<div className="wp-block-buttons">
+		<div { ...blockProps }>
 			<InnerBlocks.Content />
 		</div>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

See https://github.com/Automattic/jetpack/issues/18864

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the premium content block to use the block API version 2.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a Premium Content block
* Confirm that it still works as before in the editor and front end.
* Make sure that the deprecation works correctly coming from a previous verison of the block.
