### PR TITLE
Related Posts: add height attribute to post images

### DIFF
--- a/projects/plugins/jetpack/changelog/try-add-height-related-posts
+++ b/projects/plugins/jetpack/changelog/try-add-height-related-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Related Posts: add height attribute to post images for better compatibility with page performance analysis tools.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -5,7 +5,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Sync\Settings;
 
 class Jetpack_RelatedPosts {
-	const VERSION   = '20210219';
+	const VERSION   = '20210513';
 	const SHORTCODE = 'jetpack-related-posts';
 
 	private static $instance     = null;
@@ -307,11 +307,12 @@ EOT;
 
 		if ( ! empty( $block_attributes['show_thumbnails'] ) && ! empty( $related_post['img']['src'] ) ) {
 			$img_link = sprintf(
-				'<li class="jp-related-posts-i2__post-img-link"><a href="%1$s" %2$s><img src="%3$s" width="%4$s" alt="%5$s" /></a></li>',
+				'<li class="jp-related-posts-i2__post-img-link"><a href="%1$s" %2$s><img src="%3$s" width="%4$s" height="%5$s" alt="%6$s" /></a></li>',
 				esc_url( $related_post['url'] ),
 				( ! empty( $related_post['rel'] ) ? 'rel="' . esc_attr( $related_post['rel'] ) . '"' : '' ),
 				esc_url( $related_post['img']['src'] ),
 				esc_attr( $related_post['img']['width'] ),
+				esc_attr( $related_post['img']['height'] ),
 				esc_attr( $related_post['img']['alt_text'] )
 			);
 

--- a/projects/plugins/jetpack/modules/related-posts/related-posts.js
+++ b/projects/plugins/jetpack/modules/related-posts/related-posts.js
@@ -165,6 +165,8 @@
 						post.img.src +
 						'" width="' +
 						post.img.width +
+						'" height="' +
+						post.img.height +
 						'" alt="' +
 						post.img.alt_text +
 						'" />' +


### PR DESCRIPTION
Fixes #19840

#### Changes proposed in this Pull Request:

We already know the image height since we define it ourselves and resize the images with Photon. Let's add the height attribute to the image tags for each set of related posts (whether at the bottom of a post or within a block).

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start on a connected site where Related posts are active and where you've already got some related posts displayed and working well.
* Apply branch.
* All images should be displayed nicely without being distorted.
