### PR TITLE
DocBlock for `jetpack_on_connection_ui_init` hook

### DIFF
--- a/projects/packages/connection-ui/changelog/update-connection-ui-hook-docblock
+++ b/projects/packages/connection-ui/changelog/update-connection-ui-hook-docblock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add docblock for `jetpack_on_connection_ui_init` hook.

--- a/projects/packages/connection-ui/src/class-admin.php
+++ b/projects/packages/connection-ui/src/class-admin.php
@@ -19,6 +19,12 @@ class Admin {
 		if ( ! did_action( 'jetpack_on_connection_ui_init' ) ) {
 			add_action( 'admin_menu', array( $this, 'register_submenu_page' ), 1000 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+			/**
+			* Action called after initializing Connection UI Admin resources.
+			*
+			* @since 1.0.2
+			*/
 			do_action( 'jetpack_on_connection_ui_init' );
 		}
 	}

--- a/projects/packages/connection-ui/src/class-admin.php
+++ b/projects/packages/connection-ui/src/class-admin.php
@@ -21,10 +21,10 @@ class Admin {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 			/**
-			* Action called after initializing Connection UI Admin resources.
-			*
-			* @since 9.8.0
-			*/
+			 * Action called after initializing Connection UI Admin resources.
+			 *
+			 * @since 9.8.0
+			 */
 			do_action( 'jetpack_on_connection_ui_init' );
 		}
 	}

--- a/projects/packages/connection-ui/src/class-admin.php
+++ b/projects/packages/connection-ui/src/class-admin.php
@@ -23,7 +23,7 @@ class Admin {
 			/**
 			* Action called after initializing Connection UI Admin resources.
 			*
-			* @since 1.0.2
+			* @since 9.8.0
 			*/
 			do_action( 'jetpack_on_connection_ui_init' );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Quick follow up to https://github.com/Automattic/jetpack/pull/19820 to add a DocBlock for the `jetpack_on_connection_ui_init` hook.

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

* Proofread the change.