### PR TITLE
Upgrade Nudge: Check for undefined attribute

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-undefined-upgrade-nudge-attribute
+++ b/projects/plugins/jetpack/changelog/fix-undefined-upgrade-nudge-attribute
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Upgrade Nudges: Adds check for whether an attribute is set to avoid php warning.
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1101,7 +1101,7 @@ class Jetpack_Gutenberg {
 					$block_preview = call_user_func( $render_callback, $prepared_attributes, $block_content );
 
 					// If the upgrade nudge isn't already being displayed by a parent block, display the nudge.
-					if ( $block->attributes['shouldDisplayFrontendBanner'] ) {
+					if ( isset( $block->attributes['shouldDisplayFrontendBanner'] ) && $block->attributes['shouldDisplayFrontendBanner'] ) {
 						$upgrade_nudge = self::upgrade_nudge( $availability[ $bare_slug ]['details']['required_plan'] );
 						return $upgrade_nudge . $block_preview;
 					}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related #19407

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checks whether the `shoudlDisplayFrontendBanner` attribute is set before checking value to avoid php errors.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Testing instructions in #19407 
* Insert a paid block on a site with a free plan and observe the upgrade nudge. Open the post in the frontend and you should see the frontend nudge. Inspect error logs for errors.
