### PR TITLE
JITM: use an action to prevent JITMs from being registered multiple times

### DIFF
--- a/projects/packages/jitm/changelog/update-use_action_in_jitm
+++ b/projects/packages/jitm/changelog/update-use_action_in_jitm
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+JITM: Use an action instead of a property to prevent JITMs from being registered multiple times

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -22,13 +22,6 @@ class JITM {
 	const PACKAGE_VERSION = '1.15.2-alpha';
 
 	/**
-	 * Whether the JITMs have been registered.
-	 *
-	 * @var bool
-	 */
-	private static $jitms_registered = false;
-
-	/**
 	 * The configuration method that is called from the jetpack-config package.
 	 */
 	public static function configure() {
@@ -54,12 +47,18 @@ class JITM {
 	 * Sets up JITM action callbacks if needed.
 	 */
 	public function register() {
-		if ( self::$jitms_registered ) {
+		if ( did_action( 'jetpack_registered_jitms' ) ) {
 			// JITMs have already been registered.
 			return;
 		}
 
-		self::$jitms_registered = true;
+		/**
+		 * Fires when the JITMs are registered. This action is used to ensure that
+		 * JITMs are registered only once.
+		 *
+		 * @since 9.8
+		 */
+		do_action( 'jetpack_registered_jitms' );
 
 		if ( ! $this->jitms_enabled() ) {
 			// Do nothing.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -52,14 +52,6 @@ class JITM {
 			return;
 		}
 
-		/**
-		 * Fires when the JITMs are registered. This action is used to ensure that
-		 * JITMs are registered only once.
-		 *
-		 * @since 9.8
-		 */
-		do_action( 'jetpack_registered_jitms' );
-
 		if ( ! $this->jitms_enabled() ) {
 			// Do nothing.
 			return;
@@ -73,6 +65,14 @@ class JITM {
 		 * These are sync actions that we need to keep track of for jitms.
 		 */
 		add_filter( 'jetpack_sync_before_send_updated_option', array( $this, 'jetpack_track_last_sync_callback' ), 99 );
+
+		/**
+		 * Fires when the JITMs are registered. This action is used to ensure that
+		 * JITMs are registered only once.
+		 *
+		 * @since 9.8
+		 */
+		do_action( 'jetpack_registered_jitms' );
 	}
 
 	/**

--- a/projects/packages/jitm/tests/php/test_JITM.php
+++ b/projects/packages/jitm/tests/php/test_JITM.php
@@ -6,6 +6,7 @@ use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\JITMS\Pre_Connection_JITM;
 use Brain\Monkey;
 use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
@@ -111,6 +112,30 @@ class Test_Jetpack_JITM extends TestCase {
 
 		// Do the action that we asserted was added.
 		$jitm->jitm_enqueue_files();
+	}
+
+	/**
+	 * Test that the jetpack_registered_jitms action in JITM::register
+	 * is fired only once, regardless of how many times the JITM::register
+	 * method is called.
+	 */
+	public function test_register_jitm_action_fires_once() {
+		Functions\expect( 'get_option' )
+			->with( 'id' )
+			->andReturn( 123 );
+
+		Filters\expectApplied( 'jetpack_is_local_site' )
+			->andReturn( false);
+
+		Actions\expectAdded( 'current_screen' );
+		JITM::configure();
+		$this->assertSame( 1, did_action( 'jetpack_registered_jitms' ) );
+
+		// The current_screen action callback should be added only once.
+		Actions\expectAdded( 'current_screen' )->never();
+		JITM::configure();
+		// The jetpack_registered_jitms action should fire only once.
+		$this->assertSame( 1, did_action( 'jetpack_registered_jitms' ) );
 	}
 
 }

--- a/projects/plugins/jetpack/changelog/update-use_action_in_jitm
+++ b/projects/plugins/jetpack/changelog/update-use_action_in_jitm
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: update composer.lock
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1603,16 +1603,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.7",
+            "version": "v5.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "90374b8ed059325b49a29b55b3f8bb4062c87629"
+                "reference": "864568fdc0208b3eba3638b6000b69d2386e6768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/90374b8ed059325b49a29b55b3f8bb4062c87629",
-                "reference": "90374b8ed059325b49a29b55b3f8bb4062c87629",
+                "url": "https://api.github.com/repos/symfony/console/zipball/864568fdc0208b3eba3638b6000b69d2386e6768",
+                "reference": "864568fdc0208b3eba3638b6000b69d2386e6768",
                 "shasum": ""
             },
             "require": {
@@ -1680,7 +1680,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.7"
+                "source": "https://github.com/symfony/console/tree/v5.2.8"
             },
             "funding": [
                 {
@@ -1696,7 +1696,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-19T14:07:32+00:00"
+            "time": "2021-05-11T15:45:21+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2327,16 +2327,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.6",
+            "version": "v5.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572"
+                "reference": "01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
-                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
+                "url": "https://api.github.com/repos/symfony/string/zipball/01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db",
+                "reference": "01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db",
                 "shasum": ""
             },
             "require": {
@@ -2390,7 +2390,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.6"
+                "source": "https://github.com/symfony/string/tree/v5.2.8"
             },
             "funding": [
                 {
@@ -2406,7 +2406,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-17T17:12:15+00:00"
+            "time": "2021-05-10T14:56:10+00:00"
         },
         {
             "name": "wikimedia/at-ease",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* We're currently using a class property to prevent JITMs from being registered multiple times. Let's use an action instead, similar to the approach used in #19820 .

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install and activate the this branch of Jetpack.
2. Connect Jetpack.
3. Add this code in a snippet (you can use something like the Code Snippets plugin if you'd like):
`( new \Automattic\Jetpack\JITMS\JITM() )->configure();`
4. Open your browsers inspector.
5. Navigate to an admin page and search the network requests for jitm. You should see one request to the `wp-json/jetpack/v4/jitm endpoint`.
