### PR TITLE
Search: Apply configured highlight color to text selection

### DIFF
--- a/projects/plugins/jetpack/changelog/update-search-selected-text-color-scheme
+++ b/projects/plugins/jetpack/changelog/update-search-selected-text-color-scheme
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: Apply configured highlight color to text highlights

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
@@ -99,6 +99,7 @@ class SearchResults extends Component {
 					// eslint-disable-next-line react/no-danger
 					dangerouslySetInnerHTML={ {
 						__html: `
+							.jetpack-instant-search *::selection,
 							.jetpack-instant-search .jetpack-instant-search__search-results .jetpack-instant-search__search-results-primary mark { 
 								color: ${ textColor };
 								background-color: ${ highlightColor };


### PR DESCRIPTION
Fixes #19824.

#### Changes proposed in this Pull Request:
* Applies the configured search highlight color scheme to selected texts.

<img width="746" alt="Screen Shot 2021-05-13 at 3 25 34 PM" src="https://user-images.githubusercontent.com/4044428/118189784-77a0ee80-b3ff-11eb-853b-7cab8fdfe11a.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Spawn the search modal and try highlighting text on the page. Ensure that it matches the search term highlight color configured in the Customizer.
