### PR TITLE
Admin Menu: Fix Appearance submenus on Jetpack sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-admin-menu-customize
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-admin-menu-customize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+No changelog needed, this is a fix for a Calypso feature that has not been enabled yet

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -181,12 +181,18 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 *
 	 * @param bool $wp_admin_themes Optional. Whether Themes link should point to Calypso or wp-admin. Default false (Calypso).
 	 * @param bool $wp_admin_customize Optional. Whether Customize link should point to Calypso or wp-admin. Default false (Calypso).
+	 * @return string The Customizer URL.
 	 */
 	public function add_appearance_menu( $wp_admin_themes = false, $wp_admin_customize = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), 'switch_themes', 'https://wordpress.com/themes/' . $this->domain, null, 'dashicons-admin-appearance', 60 );
-		add_submenu_page( 'themes.php', esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', 'https://wordpress.com/themes/' . $this->domain );
+		$themes_url = 'https://wordpress.com/themes/' . $this->domain;
 		// Customize on Jetpack sites is always done on WP Admin (unsupported by Calypso).
-		add_submenu_page( 'themes.php', esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', 'customize.php' );
+		$customize_url = 'customize.php';
+
+		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), 'switch_themes', $themes_url, null, 'dashicons-admin-appearance', 60 );
+		add_submenu_page( $themes_url, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', 'https://wordpress.com/themes/' . $this->domain );
+		add_submenu_page( $themes_url, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $customize_url );
+
+		return $customize_url;
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -141,7 +141,7 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_appearance_menu( false, false );
 
 		// Check Customize menu always links to WP Admin.
-		$this->assertSame( 'customize.php', array_pop( $submenu['themes.php'] )[2] );
+		$this->assertSame( 'customize.php', array_pop( $submenu[ 'https://wordpress.com/themes/' . static::$domain ] )[2] );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR fixes a minor bug in the admin menu class used for Jetpack sites which prevented the Appearance submenu from being registered correctly. 

With this bug fixed, we'll finally be able to use the new sidebar component in Calypso for Jetpack sites, avoiding the current UI inconsistency when switching from a WP.com site to a Jetpack and vice versa. See https://github.com/Automattic/wp-calypso/pull/52871.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Go to the [WP.com API console](https://developer.wordpress.com/docs/api/console/).
- Select `WP REST API` and `wpcom/v2`.
- Make a `GET` request to `/sites/:site/admin-menu`.
- Make sure there are 2 submenu items under the Appearance menu item.

Before | After
--- | ---
<img width="1276" alt="Screen Shot 2021-05-14 at 14 05 54" src="https://user-images.githubusercontent.com/1233880/118268520-c3b26880-b4bd-11eb-8b5f-1fb1eeff75a9.png"> | <img width="1281" alt="Screen Shot 2021-05-14 at 14 05 05" src="https://user-images.githubusercontent.com/1233880/118268530-c745ef80-b4bd-11eb-8855-df2dada5cc52.png">

