### PR TITLE
Dashboard: redirect non-admins to dashboard hash when needed

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/non-admin-view/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/non-admin-view/index.jsx
@@ -34,6 +34,7 @@ class NonAdminView extends React.Component {
 		switch ( route ) {
 			case '/dashboard':
 			default:
+				this.props.history.replace( '/dashboard' );
 				pageComponent = <AtAGlance { ...this.props } />;
 				break;
 			case '/settings':

--- a/projects/plugins/jetpack/changelog/fix-redirect-non-admins-dashboard
+++ b/projects/plugins/jetpack/changelog/fix-redirect-non-admins-dashboard
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Dashboard: redirect non-admins to dashboard hash when needed
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿This was brought up and explained by @sdixon194 here:
https://github.com/Automattic/jetpack/pull/19838#pullrequestreview-660018127

When an admin enters a non-existing route in the Jetpack dashboard, we show them the At A Glance component and update the URL accordingly.
We did not update the URL for non-admins. This commit should fix that.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site that's connected to WordPress.com, and 2 users connected to WordPress.com; an admin and an editor.
* Log in as the editor.
* Go to Jetpack > Dashboard, or Jetpack > Settings if you have access to it (Post By Email or Publicize are active)
* Manually update the URL to `admin.php?page=jetpack#/foobar` for example, or to `admin.php?page=jetpack#/admin.php?page=jetpack#/security`.
* You should see the At A Glance UI appear in the dashboard, **and you should see the URL being updated to `admin.php?page=jetpack#/dashboard`**.
