### PR TITLE
repo-gardening: Cache label and files API calls

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-cache-repo-gardening-api-calls
+++ b/projects/github-actions/repo-gardening/changelog/add-cache-repo-gardening-api-calls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cache API calls for fetching labels and files on the PR.

--- a/projects/github-actions/repo-gardening/src/get-files.js
+++ b/projects/github-actions/repo-gardening/src/get-files.js
@@ -1,6 +1,9 @@
 /* global GitHub */
 const debug = require( './debug' );
 
+// Cache for getFiles.
+const cache = {};
+
 /**
  * Get list of files modified in PR.
  *
@@ -13,8 +16,13 @@ const debug = require( './debug' );
  */
 async function getFiles( octokit, owner, repo, number ) {
 	const fileList = [];
+	const cacheKey = `${ owner }/${ repo } #${ number }`;
+	if ( cache[ cacheKey ] ) {
+		debug( `get-files: Returning list of files modified ${ cacheKey } from cache.` );
+		return cache[ cacheKey ];
+	}
 
-	debug( 'add-labels: Get list of files modified in this PR.' );
+	debug( `get-files: Get list of files modified in ${ cacheKey }.` );
 
 	for await ( const response of octokit.paginate.iterator( octokit.pulls.listFiles, {
 		owner,
@@ -27,6 +35,7 @@ async function getFiles( octokit, owner, repo, number ) {
 		} );
 	}
 
+	cache[ cacheKey ] = fileList;
 	return fileList;
 }
 

--- a/projects/github-actions/repo-gardening/src/get-labels.js
+++ b/projects/github-actions/repo-gardening/src/get-labels.js
@@ -1,4 +1,8 @@
 /* global GitHub */
+const debug = require( './debug' );
+
+// Cache for getLabels.
+const cache = {};
 
 /**
  * Get labels on a PR.
@@ -12,17 +16,26 @@
  */
 async function getLabels( octokit, owner, repo, number ) {
 	const labelList = [];
+	const cacheKey = `${ owner }/${ repo } #${ number }`;
+	if ( cache[ cacheKey ] ) {
+		debug( `get-labels: Returning list of lables on ${ cacheKey } from cache.` );
+		return cache[ cacheKey ];
+	}
+
+	debug( `get-files: Get list of labels on ${ cacheKey }.` );
 
 	for await ( const response of octokit.paginate.iterator( octokit.issues.listLabelsOnIssue, {
 		owner,
 		repo,
 		issue_number: +number,
+		per_page: 100,
 	} ) ) {
 		response.data.map( label => {
 			labelList.push( label.name );
 		} );
 	}
 
+	cache[ cacheKey ] = labelList;
 	return labelList;
 }
 

--- a/projects/github-actions/repo-gardening/src/get-labels.js
+++ b/projects/github-actions/repo-gardening/src/get-labels.js
@@ -22,7 +22,7 @@ async function getLabels( octokit, owner, repo, number ) {
 		return cache[ cacheKey ];
 	}
 
-	debug( `get-files: Get list of labels on ${ cacheKey }.` );
+	debug( `get-labels: Get list of labels on ${ cacheKey }.` );
 
 	for await ( const response of octokit.paginate.iterator( octokit.issues.listLabelsOnIssue, {
 		owner,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The Gardening action runs pretty frequently, and each run might check
the list of files twice and the list of labels 12 times. We can reduce
our API calls by caching the lists so subsequent calls to getFiles or
getLabels don't re-fetch them.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Related to p1620322922356800/1620320214.350000-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the runs for the Gardening workflow on this PR. Does it report using the caches?