### PR TITLE
Related Posts: avoid fatals when class is missing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-customizer
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-customizer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Related Posts: avoid Fatal Errors when using plugins that may interact with WordPress' customizer in specific ways.

--- a/projects/plugins/jetpack/modules/related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts.php
@@ -53,7 +53,7 @@ class Jetpack_RelatedPosts_Module {
 		}
 
 		// Load Customizer controls.
-		if ( class_exists( 'WP_Customize_Manager' ) ) {
+		if ( class_exists( 'WP_Customize_Manager' ) && class_exists( 'WP_Customize_Control' ) ) {
 			require_once 'related-posts/class.related-posts-customize.php';
 		}
 	}

--- a/projects/plugins/jetpack/modules/related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts.php
@@ -53,7 +53,7 @@ class Jetpack_RelatedPosts_Module {
 		}
 
 		// Load Customizer controls.
-		if ( class_exists( 'WP_Customize_Manager' ) && class_exists( 'WP_Customize_Control' ) ) {
+		if ( class_exists( WP_Customize_Manager::class ) && class_exists( WP_Customize_Control::class ) ) {
 			require_once 'related-posts/class.related-posts-customize.php';
 		}
 	}


### PR DESCRIPTION
Internal reference: 6646-gh-jpop-issues

#### Changes proposed in this Pull Request:

In some specific edge-cases (most likely triggered by specific plugins), WP_Customize_Manager may be loaded, but not the accompanying WP_Customize_Control. Let's avoid fatals by only loading our Customizer-related classes when the classes already exist.

#### Jetpack product discussion

* Internal reference: 6646-gh-jpop-issues

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I'm still unclear on how to reproduce the issue, but we should be able to check that this doesn't break the feature.

* Go to Jetpack > Settings and enable Related Posts
* Go to site's home page
* Click on Customize link in the admin bar.
* Click on the Related Posts tab and see the invitation to visit a single post.
* Click on a single post and see the Related Posts option. 
