### PR TITLE
Second batch of improvements to Carousel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-improvement-batch-2
+++ b/projects/plugins/jetpack/changelog/update-carousel-improvement-batch-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Under-the-hood changes to improve codebase.
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -727,7 +727,13 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 #jp-carousel-comment-form-button-submit {
 	margin-top: 20px;
-	float:right;
+	float: right;
+  display: block;
+  border: solid 1px white;
+  background: rgba(34,34,34,0.9);
+	border-radius: 3px;
+	padding: 8px 16px;
+	font-size: 14px;
 }
 
 #jp-carousel-comment-form-container {
@@ -843,11 +849,9 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 }
 
 .jp-carousel-light #jp-carousel-comment-form-button-submit {
-	color: #333;
-	background: #fff;
-	background: -moz-linear-gradient(bottom,  #dcdcde,  #fff);
-	background: -webkit-gradient(linear, left bottom, left top, from(#dcdcde), to(#fff));
-	border: 1px solid #a7aaad;
+	color: black;
+	border: solid 1px black;
+  background: #fbfbfb;
 }
 
 .jp-carousel-light .jp-carousel-image-meta {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -114,6 +114,8 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 .jp-carousel-left-column-wrapper {
 	flex-grow: 1;
+	flex-shrink: 1;
+	overflow: hidden;
 }
 
 .jp-carousel-left-column-wrapper > .jp-carousel-photo-info {
@@ -374,6 +376,12 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	font-weight: 400;
 	width: 100%;
 }
+
+.jp-carousel-titleanddesc-desc {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .jp-carousel-titleanddesc-title {
 	font: 300 1.5em/1.1 "Helvetica Neue", sans-serif !important;
 	text-transform: none !important; /* prevents uppercase from leaking through */
@@ -441,6 +449,7 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	width: 209px !important;
 	margin-top: 20px;
 	margin-left: 40px;
+	flex-shrink: 0;
 }
 
 .jp-carousel-image-meta li,

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -379,7 +379,7 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 .jp-carousel-titleanddesc-desc {
 	overflow: hidden;
-	text-overflow: ellipsis;
+	overflow-wrap: break-word;
 }
 
 .jp-carousel-titleanddesc-title {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -674,14 +674,14 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	}
 }
 @keyframes load8 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
+	0% {
+		-webkit-transform: rotate(0deg);
+		transform: rotate(0deg);
+	}
+	100% {
+		-webkit-transform: rotate(360deg);
+		transform: rotate(360deg);
+	}
 }
 
 #jp-carousel-comment-form-submit-and-info-wrapper {
@@ -738,9 +738,9 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 #jp-carousel-comment-form-button-submit {
 	margin-top: 20px;
 	float: right;
-  display: block;
-  border: solid 1px white;
-  background: rgba(34,34,34,0.9);
+	display: block;
+	border: solid 1px white;
+	background: rgba(34,34,34,0.9);
 	border-radius: 3px;
 	padding: 8px 16px;
 	font-size: 14px;
@@ -773,7 +773,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	font: 13px/1.4 "Helvetica Neue", sans-serif !important;
 	border: 1px solid rgba( 255, 255, 255, 0.17 );
 	-webkit-box-shadow: inset 0px 0px 5px 5px rgba(0, 0, 0, 1);
-	        box-shadow: inset 0px 0px 5px 5px rgba(0, 0, 0, 1);
+					box-shadow: inset 0px 0px 5px 5px rgba(0, 0, 0, 1);
 }
 
 .jp-carousel-comment-post-error {
@@ -861,7 +861,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 .jp-carousel-light #jp-carousel-comment-form-button-submit {
 	color: black;
 	border: solid 1px black;
-  background: #fbfbfb;
+	background: #fbfbfb;
 }
 
 .jp-carousel-light .jp-carousel-image-meta {
@@ -931,7 +931,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	background: #f6f7f7;
 	border:1px solid #dcdcde;
 	-webkit-box-shadow: inset 0px 0px 5px rgba(0, 0, 0, 0.05);
-	        box-shadow: inset 0px 0px 5px rgba(0, 0, 0, 0.05);
+					box-shadow: inset 0px 0px 5px rgba(0, 0, 0, 0.05);
 }
 
 .jp-carousel-light .jp-carousel-slide {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -449,6 +449,7 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	width: 209px !important;
 	margin-top: 20px;
 	margin-left: 40px;
+	margin-bottom: 20px;
 	flex-shrink: 0;
 }
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1,6 +1,8 @@
 /* global wpcom, jetpackCarouselStrings, DocumentTouch */
 
 jQuery( document ).ready( function ( $ ) {
+	'use strict';
+
 	// gallery faded layer and container elements
 	var overlay,
 		gallery,
@@ -9,18 +11,15 @@ jQuery( document ).ready( function ( $ ) {
 		transitionBegin,
 		caption,
 		resizeTimeout,
-		photo_info,
 		commentInterval,
 		lastSelectedSlide,
 		screenPadding,
 		originalOverflow = $( 'body' ).css( 'overflow' ),
 		originalHOverflow = $( 'html' ).css( 'overflow' ),
 		proportion = 85,
-		last_known_location_hash = '',
-		imageMeta,
-		titleAndDescription,
-		commentForm,
-		scrollPos;
+		lastKnownLocationHash = '',
+		scrollPos,
+		isUserTyping = false;
 
 	var noop = function () {};
 
@@ -34,36 +33,46 @@ jQuery( document ).ready( function ( $ ) {
 			? wpcom.carousel.pageview
 			: noop;
 
-	var keyListener = function ( e ) {
-		switch ( e.which ) {
-			case 38: // up
-				e.preventDefault();
-				container.scrollTop( container.scrollTop() - 100 );
-				break;
-			case 40: // down
-				e.preventDefault();
-				container.scrollTop( container.scrollTop() + 100 );
-				break;
-			case 39: // right
-				e.preventDefault();
-				gallery.jp_carousel( 'next' );
-				break;
-			case 37: // left
-			case 8: // backspace
-				e.preventDefault();
-				gallery.jp_carousel( 'previous' );
-				break;
-			case 27: // escape
-				e.preventDefault();
-				container.jp_carousel( 'close' );
-				break;
-			default:
-				// making jslint happy
-				break;
+	function handleKeyboardEvent( e ) {
+		if ( ! isUserTyping ) {
+			switch ( e.which ) {
+				case 38: // up
+					e.preventDefault();
+					container.scrollTop( container.scrollTop() - 100 );
+					break;
+				case 40: // down
+					e.preventDefault();
+					container.scrollTop( container.scrollTop() + 100 );
+					break;
+				case 39: // right
+					e.preventDefault();
+					moveToNextSlide();
+					break;
+				case 37: // left
+				case 8: // backspace
+					e.preventDefault();
+					moveToPreviousSlide();
+					break;
+				case 27: // escape
+					e.preventDefault();
+					closeCarousel();
+					break;
+				default:
+					// making lint happy
+					break;
+			}
 		}
-	};
+	}
 
-	var calculatePadding = function () {
+	function disableKeyboardNavigation() {
+		isUserTyping = true;
+	}
+
+	function enableKeyboardNavigation() {
+		isUserTyping = false;
+	}
+
+	function calculatePadding() {
 		var baseScreenPadding = 110;
 		screenPadding = baseScreenPadding;
 
@@ -76,9 +85,24 @@ jQuery( document ).ready( function ( $ ) {
 				screenPadding = 0;
 			}
 		}
-	};
+	}
 
-	var resizeListener = function (/*e*/) {
+	function texturize( text ) {
+		text = '' + text; // make sure we get a string. Title "1" came in as int 1, for example, which did not support .replace().
+		text = text
+			.replace( /'/g, '&#8217;' )
+			.replace( /&#039;/g, '&#8217;' )
+			.replace( /[\u2019]/g, '&#8217;' );
+		text = text
+			.replace( /"/g, '&#8221;' )
+			.replace( /&#034;/g, '&#8221;' )
+			.replace( /&quot;/g, '&#8221;' )
+			.replace( /[\u201D]/g, '&#8221;' );
+		text = text.replace( /([\w]+)=&#[\d]+;(.+?)&#[\d]+;/g, '$1="$2"' ); // untexturize allowed HTML tags params double-quotes
+		return $.trim( text );
+	}
+
+	function resizeListener() {
 		// Don't animate if user prefers reduced motion.
 		var shouldAnimate =
 			window.matchMedia && ! window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
@@ -86,301 +110,307 @@ jQuery( document ).ready( function ( $ ) {
 		clearTimeout( resizeTimeout );
 		resizeTimeout = setTimeout( function () {
 			calculatePadding();
-			gallery.jp_carousel( 'slides' ).jp_carousel( 'fitSlide', shouldAnimate );
-			gallery.jp_carousel( 'updateSlidePositions', shouldAnimate );
-			gallery.jp_carousel( 'fitMeta', shouldAnimate );
+			var slides = getSlides( gallery );
+			fitSlides( slides );
+			updateSlidePositions( shouldAnimate );
+			fitMeta( shouldAnimate );
 		}, 200 );
-	};
+	}
 
-	var prepareGallery = function (/*dataCarouselExtra*/) {
+	function fitMeta( animated ) {
+		var newInfoPos = {
+			left: screenPadding + 'px',
+			right: screenPadding + 'px',
+		};
+
+		if ( animated ) {
+			info.animate( newInfoPos );
+		} else {
+			info.css( newInfoPos );
+		}
+	}
+
+	function initializeCarousel() {
 		if ( ! overlay ) {
 			container = $( '.jp-carousel-wrap' );
 			overlay = container.find( '.jp-carousel-overlay' );
 
 			gallery = container.find( '.jp-carousel' );
 			caption = container.find( '.jp-carousel-caption' );
-			photo_info = container.find( '.jp-carousel-photo-info' );
 			info = container.find( '.jp-carousel-info' );
-			commentForm = container.find( '.jp-carousel-comment-form-container' );
-			imageMeta = container.find( '.jp-carousel-image-meta' );
-			titleAndDescription = container.find( '.jp-carousel-titleanddesc' );
 
 			var nextButton = container.find( '.jp-carousel-next-button' );
 			var previousButton = container.find( '.jp-carousel-previous-button' );
 
 			calculatePadding();
-			gallery.jp_carousel( 'fitMeta', false );
+			fitMeta( false );
 
-			container
-				.click( function ( e ) {
-					var target = $( e.target ),
-						wrap = target.parents( 'div.jp-carousel-wrap' ),
-						data = wrap.data( 'carousel-extra' ),
-						slide = wrap.find( 'div.selected' ),
-						attachment_id = slide.data( 'attachment-id' );
-					data = data || [];
+			var textarea = $( '#jp-carousel-comment-form-comment-field' );
+			var emailField = $( '#jp-carousel-comment-form-email-field' );
+			var authorField = $( '#jp-carousel-comment-form-author-field' );
+			var urlField = $( '#jp-carousel-comment-form-url-field' );
 
-					if (
-						target.is( gallery ) ||
-						target.parents().add( target ).is( container.find( '.jp-carousel-close-hint' ) )
-					) {
-						if ( ! window.matchMedia( '(max-device-width: 760px)' ).matches ) {
-							container.jp_carousel( 'close' );
-						} else {
-							if (
-								target.parents().add( target ).is( container.find( '.jp-carousel-close-hint' ) )
-							) {
-								container.jp_carousel( 'close' );
-							}
+			[ textarea, emailField, authorField, urlField ].forEach( function ( field ) {
+				field.focus( disableKeyboardNavigation );
+				field.blur( enableKeyboardNavigation );
+			} );
 
-							if ( e.pageX <= 70 ) {
-								container.jp_carousel( 'previous' );
-							}
-							if ( $( window ).width() - e.pageX <= 70 ) {
-								container.jp_carousel( 'next' );
-							}
-						}
-					} else if ( target.hasClass( 'jp-carousel-image-download' ) ) {
-						stat( 'download_original_click' );
-					} else if ( target.hasClass( 'jp-carousel-commentlink' ) ) {
-						e.preventDefault();
-						e.stopPropagation();
-						$( window ).unbind( 'keydown', keyListener );
-						container.animate( { scrollTop: parseInt( info.position()[ 'top' ], 10 ) }, 'fast' );
-						$( '#jp-carousel-comment-form-submit-and-info-wrapper' ).slideDown( 'fast' );
-						$( '#jp-carousel-comment-form-comment-field' ).focus();
-					} else if ( target.hasClass( 'jp-carousel-comment-login' ) ) {
-						var url = jetpackCarouselStrings.login_url + '%23jp-carousel-' + attachment_id;
+			container.click( function ( e ) {
+				var target = $( e.target );
+				var isTargetCloseHint = target
+					.parents()
+					.add( target )
+					.is( container.find( '.jp-carousel-close-hint' ) );
+				var isSmallScreen = !! window.matchMedia( '(max-device-width: 760px)' ).matches;
 
-						window.location.href = url;
-					} else if ( target.parents( '#jp-carousel-comment-form-container' ).length ) {
-						var textarea = $( '#jp-carousel-comment-form-comment-field' )
-							.blur( function () {
-								$( window ).bind( 'keydown', keyListener );
-							} )
-							.focus( function () {
-								$( window ).unbind( 'keydown', keyListener );
-							} );
-
-						var emailField = $( '#jp-carousel-comment-form-email-field' )
-							.blur( function () {
-								$( window ).bind( 'keydown', keyListener );
-							} )
-							.focus( function () {
-								$( window ).unbind( 'keydown', keyListener );
-							} );
-
-						var authorField = $( '#jp-carousel-comment-form-author-field' )
-							.blur( function () {
-								$( window ).bind( 'keydown', keyListener );
-							} )
-							.focus( function () {
-								$( window ).unbind( 'keydown', keyListener );
-							} );
-
-						var urlField = $( '#jp-carousel-comment-form-url-field' )
-							.blur( function () {
-								$( window ).bind( 'keydown', keyListener );
-							} )
-							.focus( function () {
-								$( window ).unbind( 'keydown', keyListener );
-							} );
-
-						if ( textarea && textarea.attr( 'id' ) === target.attr( 'id' ) ) {
-							// For first page load
-							$( window ).unbind( 'keydown', keyListener );
-							$( '#jp-carousel-comment-form-submit-and-info-wrapper' ).slideDown( 'fast' );
-						} else if ( target.is( 'input[type="submit"]' ) ) {
-							e.preventDefault();
-							e.stopPropagation();
-
-							$( '#jp-carousel-comment-form-spinner' ).show();
-
-							var ajaxData = {
-								action: 'post_attachment_comment',
-								nonce: jetpackCarouselStrings.nonce,
-								blog_id: data[ 'blog_id' ],
-								id: attachment_id,
-								comment: textarea.val(),
-							};
-
-							if ( ! ajaxData[ 'comment' ].length ) {
-								gallery.jp_carousel( 'postCommentError', {
-									field: 'jp-carousel-comment-form-comment-field',
-									error: jetpackCarouselStrings.no_comment_text,
-								} );
-								return;
-							}
-
-							if ( 1 !== Number( jetpackCarouselStrings.is_logged_in ) ) {
-								ajaxData[ 'email' ] = emailField.val();
-								ajaxData[ 'author' ] = authorField.val();
-								ajaxData[ 'url' ] = urlField.val();
-
-								if ( 1 === Number( jetpackCarouselStrings.require_name_email ) ) {
-									if ( ! ajaxData[ 'email' ].length || ! ajaxData[ 'email' ].match( '@' ) ) {
-										gallery.jp_carousel( 'postCommentError', {
-											field: 'jp-carousel-comment-form-email-field',
-											error: jetpackCarouselStrings.no_comment_email,
-										} );
-										return;
-									} else if ( ! ajaxData[ 'author' ].length ) {
-										gallery.jp_carousel( 'postCommentError', {
-											field: 'jp-carousel-comment-form-author-field',
-											error: jetpackCarouselStrings.no_comment_author,
-										} );
-										return;
-									}
-								}
-							}
-
-							$.ajax( {
-								type: 'POST',
-								url: jetpackCarouselStrings.ajaxurl,
-								data: ajaxData,
-								dataType: 'json',
-								success: function ( response /*, status, xhr*/ ) {
-									if ( 'approved' === response.comment_status ) {
-										$( '#jp-carousel-comment-post-results' )
-											.slideUp( 'fast' )
-											.html(
-												'<span class="jp-carousel-comment-post-success">' +
-													jetpackCarouselStrings.comment_approved +
-													'</span>'
-											)
-											.slideDown( 'fast' );
-									} else if ( 'unapproved' === response.comment_status ) {
-										$( '#jp-carousel-comment-post-results' )
-											.slideUp( 'fast' )
-											.html(
-												'<span class="jp-carousel-comment-post-success">' +
-													jetpackCarouselStrings.comment_unapproved +
-													'</span>'
-											)
-											.slideDown( 'fast' );
-									} else {
-										// 'deleted', 'spam', false
-										$( '#jp-carousel-comment-post-results' )
-											.slideUp( 'fast' )
-											.html(
-												'<span class="jp-carousel-comment-post-error">' +
-													jetpackCarouselStrings.comment_post_error +
-													'</span>'
-											)
-											.slideDown( 'fast' );
-									}
-									gallery.jp_carousel( 'clearCommentTextAreaValue' );
-									gallery.jp_carousel( 'getComments', {
-										attachment_id: attachment_id,
-										offset: 0,
-										clear: true,
-									} );
-									$( '#jp-carousel-comment-form-button-submit' ).val(
-										jetpackCarouselStrings.post_comment
-									);
-									$( '#jp-carousel-comment-form-spinner' ).hide();
-								},
-								error: function (/*xhr, status, error*/) {
-									// TODO: Add error handling and display here
-									gallery.jp_carousel( 'postCommentError', {
-										field: 'jp-carousel-comment-form-comment-field',
-										error: jetpackCarouselStrings.comment_post_error,
-									} );
-									return;
-								},
-							} );
-						}
-					} else if ( ! target.parents( '.jp-carousel-info' ).length ) {
-						if ( window.matchMedia( '(max-device-width: 760px)' ).matches ) {
-							if ( e.pageX <= 70 ) {
-								container.jp_carousel( 'previous' );
-							}
-							if ( $( window ).width() - e.pageX <= 70 ) {
-								container.jp_carousel( 'next' );
-							}
-						} else {
-							container.jp_carousel( 'next' );
-						}
+				if ( target.is( gallery ) ) {
+					if ( isSmallScreen ) {
+						handleCarouselGalleryTouch( e );
+					} else {
+						closeCarousel();
 					}
-				} )
-				.bind( 'jp_carousel.afterOpen', function () {
-					$( window ).bind( 'keydown', keyListener );
-					$( window ).bind( 'resize', resizeListener );
-					gallery.opened = true;
-
-					resizeListener();
-				} )
-				.bind( 'jp_carousel.beforeClose', function () {
-					var scroll = $( window ).scrollTop();
-
-					$( window ).unbind( 'keydown', keyListener );
-					$( window ).unbind( 'resize', resizeListener );
-					$( window ).scrollTop( scroll );
-					$( '.jp-carousel-previous-button' ).hide();
-					$( '.jp-carousel-next-button' ).hide();
-					// Set height to original value
-					// Fix some themes where closing carousel brings view back to top
-					$( 'html' ).css( 'height', '' );
-				} )
-				.bind( 'jp_carousel.afterClose', function () {
-					if ( window.location.hash && history.back ) {
-						history.back();
+				} else if ( isTargetCloseHint ) {
+					closeCarousel();
+				} else if ( target.hasClass( 'jp-carousel-image-download' ) ) {
+					stat( 'download_original_click' );
+				} else if ( target.hasClass( 'jp-carousel-commentlink' ) ) {
+					handleCommentLinkClick( e );
+				} else if ( target.hasClass( 'jp-carousel-comment-login' ) ) {
+					handleCommentLoginClick( e );
+				} else if ( target.parents( '#jp-carousel-comment-form-container' ).length ) {
+					handleCommentFormClick( e );
+				} else if ( ! target.parents( '.jp-carousel-info' ).length ) {
+					if ( isSmallScreen ) {
+						handleCarouselGalleryTouch( e );
+					} else {
+						moveToNextSlide();
 					}
-					last_known_location_hash = '';
-					gallery.opened = false;
-				} )
-				.on( 'transitionend.jp-carousel ', '.jp-carousel-slide', function ( e ) {
-					// If the movement transitions take more than twice the allotted time, disable them.
-					// There is some wiggle room in the 2x, since some of that time is taken up in
-					// JavaScript, setting up the transition and calling the events.
-					if ( 'transform' === e.originalEvent.propertyName ) {
-						var transitionMultiplier =
-							( Date.now() - transitionBegin ) / 1000 / e.originalEvent.elapsedTime;
+				}
+			} );
 
-						container.off( 'transitionend.jp-carousel' );
+			$( window ).bind( 'keydown', handleKeyboardEvent );
 
-						if ( transitionMultiplier >= 2 ) {
-							$( '.jp-carousel-transitions' ).removeClass( 'jp-carousel-transitions' );
-						}
+			container.bind( 'jp_carousel.afterOpen', function () {
+				enableKeyboardNavigation();
+				$( window ).bind( 'resize', resizeListener );
+				gallery.opened = true;
+
+				resizeListener();
+			} );
+
+			container.bind( 'jp_carousel.beforeClose', function () {
+				var scroll = $( window ).scrollTop();
+
+				disableKeyboardNavigation();
+				$( window ).unbind( 'resize', resizeListener );
+				$( window ).scrollTop( scroll );
+				$( '.jp-carousel-previous-button' ).hide();
+				$( '.jp-carousel-next-button' ).hide();
+				// Set height to original value
+				// Fix some themes where closing carousel brings view back to top
+				$( 'html' ).css( 'height', '' );
+			} );
+
+			container.bind( 'jp_carousel.afterClose', function () {
+				if ( window.location.hash && history.back ) {
+					history.back();
+				}
+				lastKnownLocationHash = '';
+				gallery.opened = false;
+			} );
+
+			container.on( 'transitionend.jp-carousel ', '.jp-carousel-slide', function ( e ) {
+				// If the movement transitions take more than twice the allotted time, disable them.
+				// There is some wiggle room in the 2x, since some of that time is taken up in
+				// JavaScript, setting up the transition and calling the events.
+				if ( e.originalEvent.propertyName === 'transform' ) {
+					var transitionMultiplier =
+						( Date.now() - transitionBegin ) / 1000 / e.originalEvent.elapsedTime;
+
+					container.off( 'transitionend.jp-carousel' );
+
+					if ( transitionMultiplier >= 2 ) {
+						$( '.jp-carousel-transitions' ).removeClass( 'jp-carousel-transitions' );
 					}
-				} );
+				}
+			} );
 
-			container.touchwipe( {
+			addWipeHandler( {
+				root: container.get( 0 ),
 				wipeLeft: function ( e ) {
 					e.preventDefault();
-					gallery.jp_carousel( 'next' );
+					moveToNextSlide();
 				},
 				wipeRight: function ( e ) {
 					e.preventDefault();
-					gallery.jp_carousel( 'previous' );
+					moveToPreviousSlide();
 				},
-				preventDefaultEvents: false,
 			} );
 
 			nextButton.add( previousButton ).click( function ( e ) {
 				e.preventDefault();
 				e.stopPropagation();
 				if ( nextButton.is( this ) ) {
-					gallery.jp_carousel( 'next' );
+					moveToNextSlide();
 				} else {
-					gallery.jp_carousel( 'previous' );
+					moveToPreviousSlide();
 				}
 			} );
 		}
-	};
+	}
 
-	var processSingleImageGallery = function () {
+	function handleCarouselGalleryTouch( e ) {
+		if ( e.pageX <= 70 ) {
+			moveToPreviousSlide();
+		}
+		if ( $( window ).width() - e.pageX <= 70 ) {
+			moveToNextSlide();
+		}
+	}
+
+	function handleCommentLinkClick( e ) {
+		e.preventDefault();
+		e.stopPropagation();
+		disableKeyboardNavigation();
+		container.animate( { scrollTop: parseInt( info.position()[ 'top' ], 10 ) }, 'fast' );
+		$( '#jp-carousel-comment-form-submit-and-info-wrapper' ).slideDown( 'fast' );
+		$( '#jp-carousel-comment-form-comment-field' ).focus();
+	}
+
+	function handleCommentLoginClick( e ) {
+		var target = $( e.target );
+		var wrap = target.parents( 'div.jp-carousel-wrap' );
+		var slide = wrap.find( 'div.selected' );
+		var attachmentId = slide.data( 'attachment-id' );
+
+		window.location.href = jetpackCarouselStrings.login_url + '%23jp-carousel-' + attachmentId;
+	}
+
+	function handleCommentFormClick( e ) {
+		var target = $( e.target );
+		var wrap = target.parents( 'div.jp-carousel-wrap' );
+		var data = wrap.data( 'carousel-extra' ) || {};
+		var blogId = data[ 'blog_id' ];
+		var slide = wrap.find( 'div.selected' );
+		var attachmentId = slide.data( 'attachment-id' );
+
+		var textarea = $( '#jp-carousel-comment-form-comment-field' );
+		var emailField = $( '#jp-carousel-comment-form-email-field' );
+		var authorField = $( '#jp-carousel-comment-form-author-field' );
+		var urlField = $( '#jp-carousel-comment-form-url-field' );
+
+		if ( textarea && textarea.attr( 'id' ) === target.attr( 'id' ) ) {
+			// For first page load
+			disableKeyboardNavigation();
+			$( '#jp-carousel-comment-form-submit-and-info-wrapper' ).slideDown( 'fast' );
+		} else if ( target.is( 'input[type="submit"]' ) ) {
+			e.preventDefault();
+			e.stopPropagation();
+
+			$( '#jp-carousel-comment-form-spinner' ).show();
+
+			var ajaxData = {
+				action: 'post_attachment_comment',
+				nonce: jetpackCarouselStrings.nonce,
+				blog_id: blogId,
+				id: attachmentId,
+				comment: textarea.val(),
+			};
+
+			if ( ! ajaxData[ 'comment' ].length ) {
+				handlePostCommentError(
+					'jp-carousel-comment-form-comment-field',
+					jetpackCarouselStrings.no_comment_text
+				);
+				return;
+			}
+
+			if ( Number( jetpackCarouselStrings.is_logged_in !== 1 ) ) {
+				ajaxData[ 'email' ] = emailField.val();
+				ajaxData[ 'author' ] = authorField.val();
+				ajaxData[ 'url' ] = urlField.val();
+
+				if ( Number( jetpackCarouselStrings.require_name_email === 1 ) ) {
+					if ( ! ajaxData[ 'email' ].length || ! ajaxData[ 'email' ].match( '@' ) ) {
+						handlePostCommentError(
+							'jp-carousel-comment-form-email-field',
+							jetpackCarouselStrings.no_comment_email
+						);
+						return;
+					} else if ( ! ajaxData[ 'author' ].length ) {
+						handlePostCommentError(
+							'jp-carousel-comment-form-author-field',
+							jetpackCarouselStrings.no_comment_author
+						);
+						return;
+					}
+				}
+			}
+
+			$.ajax( {
+				type: 'POST',
+				url: jetpackCarouselStrings.ajaxurl,
+				data: ajaxData,
+				dataType: 'json',
+				success: function ( response ) {
+					if ( response.comment_status === 'approved' ) {
+						$( '#jp-carousel-comment-post-results' )
+							.slideUp( 'fast' )
+							.html(
+								'<span class="jp-carousel-comment-post-success">' +
+									jetpackCarouselStrings.comment_approved +
+									'</span>'
+							)
+							.slideDown( 'fast' );
+					} else if ( response.comment_status === 'unapproved' ) {
+						$( '#jp-carousel-comment-post-results' )
+							.slideUp( 'fast' )
+							.html(
+								'<span class="jp-carousel-comment-post-success">' +
+									jetpackCarouselStrings.comment_unapproved +
+									'</span>'
+							)
+							.slideDown( 'fast' );
+					} else {
+						// 'deleted', 'spam', false
+						$( '#jp-carousel-comment-post-results' )
+							.slideUp( 'fast' )
+							.html(
+								'<span class="jp-carousel-comment-post-error">' +
+									jetpackCarouselStrings.comment_post_error +
+									'</span>'
+							)
+							.slideDown( 'fast' );
+					}
+					clearCommentTextAreaValue();
+					fetchComments( attachmentId, 0, true );
+					$( '#jp-carousel-comment-form-button-submit' ).val( jetpackCarouselStrings.post_comment );
+					$( '#jp-carousel-comment-form-spinner' ).hide();
+				},
+				error: function () {
+					// TODO: Add error handling and display here
+					handlePostCommentError(
+						'jp-carousel-comment-form-comment-field',
+						jetpackCarouselStrings.comment_post_error
+					);
+					return;
+				},
+			} );
+		}
+	}
+
+	function processSingleImageGallery() {
 		// process links that contain img tag with attribute data-attachment-id
 		$( 'a img[data-attachment-id]' ).each( function () {
-			var container = $( this ).parent();
+			var cont = $( this ).parent();
 
 			// skip if image was already added to gallery by shortcode
-			if ( container.parent( '.gallery-icon' ).length ) {
+			if ( cont.parent( '.gallery-icon' ).length ) {
 				return;
 			}
 
 			// skip if the container is not a link
-			if ( 'undefined' === typeof $( container ).attr( 'href' ) ) {
+			if ( typeof $( cont ).attr( 'href' ) === 'undefined' ) {
 				return;
 			}
 
@@ -388,15 +418,15 @@ jQuery( document ).ready( function ( $ ) {
 
 			// if link points to 'Media File' (ignoring GET parameters) and flag is set allow it
 			if (
-				$( container ).attr( 'href' ).split( '?' )[ 0 ] ===
+				$( cont ).attr( 'href' ).split( '?' )[ 0 ] ===
 					$( this ).attr( 'data-orig-file' ).split( '?' )[ 0 ] &&
-				1 === Number( jetpackCarouselStrings.single_image_gallery_media_file )
+				Number( jetpackCarouselStrings.single_image_gallery_media_file === 1 )
 			) {
 				valid = true;
 			}
 
 			// if link points to 'Attachment Page' allow it
-			if ( $( container ).attr( 'href' ) === $( this ).attr( 'data-permalink' ) ) {
+			if ( $( cont ).attr( 'href' ) === $( this ).attr( 'data-permalink' ) ) {
 				valid = true;
 			}
 
@@ -406,1034 +436,998 @@ jQuery( document ).ready( function ( $ ) {
 			}
 
 			// make this node a gallery recognizable by event listener above
-			$( container ).addClass( 'single-image-gallery' );
+			$( cont ).addClass( 'single-image-gallery' );
 			// blog_id is needed to allow posting comments to correct blog
-			$( container ).data( 'carousel-extra', {
+			$( cont ).data( 'carousel-extra', {
 				blog_id: Number( jetpackCarouselStrings.blog_id ),
 			} );
 		} );
-	};
+	}
 
-	var methods = {
-		testForData: function ( gallery ) {
-			gallery = $( gallery );
-			return ! ( ! gallery.length || ! gallery.data( 'carousel-extra' ) );
-		},
+	function testForData( el ) {
+		var $el = $( el );
+		return ! ( ! $el.length || ! $el.data( 'carousel-extra' ) );
+	}
 
-		testIfOpened: function () {
-			return !! (
-				'undefined' !== typeof gallery &&
-				'undefined' !== typeof gallery.opened &&
-				gallery.opened
-			);
-		},
+	function isCarouselOpen() {
+		return !! (
+			typeof gallery !== 'undefined' &&
+			typeof gallery.opened !== 'undefined' &&
+			gallery.opened
+		);
+	}
 
-		openOrSelectSlide: function ( index ) {
-			// The `open` method triggers an asynchronous effect, so we will get an
-			// error if we try to use `open` then `selectSlideAtIndex` immediately
-			// after it. We can only use `selectSlideAtIndex` if the carousel is
-			// already open.
-			if ( ! $( this ).jp_carousel( 'testIfOpened' ) ) {
-				// The `open` method selects the correct slide during the
-				// initialization.
-				$( this ).jp_carousel( 'open', { start_index: index } );
-			} else {
-				gallery.jp_carousel( 'selectSlideAtIndex', index );
-			}
-		},
+	function openOrSelectSlide( gal, index ) {
+		// The `open` method triggers an asynchronous effect, so we will get an
+		// error if we try to use `openCarousel` then `selectSlideAtIndex`
+		// immediately after it. We can only use `selectSlideAtIndex` if the
+		// carousel is already open.
+		if ( ! isCarouselOpen() ) {
+			// The `open` method selects the correct slide during the
+			// initialization.
+			openCarousel( gal, { startIndex: index } );
+		} else {
+			selectSlideAtIndex( index );
+		}
+	}
 
-		open: function ( options ) {
-			var settings = {
-					items_selector:
-						'.gallery-item [data-attachment-id], .tiled-gallery-item [data-attachment-id], img[data-attachment-id]',
-					start_index: 0,
-				},
-				data = $( this ).data( 'carousel-extra' );
+	function selectSlideAtIndex( index ) {
+		var slides = getSlides( gallery ),
+			selected = slides.eq( index );
 
-			if ( ! data ) {
-				return; // don't run if the default gallery functions weren't used
-			}
+		if ( selected.length === 0 ) {
+			selected = slides.eq( 0 );
+		}
 
-			prepareGallery( data );
+		selectSlide( selected, false );
+	}
 
-			if ( gallery.jp_carousel( 'testIfOpened' ) ) {
-				return; // don't open if already opened
-			}
+	function moveToNextSlide() {
+		moveToPreviousOrNextSlide( getNextSlide );
+	}
 
-			// make sure to stop the page from scrolling behind the carousel overlay, so we don't trigger
-			// infiniscroll for it when enabled (Reader, theme infiniscroll, etc).
-			originalOverflow = $( 'body' ).css( 'overflow' );
-			$( 'body' ).css( 'overflow', 'hidden' );
-			// prevent html from overflowing on some of the new themes.
-			originalHOverflow = $( 'html' ).css( 'overflow' );
-			$( 'html' ).css( 'overflow', 'hidden' );
-			scrollPos = $( window ).scrollTop();
+	function moveToPreviousSlide() {
+		moveToPreviousOrNextSlide( getPrevSlide );
+	}
 
-			container.data( 'carousel-extra', data );
-			stat( [ 'open', 'view_image' ] );
+	function moveToPreviousOrNextSlide( slideSelectionMethod ) {
+		if ( getSlides( gallery ).length <= 1 ) {
+			return false;
+		}
 
-			return this.each( function () {
-				// If options exist, lets merge them
-				// with our default settings
-				var $this = $( this );
+		var slide = slideSelectionMethod( gallery );
 
-				if ( options ) {
-					$.extend( settings, options );
-				}
-				if ( -1 === settings.start_index ) {
-					settings.start_index = 0; //-1 returned if can't find index, so start from beginning
-				}
+		if ( slide ) {
+			container.animate( { scrollTop: 0 }, 'fast' );
+			clearCommentTextAreaValue();
+			selectSlide( slide );
+			stat( [ 'previous', 'view_image' ] );
+		}
+	}
 
-				container.trigger( 'jp_carousel.beforeOpen' ).fadeIn( 'fast', function () {
-					container.trigger( 'jp_carousel.afterOpen' );
-					gallery
-						.jp_carousel(
-							'initSlides',
-							$this.find( settings.items_selector ),
-							settings.start_index
-						)
-						.jp_carousel( 'selectSlideAtIndex', settings.start_index );
-				} );
-				gallery.html( '' );
-			} );
-		},
+	function getSelectedSlide( el ) {
+		return el.find( '.selected' );
+	}
 
-		selectSlideAtIndex: function ( index ) {
-			var slides = this.jp_carousel( 'slides' ),
-				selected = slides.eq( index );
+	function getNextSlide( galleryEl ) {
+		var slides = getSlides( galleryEl );
+		var selected = getSelectedSlide( galleryEl );
 
-			if ( 0 === selected.length ) {
-				selected = slides.eq( 0 );
-			}
+		if ( selected.length === 0 || ( slides.length > 2 && selected.is( slides.last() ) ) ) {
+			return slides.first();
+		}
 
-			gallery.jp_carousel( 'selectSlide', selected, false );
-			return this;
-		},
+		return selected.next();
+	}
 
-		close: function () {
-			// make sure to let the page scroll again
-			$( 'body' ).css( 'overflow', originalOverflow );
-			$( 'html' ).css( 'overflow', originalHOverflow );
-			this.jp_carousel( 'clearCommentTextAreaValue' );
-			return container.trigger( 'jp_carousel.beforeClose' ).fadeOut( 'fast', function () {
-				container.trigger( 'jp_carousel.afterClose' );
-				$( window ).scrollTop( scrollPos );
-			} );
-		},
+	function getPrevSlide( galleryEl ) {
+		var slides = getSlides( galleryEl );
+		var selected = getSelectedSlide( galleryEl );
 
-		next: function () {
-			this.jp_carousel( 'previousOrNext', 'nextSlide' );
-		},
+		if ( selected.length === 0 || ( slides.length > 2 && selected.is( slides.first() ) ) ) {
+			return slides.last();
+		}
 
-		previous: function () {
-			this.jp_carousel( 'previousOrNext', 'prevSlide' );
-		},
+		return selected.prev();
+	}
 
-		previousOrNext: function ( slideSelectionMethodName ) {
-			if ( ! this.jp_carousel( 'hasMultipleImages' ) ) {
-				return false;
-			}
+	function closeCarousel() {
+		// make sure to let the page scroll again
+		$( 'body' ).css( 'overflow', originalOverflow );
+		$( 'html' ).css( 'overflow', originalHOverflow );
+		clearCommentTextAreaValue();
 
-			var slide = gallery.jp_carousel( slideSelectionMethodName );
+		container.trigger( 'jp_carousel.beforeClose' );
 
-			if ( slide ) {
-				container.animate( { scrollTop: 0 }, 'fast' );
-				this.jp_carousel( 'clearCommentTextAreaValue' );
-				this.jp_carousel( 'selectSlide', slide );
-				stat( [ 'previous', 'view_image' ] );
-			}
-		},
+		container.fadeOut( 'fast', function () {
+			container.trigger( 'jp_carousel.afterClose' );
+			$( window ).scrollTop( scrollPos );
+		} );
+	}
 
-		selectedSlide: function () {
-			return this.find( '.selected' );
-		},
+	function setSlidePosition( slide, x ) {
+		transitionBegin = Date.now();
 
-		setSlidePosition: function ( x ) {
-			transitionBegin = Date.now();
+		slide.css( {
+			transform: 'translate3d(' + x + 'px,0,0)',
+		} );
+	}
 
-			return this.css( {
-				'-webkit-transform': 'translate3d(' + x + 'px,0,0)',
-				'-moz-transform': 'translate3d(' + x + 'px,0,0)',
-				'-ms-transform': 'translate(' + x + 'px,0)',
-				'-o-transform': 'translate(' + x + 'px,0)',
-				transform: 'translate3d(' + x + 'px,0,0)',
-			} );
-		},
+	function updateSlidePositions( shouldAnimate ) {
+		var current = getSelectedSlide( gallery );
+		var galleryWidth = gallery.width(),
+			currentWidth = current.width(),
+			previous = getPrevSlide( gallery ),
+			next = getNextSlide( gallery ),
+			previousPrevious = previous.prev(),
+			nextNext = next.next(),
+			left = Math.floor( ( galleryWidth - currentWidth ) * 0.5 );
 
-		updateSlidePositions: function ( animate ) {
-			var current = this.jp_carousel( 'selectedSlide' ),
-				galleryWidth = gallery.width(),
-				currentWidth = current.width(),
-				previous = gallery.jp_carousel( 'prevSlide' ),
-				next = gallery.jp_carousel( 'nextSlide' ),
-				previousPrevious = previous.prev(),
-				nextNext = next.next(),
-				left = Math.floor( ( galleryWidth - currentWidth ) * 0.5 );
+		setSlidePosition( current, left );
+		current.show();
 
-			current.jp_carousel( 'setSlidePosition', left ).show();
+		// minimum width
+		fitInfo( shouldAnimate );
 
-			// minimum width
-			gallery.jp_carousel( 'fitInfo', animate );
+		// prep the slides
+		var direction = lastSelectedSlide.is( current.prevAll() ) ? 1 : -1;
 
-			// prep the slides
-			var direction = lastSelectedSlide.is( current.prevAll() ) ? 1 : -1;
-
-			// Since we preload the `previousPrevious` and `nextNext` slides, we need
-			// to make sure they technically visible in the DOM, but invisible to the
-			// user. To hide them from the user, we position them outside the edges
-			// of the window.
-			//
-			// This section of code only applies when there are more than three
-			// slides. Otherwise, the `previousPrevious` and `nextNext` slides will
-			// overlap with the `previous` and `next` slides which must be visible
-			// regardless.
-			if ( 1 === direction ) {
-				if ( ! nextNext.is( previous ) ) {
-					nextNext.jp_carousel( 'setSlidePosition', galleryWidth + next.width() ).show();
-				}
-
-				if ( ! previousPrevious.is( next ) ) {
-					previousPrevious
-						.jp_carousel( 'setSlidePosition', -previousPrevious.width() - currentWidth )
-						.show();
-				}
-			} else {
-				if ( ! nextNext.is( previous ) ) {
-					nextNext.jp_carousel( 'setSlidePosition', galleryWidth + currentWidth ).show();
-				}
+		// Since we preload the `previousPrevious` and `nextNext` slides, we need
+		// to make sure they technically visible in the DOM, but invisible to the
+		// user. To hide them from the user, we position them outside the edges
+		// of the window.
+		//
+		// This section of code only applies when there are more than three
+		// slides. Otherwise, the `previousPrevious` and `nextNext` slides will
+		// overlap with the `previous` and `next` slides which must be visible
+		// regardless.
+		if ( direction === 1 ) {
+			if ( ! nextNext.is( previous ) ) {
+				setSlidePosition( nextNext, galleryWidth + next.width() );
+				nextNext.show();
 			}
 
-			previous
-				.jp_carousel( 'setSlidePosition', Math.floor( -previous.width() + screenPadding * 0.75 ) )
-				.show();
-			next
-				.jp_carousel( 'setSlidePosition', Math.ceil( galleryWidth - screenPadding * 0.75 ) )
-				.show();
-		},
+			if ( ! previousPrevious.is( next ) ) {
+				setSlidePosition( previousPrevious, -previousPrevious.width() - currentWidth );
+				previousPrevious.show();
+			}
+		} else {
+			if ( ! nextNext.is( previous ) ) {
+				setSlidePosition( nextNext, galleryWidth + currentWidth );
+				nextNext.show();
+			}
+		}
 
-		selectSlide: function ( slide, animate ) {
-			lastSelectedSlide = this.find( '.selected' ).removeClass( 'selected' );
+		setSlidePosition( previous, Math.floor( -previous.width() + screenPadding * 0.75 ) );
+		previous.show();
 
-			var slides = gallery.jp_carousel( 'slides' ).css( { position: 'fixed' } ),
-				current = $( slide ).addClass( 'selected' ).css( { position: 'relative' } ),
-				attachmentId = current.data( 'attachment-id' ),
-				previous = gallery.jp_carousel( 'prevSlide' ),
-				next = gallery.jp_carousel( 'nextSlide' ),
-				previousPrevious = previous.prev(),
-				nextNext = next.next(),
-				animated,
-				captionHtml;
+		setSlidePosition( next, Math.ceil( galleryWidth - screenPadding * 0.75 ) );
+		next.show();
+	}
 
-			// center the main image
-			gallery.jp_carousel( 'loadFullImage', current );
+	function selectSlide( slide, animate ) {
+		lastSelectedSlide = gallery.find( '.selected' );
+		lastSelectedSlide.removeClass( 'selected' );
 
-			caption.hide();
+		var slides = getSlides( gallery );
+		var currentSlide = $( slide );
+		var attachmentId = currentSlide.data( 'attachment-id' );
+		var previous = getPrevSlide( gallery );
+		var next = getNextSlide( gallery );
+		var previousPrevious = previous.prev();
+		var nextNext = next.next();
+		var animated;
+		var captionHtml;
 
-			if ( next.length === 0 && slides.length <= 2 ) {
-				$( '.jp-carousel-next-button' ).hide();
-			} else {
-				$( '.jp-carousel-next-button' ).show();
+		slides.css( { position: 'fixed' } );
+		currentSlide.addClass( 'selected' ).css( { position: 'relative' } );
+
+		// center the main image
+		loadFullImage( currentSlide );
+
+		caption.hide();
+
+		if ( next.length === 0 && slides.length <= 2 ) {
+			$( '.jp-carousel-next-button' ).hide();
+		} else {
+			$( '.jp-carousel-next-button' ).show();
+		}
+
+		if ( previous.length === 0 && slides.length <= 2 ) {
+			$( '.jp-carousel-previous-button' ).hide();
+		} else {
+			$( '.jp-carousel-previous-button' ).show();
+		}
+
+		animated = loadSlides(
+			currentSlide.add( previous ).add( previousPrevious ).add( next ).add( nextNext )
+		);
+
+		// slide the whole view to the x we want
+		slides.not( animated ).hide();
+
+		updateSlidePositions( animate );
+		container.trigger( 'jp_carousel.selectSlide', [ currentSlide ] );
+
+		updateTitleAndDesc( {
+			title: currentSlide.data( 'title' ),
+			desc: currentSlide.data( 'desc' ),
+		} );
+
+		var imageMeta = currentSlide.data( 'image-meta' );
+		updateExif( imageMeta );
+		updateFullSizeLink( currentSlide );
+
+		if ( Number( jetpackCarouselStrings.display_comments ) === 1 ) {
+			testCommentsOpened( currentSlide.data( 'comments-opened' ) );
+			fetchComments( attachmentId, 0, true );
+			$( '#jp-carousel-comment-post-results' ).slideUp();
+		}
+
+		// $('<div />').text(sometext).html() is a trick to go to HTML to plain
+		// text (including HTML entities decode, etc)
+		if ( currentSlide.data( 'caption' ) ) {
+			captionHtml = $( '<div />' ).text( currentSlide.data( 'caption' ) ).html();
+
+			if ( captionHtml === $( '<div />' ).text( currentSlide.data( 'title' ) ).html() ) {
+				$( '.jp-carousel-titleanddesc-title' ).fadeOut( 'fast' ).empty();
 			}
 
-			if ( previous.length === 0 && slides.length <= 2 ) {
-				$( '.jp-carousel-previous-button' ).hide();
-			} else {
-				$( '.jp-carousel-previous-button' ).show();
+			if ( captionHtml === $( '<div />' ).text( currentSlide.data( 'desc' ) ).html() ) {
+				$( '.jp-carousel-titleanddesc-desc' ).fadeOut( 'fast' ).empty();
 			}
 
-			animated = current
-				.add( previous )
-				.add( previousPrevious )
-				.add( next )
-				.add( nextNext )
-				.jp_carousel( 'loadSlide' );
+			caption.html( currentSlide.data( 'caption' ) ).fadeIn( 'slow' );
+		} else {
+			caption.fadeOut( 'fast' ).empty();
+		}
 
-			// slide the whole view to the x we want
-			slides.not( animated ).hide();
+		// Record pageview in WP Stats, for each new image loaded full-screen.
+		if ( jetpackCarouselStrings.stats ) {
+			new Image().src =
+				document.location.protocol +
+				'//pixel.wp.com/g.gif?' +
+				jetpackCarouselStrings.stats +
+				'&post=' +
+				encodeURIComponent( attachmentId ) +
+				'&rand=' +
+				Math.random();
+		}
 
-			gallery.jp_carousel( 'updateSlidePositions', animate );
-
-			container.trigger( 'jp_carousel.selectSlide', [ current ] );
-
-			gallery.jp_carousel( 'getTitleDesc', {
-				title: current.data( 'title' ),
-				desc: current.data( 'desc' ),
-			} );
-
-			var imageMeta = current.data( 'image-meta' );
-			gallery.jp_carousel( 'updateExif', imageMeta );
-			gallery.jp_carousel( 'updateFullSizeLink', current );
-
-			if ( 1 === +jetpackCarouselStrings.display_comments ) {
-				gallery.jp_carousel( 'testCommentsOpened', current.data( 'comments-opened' ) );
-				gallery.jp_carousel( 'getComments', {
-					attachment_id: attachmentId,
-					offset: 0,
-					clear: true,
-				} );
-				$( '#jp-carousel-comment-post-results' ).slideUp();
-			}
-
-			// $('<div />').text(sometext).html() is a trick to go to HTML to plain
-			// text (including HTML entities decode, etc)
-			if ( current.data( 'caption' ) ) {
-				captionHtml = $( '<div />' ).text( current.data( 'caption' ) ).html();
-
-				if ( captionHtml === $( '<div />' ).text( current.data( 'title' ) ).html() ) {
-					$( '.jp-carousel-titleanddesc-title' ).fadeOut( 'fast' ).empty();
-				}
-
-				if ( captionHtml === $( '<div />' ).text( current.data( 'desc' ) ).html() ) {
-					$( '.jp-carousel-titleanddesc-desc' ).fadeOut( 'fast' ).empty();
-				}
-
-				caption.html( current.data( 'caption' ) ).fadeIn( 'slow' );
-			} else {
-				caption.fadeOut( 'fast' ).empty();
-			}
-
-			// Record pageview in WP Stats, for each new image loaded full-screen.
-			if ( jetpackCarouselStrings.stats ) {
-				new Image().src =
-					document.location.protocol +
-					'//pixel.wp.com/g.gif?' +
-					jetpackCarouselStrings.stats +
-					'&post=' +
-					encodeURIComponent( attachmentId ) +
-					'&rand=' +
-					Math.random();
-			}
-
-			pageview( attachmentId );
-			// Load the images for the next and previous slides.
-			$( next )
-				.add( previous )
-				.each( function () {
-					gallery.jp_carousel( 'loadFullImage', $( this ) );
-				} );
-
-			window.location.hash = last_known_location_hash = '#jp-carousel-' + attachmentId;
-		},
-
-		slides: function () {
-			return this.find( '.jp-carousel-slide' );
-		},
-
-		slideDimensions: function () {
-			return {
-				width: $( window ).width() - screenPadding * 2,
-				height: Math.floor( ( $( window ).height() / 100 ) * proportion - 60 ),
-			};
-		},
-
-		loadSlide: function () {
-			return this.each( function () {
-				var slide = $( this );
-				slide.find( 'img' ).one( 'load', function () {
-					// set the width/height of the image if it's too big
-					slide.jp_carousel( 'fitSlide', false );
-				} );
-			} );
-		},
-
-		bestFit: function () {
-			var max = gallery.jp_carousel( 'slideDimensions' ),
-				orig = this.jp_carousel( 'originalDimensions' ),
-				orig_ratio = orig.width / orig.height,
-				w_ratio = 1,
-				h_ratio = 1,
-				width,
-				height;
-
-			if ( orig.width > max.width ) {
-				w_ratio = max.width / orig.width;
-			}
-			if ( orig.height > max.height ) {
-				h_ratio = max.height / orig.height;
-			}
-
-			if ( w_ratio < h_ratio ) {
-				width = max.width;
-				height = Math.floor( width / orig_ratio );
-			} else if ( h_ratio < w_ratio ) {
-				height = max.height;
-				width = Math.floor( height * orig_ratio );
-			} else {
-				width = orig.width;
-				height = orig.height;
-			}
-
-			return {
-				width: width,
-				height: height,
-			};
-		},
-
-		fitInfo: function (/*animated*/) {
-			var current = this.jp_carousel( 'selectedSlide' );
-			var size = current.jp_carousel( 'bestFit' );
-
-			photo_info.css( {
-				left: Math.floor( ( info.width() - size.width ) * 0.5 ),
-				width: Math.floor( size.width ),
+		pageview( attachmentId );
+		// Load the images for the next and previous slides.
+		$( next )
+			.add( previous )
+			.each( function () {
+				loadFullImage( $( this ) );
 			} );
 
-			return this;
-		},
+		window.location.hash = lastKnownLocationHash = '#jp-carousel-' + attachmentId;
+	}
 
-		fitMeta: function ( animated ) {
-			var newInfoPos = {
-				left: screenPadding + 'px',
-				right: screenPadding + 'px',
-			};
+	function getSlides( gal ) {
+		return gal.find( '.jp-carousel-slide' );
+	}
 
-			if ( animated ) {
-				info.animate( newInfoPos );
-			} else {
-				info.css( newInfoPos );
-			}
-		},
+	function calculateMaxSlideDimensions() {
+		return {
+			width: $( window ).width() - screenPadding * 2,
+			height: Math.floor( ( $( window ).height() / 100 ) * proportion - 60 ),
+		};
+	}
 
-		fitSlide: function (/*animated*/) {
-			return this.each( function () {
-				var $this = $( this ),
-					dimensions = $this.jp_carousel( 'bestFit' ),
-					method = 'css',
-					max = gallery.jp_carousel( 'slideDimensions' );
+	function calculateBestFit( slide ) {
+		var max = calculateMaxSlideDimensions();
+		var orig = getOriginalDimensions( slide ),
+			origRatio = orig.width / orig.height,
+			wRatio = 1,
+			hRatio = 1,
+			width,
+			height;
 
-				dimensions.left = 0;
-				dimensions.top = Math.floor( ( max.height - dimensions.height ) * 0.5 ) + 40;
-				$this[ method ]( dimensions );
+		if ( orig.width > max.width ) {
+			wRatio = max.width / orig.width;
+		}
+		if ( orig.height > max.height ) {
+			hRatio = max.height / orig.height;
+		}
+
+		if ( wRatio < hRatio ) {
+			width = max.width;
+			height = Math.floor( width / origRatio );
+		} else if ( hRatio < wRatio ) {
+			height = max.height;
+			width = Math.floor( height * origRatio );
+		} else {
+			width = orig.width;
+			height = orig.height;
+		}
+
+		return {
+			width: width,
+			height: height,
+		};
+	}
+
+	function loadSlides( slides ) {
+		return slides.each( function () {
+			var slide = $( this );
+			slide.find( 'img' ).one( 'load', function () {
+				// set the width/height of the image if it's too big
+				fitSlides( slide );
 			} );
-		},
+		} );
+	}
 
-		texturize: function ( text ) {
-			text = '' + text; // make sure we get a string. Title "1" came in as int 1, for example, which did not support .replace().
-			text = text
-				.replace( /'/g, '&#8217;' )
-				.replace( /&#039;/g, '&#8217;' )
-				.replace( /[\u2019]/g, '&#8217;' );
-			text = text
-				.replace( /"/g, '&#8221;' )
-				.replace( /&#034;/g, '&#8221;' )
-				.replace( /&quot;/g, '&#8221;' )
-				.replace( /[\u201D]/g, '&#8221;' );
-			text = text.replace( /([\w]+)=&#[\d]+;(.+?)&#[\d]+;/g, '$1="$2"' ); // untexturize allowed HTML tags params double-quotes
-			return $.trim( text );
-		},
+	function fitInfo() {
+		var current = getSelectedSlide( gallery );
+		var size = calculateBestFit( current );
 
-		initSlides: function ( items, start_index ) {
-			if ( items.length < 2 ) {
-				$( '.jp-carousel-next-button, .jp-carousel-previous-button' ).hide();
-			} else {
-				$( '.jp-carousel-next-button, .jp-carousel-previous-button' ).show();
-			}
+		container.find( '.jp-carousel-photo-info' ).css( {
+			left: Math.floor( ( info.width() - size.width ) * 0.5 ),
+			width: Math.floor( size.width ),
+		} );
+	}
 
-			// Calculate the new src.
-			items.each( function (/*i*/) {
-				var src_item = $( this ),
-					orig_size = src_item.data( 'orig-size' ) || '',
-					max = gallery.jp_carousel( 'slideDimensions' ),
-					parts = orig_size.split( ',' ),
-					medium_file = src_item.data( 'medium-file' ) || '',
-					large_file = src_item.data( 'large-file' ) || '',
-					src;
-				orig_size = { width: parseInt( parts[ 0 ], 10 ), height: parseInt( parts[ 1 ], 10 ) };
+	function fitSlides( slides ) {
+		return slides.each( function () {
+			var $slide = $( this ),
+				dimensions = calculateBestFit( $slide ),
+				max = calculateMaxSlideDimensions();
 
-				if ( typeof wpcom !== 'undefined' && wpcom.carousel && wpcom.carousel.generateImgSrc ) {
-					src = wpcom.carousel.generateImgSrc( src_item.get( 0 ), max );
-				} else {
-					src = src_item.data( 'orig-file' );
+			dimensions.left = 0;
+			dimensions.top = Math.floor( ( max.height - dimensions.height ) * 0.5 ) + 40;
+			$slide.css( dimensions );
+		} );
+	}
 
-					src = gallery.jp_carousel( 'selectBestImageSize', {
-						orig_file: src,
-						orig_width: orig_size.width,
-						orig_height: orig_size.height,
-						max_width: max.width,
-						max_height: max.height,
-						medium_file: medium_file,
-						large_file: large_file,
-					} );
+	function selectBestImageUrl( args ) {
+		if ( typeof args !== 'object' ) {
+			args = {};
+		}
+
+		if ( typeof args.origFile === 'undefined' ) {
+			return '';
+		}
+
+		if ( typeof args.origWidth === 'undefined' || typeof args.maxWidth === 'undefined' ) {
+			return args.origFile;
+		}
+
+		if ( typeof args.mediumFile === 'undefined' || typeof args.largeFile === 'undefined' ) {
+			return args.origFile;
+		}
+
+		// Check if the image is being served by Photon (using a regular expression on the hostname).
+
+		var imageLinkParser = document.createElement( 'a' );
+		imageLinkParser.href = args.largeFile;
+
+		var isPhotonUrl = /^i[0-2]\.wp\.com$/i.test( imageLinkParser.hostname );
+
+		var mediumSizeParts = getImageSizeParts( args.mediumFile, args.origWidth, isPhotonUrl );
+		var largeSizeParts = getImageSizeParts( args.largeFile, args.origWidth, isPhotonUrl );
+
+		var largeWidth = parseInt( largeSizeParts[ 0 ], 10 ),
+			largeHeight = parseInt( largeSizeParts[ 1 ], 10 ),
+			mediumWidth = parseInt( mediumSizeParts[ 0 ], 10 ),
+			mediumHeight = parseInt( mediumSizeParts[ 1 ], 10 );
+
+		// Assign max width and height.
+		args.origMaxWidth = args.maxWidth;
+		args.origMaxHeight = args.maxHeight;
+
+		// Give devices with a higher devicePixelRatio higher-res images (Retina display = 2, Android phones = 1.5, etc)
+		if ( typeof window.devicePixelRatio !== 'undefined' && window.devicePixelRatio > 1 ) {
+			args.maxWidth = args.maxWidth * window.devicePixelRatio;
+			args.maxHeight = args.maxHeight * window.devicePixelRatio;
+		}
+
+		if ( largeWidth >= args.maxWidth || largeHeight >= args.maxHeight ) {
+			return args.largeFile;
+		}
+
+		if ( mediumWidth >= args.maxWidth || mediumHeight >= args.maxHeight ) {
+			return args.mediumFile;
+		}
+
+		if ( isPhotonUrl ) {
+			// args.origFile doesn't point to a Photon url, so in this case we use args.largeFile
+			// to return the photon url of the original image.
+			var largeFileIndex = args.largeFile.lastIndexOf( '?' );
+			var origPhotonUrl = args.largeFile;
+			if ( largeFileIndex !== -1 ) {
+				origPhotonUrl = args.largeFile.substring( 0, largeFileIndex );
+				// If we have a really large image load a smaller version
+				// that is closer to the viewable size
+				if ( args.origWidth > args.maxWidth || args.origHeight > args.maxHeight ) {
+					origPhotonUrl += '?fit=' + args.origMaxWidth + '%2C' + args.origMaxHeight;
 				}
+			}
+			return origPhotonUrl;
+		}
 
-				// Set the final src
-				$( this ).data( 'gallery-src', src );
-			} );
+		return args.origFile;
+	}
 
-			// If the start_index is not 0 then preload the clicked image first.
-			if ( 0 !== start_index ) {
-				$( '<img/>' )[ 0 ].src = $( items[ start_index ] ).data( 'gallery-src' );
+	function getImageSizeParts( file, origWidth, isPhotonUrl ) {
+		var size = isPhotonUrl
+			? file.replace( /.*=([\d]+%2C[\d]+).*$/, '$1' )
+			: file.replace( /.*-([\d]+x[\d]+)\..+$/, '$1' );
+
+		var sizeParts =
+			size !== file ? ( isPhotonUrl ? size.split( '%2C' ) : size.split( 'x' ) ) : [ origWidth, 0 ];
+
+		// If one of the dimensions is set to 9999, then the actual value of that dimension can't be retrieved from the url.
+		// In that case, we set the value to 0.
+		if ( sizeParts[ 0 ] === '9999' ) {
+			sizeParts[ 0 ] = '0';
+		}
+
+		if ( sizeParts[ 1 ] === '9999' ) {
+			sizeParts[ 1 ] = '0';
+		}
+
+		return sizeParts;
+	}
+
+	function getOriginalDimensions( slide ) {
+		var splitted = $( slide ).data( 'orig-size' ).split( ',' );
+		return { width: parseInt( splitted[ 0 ], 10 ), height: parseInt( splitted[ 1 ], 10 ) };
+	}
+
+	function applyReplacements( text, replacements ) {
+		if ( ! text ) {
+			return;
+		}
+		if ( ! replacements ) {
+			return text;
+		}
+		return text.replace( /{(\d+)}/g, function ( match, number ) {
+			return typeof replacements[ number ] !== 'undefined' ? replacements[ number ] : match;
+		} );
+	}
+
+	/**
+	 * Returns a number in a fraction format that represents the shutter speed.
+	 * @param Number speed
+	 * @return String
+	 */
+	function formatShutterSpeed( speed ) {
+		var denominator;
+
+		// round to one decimal if value > 1s by multiplying it by 10, rounding, then dividing by 10 again
+		if ( speed >= 1 ) {
+			return Math.round( speed * 10 ) / 10 + 's';
+		}
+
+		// If the speed is less than one, we find the denominator by inverting
+		// the number. Since cameras usually use rational numbers as shutter
+		// speeds, we should get a nice round number. Or close to one in cases
+		// like 1/30. So we round it.
+		denominator = Math.round( 1 / speed );
+
+		return '1/' + denominator + 's';
+	}
+
+	function parseTitleAndDesc( value ) {
+		if ( ! value.match( ' ' ) && value.match( '_' ) ) {
+			return '';
+		}
+
+		return value;
+	}
+
+	function updateTitleAndDesc( data ) {
+		var title = '',
+			desc = '',
+			markup = '',
+			target;
+
+		target = $( 'div.jp-carousel-titleanddesc', 'div.jp-carousel-wrap' );
+		target.hide();
+
+		title = parseTitleAndDesc( data.title ) || '';
+		desc = parseTitleAndDesc( data.desc ) || '';
+
+		if ( title.length || desc.length ) {
+			// Convert from HTML to plain text (including HTML entities decode, etc)
+			if ( $( '<div />' ).html( title ).text() === $( '<div />' ).html( desc ).text() ) {
+				title = '';
 			}
 
-			var useInPageThumbnails =
-				items.first().closest( '.tiled-gallery.type-rectangular' ).length > 0;
-
-			// create the 'slide'
-			items.each( function ( i ) {
-				var src_item = $( this ),
-					attachment_id = src_item.data( 'attachment-id' ) || 0,
-					comments_opened = src_item.data( 'comments-opened' ) || 0,
-					image_meta = src_item.data( 'image-meta' ) || {},
-					orig_size = src_item.data( 'orig-size' ) || '',
-					thumb_size = { width: src_item[ 0 ].naturalWidth, height: src_item[ 0 ].naturalHeight },
-					title = src_item.data( 'image-title' ) || '',
-					description = src_item.data( 'image-description' ) || '',
-					caption = src_item.parents( '.gallery-item' ).find( '.gallery-caption' ).html() || '',
-					src = src_item.data( 'gallery-src' ) || '',
-					medium_file = src_item.data( 'medium-file' ) || '',
-					large_file = src_item.data( 'large-file' ) || '',
-					orig_file = src_item.data( 'orig-file' ) || '';
-
-				var tiledCaption = src_item
-					.parents( 'div.tiled-gallery-item' )
-					.find( 'div.tiled-gallery-caption' )
-					.html();
-				if ( tiledCaption ) {
-					caption = tiledCaption;
-				}
-
-				if ( attachment_id && orig_size.length ) {
-					title = gallery.jp_carousel( 'texturize', title );
-					description = gallery.jp_carousel( 'texturize', description );
-					caption = gallery.jp_carousel( 'texturize', caption );
-
-					// Initially, the image is a 1x1 transparent gif.  The preview is shown as a background image on the slide itself.
-					var image = $( '<img/>' )
-						.attr(
-							'src',
-							'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-						)
-						.css( 'width', '100%' )
-						.css( 'height', '100%' );
-
-					var slide = $(
-						'<div class="jp-carousel-slide" itemprop="associatedMedia" itemscope itemtype="https://schema.org/ImageObject"></div>'
-					)
-						.hide()
-						.css( {
-							//'position' : 'fixed',
-							left: i < start_index ? -1000 : gallery.width(),
-						} )
-						.append( image )
-						.appendTo( gallery )
-						.data( 'src', src )
-						.data( 'title', title )
-						.data( 'desc', description )
-						.data( 'caption', caption )
-						.data( 'attachment-id', attachment_id )
-						.data( 'permalink', src_item.parents( 'a' ).attr( 'href' ) )
-						.data( 'orig-size', orig_size )
-						.data( 'comments-opened', comments_opened )
-						.data( 'image-meta', image_meta )
-						.data( 'medium-file', medium_file )
-						.data( 'large-file', large_file )
-						.data( 'orig-file', orig_file )
-						.data( 'thumb-size', thumb_size );
-					if ( useInPageThumbnails ) {
-						// Use the image already loaded in the gallery as a preview.
-						slide.data( 'preview-image', src_item.attr( 'src' ) ).css( {
-							'background-image': 'url("' + src_item.attr( 'src' ) + '")',
-							'background-size': '100% 100%',
-							'background-position': 'center center',
-						} );
-					}
-
-					slide.jp_carousel( 'fitSlide', false );
-				}
-			} );
-			return this;
-		},
-
-		selectBestImageSize: function ( args ) {
-			if ( 'object' !== typeof args ) {
-				args = {};
-			}
-
-			if ( 'undefined' === typeof args.orig_file ) {
-				return '';
-			}
-
-			if ( 'undefined' === typeof args.orig_width || 'undefined' === typeof args.max_width ) {
-				return args.orig_file;
-			}
-
-			if ( 'undefined' === typeof args.medium_file || 'undefined' === typeof args.large_file ) {
-				return args.orig_file;
-			}
-
-			// Check if the image is being served by Photon (using a regular expression on the hostname).
-
-			var imageLinkParser = document.createElement( 'a' );
-			imageLinkParser.href = args.large_file;
-
-			var isPhotonUrl = /^i[0-2].wp.com$/i.test( imageLinkParser.hostname );
-
-			var medium_size_parts = gallery.jp_carousel(
-				'getImageSizeParts',
-				args.medium_file,
-				args.orig_width,
-				isPhotonUrl
-			);
-			var large_size_parts = gallery.jp_carousel(
-				'getImageSizeParts',
-				args.large_file,
-				args.orig_width,
-				isPhotonUrl
-			);
-
-			var large_width = parseInt( large_size_parts[ 0 ], 10 ),
-				large_height = parseInt( large_size_parts[ 1 ], 10 ),
-				medium_width = parseInt( medium_size_parts[ 0 ], 10 ),
-				medium_height = parseInt( medium_size_parts[ 1 ], 10 );
-
-			// Assign max width and height.
-			args.orig_max_width = args.max_width;
-			args.orig_max_height = args.max_height;
-
-			// Give devices with a higher devicePixelRatio higher-res images (Retina display = 2, Android phones = 1.5, etc)
-			if ( 'undefined' !== typeof window.devicePixelRatio && window.devicePixelRatio > 1 ) {
-				args.max_width = args.max_width * window.devicePixelRatio;
-				args.max_height = args.max_height * window.devicePixelRatio;
-			}
-
-			if ( large_width >= args.max_width || large_height >= args.max_height ) {
-				return args.large_file;
-			}
-
-			if ( medium_width >= args.max_width || medium_height >= args.max_height ) {
-				return args.medium_file;
-			}
-
-			if ( isPhotonUrl ) {
-				// args.orig_file doesn't point to a Photon url, so in this case we use args.large_file
-				// to return the photon url of the original image.
-				var largeFileIndex = args.large_file.lastIndexOf( '?' );
-				var origPhotonUrl = args.large_file;
-				if ( -1 !== largeFileIndex ) {
-					origPhotonUrl = args.large_file.substring( 0, largeFileIndex );
-					// If we have a really large image load a smaller version
-					// that is closer to the viewable size
-					if ( args.orig_width > args.max_width || args.orig_height > args.max_height ) {
-						origPhotonUrl += '?fit=' + args.orig_max_width + '%2C' + args.orig_max_height;
-					}
-				}
-				return origPhotonUrl;
-			}
-
-			return args.orig_file;
-		},
-
-		getImageSizeParts: function ( file, orig_width, isPhotonUrl ) {
-			var size = isPhotonUrl
-				? file.replace( /.*=([\d]+%2C[\d]+).*$/, '$1' )
-				: file.replace( /.*-([\d]+x[\d]+)\..+$/, '$1' );
-
-			var size_parts =
-				size !== file
-					? isPhotonUrl
-						? size.split( '%2C' )
-						: size.split( 'x' )
-					: [ orig_width, 0 ];
-
-			// If one of the dimensions is set to 9999, then the actual value of that dimension can't be retrieved from the url.
-			// In that case, we set the value to 0.
-			if ( '9999' === size_parts[ 0 ] ) {
-				size_parts[ 0 ] = '0';
-			}
-
-			if ( '9999' === size_parts[ 1 ] ) {
-				size_parts[ 1 ] = '0';
-			}
-
-			return size_parts;
-		},
-
-		originalDimensions: function () {
-			var splitted = $( this ).data( 'orig-size' ).split( ',' );
-			return { width: parseInt( splitted[ 0 ], 10 ), height: parseInt( splitted[ 1 ], 10 ) };
-		},
-
-		format: function ( args ) {
-			if ( 'object' !== typeof args ) {
-				args = {};
-			}
-			if ( ! args.text || 'undefined' === typeof args.text ) {
-				return;
-			}
-			if ( ! args.replacements || 'undefined' === typeof args.replacements ) {
-				return args.text;
-			}
-			return args.text.replace( /{(\d+)}/g, function ( match, number ) {
-				return typeof args.replacements[ number ] !== 'undefined'
-					? args.replacements[ number ]
-					: match;
-			} );
-		},
-
-		/**
-		 * Returns a number in a fraction format that represents the shutter speed.
-		 * @param Number speed
-		 * @return String
-		 */
-		shutterSpeed: function ( speed ) {
-			var denominator;
-
-			// round to one decimal if value > 1s by multiplying it by 10, rounding, then dividing by 10 again
-			if ( speed >= 1 ) {
-				return Math.round( speed * 10 ) / 10 + 's';
-			}
-
-			// If the speed is less than one, we find the denominator by inverting
-			// the number. Since cameras usually use rational numbers as shutter
-			// speeds, we should get a nice round number. Or close to one in cases
-			// like 1/30. So we round it.
-			denominator = Math.round( 1 / speed );
-
-			return '1/' + denominator + 's';
-		},
-
-		parseTitleDesc: function ( value ) {
-			if ( ! value.match( ' ' ) && value.match( '_' ) ) {
-				return '';
-			}
-
-			return value;
-		},
-
-		getTitleDesc: function ( data ) {
-			var title = '',
-				desc = '',
-				markup = '',
-				target;
-
-			target = $( 'div.jp-carousel-titleanddesc', 'div.jp-carousel-wrap' );
-			target.hide();
-
-			title = gallery.jp_carousel( 'parseTitleDesc', data.title ) || '';
-			desc = gallery.jp_carousel( 'parseTitleDesc', data.desc ) || '';
-
-			if ( title.length || desc.length ) {
-				// Convert from HTML to plain text (including HTML entities decode, etc)
-				if ( $( '<div />' ).html( title ).text() === $( '<div />' ).html( desc ).text() ) {
-					title = '';
-				}
-
-				markup = title.length
-					? '<div class="jp-carousel-titleanddesc-title">' + title + '</div>'
-					: '';
-				markup += desc.length
-					? '<div class="jp-carousel-titleanddesc-desc">' + desc + '</div>'
-					: '';
-
-				target.html( markup ).fadeIn( 'slow' );
-			}
-
-			$( 'div#jp-carousel-comment-form-container' ).css( 'margin-top', '20px' );
-			$( 'div#jp-carousel-comments-loading' ).css( 'margin-top', '20px' );
-		},
-
-		// updateExif updates the contents of the exif UL (.jp-carousel-image-exif)
-		updateExif: function ( meta ) {
-			if ( ! meta || 1 !== Number( jetpackCarouselStrings.display_exif ) ) {
-				return false;
-			}
-
-			var $ul = $( "<ul class='jp-carousel-image-exif'></ul>" );
-
-			$.each( meta, function ( key, val ) {
-				if (
-					0 === parseFloat( val ) ||
-					! val.length ||
-					-1 === $.inArray( key, $.makeArray( jetpackCarouselStrings.meta_data ) )
-				) {
-					return;
-				}
-
-				switch ( key ) {
-					case 'focal_length':
-						val = val + 'mm';
-						break;
-					case 'shutter_speed':
-						val = gallery.jp_carousel( 'shutterSpeed', val );
-						break;
-					case 'aperture':
-						val = 'f/' + val;
-						break;
-				}
-
-				$ul.append( '<li><h5>' + jetpackCarouselStrings[ key ] + '</h5>' + val + '</li>' );
-			} );
-
-			// Update (replace) the content of the ul
-			$( 'div.jp-carousel-image-meta ul.jp-carousel-image-exif' ).replaceWith( $ul );
-		},
-
-		// updateFullSizeLink updates the contents of the jp-carousel-image-download link
-		updateFullSizeLink: function ( current ) {
-			if ( ! current || ! current.data ) {
-				return false;
-			}
-			var original,
-				origSize = current.data( 'orig-size' ).split( ',' ),
-				imageLinkParser = document.createElement( 'a' );
-
-			imageLinkParser.href = current.data( 'src' ).replace( /\?.+$/, '' );
-
-			// Is this a Photon URL?
-			if ( imageLinkParser.hostname.match( /^i[\d]{1}.wp.com$/i ) !== null ) {
-				original = imageLinkParser.href;
-			} else {
-				original = current.data( 'orig-file' ).replace( /\?.+$/, '' );
-			}
-
-			var permalink = $(
-				'<a>' +
-					gallery.jp_carousel( 'format', {
-						text: jetpackCarouselStrings.download_original,
-						replacements: origSize,
-					} ) +
-					'</a>'
-			)
-				.addClass( 'jp-carousel-image-download' )
-				.attr( 'href', original )
-				.attr( 'target', '_blank' );
-
-			// Update (replace) the content of the anchor
-			$( 'div.jp-carousel-image-meta a.jp-carousel-image-download' ).replaceWith( permalink );
-		},
-
-		testCommentsOpened: function ( opened ) {
-			if ( 1 === parseInt( opened, 10 ) ) {
-				if ( 1 === Number( jetpackCarouselStrings.is_logged_in ) ) {
-					$( '.jp-carousel-commentlink' ).fadeIn( 'fast' );
-				} else {
-					$( '.jp-carousel-buttons' ).fadeIn( 'fast' );
-				}
-				commentForm.fadeIn( 'fast' );
-			} else {
-				if ( 1 === Number( jetpackCarouselStrings.is_logged_in ) ) {
-					$( '.jp-carousel-commentlink' ).fadeOut( 'fast' );
-				} else {
-					$( '.jp-carousel-buttons' ).fadeOut( 'fast' );
-				}
-				commentForm.fadeOut( 'fast' );
-			}
-		},
-
-		getComments: function ( args ) {
-			clearInterval( commentInterval );
-
-			if ( 'object' !== typeof args ) {
-				return;
-			}
-
-			if ( 'undefined' === typeof args.attachment_id || ! args.attachment_id ) {
-				return;
-			}
-
-			if ( ! args.offset || 'undefined' === typeof args.offset || args.offset < 1 ) {
-				args.offset = 0;
-			}
-
-			var comments = $( '.jp-carousel-comments' ),
-				commentsLoading = $( '#jp-carousel-comments-loading' ).show();
-
-			if ( args.clear ) {
-				comments.hide().empty();
-			}
-
-			$.ajax( {
-				type: 'GET',
-				url: jetpackCarouselStrings.ajaxurl,
-				dataType: 'json',
-				data: {
-					action: 'get_attachment_comments',
-					nonce: jetpackCarouselStrings.nonce,
-					id: args.attachment_id,
-					offset: args.offset,
-				},
-				success: function ( data /*, status, xhr*/ ) {
-					if ( args.clear ) {
-						comments.fadeOut( 'fast' ).empty();
-					}
-
-					$( data ).each( function () {
-						var comment = $( '<div></div>' )
-							.addClass( 'jp-carousel-comment' )
-							.attr( 'id', 'jp-carousel-comment-' + this[ 'id' ] )
-							.html(
-								'<div class="comment-gravatar">' +
-									this[ 'gravatar_markup' ] +
-									'</div>' +
-									'<div class="comment-author">' +
-									this[ 'author_markup' ] +
-									'</div>' +
-									'<div class="comment-date">' +
-									this[ 'date_gmt' ] +
-									'</div>' +
-									'<div class="comment-content">' +
-									this[ 'content' ] +
-									'</div>'
-							);
-						comments.append( comment );
-
-						// Set the interval to check for a new page of comments.
-						clearInterval( commentInterval );
-						commentInterval = setInterval( function () {
-							if (
-								$( '.jp-carousel-overlay' ).height() - 150 <
-								$( '.jp-carousel-wrap' ).scrollTop() + $( window ).height()
-							) {
-								gallery.jp_carousel( 'getComments', {
-									attachment_id: args.attachment_id,
-									offset: args.offset + 10,
-									clear: false,
-								} );
-								clearInterval( commentInterval );
-							}
-						}, 300 );
-					} );
-
-					// Verify (late) that the user didn't repeatldy click the arrows really fast, in which case the requested
-					// attachment id might no longer match the current attachment id by the time we get the data back or a now
-					// registered infiniscroll event kicks in, so we don't ever display comments for the wrong image by mistake.
-					var current = $( '.jp-carousel div.selected' );
-					if ( current && current.data && current.data( 'attachment-id' ) !== args.attachment_id ) {
-						comments.fadeOut( 'fast' );
-						comments.empty();
-						return;
-					}
-
-					// Increase the height of the background, semi-transparent overlay to match the new length of the comments list.
-					$( '.jp-carousel-overlay' ).height(
-						$( window ).height() +
-							titleAndDescription.height() +
-							commentForm.height() +
-							( comments.height() > 0 ? comments.height() : imageMeta.height() ) +
-							200
-					);
-
-					comments.show();
-					commentsLoading.hide();
-				},
-				error: function () {
-					// TODO: proper error handling
-					comments.fadeIn( 'fast' );
-					commentsLoading.fadeOut( 'fast' );
-				},
-			} );
-		},
-
-		postCommentError: function ( args ) {
-			if ( 'object' !== typeof args ) {
-				args = {};
-			}
+			markup = title.length
+				? '<div class="jp-carousel-titleanddesc-title">' + title + '</div>'
+				: '';
+			markup += desc.length ? '<div class="jp-carousel-titleanddesc-desc">' + desc + '</div>' : '';
+
+			target.html( markup ).fadeIn( 'slow' );
+		}
+
+		$( 'div#jp-carousel-comment-form-container' ).css( 'margin-top', '20px' );
+		$( 'div#jp-carousel-comments-loading' ).css( 'margin-top', '20px' );
+	}
+
+	// updateExif updates the contents of the exif UL (.jp-carousel-image-exif)
+	function updateExif( meta ) {
+		if ( ! meta || Number( jetpackCarouselStrings.display_exif ) !== 1 ) {
+			return false;
+		}
+
+		var $ul = $( "<ul class='jp-carousel-image-exif'></ul>" );
+
+		$.each( meta, function ( key, val ) {
 			if (
-				! args.field ||
-				'undefined' === typeof args.field ||
-				! args.error ||
-				'undefined' === typeof args.error
+				parseFloat( val ) === 0 ||
+				! val.length ||
+				$.inArray( key, $.makeArray( jetpackCarouselStrings.meta_data ) ) === -1
 			) {
 				return;
 			}
-			$( '#jp-carousel-comment-post-results' )
-				.slideUp( 'fast' )
-				.html( '<span class="jp-carousel-comment-post-error">' + args.error + '</span>' )
-				.slideDown( 'fast' );
-			$( '#jp-carousel-comment-form-spinner' ).hide();
-		},
 
-		setCommentIframeSrc: function ( attachment_id ) {
-			var iframe = $( '#jp-carousel-comment-iframe' );
-			// Set the proper irame src for the current attachment id
-			if ( iframe && iframe.length ) {
-				iframe.attr( 'src', iframe.attr( 'src' ).replace( /(postid=)\d+/, '$1' + attachment_id ) );
-				iframe.attr(
-					'src',
-					iframe.attr( 'src' ).replace( /(%23.+)?$/, '%23jp-carousel-' + attachment_id )
-				);
-			}
-		},
-
-		clearCommentTextAreaValue: function () {
-			var commentTextArea = $( '#jp-carousel-comment-form-comment-field' );
-			if ( commentTextArea ) {
-				commentTextArea.val( '' );
-			}
-		},
-
-		nextSlide: function () {
-			var slides = this.jp_carousel( 'slides' );
-			var selected = this.jp_carousel( 'selectedSlide' );
-
-			if ( selected.length === 0 || ( slides.length > 2 && selected.is( slides.last() ) ) ) {
-				return slides.first();
+			switch ( key ) {
+				case 'focal_length':
+					val = val + 'mm';
+					break;
+				case 'shutter_speed':
+					val = formatShutterSpeed( val );
+					break;
+				case 'aperture':
+					val = 'f/' + val;
+					break;
 			}
 
-			return selected.next();
-		},
+			$ul.append( '<li><h5>' + jetpackCarouselStrings[ key ] + '</h5>' + val + '</li>' );
+		} );
 
-		prevSlide: function () {
-			var slides = this.jp_carousel( 'slides' );
-			var selected = this.jp_carousel( 'selectedSlide' );
+		// Update (replace) the content of the ul
+		$( 'div.jp-carousel-image-meta ul.jp-carousel-image-exif' ).replaceWith( $ul );
+	}
 
-			if ( selected.length === 0 || ( slides.length > 2 && selected.is( slides.first() ) ) ) {
-				return slides.last();
+	// updateFullSizeLink updates the contents of the jp-carousel-image-download link
+	function updateFullSizeLink( currentSlide ) {
+		if ( ! currentSlide || ! currentSlide.data ) {
+			return false;
+		}
+		var original,
+			origSize = currentSlide.data( 'orig-size' ).split( ',' ),
+			imageLinkParser = document.createElement( 'a' );
+
+		imageLinkParser.href = currentSlide.data( 'src' ).replace( /\?.+$/, '' );
+
+		// Is this a Photon URL?
+		if ( imageLinkParser.hostname.match( /^i[\d]{1}\.wp\.com$/i ) !== null ) {
+			original = imageLinkParser.href;
+		} else {
+			original = currentSlide.data( 'orig-file' ).replace( /\?.+$/, '' );
+		}
+
+		var permalink = $(
+			'<a>' + applyReplacements( jetpackCarouselStrings.download_original, origSize ) + '</a>'
+		)
+			.addClass( 'jp-carousel-image-download' )
+			.attr( 'href', original )
+			.attr( 'target', '_blank' );
+
+		// Update (replace) the content of the anchor
+		$( 'div.jp-carousel-image-meta a.jp-carousel-image-download' ).replaceWith( permalink );
+	}
+
+	function testCommentsOpened( opened ) {
+		var commentForm = container.find( '.jp-carousel-comment-form-container' );
+
+		if ( parseInt( opened, 10 ) === 1 ) {
+			if ( Number( jetpackCarouselStrings.is_logged_in ) === 1 ) {
+				$( '.jp-carousel-commentlink' ).fadeIn( 'fast' );
+			} else {
+				$( '.jp-carousel-buttons' ).fadeIn( 'fast' );
 			}
+			commentForm.fadeIn( 'fast' );
+		} else {
+			if ( Number( jetpackCarouselStrings.is_logged_in ) === 1 ) {
+				$( '.jp-carousel-commentlink' ).fadeOut( 'fast' );
+			} else {
+				$( '.jp-carousel-buttons' ).fadeOut( 'fast' );
+			}
+			commentForm.fadeOut( 'fast' );
+		}
+	}
 
-			return selected.prev();
-		},
+	function fetchComments( attachmentId, offset, clear ) {
+		clearInterval( commentInterval );
 
-		loadFullImage: function ( slide ) {
-			var image = slide.find( 'img:first' );
+		if ( ! attachmentId ) {
+			return;
+		}
 
-			if ( ! image.data( 'loaded' ) ) {
-				// If the width of the slide is smaller than the width of the "thumbnail" we're already using,
-				// don't load the full image.
+		if ( ! offset || offset < 1 ) {
+			offset = 0;
+		}
 
-				image.on( 'load.jetpack', function () {
-					image.off( 'load.jetpack' );
-					$( this ).closest( '.jp-carousel-slide' ).css( 'background-image', '' );
-				} );
+		var comments = $( '.jp-carousel-comments' );
+		var commentsLoading = $( '#jp-carousel-comments-loading' ).show();
 
-				if (
-					! slide.data( 'preview-image' ) ||
-					( slide.data( 'thumb-size' ) && slide.width() > slide.data( 'thumb-size' ).width )
-				) {
-					image
-						.attr( 'src', image.closest( '.jp-carousel-slide' ).data( 'src' ) )
-						.attr( 'itemprop', 'image' );
-				} else {
-					image.attr( 'src', slide.data( 'preview-image' ) ).attr( 'itemprop', 'image' );
+		if ( clear ) {
+			comments.hide().empty();
+		}
+
+		$.ajax( {
+			type: 'GET',
+			url: jetpackCarouselStrings.ajaxurl,
+			dataType: 'json',
+			data: {
+				action: 'get_attachment_comments',
+				nonce: jetpackCarouselStrings.nonce,
+				id: attachmentId,
+				offset: offset,
+			},
+			success: function ( data ) {
+				if ( clear ) {
+					comments.fadeOut( 'fast' ).empty();
 				}
 
-				image.data( 'loaded', 1 );
-			}
-		},
+				$( data ).each( function () {
+					var comment = $( '<div></div>' )
+						.addClass( 'jp-carousel-comment' )
+						.attr( 'id', 'jp-carousel-comment-' + this[ 'id' ] )
+						.html(
+							'<div class="comment-gravatar">' +
+								this[ 'gravatar_markup' ] +
+								'</div>' +
+								'<div class="comment-author">' +
+								this[ 'author_markup' ] +
+								'</div>' +
+								'<div class="comment-date">' +
+								this[ 'date_gmt' ] +
+								'</div>' +
+								'<div class="comment-content">' +
+								this[ 'content' ] +
+								'</div>'
+						);
+					comments.append( comment );
 
-		hasMultipleImages: function () {
-			return gallery.jp_carousel( 'slides' ).length > 1;
-		},
-	};
+					// Set the interval to check for a new page of comments.
+					clearInterval( commentInterval );
+					commentInterval = setInterval( function () {
+						if (
+							$( '.jp-carousel-overlay' ).height() - 150 <
+							$( '.jp-carousel-wrap' ).scrollTop() + $( window ).height()
+						) {
+							fetchComments( attachmentId, offset + 10, false );
+							clearInterval( commentInterval );
+						}
+					}, 300 );
+				} );
 
-	$.fn.jp_carousel = function ( method ) {
-		// ask for the HTML of the gallery
-		// Method calling logic
-		if ( methods[ method ] ) {
-			return methods[ method ].apply( this, Array.prototype.slice.call( arguments, 1 ) );
-		} else if ( typeof method === 'object' || ! method ) {
-			return methods.open.apply( this, arguments );
-		} else {
-			$.error( 'Method ' + method + ' does not exist on jQuery.jp_carousel' );
+				// Verify (late) that the user didn't repeatldy click the arrows really fast, in which case the requested
+				// attachment id might no longer match the current attachment id by the time we get the data back or a now
+				// registered infiniscroll event kicks in, so we don't ever display comments for the wrong image by mistake.
+				var current = $( '.jp-carousel div.selected' );
+				if ( current && current.data && current.data( 'attachment-id' ) !== attachmentId ) {
+					comments.fadeOut( 'fast' );
+					comments.empty();
+					return;
+				}
+
+				// Increase the height of the background, semi-transparent overlay to match the new length of the comments list.
+				$( '.jp-carousel-overlay' ).height(
+					$( window ).height() +
+						container.find( '.jp-carousel-titleanddesc' ).height() +
+						container.find( '.jp-carousel-comment-form-container' ).height() +
+						( comments.height() > 0
+							? comments.height()
+							: container.find( '.jp-carousel-image-meta' ).height() ) +
+						200
+				);
+
+				comments.show();
+				commentsLoading.hide();
+			},
+			error: function () {
+				// TODO: proper error handling
+				comments.fadeIn( 'fast' );
+				commentsLoading.fadeOut( 'fast' );
+			},
+		} );
+	}
+
+	function handlePostCommentError( field, error ) {
+		if ( ! field || ! error ) {
+			return;
 		}
-	};
+		$( '#jp-carousel-comment-post-results' )
+			.slideUp( 'fast' )
+			.html( '<span class="jp-carousel-comment-post-error">' + error + '</span>' )
+			.slideDown( 'fast' );
+		$( '#jp-carousel-comment-form-spinner' ).hide();
+	}
+
+	function clearCommentTextAreaValue() {
+		var commentTextArea = $( '#jp-carousel-comment-form-comment-field' );
+		if ( commentTextArea ) {
+			commentTextArea.val( '' );
+		}
+	}
+
+	function loadFullImage( slideEl ) {
+		var slide = $( slideEl );
+		var image = slide.find( 'img:first' );
+
+		if ( ! image.data( 'loaded' ) ) {
+			// If the width of the slide is smaller than the width of the "thumbnail" we're already using,
+			// don't load the full image.
+
+			image.on( 'load.jetpack', function () {
+				image.off( 'load.jetpack' );
+				gallery.closest( '.jp-carousel-slide' ).css( 'background-image', '' );
+			} );
+
+			if (
+				! slide.data( 'preview-image' ) ||
+				( slide.data( 'thumb-size' ) && slide.width() > slide.data( 'thumb-size' ).width )
+			) {
+				image
+					.attr( 'src', image.closest( '.jp-carousel-slide' ).data( 'src' ) )
+					.attr( 'itemprop', 'image' );
+			} else {
+				image.attr( 'src', slide.data( 'preview-image' ) ).attr( 'itemprop', 'image' );
+			}
+
+			image.data( 'loaded', 1 );
+		}
+	}
+
+	function initCarouselSlides( items, startIndex ) {
+		if ( items.length < 2 ) {
+			$( '.jp-carousel-next-button, .jp-carousel-previous-button' ).hide();
+		} else {
+			$( '.jp-carousel-next-button, .jp-carousel-previous-button' ).show();
+		}
+
+		// Calculate the new src.
+		items.each( function () {
+			var srcItem = $( this );
+			var origSize = srcItem.data( 'orig-size' ) || '';
+			var max = calculateMaxSlideDimensions();
+			var parts = origSize.split( ',' );
+			var mediumFile = srcItem.data( 'medium-file' ) || '';
+			var largeFile = srcItem.data( 'large-file' ) || '';
+
+			var src;
+
+			origSize = { width: parseInt( parts[ 0 ], 10 ), height: parseInt( parts[ 1 ], 10 ) };
+
+			if ( typeof wpcom !== undefined && wpcom.carousel && wpcom.carousel.generateImgSrc ) {
+				src = wpcom.carousel.generateImgSrc( srcItem.get( 0 ), max );
+			} else {
+				src = srcItem.data( 'orig-file' );
+
+				src = selectBestImageUrl( {
+					origFile: src,
+					origWidth: origSize.width,
+					origHeight: origSize.height,
+					maxWidth: max.width,
+					maxHeight: max.height,
+					mediumFile: mediumFile,
+					largeFile: largeFile,
+				} );
+			}
+
+			// Set the final src
+			$( this )[ 0 ].setAttribute( 'data-gallery-src', src );
+		} );
+
+		// If the startIndex is not 0 then preload the clicked image first.
+		if ( startIndex !== 0 ) {
+			$( '<img/>' )[ 0 ].src = $( items[ startIndex ] ).data( 'gallery-src' );
+		}
+
+		var useInPageThumbnails = items.first().closest( '.tiled-gallery.type-rectangular' ).length > 0;
+
+		// create the 'slide'
+		items.each( function ( i ) {
+			var srcItem = $( this );
+
+			var attachmentId = srcItem.data( 'attachment-id' ) || 0;
+			var commentsOpened = srcItem.data( 'comments-opened' ) || 0;
+			var imageMeta = srcItem.data( 'image-meta' ) || {};
+			var origSize = srcItem.data( 'orig-size' ) || '';
+			var title = srcItem.data( 'image-title' ) || '';
+			var description = srcItem.data( 'image-description' ) || '';
+			var src = srcItem.data( 'gallery-src' ) || '';
+			var mediumFile = srcItem.data( 'medium-file' ) || '';
+			var largeFile = srcItem.data( 'large-file' ) || '';
+			var origFile = srcItem.data( 'orig-file' ) || '';
+
+			var caption = srcItem.parents( '.gallery-item' ).find( '.gallery-caption' ).html() || '';
+			var thumbSize = { width: srcItem[ 0 ].naturalWidth, height: srcItem[ 0 ].naturalHeight };
+			var permalink = srcItem.parents( 'a' ).attr( 'href' );
+
+			var tiledCaption = srcItem
+				.parents( 'div.tiled-gallery-item' )
+				.find( 'div.tiled-gallery-caption' )
+				.html();
+			if ( tiledCaption ) {
+				caption = tiledCaption;
+			}
+
+			if ( attachmentId && origSize.length ) {
+				title = texturize( title );
+				description = texturize( description );
+				caption = texturize( caption );
+
+				// Initially, the image is a 1x1 transparent gif.  The preview is shown as a background image on the slide itself.
+				var image = $( '<img/>' )
+					.attr(
+						'src',
+						'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+					)
+					.css( 'width', '100%' )
+					.css( 'height', '100%' );
+
+				var slide = $(
+					'<div class="jp-carousel-slide" itemprop="associatedMedia" itemscope itemtype="https://schema.org/ImageObject"></div>'
+				)
+					.hide()
+					.css( {
+						//'position' : 'fixed',
+						left: i < startIndex ? -1000 : gallery.width(),
+					} )
+					.append( image )
+					.appendTo( gallery )
+					.data( 'src', src )
+					.data( 'title', title )
+					.data( 'desc', description )
+					.data( 'caption', caption )
+					.data( 'attachment-id', attachmentId )
+					.data( 'permalink', permalink )
+					.data( 'orig-size', origSize )
+					.data( 'comments-opened', commentsOpened )
+					.data( 'image-meta', imageMeta )
+					.data( 'medium-file', mediumFile )
+					.data( 'large-file', largeFile )
+					.data( 'orig-file', origFile )
+					.data( 'thumb-size', thumbSize );
+				if ( useInPageThumbnails ) {
+					// Use the image already loaded in the gallery as a preview.
+					slide.data( 'preview-image', srcItem.attr( 'src' ) ).css( {
+						'background-image': 'url("' + srcItem.attr( 'src' ) + '")',
+						'background-size': '100% 100%',
+						'background-position': 'center center',
+					} );
+				}
+
+				fitSlides( slide );
+			}
+		} );
+	}
+
+	function openCarousel( gal, options ) {
+		var settings = {
+			items_selector:
+				'.gallery-item [data-attachment-id], .tiled-gallery-item [data-attachment-id], img[data-attachment-id]',
+			startIndex: 0,
+		};
+
+		var data = gal.data( 'carousel-extra' );
+
+		if ( ! data ) {
+			return; // don't run if the default gallery functions weren't used
+		}
+
+		initializeCarousel();
+
+		if ( isCarouselOpen() ) {
+			return; // don't open if already opened
+		}
+
+		// make sure to stop the page from scrolling behind the carousel overlay, so we don't trigger
+		// infiniscroll for it when enabled (Reader, theme infiniscroll, etc).
+		originalOverflow = $( 'body' ).css( 'overflow' );
+		$( 'body' ).css( 'overflow', 'hidden' );
+		// prevent html from overflowing on some of the new themes.
+		originalHOverflow = $( 'html' ).css( 'overflow' );
+		$( 'html' ).css( 'overflow', 'hidden' );
+		scrollPos = $( window ).scrollTop();
+
+		container.data( 'carousel-extra', data );
+		stat( [ 'open', 'view_image' ] );
+
+		return gal.each( function () {
+			// If options exist, lets merge them
+			// with our default settings
+			if ( options ) {
+				$.extend( settings, options );
+			}
+			if ( settings.startIndex === -1 ) {
+				settings.startIndex = 0; //-1 returned if can't find index, so start from beginning
+			}
+
+			container.trigger( 'jp_carousel.beforeOpen' );
+
+			container.fadeIn( 'fast', function () {
+				container.trigger( 'jp_carousel.afterOpen' );
+				initCarouselSlides( gal.find( settings.items_selector ), settings.startIndex );
+				selectSlideAtIndex( settings.startIndex );
+			} );
+			gallery.html( '' );
+		} );
+	}
+
+	// Wipe handler, inspired by https://www.netcu.de/jquery-touchwipe-iphone-ipad-library
+	function addWipeHandler( args ) {
+		args = args || {};
+		var config = {
+			root: document.body,
+			threshold: 150, // Required min distance traveled to be considered swipe.
+			restraint: 100, // Maximum distance allowed at the same time in perpendicular direction.
+			allowedTime: 300, // Maximum time allowed to travel that distance.
+			wipeLeft: function () {},
+			wipeRight: function () {},
+			wipeUp: function () {},
+			wipeDown: function () {},
+		};
+
+		for ( var arg in args ) {
+			config[ arg ] = args[ arg ];
+		}
+
+		var startX, startY, isMoving, startTime, elapsedTime;
+
+		function cancelTouch() {
+			config.root.removeEventListener( 'touchmove', onTouchMove );
+			startX = null;
+			isMoving = false;
+		}
+
+		function onTouchMove( e ) {
+			if ( isMoving ) {
+				var x = e.touches[ 0 ].pageX;
+				var y = e.touches[ 0 ].pageY;
+				var dx = startX - x;
+				var dy = startY - y;
+				elapsedTime = new Date().getTime() - startTime;
+				if ( elapsedTime <= config.allowedTime ) {
+					if ( Math.abs( dx ) >= config.threshold && Math.abs( dy ) <= config.restraint ) {
+						cancelTouch();
+						if ( dx > 0 ) {
+							config.wipeLeft( e );
+						} else {
+							config.wipeRight( e );
+						}
+					} else if ( Math.abs( dy ) >= config.threshold && Math.abs( dx ) <= config.restraint ) {
+						cancelTouch();
+						if ( dy > 0 ) {
+							config.wipeDown( e );
+						} else {
+							config.wipeUp( e );
+						}
+					}
+				}
+			}
+		}
+
+		function onTouchStart( e ) {
+			if ( e.touches.length === 1 ) {
+				startTime = new Date().getTime();
+				startX = e.touches[ 0 ].pageX;
+				startY = e.touches[ 0 ].pageY;
+				isMoving = true;
+				config.root.addEventListener( 'touchmove', onTouchMove, false );
+			}
+		}
+
+		if ( 'ontouchstart' in document.documentElement ) {
+			config.root.addEventListener( 'touchstart', onTouchStart, false );
+		}
+	}
 
 	// register the event listener for starting the gallery
 	$( document.body ).on(
 		'click.jp-carousel',
 		'div.gallery, div.tiled-gallery, ul.wp-block-gallery, ul.blocks-gallery-grid, figure.blocks-gallery-grid, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery',
 		function ( e ) {
-			if ( ! $( this ).jp_carousel( 'testForData', e.currentTarget ) ) {
+			if ( ! testForData( e.currentTarget ) ) {
 				return;
 			}
 			// If Gallery is made up of individual Image blocks check for custom link before
@@ -1471,8 +1465,8 @@ jQuery( document ).ready( function ( $ ) {
 			// Stopping propagation in case there are parent elements
 			// with .gallery or .tiled-gallery class
 			e.stopPropagation();
-			$( this ).jp_carousel( 'open', {
-				start_index: $( this )
+			openCarousel( $( this ), {
+				startIndex: $( this )
 					.find(
 						'.gallery-item, .tiled-gallery-item, .blocks-gallery-item, .tiled-gallery__item, .wp-block-image'
 					)
@@ -1486,7 +1480,7 @@ jQuery( document ).ready( function ( $ ) {
 	);
 
 	// handle lightbox (single image gallery) for images linking to 'Attachment Page'
-	if ( 1 === Number( jetpackCarouselStrings.single_image_gallery ) ) {
+	if ( Number( jetpackCarouselStrings.single_image_gallery ) === 1 ) {
 		processSingleImageGallery();
 		$( document.body ).on( 'post-load', function () {
 			processSingleImageGallery();
@@ -1509,7 +1503,7 @@ jQuery( document ).ready( function ( $ ) {
 			return;
 		}
 
-		if ( window.location.hash === last_known_location_hash && gallery.opened ) {
+		if ( window.location.hash === lastKnownLocationHash && gallery.opened ) {
 			return;
 		}
 
@@ -1518,7 +1512,7 @@ jQuery( document ).ready( function ( $ ) {
 			return;
 		}
 
-		last_known_location_hash = window.location.hash;
+		lastKnownLocationHash = window.location.hash;
 		matches = window.location.hash.match( hashRegExp );
 		attachmentId = parseInt( matches[ 1 ], 10 );
 		galleries = $(
@@ -1538,7 +1532,7 @@ jQuery( document ).ready( function ( $ ) {
 				} );
 
 			if ( selectedThumbnail ) {
-				$( selectedThumbnail.gallery ).jp_carousel( 'openOrSelectSlide', selectedThumbnail.index );
+				openOrSelectSlide( $( selectedThumbnail.gallery ), selectedThumbnail.index );
 				return false;
 			}
 		} );
@@ -1548,86 +1542,3 @@ jQuery( document ).ready( function ( $ ) {
 		$( window ).trigger( 'hashchange' );
 	}
 } );
-
-/**
- * jQuery Plugin to obtain touch gestures from iPhone, iPod Touch and iPad, should also work with Android mobile phones (not tested yet!)
- * Common usage: wipe images (left and right to show the previous or next image)
- *
- * @author Andreas Waltl, netCU Internetagentur (http://www.netcu.de)
- * Version 1.1.1, modified to pass the touchmove event to the callbacks.
- */
-( function ( $ ) {
-	$.fn.touchwipe = function ( settings ) {
-		var config = {
-			threshold: 150, // Required min distance traveled to be considered swipe.
-			restraint: 100, // Maximum distance allowed at the same time in perpendicular direction.
-			allowedTime: 300, // Maximum time allowed to travel that distance.
-			wipeLeft: function (/*e*/) {},
-			wipeRight: function (/*e*/) {},
-			wipeUp: function (/*e*/) {},
-			wipeDown: function (/*e*/) {},
-			preventDefaultEvents: true,
-		};
-		var startTime, elapsedTime;
-		if ( settings ) {
-			$.extend( config, settings );
-		}
-
-		this.each( function () {
-			var startX;
-			var startY;
-			var isMoving = false;
-
-			function cancelTouch() {
-				this.removeEventListener( 'touchmove', onTouchMove );
-				startX = null;
-				isMoving = false;
-			}
-
-			function onTouchMove( e ) {
-				if ( config.preventDefaultEvents ) {
-					e.preventDefault();
-				}
-				if ( isMoving ) {
-					var x = e.touches[ 0 ].pageX;
-					var y = e.touches[ 0 ].pageY;
-					var dx = startX - x;
-					var dy = startY - y;
-					elapsedTime = new Date().getTime() - startTime;
-					if ( elapsedTime <= config.allowedTime ) {
-						if ( Math.abs( dx ) >= config.threshold && Math.abs( dy ) <= config.restraint ) {
-							cancelTouch();
-							if ( dx > 0 ) {
-								config.wipeLeft( e );
-							} else {
-								config.wipeRight( e );
-							}
-						} else if ( Math.abs( dy ) >= config.threshold && Math.abs( dx ) <= config.restraint ) {
-							cancelTouch();
-							if ( dy > 0 ) {
-								config.wipeDown( e );
-							} else {
-								config.wipeUp( e );
-							}
-						}
-					}
-				}
-			}
-
-			function onTouchStart( e ) {
-				if ( e.touches.length === 1 ) {
-					startTime = new Date().getTime();
-					startX = e.touches[ 0 ].pageX;
-					startY = e.touches[ 0 ].pageY;
-					isMoving = true;
-					this.addEventListener( 'touchmove', onTouchMove, false );
-				}
-			}
-			if ( 'ontouchstart' in document.documentElement ) {
-				this.addEventListener( 'touchstart', onTouchStart, false );
-			}
-		} );
-
-		return this;
-	};
-} )( jQuery );


### PR DESCRIPTION
This is the second batch of improvements to carousel, building upon #18858 and more recent changes such as #19843.

This batch of improvements focuses on reorganising the codebase and preparing for future work that removes the dependency on `jQuery`.

#### Changes proposed in this Pull Request:
- Stop implementing the carousel as a `jQuery` extension.
  Beyond locking us into `jQuery`, this was unnecessary and confusing, given that there is only ever one instance of a carousel on the page.
- Reimplement all jQuery extension functionality as plain old functions.
- Reimplement touchwipe as a plain function
- Rename functions to follow proper naming conventions and be more descriptive of their behaviour.
- Use a flag to enable and disable keyboard bindings instead of binding and unbinding the listeners all the time.
- Standardise variables on camelCase instead of snake_case.
- Break up carousel initialization into more manageable pieces.
- Move away from PHP-style Yoda conditions.
- Stop using `var foo = function()` syntax everywhere.
- Simplify some logic and remove some duplication.
- `use strict`, to make sure we catch missing declarations and the like.
- Remove commented-out and dead code.
- Some style fixes.

#### Jetpack product discussion
For a high-level, somewhat outdated plan, see p1HpG7-bfN-p2.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Smoke-test the carousel. There should be no changes to functionality, as all of the modifications were focused on improving the codebase, with no intended user-visible changes.
