### PR TITLE
Connection: disconnect user from wpcom before to do so locally

### DIFF
--- a/projects/packages/connection/changelog/fix-disconnect-user-wpcom
+++ b/projects/packages/connection/changelog/fix-disconnect-user-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disconnection flow: disconnect users from WordPress.com before to delete data locally.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -767,12 +767,15 @@ class Manager {
 	public function disconnect_user( $user_id = null, $can_overwrite_primary_user = false ) {
 		$user_id = empty( $user_id ) ? get_current_user_id() : (int) $user_id;
 
-		$result = $this->get_tokens()->disconnect_user( $user_id, $can_overwrite_primary_user );
+		// Attempt to disconnect the user from WordPress.com.
+		$is_disconnected_from_wpcom = $this->unlink_user_from_wpcom( $user_id );
+		if ( ! $is_disconnected_from_wpcom ) {
+			return false;
+		}
 
-		if ( $result ) {
-			$xml = new \Jetpack_IXR_Client( compact( 'user_id' ) );
-			$xml->query( 'jetpack.unlink_user', $user_id );
-
+		// Disconnect the user locally.
+		$is_disconnected_locally = $this->get_tokens()->disconnect_user( $user_id, $can_overwrite_primary_user );
+		if ( $is_disconnected_locally ) {
 			// Delete cached connected user data.
 			$transient_key = "jetpack_connected_user_data_$user_id";
 			delete_transient( $transient_key );
@@ -786,7 +789,29 @@ class Manager {
 			 */
 			do_action( 'jetpack_unlinked_user', $user_id );
 		}
-		return $result;
+
+		return $is_disconnected_locally;
+	}
+
+	/**
+	 * Request to wpcom for a user to be unlinked from their WordPress.com account
+	 *
+	 * @access public
+	 *
+	 * @param Integer $user_id the user identifier.
+	 *
+	 * @return Boolean Whether the disconnection of the user was successful.
+	 */
+	public function unlink_user_from_wpcom( $user_id ) {
+		// Attempt to disconnect the user from WordPress.com.
+		$xml = new \Jetpack_IXR_Client( compact( 'user_id' ) );
+
+		$xml->query( 'jetpack.unlink_user', $user_id );
+		if ( $xml->isError() ) {
+			return false;
+		}
+
+		return (bool) $xml->getResponse();
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test_Manager_integration.php
+++ b/projects/packages/connection/tests/php/test_Manager_integration.php
@@ -647,7 +647,7 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Intercept the disconnect user API request sent to WP.com, and mock success response.
+	 * Intercept the disconnect user API request sent to WP.com, and mock failure response.
 	 *
 	 * @param bool|array $response The existing response.
 	 * @param array      $args The request arguments.

--- a/projects/packages/connection/tests/php/test_Manager_integration.php
+++ b/projects/packages/connection/tests/php/test_Manager_integration.php
@@ -28,19 +28,6 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	 */
 	public function set_up() {
 		$this->manager = new Manager();
-
-		$this->ixr_client = $this->getMockBuilder( '\Jetpack_IXR_Client' )
-			->setMethods( array( 'isError', 'getResponse' ) )
-			->getMock();
-	}
-
-	/**
-	 * Clean up the testing environment.
-	 *
-	 * @after
-	 */
-	public function tear_down() {
-		unset( $this->ixr_client );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test_Manager_unit.php
+++ b/projects/packages/connection/tests/php/test_Manager_unit.php
@@ -40,11 +40,11 @@ class ManagerTest extends TestCase {
 	 */
 	public function set_up() {
 		$this->manager = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
-			->setMethods( array( 'get_tokens', 'get_connection_owner_id' ) )
+			->setMethods( array( 'get_tokens', 'get_connection_owner_id', 'unlink_user_from_wpcom' ) )
 			->getMock();
 
 		$this->tokens = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Tokens' )
-			->setMethods( array( 'get_access_token' ) )
+			->setMethods( array( 'get_access_token', 'disconnect_user' ) )
 			->getMock();
 
 		$this->manager->method( 'get_tokens' )->will( $this->returnValue( $this->tokens ) );
@@ -353,6 +353,63 @@ class ManagerTest extends TestCase {
 		$this->assertTrue( strpos( $signed_token, 'timestamp' ) !== false );
 		$this->assertTrue( strpos( $signed_token, 'nonce' ) !== false );
 		$this->assertTrue( strpos( $signed_token, 'signature' ) !== false );
+	}
+
+	/**
+	 * Test disconnecting a user from WordPress.com.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::disconnect_user
+	 * @dataProvider get_disconnect_user_scenarios
+	 *
+	 * @param bool $remote   Was the remote disconnection successful.
+	 * @param bool $local    Was the remote disconnection successful.
+	 * @param bool $expected Expected outcome.
+	 */
+	public function test_disconnect_user( $remote, $local, $expected ) {
+		$editor_id = wp_insert_user(
+			array(
+				'user_login' => 'editor',
+				'user_pass'  => 'pass',
+				'user_email' => 'editor@editor.com',
+				'role'       => 'editor',
+			)
+		);
+		( new Tokens() )->update_user_token( $editor_id, sprintf( '%s.%s.%d', 'key', 'private', $editor_id ), false );
+
+		$this->manager->method( 'unlink_user_from_wpcom' )
+			->will( $this->returnValue( $remote ) );
+
+		$this->tokens->method( 'disconnect_user' )
+			->will( $this->returnValue( $local ) );
+
+		$result = $this->manager->disconnect_user( $editor_id );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test data for test_disconnect_user
+	 *
+	 * @return array
+	 */
+	public function get_disconnect_user_scenarios() {
+		return array(
+			'Successful remote and local disconnection' => array(
+				true,
+				true,
+				true,
+			),
+			'Failed remote and successful local disconnection' => array(
+				false,
+				true,
+				false,
+			),
+			'Successful remote and failed local disconnection' => array(
+				true,
+				false,
+				false,
+			),
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-disconnect-user-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-disconnect-user-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: REST Endpoints tests: mock successful XML-RPC response to fix failing tests.
+
+

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -688,6 +688,8 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// Mock site already registered
 		Jetpack_Options::update_option( 'user_tokens', array( $user->ID => "honey.badger.$user->ID" ) );
 
+		add_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10, 3 );
+
 		// Create REST request in JSON format and dispatch
 		$response = $this->create_and_get_request( 'connection/user', array( 'linked' => false ), 'POST' );
 
@@ -711,6 +713,8 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// Create REST request in JSON format and dispatch
 		$response = $this->create_and_get_request( 'connection/user', array( 'linked' => false ), 'POST' );
 
+		remove_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10, 3 );
+
 		// No way. Master user can't be unlinked. This is intended
 		$this->assertResponseStatus( 403, $response );
 
@@ -733,8 +737,12 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$transient_key = "jetpack_connected_user_data_$user->ID";
 		set_transient( $transient_key, 'dummy', DAY_IN_SECONDS );
 
+		add_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10, 3 );
+
 		// Create REST request in JSON format and dispatch.
 		$this->create_and_get_request( 'connection/user', array( 'linked' => false ), 'POST' );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10, 3 );
 
 		// Transient should be deleted after unlinking user.
 		$this->assertFalse( get_transient( $transient_key ) );


### PR DESCRIPTION
Fixes #19857

#### Changes proposed in this Pull Request:

* With this PR, we now attempt to make the request to disconnect the user from WordPress.com before we delete the connected data locally. This should fix the problem outlined in #19857.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

1. Start with a site connected to WordPress.com, with 2 connected users: an admin (primary user for the connection) and an extra user.
2. At this point, when looking at your `user_tokens` Jetpack option, you'll see the 2 entries, one for each user id.
3. While logged in as the primary admin, go to Users in wp-admin
4. Delete the other user.
5. Find the cache site in Network admin.
6. Ensure the wpcom user linked to the local user you just deleted got removed from Network admin.
