### PR TITLE
E2E tests: Slack notification missing html_url for scheduled jobs

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-fix-slack-notification-for-scheduled-jobs
+++ b/projects/plugins/jetpack/changelog/e2e-fix-slack-notification-for-scheduled-jobs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+E2E tests: fix Slack notification for scheduled jobs

--- a/projects/plugins/jetpack/tests/e2e/bin/slack.js
+++ b/projects/plugins/jetpack/tests/e2e/bin/slack.js
@@ -211,14 +211,17 @@ function getGithubInfo() {
 		gh.pr.title = event.pull_request.title;
 
 		gh.branch.name = event.pull_request.head.ref;
-
-		gh.run.url = `${ event.repository.html_url }/actions/runs/${ GITHUB_RUN_ID }`;
 	} else {
 		gh.branch.name = event.ref.substr( 11 );
-		gh.run.url = `${ event.server_url }/${ event.repository }/actions/runs/${ GITHUB_RUN_ID }`;
 	}
 
-	gh.branch.url = `${ event.repository.html_url }/tree/${ gh.branch.name }`;
+	if ( event.event_name === 'schedule' ) {
+		gh.run.url = `${ event.server_url }/${ event.repository }/actions/runs/${ GITHUB_RUN_ID }`;
+		gh.branch.url = `${ event.server_url }/${ event.repository }/tree/${ gh.branch.name }`;
+	} else {
+		gh.run.url = `${ event.repository.html_url }/actions/runs/${ GITHUB_RUN_ID }`;
+		gh.branch.url = `${ event.repository.html_url }/tree/${ gh.branch.name }`;
+	}
 
 	return gh;
 }

--- a/projects/plugins/jetpack/tests/e2e/bin/slack.js
+++ b/projects/plugins/jetpack/tests/e2e/bin/slack.js
@@ -200,7 +200,6 @@ function getGithubInfo() {
 	const gh = {
 		run: {
 			id: GITHUB_RUN_ID,
-			url: `${ event.repository.html_url }/actions/runs/${ GITHUB_RUN_ID }`,
 		},
 		branch: {},
 	};
@@ -212,8 +211,11 @@ function getGithubInfo() {
 		gh.pr.title = event.pull_request.title;
 
 		gh.branch.name = event.pull_request.head.ref;
+
+		gh.run.url = `${ event.repository.html_url }/actions/runs/${ GITHUB_RUN_ID }`;
 	} else {
 		gh.branch.name = event.ref.substr( 11 );
+		gh.run.url = `${ event.server_url }/${ event.repository }/actions/runs/${ GITHUB_RUN_ID }`;
 	}
 
 	gh.branch.url = `${ event.repository.html_url }/tree/${ gh.branch.name }`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes failing Slack notification for scheduled jobs. 
In case of scheduled jobs the event.json file doesn't provide an html_url property for repository making the slack script fail.

#### Jetpack product discussion
1156386383419466-as-1200337431330111/f

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Hard to test until the next scheduled Gutenberg job will run.