### PR TITLE
Add a site option when creating a site with Blank Canvas design

### DIFF
--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -153,6 +153,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_cloud_eligible',
 		'selected_features',
 		'anchor_podcast',
+		'was_created_with_blank_canvas_design',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -654,6 +655,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'anchor_podcast':
 					$options[ $key ] = $site->get_anchor_podcast();
+					break;
+				case 'was_created_with_blank_canvas_design':
+					$options[ $key ] = $site->was_created_with_blank_canvas_design();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -700,6 +700,10 @@ abstract class SAL_Site {
 		return get_option( 'selected_features' );
 	}
 
+	public function was_created_with_blank_canvas_design() {
+		return (bool) get_option( 'was_created_with_blank_canvas_design' );
+	}
+
 	/**
 	 * Get the option storing the Anchor podcast ID that identifies a site as a podcasting site.
 	 *


### PR DESCRIPTION
Summary:
In order to customize the experience when a user lands in the editor after selecting Blank Canvas (empty homepage template) we need a way to identify it.

This diff is a prerequisite of 49048-gh-wp-calypso

Test Plan:
- Add this patch and sandbox `[private link]`
- Go to https://github.com/Automattic/wp-calypso/pull/52288 and use the live link.
- Go to /new and create a site by picking Blank Canvas design.
- Add the newly created site to the sandbox too
- Check for the `is_blank_canvas` option of the site. A way to get the data easily in the console, open Focused Launch and then run `wp.data.select('automattic/site' ).getState().sites[window._currentSiteId].options`

Reviewers: #luna_team, mciampini

Reviewed By: #luna_team, mciampini

Subscribers: stefannhs, yansern, mciampini

Tags: #touches_jetpack_files

Differential Revision: D60468-code

This commit syncs r225797-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Probably no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See D60468-code
