### PR TITLE
Story Block: prevent CSS conflicts by making sure buttons don't have outlines

### DIFF
--- a/projects/plugins/jetpack/changelog/story-block-fix-css-button-outline
+++ b/projects/plugins/jetpack/changelog/story-block-fix-css-button-outline
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: this change is particularly insignificant
+
+

--- a/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
@@ -47,6 +47,7 @@
 		text-shadow: none;
 		background-color: transparent;
 		border: 0;
+		outline-width: 0;
 		cursor:pointer;
 	}
 


### PR DESCRIPTION
This is a very minor fix that prevents CSS conflicts with some themes used on WPCOM such as [Libretto](https://wordpress.com/theme/libretto).

WPCOM currently doesn't support shadow DOM as we bundle all our scripts and CSS together. As such we have some CSS conflicts on some themes. This is an attempt to fix one type of CSS conflict.
A more general approach should be taken to bring back shadow dom to WPCOM by excluding the story block styles and JS from the bundling logic (see D48402-code).
An even more general approach would be to serve stories from iframes. This is a much larger project and will be tackled at some point in the future.

#### Changes proposed in this Pull Request:
CSS rule added in story css file

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Create a story on a site that uses the Libretto theme
* Make sure the button outline is not visible
