### PR TITLE
JITM: remove the jetpack-constants dependency from composer.json

### DIFF
--- a/projects/packages/jitm/changelog/update-remove_constants
+++ b/projects/packages/jitm/changelog/update-remove_constants
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+JITM: remove jetpack-constants dependency from composer.json

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -9,12 +9,11 @@
 		"automattic/jetpack-connection": "^1.27",
 		"automattic/jetpack-device-detection": "^1.4",
 		"automattic/jetpack-logo": "^1.5",
-		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-options": "^1.12",
 		"automattic/jetpack-partner": "^1.5",
-		"automattic/jetpack-tracking": "^1.13",
 		"automattic/jetpack-redirect": "^1.5",
-		"automattic/jetpack-status": "^1.7"
+		"automattic/jetpack-status": "^1.7",
+		"automattic/jetpack-tracking": "^1.13"
 	},
 	"require-dev": {
 		"brain/monkey": "2.6.0",

--- a/projects/plugins/jetpack/changelog/update-remove_constants
+++ b/projects/plugins/jetpack/changelog/update-remove_constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: update composer.lock
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -711,13 +711,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "f7f93b12740e04db43e103b06d122fb7ac870f47"
+                "reference": "767af7aed416e2db1092c4225b38d13bc874a17a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
                 "automattic/jetpack-assets": "^1.11",
                 "automattic/jetpack-connection": "^1.27",
-                "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-device-detection": "^1.4",
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-options": "^1.12",
@@ -1603,16 +1602,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.7",
+            "version": "v5.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "90374b8ed059325b49a29b55b3f8bb4062c87629"
+                "reference": "864568fdc0208b3eba3638b6000b69d2386e6768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/90374b8ed059325b49a29b55b3f8bb4062c87629",
-                "reference": "90374b8ed059325b49a29b55b3f8bb4062c87629",
+                "url": "https://api.github.com/repos/symfony/console/zipball/864568fdc0208b3eba3638b6000b69d2386e6768",
+                "reference": "864568fdc0208b3eba3638b6000b69d2386e6768",
                 "shasum": ""
             },
             "require": {
@@ -1680,7 +1679,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.7"
+                "source": "https://github.com/symfony/console/tree/v5.2.8"
             },
             "funding": [
                 {
@@ -1696,7 +1695,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-19T14:07:32+00:00"
+            "time": "2021-05-11T15:45:21+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2327,16 +2326,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.6",
+            "version": "v5.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572"
+                "reference": "01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
-                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
+                "url": "https://api.github.com/repos/symfony/string/zipball/01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db",
+                "reference": "01b35eb64cac8467c3f94cd0ce2d0d376bb7d1db",
                 "shasum": ""
             },
             "require": {
@@ -2390,7 +2389,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.6"
+                "source": "https://github.com/symfony/string/tree/v5.2.8"
             },
             "funding": [
                 {
@@ -2406,7 +2405,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-17T17:12:15+00:00"
+            "time": "2021-05-10T14:56:10+00:00"
         },
         {
             "name": "wikimedia/at-ease",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The JITM package doesn't depend on the `jetpack-constants` package so remove it from JITM's `composer.json` file.
* Put the dependencies in alphabetical order.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* No testing required.
* Review the JITM package and verify that the jetpack-constants package is not used.
* Note that the `jetpack-constants` package is required by other packages that JITM depends on, so the `jetpack-constants` package will still be installed in JITM's vendor directory if `composer install` is run on the JITM package.
