### PR TITLE
Removes inplace connection from Restore Connection action

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/connection/actions.js
+++ b/projects/plugins/jetpack/_inc/client/state/connection/actions.js
@@ -26,10 +26,8 @@ import {
 	UNLINK_USER_SUCCESS,
 	SITE_RECONNECT,
 	SITE_RECONNECT_FAIL,
-	SITE_RECONNECT_SUCCESS,
 } from 'state/action-types';
 import restApi from 'rest-api';
-import { isSafari, doNotUseConnectionIframe } from 'state/initial-state';
 import { isReconnectingSite } from 'state/connection/reducer';
 
 export const fetchSiteConnectionStatus = () => {
@@ -275,19 +273,9 @@ export const reconnectSite = () => {
 				const authorizeUrl = connectionStatusData.authorizeUrl;
 				// status: in_progress, aka user needs to re-connect their WP.com account.
 				if ( 'in_progress' === status ) {
-					// Redirect user to authorize WP.com if in-place connection is restricted.
-					if ( isSafari( getState() ) || doNotUseConnectionIframe( getState() ) ) {
-						return window.location.replace( authorizeUrl );
-					}
-					// Set connectUrl and initiate in-place auth flow.
-					dispatch( {
-						type: CONNECT_URL_FETCH_SUCCESS,
-						connectUrl: authorizeUrl,
-					} );
-					dispatch( authorizeUserInPlace() );
-				} else {
-					window.location.reload();
+					return window.location.replace( authorizeUrl );
 				}
+				window.location.reload();
 			} )
 			.catch( error => {
 				dispatch( {

--- a/projects/plugins/jetpack/changelog/update-remove-inplace-connection-from-restore
+++ b/projects/plugins/jetpack/changelog/update-remove-inplace-connection-from-restore
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Disables in-place connection from the Restore Connection action


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR disables the in-place authorization flow from the "Restore Connection" feature.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes inplace connection from Restore Connection action

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-bZE-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Perform a site-level connection
* Use jetpack debugger plugin and set an invalid blog token
* Visit Jetpack Dashboard
* Click on "Restore Connection" once the error notice appears
* Make sure the connection is restored

---

* Perform a full connection
* Use jetpack debugger plugin and set an invalid blog token AND invalid user tokens
* Visit Jetpack Dashboard
* Click on "Restore Connection" once the error notice appears
* Make sure you are redirected to Calypso to authorize the user
* Authorize the user
* Make sure your connection is restored
* Repeat the steps above, but instead of triggering the Connection Restore from the Jetpack Dashboard, visit Tools > Site Health, expand the "Tokens health" error and click "Reconnect connection now"

---

Is there any other place where we can trigger the Reconnection from?
