### PR TITLE
Update/remove in place connection from Dashboard and Settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/monitor.jsx
@@ -17,7 +17,12 @@ import { __ } from '@wordpress/i18n';
 import analytics from 'lib/analytics';
 import getRedirectUrl from 'lib/jp-redirect';
 import { isModuleAvailable } from 'state/modules';
-import { isOfflineMode, hasConnectedOwner, authorizeUserInPlace } from 'state/connection';
+import {
+	isOfflineMode,
+	hasConnectedOwner,
+	isFetchingConnectUrl as _isFetchingConnectUrl,
+	getConnectUrl as _getConnectUrl,
+} from 'state/connection';
 import DashItem from 'components/dash-item';
 
 class DashMonitor extends Component {
@@ -35,8 +40,6 @@ class DashMonitor extends Component {
 
 		this.props.updateOptions( { monitor: true } );
 	};
-
-	connect = () => this.props.authorizeUserInPlace();
 
 	getContent() {
 		const labelName = __( 'Downtime monitoring', 'jetpack' );
@@ -100,7 +103,7 @@ class DashMonitor extends Component {
 						{ createInterpolateElement(
 							__( '<a>Connect your WordPress.com</a> account to use this feature.', 'jetpack' ),
 							{
-								a: <a href="javascript:void(0)" onClick={ this.connect } />,
+								a: <a href={ this.props.connectUrl } />,
 							}
 						) }
 					</p>
@@ -114,15 +117,10 @@ class DashMonitor extends Component {
 	}
 }
 
-export default connect(
-	state => ( {
-		isOfflineMode: isOfflineMode( state ),
-		isModuleAvailable: isModuleAvailable( state, 'monitor' ),
-		hasConnectedOwner: hasConnectedOwner( state ),
-	} ),
-	dispatch => ( {
-		authorizeUserInPlace: () => {
-			return dispatch( authorizeUserInPlace() );
-		},
-	} )
-)( DashMonitor );
+export default connect( state => ( {
+	isOfflineMode: isOfflineMode( state ),
+	isModuleAvailable: isModuleAvailable( state, 'monitor' ),
+	hasConnectedOwner: hasConnectedOwner( state ),
+	fetchingConnectUrl: _isFetchingConnectUrl( state ),
+	connectUrl: _getConnectUrl( state ),
+} ) )( DashMonitor );

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
@@ -17,7 +17,12 @@ import { __ } from '@wordpress/i18n';
 import DashItem from 'components/dash-item';
 import { getProtectCount } from 'state/at-a-glance';
 import getRedirectUrl from 'lib/jp-redirect';
-import { isOfflineMode, hasConnectedOwner, authorizeUserInPlace } from 'state/connection';
+import {
+	isOfflineMode,
+	hasConnectedOwner,
+	isFetchingConnectUrl as _isFetchingConnectUrl,
+	getConnectUrl as _getConnectUrl,
+} from 'state/connection';
 import { isModuleAvailable } from 'state/modules';
 import { numberFormat } from 'components/number-format';
 import QueryProtectCount from 'components/data/query-dash-protect';
@@ -32,8 +37,6 @@ class DashProtect extends Component {
 	};
 
 	activateProtect = () => this.props.updateOptions( { protect: true } );
-
-	connect = () => this.props.authorizeUserInPlace();
 
 	getContent() {
 		const labelName = __( 'Protect', 'jetpack' );
@@ -102,7 +105,7 @@ class DashProtect extends Component {
 								'jetpack'
 							),
 							{
-								a: <a href="javascript:void(0)" onClick={ this.connect } />,
+								a: <a href={ this.props.connectUrl } />,
 							}
 						) }
 
@@ -134,16 +137,11 @@ class DashProtect extends Component {
 	}
 }
 
-export default connect(
-	state => ( {
-		protectCount: getProtectCount( state ),
-		isOfflineMode: isOfflineMode( state ),
-		isModuleAvailable: isModuleAvailable( state, 'protect' ),
-		hasConnectedOwner: hasConnectedOwner( state ),
-	} ),
-	dispatch => ( {
-		authorizeUserInPlace: () => {
-			return dispatch( authorizeUserInPlace() );
-		},
-	} )
-)( DashProtect );
+export default connect( state => ( {
+	protectCount: getProtectCount( state ),
+	isOfflineMode: isOfflineMode( state ),
+	isModuleAvailable: isModuleAvailable( state, 'protect' ),
+	hasConnectedOwner: hasConnectedOwner( state ),
+	fetchingConnectUrl: _isFetchingConnectUrl( state ),
+	connectUrl: _getConnectUrl( state ),
+} ) )( DashProtect );

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -73,24 +73,6 @@ export class ConnectButton extends React.Component {
 		this.setState( { showModal: ! this.state.showModal } );
 	};
 
-	loadIframe = e => {
-		e.preventDefault();
-		// If the iframe is already loaded or we don't have a connectUrl yet, return.
-		if ( this.props.isAuthorizing || this.props.fetchingConnectUrl ) {
-			return;
-		}
-
-		// Track click
-		analytics.tracks.recordJetpackClick( 'link_account_in_place' );
-
-		if ( this.props.customConnect ) {
-			this.props.customConnect();
-		} else {
-			// Dispatch user in place authorization.
-			this.props.authorizeUserInPlace();
-		}
-	};
-
 	renderUserButton = () => {
 		// Already linked
 		if ( this.props.isLinked ) {
@@ -123,23 +105,6 @@ export class ConnectButton extends React.Component {
 			},
 			connectLegend =
 				this.props.connectLegend || __( 'Connect your WordPress.com account', 'jetpack' );
-
-		// Secondary users in-place connection flow
-
-		// Due to the limitation in how 3rd party cookies are handled in Safari,
-		// we're falling back to the original flow on Safari desktop and mobile,
-		// thus ignore the 'connectInPlace' property value.
-
-		// We also check the `doNotUseConnectionIframe` initial global state property.
-		// This will override the button's `connectInPlace` property.
-
-		if (
-			this.props.connectInPlace &&
-			! this.props.isSafari &&
-			! this.props.doNotUseConnectionIframe
-		) {
-			buttonProps.onClick = this.loadIframe;
-		}
 
 		return this.props.asLink ? (
 			<a { ...buttonProps }>{ connectLegend }</a>

--- a/projects/plugins/jetpack/changelog/update-remove-in-place-connection
+++ b/projects/plugins/jetpack/changelog/update-remove-in-place-connection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Disables the in-place connection flow in the Dashboard and Settings pages


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disables the in-place authorization flow from the "Connect or user" buttons in Jetpack Dashboard and Settings pages

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-bZE-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Perform a site-level connection
* Visit the Jetpack dashboard
* Check that the links to connect your user under the Stats, Protect and Monitor cards take you to Calypso
* Also check the button to connect the user down on the "Account Connection" card
* Visit Jetpack Settings page and make sure all buttons to connect your user take you to Calypso
* Log in with a secondary admin and make sure all links mentioned above also take you to Calypso
