### PR TITLE
Site-only Connection: Fix the connection owner info card

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -539,9 +539,10 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 function jetpack_current_user_data() {
 	$jetpack_connection = new Connection_Manager( 'jetpack' );
 
-	$current_user   = wp_get_current_user();
-	$is_master_user = $current_user->ID == Jetpack_Options::get_option( 'master_user' );
-	$dotcom_data    = $jetpack_connection->get_connected_user_data();
+	$current_user      = wp_get_current_user();
+	$is_user_connected = $jetpack_connection->is_user_connected( $current_user->ID );
+	$is_master_user    = $is_user_connected && (int) $current_user->ID && (int) Jetpack_Options::get_option( 'master_user' ) === (int) $current_user->ID;
+	$dotcom_data       = $jetpack_connection->get_connected_user_data();
 
 	// Add connected user gravatar to the returned dotcom_data.
 	$dotcom_data['avatar'] = ( ! empty( $dotcom_data['email'] ) ?
@@ -555,7 +556,7 @@ function jetpack_current_user_data() {
 		: false );
 
 	$current_user_data = array(
-		'isConnected' => $jetpack_connection->is_user_connected( $current_user->ID ),
+		'isConnected' => $is_user_connected,
 		'isMaster'    => $is_master_user,
 		'username'    => $current_user->user_login,
 		'id'          => $current_user->ID,

--- a/projects/plugins/jetpack/changelog/fix-site-only-connection-owner
+++ b/projects/plugins/jetpack/changelog/fix-site-only-connection-owner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Correctly display connection owner information if user token is missing, but connection owner option is set.


### PR DESCRIPTION
If user token is not present, but the connection owner option is set to the current user, Jetpack Dashboard will occasionally handle the current user as connection owner.

This PR will only set the `isMaster` initial state value to `true` if the user is connected.

#### Changes proposed in this Pull Request:
* Correctly display connection owner information if user token is missing, but connection owner option is set.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Fully connect Jetpack.
2. Use the "Broken Token" tool to remove user tokens. Make sure to keep the "Primary User" value intact.
3. Go to Jetpack Dashboard, scroll down to the "Connections" cards, and confirm that the connection owner information is displayed correctly.

**Before:**
<img width="1059" alt="Screen Shot 2021-05-19 at 10 46 57 AM" src="https://user-images.githubusercontent.com/1341249/118779838-20ce6580-b894-11eb-825c-0635c69439ef.png">

**After:**
<img width="1059" alt="Screen Shot 2021-05-19 at 10 47 28 AM" src="https://user-images.githubusercontent.com/1341249/118779865-275cdd00-b894-11eb-9263-9713d94a19b2.png">
