### PR TITLE
Feedback: Remove "Export CSV" submenu

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-feedback-export-csv-submenu
+++ b/projects/plugins/jetpack/changelog/remove-feedback-export-csv-submenu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+The "Feedback > Export CSV" submenu entry has been removed. The export funcionality is still available in "Feedback > Form responses".

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -194,13 +194,6 @@ function grunion_message_bulk_spam() {
 	echo '<div class="updated"><p>' . __( 'Feedback(s) marked as spam', 'jetpack' ) . '</p></div>';
 }
 
-// remove admin UI parts that we don't support in feedback management
-add_action( 'admin_menu', 'grunion_admin_menu' );
-function grunion_admin_menu() {
-	global $menu, $submenu;
-	unset( $submenu['edit.php?post_type=feedback'] );
-}
-
 add_filter( 'bulk_actions-edit-feedback', 'grunion_admin_bulk_actions' );
 function grunion_admin_bulk_actions( $actions ) {
 	global $current_screen;

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -163,9 +163,9 @@ class Grunion_Contact_Form_Plugin {
 		if ( is_admin() ) {
 			add_action( 'admin_init', array( $this, 'download_feedback_as_csv' ) );
 			add_action( 'admin_footer-edit.php', array( $this, 'export_form' ) );
-			add_action( 'admin_menu', array( $this, 'admin_menu' ) );
-			add_action( 'current_screen', array( $this, 'unread_count' ) );
 		}
+		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+		add_action( 'current_screen', array( $this, 'unread_count' ) );
 
 		// custom post type we'll use to keep copies of the feedback items
 		register_post_type(

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -435,7 +435,7 @@ class Grunion_Contact_Form_Plugin {
 	}
 
 	/**
-	 * Add the 'Export' and 'Form Responses' menu item as a submenu of Feedback.
+	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 */
 	public function admin_menu() {
 		$slug = 'jetpack-feedback';

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -179,7 +179,7 @@ class Grunion_Contact_Form_Plugin {
 				),
 				'menu_icon'             => 'dashicons-feedback',
 				'show_ui'               => true,
-				'show_in_menu'          => 'edit.php?post_type=feedback',
+				'show_in_menu'          => false,
 				'show_in_admin_bar'     => false,
 				'public'                => false,
 				'rewrite'               => false,
@@ -438,7 +438,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 */
 	public function admin_menu() {
-		$slug = 'jetpack-feedback';
+		$slug = 'feedback';
 
 		add_menu_page(
 			__( 'Feedback', 'jetpack' ),
@@ -485,14 +485,16 @@ class Grunion_Contact_Form_Plugin {
 		if ( isset( $screen->post_type ) && 'feedback' == $screen->post_type ) {
 			update_option( 'feedback_unread_count', 0 );
 		} else {
-			global $menu;
-			if ( isset( $menu ) && is_array( $menu ) && ! empty( $menu ) ) {
-				foreach ( $menu as $index => $menu_item ) {
+			global $submenu;
+			if ( isset( $submenu['feedback'] ) && is_array( $submenu['feedback'] ) && ! empty( $submenu['feedback'] ) ) {
+				foreach ( $submenu['feedback'] as $index => $menu_item ) {
 					if ( 'edit.php?post_type=feedback' == $menu_item[2] ) {
 						$unread = get_option( 'feedback_unread_count', 0 );
 						if ( $unread > 0 ) {
-							$unread_count       = current_user_can( 'publish_pages' ) ? " <span class='feedback-unread count-{$unread} awaiting-mod'><span class='feedback-unread-count'>" . number_format_i18n( $unread ) . '</span></span>' : '';
-							$menu[ $index ][0] .= $unread_count;
+							$unread_count = current_user_can( 'publish_pages' ) ? " <span class='feedback-unread count-{$unread} awaiting-mod'><span class='feedback-unread-count'>" . number_format_i18n( $unread ) . '</span></span>' : '';
+
+							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+							$submenu['feedback'][ $index ][0] .= $unread_count;
 						}
 						break;
 					}

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -438,7 +438,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Add the 'Export' and 'Form Responses' menu item as a submenu of Feedback.
 	 */
 	public function admin_menu() {
-		$slug = 'edit.php?post_type=feedback';
+		$slug = 'jetpack-feedback';
 
 		add_menu_page(
 			__( 'Feedback', 'jetpack' ),
@@ -450,28 +450,19 @@ class Grunion_Contact_Form_Plugin {
 			45
 		);
 
-		remove_submenu_page(
-			$slug,
-			$slug
-		);
-
 		add_submenu_page(
 			$slug,
 			__( 'Form Responses', 'jetpack' ),
 			__( 'Form Responses', 'jetpack' ),
 			'edit_pages',
-			$slug,
+			'edit.php?post_type=feedback',
 			null,
 			0
 		);
 
-		add_submenu_page(
+		remove_submenu_page(
 			$slug,
-			__( 'Export responses as CSV', 'jetpack' ),
-			__( 'Export CSV', 'jetpack' ),
-			'export',
-			'feedback-export',
-			array( $this, 'export_form' )
+			$slug
 		);
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
@@ -39,7 +39,7 @@ class P2_Admin_Menu extends WPcom_Admin_Menu {
 		}
 
 		remove_menu_page( 'link-manager.php' );
-		remove_menu_page( 'edit.php?post_type=feedback' );
+		remove_menu_page( 'feedback' );
 		remove_menu_page( 'plugins.php' );
 		remove_menu_page( 'https://wordpress.com/plugins/' . $this->domain );
 		remove_submenu_page( 'plugins.php', 'plugins.php' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/52661

#### Changes proposed in this Pull Request:
Removes the "Feedback > Export CSV" submenu entry. The export functionality is still available in "Feedback > Form responses". This aligns the behavior with WordPress.com Simple sites, which currently don't register this submenu.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Make sure the "Feedback" menu does not contain the "Export CSV" submenu.
- Go to "Feedback > Form responses".
- Make sure the "Export CSV" functionality appears when there are form responses.
- To submit a form response, follow the steps below:
  - Go to Posts > Add new.
  - Insert a Form block and publish the post.
  - Visit the published post.
  - Fill the form and submit the data.
- Make sure the "Form responses" submenu displays the count of unread form responses.