### PR TITLE
Update Nav Unification styles priority

### DIFF
--- a/projects/plugins/jetpack/changelog/update-priority-for-unified-nav-styles
+++ b/projects/plugins/jetpack/changelog/update-priority-for-unified-nav-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Update the priority for overriding unified nav styles.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -51,7 +51,7 @@ abstract class Base_Admin_Menu {
 		add_action( 'admin_menu', array( $this, 'hide_parent_of_hidden_submenus' ), 99999 );
 
 		add_filter( 'admin_menu', array( $this, 'override_svg_icons' ), 99999 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 11 );
 		add_action( 'admin_head', array( $this, 'set_site_icon_inline_styles' ) );
 		add_filter( 'rest_request_before_callbacks', array( $this, 'rest_api_init' ), 11 );
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -101,7 +101,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		$this->assertSame( $instance, static::$admin_menu );
 
 		$this->assertSame( 99998, has_action( 'admin_menu', array( $instance, 'reregister_menu_items' ) ) );
-		$this->assertSame( 10, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_scripts' ) ) );
+		$this->assertSame( 11, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_scripts' ) ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-base-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-base-admin-menu.php
@@ -85,7 +85,7 @@ class Test_Base_Admin_Menu extends WP_UnitTestCase {
 		$this->assertSame( $instance, static::$admin_menu );
 
 		$this->assertSame( 99998, has_action( 'admin_menu', array( $instance, 'reregister_menu_items' ) ) );
-		$this->assertSame( 10, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_scripts' ) ) );
+		$this->assertSame( 11, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_scripts' ) ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -101,7 +101,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		$this->assertSame( $instance, static::$admin_menu );
 
 		$this->assertSame( 99998, has_action( 'admin_menu', array( $instance, 'reregister_menu_items' ) ) );
-		$this->assertSame( 10, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_scripts' ) ) );
+		$this->assertSame( 11, has_action( 'admin_enqueue_scripts', array( $instance, 'enqueue_scripts' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes alignment issues noted here p58i-axR-p2#comment-50605

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes Gutenberg widget styles loading after the nav unification override styles by increasing the priority

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:

Firstly enable the Widgets Editor by following the instructions here p58i-axR-p2

**Simple sites**

* Apply diff to your Sandbox and ensure Sandboxing is enabled.
* Follow the steps in the P2 above to enable the feature
* Go to Appearance > Widgets or `/wp-admin/themes.php?page=gutenberg-widgets`

**Atomic sites**

* Install Jetpack Beta and activate this branch
* Follow the steps in the P2 above to enable the feature
* Go to Appearance > Widgets or `/wp-admin/themes.php?page=gutenberg-widgets`

<table>
<tr>
	<td>**Before**</td>
	<td>**After**</td>
</tr>
<tr>
	<td><img width="1791" alt="Screenshot 2021-05-19 at 13 37 08" src="https://user-images.githubusercontent.com/8639742/118814542-2afa5f00-b8a8-11eb-8795-d3e7a5a2ef5d.png"></td>
	<td><img width="1792" alt="Screenshot 2021-05-19 at 13 35 26" src="https://user-images.githubusercontent.com/8639742/118814551-2e8de600-b8a8-11eb-95f5-080a5e87ef01.png"></td>
</tr>
</table>