### PR TITLE
WP.com Toolbar: Hide the FAB icon on Yoast admin pages

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-help-icons-overlap
+++ b/projects/plugins/jetpack/changelog/fix-help-icons-overlap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Hide the FAB icon on Yoast admin pages to avoid overlap with the Yoast help icon.

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
@@ -34,7 +34,7 @@ class Inline_Help {
 		$is_framed = ! empty( $_GET['frame-nonce'] );
 
 		// Do not inject the FAB icon on Yoast screens to avoid overlap with the Yoast help icon.
-		$is_yoast = $current_screen->base && false !== strpos( $current_screen->base, '_page_wpseo_' );
+		$is_yoast = ! empty( $current_screen->base ) && false !== strpos( $current_screen->base, '_page_wpseo_' );
 
 		if ( $is_framed || $is_yoast ) {
 			return;

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
@@ -34,7 +34,7 @@ class Inline_Help {
 		$is_framed = ! empty( $_GET['frame-nonce'] );
 
 		// Do not inject the FAB icon on Yoast screens to avoid overlap with the Yoast help icon.
-		$is_yoast = false !== strpos( $current_screen->base, 'wpseo' );
+		$is_yoast = $current_screen->base && false !== strpos( $current_screen->base, '_page_wpseo_' );
 
 		if ( $is_framed || $is_yoast ) {
 			return;

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
@@ -19,22 +19,22 @@ class Inline_Help {
 	 * Inline_Help constructor.
 	 */
 	public function __construct() {
-		$this->register_actions();
+		add_action( 'current_screen', array( $this, 'register_actions' ) );
 	}
 
 	/**
 	 * Registers actions.
 	 *
+	 * @param object $current_screen Current screen object.
 	 * @return void
 	 */
-	public function register_actions() {
+	public function register_actions( $current_screen ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		// Do not inject the FAB icon on embedded screens since the parent window may already contain a FAB icon.
 		$is_framed = ! empty( $_GET['frame-nonce'] );
 
 		// Do not inject the FAB icon on Yoast screens to avoid overlap with the Yoast help icon.
-		$current_page = \filter_input( \INPUT_GET, 'page', \FILTER_SANITIZE_STRING );
-		$is_yoast     = 'admin.php' === $GLOBALS['pagenow'] && false !== strpos( $current_page, 'wpseo' );
+		$is_yoast = false !== strpos( $current_screen->base, 'wpseo' );
 
 		if ( $is_framed || $is_yoast ) {
 			return;

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
@@ -32,7 +32,11 @@ class Inline_Help {
 		// Do not inject the FAB icon on embedded screens since the parent window may already contain a FAB icon.
 		$is_framed = ! empty( $_GET['frame-nonce'] );
 
-		if ( $is_framed ) {
+		// Do not inject the FAB icon on Yoast screens to avoid overlap with the Yoast help icon.
+		$current_page = \filter_input( \INPUT_GET, 'page', \FILTER_SANITIZE_STRING );
+		$is_yoast     = 'admin.php' === $GLOBALS['pagenow'] && false !== strpos( $current_page, 'wpseo' );
+
+		if ( $is_framed || $is_yoast ) {
 			return;
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 73-gh-Automattic/wordpress-seo-premium

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hide the FAB icon on Yoast admin pages to avoid overlap with the Yoast help icon

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

73-gh-Automattic/wordpress-seo-premium

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Nope.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a free Atomic site with the Yoast plugin installed and activated.
* Go to /wp-admin/admin.php?page=wpseo_dashboard
* Without this change, the two icons overlap:
![](https://d.pr/i/x6beuq+)
* With this change, only the Yoast icon is visible.