### PR TITLE
Calendly block: Add default value to input field

### DIFF
--- a/projects/plugins/jetpack/changelog/update-calendly-block-input-default-value
+++ b/projects/plugins/jetpack/changelog/update-calendly-block-input-default-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Supplying a default value for Calendly input values to avoid React controlled component console error.

--- a/projects/plugins/jetpack/extensions/blocks/calendly/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/controls.js
@@ -47,7 +47,7 @@ export const CalendlyInspectorControls = props => {
 						id="embedCode"
 						onChange={ event => setEmbedCode( event.target.value ) }
 						placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
-						value={ embedCode }
+						value={ embedCode || '' }
 						className="components-placeholder__input"
 					/>
 					<div>

--- a/projects/plugins/jetpack/extensions/blocks/calendly/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/edit.js
@@ -137,7 +137,7 @@ export function CalendlyEdit( props ) {
 					id="embedCode"
 					onChange={ event => setEmbedCode( event.target.value ) }
 					placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
-					value={ embedCode }
+					value={ embedCode || '' }
 					className="components-placeholder__input"
 				/>
 				<div>


### PR DESCRIPTION

#### Changes proposed in this Pull Request

As noticed over in https://github.com/Automattic/jetpack/pull/19883#pullrequestreview-663951385, there is a react warning about 'component is changing an uncontrolled input' when you paste a url into placeholder url box the first time.

This PR adds a default value to the field to prevent this error.

<img width="753" alt="Screen Shot 2021-05-20 at 4 39 41 pm" src="https://user-images.githubusercontent.com/6458278/118931552-86048280-b98a-11eb-95e4-e6086857bcf0.png">

Props to @glendaviesnz for the suggestion.

#### Testing instructions:
1. Insert a Calendly block into the editor
2. Enter text in the input field and check the browser console.

The uncontrolled component error should be gone. Whoosh!