### PR TITLE
Repo gardening: release new version of the action

### DIFF
--- a/projects/github-actions/repo-gardening/CHANGELOG.md
+++ b/projects/github-actions/repo-gardening/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2021-05-20
+### Added
+- Cache API calls for fetching labels and files on the PR.
+
+### Changed
+- Check Description task: update changelogger instructions to recommend the use of the CLI tool.
+- Labels: handle Jetpack Boost plugin structure when automatically managing labels.
+- Updated package dependencies
+
 ## [1.2.0] - 2021-04-16
 ### Added
 - Add new Flag OSS task: flags entries by external contributors, adds an "OSS Citizen" label to the PR, and sends a Slack message.
@@ -29,5 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[1.2.1]: https://github.com/Automattic/action-repo-gardening/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Automattic/action-repo-gardening/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Automattic/action-repo-gardening/compare/v1.0.0...v1.1.0

--- a/projects/github-actions/repo-gardening/changelog/add-cache-repo-gardening-api-calls
+++ b/projects/github-actions/repo-gardening/changelog/add-cache-repo-gardening-api-calls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Cache API calls for fetching labels and files on the PR.

--- a/projects/github-actions/repo-gardening/changelog/add-sync-package.json-engines
+++ b/projects/github-actions/repo-gardening/changelog/add-sync-package.json-engines
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Added engines in package.json
-
-

--- a/projects/github-actions/repo-gardening/changelog/fix-changelogger-in-subdir
+++ b/projects/github-actions/repo-gardening/changelog/fix-changelogger-in-subdir
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/repo-gardening/changelog/renovate-actions-core-1.x
+++ b/projects/github-actions/repo-gardening/changelog/renovate-actions-core-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/github-actions/repo-gardening/changelog/renovate-vercel-ncc-0.x
+++ b/projects/github-actions/repo-gardening/changelog/renovate-vercel-ncc-0.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/github-actions/repo-gardening/changelog/renovate-vercel-ncc-0.x#2
+++ b/projects/github-actions/repo-gardening/changelog/renovate-vercel-ncc-0.x#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/github-actions/repo-gardening/changelog/update-docs-changelogger-in-monorepo
+++ b/projects/github-actions/repo-gardening/changelog/update-docs-changelogger-in-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Check Description task: update changelogger instructions to recommend the use of the CLI tool.

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-labels-boost
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-labels-boost
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Labels: handle Jetpack Boost plugin structure when automatically managing labels.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "1.2.1-alpha",
+	"version": "1.2.1",
 	"description": "Manage PR and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* release a new version of the action for use by third-parties.
* I am especially interested in getting #19891 to be available for the Jetpack Boost repo.

#### Jetpack product discussion

N/A
#### Does this pull request change what data or activity we track or use?
No
#### Testing instructions:
Check for typos
