### PR TITLE
Disabled editing and deleting capabilities in WP-Admin Post list for Posts Page

### DIFF
--- a/projects/plugins/jetpack/changelog/add-disable-edit-and-delete-on-posts-page
+++ b/projects/plugins/jetpack/changelog/add-disable-edit-and-delete-on-posts-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Disabled editing and deleting pages in WP-Admin Post list for the page that is configured as a Posts page in WP-Admin

--- a/projects/plugins/jetpack/changelog/add-disable-edit-and-delete-on-posts-page
+++ b/projects/plugins/jetpack/changelog/add-disable-edit-and-delete-on-posts-page
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Disabled editing and deleting pages in WP-Admin Post list for the page that is configured as a Posts page in WP-Admin
+Disabled editing and deleting pages in WP-Admin Pages list screen for the page that is configured as a Posts page.

--- a/projects/plugins/jetpack/modules/masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar.php
@@ -41,7 +41,6 @@ if ( apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
 	require_once __DIR__ . '/masterbar/admin-menu/load.php';
 }
 
-if ( defined( 'IS_WPCOM' ) && IS_WPCOM || defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-	require_once __DIR__ . '/masterbar/wp-posts-list/class-posts-list-page-notification.php';
-	Posts_List_Page_Notification::init();
+if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+	require_once __DIR__ . '/masterbar/wp-posts-list/bootstrap.php';
 }

--- a/projects/plugins/jetpack/modules/masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar.php
@@ -40,3 +40,8 @@ if ( jetpack_is_atomic_site() ) {
 if ( apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
 	require_once __DIR__ . '/masterbar/admin-menu/load.php';
 }
+
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM || defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+	require_once __DIR__ . '/masterbar/wp-posts-list/class-posts-list-page-notification.php';
+	Posts_List_Page_Notification::init();
+}

--- a/projects/plugins/jetpack/modules/masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar.php
@@ -41,6 +41,6 @@ if ( apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
 	require_once __DIR__ . '/masterbar/admin-menu/load.php';
 }
 
-if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+if ( jetpack_is_atomic_site() ) {
 	require_once __DIR__ . '/masterbar/wp-posts-list/bootstrap.php';
 }

--- a/projects/plugins/jetpack/modules/masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar.php
@@ -25,6 +25,7 @@ new Admin_Color_Schemes();
 
 if ( jetpack_is_atomic_site() ) {
 	new Inline_Help();
+	require_once __DIR__ . '/masterbar/wp-posts-list/bootstrap.php';
 }
 
 /**
@@ -39,8 +40,4 @@ if ( jetpack_is_atomic_site() ) {
  */
 if ( apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
 	require_once __DIR__ . '/masterbar/admin-menu/load.php';
-}
-
-if ( jetpack_is_atomic_site() ) {
-	require_once __DIR__ . '/masterbar/wp-posts-list/bootstrap.php';
 }

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
@@ -8,12 +8,16 @@
 /**
  * Load the Posts_List_Notification.
  */
-global $pagenow;
+function masterbar_init_wp_posts_list() {
+	global $pagenow;
 
-if (
-	( 'edit.php' === $pagenow && isset( $_GET['post_type'] ) && 'page' === $_GET['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	|| 'post.php' === $pagenow
-) {
-	require_once __DIR__ . '/class-posts-list-page-notification.php';
-	Automattic\Jetpack\Dashboard_Customizations\Posts_List_Page_Notification::init();
+	if (
+		( 'edit.php' === $pagenow && isset( $_GET['post_type'] ) && 'page' === $_GET['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		|| 'post.php' === $pagenow
+	) {
+		require_once __DIR__ . '/class-posts-list-page-notification.php';
+		Automattic\Jetpack\Dashboard_Customizations\Posts_List_Page_Notification::init();
+	}
 }
+
+add_action( 'init', 'masterbar_init_wp_posts_list', 1 );

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
@@ -5,8 +5,13 @@
  * @package Jetpack
  */
 
-use Automattic\Jetpack\Dashboard_Customizations\Posts_List_Page_Notification;
+/**
+ * Load the Posts_List_Notification.
+ */
+global $pagenow;
 
-require_once __DIR__ . '/class-posts-list-page-notification.php';
-
-Posts_List_Page_Notification::init();
+// phpcs:ignore
+if ( ( $pagenow === 'edit.php' && isset( $_GET['post_type'] ) && $_GET['post_type'] === 'page' ) || $pagenow === 'post.php' ) {
+	require_once __DIR__ . '/class-posts-list-page-notification.php';
+	Automattic\Jetpack\Dashboard_Customizations\Posts_List_Page_Notification::init();
+}

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * WP-Admin Posts list bootstrap file.
+ *
+ * @package Jetpack
+ */
+
+use Automattic\Jetpack\Dashboard_Customizations\Posts_List_Page_Notification;
+
+require_once __DIR__ . '/class-posts-list-page-notification.php';
+
+Posts_List_Page_Notification::init();

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
@@ -10,8 +10,10 @@
  */
 global $pagenow;
 
-// phpcs:ignore
-if ( ( $pagenow === 'edit.php' && isset( $_GET['post_type'] ) && $_GET['post_type'] === 'page' ) || $pagenow === 'post.php' ) {
+if (
+	( 'edit.php' === $pagenow && isset( $_GET['post_type'] ) && 'page' === $_GET['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	|| 'post.php' === $pagenow
+) {
 	require_once __DIR__ . '/class-posts-list-page-notification.php';
 	Automattic\Jetpack\Dashboard_Customizations\Posts_List_Page_Notification::init();
 }

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
@@ -129,7 +129,7 @@ class Posts_List_Page_Notification {
 			return;
 		}
 
-		$text_notice = __( 'The content of your latest posts page is automatically generated and cannot be edited', 'jetpack' );
+		$text_notice = __( 'The content of your latest posts page is automatically generated and cannot be edited.', 'jetpack' );
 		?>
 		<script>
 			document.querySelector(".posts-page .check-column").innerHTML = '' +

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
@@ -42,11 +42,18 @@ class Posts_List_Page_Notification {
 	 * @param string $posts_page_id The Posts page configured in WordPress.
 	 */
 	public function __construct( $posts_page_id ) {
+		add_action( 'init', array( $this, 'init_actions' ) );
+
+		$this->posts_page_id = '' === $posts_page_id ? null : (int) $posts_page_id;
+	}
+
+	/**
+	 * Add in all hooks.
+	 */
+	public function init_actions() {
 		\add_filter( 'map_meta_cap', array( $this, 'disable_posts_page' ), 10, 4 );
 		\add_filter( 'post_class', array( $this, 'add_posts_page_css_class' ), 10, 3 );
 		\add_action( 'admin_print_footer_scripts-edit.php', array( $this, 'add_notification_icon' ) );
-
-		$this->posts_page_id = '' === $posts_page_id ? null : (int) $posts_page_id;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
@@ -54,6 +54,7 @@ class Posts_List_Page_Notification {
 		\add_filter( 'map_meta_cap', array( $this, 'disable_posts_page' ), 10, 4 );
 		\add_filter( 'post_class', array( $this, 'add_posts_page_css_class' ), 10, 3 );
 		\add_action( 'admin_print_footer_scripts-edit.php', array( $this, 'add_notification_icon' ) );
+		\add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_css' ) );
 	}
 
 	/**
@@ -91,6 +92,15 @@ class Posts_List_Page_Notification {
 	}
 
 	/**
+	 * Load the CSS for the WP Posts List
+	 *
+	 * We would probably need to move this elsewhere when new features are introduced to wp-posts-list.
+	 */
+	public function enqueue_css() {
+		\wp_enqueue_style( 'wp-posts-list', plugins_url( 'wp-posts-list.css', __FILE__ ), array(), JETPACK__VERSION );
+	}
+
+	/**
 	 * Adds a CSS class on the page configured as a Posts Page.
 	 *
 	 * @param array  $classes A list of CSS classes.
@@ -122,7 +132,8 @@ class Posts_List_Page_Notification {
 		$text_notice = __( 'The content of your latest posts page is automatically generated and cannot be edited', 'jetpack' );
 		?>
 		<script>
-			document.querySelector(".posts-page .check-column").innerHTML = '<span title="<?php echo esc_html( $text_notice ); ?>" style="margin-left: 8px" class="dashicons dashicons-info-outline"></span>';
+			document.querySelector(".posts-page .check-column").innerHTML = '' +
+					'<div class="info"><span class="icon dashicons dashicons-info-outline"></span><span class="message"><?php echo esc_html( $text_notice ); ?></span></div>';
 		</script>
 		<?php
 	}

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/wp-posts-list.css
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/wp-posts-list.css
@@ -14,7 +14,10 @@
 	border:1px solid #c3c4c7;
 	position: absolute;
 	z-index: 1;
+	margin-left:5px;
 	padding: 16px;
+	border-radius: 2px;
+	box-shadow: 0 2px 5px rgba(0,0,0,.1),0 0 56px rgba(0,0,0,.075)
 }
 
 .posts-page .info:hover .message {
@@ -24,5 +27,7 @@
 @media screen and (max-width: 782px) {
 	.posts-page .info .icon {
 		font-size: 28px;
+		width:28px;
+		height:28px;
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/wp-posts-list.css
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/wp-posts-list.css
@@ -1,0 +1,28 @@
+.posts-page .info {
+	position: relative;
+	display: inline-block;
+	margin-left:8px;
+}
+
+.posts-page .info .message {
+	visibility: hidden;
+	width:220px;
+	font-size: .875rem;
+	background-color: #fff;
+	color: #646970;
+	text-align: left;
+	border:1px solid #c3c4c7;
+	position: absolute;
+	z-index: 1;
+	padding: 16px;
+}
+
+.posts-page .info:hover .message {
+	visibility: visible;
+}
+
+@media screen and (max-width: 782px) {
+	.posts-page .info .icon {
+		font-size: 28px;
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
@@ -22,6 +22,10 @@ class Test_Posts_List_Page_Notification extends WP_UnitTestCase {
 	public function test_it_has_instance_loaded() {
 		$instance = Posts_List_Page_Notification::init();
 
+		$this->assertSame( 10, has_action( 'init', array( $instance, 'init_actions' ) ) );
+
+		$instance->init_actions();
+
 		$this->assertSame( 10, has_action( 'map_meta_cap', array( $instance, 'disable_posts_page' ) ) );
 		$this->assertSame( 10, has_action( 'post_class', array( $instance, 'add_posts_page_css_class' ) ) );
 		$this->assertSame( 10, has_action( 'admin_print_footer_scripts-edit.php', array( $instance, 'add_notification_icon' ) ) );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tests for Posts_List_Page_Notification class.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Dashboard_Customizations\Posts_List_Page_Notification;
+
+require_jetpack_file( 'modules/masterbar/wp-posts-list/class-posts-list-page-notification.php' );
+
+/**
+ * Class Test_Posts_List_Page_Notification.
+ *
+ * @coversDefaultClass Automattic\Jetpack\Dashboard_Customizations\Posts_List_Page_Notification
+ */
+class Test_Posts_List_Page_Notification extends WP_UnitTestCase {
+
+	/**
+	 * Check if the actions are attached.
+	 */
+	public function test_it_has_instance_loaded() {
+		$instance = Posts_List_Page_Notification::init();
+
+		$this->assertSame( 10, has_action( 'map_meta_cap', array( $instance, 'disable_posts_page' ) ) );
+		$this->assertSame( 10, has_action( 'post_class', array( $instance, 'add_posts_page_css_class' ) ) );
+		$this->assertSame( 10, has_action( 'admin_print_footer_scripts-edit.php', array( $instance, 'add_notification_icon' ) ) );
+	}
+
+	/**
+	 * Check if it appends the CSS class.
+	 */
+	public function test_it_appends_css_class() {
+		$instance = new Posts_List_Page_Notification( '5' );
+
+		$classes = $instance->add_posts_page_css_class( array(), 'fox', 5 );
+		$this->assertEquals( array( 'posts-page' ), $classes );
+
+		$classes = $instance->add_posts_page_css_class( array( 'bar' ), 'fox', 5 );
+		$this->assertEquals( array( 'bar', 'posts-page' ), $classes );
+
+		$classes = $instance->add_posts_page_css_class( array( 'bar' ), 'fox', 6 );
+		$this->assertEquals( array( 'bar' ), $classes );
+	}
+
+	/**
+	 * Check if do_not_allow capability is added on Posts Page.
+	 */
+	public function test_it_disables_posts_page() {
+		$instance = new Posts_List_Page_Notification( '5' );
+
+		$this->assertEquals( array( 'do_not_allow' ), $instance->disable_posts_page( array(), 'edit_post', '6', array( 0 => 5 ) ) );
+		$this->assertEquals( array( 'do_not_allow' ), $instance->disable_posts_page( array(), 'delete_post', '6', array( 0 => 5 ) ) );
+
+		$this->assertEquals( array(), $instance->disable_posts_page( array(), 'edit_post', '6', array( 0 => 6 ) ) );
+		$this->assertEquals( array(), $instance->disable_posts_page( array(), 'delete_post', '6', array( 0 => 6 ) ) );
+	}
+}


### PR DESCRIPTION
Disables editing and deleting capabilities in WP-Admin Post list for the page that is configured as a Posts Page in WP-Admin.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/52692

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removed the edit_post and delete_post capabilities for all users for the page is configured as a Posts page in WP-Admin. 
* Added an info icon for informing the user why the page cannot be edited or deleted.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Atomic:
* Install Jetpack Beta plugin and switch to the current branch.
* Make sure that you have a Posts Page configured for your site (Configurable in Settings > Reading section). 
* Go to WP-Admin > Pages section
* Make sure that the page configured in the second step cannot be edited and deleted
* Make sure that the page has an info icon with a `title` informing why the page cannot be edited or deleted.

#### Simple Sites
* Apply the following patch on your sandbox: D61647-code
* Copy `projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php` class into the corresponding WPCOM directory. 
* Make sure that you have the `Show wp-admin pages if available` toggle on in wordpress.com/me/account section
* Go to your-site.wordpress.com/wp-admin/
* Make sure that you have a Posts Page configured for your site (Configurable in Settings > Reading section)
* Go to WP-Admin > Pages section
* Make sure that the page configured in the third step cannot be edited and deleted
* Make sure that the page has a info icon with a `title` informing why the page cannot be edited or deleted

**Note**: Since the implementation was added within a new directory (wp-posts-list) that it's not currently managed by Jetpack Fusion, the following diff also have to be reviewed: D61647-code.