### PR TITLE
Update masterbar write button URL

### DIFF
--- a/projects/plugins/jetpack/changelog/Update masterbar write button URL
+++ b/projects/plugins/jetpack/changelog/Update masterbar write button URL
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Clicking the Write button in masterbar will now use WP Admin block editor.

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -880,13 +880,11 @@ class Masterbar {
 			return;
 		}
 
-		$blog_post_page = Redirect::get_url( 'calypso-edit-post' );
-
 		$wp_admin_bar->add_menu(
 			array(
 				'parent' => 'top-secondary',
 				'id'     => 'ab-new-post',
-				'href'   => $blog_post_page,
+				'href'   => admin_url( 'post-new.php' ),
 				'title'  => '<span>' . esc_html__( 'Write', 'jetpack' ) . '</span>',
 				'meta'   => array(
 					'class' => 'mb-trackable',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/51639

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Always use WP Admin block editor for Atomic or Jetpack Users.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load `update/masterbar-write-button-destination` in your Jetpack Beta Atomic site.
* Load `/wp-admin`
* Click "Write" in the masterbar
* You should land in WP Admin Block Editor
