### PR TITLE
Repo Gardening: remove Block prefix for Boost labels

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-boost-module-name
+++ b/projects/github-actions/repo-gardening/changelog/fix-boost-module-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost: fix module name; it does not need to include a [Block] prefix.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "1.2.1",
+	"version": "1.2.2-alpha",
 	"description": "Manage PR and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -200,7 +200,7 @@ async function getLabelsToAdd( octokit, owner, repo, number ) {
 		const boostModules = file.match( /^app\/modules\/(?<boostModule>[^/]*)\// );
 		const boostModuleName = boostModules && boostModules.groups.boostModule;
 		if ( boostModuleName ) {
-			keywords.add( `[Block] ${ cleanName( boostModuleName ) }` );
+			keywords.add( `${ cleanName( boostModuleName ) }` );
 		}
 
 		// Compatibility with 3rd party tools (Boost and Jetpack).


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
Follow-up from #19891.

We do not need a [Block] prefix for Boost labels.

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here, just fixing a mistake I did yesterday.
