### PR TITLE
Hide admin menu link to plans email for P2s

### DIFF
--- a/projects/plugins/jetpack/changelog/update-p2-hide-email-plan-link
+++ b/projects/plugins/jetpack/changelog/update-p2-hide-email-plan-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Hide plan link to email plan for P2 sites

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
@@ -46,6 +46,7 @@ class P2_Admin_Menu extends WPcom_Admin_Menu {
 		remove_submenu_page( 'plugins.php', 'plugins.php' );
 
 		remove_submenu_page( 'paid-upgrades.php', 'https://wordpress.com/domains/manage/' . $this->domain );
+		remove_submenu_page( 'paid-upgrades.php', 'https://wordpress.com/email/' . $this->domain );
 
 		$themes_slug = 'https://wordpress.com/themes/' . $this->domain;
 		remove_submenu_page( $themes_slug, $themes_slug );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

For P2 sites, hide the admin bar link to email plans.

See 2674-gh-Automattic/p2

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hides the admin bar link to the paid upgrade for emails.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a P2 hub, verify that the admin menu does not have a submenu item under "Upgrades".
