### PR TITLE
Tools: Pass full dir in check-composer-deps

### DIFF
--- a/tools/check-composer-deps.sh
+++ b/tools/check-composer-deps.sh
@@ -124,10 +124,11 @@ for SLUG in "${SLUGS[@]}"; do
 			DIDCL=true
 		fi
 		if [[ -n "$(git ls-files "projects/$SLUG/composer.lock")" ]]; then
-			cd "$BASE/projects/$SLUG"
+			PROJECTFOLDER="$BASE/projects/$SLUG"
+			cd "$PROJECTFOLDER"
 			debug "Updating $SLUG composer.lock"
 			OLD="$(<composer.lock)"
-			"$BASE/tools/composer-update-monorepo.sh" --quiet "$SLUG"
+			"$BASE/tools/composer-update-monorepo.sh" --quiet "$PROJECTFOLDER"
 			if [[ "$OLD" != "$(<composer.lock)" ]] && ! $DIDCL; then
 				info "Creating changelog entry for $SLUG composer.lock update"
 				changelogger "$SLUG" '' 'Updated composer.lock.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

When running `tools/check-composer-deps.sh -u`, it errors with "Directory plugins/beta not found".

This appears to be due to the `check_dir` that is being ran within the `tools/composer-update-monorepo.sh` not passing the full slug over.

Not fully tested, but wanted to open it up for testing and discussion.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Pass the full dir

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1621617579169200-slack-CBG1CP4EN


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ./tools/check-composr-deps.sh -uv
*