### PR TITLE
Update VideoPress block for `useBlockProps`

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-use-block-props
+++ b/projects/plugins/jetpack/changelog/update-videopress-use-block-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Removed use of experimental feature and replaced with new `useBlockProps` hook to ensure video block continues to function correctly

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -21,7 +21,7 @@ import {
 	MediaUpload,
 	MediaUploadCheck,
 	RichText,
-	__experimentalBlock as Block,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -37,12 +37,6 @@ import { getClassNames } from './utils';
 import SeekbarColorSettings from './seekbar-color-settings';
 
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
-
-// For Gutenberg versions that support it, use the figure block wrapper (from '@wordpress/block-editor')
-// to wrap the VideoPress component the same way the underlying `core/video` block is wrapped.
-// (Otherwise there's an issue with Gutenberg >= 8.1 where the VideoPress block becomes unselectable,
-// see https://github.com/Automattic/jetpack/issues/15922.)
-const BlockFigureWrapper = Block ? Block.figure : 'figure';
 
 const VideoPressEdit = CoreVideoEdit =>
 	class extends Component {
@@ -265,25 +259,12 @@ const VideoPressEdit = CoreVideoEdit =>
 				attributes,
 				instanceId,
 				isFetchingPreview,
-				isSelected,
 				isUploading,
 				preview,
 				setAttributes,
 			} = this.props;
 			const { fallback, isFetchingMedia, isUpdatingRating, interactive, rating } = this.state;
-			const {
-				align,
-				autoplay,
-				caption,
-				className,
-				controls,
-				loop,
-				muted,
-				playsinline,
-				poster,
-				preload,
-				videoPressClassNames,
-			} = attributes;
+			const { autoplay, caption, controls, loop, muted, playsinline, poster, preload } = attributes;
 
 			const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
 
@@ -451,42 +432,69 @@ const VideoPressEdit = CoreVideoEdit =>
 			return (
 				<Fragment>
 					{ blockSettings }
-					<BlockFigureWrapper
-						className={ classnames( 'wp-block-video', className, videoPressClassNames, {
-							[ `align${ align }` ]: align,
-						} ) }
-					>
-						<div className="wp-block-embed__wrapper">
-							<SandBox html={ html } scripts={ scripts } type={ videoPressClassNames } />
-						</div>
-
-						{
-							/*
-							Disable the video player when the block isn't selected,
-							so the user clicking on it won't play the
-							video when the controls are enabled.
-						*/
-							! interactive && (
-								<div
-									className="block-library-embed__interactive-overlay"
-									onMouseUp={ this.hideOverlay }
-								/>
-							)
-						}
-						{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
-							<RichText
-								tagName="figcaption"
-								placeholder={ __( 'Write caption…', 'jetpack' ) }
-								value={ caption }
-								onChange={ value => setAttributes( { caption: value } ) }
-								inlineToolbar
-							/>
-						) }
-					</BlockFigureWrapper>
+					<VpBlock
+						{ ...this.props }
+						hideOverlay={ this.hideOverlay }
+						html={ html }
+						scripts={ scripts }
+						interactive={ interactive }
+						caption={ caption }
+					/>
 				</Fragment>
 			);
 		}
 	};
+
+// The actual, final rendered video player markup
+// In a separate function component so that `useBlockProps` could be called.
+const VpBlock = props => {
+	const {
+		html,
+		scripts,
+		interactive,
+		caption,
+		isSelected,
+		hideOverlay,
+		attributes,
+		setAttributes,
+	} = props;
+
+	const { align, className, videoPressClassNames } = attributes;
+
+	const blockProps = useBlockProps( {
+		className: classnames( 'wp-block-video', className, videoPressClassNames, {
+			[ `align${ align }` ]: align,
+		} ),
+	} );
+
+	return (
+		<figure { ...blockProps }>
+			<div className="wp-block-embed__wrapper">
+				<SandBox html={ html } scripts={ scripts } type={ videoPressClassNames } />
+			</div>
+
+			{
+				/*
+					Disable the video player when the block isn't selected,
+					so the user clicking on it won't play the
+					video when the controls are enabled.
+				*/
+				! interactive && (
+					<div className="block-library-embed__interactive-overlay" onMouseUp={ hideOverlay } />
+				)
+			}
+			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
+				<RichText
+					tagName="figcaption"
+					placeholder={ __( 'Write caption…', 'jetpack' ) }
+					value={ caption }
+					onChange={ value => setAttributes( { caption: value } ) }
+					inlineToolbar
+				/>
+			) }
+		</figure>
+	);
+};
 
 export default createHigherOrderComponent(
 	compose( [

--- a/projects/plugins/jetpack/extensions/blocks/videopress/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/save.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
 
 /**
@@ -31,6 +31,12 @@ const VideoPressSave = CoreVideoSave => props => {
 		} = {},
 	} = props;
 
+	const blockProps = useBlockProps.save( {
+		className: classnames( 'wp-block-video', className, videoPressClassNames, {
+			[ `align${ align }` ]: align,
+		} ),
+	} );
+
 	if ( ! guid ) {
 		/**
 		 * We return the element produced by the render so Gutenberg can add the block class when cloning the element.
@@ -58,11 +64,7 @@ const VideoPressSave = CoreVideoSave => props => {
 	} );
 
 	return (
-		<figure
-			className={ classnames( 'wp-block-video', className, videoPressClassNames, {
-				[ `align${ align }` ]: align,
-			} ) }
-		>
+		<figure { ...blockProps }>
 			<div className="wp-block-embed__wrapper">
 				{ `\n${ url }\n` /* URL needs to be on its own line. */ }
 			</div>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #18864 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* extracts the video player portion of the rendered component into a function component so the `useBlockProps` hook can be called

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure you have a Jetpack site with VideoPress enabled
* Prior to pulling PR, create a post and add a video block (it may be unclickable and very wide, this PR will fix that)
* Apply the PR
* Refresh the post and the videoblock should still work
* Add a new video block, it should render as expected
* Ensure all video block interactions continue to work as expected
