### PR TITLE
Jetpack Sync: Fix: Get Sync Objects endpoint - Meta - return multiple meta values

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-endpoints-get-sync-object-return-multiple-meta-values
+++ b/projects/packages/sync/changelog/fix-sync-endpoints-get-sync-object-return-multiple-meta-values
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Update Meta Module so get_objects_b_by_id returns all meta values.
+Update Meta Module so get_object_by_id returns all meta values.

--- a/projects/packages/sync/changelog/fix-sync-endpoints-get-sync-object-return-multiple-meta-values
+++ b/projects/packages/sync/changelog/fix-sync-endpoints-get-sync-object-return-multiple-meta-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update Meta Module so get_objects_b_by_id returns all meta values.

--- a/projects/plugins/jetpack/changelog/fix-sync-endpoints-get-sync-object-return-multiple-meta-values
+++ b/projects/plugins/jetpack/changelog/fix-sync-endpoints-get-sync-object-return-multiple-meta-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update Sync unit tests to align with new return format of get_object_by_id.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -258,8 +258,8 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		update_post_meta( $this->post_id, $this->whitelisted_post_meta, $meta_test_value );
 
 		$module = Modules::get_module( 'meta' );
-		$meta   = $module->get_object_by_id( 'post', $this->post_id, $this->whitelisted_post_meta );
-		$this->assertEquals( '', $meta['meta_value'] );
+		$metas  = $module->get_object_by_id( 'post', $this->post_id, $this->whitelisted_post_meta );
+		$this->assertEquals( '', $metas[0]['meta_value'] );
 	}
 
 	/**
@@ -270,8 +270,8 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		update_post_meta( $this->post_id, $this->whitelisted_post_meta, $meta_test_value );
 
 		$module = Modules::get_module( 'meta' );
-		$meta   = $module->get_object_by_id( 'post', $this->post_id, $this->whitelisted_post_meta );
-		$this->assertEquals( $meta_test_value, $meta['meta_value'] );
+		$metas  = $module->get_object_by_id( 'post', $this->post_id, $this->whitelisted_post_meta );
+		$this->assertEquals( $meta_test_value, $metas[0]['meta_value'] );
 	}
 
 }


### PR DESCRIPTION
When we built the endpoint, we worked under the assumption that we'll be fetching only single meta entry per object/key pair. We now need to fetch all the entries under the object/key pair.

#### Changes proposed in this Pull Request:

* Return multiple Meta entries per object/key pair.

#### Jetpack product discussion
 
This is a continued effort in bringing improved alignment between the Jetpack site and the WordPress.com cache.

#### Does this pull request change what data or activity we track or use?

Doesn't add any additional data or activity we track or use.

#### Testing instructions:

* Apply PR
* Apply D61787-code
* Run a checksum and fix for `postmeta` for your test site
* Add additional entries for meta for a `post` with the same key, e.g. `_wp_attached_file`
* Run checksum and fix again
* Make sure all the entries were synchronized over
