### PR TITLE
Instant Search: don't photon-ize SVG images

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-search-photon-svg
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-search-photon-svg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instant Search: don't photon-ize SVG images as they're not supported by Photon

--- a/projects/plugins/jetpack/modules/search/instant-search/components/test/photon-image.test.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/test/photon-image.test.js
@@ -27,3 +27,9 @@ test( 'returns the original URL for a private site', () => {
 	const { getByRole } = render( <PhotonImage src={ imageUrl } isPhotonEnabled={ false } /> );
 	expect( getByRole( 'img' ).src ).toEqual( imageUrl );
 } );
+
+test( 'returns the original URL for a SVG image', () => {
+	const imageUrl = 'http://example.com/okapi.svg';
+	const { getByRole } = render( <PhotonImage src={ imageUrl } isPhotonEnabled={ true } /> );
+	expect( getByRole( 'img' ).src ).toEqual( imageUrl );
+} );

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
@@ -29,11 +29,14 @@ export function usePhoton( initialSrc, width, height, isPhotonEnabled = true ) {
 	const [ src, setSrc ] = useState( null );
 	const initialSrcWithoutQueryString = stripQueryString( initialSrc );
 
-	// Photon does not support SVGs
-	const isSVG = initialSrcWithoutQueryString?.substr( -4 ).toLowerCase() === '.svg';
+	// Photon only supports GIF, JPG and PNG
+	// @see https://developer.wordpress.com/docs/photon/
+	const supportedImageTypes = [ 'gif', 'jpg', 'png' ];
+	const fileExtension = initialSrcWithoutQueryString?.substr( -3 ).toLowerCase();
+	const isSupportedImageType = supportedImageTypes.includes( fileExtension );
 
 	useEffect( () => {
-		if ( isPhotonEnabled && ! isSVG ) {
+		if ( isPhotonEnabled && isSupportedImageType ) {
 			const photonSrc = photon( initialSrcWithoutQueryString, {
 				resize: `${ width },${ height }`,
 			} );
@@ -41,7 +44,14 @@ export function usePhoton( initialSrc, width, height, isPhotonEnabled = true ) {
 		} else {
 			setSrc( initialSrc );
 		}
-	}, [ initialSrc, width, height, isPhotonEnabled, initialSrcWithoutQueryString, isSVG ] );
+	}, [
+		initialSrc,
+		width,
+		height,
+		isPhotonEnabled,
+		initialSrcWithoutQueryString,
+		isSupportedImageType,
+	] );
 
 	return src;
 }

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
@@ -31,8 +31,10 @@ export function usePhoton( initialSrc, width, height, isPhotonEnabled = true ) {
 
 	// Photon only supports GIF, JPG and PNG
 	// @see https://developer.wordpress.com/docs/photon/
-	const supportedImageTypes = [ 'gif', 'jpg', 'png' ];
-	const fileExtension = initialSrcWithoutQueryString?.substr( -3 ).toLowerCase();
+	const supportedImageTypes = [ 'gif', 'jpg', 'jpeg', 'png' ];
+	const fileExtension = initialSrcWithoutQueryString
+		?.substring( initialSrcWithoutQueryString.lastIndexOf( '.' ) + 1 )
+		.toLowerCase();
 	const isSupportedImageType = supportedImageTypes.includes( fileExtension );
 
 	useEffect( () => {

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
@@ -27,17 +27,21 @@ function stripQueryString( url ) {
  */
 export function usePhoton( initialSrc, width, height, isPhotonEnabled = true ) {
 	const [ src, setSrc ] = useState( null );
+	const initialSrcWithoutQueryString = stripQueryString( initialSrc );
+
+	// Photon does not support SVGs
+	const isSVG = initialSrcWithoutQueryString?.substr( -4 ).toLowerCase() === '.svg';
 
 	useEffect( () => {
-		if ( isPhotonEnabled ) {
-			const photonSrc = photon( stripQueryString( initialSrc ), {
+		if ( isPhotonEnabled && ! isSVG ) {
+			const photonSrc = photon( initialSrcWithoutQueryString, {
 				resize: `${ width },${ height }`,
 			} );
 			setSrc( photonSrc ? photonSrc : initialSrc );
 		} else {
 			setSrc( initialSrc );
 		}
-	}, [ initialSrc, width, height, isPhotonEnabled ] );
+	}, [ initialSrc, width, height, isPhotonEnabled, initialSrcWithoutQueryString, isSVG ] );
 
 	return src;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/19925.

#### Changes proposed in this Pull Request:
SVG images aren't supported by Photon. This PR skips Photon if the image is SVG.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

1. Make sure Site Accelerator for images is enabled in `/wp-admin/admin.php?page=jetpack#/performance` and that Jetpack Search has either the 'Expanded' or 'Product' result format selected.
1. Add a new page and put an SVG image as the first image
2. Publish page
3. Navigate to Jetpack Search and search for this new page
4. See if SVG image is being displayed correctly

<img width="1535" alt="Screen Shot 2021-05-25 at 14 28 05" src="https://user-images.githubusercontent.com/17325/119430815-8a9fb100-bd65-11eb-95ad-fa0ee2e461ec.png">


