### PR TITLE
Beta: Remove the jetpack_autoload_dev option and the JETPACK_AUTOLOAD_DEV constant update

### DIFF
--- a/projects/plugins/beta/changelog/update-beta_remove_autoload_dev
+++ b/projects/plugins/beta/changelog/update-beta_remove_autoload_dev
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove the jetpack_autoload_dev option and the JETPACK_AUTOLOAD_DEV constant update

--- a/projects/plugins/beta/class-jetpack-beta.php
+++ b/projects/plugins/beta/class-jetpack-beta.php
@@ -99,9 +99,6 @@ class Jetpack_Beta {
 			self::maybe_schedule_autoupdate();
 			Jetpack_Beta_Admin::init();
 		}
-
-		$current_version = $this->get_branch_and_section();
-		self::update_autoload_dev_constant( $current_version[1] );
 	}
 
 	/**
@@ -303,7 +300,6 @@ class Jetpack_Beta {
 		add_action( 'shutdown', array( __CLASS__, 'switch_active' ), 5 );
 		add_action( 'shutdown', array( __CLASS__, 'remove_dev_plugin' ), 20 );
 		delete_option( self::$option );
-		delete_option( 'jetpack_autoload_dev' );
 	}
 
 	/**
@@ -884,8 +880,6 @@ class Jetpack_Beta {
 			// Deactivate the plugin.
 			self::replace_active_plugin( 'jetpack-pressable-beta/jetpack.php' );
 		}
-
-		self::update_autoload_dev_constant( $section );
 
 		if ( 'stable' === $section &&
 		file_exists( WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . JETPACK_PLUGIN_FILE ) ) {
@@ -1493,25 +1487,5 @@ class Jetpack_Beta {
 	 */
 	public static function clear_autoloader_plugin_cache() {
 		delete_transient( 'jetpack_autoloader_plugin_paths' );
-	}
-
-	/**
-	 * Sets the 'jetpack_autoload_dev' option when a Jetpack version is activated:
-	 *   - Sets the option to true when a development version of Jetpack is activated.
-	 *   - Sets the option to false when the stable or release candidate version is  activated.
-	 *
-	 * This option is used to set the JETPACK_AUTOLOAD_DEV constant in jetpack-beta.php. The constant
-	 * is used by the Jetpack autoloader to determine whether stable or development versions of
-	 * packages should be preferred.
-	 *
-	 * @param string $section The section value for the activating Jetpack version.
-	 */
-	public static function update_autoload_dev_constant( $section ) {
-		if ( in_array( $section, array( 'stable', 'rc' ), true ) ) {
-				// The stable and rc versions use stable package versions.
-				update_option( 'jetpack_autoload_dev', 0 );
-		} else {
-				update_option( 'jetpack_autoload_dev', 1 );
-		}
 	}
 }

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -73,8 +73,3 @@ register_deactivation_hook( __FILE__, array( 'Jetpack_Beta', 'deactivate' ) );
 
 add_action( 'init', array( 'Jetpack_Beta', 'instance' ) );
 add_action( 'muplugins_loaded', array( 'Jetpack_Beta', 'is_network_enabled' ) );
-
-// Set the JETPACK_AUTOLOAD_DEV constant.
-if ( ! defined( 'JETPACK_AUTOLOAD_DEV' ) ) {
-	define( 'JETPACK_AUTOLOAD_DEV', get_option( 'jetpack_autoload_dev', 1 ) );
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The package versions in the autoloader classmap file in the Beta plugins's development versions of Jetpack
are now in a comparable format, such as `1.1.9999999.9999999-dev`. Therefore, it's no longer necessary to set
the `JETPACK_AUTOLOAD_DEV` constant when a development version of Jetpack is selected in the Beta plugin.

* The `jetpack_autoload_dev` option was used to determine whether the `JETPACK_AUTOLOAD_DEV` constant should be set, so it's no longer needed and should be removed.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Activate the Beta plugin.
* Select different versions of Jetpack and verify that no errors occur.
