### PR TITLE
CSSTidy: add support for css variable definition

### DIFF
--- a/projects/plugins/jetpack/changelog/add-css-vars-to-csstidy
+++ b/projects/plugins/jetpack/changelog/add-css-vars-to-csstidy
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Modified csstidy to allow css variable properties
+
+

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
@@ -1180,19 +1180,20 @@ class csstidy {
 		$property = strtolower($property);
 		if (in_array(trim($property), $GLOBALS['csstidy']['multiple_properties'])) $property = trim($property);
 		$all_properties = & $GLOBALS['csstidy']['all_properties'];
-		return ((isset($all_properties[$property]) && strpos($all_properties[$property], strtoupper($this->get_cfg('css_level'))) !== false) 
+		return ((isset($all_properties[$property]) && strpos($all_properties[$property], strtoupper($this->get_cfg('css_level'))) !== false)
 					|| ($this->get_cfg('preserve_css_variables') && $this->property_is_css_variable($property)));
 	}
 
 	/**
 	 * Checks if a property is a css variable
+	 * Valid patterns must start with `--` and use alphanumeric characters optionally separated by `-` or `_`. They must not end with a `-` or `_`.
 	 * @param string $property
 	 * @return bool;
 	 * @access public
 	 * @version 1.0
 	 */
 	function property_is_css_variable($property) {
-		return preg_match('/^--[a-zA-Z0-9\-_]*/', $property);
+		return preg_match('/^--([a-zA-Z0-9]+[\-_]?)+(?<![\-_])$/', $property);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * CSSTidy - CSS Parser and Optimiser
  *
@@ -1179,7 +1180,7 @@ class csstidy {
 		$property = strtolower($property);
 		if (in_array(trim($property), $GLOBALS['csstidy']['multiple_properties'])) $property = trim($property);
 		$all_properties = & $GLOBALS['csstidy']['all_properties'];
-		return ((isset($all_properties[ $property]) && strpos($all_properties[ $property ], strtoupper( $this->get_cfg('css_level'))) !== false) 
+		return ((isset($all_properties[$property]) && strpos($all_properties[$property], strtoupper($this->get_cfg('css_level'))) !== false) 
 					|| ($this->get_cfg('preserve_css_variables') && $this->property_is_css_variable($property)));
 	}
 

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
@@ -279,7 +279,7 @@ class csstidy {
 		$this->settings['preserve_css'] = false;
 		$this->settings['timestamp'] = false;
 		$this->settings['template'] = ''; // say that propertie exist
-		$this->settings['preserve_css_variables'] = false;
+		$this->settings['preserve_css_variables']     = false;
 		$this->set_cfg('template','default'); // call load_template
 		$this->optimise = new csstidy_optimise($this);
 
@@ -1186,7 +1186,7 @@ class csstidy {
 	/**
 	 * Checks if a property is a css variable
 	 * Valid patterns must start with `--` and use alphanumeric characters optionally separated by `-` or `_`. They must not end with a `-` or `_`.
-	 * 
+	 *
 	 * @param string $property The property name to be checked.
 	 * @return bool;
 	 * @access public

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
@@ -279,6 +279,7 @@ class csstidy {
 		$this->settings['preserve_css'] = false;
 		$this->settings['timestamp'] = false;
 		$this->settings['template'] = ''; // say that propertie exist
+		$this->settings['preserve_css_variables'] = false;
 		$this->set_cfg('template','default'); // call load_template
 		$this->optimise = new csstidy_optimise($this);
 
@@ -1178,7 +1179,19 @@ class csstidy {
 		$property = strtolower($property);
 		if (in_array(trim($property), $GLOBALS['csstidy']['multiple_properties'])) $property = trim($property);
 		$all_properties = & $GLOBALS['csstidy']['all_properties'];
-		return (isset($all_properties[$property]) && strpos($all_properties[$property], strtoupper($this->get_cfg('css_level'))) !== false );
+		return ((isset($all_properties[ $property]) && strpos($all_properties[ $property ], strtoupper( $this->get_cfg('css_level'))) !== false) 
+					|| ($this->get_cfg('preserve_css_variables') && $this->property_is_css_variable($property)));
+	}
+
+	/**
+	 * Checks if a property is a css variable
+	 * @param string $property
+	 * @return bool;
+	 * @access public
+	 * @version 1.0
+	 */
+	function property_is_css_variable($property) {
+		return preg_match('/^--[a-zA-Z0-9\-_]*/', $property);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * CSSTidy - CSS Parser and Optimiser
  *
@@ -1180,20 +1179,21 @@ class csstidy {
 		$property = strtolower($property);
 		if (in_array(trim($property), $GLOBALS['csstidy']['multiple_properties'])) $property = trim($property);
 		$all_properties = & $GLOBALS['csstidy']['all_properties'];
-		return ((isset($all_properties[$property]) && strpos($all_properties[$property], strtoupper($this->get_cfg('css_level'))) !== false)
-					|| ($this->get_cfg('preserve_css_variables') && $this->property_is_css_variable($property)));
+		return ( ( isset( $all_properties[ $property ] ) && strpos( $all_properties[ $property ], strtoupper( $this->get_cfg( 'css_level' ) ) ) !== false )
+					|| ( $this->get_cfg( 'preserve_css_variables' ) && $this->property_is_css_variable( $property ) ) );
 	}
 
 	/**
 	 * Checks if a property is a css variable
 	 * Valid patterns must start with `--` and use alphanumeric characters optionally separated by `-` or `_`. They must not end with a `-` or `_`.
-	 * @param string $property
+	 * 
+	 * @param string $property The property name to be checked.
 	 * @return bool;
 	 * @access public
 	 * @version 1.0
 	 */
-	function property_is_css_variable($property) {
-		return preg_match('/^--([a-zA-Z0-9]+[\-_]?)+(?<![\-_])$/', $property);
+	public function property_is_css_variable( $property ) {
+		return preg_match( '/^--([a-zA-Z0-9]+[\-_]?)+(?<![\-_])$/', $property );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -222,7 +222,6 @@ class Jetpack_Custom_CSS {
 		$csstidy->set_cfg( 'css_level',                  'CSS3.0' );
 		$csstidy->set_cfg( 'preserve_css',               true );
 		$csstidy->set_cfg( 'template',                   dirname( __FILE__ ) . '/csstidy/wordpress-standard.tpl' );
-		$csstidy->set_cfg( 'preserve_css_variables', true );
 
 		$css = $orig = $args['css'];
 
@@ -1624,9 +1623,10 @@ class Jetpack_Safe_CSS {
 		$csstidy->set_cfg( 'remove_last_;', false );
 		$csstidy->set_cfg( 'css_level', 'CSS3.0' );
 
-		// Turn off css shorthands when in block editor context as it breaks block validation.
+		// Turn off css shorthands, and allow css variables, when in block editor context otherwise block validation is broken.
 		if ( true === isset( $_REQUEST['_gutenberg_nonce'] ) && wp_verify_nonce( $_REQUEST['_gutenberg_nonce'], 'gutenberg_request' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			$csstidy->set_cfg( 'optimise_shorthands', 0 );
+			$csstidy->set_cfg( 'preserve_css_variables', true );
 		}
 
 		$css = preg_replace( '/\\\\([0-9a-fA-F]{4})/', '\\\\\\\\$1', $css );

--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -222,7 +222,7 @@ class Jetpack_Custom_CSS {
 		$csstidy->set_cfg( 'css_level',                  'CSS3.0' );
 		$csstidy->set_cfg( 'preserve_css',               true );
 		$csstidy->set_cfg( 'template',                   dirname( __FILE__ ) . '/csstidy/wordpress-standard.tpl' );
-		$csstidy->set_cfg( 'preserve_css_variables',     true );
+		$csstidy->set_cfg( 'preserve_css_variables', true );
 
 		$css = $orig = $args['css'];
 

--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -222,6 +222,7 @@ class Jetpack_Custom_CSS {
 		$csstidy->set_cfg( 'css_level',                  'CSS3.0' );
 		$csstidy->set_cfg( 'preserve_css',               true );
 		$csstidy->set_cfg( 'template',                   dirname( __FILE__ ) . '/csstidy/wordpress-standard.tpl' );
+		$csstidy->set_cfg( 'preserve_css_variables',     true );
 
 		$css = $orig = $args['css'];
 

--- a/projects/plugins/jetpack/phpunit.xml.dist
+++ b/projects/plugins/jetpack/phpunit.xml.dist
@@ -128,6 +128,9 @@
 		<testsuite name="seo-tools">
 			<directory prefix="test" suffix=".php">tests/php/modules/seo-tools</directory>
 		</testsuite>
+		<testsuite name="csstidy">
+			<directory prefix="test" suffix=".php">tests/php/modules/csstidy</directory>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
+++ b/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
@@ -61,7 +61,7 @@ class WP_Test_Jetpack_CSSTidy extends WP_UnitTestCase {
 		$this->instance->parse( $input );
 		$this->assertEquals(
 			$expected_output,
-			$expected_output
+			$this->instance->print->plain()
 		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
+++ b/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
@@ -60,7 +60,7 @@ class WP_Test_Jetpack_CSSTidy extends WP_UnitTestCase {
 		$this->instance->set_cfg( 'preserve_css_variables', $preserve_css_variables );
 		$this->instance->parse( $input );
 		$this->assertEquals(
-			$this->instance->print->plain(),
+			$expected_output,
 			$expected_output
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
+++ b/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
@@ -31,58 +31,37 @@ class WP_Test_Jetpack_CSSTidy extends WP_UnitTestCase {
 		$this->instance->set_cfg( 'discard_invalid_properties', true );
 	}
 
-	/**
-	 * Test that css variable properties are removed by default.
-	 */
-	public function test_removes_css_var_properties_by_default() {
-		$css      = 'div {--base-color:red;color:var(--base-color)}';
-		$expected = "div {\ncolor:var(--base-color)\n}";
-		$this->instance->parse( $css );
-		$this->assertEquals(
-			$this->instance->print->plain(),
-			$expected
+	/** Provides values for CSS custom property patterns */
+	public function custom_property_matches_provider() {
+		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found -- false positive
+		// 'test case description' => [ 'input', 'expected output', 'preserve_css_variables' ].
+		return array(
+			'test_removes_css_var_properties_by_default' => array( 'div {--base-color:red;color:var(--base-color)}', "div {\ncolor:var(--base-color)\n}", false ),
+			'test_css_var_properties_preserved'          => array( 'div {--base-color_for_1st-child:red;color:var(--base-color)}', "div {\n--base-color_for_1st-child:red;\ncolor:var(--base-color)\n}", true ),
+			'test_css_var_properties_with_no_alphanum_chars_removed' => array( 'div {--_:red;color:var(--base-color)}', "div {\ncolor:var(--base-color)\n}", true ),
+			'test_css_var_properties_ending_in_hyphen_removed' => array( 'div {--base-color-:red;color:var(--base-color)}', "div {\ncolor:var(--base-color)\n}", true ),
+			'test_css_var_properties_ending_in_underscore_removed' => array( 'div {--base-color_:red;color:var(--base-color)}', "div {\ncolor:var(--base-color)\n}", true ),
+			'test_unknown_properties_removed'            => array( 'div {clowns-nose:red;color:var(--base-color)}', "div {\ncolor:var(--base-color)\n}", true ),
+			'test_invalid_css_properties_removed'        => array( 'div {--$//2343--3423:red;color:var(--$//2343--3423)}', "div {\ncolor:var(--$//2343--3423)\n}", true ),
+			'test_broken_or_dangerous_css_removed'       => array( 'div {xss-trap-be-careful:red;}</style><script>alert(\'Gotcha!\')</script>color:var(--base-color)}', '', true ),
 		);
 	}
 
 	/**
-	 * Test that css variable properties are preserved when flag toggled.
+	 * Test that css variable properties are valid/invalid.
+	 *
+	 * @dataProvider custom_property_matches_provider
+	 *
+	 * @param string $input                  potential CSS custom property.
+	 * @param string $expected_output        what we expect css tidy to output.
+	 * @param bool   $preserve_css_variables the value of preserve_css_variables in csstidy's config.
 	 */
-	public function test_css_var_properties_preserved() {
-		$this->instance->set_cfg( 'preserve_css_variables', true );
-		$css      = 'div {--base-color_for_1st-child:red;color:var(--base-color)}';
-		$expected = "div {\n--base-color_for_1st-child:red;\ncolor:var(--base-color)\n}";
-		$this->instance->parse( $css );
+	public function test_custom_property_patterns( $input, $expected_output, $preserve_css_variables ) {
+		$this->instance->set_cfg( 'preserve_css_variables', $preserve_css_variables );
+		$this->instance->parse( $input );
 		$this->assertEquals(
 			$this->instance->print->plain(),
-			$expected
-		);
-	}
-
-	/**
-	 * Test that unkown properties still removed when css variables enabled.
-	 */
-	public function test_unknown_properties_removed() {
-		$this->instance->set_cfg( 'preserve_css_variables', true );
-		$css      = 'div {clowns-nose:red;color:var(--base-color)}';
-		$expected = "div {\ncolor:var(--base-color)\n}";
-		$this->instance->parse( $css );
-		$this->assertEquals(
-			$this->instance->print->plain(),
-			$expected
-		);
-	}
-
-	/**
-	 * Test that broken or potentially dangerious css still removed when css variables enabled.
-	 */
-	public function test_broken_or_dangerous_css_removed() {
-		$this->instance->set_cfg( 'preserve_css_variables', true );
-		$css      = 'div {xss-trap-be-careful:red;}</style><script>alert(\'Gotcha!\')</script>color:var(--base-color)}';
-		$expected = '';
-		$this->instance->parse( $css );
-		$this->assertEquals(
-			$this->instance->print->plain(),
-			$expected
+			$expected_output
 		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
+++ b/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Class WP_Test_Jetpack_CSSTidy.
+ *
+ * @package automattic/jetpack
+ */
+
+require_jetpack_file( 'modules/custom-css/csstidy/class.csstidy.php' );
+
+/**
+ * Class WP_Test_Jetpack_CSSTidy
+ */
+class WP_Test_Jetpack_CSSTidy extends WP_UnitTestCase {
+
+	/**
+	 * The tested instance.
+	 *
+	 * @var csstidy
+	 */
+	public $instance;
+
+	/**
+	 * Sets up each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new csstidy();
+		$this->instance->set_cfg( 'optimise_shorthands', 0 );
+	}
+
+	/**
+	 * Test that css variable properties are removed by default.
+	 */
+	public function test_removes_css_var_properties_by_default() {
+		// $this->instance->set_cfg( 'preserve_css_variables', false ); //this should be default but even if set manually css var not removed
+		$css      = 'div {--base-color:red;color:var(--base-color)}';
+		$expected = "div {\ncolor:var(--base-color)\n}";
+		$this->instance->parse( $css );
+		$this->assertEquals(
+			$this->instance->print->plain(),
+			$expected
+		);
+	}
+
+	/**
+	 * Test that css variable properties are preserved when flag toggled.
+	 */
+	public function test_removes_css_var_properties_preserved() {
+		$this->instance->set_cfg( 'preserve_css_variables', true );
+		$css      = 'div {--base-color:red;color:var(--base-color)}';
+		$expected = "div {\n--base-color:red;\ncolor:var(--base-color)\n}";
+		$this->instance->parse( $css );
+		$this->assertEquals(
+			$this->instance->print->plain(),
+			$expected
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
+++ b/projects/plugins/jetpack/tests/php/modules/csstidy/test-class.jetpack-csstidy.php
@@ -28,13 +28,13 @@ class WP_Test_Jetpack_CSSTidy extends WP_UnitTestCase {
 		parent::setUp();
 		$this->instance = new csstidy();
 		$this->instance->set_cfg( 'optimise_shorthands', 0 );
+		$this->instance->set_cfg( 'discard_invalid_properties', true );
 	}
 
 	/**
 	 * Test that css variable properties are removed by default.
 	 */
 	public function test_removes_css_var_properties_by_default() {
-		// $this->instance->set_cfg( 'preserve_css_variables', false ); //this should be default but even if set manually css var not removed
 		$css      = 'div {--base-color:red;color:var(--base-color)}';
 		$expected = "div {\ncolor:var(--base-color)\n}";
 		$this->instance->parse( $css );
@@ -47,10 +47,38 @@ class WP_Test_Jetpack_CSSTidy extends WP_UnitTestCase {
 	/**
 	 * Test that css variable properties are preserved when flag toggled.
 	 */
-	public function test_removes_css_var_properties_preserved() {
+	public function test_css_var_properties_preserved() {
 		$this->instance->set_cfg( 'preserve_css_variables', true );
-		$css      = 'div {--base-color:red;color:var(--base-color)}';
-		$expected = "div {\n--base-color:red;\ncolor:var(--base-color)\n}";
+		$css      = 'div {--base-color_for_1st-child:red;color:var(--base-color)}';
+		$expected = "div {\n--base-color_for_1st-child:red;\ncolor:var(--base-color)\n}";
+		$this->instance->parse( $css );
+		$this->assertEquals(
+			$this->instance->print->plain(),
+			$expected
+		);
+	}
+
+	/**
+	 * Test that unkown properties still removed when css variables enabled.
+	 */
+	public function test_unknown_properties_removed() {
+		$this->instance->set_cfg( 'preserve_css_variables', true );
+		$css      = 'div {clowns-nose:red;color:var(--base-color)}';
+		$expected = "div {\ncolor:var(--base-color)\n}";
+		$this->instance->parse( $css );
+		$this->assertEquals(
+			$this->instance->print->plain(),
+			$expected
+		);
+	}
+
+	/**
+	 * Test that broken or potentially dangerious css still removed when css variables enabled.
+	 */
+	public function test_broken_or_dangerous_css_removed() {
+		$this->instance->set_cfg( 'preserve_css_variables', true );
+		$css      = 'div {xss-trap-be-careful:red;}</style><script>alert(\'Gotcha!\')</script>color:var(--base-color)}';
+		$expected = '';
 		$this->instance->parse( $css );
 		$this->assertEquals(
 			$this->instance->print->plain(),


### PR DESCRIPTION
Fixes issue with block validations when css variables used, eg with group block custom color. Although this is fixed in Gutenberg 10.7 for the group block, there are a number of other blocks that support the css vars for custom colours and it may be a few releases before they are are updated.

There has been previous discussion about the removal of css tidy, and given the age of this library that is probably worth looking at - and maybe a more modern and maintained library like https://github.com/wikimedia/css-sanitizer could be investigated, but as previously discussed this is a much bigger project so adding this css var support may still make sense in the short term.

This would also currently allow the use of css vars in the custom css in the customizer - would that be a bad/dangerous thing?

#### Changes proposed in this Pull Request:
* Modify CSS Tidy library to allow css variable properties - while this is a modification to the underlying 3rd party library, this library hasn't been updated since 2007 and is no longer maintained.


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Add related patch to sandbox
* In editor code view add a `<div style="--base-color: red;color:var(--base-color)">test css var preservation</div>`
* Save the page and reload the editor and check that `--base-color` property has been preserved in editor and front end.
