### PR TITLE
Add save_post_page to synced actions

### DIFF
--- a/projects/packages/sync/changelog/sync-save-post-page-action
+++ b/projects/packages/sync/changelog/sync-save-post-page-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync the save_post_page action when a page is saved

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -138,7 +138,7 @@ class Posts extends Module {
 		add_action( 'wp_insert_post', array( $this, 'wp_insert_post' ), 11, 3 );
 		add_action( 'wp_after_insert_post', array( $this, 'wp_after_insert_post' ), 11, 2 );
 		add_action( 'jetpack_sync_save_post', $callable, 10, 4 );
-		add_action( 'save_post_page', $callable, 10, 2 );
+		add_action( 'save_post_page', $callable, 10, 3 );
 
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_published_post', $callable, 10, 2 );

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -138,6 +138,7 @@ class Posts extends Module {
 		add_action( 'wp_insert_post', array( $this, 'wp_insert_post' ), 11, 3 );
 		add_action( 'wp_after_insert_post', array( $this, 'wp_after_insert_post' ), 11, 2 );
 		add_action( 'jetpack_sync_save_post', $callable, 10, 4 );
+		add_action( 'save_post_page', $callable, 10, 2 );
 
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_published_post', $callable, 10, 2 );

--- a/projects/plugins/jetpack/changelog/add-sync-save-post-page-action
+++ b/projects/plugins/jetpack/changelog/add-sync-save-post-page-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add a phpunit test for syncing the save_post_page action

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -81,6 +81,19 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $event->args[3]['is_auto_save'] );
 	}
 
+	/**
+	 * Verify that the `save_post_page` event is raised when a page is saved
+	 */
+	public function test_save_post_page_syncs_event() {
+		$post_page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+
+		$this->sender->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event( 'save_post_page' );
+
+		$this->assertEquals( $post_page_id, $event->args[0] );
+		$this->assertEquals( $post_page_id, $event->args[1]->ID );
+	}
+
 	public function test_trash_post_trashes_data() {
 		$this->assertEquals( 1, $this->server_replica_storage->post_count( 'publish' ) );
 		$this->server_event_storage->reset();


### PR DESCRIPTION
### Purpose
As part of [ enabling the wpcom checklist on Atomic sites](https://github.com/Automattic/wp-calypso/issues/50523), we need to [keep track of whether the "Edit your homepage" task is complete](https://github.com/Automattic/wp-calypso/issues/52705)

There is existing logic in wpcom that reacts to the `save_post_page` action and marks the `onboarding_checklist_task_front_page_updated` flag to mark the "Edit your homepage" task as complete.

If we sync this event, we can hook into that existing logic.

#### What listens for the `save_post_page` action

From a code search for `save_post_page` in wpcom:
* code to update the checklist status.
* trigger a cache flush of eventbrite templates.

#### Does this pull request change what data or activity we track or use?

My PR also syncs the `save_page_post` event, but this doesn't contain any data that isn't already synced by the `jetpack_sync_save_post` event.

### Testing instructions

* Apply this PR on your test site
* Save a page
* The `save_page_post` should be raised on wpcom for the cache site

I tested this by setting up a jurassic.ninja site and setting it to sync to my developer sandbox instructions(PCYsg-g6b-p2), and then applying this diff and also D61890-code to whitelist the action
