### PR TITLE
Search: add cache buster to the static bundle filename

### DIFF
--- a/projects/plugins/jetpack/.size-limit.js
+++ b/projects/plugins/jetpack/.size-limit.js
@@ -1,6 +1,6 @@
 module.exports = [
 	{
-		path: '_inc/build/instant-search/jp-search-main.bundle.js',
+		path: '_inc/build/instant-search/jp-search-main.bundle*.js',
 		running: false,
 		limit: '4 KiB',
 	},

--- a/projects/plugins/jetpack/changelog/update-main-bundle-cache-buster
+++ b/projects/plugins/jetpack/changelog/update-main-bundle-cache-buster
@@ -1,4 +1,4 @@
 Significance: minor
 Type: compat
 
-Search: add cache buster string in main bundle filename
+Search: Add cachebuster in main bundle filename for Jetpack plugin to avoid inconsitency caused by CDN cache (WPCOM unchanged).

--- a/projects/plugins/jetpack/changelog/update-main-bundle-cache-buster
+++ b/projects/plugins/jetpack/changelog/update-main-bundle-cache-buster
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Search: add cache buster string in main bundle filename

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -106,7 +106,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @param string $plugin_base_path - Base path for use in plugins_url.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
-		// WPCOM doesn't have JETPACK__VERSION avaible, query string based cachebuster is used anyway.
+		// WPCOM doesn't have JETPACK__VERSION available and relies on query strings for cache-busting.
 		$jetpack_alpahnumeric_version = Jetpack_Search_Helpers::get_alphanumeric_version();
 		$bundle_version_extention     = $jetpack_alpahnumeric_version ? ".{$jetpack_alpahnumeric_version}" : '';
 		$polyfill_relative_path       = $path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle${bundle_version_extention}.js";

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -106,9 +106,10 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @param string $plugin_base_path - Base path for use in plugins_url.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
-		$filename_cache_buster  = Jetpack_Search_Helpers::get_alphanumeric_version();
-		$polyfill_relative_path = $path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle.${filename_cache_buster}.js";
-		$script_relative_path   = $path_prefix . "_inc/build/instant-search/jp-search-main.bundle.${filename_cache_buster}.js";
+		$jetpack_alpahnumeric_version = Jetpack_Search_Helpers::get_alphanumeric_version();
+		$filename_cache_buster        = $jetpack_alpahnumeric_version ? ".{$jetpack_alpahnumeric_version}" : '';
+		$polyfill_relative_path       = $path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle${filename_cache_buster}.js";
+		$script_relative_path         = $path_prefix . "_inc/build/instant-search/jp-search-main.bundle${filename_cache_buster}.js";
 
 		if (
 			! file_exists( JETPACK__PLUGIN_DIR . $polyfill_relative_path ) ||
@@ -121,7 +122,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$polyfill_path    = plugins_url( $polyfill_relative_path, $plugin_base_path );
 		wp_enqueue_script( 'jetpack-instant-search-ie11', $polyfill_path, array(), $polyfill_version, true );
 		$polyfill_payload_path = plugins_url(
-			$path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-payload.bundle.${filename_cache_buster}.js",
+			$path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-payload.bundle${filename_cache_buster}.js",
 			$plugin_base_path
 		);
 		$this->inject_polyfill_js_options( $polyfill_payload_path );

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -106,8 +106,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @param string $plugin_base_path - Base path for use in plugins_url.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
-		$polyfill_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle.js';
-		$script_relative_path   = $path_prefix . '_inc/build/instant-search/jp-search-main.bundle.js';
+		$filename_cache_buster  = Jetpack_Search_Helpers::get_alphanumeric_version();
+		$polyfill_relative_path = $path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle.${filename_cache_buster}.js";
+		$script_relative_path   = $path_prefix . "_inc/build/instant-search/jp-search-main.bundle.${filename_cache_buster}.js";
 
 		if (
 			! file_exists( JETPACK__PLUGIN_DIR . $polyfill_relative_path ) ||
@@ -120,7 +121,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$polyfill_path    = plugins_url( $polyfill_relative_path, $plugin_base_path );
 		wp_enqueue_script( 'jetpack-instant-search-ie11', $polyfill_path, array(), $polyfill_version, true );
 		$polyfill_payload_path = plugins_url(
-			$path_prefix . '_inc/build/instant-search/jp-search-ie11-polyfill-payload.bundle.js',
+			$path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-payload.bundle.${filename_cache_buster}.js",
 			$plugin_base_path
 		);
 		$this->inject_polyfill_js_options( $polyfill_payload_path );

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -106,10 +106,11 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @param string $plugin_base_path - Base path for use in plugins_url.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
+		// WPCOM doesn't have JETPACK__VERSION avaible, query string based cachebuster is used anyway.
 		$jetpack_alpahnumeric_version = Jetpack_Search_Helpers::get_alphanumeric_version();
-		$filename_cache_buster        = $jetpack_alpahnumeric_version ? ".{$jetpack_alpahnumeric_version}" : '';
-		$polyfill_relative_path       = $path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle${filename_cache_buster}.js";
-		$script_relative_path         = $path_prefix . "_inc/build/instant-search/jp-search-main.bundle${filename_cache_buster}.js";
+		$bundle_version_extention     = $jetpack_alpahnumeric_version ? ".{$jetpack_alpahnumeric_version}" : '';
+		$polyfill_relative_path       = $path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle${bundle_version_extention}.js";
+		$script_relative_path         = $path_prefix . "_inc/build/instant-search/jp-search-main.bundle${bundle_version_extention}.js";
 
 		if (
 			! file_exists( JETPACK__PLUGIN_DIR . $polyfill_relative_path ) ||
@@ -122,7 +123,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$polyfill_path    = plugins_url( $polyfill_relative_path, $plugin_base_path );
 		wp_enqueue_script( 'jetpack-instant-search-ie11', $polyfill_path, array(), $polyfill_version, true );
 		$polyfill_payload_path = plugins_url(
-			$path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-payload.bundle${filename_cache_buster}.js",
+			$path_prefix . "_inc/build/instant-search/jp-search-ie11-polyfill-payload.bundle${bundle_version_extention}.js",
 			$plugin_base_path
 		);
 		$this->inject_polyfill_js_options( $polyfill_payload_path );

--- a/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
+++ b/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
@@ -727,7 +727,7 @@ class Jetpack_Search_Helpers {
 	 * @return string $script_version Alphanumberic version number.
 	 */
 	public static function get_alphanumeric_version( $replace = '-' ) {
-		// Examples of JETPACK__VERSION is like: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
+		// Examples of JETPACK__VERSION are: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
 		return strtolower( preg_replace( '/[^A-Za-z0-9]/', $replace, JETPACK__VERSION ) );
 	}
 

--- a/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
+++ b/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
@@ -727,6 +727,7 @@ class Jetpack_Search_Helpers {
 	 * @return string $script_version Alphanumberic version number.
 	 */
 	public static function get_alphanumeric_version( $replace = '-' ) {
+		// Examples of JETPACK__VERSION is like: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
 		return strtolower( preg_replace( '/[^A-Za-z0-9]/', $replace, JETPACK__VERSION ) );
 	}
 

--- a/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
+++ b/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
@@ -719,6 +719,16 @@ class Jetpack_Search_Helpers {
 			: JETPACK__VERSION;
 	}
 
+	/**
+	 * Get alphanumberic Jetpack version
+	 *
+	 * @since 9.8.0
+	 * @param string $replace The string non-alphanumeric charactors are replaced by.
+	 * @return string $script_version Alphanumberic version number.
+	 */
+	public static function get_alphanumeric_version( $replace = '-' ) {
+		return strtolower( preg_replace( '/[^A-Za-z0-9]/', $replace, JETPACK__VERSION ) );
+	}
 
 	/**
 	 * Generates a customizer settings ID for a given post type.

--- a/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
+++ b/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
@@ -728,8 +728,9 @@ class Jetpack_Search_Helpers {
 	 */
 	public static function get_alphanumeric_version( $replace = '-' ) {
 		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		// Examples of JETPACK__VERSION are: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
-		return strtolower( preg_replace( '/[^A-Za-z0-9]/', $replace, JETPACK__VERSION ) );
+		// 1. Examples of JETPACK__VERSION are: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
+		// 2. WPCOM doesn't have JETPACK__VERSION
+		return defined( 'JETPACK__VERSION' ) ? strtolower( preg_replace( '/[^A-Za-z0-9]/', $replace, JETPACK__VERSION ) ) : '';
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
+++ b/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
@@ -727,6 +727,7 @@ class Jetpack_Search_Helpers {
 	 * @return string $script_version Alphanumberic version number.
 	 */
 	public static function get_alphanumeric_version( $replace = '-' ) {
+		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		// Examples of JETPACK__VERSION are: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
 		return strtolower( preg_replace( '/[^A-Za-z0-9]/', $replace, JETPACK__VERSION ) );
 	}

--- a/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
+++ b/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
@@ -723,8 +723,8 @@ class Jetpack_Search_Helpers {
 	 * Get alphanumberic Jetpack version
 	 *
 	 * @since 9.8.0
-	 * @param string $replace The string non-alphanumeric charactors are replaced by.
-	 * @return string $script_version Alphanumberic version number.
+	 * @param string $replace String to replace non-alphanumeric charactors in the Jetpack version constant.
+	 * @return string $script_version Jetpack version formatted to consist purely of alphanumerics (e.g. `9.8-alpha` becomes `9-8-alpha`).
 	 */
 	public static function get_alphanumeric_version( $replace = '-' ) {
 		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -7,10 +7,16 @@ const {
 	defaultRequestToExternal,
 	defaultRequestToHandle,
 } = require( '@wordpress/dependency-extraction-webpack-plugin/util' );
+const { readFileSync } = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
+
+const pluginFileContent = readFileSync( path.join( __dirname, '../jetpack.php' ) ).toString();
+const jetpackAlphaNumericVersion = pluginFileContent
+	.match( /define\(\s+'JETPACK__VERSION',\s+'([0-9A-Za-z.-]+)'\s+\)/ )[ 1 ]
+	.replace( /[^0-9A-Za-z]+/g, '-' );
 
 const baseWebpackConfig = getBaseWebpackConfig(
 	{ WP: false },
@@ -29,7 +35,7 @@ const baseWebpackConfig = getBaseWebpackConfig(
 			],
 		},
 		'output-chunk-filename': 'jp-search.chunk-[name]-[hash].js',
-		'output-filename': 'jp-search-[name].bundle.js',
+		'output-filename': `jp-search-[name].bundle.${ jetpackAlphaNumericVersion }.js`,
 		'output-path': path.join( __dirname, '../_inc/build/instant-search' ),
 	}
 );

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -16,7 +16,7 @@ const isDevelopment = process.env.NODE_ENV !== 'production';
 /**
  * Since the version number in package.json doesn't match PHP's `JETPACK__VERSION` constant,
  * we rely on extracting the `JETPACK__VERSION` constant directly from the plugin PHP file
- * for use in our Webpack configuration. 
+ * for use in our Webpack configuration.
  *
  * Examples of JETPACK__VERSION are: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
  */

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -21,9 +21,12 @@ const isDevelopment = process.env.NODE_ENV !== 'production';
  * Examples of JETPACK__VERSION are: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
  */
 const pluginFileContent = readFileSync( path.join( __dirname, '../jetpack.php' ) ).toString();
-const jetpackAlphaNumericVersion = pluginFileContent
-	.match( /define\(\s+'JETPACK__VERSION',\s+'([0-9A-Za-z.-]+)'\s+\)/ )[ 1 ]
-	.replace( /[^0-9A-Za-z]+/g, '-' );
+const jetpackAlphaNumericVersionMatch = pluginFileContent.match(
+	/define\(\s+'JETPACK__VERSION',\s+'([0-9A-Za-z.-]+)'\s+\)/
+);
+const jetpackAlphaNumericVersion = jetpackAlphaNumericVersionMatch
+	? `.${ jetpackAlphaNumericVersionMatch[ 1 ].replace( /[^0-9A-Za-z]+/g, '-' ) }`
+	: '';
 
 const baseWebpackConfig = getBaseWebpackConfig(
 	{ WP: false },
@@ -42,7 +45,7 @@ const baseWebpackConfig = getBaseWebpackConfig(
 			],
 		},
 		'output-chunk-filename': 'jp-search.chunk-[name]-[hash].js',
-		'output-filename': `jp-search-[name].bundle.${ jetpackAlphaNumericVersion }.js`,
+		'output-filename': `jp-search-[name].bundle${ jetpackAlphaNumericVersion }.js`,
 		'output-path': path.join( __dirname, '../_inc/build/instant-search' ),
 	}
 );

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -24,9 +24,10 @@ const pluginFileContent = readFileSync( path.join( __dirname, '../jetpack.php' )
 const jetpackAlphaNumericVersionMatch = pluginFileContent.match(
 	/define\(\s+'JETPACK__VERSION',\s+'([0-9A-Za-z.-]+)'\s+\)/
 );
-const jetpackAlphaNumericVersion = jetpackAlphaNumericVersionMatch
-	? `.${ jetpackAlphaNumericVersionMatch[ 1 ].replace( /[^0-9A-Za-z]+/g, '-' ) }`
-	: '';
+const bundleVersionExtension =
+	jetpackAlphaNumericVersionMatch?.length > 0
+		? `.${ jetpackAlphaNumericVersionMatch[ 1 ].replace( /[^0-9A-Za-z]+/g, '-' ) }`
+		: '';
 
 const baseWebpackConfig = getBaseWebpackConfig(
 	{ WP: false },
@@ -45,7 +46,7 @@ const baseWebpackConfig = getBaseWebpackConfig(
 			],
 		},
 		'output-chunk-filename': 'jp-search.chunk-[name]-[hash].js',
-		'output-filename': `jp-search-[name].bundle${ jetpackAlphaNumericVersion }.js`,
+		'output-filename': `jp-search-[name].bundle${ bundleVersionExtension }.js`,
 		'output-path': path.join( __dirname, '../_inc/build/instant-search' ),
 	}
 );

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -14,9 +14,9 @@ const webpack = require( 'webpack' );
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
 /**
- * As the version number in package.json deesn't have the same format as it is in PHP.
- * So we extract the Jetpack version from plugin PHP file and to make sure Webpack
- * gets exactly the same.
+ * Since the version number in package.json doesn't match PHP's `JETPACK__VERSION` constant,
+ * we rely on extracting the `JETPACK__VERSION` constant directly from the plugin PHP file
+ * for use in our Webpack configuration. 
  *
  * Examples of JETPACK__VERSION are: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
  */

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -13,6 +13,13 @@ const webpack = require( 'webpack' );
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
+/**
+ * As the version number in package.json deesn't have the same format as it is in PHP.
+ * So we extract the Jetpack version from plugin PHP file and to make sure Webpack
+ * gets exactly the same.
+ *
+ * Examples of JETPACK__VERSION are: `9.8-alpha`, `9.8-beta`, `9.8`, `9.8.1`, `9.8.2`.
+ */
 const pluginFileContent = readFileSync( path.join( __dirname, '../jetpack.php' ) ).toString();
 const jetpackAlphaNumericVersion = pluginFileContent
 	.match( /define\(\s+'JETPACK__VERSION',\s+'([0-9A-Za-z.-]+)'\s+\)/ )[ 1 ]


### PR DESCRIPTION
Fixes #19752

#### Changes proposed in this Pull Request:
Added cache buster in the filename of the static JS bundle to avoid CDN caching issue - old bundle would try to load the old dynamic bundles which end up 404 not found.

#### Jetpack product discussion
pcNPJE-9r-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Check out branch, try to build dev/production `yarn build-search` and `yarn build-production-search`
- Ensure JS/CSS resources are bundled correctly under `_inc/build/instant-search`. Note, the names of files should include the current version number of Jetpack
- Ensure the change still allows us to bypass caching when developing
- Ensure Instant search runs without any issue
- Ensure WPCOM bundle names are not changed
