### PR TITLE
Fixed regression introduced in posts page icon notification in WP-Admin edit.php page

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-posts-page-icon
+++ b/projects/plugins/jetpack/changelog/fix-posts-page-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed regression introduced in posts page icon notification WP-Admin edit.php page.

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
@@ -13,7 +13,6 @@ function masterbar_init_wp_posts_list() {
 
 	if (
 		( 'edit.php' === $pagenow && isset( $_GET['post_type'] ) && 'page' === $_GET['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		|| 'post.php' === $pagenow
 	) {
 		require_once __DIR__ . '/class-posts-list-page-notification.php';
 		Automattic\Jetpack\Dashboard_Customizations\Posts_List_Page_Notification::init();

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
@@ -41,9 +41,10 @@ class Posts_List_Page_Notification {
 	 *
 	 * @param string $posts_page_id The Posts page configured in WordPress.
 	 * @param string $show_on_front The show_on_front site option.
+	 * @param string $page_on_front The page_on_front site_option.
 	 */
-	public function __construct( $posts_page_id, $show_on_front ) {
-		if ( 'page' === $show_on_front ) {
+	public function __construct( $posts_page_id, $show_on_front, $page_on_front ) {
+		if ( 'page' === $show_on_front && $posts_page_id !== $page_on_front ) {
 			add_action( 'init', array( $this, 'init_actions' ) );
 		}
 
@@ -67,7 +68,7 @@ class Posts_List_Page_Notification {
 	 */
 	public static function init() {
 		if ( is_null( self::$instance ) ) {
-			self::$instance = new self( \get_option( 'page_for_posts' ), \get_option( 'show_on_front' ) );
+			self::$instance = new self( \get_option( 'page_for_posts' ), \get_option( 'show_on_front' ), \get_option( 'page_on_front' ) );
 		}
 
 		return self::$instance;

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
@@ -40,9 +40,12 @@ class Posts_List_Page_Notification {
 	 * Posts_List_Page_Notification constructor.
 	 *
 	 * @param string $posts_page_id The Posts page configured in WordPress.
+	 * @param string $show_on_front The show_on_front site option.
 	 */
-	public function __construct( $posts_page_id ) {
-		add_action( 'init', array( $this, 'init_actions' ) );
+	public function __construct( $posts_page_id, $show_on_front ) {
+		if ( 'page' === $show_on_front ) {
+			add_action( 'init', array( $this, 'init_actions' ) );
+		}
 
 		$this->posts_page_id = '' === $posts_page_id ? null : (int) $posts_page_id;
 	}
@@ -64,7 +67,7 @@ class Posts_List_Page_Notification {
 	 */
 	public static function init() {
 		if ( is_null( self::$instance ) ) {
-			self::$instance = new self( \get_option( 'page_for_posts' ) );
+			self::$instance = new self( \get_option( 'page_for_posts' ), \get_option( 'show_on_front' ) );
 		}
 
 		return self::$instance;

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
@@ -20,7 +20,7 @@ class Test_Posts_List_Page_Notification extends WP_UnitTestCase {
 	 * Check if the actions are attached.
 	 */
 	public function test_it_has_instance_loaded() {
-		$instance = Posts_List_Page_Notification::init();
+		$instance = new Posts_List_Page_Notification( '5', 'page', '4' );
 
 		$this->assertSame( 10, has_action( 'init', array( $instance, 'init_actions' ) ) );
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
@@ -35,7 +35,7 @@ class Test_Posts_List_Page_Notification extends WP_UnitTestCase {
 	 * Check if it appends the CSS class.
 	 */
 	public function test_it_appends_css_class() {
-		$instance = new Posts_List_Page_Notification( '5', 'page' );
+		$instance = new Posts_List_Page_Notification( '5', 'page', '4' );
 
 		$classes = $instance->add_posts_page_css_class( array(), 'fox', 5 );
 		$this->assertEquals( array( 'posts-page' ), $classes );
@@ -51,7 +51,7 @@ class Test_Posts_List_Page_Notification extends WP_UnitTestCase {
 	 * Check if do_not_allow capability is added on Posts Page.
 	 */
 	public function test_it_disables_posts_page() {
-		$instance = new Posts_List_Page_Notification( '5', 'page' );
+		$instance = new Posts_List_Page_Notification( '5', 'page', '' );
 
 		$this->assertEquals( array( 'do_not_allow' ), $instance->disable_posts_page( array(), 'edit_post', '6', array( 0 => 5 ) ) );
 		$this->assertEquals( array( 'do_not_allow' ), $instance->disable_posts_page( array(), 'delete_post', '6', array( 0 => 5 ) ) );
@@ -64,8 +64,19 @@ class Test_Posts_List_Page_Notification extends WP_UnitTestCase {
 	 * Check that the hooks are not loaded when the show_on_front option is not "page".
 	 */
 	public function test_it_is_not_loaded_when_show_on_front_option_is_not_page() {
-		$instance = new Posts_List_Page_Notification( '5', 'posts' );
+		$instance = new Posts_List_Page_Notification( '5', 'posts', '1' );
 
+		$this->assertFalse( has_action( 'init', array( $instance, 'init_actions' ) ) );
+	}
+
+	/**
+	 * Check that the hooks are not loaded when the posts page id and the home page id are the same.
+	 *
+	 * Although in the WP-Admin interface, when the same page is selected in both dropdowns the posts page dropdown is reset,
+	 * internally WordPress will still store the page id in "page_for_posts" site_option.
+	 */
+	public function test_it_is_not_loaded_when_posts_page_id_and_home_page_id_are_the_same() {
+		$instance = new Posts_List_Page_Notification( '5', 'page', '5' );
 		$this->assertFalse( has_action( 'init', array( $instance, 'init_actions' ) ) );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-posts-list-page-notification.php
@@ -35,7 +35,7 @@ class Test_Posts_List_Page_Notification extends WP_UnitTestCase {
 	 * Check if it appends the CSS class.
 	 */
 	public function test_it_appends_css_class() {
-		$instance = new Posts_List_Page_Notification( '5' );
+		$instance = new Posts_List_Page_Notification( '5', 'page' );
 
 		$classes = $instance->add_posts_page_css_class( array(), 'fox', 5 );
 		$this->assertEquals( array( 'posts-page' ), $classes );
@@ -51,12 +51,21 @@ class Test_Posts_List_Page_Notification extends WP_UnitTestCase {
 	 * Check if do_not_allow capability is added on Posts Page.
 	 */
 	public function test_it_disables_posts_page() {
-		$instance = new Posts_List_Page_Notification( '5' );
+		$instance = new Posts_List_Page_Notification( '5', 'page' );
 
 		$this->assertEquals( array( 'do_not_allow' ), $instance->disable_posts_page( array(), 'edit_post', '6', array( 0 => 5 ) ) );
 		$this->assertEquals( array( 'do_not_allow' ), $instance->disable_posts_page( array(), 'delete_post', '6', array( 0 => 5 ) ) );
 
 		$this->assertEquals( array(), $instance->disable_posts_page( array(), 'edit_post', '6', array( 0 => 6 ) ) );
 		$this->assertEquals( array(), $instance->disable_posts_page( array(), 'delete_post', '6', array( 0 => 6 ) ) );
+	}
+
+	/**
+	 * Check that the hooks are not loaded when the show_on_front option is not "page".
+	 */
+	public function test_it_is_not_loaded_when_show_on_front_option_is_not_page() {
+		$instance = new Posts_List_Page_Notification( '5', 'posts' );
+
+		$this->assertFalse( has_action( 'init', array( $instance, 'init_actions' ) ) );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/53167

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removed the restriction from post.php page, in order to reduce the impact.
* Handled a scenario where the posts page and the home page can point to the same page id - even though on WP-Admin interface from options-reading.php the posts page dropdown is reset when the home page dropdown contains the same page.
* Disabled the feature when "Your homepage displays" option is configured with "Your latest posts"

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the patch D61984-code on your sandbox
* Go to wp-admin/options-reading.php, set "Your homepage displays" to "a static page" and select the same page in "Homepage" and "Posts Page" dropdowns.
* Click save and you'll notice that the "Posts page" dropdown is empty again. Internally the site option was set.
* Go to wp-admin/edit.php?post_type=page and make sure that the icon is NOT shown.
* Go back to wp-admin/options-reading.php and in "Your homepage displays" section please select "Your latest posts"
* Go again in wp-admin/edit.php?post_type=page and make sure that the icon is not displayed.

In order to test this on Atomic, please switch to this branch on your local Jetpack environment and follow the same steps from above.
