### PR TITLE
Conditionally hide admin menu items for P2 hubs/spaces

### DIFF
--- a/projects/plugins/jetpack/changelog/update-p2-admin-menu-items-hide
+++ b/projects/plugins/jetpack/changelog/update-p2-admin-menu-items-hide
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+P2: Conditionally hide admin menu items for hubs/spaces

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
@@ -15,50 +15,146 @@ require_once __DIR__ . '/class-wpcom-admin-menu.php';
 class P2_Admin_Menu extends WPcom_Admin_Menu {
 
 	/**
-	 * Create the desired menu output.
+	 * Slug for the "Appearance" menu item.
+	 *
+	 * @var string
 	 */
-	public function reregister_menu_items() {
-		parent::reregister_menu_items();
-		$this->remove_menus();
-		$this->add_p2_editor_menu();
-	}
+	private $appearance_slug = 'themes.php';
 
 	/**
-	 * Remove menu items not applicable for P2 sites.
+	 * Slug for the "Jetpack" menu item.
+	 *
+	 * @var string
 	 */
-	public function remove_menus() {
+	private $jetpack_slug = 'jetpack';
+
+	/**
+	 * Slug for the "Upgrades" menu item.
+	 *
+	 * @var string
+	 */
+	private $upgrades_slug = 'paid-upgrades.php';
+
+	/**
+	 * Slug for the "Plugins" menu item.
+	 *
+	 * @var string
+	 */
+	private $plugins_slug = 'plugins.php';
+
+	/**
+	 * Slug for the "Tools" menu item.
+	 *
+	 * @var string
+	 */
+	private $tools_slug = 'tools.php';
+
+	/**
+	 * Whether or not the P2 is a hub.
+	 *
+	 * @var bool
+	 */
+	private $is_hub = false;
+
+	/**
+	 * P2_Admin_Menu constructor.
+	 */
+	protected function __construct() {
+		parent::__construct();
+
 		if (
 			defined( 'IS_WPCOM' ) && IS_WPCOM &&
 			function_exists( 'require_lib' )
 		) {
 			require_lib( 'wpforteams' );
 
-			// Only hubs can have plans.
-			if ( ! \WPForTeams\Workspace\is_workspace_hub( get_current_blog_id() ) ) {
-				remove_menu_page( 'paid-upgrades.php' );
-			}
+			$this->is_hub = \WPForTeams\Workspace\is_workspace_hub( get_current_blog_id() );
+		}
+		// Appearance -> AMP. This needs to be called here in the constructor.
+		// Running it from reregister_menu_items is not early enough.
+		remove_action( 'admin_menu', 'amp_add_customizer_link' );
+	}
+
+	/**
+	 * Create the desired menu output.
+	 */
+	public function reregister_menu_items() {
+		parent::reregister_menu_items();
+
+		if ( ! $this->is_hub ) {
+			$this->remove_menus_for_p2_space();
+			// Only add the P2 Editor menu on non-hubs.
+			$this->add_p2_editor_menu();
+		} else {
+			$this->remove_menus_for_hub();
 		}
 
+		$this->remove_menus_for_all_p2s();
+	}
+
+	/**
+	 * Remove menu items that are not applicable for P2 workspace sites.
+	 */
+	private function remove_menus_for_p2_space() {
+		// Non-hub P2s can't have plans at all.
+		remove_menu_page( $this->upgrades_slug );
+		// Jetpack -> Backup.
+		remove_submenu_page( $this->jetpack_slug, 'https://wordpress.com/backup/' . $this->domain );
+		// Appearance -> Themes.
+		remove_submenu_page( $this->appearance_slug, 'https://wordpress.com/themes/' . $this->domain );
+		// Appearance -> Additional CSS.
+		$customize_custom_css_url = add_query_arg(
+			array( 'autofocus' => array( 'section' => 'css_nudge' ) ),
+			'https://wordpress.com/customize/' . $this->domain
+		);
+		remove_submenu_page( $this->appearance_slug, $customize_custom_css_url );
+	}
+
+	/**
+	 * Remove menu items that are not applicable for P2 hubs.
+	 */
+	private function remove_menus_for_hub() {
+		// Hubs can have plans, but not domain and email products.
+		remove_submenu_page( $this->upgrades_slug, 'https://wordpress.com/domains/manage/' . $this->domain );
+		remove_submenu_page( $this->upgrades_slug, 'https://wordpress.com/email/' . $this->domain );
+		// Stats.
+		remove_menu_page( 'https://wordpress.com/stats/day/' . $this->domain );
+		// Hide all Jetpack for hubs.
+		remove_menu_page( $this->jetpack_slug );
+		// Hide posts.
+		remove_menu_page( 'edit.php' );
+		// Hide pages.
+		remove_menu_page( 'edit.php?post_type=page' );
+		// Hide media.
+		remove_menu_page( 'https://wordpress.com/media/' . $this->domain );
+		// Hide comments.
+		remove_menu_page( 'https://wordpress.com/comments/all/' . $this->domain );
+		// Hide appearance.
+		remove_menu_page( $this->appearance_slug );
+		// Tools.
+		remove_menu_page( $this->tools_slug );
+	}
+
+	/**
+	 * Remove menu items that are not applicable for all P2s.
+	 */
+	private function remove_menus_for_all_p2s() {
+		// The following menu items are hidden for both hubs and P2 sites.
 		remove_menu_page( 'link-manager.php' );
 		remove_menu_page( 'feedback' );
-		remove_menu_page( 'plugins.php' );
+		remove_menu_page( $this->plugins_slug );
 		remove_menu_page( 'https://wordpress.com/plugins/' . $this->domain );
-		remove_submenu_page( 'plugins.php', 'plugins.php' );
 
-		remove_submenu_page( 'paid-upgrades.php', 'https://wordpress.com/domains/manage/' . $this->domain );
-		remove_submenu_page( 'paid-upgrades.php', 'https://wordpress.com/email/' . $this->domain );
-
-		$themes_slug = 'https://wordpress.com/themes/' . $this->domain;
-		remove_submenu_page( $themes_slug, $themes_slug );
-
-		$tools_slug = 'https://wordpress.com/marketing/tools/' . $this->domain;
-		remove_submenu_page( $tools_slug, 'https://wordpress.com/marketing/tools/' . $this->domain );
-		remove_submenu_page( $tools_slug, 'https://wordpress.com/earn/' . $this->domain );
+		remove_submenu_page( $this->tools_slug, 'https://wordpress.com/marketing/tools/' . $this->domain );
+		remove_submenu_page( $this->tools_slug, 'https://wordpress.com/earn/' . $this->domain );
 
 		remove_submenu_page( 'https://wordpress.com/settings/general/' . $this->domain, 'sharing' );
 		remove_submenu_page( 'https://wordpress.com/settings/general/' . $this->domain, 'polls&action=options' );
 		remove_submenu_page( 'https://wordpress.com/settings/general/' . $this->domain, 'ratings&action=options' );
-		remove_submenu_page( 'https://wordpress.com/settings/general/' . $this->domain, 'https://wordpress.com/hosting-config/' . $this->domain );
+		remove_submenu_page(
+			'options-general.php',
+			'https://wordpress.com/hosting-config/' . $this->domain
+		);
 		remove_submenu_page(
 			'https://wordpress.com/settings/general/' . $this->domain,
 			'https://wordpress.com/marketing/sharing-buttons/' . $this->domain
@@ -68,7 +164,7 @@ class P2_Admin_Menu extends WPcom_Admin_Menu {
 	/**
 	 * Adds the P2 Editor menu.
 	 */
-	public function add_p2_editor_menu() {
+	private function add_p2_editor_menu() {
 		/** This action is documented in `wp-content/plugins/p2-editor/classes/p2-editor-admin.php` */
 		if ( apply_filters( 'p2tenberg_admin_patterns', apply_filters( 'p2editor_admin_patterns', true ) ) !== true ) {
 			return;
@@ -76,7 +172,15 @@ class P2_Admin_Menu extends WPcom_Admin_Menu {
 
 		// Add the menu only in Calypso (it already exists in WP Admin).
 		if ( $this->is_api_request ) {
-			add_menu_page( esc_attr__( 'P2 Editor', 'jetpack' ), __( 'P2 Editor', 'jetpack' ), 'manage_options', 'p2editor', '', 'dashicons-admin-multisite' );
+			add_menu_page(
+				esc_attr__( 'P2 Editor', 'jetpack' ),
+				__( 'P2 Editor', 'jetpack' ),
+				'manage_options',
+				'p2editor',
+				'',
+				'dashicons-admin-multisite'
+			);
 		}
 	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

1. On **P2 hubs**, we are hiding admin menu items that would be confusing or don't apply.
    - Posts
    - Pages
    - Media
    - Comments
    - Statistics
    - Jetpack
    - Appearance
    - Tools
    - P2Editor
    
2. On P2 **workspace sites** we are hiding a few menu items:
    - Jetpack -> Backup
    - All under “Appearance” except “Customise”.

Note that this only hides the items in Calypso in most cases. See `2887-gh-Automattic/p2` and `2888-gh-Automattic/p2`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hiding the menu items.
* Hubs and spaces now have distinct functions that hide menu items for them.
* Added slugs as class variables so they can be shared between functions.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a P2 hub and verify that the menu items in the first list above are hidden.
* Go to a P2 workspace site and verify that the menu items in the second list above are hidden.

