### PR TITLE
Story Block: Fix Notice: Undefined variable: poster_url

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-9.8-story-block-notice-message
+++ b/projects/plugins/jetpack/changelog/fix-9.8-story-block-notice-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix Notice: Undefined variable: poster_url

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -91,6 +91,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 				);
 
 				// Set the poster attribute for the video tag if a poster image is available.
+				$poster_url = null;
 				if ( ! empty( $video_meta['videopress']['poster'] ) ) {
 					$poster_url = $video_meta['videopress']['poster'];
 				} elseif ( ! empty( $video_meta['thumb'] ) ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/19947

#### Changes proposed in this Pull Request:
This PR fixes a notice message showing up in `story.php`.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Create a story block on a local site (not connected to WPCOM)
* Render the post
* Check the logs in wp-content, there should be no notice message
