### PR TITLE
AMP: Fix invalid `@media only` block styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-invalid-media-only-styles-amp
+++ b/projects/plugins/jetpack/changelog/fix-invalid-media-only-styles-amp
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Invalid ï¿ï¿ï¿@media only styles for AMP have been fixed
+Fix invalid `@media only` block styles

--- a/projects/plugins/jetpack/changelog/fix-invalid-media-only-styles-amp
+++ b/projects/plugins/jetpack/changelog/fix-invalid-media-only-styles-amp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Invalid ï¿ï¿ï¿@media only styles for AMP have been fixed

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -242,7 +242,7 @@
 	}
 }
 
-@media only email {
+.is-email {
 	.wp-block-jetpack-slideshow .wp-block-jetpack-slideshow_container {
 		overflow: visible;
 		opacity: 1;

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
@@ -122,7 +122,7 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 	}
 }
 
-@media only email {
+.is-email {
 	.tiled-gallery__gallery {
 		display: block;
 	}

--- a/projects/plugins/jetpack/modules/simple-payments/simple-payments.css
+++ b/projects/plugins/jetpack/modules/simple-payments/simple-payments.css
@@ -132,28 +132,26 @@ body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message 
 	}
 }
 
-@media only email {
-	.jetpack-simple-payments-product {
-		display: table;
-		width: 100%;
-	}
+.is-email .jetpack-simple-payments-product {
+	display: table;
+	width: 100%;
+}
 
-	.jetpack-simple-payments-product-image {
-		display: table-cell;
-		width: 30%;
-		vertical-align: top;
-	}
+.is-email .jetpack-simple-payments-product-image {
+	display: table-cell;
+	width: 30%;
+	vertical-align: top;
+}
 
-	.jetpack-simple-payments-image {
-		padding-top: 0;
-	}
+.is-email .jetpack-simple-payments-image {
+	padding-top: 0;
+}
 
-	.jetpack-simple-payments-image figure {
-		margin: 0;
-	}
+.is-email .jetpack-simple-payments-image figure {
+	margin: 0;
+}
 
-	.jetpack-simple-payments-product-image + .jetpack-simple-payments-details {
-		display: table-cell;
-		width: 70%;
-	}
+.is-email .jetpack-simple-payments-product-image + .jetpack-simple-payments-details {
+	display: table-cell;
+	width: 70%;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/19922

#### Changes proposed in this Pull Request:
Removes the `@media only <FALLBACK_CONTEXT>` styles used in some blocks when rendered in other contexts than the web (e.g. emails or notifications) since they are breaking the AMP validation. They have been replaced with a regular CSS selector targeting the `is-<FALLBACK_CONTEXT>` class, which is now added to posts rendered on fallback contexts (see D62038-code).

Before | After
--- | ---
<img width="1275" alt="Screen Shot 2021-05-28 at 15 32 20" src="https://user-images.githubusercontent.com/1233880/119993419-d18ee000-bfcb-11eb-96a0-eaf7d8a2bb12.png"> | <img width="984" alt="Screen Shot 2021-05-28 at 15 38 05" src="https://user-images.githubusercontent.com/1233880/119993433-d5226700-bfcb-11eb-93af-2b73288041fe.png">

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Go to Posts > Add new.
- Insert these blocks: Slideshow, Tiled Gallery, Pay with PayPal.
- Publish the post.
- Copy the published post URL and add `?amp#development=amp` at the end.
- Visit the above URL.
- Inspect the browser JS console.
- Make sure the AMP validation is successful.
- Make sure there are no regressions when the post is rendered on a fallback context (see D62038-code).
