### PR TITLE
Remove an unneeded phpcs:ignore

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-unneeded-phpcs-ignore
+++ b/projects/plugins/jetpack/changelog/fix-unneeded-phpcs-ignore
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove an unneeded phpcs:ignore
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6043,9 +6043,8 @@ endif;
 			? $_REQUEST
 			: $environment;
 
-		//phpcs:ignore MediaWiki.Classes.UnusedUseStatement.UnusedUse,VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		list( $env_token, $env_version, $env_user_id ) = explode( ':', $environment['token'] );
-		$token = ( new Tokens() )->get_access_token( $env_user_id, $env_token );
+		list( $env_token,, $env_user_id ) = explode( ':', $environment['token'] );
+		$token                            = ( new Tokens() )->get_access_token( $env_user_id, $env_token );
 		if ( ! $token || empty( $token->secret ) ) {
 			wp_die( __( 'You must connect your Jetpack plugin to WordPress.com to use this feature.', 'jetpack' ) );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
A comment on another PR where someone almost added an unnecessary
`phpcs:ignore MediaWiki.Classes.UnusedUseStatement.UnusedUse` made me
wonder if we had done that anywhere else.

I found only one, and removed it. I also cleaned up the unused variable
so the other sniff no longer needs ignoring on that line either.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I guess make sure the code still works. I can't see how it wouldn't though.