### PR TITLE
Story Block: Fix syncing muted state

### DIFF
--- a/projects/plugins/jetpack/changelog/story-block-fix-muted
+++ b/projects/plugins/jetpack/changelog/story-block-fix-muted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Story Block: Fix syncing muted state

--- a/projects/plugins/jetpack/extensions/blocks/story/player/store/constants.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/store/constants.js
@@ -33,7 +33,7 @@ export const defaultPlayerSettings = {
 	},
 	defaultAspectRatio: 720 / 1280,
 	cropUpTo: 0.2, // crop percentage allowed, after which media is displayed in letterbox
-	volume: 0.5,
+	volume: 0.8,
 	maxBullets: 7,
 	maxBulletsFullscreen: 14,
 };

--- a/projects/plugins/jetpack/extensions/blocks/story/player/store/effects.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/store/effects.js
@@ -75,11 +75,9 @@ function syncWithMediaElement( action, store ) {
 		return;
 	}
 
-	if ( muted ) {
-		mediaElement.muted = muted;
-		if ( ! muted ) {
-			mediaElement.volume = 0.5; //settings.volume;
-		}
+	mediaElement.muted = muted;
+	if ( ! muted ) {
+		mediaElement.volume = 0.5; //settings.volume;
 	}
 
 	if ( playing ) {

--- a/projects/plugins/jetpack/extensions/blocks/story/player/store/effects.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/store/effects.js
@@ -15,6 +15,7 @@ import {
 	getCurrentMediaElement,
 	getCurrentMediaDuration,
 	getPreviousSlideMediaElement,
+	getSettings,
 	getSlideCount,
 } from './selectors';
 
@@ -63,6 +64,7 @@ function syncWithMediaElement( action, store ) {
 	const playing = isPlaying( getState(), playerId );
 	const mediaElement = getCurrentMediaElement( getState(), playerId );
 	const previousMediaElement = getPreviousSlideMediaElement( getState(), playerId );
+	const settings = getSettings( getState(), playerId );
 
 	if ( isVideo( previousMediaElement ) ) {
 		previousMediaElement.currentTime = 0;
@@ -75,9 +77,11 @@ function syncWithMediaElement( action, store ) {
 		return;
 	}
 
-	mediaElement.muted = muted;
-	if ( ! muted ) {
-		mediaElement.volume = 0.5; //settings.volume;
+	if ( muted !== mediaElement.muted ) {
+		mediaElement.muted = muted;
+		if ( ! muted ) {
+			mediaElement.volume = settings.volume;
+		}
 	}
 
 	if ( playing ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/19948

#### Changes proposed in this Pull Request:
This PR fixes the mute button which was not working when playing a story

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Play a story containing a video
* Toggle the mute button several times
* Make sure it mutes and unmutes the video as expected each time.
