### PR TITLE
Backup Plugin: update RNA Connection usage

### DIFF
--- a/projects/plugins/backup/changelog/update-backup-plugin-rna-connection
+++ b/projects/plugins/backup/changelog/update-backup-plugin-rna-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update RNA Connection usage based on Automattic/jetpack/pull/19837

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -2804,16 +2804,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -2825,7 +2825,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2863,7 +2863,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -2879,20 +2879,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
                 "shasum": ""
             },
             "require": {
@@ -2904,7 +2904,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2944,7 +2944,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -2960,20 +2960,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
                 "shasum": ""
             },
             "require": {
@@ -2985,7 +2985,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3028,7 +3028,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3044,20 +3044,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
                 "shasum": ""
             },
             "require": {
@@ -3069,7 +3069,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3108,7 +3108,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3124,20 +3124,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
                 "shasum": ""
             },
             "require": {
@@ -3146,7 +3146,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3187,7 +3187,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3203,20 +3203,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
                 "shasum": ""
             },
             "require": {
@@ -3225,7 +3225,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3270,7 +3270,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3286,7 +3286,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/process",

--- a/projects/plugins/backup/src/js/actions/connection-status.js
+++ b/projects/plugins/backup/src/js/actions/connection-status.js
@@ -1,17 +1,9 @@
-const CONNECTION_STATUS_REGISTERED = 'CONNECTION_STATUS_REGISTERED';
-const CONNECTION_STATUS_USER_CONNECTED = 'CONNECTION_STATUS_USER_CONNECTED';
+const SET_CONNECTION_STATUS = 'SET_CONNECTION_STATUS';
 
 const connectionStatusActions = {
-	connectionStatusSetRegistered: isRegistered => {
-		return { type: CONNECTION_STATUS_REGISTERED, isRegistered };
-	},
-	connectionStatusSetUserConnected: isUserConnected => {
-		return { type: CONNECTION_STATUS_USER_CONNECTED, isUserConnected };
+	setConnectionStatus: connectionStatus => {
+		return { type: SET_CONNECTION_STATUS, connectionStatus };
 	},
 };
 
-export {
-	CONNECTION_STATUS_REGISTERED,
-	CONNECTION_STATUS_USER_CONNECTED,
-	connectionStatusActions as default,
-};
+export { SET_CONNECTION_STATUS, connectionStatusActions as default };

--- a/projects/plugins/backup/src/js/actions/index.js
+++ b/projects/plugins/backup/src/js/actions/index.js
@@ -2,11 +2,9 @@
  * Internal dependencies
  */
 import connectionStatusActions from './connection-status';
-import connectionDataActions from './connection-data';
 
 const actions = {
 	...connectionStatusActions,
-	...connectionDataActions,
 };
 
 export default actions;

--- a/projects/plugins/backup/src/js/hooks/useConnection.js
+++ b/projects/plugins/backup/src/js/hooks/useConnection.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { JetpackConnection } from '@automattic/jetpack-connection';
 
@@ -16,53 +16,31 @@ import { STORE_ID } from '../store';
  * @returns {Array} connectionStatus, renderJetpackConnection
  */
 export default function useConnection() {
-	const connectionStatus = useSelect( select => select( STORE_ID ).getConnectionStatus(), [] );
 	const APINonce = useSelect( select => select( STORE_ID ).getAPINonce(), [] );
 	const APIRoot = useSelect( select => select( STORE_ID ).getAPIRoot(), [] );
-	const authorizationUrl = useSelect( select => select( STORE_ID ).getAuthorizationUrl(), [] );
 	const doNotUseConnectionIframe = useSelect(
 		select => select( STORE_ID ).getDoNotUseConnectionIframe(),
 		[]
 	);
 	const registrationNonce = useSelect( select => select( STORE_ID ).getRegistrationNonce(), [] );
-
-	const {
-		connectionStatusSetRegistered,
-		connectionStatusSetUserConnected,
-		connectionDataSetAuthorizationUrl,
-	} = useDispatch( STORE_ID );
-
-	const onUserConnected = useCallback( () => {
-		connectionStatusSetUserConnected( true );
-	}, [ connectionStatusSetUserConnected ] );
-
-	const onRegistered = useCallback(
-		response => {
-			connectionStatusSetRegistered( true );
-
-			if ( response.authorizeUrl ) {
-				connectionDataSetAuthorizationUrl( response.authorizeUrl );
-			}
-		},
-		[ connectionStatusSetRegistered, connectionDataSetAuthorizationUrl ]
-	);
+	const connectionStatus = useSelect( select => select( STORE_ID ).getConnectionStatus(), [] );
+	const { setConnectionStatus } = useDispatch( STORE_ID );
 
 	const renderJetpackConnection = () => {
 		return (
 			<JetpackConnection
 				apiRoot={ APIRoot }
 				apiNonce={ APINonce }
-				authorizationUrl={ authorizationUrl }
-				isRegistered={ connectionStatus.isRegistered }
-				isUserConnected={ connectionStatus.isUserConnected }
-				hasConnectedOwner={ connectionStatus.hasConnectedOwner }
 				forceCalypsoFlow={ doNotUseConnectionIframe }
-				onRegistered={ onRegistered }
-				onUserConnected={ onUserConnected }
 				registrationNonce={ registrationNonce }
 				from="jetpack-backup"
 				redirectUri="admin.php?page=jetpack-backup"
-			/>
+			>
+				{ status => {
+					setConnectionStatus( status );
+					return null;
+				} }
+			</JetpackConnection>
 		);
 	};
 

--- a/projects/plugins/backup/src/js/reducers/connection-data.js
+++ b/projects/plugins/backup/src/js/reducers/connection-data.js
@@ -1,17 +1,4 @@
-/**
- * Internal dependencies
- */
-import { CONNECTION_DATA_SET_AUTHORIZATION_URL } from '../actions/connection-data';
-
-const settings = ( state = {}, action ) => {
-	switch ( action.type ) {
-		case CONNECTION_DATA_SET_AUTHORIZATION_URL:
-			return {
-				...state,
-				authorizationUrl: action.url,
-			};
-	}
-
+const settings = ( state = {} ) => {
 	return state;
 };
 

--- a/projects/plugins/backup/src/js/reducers/connection-status.js
+++ b/projects/plugins/backup/src/js/reducers/connection-status.js
@@ -1,23 +1,12 @@
 /**
  * Internal dependencies
  */
-import {
-	CONNECTION_STATUS_REGISTERED,
-	CONNECTION_STATUS_USER_CONNECTED,
-} from '../actions/connection-status';
+import { SET_CONNECTION_STATUS } from '../actions/connection-status';
 
 const connectionStatus = ( state = {}, action ) => {
 	switch ( action.type ) {
-		case CONNECTION_STATUS_REGISTERED:
-			return {
-				...state,
-				isRegistered: action.isRegistered,
-			};
-		case CONNECTION_STATUS_USER_CONNECTED:
-			return {
-				...state,
-				isUserConnected: action.isUserConnected,
-			};
+		case SET_CONNECTION_STATUS:
+			return action.connectionStatus;
 	}
 
 	return state;

--- a/projects/plugins/backup/src/js/selectors/connection-data.js
+++ b/projects/plugins/backup/src/js/selectors/connection-data.js
@@ -1,6 +1,5 @@
 const settingsSelectors = {
 	getDoNotUseConnectionIframe: state => state.connectionData.doNotUseConnectionIframe || null,
-	getAuthorizationUrl: state => state.connectionData.authorizationUrl || null,
 };
 
 export default settingsSelectors;

--- a/projects/plugins/backup/src/php/class-initial-state.php
+++ b/projects/plugins/backup/src/php/class-initial-state.php
@@ -5,8 +5,6 @@
  * @package automattic/jetpack-backup
  */
 
-use Automattic\Jetpack\Connection\Manager;
-use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 
@@ -14,21 +12,6 @@ use Automattic\Jetpack\Device_Detection\User_Agent_Info;
  * The React initial state.
  */
 class Initial_State {
-
-	/**
-	 * The connection manager object.
-	 *
-	 * @var Manager
-	 */
-	private $manager;
-
-	/**
-	 * The constructor.
-	 */
-	public function __construct() {
-		$this->manager = new Manager();
-	}
-
 	/**
 	 * Get the initial state data.
 	 *
@@ -36,17 +19,13 @@ class Initial_State {
 	 */
 	private function get_data() {
 		return array(
-			'connectionStatus' => REST_Connector::connection_status( false ),
-			'API'              => array(
+			'API'            => array(
 				'WP_API_root'       => esc_url_raw( rest_url() ),
 				'WP_API_nonce'      => wp_create_nonce( 'wp_rest' ),
 				'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 			),
-			'connectionData'   => array(
+			'connectionData' => array(
 				'doNotUseConnectionIframe' => ! $this->can_use_connection_iframe(),
-				'authorizationUrl'         => ( $this->manager->is_connected() && ! $this->manager->is_user_connected() )
-					? $this->manager->get_authorization_url( null, admin_url( 'admin.php?page=jetpack-backup' ) )
-					: null,
 			),
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Update RNA Connection usage based on the changes made in: Automattic/jetpack/pull/19837

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

*   Check out these changes to your local monorepo dev environment.
*   You can build the Backup plugin with the Jetpack CLI: `jetpack build`
*   Deactivate the Jetpack plugin (we don't want a connection to start with) and make sure the Jetpack Backup plugin is activated.
*   Check to make sure you see the `Connection Manager` as a submenu under Tools (but don't connect there).
*   Go to the Backup plugin admin page: `/wp-admin/admin.php?page=jetpack-backup`
*   Click on the Connect button, after a moment the site connection will be made and an iframe shown with an Approve button for making the user connection. Once both connections are made you should see `Site and User Connected` at the top.
*   Disconnect the site/user connection (e.g. activate and then deactivate the JP plugin).
*   Add `define( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME', true );` to your wp-config
*   Again, starting on the Backup plugin admin page click on the Connect button, the site connection will be made, and then you will be taken to the Calypso flow for the user auth. Once the user auth is approved, you should be redirected back to the plugin admin page and see the `Site and User Connected` text.