### PR TITLE
Carousel: fix photo info position

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-carousel-info-pos
+++ b/projects/plugins/jetpack/changelog/update-fix-carousel-info-pos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: fix photo info position

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -20,7 +20,7 @@
 	top: 0;
 	left: 0;
 	right: 0;
-	bottom: 15vh;
+	bottom: 20vh;
 }
 
 div.jp-carousel-fadeaway {
@@ -82,8 +82,8 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	display: flex;
 	flex-direction: column;
 	position: absolute;
-	top: 86vh; /* Fallback, if calc is not supported */
-	top: calc( 85vh + 5px );
+	top: 81vh; /* Fallback, if calc is not supported */
+	top: calc( 80vh + 5px );
 	bottom: 0;
 	text-align: left !important;
 	-webkit-font-smoothing: subpixel-antialiased !important;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -16,7 +16,7 @@ jQuery( document ).ready( function ( $ ) {
 		screenPadding,
 		originalOverflow = $( 'body' ).css( 'overflow' ),
 		originalHOverflow = $( 'html' ).css( 'overflow' ),
-		proportion = 85,
+		proportion = 80,
 		lastKnownLocationHash = '',
 		scrollPos,
 		isUserTyping = false;


### PR DESCRIPTION
Fixes carousel info position, so that more of it is visible without scrolling down.

Fixes #19969.

#### Changes proposed in this Pull Request:
* Fix carousel info position

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
See the instructions in #19969.
