### PR TITLE
Uses the sanitized variable

### DIFF
--- a/projects/packages/connection/changelog/fix-use-santized-variable
+++ b/projects/packages/connection/changelog/fix-use-santized-variable
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: fix from something forgotten on #19833
+
+

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1016,7 +1016,7 @@ class Manager {
 		$allow_inplace_authorization = isset( $registration_details->allow_inplace_authorization ) ? $registration_details->allow_inplace_authorization : false;
 		$alternate_authorization_url = isset( $registration_details->alternate_authorization_url ) ? $registration_details->alternate_authorization_url : '';
 
-		if ( ! $registration_details->allow_inplace_authorization ) {
+		if ( ! $allow_inplace_authorization ) {
 			// Forces register_site REST endpoint to return the Calypso authorization URL.
 			add_filter( 'jetpack_use_iframe_authorization_flow', '__return_false', 20 );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

In #19833 we added a new check on the registration flow that expects a new key in the register response sent by WPCOM.

We made sure to check if the new key is present to avoid errors, but we forgot to use the variable a few lines later! This PR fixes it.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes a variable usage

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing really, but you can check if the registration process works.
