### PR TITLE
E2E tests: Fix for tunnel logs not being written to file

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -137,7 +137,7 @@ jobs:
       continue-on-error: true
       run: |
         pnpm run tunnel-off
-        pnpm pm2 -- logs --nostream --lines 10000 > output/logs/tunnel.log
+        pnpm -r exec pm2 -- logs --nostream --lines 10000 > output/logs/tunnel.log
 
     - name: Upload test artifacts
       if: ${{ always() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -137,7 +137,7 @@ jobs:
       continue-on-error: true
       run: |
         pnpm run tunnel-off
-        pnpm -r exec pm2 -- logs --nostream --lines 10000 > output/logs/tunnel.log
+        pnpm run tunnel-write-logs
 
     - name: Upload test artifacts
       if: ${{ always() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -137,7 +137,7 @@ jobs:
       continue-on-error: true
       run: |
         pnpm run tunnel-off
-        pnpm run pm2 -- logs --nostream --lines 10000 > output/logs/tunnel.log
+        pnpm exec pm2 -- logs --nostream --lines 10000 > output/logs/tunnel.log
 
     - name: Upload test artifacts
       if: ${{ always() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -137,7 +137,7 @@ jobs:
       continue-on-error: true
       run: |
         pnpm run tunnel-off
-        pnpm exec pm2 -- logs --nostream --lines 10000 > output/logs/tunnel.log
+        pnpm pm2 -- logs --nostream --lines 10000 > output/logs/tunnel.log
 
     - name: Upload test artifacts
       if: ${{ always() }}

--- a/projects/plugins/jetpack/changelog/fix-e2e-tunnel-logs-pnpm-run
+++ b/projects/plugins/jetpack/changelog/fix-e2e-tunnel-logs-pnpm-run
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: fix tunnel log not being written

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -20,6 +20,7 @@
 		"tunnel-on": "pm2 start bin/ecosystem.config.js && pm2 logs --nostream --lines 4",
 		"tunnel-reset": "rm -rf config/tmp && pnpm run tunnel-on",
 		"tunnel-off": "pm2 delete bin/ecosystem.config.js && NODE_ENV=test node bin/tunnel.js off",
+	  	"tunnel-write-logs": "pm2 logs --nostream --lines 10000 > output/logs/tunnel.log",
 		"pretest-e2e": "pnpm run clean",
 		"test-e2e": "NODE_CONFIG_DIR='./config' jest --config jest.config.js --runInBand --verbose --detectOpenHandles --json --outputFile=output/summary.json",
 		"test-decrypt-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./config/encrypted.enc -out ./config/local-test.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The command that writes tunnel logs to file in e2e tests workflow got broken with the migration from yarn to pnpm.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI green, no errors reported in E2E tests workflow. `e2e/output/logs/tunnel.log` gets created and is not empty.
