### PR TITLE
Client Side lock to ensure Jetpack and Core autoupdate don't run simultaneously

### DIFF
--- a/projects/plugins/jetpack/changelog/update-client-lock-autoupdates
+++ b/projects/plugins/jetpack/changelog/update-client-lock-autoupdates
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Obtain lock before performing autoupdates.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -299,6 +299,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	}
 
 	protected function update() {
+
 		$query_args = $this->query_args();
 		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] ) {
 			Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
@@ -324,6 +325,12 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		remove_action( 'upgrader_process_complete', array( 'Language_Pack_Upgrader', 'async_upgrade' ), 20 );
 		remove_action( 'upgrader_process_complete', 'wp_version_check' );
 		remove_action( 'upgrader_process_complete', 'wp_update_themes' );
+
+		// Early return if unable to obtain auto_updater lock.
+		// @see https://github.com/WordPress/wordpress-develop/blob/66469efa99e7978c8824e287834135aa9842e84f/src/wp-admin/includes/class-wp-automatic-updater.php#L453.
+		if ( ! WP_Upgrader::create_lock( 'auto_updater' ) ) {
+			return;
+		}
 
 		$result = false;
 
@@ -367,6 +374,9 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				return $errors;
 			}
 		}
+
+		// release auto_udpate lock.
+		WP_Upgrader::release_lock( 'auto_updater' );
 
 		if ( ! $this->bulk && ! $result && $update_attempted ) {
 			return new WP_Error( 'update_fail', __( 'There was an error updating your plugin', 'jetpack' ), 400 );

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -329,7 +329,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		// Early return if unable to obtain auto_updater lock.
 		// @see https://github.com/WordPress/wordpress-develop/blob/66469efa99e7978c8824e287834135aa9842e84f/src/wp-admin/includes/class-wp-automatic-updater.php#L453.
 		if ( ! WP_Upgrader::create_lock( 'auto_updater' ) ) {
-			return;
+			return new WP_Error( 'update_fail', __( 'Updates are already in progress.', 'jetpack' ), 400 );
 		}
 
 		$result = false;

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-plugins-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-plugins-endpoints.php
@@ -93,6 +93,89 @@ class WP_Test_Jetpack_Json_Api_Plugins_Endpoints extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify plugin update endpoint adheres to lock.
+	 *
+	 * @author mdbitz
+	 * @covers Jetpack_JSON_API_Plugins_Modify_Endpoint
+	 * @group external-http
+	 */
+	public function test_Jetpack_JSON_API_Plugins_Modify_Endpoint_locked() {
+		$endpoint = new Jetpack_JSON_API_Plugins_Modify_Endpoint(
+			array(
+				'description'          => 'Update a Plugin on your Jetpack Site',
+				'group'                => 'plugins',
+				'stat'                 => 'plugins:1:update',
+				'method'               => 'GET',
+				'path'                 => '/sites/%s/plugins/%s/update/',
+				'path_labels'          => array(
+					'$site'   => '(int|string) The site ID, The site domain',
+					'$plugin' => '(string) The plugin file name',
+				),
+				'response_format'      => Jetpack_JSON_API_Plugins_Endpoint::$_response_format,
+				'example_request_data' => array(
+					'headers' => array(
+						'authorization' => 'Bearer YOUR_API_TOKEN',
+					),
+				),
+				'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/plugins/hello/update',
+			)
+		);
+
+		/**
+		 * Changes the Accessibility of the protected upgrade_plugin method.
+		 */
+		$class                = new ReflectionClass( 'Jetpack_JSON_API_Plugins_Modify_Endpoint' );
+		$update_plugin_method = $class->getMethod( 'update' );
+		$update_plugin_method->setAccessible( true );
+
+		$plugin_property = $class->getProperty( 'plugins' );
+		$plugin_property->setAccessible( true );
+		$plugin_property->setValue( $endpoint, array( 'the/the.php' ) );
+
+		$the_plugin_file = 'the/the.php';
+		$the_real_folder = WP_PLUGIN_DIR . '/the';
+		$the_real_file   = WP_PLUGIN_DIR . '/' . $the_plugin_file;
+
+		/*
+		 * Create an oudated version of 'The' plugin
+		 */
+
+		// Check if 'The' plugin folder is already there.
+		if ( ! file_exists( $the_real_folder ) ) {
+			mkdir( $the_real_folder );
+			$clean = true;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+		file_put_contents(
+			$the_real_file,
+			'<?php
+			/*
+			 * Plugin Name: The
+			 * Version: 1.0
+			 */'
+		);
+
+		// Obtain lock.
+		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		WP_Upgrader::create_lock( 'auto_updater' );
+
+		// Invoke the upgrade_plugin method.
+		$result = $update_plugin_method->invoke( $endpoint );
+
+		// Release lock.
+		WP_Upgrader::release_lock( 'auto_updater' );
+
+		// clean up.
+		if ( isset( $clean ) ) {
+			$this->rmdir( $the_real_folder );
+		}
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+	}
+
+	/**
 	 * @author tonykova
 	 * @covers Jetpack_API_Plugins_Install_Endpoint
 	 * @group external-http


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

It is possible for Core and Jetpack update processes to run in parallel. This update has Jetpack obtain the auto-updater lock before attempting to perform updates.

#### Changes proposed in this Pull Request:
* Obtain lock before attempting to perform updates.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See https://wp.me/p9o2xV-1s0

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* NO

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Unit Test added to show behavior. 

Manual Testing can be done by openning wp shell on your test site and running
```
		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
		WP_Upgrader::create_lock( 'auto_updater' );
```
to obtain a lock. Afterwards trigger the plugin update and confirm a WP_Error is returned.