### PR TITLE
Docker: fix frontend fatal when using JT

### DIFF
--- a/tools/docker/mu-plugins/01-monorepo.php
+++ b/tools/docker/mu-plugins/01-monorepo.php
@@ -119,6 +119,7 @@ class Monorepo {
 			return $wp_plugins;
 		}
 
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		foreach ( $plugin_files as $plugin_file ) {
 			if ( ! is_readable( "$plugin_root/$plugin_file" ) ) {
 				continue;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Error only occured on a logged-in view while visiting the **frontend** of
the local Docker site exposed via JT. Error did not happen on logged out
views, or if visiting the site at localhost (not using JT).

```
Fatal error: Uncaught Error: Call to undefined function
Jetpack\Docker\MuPlugin\get_plugin_data() in
/var/www/html/wp-content/mu-plugins/01-monorepo.php on line 128
```
Requiring `wp-admin/includes/plugin.php` as a quick fix.

#### Jetpack product discussion

* Internal: p1622833970293800-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

* Before pulling down changes, see if you can reproduce the fatal by visiting your local Docker site exposed via JT.
* After pulling down these changes, I was no longer seeing the fatal error.