### PR TITLE
Add flag to authorization url when coming from Jetpack site-only checkout

### DIFF
--- a/projects/plugins/jetpack/changelog/add-site-only-checkout-flag
+++ b/projects/plugins/jetpack/changelog/add-site-only-checkout-flag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Adds a flag to the site-only-checkout authorization redirect url, no need for changelog entry
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4362,14 +4362,19 @@ p {
 						exit;
 					}
 
-					$redirect_url = self::admin_url(
-						array(
-							'page'     => 'jetpack',
-							'action'   => 'authorize_redirect',
-							'dest_url' => rawurlencode( $dest_url ),
-							'done'     => '1',
-						)
+					$redirect_args = array(
+						'page'     => 'jetpack',
+						'action'   => 'authorize_redirect',
+						'dest_url' => rawurlencode( $dest_url ),
+						'done'     => '1',
 					);
+
+					if ( ! empty( $_GET['from'] ) && 'jetpack_site_only_checkout' === $_GET['from'] ) {
+						// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+						$redirect_args['from'] = $_GET['from'];
+					}
+
+					$redirect_url = self::admin_url( $redirect_args );
 
 					wp_safe_redirect( static::build_authorize_url( $redirect_url ) );
 					exit;

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4370,8 +4370,7 @@ p {
 					);
 
 					if ( ! empty( $_GET['from'] ) && 'jetpack_site_only_checkout' === $_GET['from'] ) {
-						// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-						$redirect_args['from'] = $_GET['from'];
+						$redirect_args['from'] = 'jetpack_site_only_checkout';
 					}
 
 					$redirect_url = self::admin_url( $redirect_args );

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4373,9 +4373,7 @@ p {
 						$redirect_args['from'] = 'jetpack_site_only_checkout';
 					}
 
-					$redirect_url = self::admin_url( $redirect_args );
-
-					wp_safe_redirect( static::build_authorize_url( $redirect_url ) );
+					wp_safe_redirect( static::build_authorize_url( self::admin_url( $redirect_args ) ) );
 					exit;
 				case 'authorize':
 					_doing_it_wrong( __METHOD__, 'The `page=jetpack&action=authorize` webhook is deprecated. Use `handler=jetpack-connection-webhooks&action=authorize` instead', 'Jetpack 9.5.0' );


### PR DESCRIPTION
For the Logged-out visitor checkout project, this PR allows us to accept a `&from=jetpack_site_only_checkout` query param and send that param into the authorization url so that we can know that we are connecting a user account coming from the site-only checkout flow.  

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

After the logged-out checkout process we need a way to user-connect the site, so after purchase is complete we redirect them back to the Jetpack site with the `page=jetpack&action=authorize_redirect` GET parameters. This initiates the user connection flow. However for this to work we need to know that we are coming from the logged-out checkout flow in Calypso so for that we add an additional `from=` GET flag: 
( `page=jetpack&action=authorize_redirect&from=jetpack_site_only_checkout` ).  In this PR then, we can accept the `from=jetpack_site_only_checkout` param and pass it along into the authorization redirect url.

This PR is needed in order for [Jetpack Logged-out Checkout: Auto-connect user after checkout](https://github.com/Automattic/wp-calypso/pull/53477) to work.


#### Jetpack product discussion

Logged out visitor checkout project thread: pbtFFM-OD-p2
The Asana task: 1200152453830945-as-1200329115728364
The idea behind this PR comes from here: p9dueE-2YE-p2#comment-5277

<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?

No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Checkout this PR (or create a JN site with the Jetpack Beta plugin pointing to this branch)
2. Connect Jetpack with a **site-only connection**.  
3. Make sure you are logged-in to wordpress.com.
4. On your site, go to: `/wp-admin/admin.php?page=jetpack&action=authorize_redirect&from=jetpack_site_only_checkout&dest_url=http://wordpress.com`
5. Verify that you are redirected to `https://wordpress.com/jetpack/connect/authorize?...`
6. Inspect the url and verify that the `redirect_after_auth` query param contains the `&from=jetpack_site_only_checkout` in the value.

The instructions for testing the entire flow are on PR: [Jetpack Logged-out Checkout: Auto-connect user after checkout](https://github.com/Automattic/wp-calypso/pull/53477)

