### PR TITLE
General: Basic updates to prepare for WP 5.8

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -56,7 +56,7 @@ case "$WP_BRANCH" in
 	previous)
 		# We hard-code the version here because there's a time near WP releases where
 		# we've dropped the old 'previous' but WP hasn't actually released the new 'latest'
-		git clone --depth=1 --branch 5.6 git://develop.git.wordpress.org/ /tmp/wordpress-previous
+		git clone --depth=1 --branch 5.7 git://develop.git.wordpress.org/ /tmp/wordpress-previous
 		;;
 esac
 echo "::endgroup::"

--- a/.phpcs.config.xml
+++ b/.phpcs.config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset>
-	<config name="minimum_supported_wp_version" value="5.6" />
+	<config name="minimum_supported_wp_version" value="5.7" />
 	<config name="testVersion" value="5.6-"/>
 
 	<!-- Check all PHP files in directory tree by default. -->

--- a/projects/plugins/backup/changelog/bump-to-5.7
+++ b/projects/plugins/backup/changelog/bump-to-5.7
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Bump to 5.7 minimum WP supported version
+
+

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -1,9 +1,9 @@
 === Jetpack Backup ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 5.5
+Requires at least: 5.7
 Requires PHP: 5.6
-Tested up to: 5.6
+Tested up to: 5.8
 Stable tag: 1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
+use Automattic\Jetpack\Identity_Crisis;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\Status;
@@ -76,7 +77,7 @@ class Jetpack_Redux_State_Helper {
 		 * Adds information to the `connectionStatus` API field that is unique to the Jetpack React dashboard.
 		 */
 		$connection_status = array(
-			'isInIdentityCrisis' => Jetpack::validate_sync_error_idc_option(),
+			'isInIdentityCrisis' => Identity_Crisis::validate_sync_error_idc_option(),
 			'sandboxDomain'      => JETPACK__SANDBOX_DOMAIN,
 
 			/**

--- a/projects/plugins/jetpack/changelog/bump-to-5.7
+++ b/projects/plugins/jetpack/changelog/bump-to-5.7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Updated minimum supported WordPress to 5.7 in anticipation for WordPress 5.8 coming later this month.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -8,7 +8,7 @@
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
- * Requires at least: 5.6
+ * Requires at least: 5.7
  * Requires PHP: 5.6
  *
  * @package automattic/jetpack

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -30,7 +30,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '5.6' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '5.7' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
 define( 'JETPACK__VERSION', '9.9-alpha' );
 

--- a/projects/plugins/jetpack/modules/shortcodes/instagram.php
+++ b/projects/plugins/jetpack/modules/shortcodes/instagram.php
@@ -30,18 +30,6 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
  * @since 9.1.0
  */
 function jetpack_instagram_enable_embeds() {
-
-	/**
-	 * Instagram's custom Embed provider.
-	 * We first remove the embed provider that's registered by Core; then, we declare our own.
-	 *
-	 * We can drop the `wp_oembed_remove_provider` line once Core stops adding its own Instagram provider:
-	 * https://core.trac.wordpress.org/ticket/50861.
-	 *
-	 * @todo Remove once 5.6 is our minimum version. (Technically WP dropped their provider in 5.5.2).
-	 */
-	wp_oembed_remove_provider( '#https?://(www\.)?instagr(\.am|am\.com)/(p|tv)/.*#i' );
-
 	wp_oembed_add_provider(
 		'#https?://(www\.)?instagr(\.am|am\.com)/(p|tv|reel)/.*#i',
 		'https://graph.facebook.com/v5.0/instagram_oembed/',

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -2,9 +2,9 @@
 Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, andy, annezazu, apeatling, azaozz, batmoo, barry, beaulebens, biskobe, blobaugh, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, robertbpugh, roccotripaldi, samhotchkiss, scarstocea, scottsweb, sdquirk, sermitr, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: WP, backup, social, AMP, WooCommerce, malware, scan, spam, CDN, social
 Stable tag: 9.6
-Requires at least: 5.6
+Requires at least: 5.7
 Requires PHP: 5.6
-Tested up to: 5.7
+Tested up to: 5.8
 
 The best WP plugin for backup, anti spam, malware scan, CDN, AMP, social, search, contact form, and integrations with Woo, Facebook, Instagram, Google
 

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -514,9 +514,9 @@ function createReadMeTxt( answers ) {
 		`=== Jetpack ${ answers.name } ===\n` +
 		'Contributors: automattic,\n' +
 		'Tags: jetpack, stuff\n' +
-		'Requires at least: 5.5\n' +
+		'Requires at least: 5.7\n' +
 		'Requires PHP: 5.6\n' +
-		'Tested up to: 5.6\n' +
+		'Tested up to: 5.8\n' +
 		'Stable tag: 1.0\n' +
 		'License: GPLv2 or later\n' +
 		'License URI: http://www.gnu.org/licenses/gpl-2.0.html\n' +


### PR DESCRIPTION
- Bump minimum supported/tested version to 5.7/5.8
- Remove Instagram oembed removal. Ref #19736

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

See #19654

#### Changes proposed in this Pull Request:
* Bump versions.
* Remove Instagram code
* More coming.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See 19654

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Running WP 5.7 or 5.8, test an Instagram embed.
*
