### PR TITLE
Gif Block: Fix issues in Widget Editor / Customizer

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gif-block-widget-editor
+++ b/projects/plugins/jetpack/changelog/fix-gif-block-widget-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix the GIF block to support the widget editor and customizer preview pane.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -577,7 +577,15 @@ class Jetpack_Gutenberg {
 		if ( self::block_has_asset( $style_relative_path ) ) {
 			$style_version = self::get_asset_version( $style_relative_path );
 			$view_style    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
-			wp_enqueue_style( 'jetpack-block-' . $type, $view_style, array(), $style_version );
+
+			// If this is a customizer preview, render the style directly to the preview after autosave.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( is_customize_preview() && ! empty( $_GET['customize_autosaved'] ) ) {
+				// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				echo '<link rel="stylesheet" id="jetpack-block-' . esc_attr( $type ) . '" href="' . esc_attr( $view_style ) . '?ver=' . esc_attr( $style_version ) . '" media="all">';
+			} else {
+				wp_enqueue_style( 'jetpack-block-' . $type, $view_style, array(), $style_version );
+			}
 		}
 
 	}
@@ -611,7 +619,14 @@ class Jetpack_Gutenberg {
 		if ( ! Blocks::is_amp_request() && self::block_has_asset( $script_relative_path ) ) {
 			$script_version = self::get_asset_version( $script_relative_path );
 			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
-			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $script_dependencies, $script_version, false );
+
+			// If this is a customizer preview, render the script directly to the preview after autosave.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( is_customize_preview() && ! empty( $_GET['customize_autosaved'] ) ) {
+				echo '<script id="jetpack-block-' . esc_attr( $type ) . '" src="' . esc_attr( $view_script ) . '?ver=' . esc_attr( $script_version ) . '"></script>';
+			} else {
+				wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $script_dependencies, $script_version, false );
+			}
 		}
 
 		wp_localize_script(

--- a/projects/plugins/jetpack/extensions/blocks/gif/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/gif/edit.js
@@ -16,12 +16,7 @@ import SearchForm from './components/search-form';
 import Controls from './controls';
 import useFetchGiphyData from './hooks/use-fetch-giphy-data';
 
-function GifEdit( {
-	attributes,
-	setAttributes,
-	className,
-	isSelected,
-} ) {
+function GifEdit( { attributes, setAttributes, className, isSelected } ) {
 	const { align, caption, giphyUrl, searchText, paddingTop } = attributes;
 	const classes = classNames( className, `align${ align }` );
 	const [ captionFocus, setCaptionFocus ] = useState( false );
@@ -39,7 +34,7 @@ function GifEdit( {
 		}
 	}, [ giphyData, setAttributes ] );
 
-	const onSubmit = ( event ) => {
+	const onSubmit = event => {
 		event.preventDefault();
 
 		if ( ! attributes.searchText || isFetching ) {
@@ -49,8 +44,8 @@ function GifEdit( {
 		fetchGiphyData( getUrl( attributes.searchText ) );
 	};
 
-	const onChange = ( event ) => setAttributes( { searchText: event.target.value } );
-	const onSelectThumbnail = ( thumbnail ) => setAttributes( getSelectedGiphyAttributes( thumbnail ) );
+	const onChange = event => setAttributes( { searchText: event.target.value } );
+	const onSelectThumbnail = thumbnail => setAttributes( getSelectedGiphyAttributes( thumbnail ) );
 
 	return (
 		<div className={ classes }>
@@ -89,7 +84,10 @@ function GifEdit( {
 									<button
 										className="wp-block-jetpack-gif_thumbnail-container"
 										key={ thumbnail.id }
-										onClick={ () => onSelectThumbnail( thumbnail ) }
+										onClick={ e => {
+											e.preventDefault();
+											onSelectThumbnail( thumbnail );
+										} }
 										style={ thumbnailStyle }
 									/>
 								);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/19962

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix an issue where the customizer would ask to redirect away when selecting a gif after searching

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the customizer with a non block theme activated
* Edit a widget area and add a GIF block
* Search for a gif and select a thumbnail
* Confirm the thumbnail is selected, and the gif appears in the preview
* Confirm the customizer does not try to redirect away to another page.
