### PR TITLE
Jetpack Site Logo: add integer check for custom_logo

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-fullofcaffeine-r226957-wpcom-1623188698
+++ b/projects/plugins/jetpack/changelog/fusion-sync-fullofcaffeine-r226957-wpcom-1623188698
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Theme Tools: Improve compatibility between Site Logo and the new Site Logo block from WordPress.

--- a/projects/plugins/jetpack/modules/theme-tools/site-logo/inc/functions.php
+++ b/projects/plugins/jetpack/modules/theme-tools/site-logo/inc/functions.php
@@ -131,8 +131,8 @@ function jetpack_the_site_logo() {
 	$logo_id      = get_theme_mod( 'custom_logo' );
 	$jetpack_logo = site_logo()->logo;
 
-	// Use WP Core logo if present, otherwise use Jetpack's.
-	if ( ! $logo_id && isset( $jetpack_logo['id'] ) ) {
+	// Use WP Core logo if present and is an id (of an attachment), otherwise use Jetpack's.
+	if ( ! is_numeric( $logo_id ) && isset( $jetpack_logo['id'] ) ) {
 		$logo_id = $jetpack_logo['id'];
 	}
 


### PR DESCRIPTION
Summary:
Resolves 53517-gh-wp-calypso and supports #19654

Implementation by @creativecoder.

Code recently added to Gutenberg syncs site_logo options and custom_logo theme mod. This causes a conflict with the legacy Jetpack site logo functionality.

This is an initial fix--we'll need to follow up to reconcile the new site_logo option and Jetpacks legacy logo functionality.

Related convo: p1623174912090300-slack-CBTN58FTJ.

Test Plan:
- Sandbox a Simple Site
- Activate a theme that uses `jetpack_the_site_logo` to display a logo, such as premium/soho (`wp theme activate premium/soho --url=[private link]`)
- Navigate to the customizer, set a logo, and save the changes
- Without this change, the logo does not display
- With this change, the logo should display

Reviewers: paulbunkham, kraftbj, fullofcaffeine, bernhardreiter

Tags: #touches_jetpack_files

Differential Revision: D62504-code

This commit syncs r226957-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
