### PR TITLE
Image Carousel: Show carousel enable toggle in media options.

### DIFF
--- a/projects/plugins/jetpack/changelog/Image Carousel- Show carousel enable toggle in media options.
+++ b/projects/plugins/jetpack/changelog/Image Carousel- Show carousel enable toggle in media options.
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Image Carousel- Show carousel enable toggle in media options.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -952,10 +952,8 @@ class Jetpack_Carousel {
 	function register_settings() {
 		add_settings_section( 'carousel_section', __( 'Image Gallery Carousel', 'jetpack' ), array( $this, 'carousel_section_callback' ), 'media' );
 
-		if ( ! $this->in_jetpack ) {
-			add_settings_field( 'carousel_enable_it', __( 'Enable carousel', 'jetpack' ), array( $this, 'carousel_enable_it_callback' ), 'media', 'carousel_section' );
-			register_setting( 'media', 'carousel_enable_it', array( $this, 'carousel_enable_it_sanitize' ) );
-		}
+		add_settings_field( 'carousel_enable_it', __( 'Enable carousel', 'jetpack' ), array( $this, 'carousel_enable_it_callback' ), 'media', 'carousel_section' );
+		register_setting( 'media', 'carousel_enable_it', array( $this, 'carousel_enable_it_sanitize' ) );
 
 		add_settings_field( 'carousel_background_color', __( 'Background color', 'jetpack' ), array( $this, 'carousel_background_color_callback' ), 'media', 'carousel_section' );
 		register_setting( 'media', 'carousel_background_color', array( $this, 'carousel_background_color_sanitize' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Relates to https://github.com/Automattic/wp-calypso/issues/36415

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the condition of whether this module is configurable through Jetpack interface so that the enable / disable toggle is always visible in `/wp-admin/options-media.php` 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Please test this on a WoA blog

* Go to `/wp-admin/options-media.php` of an Atomic site
* Check that you can enable / disable the Carousel "Display images in full-size carousel slideshow."

Before | After
-------|------
![](https://cln.sh/HTqfSz+) | ![](https://cln.sh/7WdtxS+)
