### PR TITLE
E2E test reports: send more information about pr to test report

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -219,7 +219,7 @@ jobs:
         run: |
           if [ "$GITHUB_EVENT_NAME" == pull_request ]; then
           	BRANCH=$GITHUB_HEAD_REF
-            EVENT_NAME=github.event.pull_request.title
+            EVENT_NAME="${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
           else
           	BRANCH=${GITHUB_REF:11}
             EVENT_NAME="Run $GITHUB_RUN_ID"
@@ -228,7 +228,7 @@ jobs:
           curl -X POST https://api.github.com/repos/automattic/jetpack-e2e-reports/dispatches \
           -H "Accept: application/vnd.github.v3+json" \
           -u user:${{ secrets.E2E_TEST_REPORTS_TOKEN }} \
-          --data "{\"event_type\": \"Run $EVENT_NAME\",
+          --data "{\"event_type\": \"$EVENT_NAME\",
           \"client_payload\": {
           \"repository\": \"$GITHUB_REPOSITORY\",
           \"run_id\": \"$GITHUB_RUN_ID\",

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -219,18 +219,21 @@ jobs:
         run: |
           if [ "$GITHUB_EVENT_NAME" == pull_request ]; then
           	BRANCH=$GITHUB_HEAD_REF
+            EVENT_NAME=github.event.pull_request.title
           else
           	BRANCH=${GITHUB_REF:11}
+            EVENT_NAME="Run $GITHUB_RUN_ID"
           fi
 
           curl -X POST https://api.github.com/repos/automattic/jetpack-e2e-reports/dispatches \
           -H "Accept: application/vnd.github.v3+json" \
           -u user:${{ secrets.E2E_TEST_REPORTS_TOKEN }} \
-          --data "{\"event_type\": \"Run $GITHUB_RUN_ID\",
+          --data "{\"event_type\": \"Run $EVENT_NAME\",
           \"client_payload\": {
           \"repository\": \"$GITHUB_REPOSITORY\",
           \"run_id\": \"$GITHUB_RUN_ID\",
           \"run_number\": \"$GITHUB_RUN_NUMBER\",
           \"branch\": \"$BRANCH\",
-          \"pr\": \"${{ github.event.pull_request.number }}\"
+          \"pr_title\": \"${{ github.event.pull_request.title }}\",
+          \"pr_number\": \"${{ github.event.pull_request.number }}\"
           }}"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -234,6 +234,7 @@ jobs:
           \"run_id\": \"$GITHUB_RUN_ID\",
           \"run_number\": \"$GITHUB_RUN_NUMBER\",
           \"branch\": \"$BRANCH\",
+          \"pr\": \"${{ github.event.pull_request.number }}\",
           \"pr_title\": \"${{ github.event.pull_request.title }}\",
           \"pr_number\": \"${{ github.event.pull_request.number }}\"
           }}"

--- a/projects/plugins/jetpack/changelog/e2e-e2e-test-report-send-pr-info
+++ b/projects/plugins/jetpack/changelog/e2e-e2e-test-report-send-pr-info
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+E2E test reports: send more information about PR to test reporter


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Send more information about the tested PR in request to test reporter. 
- added PR title
- use PR title as event name

#### Jetpack product discussion
1156386383419466-as-1200453732403160/f

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI green. Test report workflow is triggered with correct information in `automattic/jetpack-e2e-reports`