### PR TITLE
Docker: Bump Ubuntu to 20.04 LTS

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal
 
 VOLUME ["/var/www/html"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Our Dockerfile was set to use `xenial`, 16.04 LTS, which is now EOL. Updating to the latest LTS release.

Funny part is I even RT'd this from the maintainer of the PHP packages we use, yet was still wondering why the docker build failed for me...

https://twitter.com/oerdnj/status/1401670677376159745

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update to Ubuntu 20.04 LTS.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run various docker commands and confirm that we're still in business.
*
