### PR TITLE
Inline PDFs: Fix height to overcome theme specific CSS.

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-scruffian-r227092-wpcom-1623406878
+++ b/projects/plugins/jetpack/changelog/fusion-sync-scruffian-r227092-wpcom-1623406878
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Inline PDFs: Fix the height to 800px to overcome theme specific CSS.

--- a/projects/plugins/jetpack/modules/shortcodes/inline-pdfs.php
+++ b/projects/plugins/jetpack/modules/shortcodes/inline-pdfs.php
@@ -37,7 +37,7 @@ function jetpack_inline_pdf_embed_handler( $matches, $attr, $url ) {
 	);
 
 	return sprintf(
-		'<object data="%1$s" type="application/pdf" width="100%%" height="800">
+		'<object data="%1$s" type="application/pdf" width="100%%" height="800" style="height: 800px;">
 			<p><a href="%1$s">%2$s</a></p>
 		</object>',
 		esc_attr( $url ),

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.inline-pdf.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.inline-pdf.php
@@ -46,7 +46,7 @@ class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 
 		$this->assertContains(
 			sprintf(
-				'<p><object data="%1$s" type="application/pdf" width="100%%" height="800"><p><a href="%1$s">Click to access %2$s</a></p></object></p>' . "\n",
+				'<p><object data="%1$s" type="application/pdf" width="100%%" height="800" style="height: 800px;"><p><a href="%1$s">Click to access %2$s</a></p></object></p>' . "\n",
 				$url,
 				$filename
 			),


### PR DESCRIPTION
Summary: Some themes set a height for object elements, but we always want these ones to be 800px high.

Test Plan: See 1919-gh-themes

Reviewers: #themes_team, lance, jeffikus

Reviewed By: #themes_team, jeffikus

Subscribers: jeffikus

Tags: #touches_jetpack_files

Differential Revision: D62535-code

This commit syncs r227092-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Some themes set a height for object elements, but we always want these ones to be 800px high.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See https://github.com/Automattic/themes/issues/1919