### PR TITLE
[Simple Payments]: Do not duplicate productId on block duplication

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/index.js
@@ -131,6 +131,7 @@ export const settings = {
 		},
 		productId: {
 			type: 'number',
+			unique: true,
 		},
 		title: {
 			type: 'string',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
This PR is one possible solution to #12801. It relies on the addition of support for unique block attributes proposed in this (currently open) Gutenberg PR: https://github.com/WordPress/gutenberg/pull/32604.

Fixes #12801

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When a Simple Payments block is duplicated, all of its attributes are copied including the `productId`. This causes the duplicated block to point to the same product resource under the covers -- so if the user then edits the duplicate and saves the post, the edits will (confusingly) be applied to _both_ blocks. This PR resolves the problem by marking the `productId` attribute of the Simple Payments block as `unique` so that it is not copied on block duplication.

Now when the block is duplicated, all of its fields (price, title, description, etc) will be copied, but a new product is created on the backend. Edits to each block can be made individually.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Pull this Gutenberg PR: https://github.com/WordPress/gutenberg/pull/32604.
* Pull this branch in Jetpack
* Sync both Gutenberg and Jetpack to your sandbox
* Create a post and insert a Pay with Paypal block. Fill out all of its fields.
* Duplicate the block. The new block should look identical to the first.
* Optionally, view the blocks in the Code editor to see their attributes. Verify that they have different values for `productId`.
* Edit the fields of the second block.
* Save the post.
* Refresh the page; your edits should only be applied to the second block. View the post on the frontend and verify that this true on the frontend as well.
