### PR TITLE
Instant Search: prevent override of modal close button styles by theme

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-modal-close-button-elementor
+++ b/projects/plugins/jetpack/changelog/fix-modal-close-button-elementor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instant Search: prevent override of modal close button styles by theme

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.scss
@@ -80,16 +80,16 @@ body.enable-search-modal .cover-modal.show-modal.search-modal.active {
 	}
 
 	.jetpack-instant-search__box,
-	.jetpack-instant-search__overlay-close {
+	button.jetpack-instant-search__overlay-close {
 		border-color: $color-dark-layout-borders;
 	}
 
 	.jetpack-instant-search__box-gridicon svg,
-	.jetpack-instant-search__overlay-close svg.gridicon {
+	button.jetpack-instant-search__overlay-close svg.gridicon {
 		fill: $color-dark-text-lighter;
 	}
 
-	.jetpack-instant-search__overlay-close {
+	button.jetpack-instant-search__overlay-close {
 		border-color: $color-dark-layout-borders;
 		&:focus,
 		&:hover {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-results.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-results.scss
@@ -217,7 +217,8 @@ $modal-max-width-lg: 95%;
 	width: 100%;
 }
 
-.jetpack-instant-search__overlay-close {
+// Applied to button. so we override any generic button styles from the theme
+button.jetpack-instant-search__overlay-close {
 	@include remove-button-styling();
 	align-items: center;
 	cursor: pointer;


### PR DESCRIPTION
Fixes #20051.

#### Changes proposed in this Pull Request:
If a theme defines a generic style for the `button` element, it can override the button style for the Instant Search modal close button. For example:

```
.my-theme button {
  border: 40px solid red;
}
```

This PR ensures that the modal close button appears as intended, even in this situation.

This behaviour was observed on https://otzaracademi.co.il/?s=, where the padding and border settings result in the button looking like this:

<img width="145" alt="Screen Shot 2021-06-14 at 16 50 32" src="https://user-images.githubusercontent.com/17325/121840835-34ed7180-cd31-11eb-8222-a534f34fc368.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Apply the otzaracademi button CSS as custom CSS on your test site:

```
.your-theme button {
color: #1A6C7A;
background-color: rgba(2, 1, 1, 0);
border-style: solid;
border-width: 2px 2px 2px 2px;
border-color: #1A6C7A;
border-radius: 0px 0px 0px 0px;
padding: 16px 40px 16px 40px;
}
```

Perform a search to open the modal, and ensure that the modal close button still looks as intended:

<img width="172" alt="Screen Shot 2021-06-14 at 16 50 26" src="https://user-images.githubusercontent.com/17325/121840912-623a1f80-cd31-11eb-9cc4-a34933703a90.png">
