### PR TITLE
Connection: Move 'connection/owner' endpoint to Connection

### DIFF
--- a/projects/packages/connection/changelog/update-move-connection-owner-endpoint
+++ b/projects/packages/connection/changelog/update-move-connection-owner-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Move 'connection/owner' endpoint to Connection package.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
+use Jetpack_IXR_Client;
 use WP_Error;
 use WP_User;
 
@@ -681,7 +682,7 @@ class Manager {
 			return $cached_user_data;
 		}
 
-		$xml = new \Jetpack_IXR_Client(
+		$xml = new Jetpack_IXR_Client(
 			array(
 				'user_id' => $user_id,
 			)
@@ -820,9 +821,94 @@ class Manager {
 	 */
 	public function unlink_user_from_wpcom( $user_id ) {
 		// Attempt to disconnect the user from WordPress.com.
-		$xml = new \Jetpack_IXR_Client( compact( 'user_id' ) );
+		$xml = new Jetpack_IXR_Client( compact( 'user_id' ) );
 
 		$xml->query( 'jetpack.unlink_user', $user_id );
+		if ( $xml->isError() ) {
+			return false;
+		}
+
+		return (bool) $xml->getResponse();
+	}
+
+	/**
+	 * Update the connection owner.
+	 *
+	 * @since 9.9.0
+	 *
+	 * @param Integer $new_owner_id The ID of the user to become the connection owner.
+	 *
+	 * @return true|WP_Error True if owner successfully changed, WP_Error otherwise.
+	 */
+	public function update_connection_owner( $new_owner_id ) {
+		if ( ! user_can( $new_owner_id, 'administrator' ) ) {
+			return new WP_Error(
+				'new_owner_not_admin',
+				__( 'New owner is not admin', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$old_owner_id = $this->get_connection_owner_id();
+
+		if ( $old_owner_id === $new_owner_id ) {
+			return new WP_Error(
+				'new_owner_is_existing_owner',
+				__( 'New owner is same as existing owner', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! $this->is_user_connected( $new_owner_id ) ) {
+			return new WP_Error(
+				'new_owner_not_connected',
+				__( 'New owner is not connected', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Notify WPCOM about the connection owner change.
+		$owner_updated_wpcom = $this->update_connection_owner_wpcom( $new_owner_id );
+
+		if ( $owner_updated_wpcom ) {
+			// Update the connection owner in Jetpack only if they were successfully updated on WPCOM.
+			// This will ensure consistency with WPCOM.
+			\Jetpack_Options::update_option( 'master_user', $new_owner_id );
+
+			// Track it.
+			( new Tracking() )->record_user_event( 'set_connection_owner_success' );
+
+			return true;
+		}
+		return new WP_Error(
+			'error_setting_new_owner',
+			__( 'Could not confirm new owner.', 'jetpack' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	/**
+	 * Request to WPCOM to update the connection owner.
+	 *
+	 * @since 9.9.0
+	 *
+	 * @param Integer $new_owner_id The ID of the user to become the connection owner.
+	 *
+	 * @return Boolean Whether the disconnection of the user was successful.
+	 */
+	public function update_connection_owner_wpcom( $new_owner_id ) {
+		// Notify WPCOM about the connection owner change.
+		$xml = new Jetpack_IXR_Client(
+			array(
+				'user_id' => get_current_user_id(),
+			)
+		);
+		$xml->query(
+			'jetpack.switchBlogOwner',
+			array(
+				'new_blog_owner' => $new_owner_id,
+			)
+		);
 		if ( $xml->isError() ) {
 			return false;
 		}
@@ -1495,7 +1581,7 @@ class Manager {
 			return false;
 		}
 
-		$xml = new \Jetpack_IXR_Client();
+		$xml = new Jetpack_IXR_Client();
 		$xml->query( 'jetpack.deregister', get_current_user_id() );
 
 		return true;

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -894,7 +894,7 @@ class Manager {
 	 *
 	 * @param Integer $new_owner_id The ID of the user to become the connection owner.
 	 *
-	 * @return Boolean Whether the disconnection of the user was successful.
+	 * @return Boolean Whether the ownership transfer was successful.
 	 */
 	public function update_connection_owner_wpcom( $new_owner_id ) {
 		// Notify WPCOM about the connection owner change.

--- a/projects/plugins/jetpack/changelog/update-move-connection-owner-endpoint
+++ b/projects/plugins/jetpack/changelog/update-move-connection-owner-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Move 'connection/owner' endpoint to Connection package.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -975,48 +975,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test changing the master user.
-	 *
-	 * @since 6.2.0
-	 * @since 7.7.0 No longer need to be master user to update.
-	 */
-	public function test_change_owner() {
-
-		// Create a user and set it up as current.
-		$user = $this->create_and_get_user( 'administrator' );
-		$user->add_cap( 'jetpack_disconnect' );
-		wp_set_current_user( $user->ID );
-
-		// Mock site already registered
-		Jetpack_Options::update_option( 'user_tokens', array( $user->ID => "honey.badger.$user->ID" ) );
-
-		// Set up user as master user
-		Jetpack_Options::update_option( 'master_user', $user->ID );
-
-		// Attempt owner change with bad user
-		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => 999 ), 'POST' );
-		$this->assertResponseStatus( 400, $response );
-
-		// Attempt owner change to same user
-		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => $user->ID ), 'POST' );
-		$this->assertResponseStatus( 400, $response );
-
-		// Create another user
-		$new_owner = $this->create_and_get_user( 'administrator' );
-		Jetpack_Options::update_option( 'user_tokens', array(
-			$user->ID => "honey.badger.$user->ID",
-			$new_owner->ID => "honey.badger.$new_owner->ID",
-		) );
-
-		// Change owner to valid user
-		add_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10, 3 );
-		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => $new_owner->ID ), 'POST' );
-		$this->assertResponseStatus( 200, $response );
-		$this->assertEquals( $new_owner->ID, Jetpack_Options::get_option( 'master_user' ), 'Master user not changed' );
-		remove_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10 );
-	}
-
-	/**
 	 * Test saving and retrieving the recommendations data.
 	 *
 	 * @since 9.3.0


### PR DESCRIPTION
This PR moves the `connection/owner` endpoint from the Jetpack plugin to the Connection package.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves the `connection/owner` endpoint for updating the connection owner to the Connection package
* Introduces the `update_connection_owner` method in `Manager` as this is considered business logic, keeping the endpoint callback thiner.
* Updates the existing logic by only refreshing the `master_user` option when the corresponding remote call to WPCOM is successful. This will ensure consistency between the local and remote connection owner.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1191179647901802-as-1200454472172402/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
The easiest way to test this would be via the newly "Connected Admins" functionality introduced in the Jetpack Debugger:
- Spin up a new JN site
- Connect 2 admin users
- Go to the Debugger and click the "Make primary user" link next to the secondary admin listed under the "Connected Admins" section
- The secondary admin should be now the Primary user. Verify this by also visiting your site's Jetpack Dashboard and checking the "User Connection" info.