### PR TITLE
Allow for constants to be retrieved by the sync/object endpoint

### DIFF
--- a/projects/packages/sync/changelog/add-constants-get-objects-by-id
+++ b/projects/packages/sync/changelog/add-constants-get-objects-by-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Expand sync/object to support constants

--- a/projects/packages/sync/src/modules/class-constants.php
+++ b/projects/packages/sync/src/modules/class-constants.php
@@ -282,4 +282,56 @@ class Constants extends Module {
 	public function total( $config ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return count( $this->get_constants_whitelist() );
 	}
+
+	/**
+	 * Retrieve a set of constants by their IDs.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type.
+	 * @param array  $ids         Object IDs.
+	 * @return array Array of objects.
+	 */
+	public function get_objects_by_id( $object_type, $ids ) {
+		if ( empty( $ids ) || empty( $object_type ) || 'constant' !== $object_type ) {
+			return array();
+		}
+
+		$objects = array();
+		foreach ( (array) $ids as $id ) {
+			$object = $this->get_object_by_id( $object_type, $id );
+
+			if ( 'all' === $id ) {
+				// If all was requested it contains all options and can simply be returned.
+				return $object;
+			}
+			$objects[ $id ] = $object;
+		}
+
+		return $objects;
+	}
+
+	/**
+	 * Retrieve a constant by its name.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Type of the sync object.
+	 * @param string $id          ID of the sync object.
+	 * @return mixed              Value of Constant.
+	 */
+	public function get_object_by_id( $object_type, $id ) {
+		if ( 'constant' === $object_type ) {
+
+			// Only whitelisted constants can be returned.
+			if ( in_array( $id, $this->get_constants_whitelist(), true ) ) {
+				return $this->get_constant( $id );
+			} elseif ( 'all' === $id ) {
+				return $this->get_all_constants();
+			}
+		}
+
+		return false;
+	}
+
 }

--- a/projects/plugins/jetpack/changelog/add-constants-get-objects-by-id
+++ b/projects/plugins/jetpack/changelog/add-constants-get-objects-by-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Unit Tests for Sync constants

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -74,4 +74,24 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'TEST_ABC' ) );
 	}
+
+	/**
+	 * Verify that all constants are returned by get_objects_by_id.
+	 */
+	public function test_get_objects_by_id_all() {
+		$module        = Modules::get_module( 'constants' );
+		$all_constants = $module->get_objects_by_id( 'constant', array( 'all' ) );
+		$this->assertEquals( $module->get_all_constants(), $all_constants );
+	}
+
+	/**
+	 * Verify that get_object_by_id returns a allowed constant.
+	 */
+	public function test_get_objects_by_id_singular() {
+		$module        = Modules::get_module( 'constants' );
+		$constants     = $module->get_all_constants();
+		$get_constants = $module->get_objects_by_id( 'constant', array( 'EMPTY_TRASH_DAYS' ) );
+		$this->assertEquals( $constants['EMPTY_TRASH_DAYS'], $get_constants['EMPTY_TRASH_DAYS'] );
+	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This update allows us to expand the checksum process so that we ensure constants are always in sync. It implements get_objects_by_ids and get_object_by_id for the Constants module that allows for us to retrieve the current value on demand. Pulled constants are limited to the allowed Sync constants.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Expand sync/object endpoint to include retrieval of constants.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No constants are already retrievable via a Full Sync this simply exposes a new endpoint to request the data.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Access shell on your WP.com sandbox
2) $jsm = new Jetpack_Sync_Manager( get_current_blog_id() );
3) $jsm->get_sync_objects( 'constants', 'constant', array( 'all' ) );
4) Verify that constants are retrieved
5) $jsm->get_sync_objects( 'constants', 'constant', array( 'blue-bird' ) );
6) Verify that empty array is returned
7) Specify your own constant names and that only allowed will be returned.
