### PR TITLE
Allow for theme-info to be retrieved by the sync/object endpoint

### DIFF
--- a/projects/packages/sync/changelog/add-themes-get-objects-by-id
+++ b/projects/packages/sync/changelog/add-themes-get-objects-by-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enable sync/object endpoint support for theme-info

--- a/projects/packages/sync/src/modules/class-themes.php
+++ b/projects/packages/sync/src/modules/class-themes.php
@@ -842,4 +842,21 @@ class Themes extends Module {
 		return 1;
 	}
 
+	/**
+	 * Retrieve a set of constants by their IDs.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type.
+	 * @param array  $ids         Object IDs.
+	 * @return array Array of objects.
+	 */
+	public function get_objects_by_id( $object_type, $ids ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( 'theme-info' !== $object_type ) {
+			return array();
+		}
+
+		return array( $this->get_theme_info() );
+	}
+
 }

--- a/projects/plugins/jetpack/changelog/add-themes-get-objects-by-id
+++ b/projects/plugins/jetpack/changelog/add-themes-get-objects-by-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Sync tests for get_objects_by_id implementation for themes

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Modules;
 
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
@@ -478,5 +479,14 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$upgrader = new Theme_Upgrader( new Silent_Upgrader_Skin() );
 		$upgrader->install( $api->download_link, array( 'overwrite_package' => $overwrite ) );
+	}
+
+	/**
+	 * Verify that all constants are returned by get_objects_by_id.
+	 */
+	public function test_get_objects_by_id() {
+		$module     = Modules::get_module( 'themes' );
+		$theme_info = $module->get_objects_by_id( 'theme-info', array() );
+		$this->assertEquals( $module->expand_theme_data(), $theme_info );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This update allows us to expand the checksum process so that we ensure theme-info is always in sync. It implements get_objects_by_ids for the Themes module that allows for us to retrieve the current value on demand.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Expand sync/object endpoint to include retrieval of theme-info.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Access shell on your WP.com sandbox
2) $jsm = new Jetpack_Sync_Manager( get_current_blog_id() );
3) $jsm->get_sync_objects( 'themes', 'theme-info', array( ) );
4) Verify that theme-info is retrieved

```
array(1) {
  [0]=>
  array(4) {
    ["name"]=>
    string(17) "Twenty Twenty-One"
    ["version"]=>
    string(3) "1.3"
    ["slug"]=>
    string(15) "twentytwentyone"
    ["uri"]=>
    string(45) "https://wordpress.org/themes/twentytwentyone/"
  }
}
```
