### PR TITLE
Allow for updates to be retrieved by the sync/object endpoint

### DIFF
--- a/projects/packages/sync/changelog/add-updates-get-objects-by-id
+++ b/projects/packages/sync/changelog/add-updates-get-objects-by-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enhance updates module to support get_objects_by_id

--- a/projects/packages/sync/src/modules/class-updates.php
+++ b/projects/packages/sync/src/modules/class-updates.php
@@ -524,4 +524,55 @@ class Updates extends Module {
 		return 3;
 	}
 
+	/**
+	 * Retrieve a set of updates by their IDs.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type.
+	 * @param array  $ids         Object IDs.
+	 * @return array Array of objects.
+	 */
+	public function get_objects_by_id( $object_type, $ids ) {
+		if ( empty( $ids ) || empty( $object_type ) || 'update' !== $object_type ) {
+			return array();
+		}
+
+		$objects = array();
+		foreach ( (array) $ids as $id ) {
+			$object = $this->get_object_by_id( $object_type, $id );
+
+			if ( 'all' === $id ) {
+				// If all was requested it contains all updates and can simply be returned.
+				return $object;
+			}
+			$objects[ $id ] = $object;
+		}
+
+		return $objects;
+	}
+
+	/**
+	 * Retrieve a update by its id.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Type of the sync object.
+	 * @param string $id          ID of the sync object.
+	 * @return mixed              Value of Update.
+	 */
+	public function get_object_by_id( $object_type, $id ) {
+		if ( 'update' === $object_type ) {
+
+			// Only whitelisted constants can be returned.
+			if ( in_array( $id, array( 'core', 'plugins', 'themes' ), true ) ) {
+				return get_site_transient( 'update_' . $id );
+			} elseif ( 'all' === $id ) {
+				return $this->get_all_updates();
+			}
+		}
+
+		return false;
+	}
+
 }

--- a/projects/plugins/jetpack/changelog/add-updates-get-objects-by-id
+++ b/projects/plugins/jetpack/changelog/add-updates-get-objects-by-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Sync unit tests for get_object_by_id methods in Updates module

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -278,4 +278,23 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0], 'foo' ); // New version
 	}
+
+	/**
+	 * Verify that all updates are returned by get_objects_by_id.
+	 */
+	public function test_get_objects_by_id_all() {
+		$module      = Modules::get_module( 'updates' );
+		$all_updates = $module->get_objects_by_id( 'update', array( 'all' ) );
+		$this->assertEquals( $module->get_all_updates(), $all_updates );
+	}
+
+	/**
+	 * Verify that get_object_by_id returns an allowed update.
+	 */
+	public function test_get_objects_by_id_singular() {
+		$module      = Modules::get_module( 'updates' );
+		$updates     = $module->get_all_updates();
+		$get_updates = $module->get_objects_by_id( 'update', array( 'core' ) );
+		$this->assertEquals( $updates['core'], $get_updates['core'] );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This implements get_objects_by_ids and get_object_by_id for the Updates module that allows for us to retrieve the current value on demand.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Expand sync/object endpoint to include retrieval of updates.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Access shell on your WP.com sandbox
2) $jsm = new Jetpack_Sync_Manager( get_current_blog_id() );
3) $jsm->get_sync_objects( 'updates', 'update', array( 'all' ) );
4) Verify that updates are retrieved
5) $jsm->get_sync_objects( 'updates', 'update', array( 'blue-bird' ) );
6) Verify that empty array is returned
7) Specify 'plugins', 'core', 'themes'  for ids and verify they are returned.
