### PR TITLE
Shortcodes: YouTube: Correctly handle t value as seconds

### DIFF
--- a/projects/plugins/jetpack/changelog/add-yt-t-arg
+++ b/projects/plugins/jetpack/changelog/add-yt-t-arg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortcodes: Correctly handle YouTube URLs that include a start time.

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -223,20 +223,24 @@ function youtube_id( $url ) {
 	if ( isset( $args['start'] ) ) {
 		$start = (int) $args['start'];
 	} elseif ( isset( $args['t'] ) ) {
-		$time_pieces = preg_split( '/(?<=\D)(?=\d+)/', $args['t'] );
+		if ( is_numeric( $args['t'] ) ) {
+			$start = (int) $args['t'];
+		} else {
+			$time_pieces = preg_split( '/(?<=\D)(?=\d+)/', $args['t'] );
 
-		foreach ( $time_pieces as $time_piece ) {
-			$int = (int) $time_piece;
-			switch ( substr( $time_piece, -1 ) ) {
-				case 'h':
-					$start += $int * 3600;
-					break;
-				case 'm':
-					$start += $int * 60;
-					break;
-				case 's':
-					$start += $int;
-					break;
+			foreach ( $time_pieces as $time_piece ) {
+				$int = (int) $time_piece;
+				switch ( substr( $time_piece, - 1 ) ) {
+					case 'h':
+						$start += $int * 3600;
+						break;
+					case 'm':
+						$start += $int * 60;
+						break;
+					case 's':
+						$start += $int;
+						break;
+				}
 			}
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.youtube.php
@@ -60,6 +60,39 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests options within a YouTube URL as parsed as expected iframe parameters.
+	 *
+	 * @author kraftbj
+	 * @covers ::youtube_id
+	 * @dataProvider get_youtube_id_options
+	 * @since 9.9
+	 *
+	 * @param string $url The YouTube URL.
+	 * @param string $expected The expected iframe parameter output.
+	 */
+	public function test_shortcodes_youtube_id_options( $url, $expected ) {
+		$output = youtube_id( $url );
+
+		$this->assertContains( $expected, $output );
+	}
+
+	/**
+	 * Data provider with various YouTube URLs with the expected iframe parameter.
+	 */
+	public function get_youtube_id_options() {
+		return array(
+			't_as_seconds' => array(
+				'https://youtu.be/o-IvKy3322k?t=10683',
+				'start=10683',
+			),
+			't_as_mixed'   => array(
+				'https://youtu.be/o-IvKy3322k?t=1m1s',
+				'start=61',
+			),
+		);
+	}
+
+	/**
 	 * @author Toro_Unit
 	 * @covers ::youtube_shortcode
 	 * @since 3.9
@@ -74,7 +107,10 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 		wpcom_youtube_embed_crazy_url_init();
 		setup_postdata( $post );
 		ob_start();
+		// This below is needed since Core inserts "loading=lazy" right after the iframe opener.
+		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 		the_content();
+		remove_all_filters( 'wp_lazy_loading_enabled' );
 		$actual = ob_get_clean();
 		wp_reset_postdata();
 		$this->assertContains( '<span class="embed-youtube"', $actual );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Note: This merges into the embed double-quote branch to prevent merge conflict.

Fixes situation where an URL like https://youtu.be/o-IvKy3322k?t=10683 does not render as an embed that starts at the expected timestamp.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Handles t values whether it is in seconds or "mixed" (`2m30`).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1623433589233700-slack-C029LRAU2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unit Tests
* Connected Jetpack, enable the Shortcodes module so Jetpack takes over YouTube oembed from Core.
* Insert https://youtu.be/o-IvKy3322k?t=10683 to a post. Before this patch, it'll start at 0:00. After, it'll start at the proper time.