### PR TITLE
Backup: 0.1.0-beta changelog

### DIFF
--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## 0.3.0 - 2021-06-15
+### Added
+- Added dev dependency on react (in addition to existing peer dep) for tests to run.
+- Added missing dependencies.
+
+### Changed
+- Getting rid of the 'authorizeUrl' parameter, retrieving the value via REST API, and extrating the user connection functionality into a separate 'ConnectUser' component.
+
 ## 0.2.0 - 2021-05-25
 ### Added
 - Add connection components.
@@ -14,5 +22,6 @@
 - `InPlaceConnection` component added.
 
 ## 0.2.0 - 2021-05-18
+
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.

--- a/projects/js-packages/connection/changelog/feature-replace-yarn-1-with-pnpm
+++ b/projects/js-packages/connection/changelog/feature-replace-yarn-1-with-pnpm
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added missing dependencies.

--- a/projects/js-packages/connection/changelog/fix-url-dependency-issue
+++ b/projects/js-packages/connection/changelog/fix-url-dependency-issue
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed the npm dependency issue.
-
-

--- a/projects/js-packages/connection/changelog/remove-unneeded-monorepo-deps
+++ b/projects/js-packages/connection/changelog/remove-unneeded-monorepo-deps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added dev dependency on react (in addition to existing peer dep) for tests to run.

--- a/projects/js-packages/connection/changelog/update-refactor-rna-connection
+++ b/projects/js-packages/connection/changelog/update-refactor-rna-connection
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Getting rid of the 'authorizeUrl' parameter, retrieving the value via REST API, and extrating the user connection functionality into a separate 'ConnectUser' component.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.3.0-alpha",
+	"version": "0.3.0",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/connection-ui/CHANGELOG.md
+++ b/projects/packages/connection-ui/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2021-06-15
+### Changed
+- Remove the 'authorizeUrl' RNA Connection parameter as it's no longer needed.
+- Update docs to replace yarn with pnpm.
+
+### Fixed
+- Remove dependency on @wordpress/url as it caused dependency issues in build test flows.
+- Use `absoluteRuntime` in babel JS build to avoid module not found errors.
+
 ## [1.1.0] - 2021-05-25
 ### Added
 - Integrate the connection flow using RNA Connection package.
@@ -35,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Connection UI: Building the Framework
 
+[1.1.1]: https://github.com/Automattic/jetpack-connection-ui/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Automattic/jetpack-connection-ui/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/Automattic/jetpack-connection-ui/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Automattic/jetpack-connection-ui/compare/v1.0.0...v1.0.1

--- a/projects/packages/connection-ui/changelog/feature-replace-yarn-1-with-pnpm
+++ b/projects/packages/connection-ui/changelog/feature-replace-yarn-1-with-pnpm
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update docs to replace yarn with pnpm.

--- a/projects/packages/connection-ui/changelog/fix-babel-transform-runtime-absoluteRuntime
+++ b/projects/packages/connection-ui/changelog/fix-babel-transform-runtime-absoluteRuntime
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Use `absoluteRuntime` in babel JS build to avoid module not found errors.

--- a/projects/packages/connection-ui/changelog/fix-url-dependency-issue
+++ b/projects/packages/connection-ui/changelog/fix-url-dependency-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Remove dependency on @wordpress/url as it caused dependency issues in build test flows.

--- a/projects/packages/connection-ui/changelog/update-refactor-rna-connection
+++ b/projects/packages/connection-ui/changelog/update-refactor-rna-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove the 'authorizeUrl' RNA Connection parameter as it's no longer needed.

--- a/projects/packages/connection-ui/changelog/update-use-identity-crisis-package
+++ b/projects/packages/connection-ui/changelog/update-use-identity-crisis-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: composer version update.
-
-

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "1.1.1-alpha",
+	"version": "1.1.1",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-connection-ui",

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.28.0] - 2021-06-15
+### Added
+- Added Urls class, migrated from Sync Functions.
+- Adding new REST endpoint /jetpack/v4/user-token that allows us to add/update user tokens remotely.
+- Add new 'connection/authorize_url' endpoint.
+- Adds information received from the server to the register_site REST response.
+- Enable site-level authentication (blog token) for REST API endpoints.
+- Move 'connection/owner' endpoint to Connection package.
+
 ## [1.27.0] - 2021-05-25
 ### Added
 - Add "isUserConnected" to the connection status data.
@@ -361,6 +370,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[1.28.0]: https://github.com/Automattic/jetpack-connection/compare/v1.27.0...v1.28.0
 [1.27.0]: https://github.com/Automattic/jetpack-connection/compare/v1.26.0...v1.27.0
 [1.26.0]: https://github.com/Automattic/jetpack-connection/compare/v1.25.2...v1.26.0
 [1.25.2]: https://github.com/Automattic/jetpack-connection/compare/v1.25.1...v1.25.2

--- a/projects/packages/connection/changelog/add-purchase-token-endpoints
+++ b/projects/packages/connection/changelog/add-purchase-token-endpoints
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Enable site-level authentication (blog token) for REST API endpoints

--- a/projects/packages/connection/changelog/add-user-token-restore
+++ b/projects/packages/connection/changelog/add-user-token-restore
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Adding new REST endpoint /jetpack/v4/user-token that allows us to add/update user tokens remotely.

--- a/projects/packages/connection/changelog/fix-use-santized-variable
+++ b/projects/packages/connection/changelog/fix-use-santized-variable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: fix from something forgotten on #19833
-
-

--- a/projects/packages/connection/changelog/update-decouple_register_and_authorize
+++ b/projects/packages/connection/changelog/update-decouple_register_and_authorize
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Adds information received from the server to the register_site REST response

--- a/projects/packages/connection/changelog/update-move-connection-owner-endpoint
+++ b/projects/packages/connection/changelog/update-move-connection-owner-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Move 'connection/owner' endpoint to Connection package.

--- a/projects/packages/connection/changelog/update-refactor-rna-connection
+++ b/projects/packages/connection/changelog/update-refactor-rna-connection
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add new 'connection/authorize_url' endpoint.

--- a/projects/packages/connection/changelog/update-use-identity-crisis-package
+++ b/projects/packages/connection/changelog/update-use-identity-crisis-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added Urls class, migrated from Sync Functions.

--- a/projects/packages/heartbeat/CHANGELOG.md
+++ b/projects/packages/heartbeat/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.8] - 2021-06-15
+### Changed
+- Updated package dependencies.
+
 ## [1.3.7] - 2021-05-25
 ### Fixed
 - Fixed new PHPCS errors.
@@ -64,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use new heartbeat package
 - Creates the Jetpack Heartbeat package
 
+[1.3.8]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.3.7...v1.3.8
 [1.3.7]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.3.6...v1.3.7
 [1.3.6]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.3.5...v1.3.6
 [1.3.5]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.3.4...v1.3.5

--- a/projects/packages/heartbeat/changelog/add-purchase-token-endpoints
+++ b/projects/packages/heartbeat/changelog/add-purchase-token-endpoints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -4,3 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 - 2021-06-15
+### Added
+- Sync: Adding the Identity_Crisis package.
+
+### Changed
+- Updated package dependencies.
+- Use Connection/Urls for home_url and site_url functions migrated from Sync.

--- a/projects/packages/identity-crisis/changelog/add-identity-crisis-package
+++ b/projects/packages/identity-crisis/changelog/add-identity-crisis-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Sync: Adding the Identity_Crisis package.

--- a/projects/packages/identity-crisis/changelog/add-purchase-token-endpoints
+++ b/projects/packages/identity-crisis/changelog/add-purchase-token-endpoints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/changelog/bump-can-i-use
+++ b/projects/packages/identity-crisis/changelog/bump-can-i-use
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Bumped caniuse db for dev
-
-

--- a/projects/packages/identity-crisis/changelog/feature-replace-yarn-1-with-pnpm
+++ b/projects/packages/identity-crisis/changelog/feature-replace-yarn-1-with-pnpm
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Switch to pnpm
-
-

--- a/projects/packages/identity-crisis/changelog/update-hosted-git-info-dep
+++ b/projects/packages/identity-crisis/changelog/update-hosted-git-info-dep
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Dependencies: update hosted-git-info
-
-

--- a/projects/packages/identity-crisis/changelog/update-refactor-rna-connection
+++ b/projects/packages/identity-crisis/changelog/update-refactor-rna-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/changelog/update-use-identity-crisis-package
+++ b/projects/packages/identity-crisis/changelog/update-use-identity-crisis-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Use Connection/Urls for home_url and site_url functions migrated from Sync.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-identity-crisis",

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -27,7 +27,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/options/CHANGELOG.md
+++ b/projects/packages/options/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2021-06-15
+### Changed
+- Added 'purchaseToken' option for logged out user purchases on WordPress.com.
+
 ## [1.12.1] - 2021-05-25
 ### Changed
 - Updated package dependencies.
@@ -107,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[1.13.0]: https://github.com/Automattic/jetpack-options/compare/v1.12.1...v1.13.0
 [1.12.1]: https://github.com/Automattic/jetpack-options/compare/v1.12.0...v1.12.1
 [1.12.0]: https://github.com/Automattic/jetpack-options/compare/v1.11.4...v1.12.0
 [1.11.4]: https://github.com/Automattic/jetpack-options/compare/v1.11.3...v1.11.4

--- a/projects/packages/options/changelog/add-purchase-token-endpoints
+++ b/projects/packages/options/changelog/add-purchase-token-endpoints
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Added 'purchase_token' option for logged-out user purchases on WordPress.com

--- a/projects/packages/options/changelog/try-add-jetpack-purchase-token
+++ b/projects/packages/options/changelog/try-add-jetpack-purchase-token
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Added 'purchaseToken' option for logged out user purchases on WordPress.com.

--- a/projects/packages/redirect/CHANGELOG.md
+++ b/projects/packages/redirect/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2021-06-15
+### Changed
+- Updated package dependencies.
+
 ## [1.6.0] - 2021-05-25
 ### Removed
 - Removed filter from the final Redirect URL
@@ -70,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create Jetpack Redirect package
 
+[1.6.1]: https://github.com/Automattic/jetpack-redirect/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/Automattic/jetpack-redirect/compare/v1.5.5...v1.6.0
 [1.5.5]: https://github.com/Automattic/jetpack-redirect/compare/v1.5.4...v1.5.5
 [1.5.4]: https://github.com/Automattic/jetpack-redirect/compare/v1.5.3...v1.5.4

--- a/projects/packages/redirect/changelog/update-use-identity-crisis-package
+++ b/projects/packages/redirect/changelog/update-use-identity-crisis-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2021-06-15
+### Changed
+- Update callback to Jetpack to new Identity_Crisis class.
+
 ## [1.7.6] - 2021-05-25
 ### Changed
 - Updated package dependencies.
@@ -98,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[1.8.0]: https://github.com/Automattic/jetpack-status/compare/v1.7.6...v1.8.0
 [1.7.6]: https://github.com/Automattic/jetpack-status/compare/v1.7.5...v1.7.6
 [1.7.5]: https://github.com/Automattic/jetpack-status/compare/v1.7.4...v1.7.5
 [1.7.4]: https://github.com/Automattic/jetpack-status/compare/v1.7.3...v1.7.4

--- a/projects/packages/status/changelog/update-use-identity-crisis-package
+++ b/projects/packages/status/changelog/update-use-identity-crisis-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update callback to Jetpack to new Identity_Crisis class

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.0] - 2021-06-15
+### Changed
+- Sync: Adding the Identity_Crisis package.
+- Updated package dependencies.
+
+### Deprecated
+- Deprecated URL methods in `Automattic\Jetpack\Sync\Functions` in favor of `Automattic\Jetpack\Connection\Urls`.
+
 ## [1.21.3] - 2021-05-25
 ### Changed
 - Performance: If no Full Sync is in process early return before we update options.
@@ -384,6 +392,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.22.0]: https://github.com/Automattic/jetpack-sync/compare/v1.21.3...v1.22.0
 [1.21.3]: https://github.com/Automattic/jetpack-sync/compare/v1.21.2...v1.21.3
 [1.21.2]: https://github.com/Automattic/jetpack-sync/compare/v1.21.1...v1.21.2
 [1.21.1]: https://github.com/Automattic/jetpack-sync/compare/v1.21.0...v1.21.1

--- a/projects/packages/sync/changelog/add-identity-crisis-package
+++ b/projects/packages/sync/changelog/add-identity-crisis-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Sync: Adding the Identity_Crisis package.

--- a/projects/packages/sync/changelog/add-purchase-token-endpoints
+++ b/projects/packages/sync/changelog/add-purchase-token-endpoints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/sync/changelog/update-refactor-rna-connection
+++ b/projects/packages/sync/changelog/update-refactor-rna-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/sync/changelog/update-use-identity-crisis-package
+++ b/projects/packages/sync/changelog/update-use-identity-crisis-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Deprecated URL methods in `Automattic\Jetpack\Sync\Functions` in favor of `Automattic\Jetpack\Connection\Urls`.

--- a/projects/packages/terms-of-service/CHANGELOG.md
+++ b/projects/packages/terms-of-service/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.8] - 2021-06-15
+- Updated package dependencies.
+
 ## [1.9.7] - 2021-05-25
 ### Changed
 - Updated package dependencies.
@@ -134,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Package: Create new TOS package
 
+[1.9.8]: https://github.com/Automattic/jetpack-terms-of-service/compare/v1.9.7...v1.9.8
 [1.9.7]: https://github.com/Automattic/jetpack-terms-of-service/compare/v1.9.6...v1.9.7
 [1.9.6]: https://github.com/Automattic/jetpack-terms-of-service/compare/v1.9.5...v1.9.6
 [1.9.5]: https://github.com/Automattic/jetpack-terms-of-service/compare/v1.9.4...v1.9.5

--- a/projects/packages/terms-of-service/changelog/add-purchase-token-endpoints
+++ b/projects/packages/terms-of-service/changelog/add-purchase-token-endpoints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/terms-of-service/changelog/update-use-identity-crisis-package
+++ b/projects/packages/terms-of-service/changelog/update-use-identity-crisis-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/tracking/CHANGELOG.md
+++ b/projects/packages/tracking/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.7] - 2021-06-15
+### Changed
+- Updated package dependencies.
+
 ## [1.13.6] - 2021-05-25
 ### Added
 - Adding the tracks-callables.js file to the Tracking package.
@@ -145,6 +149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create package for Jetpack Tracking
 
+[1.13.7]: https://github.com/Automattic/jetpack-tracking/compare/v1.13.6...v1.13.7
 [1.13.6]: https://github.com/Automattic/jetpack-tracking/compare/v1.13.5...v1.13.6
 [1.13.5]: https://github.com/Automattic/jetpack-tracking/compare/v1.13.4...v1.13.5
 [1.13.4]: https://github.com/Automattic/jetpack-tracking/compare/v1.13.3...v1.13.4

--- a/projects/packages/tracking/changelog/add-purchase-token-endpoints
+++ b/projects/packages/tracking/changelog/add-purchase-token-endpoints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/tracking/changelog/update-use-identity-crisis-package
+++ b/projects/packages/tracking/changelog/update-use-identity-crisis-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/backup/CHANGELOG.md
+++ b/projects/plugins/backup/CHANGELOG.md
@@ -5,3 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0-beta - 2021-06-15
+### Added
+- Added RNA connection to the plugin.
+- Initial wire frame for the Jetpack Backup plugin.
+
+### Changed
+- Changes associated with plugin release process.
+- Updated package dependencies.
+- Update RNA Connection usage based on Automattic/jetpack/pull/19837.
+- Utilize the config package for sync and connection.
+
+### Fixed
+- Use `absoluteRuntime` in babel JS build to avoid module not found errors.

--- a/projects/plugins/backup/changelog/add-jetpack-backup-plugin-demo
+++ b/projects/plugins/backup/changelog/add-jetpack-backup-plugin-demo
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Initial wire frame for the Jetpack Backup plugin.

--- a/projects/plugins/backup/changelog/add-license-info
+++ b/projects/plugins/backup/changelog/add-license-info
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Added license to build process
-
-

--- a/projects/plugins/backup/changelog/add-purchase-token-endpoints
+++ b/projects/plugins/backup/changelog/add-purchase-token-endpoints
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/add-rna-connection
+++ b/projects/plugins/backup/changelog/add-rna-connection
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated requirements.

--- a/projects/plugins/backup/changelog/bump-can-i-use
+++ b/projects/plugins/backup/changelog/bump-can-i-use
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Bumped caniuse db for dev
-
-

--- a/projects/plugins/backup/changelog/bump-to-5.7
+++ b/projects/plugins/backup/changelog/bump-to-5.7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Bump to 5.7 minimum WP supported version
-
-

--- a/projects/plugins/backup/changelog/feature-replace-yarn-1-with-pnpm
+++ b/projects/plugins/backup/changelog/feature-replace-yarn-1-with-pnpm
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Switch to pnpm
-
-

--- a/projects/plugins/backup/changelog/fix-babel-transform-runtime-absoluteRuntime
+++ b/projects/plugins/backup/changelog/fix-babel-transform-runtime-absoluteRuntime
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Use `absoluteRuntime` in babel JS build to avoid module not found errors.

--- a/projects/plugins/backup/changelog/fix-changelogger-in-subdir
+++ b/projects/plugins/backup/changelog/fix-changelogger-in-subdir
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/backup/changelog/fix-url-dependency-issue
+++ b/projects/plugins/backup/changelog/fix-url-dependency-issue
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Lock file updated.
-
-

--- a/projects/plugins/backup/changelog/remove-unneeded-monorepo-deps
+++ b/projects/plugins/backup/changelog/remove-unneeded-monorepo-deps
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add @wordpress/browserslist-config entry to package.json
-
-

--- a/projects/plugins/backup/changelog/renovate-react-monorepo
+++ b/projects/plugins/backup/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/plugins/backup/changelog/try-backup-plugin-release
+++ b/projects/plugins/backup/changelog/try-backup-plugin-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Changes associated with plugin release process.

--- a/projects/plugins/backup/changelog/update-backup-add-config-pkg
+++ b/projects/plugins/backup/changelog/update-backup-add-config-pkg
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Utilize the config package for sync and connection.

--- a/projects/plugins/backup/changelog/update-backup-plugin-add-connection
+++ b/projects/plugins/backup/changelog/update-backup-plugin-add-connection
@@ -1,4 +1,0 @@
-Significance: major
-Type: added
-
-Added RNA connection to the plugin.

--- a/projects/plugins/backup/changelog/update-backup-plugin-rna-connection
+++ b/projects/plugins/backup/changelog/update-backup-plugin-rna-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update RNA Connection usage based on Automattic/jetpack/pull/19837

--- a/projects/plugins/backup/changelog/update-decouple_register_and_authorize
+++ b/projects/plugins/backup/changelog/update-decouple_register_and_authorize
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-updated composer.lock

--- a/projects/plugins/backup/changelog/update-refactor-rna-connection
+++ b/projects/plugins/backup/changelog/update-refactor-rna-connection
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Refreshed yarn.lock to update the RNA Connection package.
-
-

--- a/projects/plugins/backup/changelog/update-use-identity-crisis-package
+++ b/projects/plugins/backup/changelog/update-use-identity-crisis-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated deps
-
-

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -41,7 +41,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ0_1_0_alpha"
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ0_1_0_beta"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-backup-plugin",

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Backup
  * Plugin URI: https://jetpack.com/jetpack-backup
  * Description: Easily restore or download a backup of your site from a specific moment in time.
- * Version: 0.1.0-alpha
+ * Version: 0.1.0-beta
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -33,8 +33,19 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
+### 0.1.0-beta - 2021-06-15
+#### Added
+- Added RNA connection to the plugin.
+- Initial wire frame for the Jetpack Backup plugin.
 
-<!-- When you do a release, use the monorepo script tools/plugin-changelog-to-readme.sh to copy from CHANGELOG.md to here. -->
+#### Changed
+- Changes associated with plugin release process.
+- Updated package dependencies.
+- Update RNA Connection usage based on Automattic/jetpack/pull/19837.
+- Utilize the config package for sync and connection.
+
+#### Fixed
+- Use `absoluteRuntime` in babel JS build to avoid module not found errors.
 
 == Arbitrary section ==
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Follow-up to #20061 testing beta release process for Jetpack Backup plugin.

#### Jetpack product discussion

* Internal: p1HpG7-b9F-p2

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

* `tools/changelogger-release.sh -b plugins/backup` has been run, review updated changelogs and `projects/plugins/backup/readme.txt` for accuracy.
* Observe that `projects/plugins/backup/composer.json` has updated `autoloader-suffix` with correct version.
* Once merged, next step will be creating the beta release branch using `tools/create-release-branch.sh`