### PR TITLE
Plugin API: Only use should_update if we are trying to autoupdate

### DIFF
--- a/projects/plugins/jetpack/changelog/kraftbj-patch-2-autoupdate
+++ b/projects/plugins/jetpack/changelog/kraftbj-patch-2-autoupdate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+API: properly allow requests to upgrade a plugin outside of autoupdates.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -341,8 +341,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				continue;
 			}
 
-			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated.
-			if ( ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $update_plugins->response[ $plugin ], WP_PLUGIN_DIR ) ) {
+			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated if it is a Jetpack autoupdate request.
+			if ( Constants::get_constant( 'JETPACK_PLUGIN_AUTOUPDATE' ) && ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $update_plugins->response[ $plugin ], WP_PLUGIN_DIR ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes p9dueE-340-p2

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Only check autoupdate requirements if it is an autoupdate attempt.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1623790405112000-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try upgrading a plugin via the mobile app ( see p9dueE-340-p2 )
* Separately, mark a plugin as autoupdatable, and ensure there is a new version (manually lower the version if needed). Does it still autoupdate correctly?