### PR TITLE
Search: Fix render-breaking typo for Expanded search results

### DIFF
--- a/projects/plugins/jetpack/changelog/add-gutenberg-search-configurator
+++ b/projects/plugins/jetpack/changelog/add-gutenberg-search-configurator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: Fix render-breaking typo for Expanded search results

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.jsx
@@ -67,7 +67,7 @@ export default function SearchResultExpanded( props ) {
 						<PhotonImage
 							alt={ highlight.title }
 							className="jetpack-instant-search__search-result-expanded__image"
-							isPhotonEnabled={ this.props.isPhotonEnabled }
+							isPhotonEnabled={ props.isPhotonEnabled }
 							src={ `//${ firstImage }` }
 						/>
 					) : null }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Fixes a render-breaking bug for Expanded search results with Photonized images.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Ensure that you've enabled Photon ("Site Accelerator") via `/wp-admin/admin.php?page=jetpack#/performance`.
* Enable Expanded search results via the Jetpack Search section in the Customizer.
* Perform a search. Ensure that there are no render breaking error logs in the console.