### PR TITLE
tools: Set `-c core.quotepath=off` to various git diff, ls-files, and check-attr

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -163,12 +163,12 @@ for SLUG in "${SLUGS[@]}"; do
 	# Copy only wanted files, based on .gitignore and .gitattributes.
 	{
 		# Include unignored files by default.
-		git ls-files
+		git -c core.quotepath=off ls-files
 		# Include ignored files that are tagged as production-include.
-		git ls-files --others --ignored --exclude-standard | git check-attr --stdin production-include | sed -n 's/: production-include: \(unspecified\|unset\)$//;t;s/: production-include: .*//p'
+		git -c core.quotepath=off ls-files --others --ignored --exclude-standard | git -c core.quotepath=off check-attr --stdin production-include | sed -n 's/: production-include: \(unspecified\|unset\)$//;t;s/: production-include: .*//p'
 	} |
 		# Remove all files tagged with production-exclude. This can override production-include.
-		git check-attr --stdin production-exclude | sed -n 's/: production-exclude: \(unspecified\|unset\)$//p' |
+		git -c core.quotepath=off check-attr --stdin production-exclude | sed -n 's/: production-exclude: \(unspecified\|unset\)$//p' |
 		# Copy the resulting list of files into the clone.
 		xargs cp --parents --target-directory="$BUILD_DIR"
 

--- a/.github/files/check-lock-files.sh
+++ b/.github/files/check-lock-files.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 BASE="$PWD"
 
 EXIT=0
-for FILE in $(git ls-files 'composer.lock' '**/composer.lock'); do
+for FILE in $(git -c core.quotepath=off ls-files 'composer.lock' '**/composer.lock'); do
 	DIR="$(dirname "$FILE")"
 	cd "$DIR"
 	echo "::group::$FILE - composer install"
@@ -23,7 +23,7 @@ for FILE in $(git ls-files 'composer.lock' '**/composer.lock'); do
 	cd "$BASE"
 done
 
-for FILE in $(git ls-files 'pnpm-lock.yaml' '**/pnpm-lock.yaml'); do
+for FILE in $(git -c core.quotepath=off ls-files 'pnpm-lock.yaml' '**/pnpm-lock.yaml'); do
 	cd $(dirname "$FILE")
 	echo "::group::$FILE - pnpm install"
 	pnpm install

--- a/.github/files/check-monorepo-package-repos.sh
+++ b/.github/files/check-monorepo-package-repos.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 EXIT=0
-for FILE in $(git ls-files '**/composer.json'); do
+for FILE in $(git -c core.quotepath=off ls-files '**/composer.json'); do
 	if jq -e '.repositories[]? | select( .type == "path" and ( .url | startswith( "../" ) ) and ( .options?.monorepo? | not ) )' "$FILE" &>/dev/null; then
 		EXIT=1
 		LINE=$(grep --line-number --max-count=1 '^	"repositories":' "$FILE")

--- a/.github/files/list-changed-projects.php
+++ b/.github/files/list-changed-projects.php
@@ -113,7 +113,7 @@ function get_changed_projects() {
 
 	$pipes = null;
 	$p     = proc_open(
-		sprintf( 'git diff --no-renames --name-only %s...%s', escapeshellarg( $base ), escapeshellarg( $head ) ),
+		sprintf( 'git -c core.quotepath=off diff --no-renames --name-only %s...%s', escapeshellarg( $base ), escapeshellarg( $head ) ),
 		array( array( 'pipe', 'r' ), array( 'pipe', 'w' ), STDERR ),
 		$pipes
 	);

--- a/.github/files/renovate-helper.sh
+++ b/.github/files/renovate-helper.sh
@@ -83,7 +83,7 @@ CL="$BASE/projects/packages/changelogger/bin/changelogger"
 echo "::endgroup::"
 
 ANY=false
-for DIR in $(git diff --name-only "$BASE_REF"..."$HEAD_REF" | sed -nE 's!^(projects/[^/]+/[^/]+)/.*!\1!p' | sort -u); do
+for DIR in $(git -c core.quotepath=off diff --name-only "$BASE_REF"..."$HEAD_REF" | sed -nE 's!^(projects/[^/]+/[^/]+)/.*!\1!p' | sort -u); do
 	ANY=true
 	SLUG="${DIR#projects/}"
 	echo "::group::Adding change file for $SLUG"

--- a/.github/files/require-change-file-for-touched-projects.php
+++ b/.github/files/require-change-file-for-touched-projects.php
@@ -73,7 +73,7 @@ $head = $event->pull_request->head->sha;
 debug( 'Checking diff from %s...%s.', $base, $head );
 $pipes = null;
 $p     = proc_open(
-	sprintf( 'git diff --no-renames --name-only %s...%s', escapeshellarg( $base ), escapeshellarg( $head ) ),
+	sprintf( 'git -c core.quotepath=off diff --no-renames --name-only %s...%s', escapeshellarg( $base ), escapeshellarg( $head ) ),
 	array( array( 'pipe', 'r' ), array( 'pipe', 'w' ), STDERR ),
 	$pipes
 );

--- a/tools/check-composer-deps.sh
+++ b/tools/check-composer-deps.sh
@@ -123,7 +123,7 @@ for SLUG in "${SLUGS[@]}"; do
 			changelogger "$SLUG" 'Updated package dependencies.'
 			DIDCL=true
 		fi
-		if [[ -n "$(git ls-files "projects/$SLUG/composer.lock")" ]]; then
+		if [[ -n "$(git -c core.quotepath=off ls-files "projects/$SLUG/composer.lock")" ]]; then
 			PROJECTFOLDER="$BASE/projects/$SLUG"
 			cd "$PROJECTFOLDER"
 			debug "Updating $SLUG composer.lock"

--- a/tools/check-copied-files.sh
+++ b/tools/check-copied-files.sh
@@ -137,7 +137,7 @@ compare readme.md projects/plugins/jetpack/readme.md '^## Security' '^<!-- end s
 compare projects/packages/identity-crisis/src/scss/functions/colors.scss projects/plugins/jetpack/_inc/client/scss/functions/colors.scss
 compare projects/packages/identity-crisis/src/scss/variables/_colors.scss projects/plugins/jetpack/_inc/client/scss/variables/_colors.scss
 
-for f in $(git ls-files '**/package.json'); do
+for f in $(git -c core.quotepath=off ls-files '**/package.json'); do
 	compareJSON package.json "$f" '.engines'
 done
 

--- a/tools/cli/commands/clean.js
+++ b/tools/cli/commands/clean.js
@@ -209,13 +209,13 @@ async function collectAllFiles( toClean, argv ) {
 
 	if ( toClean.includes( 'untracked' ) ) {
 		allFiles.untracked = child_process.execSync(
-			`git ls-files ${ argv.project } --exclude-standard --directory --other`
+			`git -c core.quotepath=off ls-files ${ argv.project } --exclude-standard --directory --other`
 		);
 		allFiles.untracked = allFiles.untracked.toString().trim().split( '\n' );
 	}
 
 	allFiles.combined = child_process.execSync(
-		`git ls-files ${ argv.project } --exclude-standard --directory --ignored --other`
+		`git -c core.quotepath=off ls-files ${ argv.project } --exclude-standard --directory --ignored --other`
 	);
 	allFiles.combined = allFiles.combined.toString().trim().split( '\n' );
 	for ( const file of allFiles.combined ) {

--- a/tools/git-hooks/post-merge-checkout-hook.sh
+++ b/tools/git-hooks/post-merge-checkout-hook.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-changedFiles="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+changedFiles="$(git -c core.quotepath=off diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
 
 runOnChange() {
 	echo "$changedFiles" | grep -q "^$1" && echo -e "$2"
 }
 
 runOnChange 'pnpm-lock.yaml\|composer.lock' "A lock file has changed. Consider updating your working copy by running: jetpack install -r"
-for f in $(git ls-files '**/composer.lock'); do
+for f in $(git -c core.quotepath=off ls-files '**/composer.lock'); do
 	slug="${f#projects/}"
 	slug="${slug%/composer.lock}"
 	runOnChange "$f" "$f has changed. Consider updating your working copy by running: jetpack install $slug"

--- a/tools/git-hooks/pre-commit-hook.js
+++ b/tools/git-hooks/pre-commit-hook.js
@@ -119,11 +119,11 @@ function sortPackageJson( jsFiles ) {
 }
 
 const gitFiles = parseGitDiffToPathArray(
-	'git diff --cached --name-only --diff-filter=ACM'
+	'git -c core.quotepath=off diff --cached --name-only --diff-filter=ACM'
 ).filter( Boolean );
-const dirtyFiles = parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ).filter(
-	Boolean
-);
+const dirtyFiles = parseGitDiffToPathArray(
+	'git -c core.quotepath=off diff --name-only --diff-filter=ACM'
+).filter( Boolean );
 const jsFiles = gitFiles.filter( filterJsFiles );
 const phpFiles = gitFiles.filter( name => name.endsWith( '.php' ) );
 const phpcsFiles = phpFiles.filter( phpcsFilesToFilter );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Otherwise git will quote and escape filenames that include Unicode,
which generally isn't what our scripts are expecting.

See https://github.com/Automattic/jetpack/pull/20085/checks?check_run_id=2834404562#step:9:27 for an example of what this fixes.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Do the scripts work if you arrange for them to work on files with Unicode in their names?