### PR TITLE
Nav Unification: Remove "Jetpack > Settings" submenu

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-nav-unification-jetpack-submenus-atomic
+++ b/projects/plugins/jetpack/changelog/remove-nav-unification-jetpack-submenus-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This only affects WP.com sites
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -457,7 +457,6 @@ class Admin_Menu extends Base_Admin_Menu {
 		/* translators: Jetpack sidebar menu item. */
 		add_submenu_page( 'jetpack', esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'manage_options', 'https://wordpress.com/jetpack-search/' . $this->domain, null, 4 );
 
-		$this->hide_submenu_page( 'jetpack', 'jetpack#/dashboard' );
 		$this->hide_submenu_page( 'jetpack', 'jetpack#/settings' );
 		$this->hide_submenu_page( 'jetpack', 'stats' );
 		$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -455,8 +455,10 @@ class Admin_Menu extends Base_Admin_Menu {
 		add_submenu_page( 'jetpack', esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, 2 );
 		add_submenu_page( 'jetpack', esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 3 );
 		/* translators: Jetpack sidebar menu item. */
-		add_submenu_page( 'jetpack', esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'read', 'https://wordpress.com/jetpack-search/' . $this->domain, null, 4 );
+		add_submenu_page( 'jetpack', esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'manage_options', 'https://wordpress.com/jetpack-search/' . $this->domain, null, 4 );
 
+		$this->hide_submenu_page( 'jetpack', 'jetpack#/dashboard' );
+		$this->hide_submenu_page( 'jetpack', 'jetpack#/settings' );
 		$this->hide_submenu_page( 'jetpack', 'stats' );
 		$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
 		$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/51342

#### Changes proposed in this Pull Request:
The _Jetpack_ menu currently contains a _Settings_ submenu which are redundant for WP.com sites, since the options that can be managed from that page can be already managed from other WP.com pages:
Jetpack page | WP.com page
--- | ---
Jetpack > Settings > Security | Settings > General > Security
Jetpack > Settings > Performance | Settings > General > Performance
Jetpack > Settings > Writing | Settings > General > Writing (as of https://github.com/Automattic/wp-calypso/pull/53656)
Jetpack > Settings > Sharing > Publicize | Tools > Marketing > Connections (as of https://github.com/Automattic/wp-calypso/pull/53630)
Jetpack > Settings > Sharing > Sharing | Tools > Marketing > Sharing buttons (as of https://github.com/Automattic/wp-calypso/pull/53632)
Jetpack > Settings > Sharing > Like | Tools > Marketing > Sharing buttons > Show like button
Jetpack > Settings > Discussion | Settings > General > Discussion
Jetpack > Settings > Traffic | Tools > Marketing > Traffic
Jetpack > Settings > Traffic > Ads | Tools > Earn > View ad dashboard > Settings (as of https://github.com/Automattic/wp-calypso/pull/53736)

To simplify the experience for Atomic users and bring the Jetpack menu closer to Simple sites, this PR removes that submenu so the settings are managed only from one single place.

This PR also includes a minor change for the Jetpack > Search menu so it only appears for users who can actually purchase the upgrade.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Install Jetpack Beta on Atomic site and activate the branch of this PR.
* Inspect the sidebar menu.
* Make sure the _Jetpack_ menu does not include the _Settings_ submenu.
* Make sure the _Jetpack_ menu does not include the _Search_ submenu for non-admins.
