### PR TITLE
Beta: Soft-require Markdown

### DIFF
--- a/projects/plugins/beta/changelog/update-beta-no-jetpack-dev
+++ b/projects/plugins/beta/changelog/update-beta-no-jetpack-dev
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Load markdown library from either a dev or stable version of Jetpack.

--- a/projects/plugins/beta/class-jetpack-beta-admin.php
+++ b/projects/plugins/beta/class-jetpack-beta-admin.php
@@ -247,7 +247,7 @@ class Jetpack_Beta_Admin {
 		}
 
 		if ( ! class_exists( 'WPCom_Markdown' ) ) {
-			return $content;
+			return apply_filters( 'jetpack_beta_test_content', $content );
 		}
 		$rendered_html = WPCom_Markdown::get_instance()->transform(
 			$content,

--- a/projects/plugins/beta/class-jetpack-beta-admin.php
+++ b/projects/plugins/beta/class-jetpack-beta-admin.php
@@ -241,7 +241,13 @@ class Jetpack_Beta_Admin {
 
 		jetpack_require_lib( 'markdown' );
 		if ( ! class_exists( 'WPCom_Markdown' ) ) {
-			require_once WP_PLUGIN_DIR . '/' . Jetpack_Beta::get_plugin_slug() . '/modules/markdown/easy-markdown.php';
+			if ( ! include_once WP_PLUGIN_DIR . '/' . Jetpack_Beta::get_plugin_slug() . '/modules/markdown/easy-markdown.php' ) {
+				include_once WP_PLUGIN_DIR . '/jetpack/modules/markdown/easy-markdown.php';
+			};
+		}
+
+		if ( ! class_exists( 'WPCom_Markdown' ) ) {
+			return $content;
 		}
 		$rendered_html = WPCom_Markdown::get_instance()->transform(
 			$content,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

If the Jetpack plugin is active (in the 'jetpack' directory) and there is not a beta version yet downloaded (thus the `jetpack-dev` directory does not exist), the Beta plugin will fatal due to the inability to include the markdown directory.

We'll need to soon probably package Markdown processing within the beta plugin itself to make it usable for non-Jetpack plugins, so this is a shim to prevent the fatal before the deeper dive.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Load markdown from either a beta or stable version of Jetpack.
* If neither, return the content.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Within our Docker setup, have Jetpack and the Beta plugin active.
* Ensure in `tools/docker/wordpress/wp-content/plugins` there is no `jetpack-dev dir.
* Load the Jetpack beta page. Scroll to the bottom. Without patch, see "critical error" message. With patch, no error and there's testing help outputted.
