### PR TITLE
[Carousel]: Increase the size of the touch zone for the close button

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-increase-touch-zone-for-carousel-close
+++ b/projects/plugins/jetpack/changelog/fix-increase-touch-zone-for-carousel-close
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+[Carousel]: Improve size of touch zone for close button.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -292,6 +292,7 @@ div.jp-carousel-buttons a:hover {
 	cursor: default;
 	letter-spacing: 0 !important;
 	padding: 0.35em 25px 0.35em 0;
+	box-sizing: border-box;
 	position: fixed;
 	text-align: right;
 	width: 100%;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -291,10 +291,10 @@ div.jp-carousel-buttons a:hover {
 	color: #999;
 	cursor: default;
 	letter-spacing: 0 !important;
-	padding: 0.35em 0 0;
+	padding: 0.35em 25px 0.35em 0;
 	position: fixed;
 	text-align: right;
-	width: calc( 100vw - 25px );
+	width: 100%;
 }
 
 .jp-carousel-transitions .jp-carousel-close-hint {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 278-gh-Automattic/view-design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* On mobile devices it can be difficult to press the close button for the carousel; if you don't press close enough, it instead flips through to the next image. This PR just increases the size of the touch zone to improve accessibility (see screenshots).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post and insert the Gallery block. Add multiple photos and publish the post.
* View the published post in a mobile view.
* On the frontend, click an image within the gallery to view the image in the carousel.
* Try clicking on/near the button and verify that the carousel closes.

| Before | After |
| --- | --- |
| <img width="423" alt="Screen Shot 2021-06-16 at 3 11 35 PM" src="https://user-images.githubusercontent.com/63313398/122301973-5166e680-ceb6-11eb-86e1-5a70ad310815.png"> | <img width="425" alt="Screen Shot 2021-06-16 at 3 11 05 PM" src="https://user-images.githubusercontent.com/63313398/122301996-57f55e00-ceb6-11eb-85f8-bbfc563e597f.png"> |

