### PR TITLE
Admin menu: Register Calypso settings pages as independent submenus

### DIFF
--- a/projects/plugins/jetpack/changelog/update-admin-menu-calypso-settings-submenus
+++ b/projects/plugins/jetpack/changelog/update-admin-menu-calypso-settings-submenus
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Admin menu: Register Calypso settings pages as independent submenus

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -430,12 +430,17 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->update_submenus( 'options-general.php', array( 'options-general.php' => 'https://wordpress.com/settings/general/' . $this->domain ) );
 		add_submenu_page( 'options-general.php', esc_attr__( 'Advanced General', 'jetpack' ), __( 'Advanced General', 'jetpack' ), 'manage_options', 'options-general.php', null, 1 );
 
+		add_submenu_page( 'options-general.php', esc_attr__( 'Performance', 'jetpack' ), __( 'Performance', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain, null, 2 );
+
 		if ( $wp_admin ) {
 			return;
 		}
 
-		$this->hide_submenu_page( 'options-general.php', 'options-discussion.php' );
-		$this->hide_submenu_page( 'options-general.php', 'options-writing.php' );
+		$submenus_to_update = array(
+			'options-writing.php'    => 'https://wordpress.com/settings/writing/' . $this->domain,
+			'options-discussion.php' => 'https://wordpress.com/settings/discussion/' . $this->domain,
+		);
+		$this->update_submenus( 'options-general.php', $submenus_to_update );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -292,7 +292,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_options_menu( $wp_admin = false ) {
 		parent::add_options_menu( $wp_admin );
 
-		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Security', 'jetpack' ), __( 'Security', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/security/' . $this->domain, null, 2 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 11 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, 12 );
 
 		// No need to add a menu linking to WP Admin if there is already one.
 		if ( ! $wp_admin ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -296,6 +296,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 11 );
 		add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, 12 );
 
+		// Page Optimize is active by default on all Atomic sites and registers a Settings > Performance submenu which
+		// would conflict with our own Settings > Performance that links to Calypso, so we hide it it since the Calypso
+		// performance settings already have a link to Page Optimize settings page.
+		$this->hide_submenu_page( 'options-general.php', 'page-optimize' );
+
 		// No need to add a menu linking to WP Admin if there is already one.
 		if ( ! $wp_admin ) {
 			add_submenu_page( 'options-general.php', esc_attr__( 'Advanced Writing', 'jetpack' ), __( 'Advanced Writing', 'jetpack' ), 'manage_options', 'options-writing.php' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -222,7 +222,20 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 * @param bool $wp_admin Optional. Whether links should point to Calypso or wp-admin. Default false (Calypso).
 	 */
 	public function add_options_menu( $wp_admin = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		add_menu_page( esc_attr__( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/general/' . $this->domain, null, 'dashicons-admin-settings', 80 );
+		$slug = 'https://wordpress.com/settings/general/' . $this->domain;
+		add_menu_page( esc_attr__( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_options', $slug, null, 'dashicons-admin-settings', 80 );
+		add_submenu_page( $slug, esc_attr__( 'General', 'jetpack' ), __( 'General', 'jetpack' ), 'manage_options', $slug );
+		add_submenu_page( $slug, esc_attr__( 'Security', 'jetpack' ), __( 'Security', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/security/' . $this->domain );
+		add_submenu_page( $slug, esc_attr__( 'Performance', 'jetpack' ), __( 'Performance', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain );
+		add_submenu_page( $slug, esc_attr__( 'Writing', 'jetpack' ), __( 'Writing', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/writing/' . $this->domain );
+		add_submenu_page( $slug, esc_attr__( 'Discussion', 'jetpack' ), __( 'Discussion', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/discussion/' . $this->domain );
+
+		$has_scan     = \Jetpack_Plan::supports( 'scan' );
+		$rewind_state = get_transient( 'jetpack_rewind_state' );
+		$has_backup   = $rewind_state && in_array( $rewind_state->state, array( 'awaiting_credentials', 'provisioning', 'active' ), true );
+		if ( $has_scan || $has_backup ) {
+			add_submenu_page( $slug, esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -306,7 +306,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_options_menu( $wp_admin = false ) {
 		parent::add_options_menu( $wp_admin );
 
-		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 6 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 10 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -404,7 +404,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_options_menu();
 
-		$this->assertSame( 'https://wordpress.com/settings/general/' . static::$domain, array_shift( $submenu['options-general.php'] )[2] );
+		$this->assertSame( 'https://wordpress.com/settings/general/' . static::$domain, $submenu['options-general.php'][0][2] );
 		$this->assertSame( 'options-general.php', $submenu['options-general.php'][1][2] );
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -335,7 +335,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		global $submenu;
 
 		static::$admin_menu->add_options_menu();
-		$this->assertSame( 'https://wordpress.com/hosting-config/' . static::$domain, $submenu['options-general.php'][6][2] );
+		$this->assertSame( 'https://wordpress.com/hosting-config/' . static::$domain, $submenu['options-general.php'][11][2] );
 		$this->assertSame( 'options-writing.php', array_pop( $submenu['options-general.php'] )[2] );
 
 		// Reset.

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -313,7 +313,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_options_menu();
 
-		$this->assertSame( 'https://wordpress.com/hosting-config/' . static::$domain, $submenu['options-general.php'][6][2] );
+		$this->assertSame( 'https://wordpress.com/hosting-config/' . static::$domain, $submenu['options-general.php'][10][2] );
 	}
 
 	/**


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/53774.

#### Changes proposed in this Pull Request:

In order to accommodate changes that seek to remove the settings navigation bar from Calypso (https://github.com/Automattic/wp-calypso/issues/53774), this PR registers the different Calypso settings pages as independent submenus of the Settings menu.

Site | Before | After
--- | --- | ---
Simple | <img width="279" alt="Screen Shot 2021-06-17 at 17 12 52" src="https://user-images.githubusercontent.com/1233880/122424785-492eaa00-cf8f-11eb-825d-4e130b68ab0b.png"> | <img width="289" alt="Screen Shot 2021-06-17 at 17 11 55" src="https://user-images.githubusercontent.com/1233880/122424825-4fbd2180-cf8f-11eb-9830-3e88f71dd3ee.png">
Atomic | <img width="277" alt="Screen Shot 2021-06-17 at 17 52 21" src="https://user-images.githubusercontent.com/1233880/122431508-d0cae780-cf94-11eb-81fe-0484071b8686.png"> | <img width="276" alt="Screen Shot 2021-06-18 at 16 37 45" src="https://user-images.githubusercontent.com/1233880/122577856-8e1c1480-d053-11eb-88d1-66dd88fdbf2b.png">
Jetpack | <img width="278" alt="Screen Shot 2021-06-17 at 16 51 39" src="https://user-images.githubusercontent.com/1233880/122420988-5bf3af80-cf8c-11eb-97e1-b0833cae9fa9.png"> | <img width="281" alt="Screen Shot 2021-06-17 at 16 52 50" src="https://user-images.githubusercontent.com/1233880/122421146-79c11480-cf8c-11eb-82b4-eda71aedd7dc.png">

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Simple sites:
  - Apply D62989-code to your sandbox.
  - Sandbox the API and a Simple site.
  - Go to https://wordpress.com/settings.
  - Pick the Simple site you sandboxed above.
  - Make sure that the Settings menu contains, among others, the following submenus: Performance, Writing, Discussion.
  - Make sure that Settings > Writing links to Calypso or WP Admin based on [the "show wp-admin pages" toggle](https://wordpress.com/me/account).
  - Make sure that Settings > Discussion links to Calypso or WP Admin based on [the "show wp-admin pages" toggle](https://wordpress.com/me/account).
- Atomic sites:
  - Install Jetpack Beta on an Atomic site and switch to the branch of this PR.
  - Go to https://wordpress.com/settings.
  - Pick the Atomic site where you've installed Jetpack Beta.
  - Make sure that that Settings menu contains, among others, the following submenus: Security, Performance, Writing, Discussion, Jetpack.
  - Make sure that Settings > Writing links to Calypso or WP Admin based on [the "show wp-admin pages" toggle](https://wordpress.com/me/account).
  - Make sure that Settings > Discussion links to Calypso or WP Admin based on [the "show wp-admin pages" toggle](https://wordpress.com/me/account).
  - Make sure that Settings > Performance is not duplicated and it links to Calypso.
- Jetpack site:
  - Spin up a Jetpack site running the branch of this PR and connect it to WP.com.
  - Go to https://wordpress.com/settings.
  - Pick the Jetpack site running the branch of this PR.
  - Make sure that that Settings menu contains the following submenus: General, Security, Performance, Writing, Discussion.
  - Make sure that the Jetpack submenu appears when the backups and/or security scans are configured and active.
