### PR TITLE
actions: Set concurrency for gardening workflow

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -8,7 +8,9 @@ on:
     branches:
       - master # Every time a PR is merged to master.
 concurrency:
-  group: gardening-${{ github.event_name }}-${{ github.event.action }}-${{ github.ref }}
+  # For pull_request and pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
+  # Don't cancel any for pushes, accomplished by grouping on the unique run_id.
+  group: gardening-${{ github.event_name }}-${{ github.event_name == 'push' && github.run_id || github.event.action }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - master # Every time a PR is merged to master.
+concurrency:
+  group: gardening-${{ github.event_name }}-${{ github.event.action }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # review-crew-afk:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This might help reduce our API call usage from turnstyle, by cancelling
extraneous jobs in cases where we get multiple "pull_request labeled"
events in quick succession or something like that.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Just generic discussion about hitting the GH API rate limits.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try triggering multiple events in quick succession, e.g. changing labels multiple times. See whether some of the resulting Gardening jobs get cancelled.