### PR TITLE
Jetpack carousel: prevent vertical scrolling

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-carousel-module-hide-comments-and-meta
+++ b/projects/plugins/jetpack/changelog/update-jetpack-carousel-module-hide-comments-and-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adding toggle visibility controls for photo metadata and comments in narrow screen widths and increasing size/contrast of touch controls to improve UI on smaller screens.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -966,7 +966,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	line-height: 1;
 	font-weight: 400;
 	font-style: normal;
-	margin-left: 40px;
+	margin-left: 25px;
 }
 
 .jp-carousel-icon-comments {
@@ -1012,9 +1012,9 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	}
 
 	.jp-carousel-close-hint span {
-		font-size: 32px !important;
-		height: 32px;
-		width: 32px;
+		font-size: 36px !important;
+		height: 36px;
+		width: 36px;
 		font-weight: 800 !important;
 		color: #fff;
 	}
@@ -1044,6 +1044,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 	.jp-carousel-image-meta {
 		display: none !important;
+		margin-top: 10px;
 	}
 
 	.jp-carousel-image-meta.jp-carousel-show {
@@ -1052,8 +1053,12 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 	.jp-carousel-titleanddesc {
 		padding-top: 0 !important;
+		margin: 0 0 10px 0;
 		border: none !important;
-		display: none;
+	}
+
+	.jp-carousel-titleanddesc-desc p {
+		margin: 0;
 	}
 
 	.jp-carousel-titleanddesc.jp-carousel-show {
@@ -1061,7 +1066,9 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	}
 
 	.jp-carousel-titleanddesc-title {
-		font-size: 1em !important;
+		font-size: 1.1em !important;
+		margin-bottom: 5px;
+		font-weight: 400 !important;
 	}
 
 	.jp-carousel-left-column-wrapper {
@@ -1087,4 +1094,16 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		display: block;
 	}
 	/** Icons End **/
+}
+
+
+@media only screen and (max-width: 480px) {
+	.jp-carousel {
+		bottom: 30vh;
+	}
+
+	.jp-carousel-info {
+		top: 71vh; /* Fallback, if calc is not supported */
+		top: calc( 70vh + 5px );
+	}
 }

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -948,9 +948,39 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	background: -webkit-gradient(linear, left bottom, left top, from(rgba(255,255,255,0.75)), to(rgba(255,255,255,0)));
 }
 
+/** Icons Start **/
+.jp-carousel-photo-icons-container {
+	display: none;
+	text-align: right;
+}
+
+.jp-carousel-icon {
+	color: #fff;
+	cursor: pointer;
+	font-family: dashicons;
+	display: inline-block;
+	width: 32px;
+	height: 30px;
+	font-size: 30px;
+	display: inline-block;
+	line-height: 1;
+	font-weight: 400;
+	font-style: normal;
+	margin-left: 40px;
+}
+
+.jp-carousel-icon-comments {
+	display: none;
+}
+
+.jp-carousel-icon-comments.jp-carousel-show {
+	display: inline-block;
+}
+
+/** Icons End **/
+
 /* Small screens */
 @media only screen and (max-width: 760px) {
-
 	.jp-carousel-info {
 		margin: 0 10px !important;
 	}
@@ -977,10 +1007,16 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	}
 
 	.jp-carousel-close-hint {
-	 	font-weight: 800 !important;
-		font-size: 26px !important;
 		position: fixed !important;
 		top: 0;
+	}
+
+	.jp-carousel-close-hint span {
+		font-size: 32px !important;
+		height: 32px;
+		width: 32px;
+		font-weight: 800 !important;
+		color: #fff;
 	}
 
 	.jp-carousel-slide img {
@@ -996,14 +1032,34 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		display: none;
 	}
 
+	.jp-carousel-comments,
+	#jp-carousel-comments-loading,
 	#jp-carousel-comment-form-container {
 		display: none !important;
+	}
+
+	.jp-carousel-comments.jp-carousel-show {
+		display: block !important;
+	}
+
+	.jp-carousel-image-meta {
+		display: none !important;
+	}
+
+	.jp-carousel-image-meta.jp-carousel-show {
+		display: block !important;
 	}
 
 	.jp-carousel-titleanddesc {
 		padding-top: 0 !important;
 		border: none !important;
+		display: none;
 	}
+
+	.jp-carousel-titleanddesc.jp-carousel-show {
+		display: block !important;
+	}
+
 	.jp-carousel-titleanddesc-title {
 		font-size: 1em !important;
 	}
@@ -1022,11 +1078,13 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		display: none;
 	}
 
-	.jp-carousel-left-column-wrapper > .jp-carousel-photo-info {
-		display: block;
-	}
-
 	.jp-carousel-caption {
 		overflow: visible !important;
 	}
+
+	/** Icons Start **/
+	.jp-carousel-photo-icons-container {
+		display: block;
+	}
+	/** Icons End **/
 }

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -13,14 +13,15 @@
 	bottom: 0;
 	left: 0;
 	background: #000;
+	z-index: -100;
 }
 
 .jp-carousel {
-	position: absolute;
+/*	position: absolute;
 	top: 0;
 	left: 0;
 	right: 0;
-	bottom: 20vh;
+	bottom: 20vh;*/
 }
 
 div.jp-carousel-fadeaway {
@@ -31,6 +32,9 @@ div.jp-carousel-fadeaway {
 	z-index: 2147483647;
 	width: 100%;
 	height: 15px;
+	overflow-x: hidden;
+	overflow-y: auto;
+	direction: ltr;
 }
 
 .jp-carousel-next-button span,
@@ -76,17 +80,40 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	overflow-x: hidden;
 	overflow-y: auto;
 	direction: ltr;
+	display: grid;
+	grid-template-rows: 1fr 58px; /* main carousel and info area as footer */
+	height: 100%;
+	width: 105vw;
 }
 
 .jp-carousel-info {
 	display: flex;
 	flex-direction: column;
-	position: absolute;
-	top: 81vh; /* Fallback, if calc is not supported */
-	top: calc( 80vh + 5px );
-	bottom: 0;
 	text-align: left !important;
 	-webkit-font-smoothing: subpixel-antialiased !important;
+	overflow: hidden;
+	width: 100vw;
+	position: relative;
+}
+
+.jp-carousel-info-inner {
+	background-color: #000;
+	z-index: 1000000;
+}
+
+.jp-carousel-info.jp-carousel-info-show {
+	overflow: visible;
+}
+
+.jp-carousel-footer {
+	padding: 10px;
+}
+
+.jp-carousel-info-content {
+    display: flex;
+    flex-direction: column;
+    margin: 0 137px;
+    top: 100%;
 }
 
 .jp-carousel-info-columns {
@@ -122,12 +149,12 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	display: none;
 }
 
-.jp-carousel-transitions .jp-carousel-photo-info {
+/*.jp-carousel-transitions .jp-carousel-photo-info {
 	-webkit-transition: 400ms ease-out;
 	-moz-transition: 400ms ease-out;
 	-o-transition: 400ms ease-out;
 	transition: 400ms ease-out;
-}
+}*/
 
 .jp-carousel-info h2 {
 	background: none !important;
@@ -368,12 +395,8 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 /** Title and Desc Start **/
 .jp-carousel-titleanddesc {
-	border-top: 1px solid #222;
 	color: #999;
 	font-size: 15px;
-	padding-top: 24px;
-	margin-top: 20px;
-	margin-bottom: 20px;
 	font-weight: 400;
 	width: 100%;
 }
@@ -447,9 +470,6 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	font: 12px/1.4 "Helvetica Neue", sans-serif !important;
 	overflow: hidden;
 	padding: 18px 20px;
-	width: 209px !important;
-	margin-top: 20px;
-	margin-left: 40px;
 	margin-bottom: 20px;
 	flex-shrink: 0;
 }
@@ -792,7 +812,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	color: #999;
 	text-align: left;
 	margin-bottom: 20px;
-	width: 100;
 	bottom: 10px;
 	margin-top: 20px;
 }
@@ -950,7 +969,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 /** Icons Start **/
 .jp-carousel-photo-icons-container {
-	display: none;
 	text-align: right;
 }
 
@@ -967,6 +985,10 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	font-weight: 400;
 	font-style: normal;
 	margin-left: 25px;
+}
+
+.jp-carousel-icon path {
+	fill: white;
 }
 
 .jp-carousel-icon-comments {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -225,7 +225,7 @@
 			scrollToElement: scrollToElement,
 			getJSONAttribute: getJSONAttribute,
 			convertToPlainText: convertToPlainText,
-			emitEvent: emitEvent,
+			emitEvent: emitEvent
 		};
 	} )();
 
@@ -464,6 +464,8 @@
 						handleCommentLoginClick( e );
 					} else if ( domUtil.closest( target, '#jp-carousel-comment-form-container' ) ) {
 						handleCommentFormClick( e );
+					} else if ( domUtil.closest( target, '.jp-carousel-photo-icons-container' ) ) {
+						handleIconClick( e );
 					} else if ( ! domUtil.closest( target, '.jp-carousel-info' ) ) {
 						if ( isSmallScreen ) {
 							handleCarouselGalleryTouch( e );
@@ -1175,6 +1177,39 @@
 		}
 
 		/**
+		 * Handles clicks to icons in the icon container.
+		 * @param {MouseEvent|TouchEvent|KeyBoardEvent} Event object.
+		 */
+		function handleIconClick( e ) {
+			e.preventDefault();
+			e.stopPropagation();
+
+			var target = e.target;
+
+			if ( domUtil.closest( target, '.jp-carousel-icon-info' ) ) {
+				var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
+				var titleAndDescContainer = carousel.container.querySelector( '.jp-carousel-titleanddesc' );
+
+				if ( photoMetaContainer ) {
+					photoMetaContainer.classList.toggle( 'jp-carousel-show' );
+					domUtil.scrollToElement( photoMetaContainer );
+				}
+
+				if ( titleAndDescContainer ) {
+					titleAndDescContainer.classList.toggle( 'jp-carousel-show' );
+				}
+			}
+
+			if ( domUtil.closest( target, '.jp-carousel-icon-comments' ) ) {
+				var commentsContainer = carousel.container.querySelector( '.jp-carousel-comments' );
+				if ( commentsContainer ) {
+					commentsContainer.classList.toggle( 'jp-carousel-show' );
+					domUtil.scrollToElement( commentsContainer );
+				}
+			}
+		}
+
+		/**
 		 * Returns a number in a fraction format that represents the shutter speed.
 		 * @param Number speed
 		 * @return String
@@ -1311,6 +1346,8 @@
 
 		function fetchComments( attachmentId, offset ) {
 			var shouldClear = offset === undefined;
+			var commentsIcon = carousel.container.querySelector( '.jp-carousel-icon-comments' );
+			commentsIcon.classList.remove( 'jp-carousel-show' );
 
 			clearInterval( commentInterval );
 
@@ -1324,6 +1361,7 @@
 
 			var comments = carousel.container.querySelector( '.jp-carousel-comments' );
 			var commentsLoading = carousel.container.querySelector( '#jp-carousel-comments-loading' );
+
 			domUtil.show( commentsLoading );
 
 			if ( shouldClear ) {
@@ -1374,6 +1412,10 @@
 					comments.innerHTML = '';
 				}
 
+				if ( data.length === 0 ) {
+					return;
+				}
+
 				for ( var i = 0; i < data.length; i++ ) {
 					var entry = data[ i ];
 					var comment = document.createElement( 'div' );
@@ -1405,7 +1447,9 @@
 				}
 
 				domUtil.show( comments );
+				commentsIcon.classList.add( 'jp-carousel-show' );
 				domUtil.hide( commentsLoading );
+
 			};
 
 			xhr.onerror = onError;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -402,8 +402,8 @@
 		}
 
 		function fitMeta() {
-			carousel.info.style.left = screenPadding + 'px';
-			carousel.info.style.right = screenPadding + 'px';
+/*			carousel.info.style.left = screenPadding + 'px';
+			carousel.info.style.right = screenPadding + 'px';*/
 		}
 
 		function initializeCarousel() {
@@ -753,12 +753,12 @@
 			var previousPrevious = getPrevSlide( prev );
 			var nextNext = getNextSlide( next );
 			var captionHtml;
-			var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
+			var photoMetaContainer = carousel.container.querySelector( '.jp-carousel-image-meta' );
 			var commentsContainer = carousel.container.querySelector( '.jp-carousel-comments' );
 
 			// Hide comments and photo info and meta for smaller screens.
-			photoMetaContainer.classList.remove( 'jp-carousel-show' );
-			commentsContainer.classList.remove( 'jp-carousel-show' );
+			photoMetaContainer && photoMetaContainer.classList.remove( 'jp-carousel-show' );
+			commentsContainer && commentsContainer.classList.remove( 'jp-carousel-show' );
 
 			carousel.slides.forEach( function ( slide ) {
 				slide.el.style.position = 'fixed';
@@ -812,22 +812,18 @@
 
 				if ( domUtil.convertToPlainText( current.attrs.title ) === captionHtml ) {
 					var title = carousel.container.querySelector( '.jp-carousel-titleanddesc-title' );
-					domUtil.fadeOut( title, function () {
-						title.innerHTML = '';
-					} );
+					title.innerHTML = '';
 				}
 
 				if ( domUtil.convertToPlainText( current.attrs.desc ) === captionHtml ) {
 					var desc = carousel.container.querySelector( '.jp-carousel-titleanddesc-desc' );
-					domUtil.fadeOut( desc, function () {
-						desc.innerHTML = '';
-					} );
+					desc.innerHTML = '';
 				}
 
 				carousel.caption.innerHTML = current.attrs.caption;
-				domUtil.fadeIn( carousel.caption );
+				domUtil.show( carousel.caption );
 			} else {
-				domUtil.fadeOut( carousel.caption, function () {
+				domUtil.hide( carousel.caption, function () {
 					carousel.caption.innerHTML = '';
 				} );
 			}
@@ -1060,14 +1056,14 @@
 		}
 
 		function fitInfo() {
-			var size = calculateBestFit( carousel.currentSlide );
+/*			var size = calculateBestFit( carousel.currentSlide );
 
 			var photoInfos = carousel.container.querySelectorAll( '.jp-carousel-photo-info' );
 			Array.prototype.forEach.call( photoInfos, function ( photoInfo ) {
 				photoInfo.style.left =
 					Math.floor( ( carousel.info.offsetWidth - size.width ) * 0.5 ) + 'px';
 				photoInfo.style.width = Math.floor( size.width ) + 'px';
-			} );
+			} );*/
 		}
 
 		function fitSlides( slides ) {
@@ -1193,11 +1189,15 @@
 
 			if ( domUtil.closest( target, '.jp-carousel-icon-info' ) ) {
 				var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
+				var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
 
 				if ( photoMetaContainer ) {
 					photoMetaContainer.classList.toggle( 'jp-carousel-show' );
 					if ( photoMetaContainer.classList.contains( 'jp-carousel-show' ) ) {
+						carousel.info.classList.add( 'jp-carousel-info-show' );
 						domUtil.scrollToElement( photoMetaContainer );
+					} else {
+						carousel.info.classList.remove( 'jp-carousel-info-show' );
 					}
 				}
 			}
@@ -1208,6 +1208,9 @@
 					commentsContainer.classList.toggle( 'jp-carousel-show' );
 					if ( commentsContainer.classList.contains( 'jp-carousel-show' ) ) {
 						domUtil.scrollToElement( commentsContainer );
+						carousel.info.classList.add( 'jp-carousel-info-show' );
+					} else {
+						carousel.info.classList.remove( 'jp-carousel-info-show' );
 					}
 				}
 			}
@@ -1250,6 +1253,11 @@
 			var target;
 
 			target = carousel.container.querySelector( '.jp-carousel-titleanddesc' );
+
+			if ( ! target ) {
+				return;
+			}
+
 			domUtil.hide( target );
 
 			title = parseTitleOrDesc( data.title ) || '';
@@ -1265,7 +1273,7 @@
 				markup += desc ? '<div class="jp-carousel-titleanddesc-desc">' + desc + '</div>' : '';
 
 				target.innerHTML = markup;
-				domUtil.fadeIn( target );
+				domUtil.show( target );
 			}
 		}
 
@@ -1275,7 +1283,12 @@
 				return false;
 			}
 
-			var ul = carousel.info.querySelector( '.jp-carousel-image-meta ul.jp-carousel-image-exif' );
+			var ul = carousel.container.querySelector( '.jp-carousel-image-meta ul.jp-carousel-image-exif' );
+
+			if ( ! ul ) {
+				return;
+			}
+
 			var html = '';
 
 			for ( var key in meta ) {
@@ -1323,7 +1336,12 @@
 				original = currentSlide.attrs.origFile.replace( /\?.+$/, '' );
 			}
 
-			var permalink = carousel.info.querySelector( '.jp-carousel-image-download' );
+			var permalink = carousel.container.querySelector( '.jp-carousel-image-download' );
+
+			if ( ! permalink ) {
+				return;
+			}
+
 			permalink.innerHTML = util.applyReplacements(
 				jetpackCarouselStrings.download_original,
 				origSize
@@ -1351,7 +1369,10 @@
 		function fetchComments( attachmentId, offset ) {
 			var shouldClear = offset === undefined;
 			var commentsIcon = carousel.container.querySelector( '.jp-carousel-icon-comments' );
-			commentsIcon.classList.remove( 'jp-carousel-show' );
+			commentsIcon && commentsIcon.classList.remove( 'jp-carousel-show' );
+
+			var comments = carousel.container.querySelector( '.jp-carousel-comments' );
+			var commentsLoading = carousel.container.querySelector( '#jp-carousel-comments-loading' );
 
 			clearInterval( commentInterval );
 
@@ -1363,8 +1384,6 @@
 				offset = 0;
 			}
 
-			var comments = carousel.container.querySelector( '.jp-carousel-comments' );
-			var commentsLoading = carousel.container.querySelector( '#jp-carousel-comments-loading' );
 
 			domUtil.show( commentsLoading );
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -225,7 +225,7 @@
 			scrollToElement: scrollToElement,
 			getJSONAttribute: getJSONAttribute,
 			convertToPlainText: convertToPlainText,
-			emitEvent: emitEvent
+			emitEvent: emitEvent,
 		};
 	} )();
 
@@ -753,6 +753,12 @@
 			var previousPrevious = getPrevSlide( prev );
 			var nextNext = getNextSlide( next );
 			var captionHtml;
+			var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
+			var commentsContainer = carousel.container.querySelector( '.jp-carousel-comments' );
+
+			// Hide comments and photo info and meta for smaller screens.
+			photoMetaContainer.classList.remove( 'jp-carousel-show' );
+			commentsContainer.classList.remove( 'jp-carousel-show' );
 
 			carousel.slides.forEach( function ( slide ) {
 				slide.el.style.position = 'fixed';
@@ -1182,21 +1188,17 @@
 		 */
 		function handleIconClick( e ) {
 			e.preventDefault();
-			e.stopPropagation();
 
 			var target = e.target;
 
 			if ( domUtil.closest( target, '.jp-carousel-icon-info' ) ) {
 				var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
-				var titleAndDescContainer = carousel.container.querySelector( '.jp-carousel-titleanddesc' );
 
 				if ( photoMetaContainer ) {
 					photoMetaContainer.classList.toggle( 'jp-carousel-show' );
-					domUtil.scrollToElement( photoMetaContainer );
-				}
-
-				if ( titleAndDescContainer ) {
-					titleAndDescContainer.classList.toggle( 'jp-carousel-show' );
+					if ( photoMetaContainer.classList.contains( 'jp-carousel-show' ) ) {
+						domUtil.scrollToElement( photoMetaContainer );
+					}
 				}
 			}
 
@@ -1204,7 +1206,9 @@
 				var commentsContainer = carousel.container.querySelector( '.jp-carousel-comments' );
 				if ( commentsContainer ) {
 					commentsContainer.classList.toggle( 'jp-carousel-show' );
-					domUtil.scrollToElement( commentsContainer );
+					if ( commentsContainer.classList.contains( 'jp-carousel-show' ) ) {
+						domUtil.scrollToElement( commentsContainer );
+					}
 				}
 			}
 		}
@@ -1449,7 +1453,6 @@
 				domUtil.show( comments );
 				commentsIcon.classList.add( 'jp-carousel-show' );
 				domUtil.hide( commentsLoading );
-
 			};
 
 			xhr.onerror = onError;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -372,11 +372,11 @@ class Jetpack_Carousel {
 				<div class="jp-carousel-info-columns">
 					<div class="jp-carousel-left-column-wrapper">
 						<div class="jp-carousel-photo-icons-container">
-							<span class="jp-carousel-icon jp-carousel-icon-info">
-								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
-							</span>
-							<span class="jp-carousel-icon jp-carousel-icon-comments">
+							<span class="jp-carousel-icon jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
 								<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="36" height="36" role="img" aria-hidden="true" focusable="false"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"></path></svg>
+							</span>
+							<span class="jp-carousel-icon jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
 							</span>
 						</div>
 						<div class="jp-carousel-titleanddesc"></div>

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -371,6 +371,14 @@ class Jetpack_Carousel {
 				</div>
 				<div class="jp-carousel-info-columns">
 					<div class="jp-carousel-left-column-wrapper">
+						<div class="jp-carousel-photo-icons-container">
+							<span class="jp-carousel-icon jp-carousel-icon-info">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
+							</span>
+							<span class="jp-carousel-icon jp-carousel-icon-comments">
+								<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="36" height="36" role="img" aria-hidden="true" focusable="false"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"></path></svg>
+							</span>
+						</div>
 						<div class="jp-carousel-titleanddesc"></div>
 						<!-- Intentional duplicate -->
 						<div class="jp-carousel-photo-info">

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -362,114 +362,116 @@ class Jetpack_Carousel {
 			itemscope
 			itemtype="https://schema.org/ImageGallery"
 			style="display: none;">
+
 			<div class="jp-carousel-overlay"></div>
 			<div class="jp-carousel"></div>
-			<div class="jp-carousel-fadeaway"></div>
+
+
+			<!-- FOOTER: controls -->
 			<div class="jp-carousel-info">
-				<div class="jp-carousel-photo-info">
-					<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
-				</div>
-				<div class="jp-carousel-info-columns">
-					<div class="jp-carousel-left-column-wrapper">
+				<div class="jp-carousel-info-inner">
+					<div class="jp-carousel-footer">
 						<div class="jp-carousel-photo-icons-container">
-							<span class="jp-carousel-icon jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
-								<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="36" height="36" role="img" aria-hidden="true" focusable="false"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"></path></svg>
-							</span>
 							<span class="jp-carousel-icon jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
-								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
+							</span>
+							<span class="jp-carousel-icon jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
+								<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"></path></svg>
 							</span>
 						</div>
-						<div class="jp-carousel-titleanddesc"></div>
-						<!-- Intentional duplicate -->
-						<div class="jp-carousel-photo-info">
-							<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
-						</div>
-						<?php if ( $localize_strings['display_comments'] ) : ?>
-							<div id="jp-carousel-comment-form-container">
-								<?php if ( $use_local_comments ) : ?>
-									<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
-										<div id="jp-carousel-comment-form-commenting-as">
-											<p id="jp-carousel-commenting-as">
-												<?php
-													echo wp_kses(
-														__( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ),
-														array(
-															'a' => array(
-																'href'  => array(),
-																'class' => array(),
-															),
-														)
-													);
-												?>
-											</p>
-										</div>
-									<?php else : ?>
-										<form id="jp-carousel-comment-form">
-											<label for="jp-carousel-comment-form-comment-field" class="screen-reader-text"><?php echo esc_attr( $localize_strings['write_comment'] ); ?></label>
-											<textarea
-												name="comment"
-												class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"
-												id="jp-carousel-comment-form-comment-field"
-												placeholder="<?php echo esc_attr( $localize_strings['write_comment'] ); ?>"
-											></textarea>
-											<div id="jp-carousel-comment-form-submit-and-info-wrapper">
-												<div id="jp-carousel-comment-form-commenting-as">
-													<?php if ( $localize_strings['is_logged_in'] ) : ?>
-														<p id="jp-carousel-commenting-as">
-															<?php
-																printf(
-																	/* translators: %s is replaced with the user's display name */
-																	esc_html__( 'Commenting as %s', 'jetpack' ),
-																	esc_html( $current_user->data->display_name )
-																);
-															?>
-														</p>
-													<?php else : ?>
-														<fieldset>
-															<label for="jp-carousel-comment-form-email-field"><?php echo esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ); ?></label>
-															<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
-														</fieldset>
-														<fieldset>
-															<label for="jp-carousel-comment-form-author-field"><?php echo esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ); ?></label>
-															<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
-														</fieldset>
-														<fieldset>
-															<label for="jp-carousel-comment-form-url-field"><?php esc_html_e( 'Website', 'jetpack' ); ?></label>
-															<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" />
-														</fieldset>
-													<?php endif ?>
-												</div>
-												<input
-													type="submit"
-													name="submit"
-													class="jp-carousel-comment-form-button"
-													id="jp-carousel-comment-form-button-submit"
-													value="<?php echo esc_attr( $localize_strings['post_comment'] ); ?>" />
-												<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
-												<div id="jp-carousel-comment-post-results"></div>
-											</div>
-										</form>
-									<?php endif ?>
-								<?php endif ?>
-							</div>
-							<div class="jp-carousel-comments"></div>
-							<div id="jp-carousel-comments-loading">
-								<span><?php echo esc_html( $localize_strings['loading_comments'] ); ?></span>
-							</div>
-						<?php endif ?>
 					</div>
-					<div class="jp-carousel-image-meta">
-						<div class="jp-carousel-buttons">
+
+					<!-- FOOTER CONTENT: gallery comments/metadata-->
+					<div class="jp-carousel-info-content">
+						<div class="jp-carousel-comments-wrapper">
 							<?php if ( $localize_strings['display_comments'] ) : ?>
-							<a class="jp-carousel-commentlink" href="#"><?php echo esc_html( $localize_strings['comment'] ); ?></a>
+								<div id="jp-carousel-comments-loading">
+									<span><?php echo esc_html( $localize_strings['loading_comments'] ); ?></span>
+								</div>
+								<div class="jp-carousel-comments"></div>
+								<div id="jp-carousel-comment-form-container">
+									<?php if ( $use_local_comments ) : ?>
+										<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
+											<div id="jp-carousel-comment-form-commenting-as">
+												<p id="jp-carousel-commenting-as">
+													<?php
+														echo wp_kses(
+															__( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ),
+															array(
+																'a' => array(
+																	'href'  => array(),
+																	'class' => array(),
+																),
+															)
+														);
+													?>
+												</p>
+											</div>
+										<?php else : ?>
+											<form id="jp-carousel-comment-form">
+												<label for="jp-carousel-comment-form-comment-field" class="screen-reader-text"><?php echo esc_attr( $localize_strings['write_comment'] ); ?></label>
+												<textarea
+													name="comment"
+													class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"
+													id="jp-carousel-comment-form-comment-field"
+													placeholder="<?php echo esc_attr( $localize_strings['write_comment'] ); ?>"
+												></textarea>
+												<div id="jp-carousel-comment-form-submit-and-info-wrapper">
+													<div id="jp-carousel-comment-form-commenting-as">
+														<?php if ( $localize_strings['is_logged_in'] ) : ?>
+															<p id="jp-carousel-commenting-as">
+																<?php
+																	printf(
+																		/* translators: %s is replaced with the user's display name */
+																		esc_html__( 'Commenting as %s', 'jetpack' ),
+																		esc_html( $current_user->data->display_name )
+																	);
+																?>
+															</p>
+														<?php else : ?>
+															<fieldset>
+																<label for="jp-carousel-comment-form-email-field"><?php echo esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ); ?></label>
+																<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
+															</fieldset>
+															<fieldset>
+																<label for="jp-carousel-comment-form-author-field"><?php echo esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ); ?></label>
+																<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
+															</fieldset>
+															<fieldset>
+																<label for="jp-carousel-comment-form-url-field"><?php esc_html_e( 'Website', 'jetpack' ); ?></label>
+																<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" />
+															</fieldset>
+														<?php endif ?>
+													</div>
+													<input
+														type="submit"
+														name="submit"
+														class="jp-carousel-comment-form-button"
+														id="jp-carousel-comment-form-button-submit"
+														value="<?php echo esc_attr( $localize_strings['post_comment'] ); ?>" />
+													<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
+													<div id="jp-carousel-comment-post-results"></div>
+												</div>
+											</form>
+										<?php endif ?>
+									<?php endif ?>
+								</div>
 							<?php endif ?>
 						</div>
-						<ul class="jp-carousel-image-exif" style="display: none;"></ul>
-						<a class="jp-carousel-image-download" target="_blank" style="display: none;"></a>
-						<div class="jp-carousel-image-map" style="display: none;"></div>
+						<div class="jp-carousel-image-meta">
+							<div class="jp-carousel-titleanddesc"></div>
+							<div class="jp-carousel-photo-info">
+								<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
+							</div>
+							<ul class="jp-carousel-image-exif" style="display: none;"></ul>
+							<a class="jp-carousel-image-download" target="_blank" style="display: none;"></a>
+							<div class="jp-carousel-image-map" style="display: none;"></div>
+						</div>
 					</div>
 				</div>
 			</div>
+
+			<!-- gallery nav/close controls - legacy until swiper JS -->
 			<div class="jp-carousel-next-button" style="display: none;">
 				<span></span>
 			</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/view-design/issues/281#issuecomment-863389575 and resolves https://github.com/Automattic/view-design/issues/284

#### Changes proposed in this Pull Request:

- Adding comment and info icons to toggle comment and photo metadata sections in narrow screen widths
- Increasing the size and contrast of the close button and new icons
- Narrowing the margins of content areas to optimize use of screen real estate in narrow widths


![Jun-18-2021 16-09-58](https://user-images.githubusercontent.com/6458278/122514692-ae49d480-d04f-11eb-9157-133be0085a5d.gif)


#### Jetpack product discussion
p9Jlb4-2cI-p2

#### Does this pull request change what data or activity we track or use?
Nein.

#### Testing instructions:
🚧 To come
