### PR TITLE
[WIP] Carousel: Try swapping out carousel image for original image when zooming in

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -399,6 +399,20 @@
 			}, 200 );
 		}
 
+		function visualViewportListener() {
+			if ( visualViewport.scale <= 1 ) {
+				return;
+			}
+			var currentSlide = carousel.currentSlide;
+
+			if ( typeof currentSlide !== 'undefined' && currentSlide.attrs && currentSlide.el ) {
+				var image = currentSlide.el.querySelector( 'img' );
+				if ( !! currentSlide.attrs.origFile && image.src !== currentSlide.attrs.origFile ) {
+					image.src = currentSlide.attrs.origFile;
+				}
+			}
+		}
+
 		function fitMeta() {
 			carousel.info.style.left = screenPadding + 'px';
 			carousel.info.style.right = screenPadding + 'px';
@@ -475,6 +489,9 @@
 
 				carousel.container.addEventListener( 'jp_carousel.beforeOpen', function () {
 					window.addEventListener( 'resize', resizeListener );
+					if ( typeof visualViewport !== 'undefined' ) {
+						visualViewport.addEventListener( 'resize', visualViewportListener );
+					}
 					resizeListener();
 				} );
 
@@ -485,6 +502,9 @@
 				carousel.container.addEventListener( 'jp_carousel.beforeClose', function () {
 					disableKeyboardNavigation();
 					window.removeEventListener( 'resize', resizeListener );
+					if ( typeof visualViewport !== 'undefined' ) {
+						visualViewport.addEventListener( 'resize', visualViewportListener );
+					}
 					domUtil.hide( carousel.prevButton );
 					domUtil.hide( carousel.nextButton );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Might resolves 285-gh-Automattic/view-design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Exploring how we might swap out the current image for the original size image when zooming in, to ensure that zooming in on an image always displays the highest resolution it can

Note: this PR really doesn't work very well on Safari mobile, so the approach will likely need to be rethought. Just saving my progress here for the moment.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*