### PR TITLE
[Carousel] Maximize best fit of images to largest size possible

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -955,10 +955,10 @@
 			var direction = current && last && last.index < current.index ? 1 : -1;
 
 			if ( carousel.slides.length > 1 ) {
-				// Since we preload the `previousPrevious` and `nextNext` slides, we need
-				// to make sure they technically visible in the DOM, but invisible to the
-				// user. To hide them from the user, we position them outside the edges
-				// of the window.
+				// Since we preload the `previous`, `previousPrevious`, `next`, and `nextNext`
+				// slides, we need to make sure they technically visible in the DOM, but
+				// invisible to the user. To hide them from the user, we position them outside
+				// the edges of the window.
 				//
 				// This section of code only applies when there are more than three
 				// slides. Otherwise, the `previousPrevious` and `nextNext` slides will
@@ -984,23 +984,18 @@
 					}
 				}
 
-				setSlidePosition(
-					previous.el,
-					Math.floor( -getSlideWidth( previous ) + screenPadding * 0.75 )
-				);
+				setSlidePosition( previous.el, -getSlideWidth( previous ) - currentWidth );
 				domUtil.show( previous.el );
 
-				setSlidePosition( next.el, Math.ceil( galleryWidth - screenPadding * 0.75 ) );
+				setSlidePosition( next.el, galleryWidth + currentWidth );
 				domUtil.show( next.el );
 			}
 		}
 
 		function calculateMaxSlideDimensions() {
-			var screenHeightPercent = 80;
-
 			return {
-				width: window.innerWidth - screenPadding * 2,
-				height: Math.floor( ( window.innerHeight / 100 ) * screenHeightPercent - 60 ),
+				width: window.innerWidth,
+				height: window.innerHeight,
 			};
 		}
 
@@ -1070,7 +1065,7 @@
 				var max = calculateMaxSlideDimensions();
 
 				dimensions.left = 0;
-				dimensions.top = Math.floor( ( max.height - dimensions.height ) * 0.5 ) + 40;
+				dimensions.top = Math.floor( ( max.height - dimensions.height ) * 0.5 );
 
 				for ( var dimension in dimensions ) {
 					slide.el.style.setProperty( dimension, dimensions[ dimension ] + 'px' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 279-gh-Automattic/view-design

WIP: Waiting on changes to the info section in order to correctly calculate height.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes padding so that the best fit of carousel images fills the maximum space in the viewport (so expands to full width or full height depending on orientation)
* Removes the semi-transparent previous/next image previews to the left and right of the current image in the carousel

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post and add a mobile gallery with a variety of images, including full-screen images in both portrait and landscape.
* View the post on the frontend and click an image to open the carousel.
* Verify that images fill up as much of the screen as possible (full-screen landscape images stretch to full width, full-screen portrait images stretch to full height)
* Verify that the semi-transparent preview images to the right and left do not appear
* Test on a variety of devices including a physical mobile device
* On the mobile device, test that tapping on the left/right side of the screen still navigates to the previous/next photo, even when the current image fills the whole viewport

#### Notes
* Vertical scroll is being removed in #20108
* The height will need to compensate for the fixed height of the info section on the bottom, once that is implemented


#### Screenshots

| | Before | After |
| --- | --- | --- |
| Full width | ![IMG_4257](https://user-images.githubusercontent.com/63313398/122586384-7623a100-d011-11eb-9352-baaf242ce56a.PNG) | ![IMG_4255](https://user-images.githubusercontent.com/63313398/122586401-7cb21880-d011-11eb-95a8-37b54012dfd1.PNG) |
| Full height | ![IMG_4258](https://user-images.githubusercontent.com/63313398/122586428-85a2ea00-d011-11eb-8035-d3a97b711e26.PNG) | ![IMG_4256](https://user-images.githubusercontent.com/63313398/122586442-8b003480-d011-11eb-9b3e-d5d3092b0e01.PNG) |



