### PR TITLE
Add/share and embed fields in Calypso media edit modal

### DIFF
--- a/projects/plugins/jetpack/changelog/add-share-and-embed-fields
+++ b/projects/plugins/jetpack/changelog/add-share-and-embed-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added display_embed and rating properties from VideoPress in the update and get media API endpoints.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1451,10 +1451,11 @@ abstract class WPCOM_JSON_API_Endpoint {
 				}
 
 				if ( isset( $info->display_embed ) ) {
-					$response['display_embed'] = $info->display_embed;
+					$response['display_embed'] = (string) (int) $info->display_embed;
 					// If not, default to metadata (for WPCOM).
 				} elseif ( isset( $metadata['videopress']['display_embed'] ) ) {
-					$response['display_embed'] = $metadata['videopress']['display_embed'];
+					// We convert it to int then to string so that (bool) false to become "0".
+					$response['display_embed'] = (string) (int) $metadata['videopress']['display_embed'];
 				}
 
 				// Thumbnails

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1446,6 +1446,17 @@ abstract class WPCOM_JSON_API_Endpoint {
 					$info = (object) $metadata['videopress'];
 				}
 
+				if ( isset( $info->rating ) ) {
+					$response['rating'] = $info->rating;
+				}
+
+				if ( isset( $info->display_embed ) ) {
+					$response['display_embed'] = $info->display_embed;
+					// If not, default to metadata (for WPCOM).
+				} elseif ( isset( $metadata['videopress']['display_embed'] ) ) {
+					$response['display_embed'] = $metadata['videopress']['display_embed'];
+				}
+
 				// Thumbnails
 				if ( function_exists( 'video_format_done' ) && function_exists( 'video_image_url_by_guid' ) ) {
 					$response['thumbnails'] = array(

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-v1-1-endpoint.php
@@ -1,47 +1,51 @@
 <?php
 
-new WPCOM_JSON_API_Get_Media_v1_1_Endpoint( array(
-	'description' => 'Get a single media item (by ID).',
-	'group'       => 'media',
-	'stat'        => 'media:1',
-	'min_version' => '1.1',
-	'max_version' => '1.1',
-	'method'      => 'GET',
-	'path'        => '/sites/%s/media/%d',
-	'path_labels' => array(
-		'$site'    => '(int|string) Site ID or domain',
-		'$media_ID' => '(int) The ID of the media item',
-	),
-	'response_format' => array(
-		'ID'               => '(int) The ID of the media item',
-		'date'             => '(ISO 8601 datetime) The date the media was uploaded',
-		'post_ID'          => '(int) ID of the post this media is attached to',
-		'author_ID'        => '(int) ID of the user who uploaded the media',
-		'URL'              => '(string) URL to the file',
-		'guid'             => '(string) Unique identifier',
-		'file'			   => '(string) Filename',
-		'extension'        => '(string) File extension',
-		'mime_type'        => '(string) File MIME type',
-		'title'            => '(string) Filename',
-		'caption'          => '(string) User-provided caption of the file',
-		'description'      => '(string) Description of the file',
-		'alt'              => '(string)  Alternative text for image files.',
-		'thumbnails'       => '(object) Media item thumbnail URL options',
-		'height'           => '(int) (Image & video only) Height of the media item',
-		'width'            => '(int) (Image & video only) Width of the media item',
-		'length'           => '(int) (Video & audio only) Duration of the media item, in seconds',
-		'exif'             => '(array) (Image & audio only) Exif (meta) information about the media item',
-		'videopress_guid'  => '(string) (Video only) VideoPress GUID of the video when uploaded on a blog with VideoPress',
-		'videopress_processing_done'  => '(bool) (Video only) If the video is uploaded on a blog with VideoPress, this will return the status of processing on the video.'
-	),
+new WPCOM_JSON_API_Get_Media_v1_1_Endpoint(
+	array(
+		'description'          => 'Get a single media item (by ID).',
+		'group'                => 'media',
+		'stat'                 => 'media:1',
+		'min_version'          => '1.1',
+		'max_version'          => '1.1',
+		'method'               => 'GET',
+		'path'                 => '/sites/%s/media/%d',
+		'path_labels'          => array(
+			'$site'     => '(int|string) Site ID or domain',
+			'$media_ID' => '(int) The ID of the media item',
+		),
+		'response_format'      => array(
+			'ID'                         => '(int) The ID of the media item',
+			'date'                       => '(ISO 8601 datetime) The date the media was uploaded',
+			'post_ID'                    => '(int) ID of the post this media is attached to',
+			'author_ID'                  => '(int) ID of the user who uploaded the media',
+			'URL'                        => '(string) URL to the file',
+			'guid'                       => '(string) Unique identifier',
+			'file'                       => '(string) Filename',
+			'extension'                  => '(string) File extension',
+			'mime_type'                  => '(string) File MIME type',
+			'title'                      => '(string) Filename',
+			'caption'                    => '(string) User-provided caption of the file',
+			'description'                => '(string) Description of the file',
+			'alt'                        => '(string)  Alternative text for image files.',
+			'thumbnails'                 => '(object) Media item thumbnail URL options',
+			'height'                     => '(int) (Image & video only) Height of the media item',
+			'width'                      => '(int) (Image & video only) Width of the media item',
+			'length'                     => '(int) (Video & audio only) Duration of the media item, in seconds',
+			'exif'                       => '(array) (Image & audio only) Exif (meta) information about the media item',
+			'rating'                     => '(string) (Video only) VideoPress rating of the video',
+			'display_embed'              => '(string) Video only. Whether to share or not the video.',
+			'videopress_guid'            => '(string) (Video only) VideoPress GUID of the video when uploaded on a blog with VideoPress',
+			'videopress_processing_done' => '(bool) (Video only) If the video is uploaded on a blog with VideoPress, this will return the status of processing on the video.',
+		),
 
-	'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/media/934',
-	'example_request_data' =>  array(
-		'headers' => array(
-			'authorization' => 'Bearer YOUR_API_TOKEN'
-		)
+		'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/media/934',
+		'example_request_data' => array(
+			'headers' => array(
+				'authorization' => 'Bearer YOUR_API_TOKEN',
+			),
+		),
 	)
-) );
+);
 
 class WPCOM_JSON_API_Get_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint {
 	function callback( $path = '', $blog_id = 0, $media_id = 0 ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-v1-2-endpoint.php
@@ -2,52 +2,56 @@
 
 jetpack_require_lib( 'class.media' );
 
-new WPCOM_JSON_API_Get_Media_v1_2_Endpoint( array(
-	'description' => 'Get a single media item (by ID).',
-	'group'       => 'media',
-	'stat'        => 'media:1',
-	'min_version' => '1.2',
-	'max_version' => '1.2',
-	'method'      => 'GET',
-	'path'        => '/sites/%s/media/%d',
-	'path_labels' => array(
-		'$site'    => '(int|string) Site ID or domain',
-		'$media_ID' => '(int) The ID of the media item',
-	),
-	'response_format' => array(
-		'ID'               => '(int) The ID of the media item',
-		'date'             => '(ISO 8601 datetime) The date the media was uploaded',
-		'post_ID'          => '(int) ID of the post this media is attached to',
-		'author_ID'        => '(int) ID of the user who uploaded the media',
-		'URL'              => '(string) URL to the file',
-		'guid'             => '(string) Unique identifier',
-		'file'             => '(string) Filename',
-		'extension'        => '(string) File extension',
-		'mime_type'        => '(string) File MIME type',
-		'title'            => '(string) Filename',
-		'caption'          => '(string) User-provided caption of the file',
-		'description'      => '(string) Description of the file',
-		'alt'              => '(string)  Alternative text for image files.',
-		'thumbnails'       => '(object) Media item thumbnail URL options',
-		'height'           => '(int) (Image & video only) Height of the media item',
-		'width'            => '(int) (Image & video only) Width of the media item',
-		'length'           => '(int) (Video & audio only) Duration of the media item, in seconds',
-		'exif'             => '(array) (Image & audio only) Exif (meta) information about the media item',
-		'videopress_guid'  => '(string) (Video only) VideoPress GUID of the video when uploaded on a blog with VideoPress',
-		'videopress_processing_done'  => '(bool) (Video only) If the video is uploaded on a blog with VideoPress, this will return the status of processing on the video.',
-		'revision_history' => '(object) An object with `items` and `original` keys. ' .
-								'`original` is an object with data about the original image. ' .
-								'`items` is an array of snapshots of the previous images of this Media. ' .
-								'Each item has the `URL`, `file, `extension`, `date`, and `mime_type` fields.'
-	),
+new WPCOM_JSON_API_Get_Media_v1_2_Endpoint(
+	array(
+		'description'          => 'Get a single media item (by ID).',
+		'group'                => 'media',
+		'stat'                 => 'media:1',
+		'min_version'          => '1.2',
+		'max_version'          => '1.2',
+		'method'               => 'GET',
+		'path'                 => '/sites/%s/media/%d',
+		'path_labels'          => array(
+			'$site'     => '(int|string) Site ID or domain',
+			'$media_ID' => '(int) The ID of the media item',
+		),
+		'response_format'      => array(
+			'ID'                         => '(int) The ID of the media item',
+			'date'                       => '(ISO 8601 datetime) The date the media was uploaded',
+			'post_ID'                    => '(int) ID of the post this media is attached to',
+			'author_ID'                  => '(int) ID of the user who uploaded the media',
+			'URL'                        => '(string) URL to the file',
+			'guid'                       => '(string) Unique identifier',
+			'file'                       => '(string) Filename',
+			'extension'                  => '(string) File extension',
+			'mime_type'                  => '(string) File MIME type',
+			'title'                      => '(string) Filename',
+			'caption'                    => '(string) User-provided caption of the file',
+			'description'                => '(string) Description of the file',
+			'alt'                        => '(string)  Alternative text for image files.',
+			'thumbnails'                 => '(object) Media item thumbnail URL options',
+			'height'                     => '(int) (Image & video only) Height of the media item',
+			'width'                      => '(int) (Image & video only) Width of the media item',
+			'length'                     => '(int) (Video & audio only) Duration of the media item, in seconds',
+			'exif'                       => '(array) (Image & audio only) Exif (meta) information about the media item',
+			'rating'                     => '(string) (Video only) VideoPress rating of the video',
+			'display_embed'              => '(string) Video only. Whether to share or not the video.',
+			'videopress_guid'            => '(string) (Video only) VideoPress GUID of the video when uploaded on a blog with VideoPress',
+			'videopress_processing_done' => '(bool) (Video only) If the video is uploaded on a blog with VideoPress, this will return the status of processing on the video.',
+			'revision_history'           => '(object) An object with `items` and `original` keys. ' .
+									'`original` is an object with data about the original image. ' .
+									'`items` is an array of snapshots of the previous images of this Media. ' .
+									'Each item has the `URL`, `file, `extension`, `date`, and `mime_type` fields.',
+		),
 
-	'example_request'      => 'https://public-api.wordpress.com/rest/v1.2/sites/82974409/media/934',
-	'example_request_data' =>  array(
-		'headers' => array(
-			'authorization' => 'Bearer YOUR_API_TOKEN'
-		)
+		'example_request'      => 'https://public-api.wordpress.com/rest/v1.2/sites/82974409/media/934',
+		'example_request_data' => array(
+			'headers' => array(
+				'authorization' => 'Bearer YOUR_API_TOKEN',
+			),
+		),
 	)
-) );
+);
 
 class WPCOM_JSON_API_Get_Media_v1_2_Endpoint extends WPCOM_JSON_API_Get_Media_v1_1_Endpoint {
 	function callback( $path = '', $blog_id = 0, $media_id = 0 ) {
@@ -57,10 +61,10 @@ class WPCOM_JSON_API_Get_Media_v1_2_Endpoint extends WPCOM_JSON_API_Get_Media_v1
 			return $response;
 		}
 
-		$media_item = get_post( $media_id );
+		$media_item         = get_post( $media_id );
 		$response->modified = (string) $this->format_date( $media_item->post_modified_gmt, $media_item->post_modified );
 
-		// expose `revision_history` object
+		// expose `revision_history` object.
 		$response->revision_history = (object) array(
 			'items'       => (array) Jetpack_Media::get_revision_history( $media_id ),
 			'original'    => (object) Jetpack_Media::get_original_media( $media_id )

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -131,6 +131,7 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			}
 		}
 
+		// Pass the item to the handle_video_meta() that checks if it's a VideoPress item and saves it.
 		$result = $this->handle_video_meta( $media_id, $input, $item );
 
 		if ( is_wp_error( $result ) ) {
@@ -145,7 +146,7 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 	}
 
 	/**
-	 * Persist the videopress metadata.
+	 * Persist the VideoPress metadata if the given item argument is a VideoPress item.
 	 *
 	 * @param string   $media_id The ID of the video.
 	 * @param array    $input    The request input.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -158,7 +158,7 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			return false;
 		}
 
-		if ( ! Videopress_Attachment_Metadata::is_videopress_media( $item ) ) {
+		if ( ! \Videopress_Attachment_Metadata::is_videopress_media( $item ) ) {
 			return false;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -1,61 +1,67 @@
 <?php
 
-new WPCOM_JSON_API_Update_Media_v1_1_Endpoint( array(
-	'description' => 'Edit basic information about a media item.',
-	'group'       => 'media',
-	'stat'        => 'media:1:POST',
-	'min_version' => '1.1',
-	'max_version' => '1.1',
-	'method'      => 'POST',
-	'path'        => '/sites/%s/media/%d',
-	'path_labels' => array(
-		'$site'    => '(int|string) Site ID or domain',
-		'$media_ID' => '(int) The ID of the media item',
-	),
-
-	'request_format' => array(
-		'parent_id'   => '(int) ID of the post this media is attached to',
-		'title'       => '(string) The file name.',
-		'caption'     => '(string) File caption.',
-		'description' => '(HTML) Description of the file.',
-		'alt'         => "(string) Alternative text for image files.",
-		'artist'      => "(string) Audio Only. Artist metadata for the audio track.",
-		'album'       => "(string) Audio Only. Album metadata for the audio track.",
-	),
-
-	'response_format' => array(
-		'ID'               => '(int) The ID of the media item',
-		'date'             => '(ISO 8601 datetime) The date the media was uploaded',
-		'post_ID'          => '(int) ID of the post this media is attached to',
-		'author_ID'        => '(int) ID of the user who uploaded the media',
-		'URL'              => '(string) URL to the file',
-		'guid'             => '(string) Unique identifier',
-		'file'			   => '(string) File name',
-		'extension'        => '(string) File extension',
-		'mime_type'        => '(string) File mime type',
-		'title'            => '(string) File name',
-		'caption'          => '(string) User provided caption of the file',
-		'description'      => '(string) Description of the file',
-		'alt'              => '(string)  Alternative text for image files.',
-		'thumbnails'       => '(object) Media item thumbnail URL options',
-		'height'           => '(int) (Image & video only) Height of the media item',
-		'width'            => '(int) (Image & video only) Width of the media item',
-		'length'           => '(int) (Video & audio only) Duration of the media item, in seconds',
-		'exif'             => '(array) (Image & audio only) Exif (meta) information about the media item',
-		'videopress_guid'  => '(string) (Video only) VideoPress GUID of the video when uploaded on a blog with VideoPress',
-		'videopress_processing_done'  => '(bool) (Video only) If the video is uploaded on a blog with VideoPress, this will return the status of processing on the video.'
-	),
-
-	'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/media/446',
-	'example_request_data' =>  array(
-		'headers' => array(
-			'authorization' => 'Bearer YOUR_API_TOKEN'
+new WPCOM_JSON_API_Update_Media_v1_1_Endpoint(
+	array(
+		'description'          => 'Edit basic information about a media item.',
+		'group'                => 'media',
+		'stat'                 => 'media:1:POST',
+		'min_version'          => '1.1',
+		'max_version'          => '1.1',
+		'method'               => 'POST',
+		'path'                 => '/sites/%s/media/%d',
+		'path_labels'          => array(
+			'$site'     => '(int|string) Site ID or domain',
+			'$media_ID' => '(int) The ID of the media item',
 		),
-		'body' => array(
-			'title' => 'Updated Title'
-		)
+
+		'request_format'       => array(
+			'parent_id'     => '(int) ID of the post this media is attached to',
+			'title'         => '(string) The file name.',
+			'caption'       => '(string) File caption.',
+			'description'   => '(HTML) Description of the file.',
+			'alt'           => '(string) Alternative text for image files.',
+			'rating'        => '(string) Video only. Video rating.',
+			'display_embed' => '(string) Video only. Whether to share or not the video.',
+			'artist'        => '(string) Audio Only. Artist metadata for the audio track.',
+			'album'         => '(string) Audio Only. Album metadata for the audio track.',
+		),
+
+		'response_format'      => array(
+			'ID'                         => '(int) The ID of the media item',
+			'date'                       => '(ISO 8601 datetime) The date the media was uploaded',
+			'post_ID'                    => '(int) ID of the post this media is attached to',
+			'author_ID'                  => '(int) ID of the user who uploaded the media',
+			'URL'                        => '(string) URL to the file',
+			'guid'                       => '(string) Unique identifier',
+			'file'                       => '(string) File name',
+			'extension'                  => '(string) File extension',
+			'mime_type'                  => '(string) File mime type',
+			'title'                      => '(string) File name',
+			'caption'                    => '(string) User provided caption of the file',
+			'description'                => '(string) Description of the file',
+			'alt'                        => '(string)  Alternative text for image files.',
+			'thumbnails'                 => '(object) Media item thumbnail URL options',
+			'height'                     => '(int) (Image & video only) Height of the media item',
+			'width'                      => '(int) (Image & video only) Width of the media item',
+			'length'                     => '(int) (Video & audio only) Duration of the media item, in seconds',
+			'exif'                       => '(array) (Image & audio only) Exif (meta) information about the media item',
+			'rating'                     => '(string) (Video only) VideoPress rating of the video',
+			'display_embed'              => '(string) Video only. Whether to share or not the video.',
+			'videopress_guid'            => '(string) (Video only) VideoPress GUID of the video when uploaded on a blog with VideoPress',
+			'videopress_processing_done' => '(bool) (Video only) If the video is uploaded on a blog with VideoPress, this will return the status of processing on the video.',
+		),
+
+		'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/media/446',
+		'example_request_data' => array(
+			'headers' => array(
+				'authorization' => 'Bearer YOUR_API_TOKEN',
+			),
+			'body'    => array(
+				'title' => 'Updated Title',
+			),
+		),
 	)
-) );
+);
 
 class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint {
 	function callback( $path = '', $blog_id = 0, $media_id = 0 ) {
@@ -74,7 +80,7 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			return new WP_Error( 'unknown_media', 'Unknown Media', 404 );
 		}
 
-		$input = $this->input( true );
+		$input  = $this->input( true );
 		$insert = array();
 
 		if ( isset( $input['title'] ) ) {
@@ -98,7 +104,7 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			update_post_meta( $media_id, '_wp_attachment_image_alt', $alt );
 		}
 
-		// audio only artist/album info
+		// audio only artist/album info.
 		if ( 0 === strpos( $item->mime_type, 'audio/' ) ) {
 			$changed = false;
 			$id3data = wp_get_attachment_metadata( $media_id );
@@ -110,12 +116,12 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 
 			$id3_keys = array(
 				'artist' => __( 'Artist', 'jetpack' ),
-				'album' => __( 'Album', 'jetpack' )
+				'album'  => __( 'Album', 'jetpack' ),
 			);
 
 			foreach ( $id3_keys as $key => $label ) {
 				if ( isset( $input[ $key ] ) ) {
-					$changed = true;
+					$changed         = true;
 					$id3data[ $key ] = wp_strip_all_tags( $input[ $key ], true );
 				}
 			}
@@ -125,10 +131,45 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			}
 		}
 
+		$result = $this->handle_video_meta( $media_id, $input, $item );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
 		$insert['ID'] = $media_id;
 		wp_update_post( (object) $insert );
 
 		$item = $this->get_media_item_v1_1( $media_id );
 		return $item;
+	}
+
+	/**
+	 * Persist the videopress metadata.
+	 *
+	 * @param string   $media_id The ID of the video.
+	 * @param array    $input    The request input.
+	 * @param stdClass $item     The response item.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function handle_video_meta( $media_id, $input, $item ) {
+		if ( ! class_exists( \Videopress_Attachment_Metadata::class ) ) {
+			return false;
+		}
+
+		if ( ! Videopress_Attachment_Metadata::is_videopress_media( $item ) ) {
+			return false;
+		}
+
+		return \Videopress_Attachment_Metadata::persist_metadata(
+			$media_id,
+			$item->videopress_guid,
+			$input['title'],
+			$input['caption'],
+			$input['description'],
+			$input['rating'],
+			$input['display_embed']
+		);
 	}
 }

--- a/projects/plugins/jetpack/modules/videopress.php
+++ b/projects/plugins/jetpack/modules/videopress.php
@@ -19,6 +19,8 @@ include_once dirname( __FILE__ ) . '/videopress/class.videopress-xmlrpc.php';
 include_once dirname( __FILE__ ) . '/videopress/class.videopress-cli.php';
 include_once dirname( __FILE__ ) . '/videopress/class.jetpack-videopress.php';
 
+require_once __DIR__ . '/videopress/class-videopress-attachment-metadata.php';
+
 if ( is_admin() ) {
 	include_once dirname( __FILE__ ) . '/videopress/editor-media-view.php';
 	include_once dirname( __FILE__ ) . '/videopress/class.videopress-edit-attachment.php';

--- a/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
+++ b/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
@@ -88,7 +88,7 @@ class Videopress_Attachment_Metadata {
 	 * @return bool
 	 */
 	private static function is_display_embed_valid( $display_embed ) {
-		return ( 0 === $display_embed || 1 === $display_embed );
+		return ( '0' === $display_embed || '1' === $display_embed );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
+++ b/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
@@ -52,7 +52,7 @@ class Videopress_Attachment_Metadata {
 		$meta = wp_get_attachment_metadata( $post_id );
 
 		if ( isset( $values['display_embed'] ) ) {
-			$meta['videopress']['display_embed'] = $values['display_embed'];
+			$meta['videopress']['display_embed'] = (bool) $values['display_embed']; // convert it to bool since that's how we store it on wp-admin side.
 		}
 
 		if ( isset( $values['rating'] ) ) {
@@ -83,7 +83,7 @@ class Videopress_Attachment_Metadata {
 	/**
 	 * Check if display_embed has valid values.
 	 *
-	 * @param null|int $display_embed The input display embed.
+	 * @param mixed $display_embed The input display embed.
 	 *
 	 * @return bool
 	 */
@@ -151,7 +151,7 @@ class Videopress_Attachment_Metadata {
 		}
 
 		if ( self::is_display_embed_valid( $display_embed ) ) {
-			$values['display_embed'] = (string) $display_embed;
+			$values['display_embed'] = (int) $display_embed;
 		}
 
 		return $values;

--- a/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
+++ b/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
@@ -33,6 +33,8 @@ class Videopress_Attachment_Metadata {
 			'headers' => array( 'content-type' => 'application/json' ),
 		);
 
+		$display_embed = (int) $display_embed;
+
 		$values         = self::build_wpcom_api_request_values( $post_title, $caption, $post_excerpt, $rating, $display_embed );
 		$endpoint       = 'videos';
 		$values['guid'] = $guid;
@@ -51,7 +53,7 @@ class Videopress_Attachment_Metadata {
 
 		$meta = wp_get_attachment_metadata( $post_id );
 
-		if ( isset( $values['display_embed'] ) ) {
+		if ( self::is_display_embed_valid( $display_embed ) ) {
 			$meta['videopress']['display_embed'] = (bool) $values['display_embed']; // convert it to bool since that's how we store it on wp-admin side.
 		}
 
@@ -88,7 +90,7 @@ class Videopress_Attachment_Metadata {
 	 * @return bool
 	 */
 	private static function is_display_embed_valid( $display_embed ) {
-		return ( '0' === $display_embed || '1' === $display_embed );
+		return ( 0 === $display_embed || 1 === $display_embed );
 	}
 
 	/**
@@ -151,7 +153,7 @@ class Videopress_Attachment_Metadata {
 		}
 
 		if ( self::is_display_embed_valid( $display_embed ) ) {
-			$values['display_embed'] = (int) $display_embed;
+			$values['display_embed'] = $display_embed;
 		}
 
 		return $values;

--- a/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
+++ b/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
@@ -141,7 +141,7 @@ class Videopress_Attachment_Metadata {
 		}
 
 		if ( isset( $caption ) ) {
-			$values['caption'] = $caption;
+			$values['caption'] = trim( wp_strip_all_tags( $caption ) );
 		}
 
 		if ( isset( $post_excerpt ) ) {

--- a/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
+++ b/projects/plugins/jetpack/modules/videopress/class-videopress-attachment-metadata.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Handle the VideoPress metadata properties.
+ *
+ * @package Jetpack
+ */
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class Videopress_Attachment_Metadata
+ */
+class Videopress_Attachment_Metadata {
+
+	/**
+	 * Persist the VideoPress metadata information, including rating and display_embed.
+	 *
+	 * @param string|int $post_id       The post id.
+	 * @param string     $guid          VideoPress Guid.
+	 * @param string     $post_title    The post title.
+	 * @param string     $caption       Video caption.
+	 * @param string     $post_excerpt  The post excerpt.
+	 * @param string     $rating        The rating.
+	 * @param int        $display_embed The display_embed.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public static function persist_metadata( $post_id, $guid, $post_title, $caption, $post_excerpt, $rating, $display_embed ) {
+		$post_id = absint( $post_id );
+
+		$args = array(
+			'method'  => 'POST',
+			'headers' => array( 'content-type' => 'application/json' ),
+		);
+
+		$values         = self::build_wpcom_api_request_values( $post_title, $caption, $post_excerpt, $rating, $display_embed );
+		$endpoint       = 'videos';
+		$values['guid'] = $guid;
+
+		$result = Client::wpcom_json_api_request_as_blog( $endpoint, '2', $args, wp_json_encode( $values ), 'wpcom' );
+
+		$validated_result = self::validate_result( $result );
+		if ( true !== $validated_result ) {
+			return $validated_result;
+		}
+
+		// If we are in WPCOM, then we don't need to make anything else since we've already updated the video information.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return true;
+		}
+
+		$meta = wp_get_attachment_metadata( $post_id );
+
+		if ( isset( $values['display_embed'] ) ) {
+			$meta['videopress']['display_embed'] = $values['display_embed'];
+		}
+
+		if ( isset( $values['rating'] ) ) {
+			$meta['videopress']['rating'] = $values['rating'];
+		}
+
+		wp_update_attachment_metadata( $post_id, $meta );
+
+		return true;
+	}
+
+	/**
+	 * Check if the given media item is a VideoPress file.
+	 *
+	 * @param stdClass $item The media item.
+	 *
+	 * @return bool
+	 */
+	public static function is_videopress_media( $item ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return 0 === strpos( $item->mime_type, 'video/' );
+		}
+
+		// Else, we are in Jetpack and we need to check if the video is video/videopress.
+		return 'video/videopress' === $item->mime_type;
+	}
+
+	/**
+	 * Check if display_embed has valid values.
+	 *
+	 * @param null|int $display_embed The input display embed.
+	 *
+	 * @return bool
+	 */
+	private static function is_display_embed_valid( $display_embed ) {
+		return ( 0 === $display_embed || 1 === $display_embed );
+	}
+
+	/**
+	 * Validate the response received from WPCOM.
+	 *
+	 * @param array|\WP_Error $result The result returned by the client.
+	 */
+	private static function validate_result( $result ) {
+		$response_code = isset( $result['response']['code'] ) ? $result['response']['code'] : 500;
+
+		// When Client::wpcom_json_api_request_as_blog is called in WPCOM, bad response codes are not converted to WP_Error.
+		// Because of this, we need to manually check the response code to check if the direct API call is 200 (OK).
+		if ( 200 === $response_code && ! is_wp_error( $result ) ) {
+			return true;
+		}
+
+		$error_message = __(
+			'There was an issue saving your updates to the VideoPress service. Please try again later.',
+			'jetpack'
+		);
+
+		$error_code = $response_code;
+
+		if ( is_wp_error( $result ) ) {
+			$error_code = $result->get_error_code();
+		}
+
+		return new \WP_Error( $error_code, $error_message );
+	}
+
+	/**
+	 * Build the request values that will be passed to the WPCOM API.
+	 *
+	 * @param string $post_title The video title.
+	 * @param string $caption The video caption.
+	 * @param string $post_excerpt The except.
+	 * @param string $rating The video rating.
+	 * @param string $display_embed The video display_embed.
+	 *
+	 * @return array
+	 */
+	private static function build_wpcom_api_request_values( $post_title, $caption, $post_excerpt, $rating, $display_embed ) {
+		$values = array();
+
+		// Add the video title & description in, so that we save it properly.
+		if ( isset( $post_title ) ) {
+			$values['title'] = trim( wp_strip_all_tags( $post_title ) );
+		}
+
+		if ( isset( $caption ) ) {
+			$values['caption'] = $caption;
+		}
+
+		if ( isset( $post_excerpt ) ) {
+			$values['description'] = trim( wp_strip_all_tags( $post_excerpt ) );
+		}
+
+		if ( isset( $rating ) ) {
+			$values['rating'] = $rating;
+		}
+
+		if ( self::is_display_embed_valid( $display_embed ) ) {
+			$values['display_embed'] = (string) $display_embed;
+		}
+
+		return $values;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Add the `Share` and `Rating` configuration options in Calypso Media Edit modal for WPCOM and Jetpack sites (including atomic).
Fixes https://github.com/Automattic/wp-calypso/issues/51040

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* I've extracted and refactored the implementation from class.videopress-edit-attachment.php save_fields method in order to be able to use it in WP-Admin and in the API.
* The API rest endpoints for listing and updating the media which we are currently using in Calypso contains two new properties to for rating and share.
* In the WPCOM patch there's also a fix in VideoMeta that fixes `Duplicated entry` SQL errors triggered when un-checking and checking the Sharing checkbox.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Atomic and Jetpack:
* Use Jetpack Beta to switch to this branch.
  
Simple sites:
* Sandbox your environment and apply the patch D63097-code.

* Use the Calypso live test site for [this PR](https://github.com/Automattic/wp-calypso/pull/53860) or spin up the local environment.
* Go to calypso/media/your-at-site/ and click on a video managed by VideoPress (Business plan Atomic sites should have all the videos managed by VideoPress).
* Make sure that the Rating and Share options are present and editable.
* Change these options and save them, and immediately click Edit the Video again without refreshing the page.
* Refresh the page and click edit and make sure that options are persisted.
* Go to wp-admin/media.php, click on the video previously selected.
* Make sure that the options previously configured in Calypso are the same.

For Simple Sites only:
* Make sure that when un-checking the `Sharing` checkbox there's no SQL error in your php-errors file log by executing `tail -r /tmp/php-errors` on your sandbox.