### PR TITLE
E2E: include test report url in Slack notification

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-report-url-in-slack-notif
+++ b/projects/plugins/jetpack/changelog/e2e-report-url-in-slack-notif
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+E2E tests: add test report in Slack notification

--- a/projects/plugins/jetpack/tests/e2e/bin/slack.js
+++ b/projects/plugins/jetpack/tests/e2e/bin/slack.js
@@ -226,6 +226,8 @@ function buildDefaultMessage( isSuccess, forceHeaderText = undefined ) {
 	const gh = getGithubContext();
 
 	const btnStyle = isSuccess ? 'primary' : 'danger';
+	const dashboardUrl = 'https://automattic.github.io/jetpack-e2e-reports';
+	let reportUrl = dashboardUrl;
 
 	const buttons = [
 		{
@@ -270,7 +272,21 @@ function buildDefaultMessage( isSuccess, forceHeaderText = undefined ) {
 			: `${ isSuccess ? 'All tests passed' : 'There are test failures' } for PR \`<${ gh.pr.url }|${
 					gh.pr.title
 			  }>\``;
+
+		reportUrl = `${ dashboardUrl }/${ gh.pr.number }/report`;
+	} else {
+		reportUrl = `${ dashboardUrl }/${ gh.branch.name }/report`;
 	}
+
+	buttons.push( {
+		type: 'button',
+		text: {
+			type: 'plain_text',
+			text: `Report`,
+		},
+		url: reportUrl,
+		style: btnStyle,
+	} );
 
 	const blocks = [
 		{

--- a/projects/plugins/jetpack/tests/e2e/bin/slack.js
+++ b/projects/plugins/jetpack/tests/e2e/bin/slack.js
@@ -227,7 +227,7 @@ function buildDefaultMessage( isSuccess, forceHeaderText = undefined ) {
 
 	const btnStyle = isSuccess ? 'primary' : 'danger';
 	const dashboardUrl = 'https://automattic.github.io/jetpack-e2e-reports';
-	let reportUrl = dashboardUrl;
+	let reportUrl;
 
 	const buttons = [
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Include the test report url in Slack notification.

#### Jetpack product discussion
1156386383419466-as-1200408419584760/f

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Check Slack notification for this PR. It should include a new button for report which links to the test report.
