### PR TITLE
Add e2e report url in pr bot comment

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/e2e-gardening-add-e2e-report-url
+++ b/projects/github-actions/repo-gardening/changelog/e2e-gardening-add-e2e-report-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Included e2e test report url in PR bot comment

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "1.3.1-alpha",
+	"version": "1.4.0-alpha",
 	"description": "Manage PR and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -250,7 +250,7 @@ async function getChangelogEntries( octokit, owner, repo, number ) {
 				path.resolve(
 					process.env.GITHUB_WORKSPACE + `/projects/${ project }`,
 					( json.extra && json.extra.changelogger && json.extra.changelogger[ 'changes-dir' ] ) ||
-						'changelog'
+					'changelog'
 				)
 			) + '/';
 		const found = files.find( file => file.startsWith( changelogDir ) );
@@ -511,6 +511,12 @@ When contributing to Jetpack, we have [a few suggestions](https://github.com/Aut
 
 
 This comment will be updated as you work on your PR and make changes. If you think that some of those checks are not needed for your PR, please explain why you think so. Thanks for cooperation :robot:
+
+******`;
+
+	comment += `
+
+The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e-reports/${ number }/report/). Please note that it can take a few minutes after the e2e tests checks are complete for the report to be available.
 
 ******`;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add a new section in PR bot comment with link to e2e tests report.

#### Jetpack product discussion
1156386383419466-as-1200466130024533/f

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Check bot comment of this PR. It should include a section with a link to e2e test report.
