### PR TITLE
[WIP] [DO NOT MERGE] Carousel: Use CSS Grid for fixed info footer, add icons

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-carousel-with-fixed-footer-for-comments-and-meta
+++ b/projects/plugins/jetpack/changelog/update-jetpack-carousel-with-fixed-footer-for-comments-and-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Carousel: Add fixed footer with buttons to toggle visibility of info and comments areas.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -92,6 +92,15 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 .jp-carousel-info-footer {
 	background-color: #000;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.jp-carousel-pagination {
+	color: #fff;
+	padding-left: 32px;
+	font-size: 12px;
 }
 
 .jp-carousel-info-extra {
@@ -967,6 +976,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 .jp-carousel-photo-icons-container {
 	display: block;
 	text-align: right;
+	margin-right: 16px;
 }
 
 .jp-carousel-icon {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -89,7 +89,6 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	-webkit-font-smoothing: subpixel-antialiased !important;
 	z-index: 100;
 	background-color: #000;
-	margin-left: 1vw; /* This is to even up the mysterious rhs scroll/row gap */
 }
 
 .jp-carousel-info-footer {
@@ -390,12 +389,12 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 /** Title and Desc Start **/
 .jp-carousel-titleanddesc {
-    border-top: 1px solid #222;
-    color: #999;
-    font-size: 15px;
-    padding-top: 15px;
-    margin-bottom: 0;
-    font-weight: 4
+	border-top: 1px solid #222;
+	color: #999;
+	font-size: 15px;
+	padding-top: 15px;
+	margin-bottom: 0;
+	font-weight: 400;
 	width: 100%;
 }
 
@@ -461,13 +460,13 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 /** Meta Box Start **/
 .jp-carousel-image-meta {
-    color: #fff;
-    font-size: 13px;
-    font: 12px/1.4 "Helvetica Neue", sans-serif !important;
-    width: 100%;
-    display: none;
-    padding: 10px;
-    background: #222;
+	color: #fff;
+	font-size: 13px;
+	font: 12px/1.4 "Helvetica Neue", sans-serif !important;
+	width: 100%;
+	display: none;
+	padding: 10px;
+	background: #222;
 }
 
 .jp-carousel-image-meta.jp-carousel-show {
@@ -618,7 +617,7 @@ a.jp-carousel-image-download:hover {
 	color:#999;
 	font-size: 11px;
 	border-bottom: 1px solid #222;
-    margin-bottom: 6px;
+	margin-bottom: 6px;
 }
 
 #jp-carousel-comment-form {
@@ -977,6 +976,8 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 .jp-carousel-icon {
 	color: #fff;
 	fill: #fff;
+	background-color: black;
+	border: none;
 	cursor: pointer;
 	font-family: dashicons;
 	display: inline-block;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -13,14 +13,15 @@
 	bottom: 0;
 	left: 0;
 	background: #000;
+	z-index: -100;
 }
 
 .jp-carousel {
-	position: absolute;
+	/* position: absolute;
 	top: 0;
 	left: 0;
 	right: 0;
-	bottom: 20vh;
+	bottom: 20vh; */
 }
 
 div.jp-carousel-fadeaway {
@@ -76,15 +77,14 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	overflow-x: hidden;
 	overflow-y: auto;
 	direction: ltr;
+	display: grid;
+	grid-template-rows: 1fr 48px; /* main carousel and info area as footer */
 }
 
 .jp-carousel-info {
+	background-color: #333;
 	display: flex;
 	flex-direction: column;
-	position: absolute;
-	top: 81vh; /* Fallback, if calc is not supported */
-	top: calc( 80vh + 5px );
-	bottom: 0;
 	text-align: left !important;
 	-webkit-font-smoothing: subpixel-antialiased !important;
 }
@@ -947,6 +947,42 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	background: -moz-linear-gradient(bottom, rgba(255,255,255,0.75), rgba(255,255,255,0));
 	background: -webkit-gradient(linear, left bottom, left top, from(rgba(255,255,255,0.75)), to(rgba(255,255,255,0)));
 }
+
+/** Icons Start **/
+.jp-carousel-photo-icons-container {
+	display: block;
+	text-align: right;
+}
+
+.jp-carousel-icon {
+	color: #fff;
+	fill: #fff;
+	cursor: pointer;
+	font-family: dashicons;
+	display: inline-block;
+	width: 32px;
+	height: 32px;
+	font-size: 30px;
+	display: inline-block;
+	line-height: 1;
+	font-weight: 400;
+	font-style: normal;
+	margin-left: 16px;
+	margin-right: 16px;
+	margin-top: 8px;
+	margin-bottom: 8px;
+}
+
+/* .jp-carousel-icon-comments {
+	display: none;
+} */
+
+.jp-carousel-icon-comments.jp-carousel-show {
+	display: inline-block;
+}
+
+/** Icons End **/
+
 
 /* Small screens */
 @media only screen and (max-width: 760px) {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -320,6 +320,7 @@ div.jp-carousel-buttons a:hover {
 	position: fixed;
 	text-align: right;
 	width: 100%;
+	color: #fff;
 }
 
 .jp-carousel-transitions .jp-carousel-close-hint {
@@ -344,7 +345,6 @@ div.jp-carousel-buttons a:hover {
 	font-size: 36px !important;
 	height: 36px;
 	width: 36px;
-	color: #fff;
 }
 
 .jp-carousel-transitions .jp-carousel-close-hint span {
@@ -815,6 +815,51 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	margin-top: 20px;
 }
 
+/** Icons Start **/
+.jp-carousel-photo-icons-container {
+	display: block;
+	text-align: right;
+	margin-right: 16px;
+}
+
+.jp-carousel-icon-btn {
+	padding: 8px 16px;
+	text-decoration: none;
+	border: none;
+	background: none;
+	display: inline-block;
+	height: 48px;
+}
+
+.jp-carousel-icon {
+	color: #fff;
+	fill: #fff;
+	background-color: #000;
+	border: none;
+	border-radius: 2px;
+	cursor: pointer;
+	font-family: dashicons;
+	display: inline-block;
+	width: 32px;
+	height: 32px;
+	font-size: 30px;
+	line-height: 1;
+	font-weight: 400;
+	font-style: normal;
+
+}
+
+.jp-carousel-icon-btn:hover .jp-carousel-icon {
+	color: #000;
+	fill: #000;
+	background-color: #fff;
+}
+
+.jp-carousel-icon-comments.jp-carousel-show {
+	display: inline-block;
+}
+
+/** Icons End **/
 
 /* ----- Light variant ----- */
 
@@ -966,37 +1011,33 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	background: -webkit-gradient(linear, left bottom, left top, from(rgba(255,255,255,0.75)), to(rgba(255,255,255,0)));
 }
 
-/** Icons Start **/
-.jp-carousel-photo-icons-container {
-	display: block;
-	text-align: right;
-	margin-right: 16px;
+.jp-carousel-light .jp-carousel-info {
+	background-color: #fff;
 }
 
-.jp-carousel-icon {
+.jp-carousel-light .jp-carousel-info-footer {
+	background-color: #fff;
+}
+
+.jp-carousel-light .jp-carousel-info-extra {
+	background-color: #fff;
+}
+
+.jp-carousel-light .jp-carousel-icon {
+	color: #000;
+	fill: #000;
+	background-color: #fff;
+}
+
+.jp-carousel-light .jp-carousel-icon-btn:hover .jp-carousel-icon {
 	color: #fff;
 	fill: #fff;
-	background-color: black;
-	border: none;
-	cursor: pointer;
-	font-family: dashicons;
-	display: inline-block;
-	width: 32px;
-	height: 32px;
-	font-size: 30px;
-	display: inline-block;
-	line-height: 1;
-	font-weight: 400;
-	font-style: normal;
-	margin: 8px 16px;
+	background-color: #000;
 }
 
-.jp-carousel-icon-comments.jp-carousel-show {
-	display: inline-block;
+.jp-carousel-light .jp-carousel-pagination {
+	color: #000;
 }
-
-/** Icons End **/
-
 
 /* Small screens */
 @media only screen and (max-width: 760px) {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -78,15 +78,30 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	overflow-y: auto;
 	direction: ltr;
 	display: grid;
-	grid-template-rows: 1fr 48px; /* main carousel and info area as footer */
+	grid-template-rows: 1fr 50px; /* main carousel and info area as footer */
+	height: 100%;
 }
 
 .jp-carousel-info {
-	background-color: #333;
 	display: flex;
 	flex-direction: column;
 	text-align: left !important;
 	-webkit-font-smoothing: subpixel-antialiased !important;
+	z-index: 100;
+}
+
+.jp-carousel-info-footer {
+	background-color: #000;
+}
+
+.jp-carousel-info-extra {
+	background-color: #000;
+	padding: 1em 6em;
+	display: none;
+}
+
+.jp-carousel-info-extra.jp-carousel-show {
+	display: block;
 }
 
 .jp-carousel-info-columns {
@@ -987,8 +1002,8 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 /* Small screens */
 @media only screen and (max-width: 760px) {
 
-	.jp-carousel-info {
-		margin: 0 10px !important;
+	.jp-carousel-info-extra {
+		padding: 1em 1em;
 	}
 
 	.jp-carousel-info-columns {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -88,6 +88,8 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	text-align: left !important;
 	-webkit-font-smoothing: subpixel-antialiased !important;
 	z-index: 100;
+	background-color: #000;
+	margin-left: 1vw; /* This is to even up the mysterious rhs scroll/row gap */
 }
 
 .jp-carousel-info-footer {
@@ -104,20 +106,13 @@ only screen and (min-device-pixel-ratio: 1.5) {
 }
 
 .jp-carousel-info-extra {
-	background-color: #000;
-	padding: 1em 6em;
 	display: none;
+	background: #000;
+	padding: 0 20px 20px 20px;
 }
 
 .jp-carousel-info-extra.jp-carousel-show {
 	display: block;
-}
-
-.jp-carousel-info-columns {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-items: flex-start;
 }
 
 .jp-carousel-info ::selection {
@@ -131,18 +126,21 @@ only screen and (min-device-pixel-ratio: 1.5) {
 }
 
 .jp-carousel-photo-info {
-	position: relative;
-	left: 25%;
-	width: 50%;
+	left: 0 !important;
+	width: 100% !important;
 }
 
-.jp-carousel-left-column-wrapper {
-	flex-grow: 1;
-	flex-shrink: 1;
-	overflow: hidden;
+.jp-carousel-comments-wrapper {
+	padding: 0;
+	width: 100% !important;
+	display: none;
 }
 
-.jp-carousel-left-column-wrapper > .jp-carousel-photo-info {
+.jp-carousel-comments-wrapper.jp-carousel-show {
+	display: block;
+}
+
+.jp-carousel-comments-wrapper > .jp-carousel-photo-info {
 	display: none;
 }
 
@@ -316,7 +314,6 @@ div.jp-carousel-buttons a:hover {
 }
 
 .jp-carousel-close-hint {
-	color: #999;
 	cursor: default;
 	letter-spacing: 0 !important;
 	padding: 0.35em 25px 0.35em 0;
@@ -336,18 +333,19 @@ div.jp-carousel-buttons a:hover {
 .jp-carousel-close-hint span {
 	cursor: pointer;
 	background-color: black;
-	background-color: rgba(0,0,0,0.8);
 	display: inline-block;
-	height: 22px;
-	font: 400 24px/1 "Helvetica Neue", sans-serif !important;
+	font: 800 36px/1 "Helvetica Neue", sans-serif !important;
 	line-height: 22px;
 	margin: 0 0 0 0.4em;
 	text-align: center;
 	vertical-align: middle;
-	width: 22px;
 	-moz-border-radius: 4px;
 	-webkit-border-radius: 4px;
 	border-radius: 4px;
+	font-size: 36px !important;
+	height: 36px;
+	width: 36px;
+	color: #fff;
 }
 
 .jp-carousel-transitions .jp-carousel-close-hint span {
@@ -392,13 +390,12 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 /** Title and Desc Start **/
 .jp-carousel-titleanddesc {
-	border-top: 1px solid #222;
-	color: #999;
-	font-size: 15px;
-	padding-top: 24px;
-	margin-top: 20px;
-	margin-bottom: 20px;
-	font-weight: 400;
+    border-top: 1px solid #222;
+    color: #999;
+    font-size: 15px;
+    padding-top: 15px;
+    margin-bottom: 0;
+    font-weight: 4
 	width: 100%;
 }
 
@@ -411,14 +408,14 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	font: 300 1.5em/1.1 "Helvetica Neue", sans-serif !important;
 	text-transform: none !important; /* prevents uppercase from leaking through */
 	color: #fff;
-	margin: 0 0 15px;
-	padding:0;
+	margin: 0 0 7px;
+	padding: 0;
 }
 
 .jp-carousel-titleanddesc-desc p {
 	color: #999;
 	line-height:1.4;
-	margin-bottom: 0.75em;
+	margin-bottom: 0;
 }
 
 .jp-carousel-titleanddesc p a,
@@ -456,26 +453,25 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
 .jp-carousel-photo-info h1:before,
 .jp-carousel-photo-info h1:after,
-.jp-carousel-left-column-wrapper h1:before,
-.jp-carousel-left-column-wrapper h1:after {
+.jp-carousel-comments-wrapper h1:before,
+.jp-carousel-comments-wrapper h1:after {
 	content:none !important;
 }
 /** Title and Desc End **/
 
 /** Meta Box Start **/
 .jp-carousel-image-meta {
-	background: #111;
-	border: 1px solid #222;
-	color: #fff;
-	font-size: 13px;
-	font: 12px/1.4 "Helvetica Neue", sans-serif !important;
-	overflow: hidden;
-	padding: 18px 20px;
-	width: 209px !important;
-	margin-top: 20px;
-	margin-left: 40px;
-	margin-bottom: 20px;
-	flex-shrink: 0;
+    color: #fff;
+    font-size: 13px;
+    font: 12px/1.4 "Helvetica Neue", sans-serif !important;
+    width: 100%;
+    display: none;
+    padding: 10px;
+    background: #222;
+}
+
+.jp-carousel-image-meta.jp-carousel-show {
+	display: block;
 }
 
 .jp-carousel-image-meta li,
@@ -563,9 +559,9 @@ a.jp-carousel-image-download:hover {
 .jp-carousel-comment {
 	background: none transparent;
 	color: #999;
-	clear: left;
 	overflow: auto;
 	width: 100%;
+	display: flex;
 }
 
 .jp-carousel-comment + .jp-carousel-comment {
@@ -581,13 +577,13 @@ a.jp-carousel-image-download:hover {
 }
 
 .jp-carousel-comment .comment-author {
-	font-size: 13px;
-	font-weight:400;
+	font-size: 15px;
+	font-weight:500;
 	padding:0;
 	width:auto;
 	display: inline;
-	float:none;
-	border:none;
+	float: none;
+	border: none;
 	margin:0;
 }
 
@@ -596,12 +592,15 @@ a.jp-carousel-image-download:hover {
 }
 
 .jp-carousel-comment .comment-gravatar {
-	float:left;
+	float: none;
+}
+
+.jp-carousel-comment .comment-gravatar img {
+	min-width: 64px;
 }
 
 .jp-carousel-comment .comment-content {
 	border:none;
-	margin-left:85px;
 	padding: 0;
 }
 
@@ -617,16 +616,13 @@ a.jp-carousel-image-download:hover {
 
 .jp-carousel-comment .comment-date {
 	color:#999;
-	margin-top: 4px;
-	font-size:11px;
-	display: inline;
-	float: right;
-	/*clear: right;*/
+	font-size: 11px;
+	border-bottom: 1px solid #222;
+    margin-bottom: 6px;
 }
 
 #jp-carousel-comment-form {
 	margin:0 0 10px !important;
-	float: left;
 	width: 100%;
 }
 
@@ -711,7 +707,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 #jp-carousel-comment-form-submit-and-info-wrapper {
 	display: none;
-	/*margin-bottom:15px;*/
 	overflow: hidden;
 	width: 100%
 }
@@ -992,15 +987,8 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	line-height: 1;
 	font-weight: 400;
 	font-style: normal;
-	margin-left: 16px;
-	margin-right: 16px;
-	margin-top: 8px;
-	margin-bottom: 8px;
+	margin: 8px 16px;
 }
-
-/* .jp-carousel-icon-comments {
-	display: none;
-} */
 
 .jp-carousel-icon-comments.jp-carousel-show {
 	display: inline-block;
@@ -1011,15 +999,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 /* Small screens */
 @media only screen and (max-width: 760px) {
-
-	.jp-carousel-info-extra {
-		padding: 1em 1em;
-	}
-
-	.jp-carousel-info-columns {
-		flex-direction: column;
-	}
-
 	.jp-carousel-next-button, .jp-carousel-previous-button {
 		display: none !important;
 	}
@@ -1057,33 +1036,15 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		display: none;
 	}
 
-	#jp-carousel-comment-form-container {
-		display: none !important;
-	}
-
-	.jp-carousel-titleanddesc {
-		padding-top: 0 !important;
-		border: none !important;
-	}
 	.jp-carousel-titleanddesc-title {
-		font-size: 1em !important;
-	}
-
-	.jp-carousel-left-column-wrapper {
-		padding: 0;
-		width: 100% !important;
-	}
-
-	.jp-carousel-photo-info {
-		left: 0 !important;
-		width: 100% !important;
+		font-size: 1.25em !important;
 	}
 
 	.jp-carousel-info > .jp-carousel-photo-info {
 		display: none;
 	}
 
-	.jp-carousel-left-column-wrapper > .jp-carousel-photo-info {
+	.jp-carousel-comments-wrapper > .jp-carousel-photo-info {
 		display: block;
 	}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -464,6 +464,8 @@
 						handleCommentLoginClick( e );
 					} else if ( domUtil.closest( target, '#jp-carousel-comment-form-container' ) ) {
 						handleCommentFormClick( e );
+					} else if ( domUtil.closest( target, '.jp-carousel-photo-icons-container' ) ) {
+						handleIconClick( e );
 					} else if ( ! domUtil.closest( target, '.jp-carousel-info' ) ) {
 						if ( isSmallScreen ) {
 							handleCarouselGalleryTouch( e );
@@ -668,6 +670,39 @@
 				var encodedData = params.join( '&' );
 
 				xhr.send( encodedData );
+			}
+		}
+
+		/**
+		 * Handles clicks to icons in the icon container.
+		 * @param {MouseEvent|TouchEvent|KeyBoardEvent} Event object.
+		 */
+		function handleIconClick( e ) {
+			e.preventDefault();
+
+			var target = e.target;
+
+			var extraInfoContainer = carousel.info.querySelector( '.jp-carousel-info-extra' );
+
+			if ( domUtil.closest( target, '.jp-carousel-icon-info' ) ) {
+				var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
+
+				if ( photoMetaContainer ) {
+					extraInfoContainer.classList.toggle( 'jp-carousel-show' );
+					if ( extraInfoContainer.classList.contains( 'jp-carousel-show' ) ) {
+						domUtil.scrollToElement( photoMetaContainer );
+					}
+				}
+			}
+
+			if ( domUtil.closest( target, '.jp-carousel-icon-comments' ) ) {
+				var commentsContainer = carousel.container.querySelector( '.jp-carousel-comments' );
+				if ( commentsContainer ) {
+					extraInfoContainer.classList.toggle( 'jp-carousel-show' );
+					if ( extraInfoContainer.classList.contains( 'jp-carousel-show' ) ) {
+						domUtil.scrollToElement( commentsContainer );
+					}
+				}
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -681,26 +681,32 @@
 			e.preventDefault();
 
 			var target = e.target;
-
 			var extraInfoContainer = carousel.info.querySelector( '.jp-carousel-info-extra' );
+			var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
+			var commentsContainer = carousel.info.querySelector( '.jp-carousel-comments-wrapper' );
 
 			if ( domUtil.closest( target, '.jp-carousel-icon-info' ) ) {
-				var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
-
+				commentsContainer.classList.remove( 'jp-carousel-show' );
 				if ( photoMetaContainer ) {
-					extraInfoContainer.classList.toggle( 'jp-carousel-show' );
-					if ( extraInfoContainer.classList.contains( 'jp-carousel-show' ) ) {
-						domUtil.scrollToElement( photoMetaContainer );
+					photoMetaContainer.classList.toggle( 'jp-carousel-show' );
+					if ( photoMetaContainer.classList.contains( 'jp-carousel-show' ) ) {
+						extraInfoContainer.classList.add( 'jp-carousel-show' );
+						domUtil.scrollToElement( extraInfoContainer );
+					} else {
+						extraInfoContainer.classList.remove( 'jp-carousel-show' );
 					}
 				}
 			}
 
 			if ( domUtil.closest( target, '.jp-carousel-icon-comments' ) ) {
-				var commentsContainer = carousel.container.querySelector( '.jp-carousel-comments' );
+				photoMetaContainer.classList.remove( 'jp-carousel-show' );
 				if ( commentsContainer ) {
-					extraInfoContainer.classList.toggle( 'jp-carousel-show' );
-					if ( extraInfoContainer.classList.contains( 'jp-carousel-show' ) ) {
-						domUtil.scrollToElement( commentsContainer );
+					commentsContainer.classList.toggle( 'jp-carousel-show' );
+					if ( commentsContainer.classList.contains( 'jp-carousel-show' ) ) {
+						extraInfoContainer.classList.add( 'jp-carousel-show' );
+						domUtil.scrollToElement( extraInfoContainer );
+					} else {
+						extraInfoContainer.classList.remove( 'jp-carousel-show' );
 					}
 				}
 			}
@@ -786,6 +792,13 @@
 			var previousPrevious = getPrevSlide( prev );
 			var nextNext = getNextSlide( next );
 			var captionHtml;
+			var extraInfoContainer = carousel.info.querySelector( '.jp-carousel-info-extra' );
+			var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
+			var commentsContainer = carousel.info.querySelector( '.jp-carousel-comments-wrapper' );
+			// Hide comments and photo info
+			extraInfoContainer.classList.remove( 'jp-carousel-show' );
+			photoMetaContainer.classList.remove( 'jp-carousel-show' );
+			commentsContainer.classList.remove( 'jp-carousel-show' );
 
 			carousel.slides.forEach( function ( slide ) {
 				slide.el.style.position = 'fixed';
@@ -986,14 +999,10 @@
 			var next = getNextSlide( current );
 			var previousPrevious = getPrevSlide( previous );
 			var nextNext = getNextSlide( next );
-
 			var left = Math.floor( ( galleryWidth - currentWidth ) * 0.5 );
 
 			setSlidePosition( current.el, left );
 			domUtil.show( current.el );
-
-			// minimum width
-			fitInfo();
 
 			// prep the slides
 			var direction = current && last && last.index < current.index ? 1 : -1;
@@ -1091,17 +1100,6 @@
 				};
 				img.addEventListener( 'load', loadHandler );
 			}
-		}
-
-		function fitInfo() {
-			var size = calculateBestFit( carousel.currentSlide );
-
-			var photoInfos = carousel.container.querySelectorAll( '.jp-carousel-photo-info' );
-			Array.prototype.forEach.call( photoInfos, function ( photoInfo ) {
-				photoInfo.style.left =
-					Math.floor( ( carousel.info.offsetWidth - size.width ) * 0.5 ) + 'px';
-				photoInfo.style.width = Math.floor( size.width ) + 'px';
-			} );
 		}
 
 		function fitSlides( slides ) {
@@ -1425,13 +1423,13 @@
 						'<div class="comment-gravatar">' +
 						entry.gravatar_markup +
 						'</div>' +
+						'<div class="comment-content">' +
 						'<div class="comment-author">' +
 						entry.author_markup +
 						'</div>' +
 						'<div class="comment-date">' +
 						entry.date_gmt +
 						'</div>' +
-						'<div class="comment-content">' +
 						entry.content +
 						'</div>';
 					comments.appendChild( comment );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -859,6 +859,13 @@
 				} );
 			}
 
+			// Update pagination in footer.
+			var pagination = carousel.info.querySelector( '.jp-carousel-pagination' );
+			if ( pagination ) {
+				var currentPage = index + 1;
+				pagination.innerHTML = '<span>' + currentPage + ' / ' + carousel.slides.length + '</span>';
+			}
+
 			// Record pageview in WP Stats, for each new image loaded full-screen.
 			if ( jetpackCarouselStrings.stats ) {
 				new Image().src =

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -365,7 +365,7 @@ class Jetpack_Carousel {
 			<div class="jp-carousel-overlay"></div>
 			<div class="jp-carousel"></div>
 			<div class="jp-carousel-info">
-				<div class="jp-carousel-footer">
+				<div class="jp-carousel-info-footer">
 					<div class="jp-carousel-photo-icons-container">
 						<span class="jp-carousel-icon jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
@@ -375,99 +375,101 @@ class Jetpack_Carousel {
 						</span>
 					</div>
 				</div>
-				<div class="jp-carousel-photo-info">
-					<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
-				</div>
-				<div class="jp-carousel-info-columns">
-					<div class="jp-carousel-left-column-wrapper">
-						<div class="jp-carousel-titleanddesc"></div>
-						<!-- Intentional duplicate -->
-						<div class="jp-carousel-photo-info">
-							<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
-						</div>
-						<?php if ( $localize_strings['display_comments'] ) : ?>
-							<div id="jp-carousel-comment-form-container">
-								<?php if ( $use_local_comments ) : ?>
-									<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
-										<div id="jp-carousel-comment-form-commenting-as">
-											<p id="jp-carousel-commenting-as">
-												<?php
-													echo wp_kses(
-														__( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ),
-														array(
-															'a' => array(
-																'href'  => array(),
-																'class' => array(),
-															),
-														)
-													);
-												?>
-											</p>
-										</div>
-									<?php else : ?>
-										<form id="jp-carousel-comment-form">
-											<label for="jp-carousel-comment-form-comment-field" class="screen-reader-text"><?php echo esc_attr( $localize_strings['write_comment'] ); ?></label>
-											<textarea
-												name="comment"
-												class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"
-												id="jp-carousel-comment-form-comment-field"
-												placeholder="<?php echo esc_attr( $localize_strings['write_comment'] ); ?>"
-											></textarea>
-											<div id="jp-carousel-comment-form-submit-and-info-wrapper">
-												<div id="jp-carousel-comment-form-commenting-as">
-													<?php if ( $localize_strings['is_logged_in'] ) : ?>
-														<p id="jp-carousel-commenting-as">
-															<?php
-																printf(
-																	/* translators: %s is replaced with the user's display name */
-																	esc_html__( 'Commenting as %s', 'jetpack' ),
-																	esc_html( $current_user->data->display_name )
-																);
-															?>
-														</p>
-													<?php else : ?>
-														<fieldset>
-															<label for="jp-carousel-comment-form-email-field"><?php echo esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ); ?></label>
-															<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
-														</fieldset>
-														<fieldset>
-															<label for="jp-carousel-comment-form-author-field"><?php echo esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ); ?></label>
-															<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
-														</fieldset>
-														<fieldset>
-															<label for="jp-carousel-comment-form-url-field"><?php esc_html_e( 'Website', 'jetpack' ); ?></label>
-															<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" />
-														</fieldset>
-													<?php endif ?>
-												</div>
-												<input
-													type="submit"
-													name="submit"
-													class="jp-carousel-comment-form-button"
-													id="jp-carousel-comment-form-button-submit"
-													value="<?php echo esc_attr( $localize_strings['post_comment'] ); ?>" />
-												<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
-												<div id="jp-carousel-comment-post-results"></div>
-											</div>
-										</form>
-									<?php endif ?>
-								<?php endif ?>
-							</div>
-							<div class="jp-carousel-comments"></div>
-							<div id="jp-carousel-comments-loading">
-								<span><?php echo esc_html( $localize_strings['loading_comments'] ); ?></span>
-							</div>
-						<?php endif ?>
+				<div class="jp-carousel-info-extra">
+					<div class="jp-carousel-photo-info">
+						<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
 					</div>
-					<div class="jp-carousel-image-meta">
-						<div class="jp-carousel-buttons">
+					<div class="jp-carousel-info-columns">
+						<div class="jp-carousel-left-column-wrapper">
+							<div class="jp-carousel-titleanddesc"></div>
+							<!-- Intentional duplicate -->
+							<div class="jp-carousel-photo-info">
+								<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
+							</div>
 							<?php if ( $localize_strings['display_comments'] ) : ?>
-							<a class="jp-carousel-commentlink" href="#"><?php echo esc_html( $localize_strings['comment'] ); ?></a>
+								<div id="jp-carousel-comment-form-container">
+									<?php if ( $use_local_comments ) : ?>
+										<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
+											<div id="jp-carousel-comment-form-commenting-as">
+												<p id="jp-carousel-commenting-as">
+													<?php
+														echo wp_kses(
+															__( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ),
+															array(
+																'a' => array(
+																	'href'  => array(),
+																	'class' => array(),
+																),
+															)
+														);
+													?>
+												</p>
+											</div>
+										<?php else : ?>
+											<form id="jp-carousel-comment-form">
+												<label for="jp-carousel-comment-form-comment-field" class="screen-reader-text"><?php echo esc_attr( $localize_strings['write_comment'] ); ?></label>
+												<textarea
+													name="comment"
+													class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"
+													id="jp-carousel-comment-form-comment-field"
+													placeholder="<?php echo esc_attr( $localize_strings['write_comment'] ); ?>"
+												></textarea>
+												<div id="jp-carousel-comment-form-submit-and-info-wrapper">
+													<div id="jp-carousel-comment-form-commenting-as">
+														<?php if ( $localize_strings['is_logged_in'] ) : ?>
+															<p id="jp-carousel-commenting-as">
+																<?php
+																	printf(
+																		/* translators: %s is replaced with the user's display name */
+																		esc_html__( 'Commenting as %s', 'jetpack' ),
+																		esc_html( $current_user->data->display_name )
+																	);
+																?>
+															</p>
+														<?php else : ?>
+															<fieldset>
+																<label for="jp-carousel-comment-form-email-field"><?php echo esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ); ?></label>
+																<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
+															</fieldset>
+															<fieldset>
+																<label for="jp-carousel-comment-form-author-field"><?php echo esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ); ?></label>
+																<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
+															</fieldset>
+															<fieldset>
+																<label for="jp-carousel-comment-form-url-field"><?php esc_html_e( 'Website', 'jetpack' ); ?></label>
+																<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" />
+															</fieldset>
+														<?php endif ?>
+													</div>
+													<input
+														type="submit"
+														name="submit"
+														class="jp-carousel-comment-form-button"
+														id="jp-carousel-comment-form-button-submit"
+														value="<?php echo esc_attr( $localize_strings['post_comment'] ); ?>" />
+													<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
+													<div id="jp-carousel-comment-post-results"></div>
+												</div>
+											</form>
+										<?php endif ?>
+									<?php endif ?>
+								</div>
+								<div class="jp-carousel-comments"></div>
+								<div id="jp-carousel-comments-loading">
+									<span><?php echo esc_html( $localize_strings['loading_comments'] ); ?></span>
+								</div>
 							<?php endif ?>
 						</div>
-						<ul class="jp-carousel-image-exif" style="display: none;"></ul>
-						<a class="jp-carousel-image-download" target="_blank" style="display: none;"></a>
-						<div class="jp-carousel-image-map" style="display: none;"></div>
+						<div class="jp-carousel-image-meta">
+							<div class="jp-carousel-buttons">
+								<?php if ( $localize_strings['display_comments'] ) : ?>
+								<a class="jp-carousel-commentlink" href="#"><?php echo esc_html( $localize_strings['comment'] ); ?></a>
+								<?php endif ?>
+							</div>
+							<ul class="jp-carousel-image-exif" style="display: none;"></ul>
+							<a class="jp-carousel-image-download" target="_blank" style="display: none;"></a>
+							<div class="jp-carousel-image-map" style="display: none;"></div>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -364,8 +364,17 @@ class Jetpack_Carousel {
 			style="display: none;">
 			<div class="jp-carousel-overlay"></div>
 			<div class="jp-carousel"></div>
-			<div class="jp-carousel-fadeaway"></div>
 			<div class="jp-carousel-info">
+				<div class="jp-carousel-footer">
+					<div class="jp-carousel-photo-icons-container">
+						<span class="jp-carousel-icon jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
+						</span>
+						<span class="jp-carousel-icon jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
+							<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"></path></svg>
+						</span>
+					</div>
+				</div>
 				<div class="jp-carousel-photo-info">
 					<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
 				</div>

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -368,12 +368,12 @@ class Jetpack_Carousel {
 				<div class="jp-carousel-info-footer">
 					<div class="jp-carousel-pagination"></div>
 					<div class="jp-carousel-photo-icons-container">
-						<span class="jp-carousel-icon jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
+						<a href="#" class="jp-carousel-icon jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
-						</span>
-						<span class="jp-carousel-icon jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
+						</a>
+						<a href="#" class="jp-carousel-icon jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
 							<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"></path></svg>
-						</span>
+						</a>
 					</div>
 				</div>
 				<div class="jp-carousel-info-extra">

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -366,6 +366,8 @@ class Jetpack_Carousel {
 			<div class="jp-carousel"></div>
 			<div class="jp-carousel-info">
 				<div class="jp-carousel-info-footer">
+					<div class="jp-carousel-pagination">
+					</div>
 					<div class="jp-carousel-photo-icons-container">
 						<span class="jp-carousel-icon jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -368,11 +368,15 @@ class Jetpack_Carousel {
 				<div class="jp-carousel-info-footer">
 					<div class="jp-carousel-pagination"></div>
 					<div class="jp-carousel-photo-icons-container">
-						<a href="#" class="jp-carousel-icon jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
+						<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
+							<span class="jp-carousel-icon">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
+							</span>
 						</a>
-						<a href="#" class="jp-carousel-icon jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
-							<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"></path></svg>
+						<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
+							<span class="jp-carousel-icon">
+								<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"></path></svg>
+							</span>
 						</a>
 					</div>
 				</div>

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -366,8 +366,7 @@ class Jetpack_Carousel {
 			<div class="jp-carousel"></div>
 			<div class="jp-carousel-info">
 				<div class="jp-carousel-info-footer">
-					<div class="jp-carousel-pagination">
-					</div>
+					<div class="jp-carousel-pagination"></div>
 					<div class="jp-carousel-photo-icons-container">
 						<span class="jp-carousel-icon jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
@@ -378,17 +377,19 @@ class Jetpack_Carousel {
 					</div>
 				</div>
 				<div class="jp-carousel-info-extra">
-					<div class="jp-carousel-photo-info">
-						<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
+					<div class="jp-carousel-title-and-caption">
+						<div class="jp-carousel-titleanddesc"></div>
+						<div class="jp-carousel-photo-info">
+							<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
+						</div>
 					</div>
-					<div class="jp-carousel-info-columns">
-						<div class="jp-carousel-left-column-wrapper">
-							<div class="jp-carousel-titleanddesc"></div>
-							<!-- Intentional duplicate -->
-							<div class="jp-carousel-photo-info">
-								<h2 class="jp-carousel-caption" itemprop="caption description"></h2>
-							</div>
+					<div class="jp-carousel-info-content-wrapper">
+						<div class="jp-carousel-comments-wrapper">
 							<?php if ( $localize_strings['display_comments'] ) : ?>
+								<div id="jp-carousel-comments-loading">
+									<span><?php echo esc_html( $localize_strings['loading_comments'] ); ?></span>
+								</div>
+								<div class="jp-carousel-comments"></div>
 								<div id="jp-carousel-comment-form-container">
 									<?php if ( $use_local_comments ) : ?>
 										<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
@@ -456,18 +457,9 @@ class Jetpack_Carousel {
 										<?php endif ?>
 									<?php endif ?>
 								</div>
-								<div class="jp-carousel-comments"></div>
-								<div id="jp-carousel-comments-loading">
-									<span><?php echo esc_html( $localize_strings['loading_comments'] ); ?></span>
-								</div>
 							<?php endif ?>
 						</div>
 						<div class="jp-carousel-image-meta">
-							<div class="jp-carousel-buttons">
-								<?php if ( $localize_strings['display_comments'] ) : ?>
-								<a class="jp-carousel-commentlink" href="#"><?php echo esc_html( $localize_strings['comment'] ); ?></a>
-								<?php endif ?>
-							</div>
 							<ul class="jp-carousel-image-exif" style="display: none;"></ul>
 							<a class="jp-carousel-image-download" target="_blank" style="display: none;"></a>
 							<div class="jp-carousel-image-map" style="display: none;"></div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

***Note: work on this change is progressing in #20145***

This is a WIP experiment, hacking around using CSS grid for laying out the info footer for the Jetpack Carousel. This exploration is branched from Ramon's work in https://github.com/Automattic/jetpack/pull/20108.

Possible fix for: Automattic/view-design#281 and resolves Automattic/view-design#284

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add an apparent fixed footer to the Jetpack Carousel, with info and comment buttons
* Hide the extra info area beneath the footer by default, to prevent vertical scrolling
* When the info or comment button is clicked, reveal

#### Screenshot of WIP

![carousel-footer-reveal-with-pages-sml](https://user-images.githubusercontent.com/14988353/122881065-1402cd00-d37e-11eb-9ce4-184448b227e4.gif)

#### To-dos

* [x] Should we hide the extra footer area when navigating back / forward through slides?
* [ ] Add smooth scrolling to scrolling up / down
* [ ] Add a timeout before toggling the show class _off_ so that we can smooth scroll up _before_ the extra info content is hidden
* [ ] Tweak the tap targets of the buttons so that they are larger — currently (with my thumbs at least) it's difficult to tap the buttons on mobile (iPhone 8)
* [ ] Tweak styling and positioning of buttons to better match designs
* [ ] Tweak styling, width and positioning of columns, info, captions, etc beneath the new footer
* [ ] Update styling to ensure it works in Light mode as well as the default Dark colour scheme
* [ ] Should we add in the description to the footer (as per the designs) or leave it off for the time being?
* [ ] Should we add in a number indicator in the bottom left (e.g. 1/5)?
* [ ] Invert the fill / background colours of the icon buttons when they're selected? (It looks like this is suggested from the designs)
* [ ] Conditionally hide the info and comment icons based on the site's Jetpack settings for showing Exif metadata / comments:

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Designs: p9Jlb4-2cI-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an image gallery to a post on your test site
* With Jetpack active, and the Jetpack Carousel module activated, view the post on the front end of your site
* Click an image in the gallery to open up the carousel, and try out the info and comment buttons in the footer
* Go to the Jetpack settings and update the carousel to use the white colour scheme and check that the styling is correct (note: styling support for light theme hasn't been added yet) `/wp-admin/admin.php?page=jetpack#/writing`

![image](https://user-images.githubusercontent.com/14988353/122874729-a99a5e80-d376-11eb-811c-eadf6cf6750f.png)