### PR TITLE
Jetpack Backup: Utilize endpoints from backup package

### DIFF
--- a/projects/plugins/backup/changelog/update-backup-plugin-with-backup-pkg
+++ b/projects/plugins/backup/changelog/update-backup-plugin-with-backup-pkg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add backup package dependency.

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-autoloader": "2.10.x-dev",
+		"automattic/jetpack-backup": "1.1.x-dev",
 		"automattic/jetpack-config": "1.4.x-dev",
 		"automattic/jetpack-connection": "1.28.x-dev",
 		"automattic/jetpack-connection-ui": "1.2.x-dev",

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1701fdfb9bd16deeb2df11f37417e8c1",
+    "content-hash": "74c52cf5e29b9385f38ed0b7ebbbb85c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -163,6 +163,66 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
+            "transport-options": {
+                "monorepo": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-backup",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/backup",
+                "reference": "5fb371087dab728ea1188acfa3698dbfa2b7320c"
+            },
+            "require": {
+                "automattic/jetpack-connection": "^1.28"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
+                "automattic/wordbless": "@dev",
+                "yoast/phpunit-polyfills": "0.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-backup",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "actions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "@composer install",
+                    "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-update-cmd": [
+                    "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Tools to assist with backing up Jetpack sites.",
             "transport-options": {
                 "monorepo": true,
                 "relative": true
@@ -4143,6 +4203,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "automattic/jetpack-autoloader": 20,
+        "automattic/jetpack-backup": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-connection-ui": 20,

--- a/projects/plugins/backup/src/php/class-jetpack-backup.php
+++ b/projects/plugins/backup/src/php/class-jetpack-backup.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+
 /**
  * Class Jetpack_Backup
  */
@@ -17,6 +19,9 @@ class Jetpack_Backup {
 	 * Constructor.
 	 */
 	public function __construct() {
+		// Set up the REST authentication hooks.
+		Connection_Rest_Authentication::init();
+
 		add_action(
 			'admin_menu',
 			function () {


### PR DESCRIPTION
This PR updates the Backup plugin to utilize the `jetpack/v4` core API endpoints defined in the backup package.

#### Changes proposed in this Pull Request:
* Update Backup Plugin dependencies by adding `automattic/jetpack-backup` in `composer.json`
* Resolve Jetpack REST auth issue by early initializing the Connection's `Rest_Authentication` class in the `Jetpack_Backup` class's constructor.

#### Jetpack product discussion
1199658893173824-as-1200402244140846

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Make sure JP is deactivated and site/user connection established via the Backup plugin
-  Follow the instructions here: 29958-pb/#php