### PR TITLE
Carousel: yet more resilience to missing data

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-missing-attribute-resilience-part-2
+++ b/projects/plugins/jetpack/changelog/update-carousel-missing-attribute-resilience-part-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: add yet more resilience to missing image data.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1518,8 +1518,8 @@
 
 				var origDimensions = getOriginalDimensions( item );
 
-				attrs.origWidth = origDimensions.width;
-				attrs.origHeight = origDimensions.height;
+				attrs.origWidth = origDimensions.width || attrs.thumbSize.width;
+				attrs.origHeight = origDimensions.height || attrs.thumbSize.height;
 
 				if ( typeof wpcom !== 'undefined' && wpcom.carousel && wpcom.carousel.generateImgSrc ) {
 					attrs.src = wpcom.carousel.generateImgSrc( item, max );


### PR DESCRIPTION
The carousel now uses the thumbnail dimensions when image sizes are missing in the markup.

Ffixes #11191. Hopefully once and for all 🙂

#### Changes proposed in this Pull Request:
* Uses the thumbnail dimensions when image sizes are missing.

#### Jetpack product discussion
None, but see #11191.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
This test requires a gallery with missing size information, such as the one pointed to in https://github.com/Automattic/jetpack/issues/11191#issuecomment-866067231.

If you're testing on that particular page, do note that it appears to load the Carousel twice, both in a concatenated JS file, and as a separately loaded resource.
