### PR TITLE
[Slideshow Block]: Update block icon

### DIFF
--- a/projects/plugins/jetpack/changelog/update-slideshow-icon
+++ b/projects/plugins/jetpack/changelog/update-slideshow-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Slideshow Block: Updated icon.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { Path, SVG } from '@wordpress/components';
+import { Path, Rect, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -21,9 +21,24 @@ import slideshowExample2 from './slideshow_example-2.jpg';
 import slideshowExample3 from './slideshow_example-3.jpg';
 
 export const icon = (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path d="M0 0h24v24H0z" fill="none" />
-		<Path d="M10 8v8l5-4-5-4zm9-5H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z" />
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+		<Path
+			d="M21 8V19C21 20.1046 20.1057 21 19.0011 21C15.8975 21 9.87435 21 6 21"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+		/>
+		<Rect
+			x="3.75"
+			y="3.75"
+			width="13.5"
+			height="13.5"
+			rx="0.875"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+		/>
+		<Path d="M9 14L12 11L9 8" fill="none" stroke="currentColor" strokeWidth="1.5" />
 	</SVG>
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes 291-gh-Automattic/view-design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the block icon for the slideshow block to a more accurate icon (see screenshots)

#### Screenshots
| Before | After |
| --- | --- |
| <img width="161" alt="Screen Shot 2021-06-23 at 5 01 26 PM" src="https://user-images.githubusercontent.com/63313398/123182849-2136bf00-d445-11eb-93b5-78d7d3ee80ff.png"> | <img width="158" alt="Screen Shot 2021-06-23 at 5 01 45 PM" src="https://user-images.githubusercontent.com/63313398/123182868-285dcd00-d445-11eb-93fd-f01c0506b337.png"> |

* Inline block inserter:
<img width="367" alt="Screen Shot 2021-06-23 at 5 05 36 PM" src="https://user-images.githubusercontent.com/63313398/123183015-7a065780-d445-11eb-888d-387283c5bea7.png">

* Block toolbar and placeholder: 
<img width="237" alt="Screen Shot 2021-06-23 at 5 06 04 PM" src="https://user-images.githubusercontent.com/63313398/123183033-85598300-d445-11eb-9e92-b26a9a977a6a.png">

* Block inserter and preview: 
<img width="488" alt="Screen Shot 2021-06-23 at 5 06 18 PM" src="https://user-images.githubusercontent.com/63313398/123183058-8e4a5480-d445-11eb-90e6-529bf2947c33.png">



#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post.
* Open the block inserter in the side panel and search for the Slideshow block. Confirm that the icon looks correct.
* Hover over the block in the inserter to open the preview. Verify the icon there also looks correct.
* Insert the block and verify the icons in the block toolbar and in the placeholder content look correct.
* Open the inline block inserter and search for Slideshow again; verify this icon looks correct.