### PR TITLE
build: Stop creating legacy jetpack-dev artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.repository == 'Automattic/jetpack'
-    timeout-minutes: 15  # 2021-01-18: Successful runs seem to usually take ~2 minutes, but sometimes the upload is slow and it takes 12.
+    timeout-minutes: 10  # 2021-06-24: Successful runs should take just a few seconds now. But sometimes the upload is slow.
     steps:
       - uses: actions/checkout@v2
         with:
@@ -176,11 +176,6 @@ jobs:
           fi
           echo "::set-output name=plugin-data::$PLUGIN_DATA"
 
-          # Prepare legacy jetpack-dev artifact
-          mkdir to-upload
-          mv work/jetpack-dev to-upload/jetpack-dev
-          echo "::set-output name=jetpack-version::$(<to-upload/jetpack-dev/version.txt)"
-
       - name: Create plugins artifact
         uses: actions/upload-artifact@v2
         with:
@@ -189,24 +184,14 @@ jobs:
           # Only need to retain for a day since the beta builder slurps it up to distribute.
           retention-days: 1
 
-      - name: Create legacy jetpack-dev artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: jetpack-dev
-          path: to-upload
-          # Only need to retain for a day since the beta builder slurps it up to distribute.
-          retention-days: 1
-
       - name: Inform Beta Download webhook
         env:
           SECRET: ${{ secrets.JPBETA_SECRET }}
           PLUGIN_DATA: ${{ steps.prepare.outputs.plugin-data }}
           PR: ${{ github.event.number }}
-          JPVER: ${{ steps.prepare.outputs.jetpack-version }}
         run: |
-          # TODO: Remove the JPVER bit when the legacy jetpack-dev artifact is removed.
           curl -v --fail -L \
-            --url "https://betadownload.jetpack.me/gh-action.php?run_id=$GITHUB_RUN_ID&pr=$PR&commit=$GITHUB_SHA&version=$JPVER" \
+            --url "https://betadownload.jetpack.me/gh-action.php?run_id=$GITHUB_RUN_ID&pr=$PR&commit=$GITHUB_SHA" \
             --form-string "repo=$GITHUB_REPOSITORY" \
             --form-string "branch=${GITHUB_REF#refs/heads/}" \
             --form-string "plugins=$PLUGIN_DATA" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The Beta Download webhook has been updated to use the new plugins
artifact.

This should shave about 80 seconds off the time it takes for a build to
be available in the Beta plugin, as creating that jetpack-dev was
relatively slow.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-362-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See that the "Build / Create artifact for Jetpack Beta plugin" job completed successfully on this PR.
* See that entries for this PR show up in both https://betadownload.jetpack.me/jetpack-branches.json and https://betadownload.jetpack.me/vaultpress-branches.json.