### PR TITLE
Carousel: Prevent pinch zooming on anything other than the image

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -396,6 +396,14 @@
 					lastKnownLocationHash = '';
 					carousel.isOpen = false;
 				} );
+
+				carousel.overlay.addEventListener( 'touchstart', function ( e ) {
+					if ( e.touches.length > 1 ) {
+						if ( ! domUtil.closest( e.target, '.jp-carousel-wrap' ) ) {
+							e.preventDefault();
+						}
+					}
+				} );
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/view-design/issues/297

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* It's possible to pinch to zoom outside of the main image, triggering browser page zoom. This messes up the whole carousel. This change will prevent pinch to zoom on touch devices outside of the main image.

| Before        | After           |
| ------------- |:-------------:| 
| https://user-images.githubusercontent.com/1464705/123320431-95756f00-d4e6-11eb-8f05-12de160706bf.mp4 | https://user-images.githubusercontent.com/1464705/123320435-97d7c900-d4e6-11eb-8a08-2b594e6e0c0f.mp4 |

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the simulator or an actual touch device
* Try pinching on the bottom bar, or on the comment form or info data after tapping the buttons to show them
* The browser should not zoom.
* Confirm you can still pinch to zoom on the image.
