### PR TITLE
Carousel: Highlight info and comment icons when section is open

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -947,7 +947,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	background-color: #fff;
 }
 
-.jp-carousel-light .jp-carousel-icon-btn:hover .jp-carousel-icon {
+.jp-carousel-light .jp-carousel-icon-btn.jp-carousel-selected .jp-carousel-icon {
 	color: #fff;
 	fill: #fff;
 	background-color: #000;
@@ -1000,7 +1000,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 }
 
-.jp-carousel-icon-btn:hover .jp-carousel-icon {
+.jp-carousel-icon-btn.jp-carousel-selected .jp-carousel-icon {
 	color: #000;
 	fill: #000;
 	background-color: #fff;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -655,6 +655,8 @@
 			var extraInfoContainer = carousel.info.querySelector( '.jp-carousel-info-extra' );
 			var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
 			var commentsContainer = carousel.info.querySelector( '.jp-carousel-comments-wrapper' );
+			var infoIcon = carousel.info.querySelector( '.jp-carousel-icon-info' );
+			var commentsIcon = carousel.info.querySelector( '.jp-carousel-icon-comments' );
 
 			// Hide comments and photo info
 			if ( extraInfoContainer ) {
@@ -662,9 +664,11 @@
 			}
 			if ( photoMetaContainer ) {
 				photoMetaContainer.classList.remove( 'jp-carousel-show' );
+				infoIcon.classList.remove( 'jp-carousel-selected' );
 			}
 			if ( commentsContainer ) {
 				commentsContainer.classList.remove( 'jp-carousel-show' );
+				commentsIcon.classList.remove( 'jp-carousel-selected' );
 			}
 
 			loadFullImage( carousel.slides[ index ] );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -539,11 +539,16 @@
 			var extraInfoContainer = carousel.info.querySelector( '.jp-carousel-info-extra' );
 			var photoMetaContainer = carousel.info.querySelector( '.jp-carousel-image-meta' );
 			var commentsContainer = carousel.info.querySelector( '.jp-carousel-comments-wrapper' );
+			var infoIcon = carousel.info.querySelector( '.jp-carousel-icon-info' );
+			var commentsIcon = carousel.info.querySelector( '.jp-carousel-icon-comments' );
 
 			if (
 				domUtil.closest( target, '.jp-carousel-icon-info' ) ||
 				target.classList.contains( 'jp-carousel-photo-title' )
 			) {
+				commentsIcon.classList.remove( 'jp-carousel-selected' );
+				infoIcon.classList.toggle( 'jp-carousel-selected' );
+
 				if ( commentsContainer ) {
 					commentsContainer.classList.remove( 'jp-carousel-show' );
 				}
@@ -559,6 +564,9 @@
 			}
 
 			if ( domUtil.closest( target, '.jp-carousel-icon-comments' ) ) {
+				infoIcon.classList.remove( 'jp-carousel-selected' );
+				commentsIcon.classList.toggle( 'jp-carousel-selected' );
+
 				if ( photoMetaContainer ) {
 					photoMetaContainer.classList.remove( 'jp-carousel-show' );
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes 295-gh-Automattic/view-design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Previously the comment and info icons would appear highlighted on hover; this works on desktop, but 'sticky' hovering on mobile meant that the icon would become highlighted after being tapped and remain this way until the user taps elsewhere.

This PR modifies the behavior using an extra class on the icons, so that the icon is highlighted when its respective section is showing (eg the comment icon is highlighted when the comment form is expanded and is removed when the form is collapsed, likewise for info).

https://user-images.githubusercontent.com/63313398/123320981-4b40bd80-d4e7-11eb-8d6c-a28179125244.mov
#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a gallery to a page and open an image in the carousel.
* Both icons should be un-highlighted, and neither the meta nor comments section showing.
* Test tapping the info icon to open/highlight icon
* Test tapping the info icon when it is already open, to close section/unhighlight icon
* Test tapping the info icon while the comments section is open; comments should close/unhighlight icon and info should open/highlight icon
* Test tapping comments icon to open/highlight icon
* Test tapping comments icon when it is already open, to close section/unhighlight icon
* Test tapping the comments icon while the info section is open; comments should open/highlight icon and info should close/unhighlight icon
* Test tapping the info icon and swiping to another image; section should close/unhighlight icon
* Test tapping the comments icon and swiping to another image; section should close/unhighlight icon

Test on mobile as well as desktop, in dark and light mode.