### PR TITLE
Carousel: Disable native browser zooming

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -397,11 +397,10 @@
 					carousel.isOpen = false;
 				} );
 
+				// Prevent native browser zooming
 				carousel.overlay.addEventListener( 'touchstart', function ( e ) {
 					if ( e.touches.length > 1 ) {
-						if ( ! domUtil.closest( e.target, '.jp-carousel-wrap' ) ) {
-							e.preventDefault();
-						}
+						e.preventDefault();
 					}
 				} );
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/view-design/issues/293
Fixes https://github.com/Automattic/view-design/issues/298

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Prevent native browser zooming in the whole of the carousel. The zoom/pan implementation added by Swiper is unaffected by this, meaning you stop all accidental zooming.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use a touch device
* Try and get the browser to zoom. Try zooming out when the image is fully zoomed out.
* Try zooming in as soon as the first image loads, and make sure it doesn't trigger the browser zoom.
