### PR TITLE
Fix/carousel form padding

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -551,6 +551,11 @@ a.jp-carousel-image-download:hover {
 	width: 100%;
 }
 
+#jp-carousel-comment-form.jp-carousel-is-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
 textarea#jp-carousel-comment-form-comment-field {
 	background: rgba( 34, 34, 34, 0.9 );
 	border: 1px solid #3a3a3a;
@@ -648,6 +653,12 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	transform: translateZ( 0 );
 	-webkit-animation: load8 1.1s infinite linear;
 	animation: load8 1.1s infinite linear;
+	margin: 0 auto;
+    position: absolute; /* relative to .jp-carousel-comment-form-container */
+    top: 40%;
+    left: 0;
+    bottom: 0;
+    right: 0;
 }
 
 @-webkit-keyframes load8 {
@@ -737,12 +748,19 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	font-size: 14px;
 }
 
+#jp-carousel-comment-form-button-submit:active,
+#jp-carousel-comment-form-button-submit:focus {
+	background: white;
+    color: rgba( 34, 34, 34, 0.9 );
+}
+
 #jp-carousel-comment-form-container {
 	margin-bottom: 15px;
 	overflow: auto;
 	width: 100%;
 	margin-top: 20px;
 	color: #999;
+	position: relative;
 }
 
 #jp-carousel-comment-post-results {
@@ -1093,5 +1111,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	#jp-carousel-comment-form-commenting-as fieldset,
 	#jp-carousel-comment-form-commenting-as input {
 		width: 100%;
+		float: none;
 	}
 }

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -671,6 +671,11 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	}
 }
 
+.jp-carousel-info-content-wrapper {
+	max-width: 800px;
+	margin: auto;
+}
+
 #jp-carousel-comment-form-submit-and-info-wrapper {
 	display: none;
 	overflow: hidden;
@@ -723,7 +728,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 #jp-carousel-comment-form-button-submit {
 	margin-top: 20px;
-	float: right;
+	margin-left: auto;
 	display: block;
 	border: solid 1px white;
 	background: rgba( 34, 34, 34, 0.9 );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -682,7 +682,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	border: 1px solid #3a3a3a;
 	color: #a7aaad;
 	font: 16px/1.4 'Helvetica Neue', sans-serif !important;
-	padding: 3px 6px;
+	padding: 10px;
 	float: left;
 	-webkit-box-shadow: inset 2px 2px 2px rgba( 0, 0, 0, 0.2 );
 	box-shadow: inset 2px 2px 2px rgba( 0, 0, 0, 0.2 );
@@ -1083,5 +1083,10 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 	.jp-carousel-comment .avatar {
 		min-width: 48px;
+	}
+
+	#jp-carousel-comment-form-commenting-as fieldset,
+	#jp-carousel-comment-form-commenting-as input {
+		width: 100%;
 	}
 }

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -431,6 +431,9 @@
 			var elClass = 'jp-carousel-comment-post-' + ( isSuccess ? 'success' : 'error' );
 			results.innerHTML = '<span class="' + elClass + '">' + msg + '</span>';
 			domUtil.hide( carousel.overlay.querySelector( '#jp-carousel-comment-form-spinner' ) );
+			carousel.overlay
+				.querySelector( '#jp-carousel-comment-form' )
+				.classList.remove( 'jp-carousel-is-disabled' );
 			domUtil.show( results );
 		}
 
@@ -442,6 +445,7 @@
 			var wrapper = document.querySelector( '#jp-carousel-comment-form-submit-and-info-wrapper' );
 			var spinner = document.querySelector( '#jp-carousel-comment-form-spinner' );
 			var submit = document.querySelector( '#jp-carousel-comment-form-button-submit' );
+			var form = document.querySelector( '#jp-carousel-comment-form' );
 
 			if (
 				carousel.commentField &&
@@ -455,6 +459,7 @@
 				e.stopPropagation();
 
 				domUtil.show( spinner );
+				form.classList.add( 'jp-carousel-is-disabled' );
 
 				var ajaxData = {
 					action: 'post_attachment_comment',
@@ -515,6 +520,7 @@
 						fetchComments( attachmentId );
 						submit.value = jetpackCarouselStrings.post_comment;
 						domUtil.hide( spinner );
+						form.classList.remove( 'jp-carousel-is-disabled' );
 					} else {
 						// TODO: Add error handling and display here
 						updatePostResults( jetpackCarouselStrings.comment_post_error, false );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -428,6 +428,8 @@ class Jetpack_Carousel {
 								</div>
 								<div class="jp-carousel-comments"></div>
 								<div id="jp-carousel-comment-form-container">
+									<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
+									<div id="jp-carousel-comment-post-results"></div>
 									<?php if ( $use_local_comments ) : ?>
 										<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
 											<div id="jp-carousel-comment-form-commenting-as">
@@ -487,8 +489,6 @@ class Jetpack_Carousel {
 														class="jp-carousel-comment-form-button"
 														id="jp-carousel-comment-form-button-submit"
 														value="<?php echo esc_attr( $localize_strings['post_comment'] ); ?>" />
-													<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
-													<div id="jp-carousel-comment-post-results"></div>
 												</div>
 											</form>
 										<?php endif ?>


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Tidies up comment form padding and widths on smaller screens

Before:
<img width="529" alt="Screen Shot 2021-06-25 at 8 46 10 AM" src="https://user-images.githubusercontent.com/3629020/123333296-afba5600-d595-11eb-8f9a-a18933625939.png">

After:
<img width="531" alt="Screen Shot 2021-06-25 at 8 45 05 AM" src="https://user-images.githubusercontent.com/3629020/123333312-b47f0a00-d595-11eb-9575-0991f272cf8a.png">

* Also constrains the width of the info area for better layout on larger screens

Before:
<img width="1738" alt="Screen Shot 2021-06-25 at 9 12 05 AM" src="https://user-images.githubusercontent.com/3629020/123333388-cf517e80-d595-11eb-81d2-41f01891d3ab.png">

After:
<img width="1749" alt="Screen Shot 2021-06-25 at 9 11 35 AM" src="https://user-images.githubusercontent.com/3629020/123333406-d37d9c00-d595-11eb-95d8-e2d33cf87458.png">

