### PR TITLE
Carousel: Update styling of image title and do not display on mobile

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -325,6 +325,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 	border: none !important;
 	display: inline-block;
 	font: normal 20px/1.3em 'Helvetica Neue', sans-serif;
+	line-height: normal;
 	letter-spacing: 0 !important;
 	margin: 0 0 10px 0;
 	padding: 0;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -1087,6 +1087,9 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		overflow: visible !important;
 	}
 
+	.jp-carousel-info-footer .jp-carousel-photo-title-container {
+		display: none;
+	}
 	.jp-carousel-photo-icons-container {
 		margin: 0 15px 0 0;
 		white-space: nowrap;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -276,7 +276,9 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 
 /** Pagination Start **/
 .jp-carousel-pagination-container {
+	flex: 1;
 	padding-left: 35px;
+	padding-right: 15px;
 	margin-bottom: 30px;
 	margin-top: 13px;
 }
@@ -311,7 +313,11 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 /** Title and Desc Start **/
 .jp-carousel-info-footer .jp-carousel-photo-title-container {
 	flex-basis: 50vw;
+	flex: 1;
+	justify-content: center;
 	overflow: hidden;
+	margin-bottom: 30px;
+	margin-top: 13px;
 }
 
 .jp-carousel-photo-title {
@@ -330,7 +336,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 
 .jp-carousel-info-footer .jp-carousel-photo-title {
 	text-align: center;
-	font: normal 13px/1em 'Helvetica Neue', sans-serif;
+	font: normal 15px/1em 'Helvetica Neue', sans-serif;
 	white-space: nowrap;
 	color: #999;
 	cursor: pointer;
@@ -980,6 +986,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 /** Icons Start **/
 .jp-carousel-photo-icons-container {
+	flex: 1;
 	display: block;
 	text-align: right;
 	margin: 15px 20px 20px 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes 307-gh-Automattic/view-design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Increases font size of image title in info bar
* Adjusts margins and centers underneath the image
* Does not display title in info bar on small screens

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

|  | Before | After |
| --- | --- | --- |
| Desktop | <img width="1498" alt="Screen Shot 2021-06-24 at 5 16 45 PM" src="https://user-images.githubusercontent.com/63313398/123350549-14cb6880-d510-11eb-935e-827492a4f894.png"> | <img width="1491" alt="Screen Shot 2021-06-24 at 5 33 52 PM" src="https://user-images.githubusercontent.com/63313398/123351648-6e349700-d512-11eb-8681-7421d06bf6bc.png"> |
| Mobile | <img width="311" alt="Screen Shot 2021-06-24 at 5 17 25 PM" src="https://user-images.githubusercontent.com/63313398/123350589-27de3880-d510-11eb-80c5-fcd00dd7f7c4.png"> | <img width="304" alt="Screen Shot 2021-06-24 at 5 15 12 PM" src="https://user-images.githubusercontent.com/63313398/123350604-2dd41980-d510-11eb-8b15-ad3c079d936e.png"> |


Test:
* Add an image to your test gallery with a title
* View in different size screens and make sure the title looks correct
* The title should not display at all on mobile in the info bar, but if you open the info section by clicking the icon you should still be able to see it there (see screenshots)


