### PR TITLE
Refactor Carousel: Fix/footer alignment and slide hash history

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -53,7 +53,7 @@
 
 .jp-carousel-container {
 	display: grid;
-	grid-template-rows: 1fr 80px; /* 1. main carousel, 2. info area as footer */
+	grid-template-rows: 1fr 64px; /* 1. main carousel, 2. info area as footer */
 	height: 100%;
 }
 
@@ -84,12 +84,11 @@
 .jp-carousel-info-footer {
 	position: relative;
 	background-color: #000;
-	height: 80px;
+	height: 64px;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	width: 100vw;
-	top: -15px;
 }
 
 .jp-carousel-info-extra {
@@ -277,9 +276,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 /** Pagination Start **/
 .jp-carousel-pagination-container {
 	flex: 1;
-	padding: 8px 15px 0 35px;
-	margin: 0;
-	height: 100%;
+	margin: 0 15px 0 35px;
 }
 
 .jp-swiper-pagination,
@@ -289,8 +286,13 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 	white-space: nowrap;
 	display: none;
 	position: static !important;
-	text-align: left !important;
 }
+
+.jp-carousel-pagination-container .swiper-pagination {
+	text-align: left;
+	line-height: 8px;
+}
+
 .jp-carousel-pagination {
 	padding-left: 5px;
 }
@@ -317,8 +319,6 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 	justify-content: center;
 	overflow: hidden;
 	margin: 0;
-	height: 100%;
-	padding-top: 8px;
 }
 
 .jp-carousel-photo-title {
@@ -1014,18 +1014,17 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	flex: 1;
 	display: block;
 	text-align: right;
-	margin: 15px 20px 20px 0;
-	height: 100%;
+	margin: 0 20px 0 30px;
     white-space: nowrap;
 }
 
 .jp-carousel-icon-btn {
-	padding: 8px 16px;
+	padding: 16px 16px;
 	text-decoration: none;
 	border: none;
 	background: none;
 	display: inline-block;
-	height: 60px;
+	height: 64px;
 }
 
 .jp-carousel-icon {
@@ -1118,6 +1117,11 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		display: none;
 	}
 
+	.jp-carousel-photo-icons-container {
+		margin: 0 15px 0 0;
+		white-space: nowrap;
+	}
+
 	.jp-carousel-icon-btn {
 		padding-left: 20px;
 	}
@@ -1127,7 +1131,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	}
 
 	.jp-carousel-pagination-container {
-		padding-left: 25px;
+		margin-left: 25px;
 	}
 
 	.jp-carousel-comment .avatar {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -325,6 +325,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 	border: none !important;
 	display: inline-block;
 	font: normal 20px/1.3em 'Helvetica Neue', sans-serif;
+	line-height: normal;
 	letter-spacing: 0 !important;
 	margin: 0 0 10px 0;
 	padding: 0;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -1087,6 +1087,9 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		overflow: visible !important;
 	}
 
+	.jp-carousel-info-footer .jp-carousel-photo-title-container {
+		display: none;
+	}
 	.jp-carousel-photo-icons-container {
 		margin: 0 15px 0 0;
 		white-space: nowrap;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -276,7 +276,9 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 
 /** Pagination Start **/
 .jp-carousel-pagination-container {
+	flex: 1;
 	padding-left: 35px;
+	padding-right: 15px;
 	margin-bottom: 30px;
 	margin-top: 13px;
 }
@@ -311,7 +313,11 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 /** Title and Desc Start **/
 .jp-carousel-info-footer .jp-carousel-photo-title-container {
 	flex-basis: 50vw;
+	flex: 1;
+	justify-content: center;
 	overflow: hidden;
+	margin-bottom: 30px;
+	margin-top: 13px;
 }
 
 .jp-carousel-photo-title {
@@ -330,7 +336,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 
 .jp-carousel-info-footer .jp-carousel-photo-title {
 	text-align: center;
-	font: normal 13px/1em 'Helvetica Neue', sans-serif;
+	font: normal 15px/1em 'Helvetica Neue', sans-serif;
 	white-space: nowrap;
 	color: #999;
 	cursor: pointer;
@@ -980,6 +986,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 /** Icons Start **/
 .jp-carousel-photo-icons-container {
+	flex: 1;
 	display: block;
 	text-align: right;
 	margin: 15px 20px 20px 0;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -53,7 +53,7 @@
 
 .jp-carousel-container {
 	display: grid;
-	grid-template-rows: 1fr 50px; /* 1. main carousel, 2. info area as footer */
+	grid-template-rows: 1fr 80px; /* 1. main carousel, 2. info area as footer */
 	height: 100%;
 }
 
@@ -277,19 +277,19 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 /** Pagination Start **/
 .jp-carousel-pagination-container {
 	flex: 1;
-	padding-left: 35px;
-	padding-right: 15px;
-	margin-bottom: 30px;
-	margin-top: 13px;
+	padding: 8px 15px 0 35px;
+	margin: 0;
+	height: 100%;
 }
 
 .jp-swiper-pagination,
 .jp-carousel-pagination {
 	color: #fff;
-	font-size: 15px;
+	font-size: 15px; /* same as .jp-carousel-info-footer .jp-carousel-photo-title  */
 	white-space: nowrap;
 	display: none;
 	position: static !important;
+	text-align: left !important;
 }
 .jp-carousel-pagination {
 	padding-left: 5px;
@@ -316,8 +316,9 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 	flex: 1;
 	justify-content: center;
 	overflow: hidden;
-	margin-bottom: 30px;
-	margin-top: 13px;
+	margin: 0;
+	height: 100%;
+	padding-top: 8px;
 }
 
 .jp-carousel-photo-title {
@@ -337,7 +338,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 
 .jp-carousel-info-footer .jp-carousel-photo-title {
 	text-align: center;
-	font: normal 15px/1em 'Helvetica Neue', sans-serif;
+	font-size: 15px; /* same as .jp-carousel-pagination */
 	white-space: nowrap;
 	color: #999;
 	cursor: pointer;
@@ -991,6 +992,8 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	display: block;
 	text-align: right;
 	margin: 15px 20px 20px 0;
+	height: 100%;
+    white-space: nowrap;
 }
 
 .jp-carousel-icon-btn {
@@ -1090,10 +1093,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 	.jp-carousel-info-footer .jp-carousel-photo-title-container {
 		display: none;
-	}
-	.jp-carousel-photo-icons-container {
-		margin: 0 15px 0 0;
-		white-space: nowrap;
 	}
 
 	.jp-carousel-icon-btn {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -660,6 +660,8 @@
 				loadSwiper( gal, { startIndex: index } );
 			} else {
 				selectSlideAtIndex( index );
+				// We have to force swiper to slide to the index onHasChange.
+				swiper.slideTo( index + 1 );
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -390,8 +390,15 @@
 				} );
 
 				carousel.overlay.addEventListener( 'jp_carousel.afterClose', function () {
-					if ( window.location.hash && history.back ) {
-						history.back();
+					// don't force the browser back when the carousel closes.
+					if ( window.history.pushState ) {
+						history.pushState(
+							'',
+							document.title,
+							window.location.pathname + window.location.search
+						);
+					} else {
+						window.location.href = '';
 					}
 					lastKnownLocationHash = '';
 					carousel.isOpen = false;


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/pull/20107

#### Changes proposed in this Pull Request:

This PR:

- Carries on from https://github.com/Automattic/jetpack/pull/20178 and:
  - Aligns the footer child elements as close to the vertical middle as we can.
  - Left aligns the dot pagination.
  - Aligns the image title horizontally by adding equal margins to the footer's flex items
  - Updates the footer to be 64px tall, and removes vertical scroll
- Removes `history.back()` to avoid navigating to a blank page when first opening a slide, e.g., `/?p=52#jp-carousel-41`
- Forces a `swiper.slideTo` when we detect `onHashChange` so the slider moves to the correct image on browser navigation

![navigate-gallery](https://user-images.githubusercontent.com/6458278/123380125-69371c80-d5d2-11eb-9065-c8f4c00baa27.gif)


#### Jetpack product discussion
Designs: p9Jlb4-2cI-p2
Refactor discussions: pcjTuq-oz-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

1. Open a carousel image directly from the browser, i.e., navigate to `/?p=52#jp-carousel-41`. The correct slide should open.
2. Slide forward a few images. 
3. Use the browser back button. You should be able to navigate through the history.
4. In a new window with no browser history navigate directly to an image again. The correct slide should open. Close the gallery. You should be on the post page and not be taken back anywhere.
5. Check that the footer elements (pagination, title, icons) are aligned okay in desktop and mobile.

Desktop with text centred horizontally:

| Desktop numbers | Desktop dots |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/123388656-62150c00-d5dc-11eb-9daf-05836dcf7ca5.png) | ![image](https://user-images.githubusercontent.com/14988353/123387631-5543e880-d5db-11eb-8fa6-747e7cda67cb.png) |

| Mobile numbers | Mobile dots |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/123388939-b61ff080-d5dc-11eb-94ca-c0c1f1aa3020.png) | ![image](https://user-images.githubusercontent.com/14988353/123388804-8ec92380-d5dc-11eb-849a-edbc006e6cdf.png) |
