### PR TITLE
Delete the modules/mobile-push.php file

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove_mobile_push_file
+++ b/projects/plugins/jetpack/changelog/update-remove_mobile_push_file
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove modules/mobile-push.php file.
+
+

--- a/projects/plugins/jetpack/modules/mobile-push.php
+++ b/projects/plugins/jetpack/modules/mobile-push.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. See notes.php for the new module
- *
- * @package automattic/jetpack
- **/

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -247,7 +247,6 @@
 	"projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php",
 	"projects/plugins/jetpack/modules/markdown.php",
 	"projects/plugins/jetpack/modules/markdown/easy-markdown.php",
-	"projects/plugins/jetpack/modules/mobile-push.php",
 	"projects/plugins/jetpack/modules/monitor.php",
 	"projects/plugins/jetpack/modules/notes.php",
 	"projects/plugins/jetpack/modules/photon-cdn.php",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Delete the `modules/mobile-push.php` file. This module appears to have been deprecated 8 years ago.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
I don't think any testing is necessary.
