### PR TITLE
Carousel refactor: photon images not sized correctly

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -799,11 +799,9 @@
 		}
 
 		function calculateMaxSlideDimensions() {
-			var screenHeightPercent = 80;
-
 			return {
-				width: window.innerWidth - screenPadding * 2,
-				height: Math.floor( ( window.innerHeight / 100 ) * screenHeightPercent - 60 ),
+				width: window.innerWidth,
+				height: window.innerHeight - 64, //subtract height of bottom info bar,
 			};
 		}
 


### PR DESCRIPTION
With the refactor of the carousel module to use swiper js the max width and height calculations to work out photon resize settings were not working correctly, so images ended up too small when photon was enabled.

#### Changes proposed in this Pull Request:

* Changes max height and width calculations to be max window size minus the bottom info bar.

#### Testing instructions:
* Check out this PR on local install with Jurassic tube and photon enabled, or on JN site if photon doesn't work for you locally
* Add a gallery with large HD images that are bigger than device window size
* Check that photon resizing is applied but phots still fit the screen size

Before: 
https://user-images.githubusercontent.com/3629020/123568180-e56e7180-d817-11eb-977b-0f7815a19796.mp4

After:
https://user-images.githubusercontent.com/3629020/123568193-ebfce900-d817-11eb-99e0-643fcc34d681.mp4



