### PR TITLE
Site Editor Compatibility: register wp-mediaelement styles for Podcast Player 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-podcast-player-enqueue-wp-mediaelement
+++ b/projects/plugins/jetpack/changelog/fix-podcast-player-enqueue-wp-mediaelement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Since Gutenberg #31873 we can specify Site Editor assets to enqueue in the register block function. We need to specify wp-mediaelement styles for the podcast player.

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -50,6 +50,9 @@ function register_block() {
 				),
 			),
 			'render_callback' => __NAMESPACE__ . '\render_block',
+			// Since Gutenberg #31873.
+			'style'           => 'wp-mediaelement',
+
 		)
 	);
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/19483

#### Changes proposed in this Pull Request

In https://github.com/Automattic/jetpack/pull/19578 we created a "fix" so that we could copy over the media element style assets enqueued for the podcast player into the Site Editor iframe.

We did this in order that for podcast player to look as it should in the Site Editor. 

Since https://github.com/WordPress/gutenberg/pull/31873 we can specify Site Editor assets to enqueue in the register block function. 

Also since that PR, WPCOM doesn't appear to load enqueued wp-mediaelement styles anymore :)

Therefore we need to specify `wp-mediaelement` styles for the podcast player.

This fix affects sites running Gutenberg 10.7 or later. 


**Before on WPCOM**
<img width="480" alt="Screen Shot 2021-06-28 at 12 54 02 pm" src="https://user-images.githubusercontent.com/6458278/123572678-ef8c7200-d80f-11eb-9c2c-53e4430c2f94.png">

**After on WPCOM**
<img width="568" alt="Screen Shot 2021-06-28 at 2 43 16 pm" src="https://user-images.githubusercontent.com/6458278/123581400-2e75f400-d81f-11eb-9fc9-9e0abfc8040f.png">


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions


1. Using a block-based theme, e.g., TT1 add a Podcast block to the site editor. Here's an RSS feed link: https://distributed.blog/category/podcast/feed/ 😄 
2. Once loaded, you should be able to interact with the player as expected.
3. Add another one.
4. Both should work 
5. Check that, for every podcast block you add, we're not duplicating the mediaelement-css assets.
6. Take a look at the frontend. The player(s) should both load.
7. Check a few other themes for regressions.
8. Sync the changes to WPCOM and ensure that both the block and site editors work as expected.
9. Chilled red wine is fine. Deal with it.

