### PR TITLE
Carousel: Try to re-enable double tap zoom in Chrome iOS

### DIFF
--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -407,9 +407,25 @@
 				// Prevent native browser zooming
 				carousel.overlay.addEventListener( 'touchstart', function ( e ) {
 					if ( e.touches.length > 1 ) {
-						e.preventDefault();
+						if ( ! domUtil.closest( e.target, '.swiper-zoom-container' ) ) {
+							e.preventDefault();
+						}
 					}
 				} );
+
+				// Allow Swiper to handle double tap zoom.
+				var lastTouchEnd = 0;
+				carousel.overlay.addEventListener(
+					'touchend',
+					function ( event ) {
+						var now = new Date().getTime();
+						if ( now - lastTouchEnd <= 300 ) {
+							event.preventDefault();
+						}
+						lastTouchEnd = now;
+					},
+					false
+				);
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Possible fix for: 314-gh-Automattic/view-design

This is a possible fix for the "double-tap to zoom" behaviour being buggy in iOS Chrome. It attempts to fix the behaviour by trying to defer double-tap zoom to Swiper, while at the same time allowing pinch zoom to continue be available within the image (still deferred to Swiper).

It's potentially still buggy: so in evaluating this change, the question is — is it improved with this change applied?

#### Screenshot

https://user-images.githubusercontent.com/14988353/123596296-596b4280-d835-11eb-919c-6f6a06fe756d.MP4

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update logic that prevents the `touchstart` event to do so on all elements that are not the Swiper zoom container — the objective with the selector used is that we shouldn't allow pinch zoom at all on anything except for the zoom container. With pinch zoom allowed, Swiper should (in theory) handle it for us.
* Add event listener to prevent default double-tap behaviour, which should allow Chrome on iOS to defer the double-tap behaviour to Swiper, instead of using the browser double-tap. (kudos @glendaviesnz for this code)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a local Jetpack environment, activate the Carousel module and create a post with an image gallery in it
* Visit your site from iOS Safari and iOS Chrome and see if the pinch zoom behaviour works as expected. It should (hopefully) not introduce any regressions... e.g. it should persist the fix in https://github.com/Automattic/jetpack/pull/20173
* In both iOS Safari and iOS chrome, try double-tapping the image in the gallery — it should zoom in on the image and you should be able to pan around. Note that in iOS Chrome there is the separate issue of jankiness (315-gh-Automattic/view-design), which is not resolved in this PR.