### PR TITLE
Dashboard Switcher: do not show it on index.php

### DIFF
--- a/projects/plugins/jetpack/changelog/update-removes-dashboard-switcher-from-index
+++ b/projects/plugins/jetpack/changelog/update-removes-dashboard-switcher-from-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Removes dashboard switcher from index.php to improve parity with Calypso.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
@@ -6,7 +6,6 @@
  */
 
 $common_mappings = array(
-	'dashboard.php'                                  => 'https://wordpress.com/home/',
 	'upload.php?post_type=attachment'                => 'https://wordpress.com/media/',
 	'edit.php?post_type=post'                        => 'https://wordpress.com/posts/',
 	'edit-comments.php'                              => 'https://wordpress.com/comments/',

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -564,12 +564,6 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		$screens = array(
 			(object) array(
-				'base'      => 'dashboard',
-				'post_type' => '',
-				'taxonomy'  => '',
-				'mapping'   => 'https://wordpress.com/home/',
-			),
-			(object) array(
 				'base'      => 'edit',
 				'post_type' => 'post',
 				'taxonomy'  => '',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/20197

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
As discussed here pd2C0z-3q-p2#comment-146 we are not going to show a dashboard switcher in `/wp-admin/index.php` and instead we are adding a submenu item. This PR removes the switcher from `/wp-admin/index.php` .

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/index.php` 
* Click screen options
* You shouldn't be presented with the dashboard switcher.
* Go to `/wp-admin/edit.php`
* Make sure you are still seeing the dashboard switcher and no regressions are introduced.

Before | After
-------|------
![](https://cln.sh/56xnuB+) | ![](https://cln.sh/6VRcjd+)