### PR TITLE
Connection: route for the "Disconnect" modal

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -94,7 +94,7 @@ export class DashConnections extends Component {
 					</div>
 					{ this.props.userCanDisconnectSite && (
 						<div className="jp-connection-settings__actions">
-							<ConnectButton asLink />
+							<ConnectButton asLink autoOpenModal={ true } />
 						</div>
 					) }
 				</div>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -94,7 +94,7 @@ export class DashConnections extends Component {
 					</div>
 					{ this.props.userCanDisconnectSite && (
 						<div className="jp-connection-settings__actions">
-							<ConnectButton asLink autoOpenModal={ true } />
+							<ConnectButton asLink autoOpenInDisconnectRoute={ true } />
 						</div>
 					) }
 				</div>

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { getFragment } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -45,6 +46,7 @@ export class ConnectButton extends React.Component {
 		connectLegend: PropTypes.string,
 		connectInPlace: PropTypes.bool,
 		customConnect: PropTypes.func,
+		autoOpenModal: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -52,11 +54,15 @@ export class ConnectButton extends React.Component {
 		from: '',
 		asLink: false,
 		connectInPlace: true,
+		autoOpenModal: false,
 	};
 
-	state = {
-		showModal: false,
-	};
+	constructor( props ) {
+		super( props );
+		this.state = {
+			showModal: props.autoOpenModal && '#/disconnect' === getFragment( window.location.href ),
+		};
+	}
 
 	handleOpenModal = e => {
 		analytics.tracks.recordJetpackClick( 'manage_site_connection' );

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -46,7 +46,7 @@ export class ConnectButton extends React.Component {
 		connectLegend: PropTypes.string,
 		connectInPlace: PropTypes.bool,
 		customConnect: PropTypes.func,
-		autoOpenModal: PropTypes.bool,
+		autoOpenInDisconnectRoute: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -54,13 +54,14 @@ export class ConnectButton extends React.Component {
 		from: '',
 		asLink: false,
 		connectInPlace: true,
-		autoOpenModal: false,
+		autoOpenInDisconnectRoute: false,
 	};
 
 	constructor( props ) {
 		super( props );
 		this.state = {
-			showModal: props.autoOpenModal && '#/disconnect' === getFragment( window.location.href ),
+			showModal:
+				props.autoOpenInDisconnectRoute && '#/disconnect' === getFragment( window.location.href ),
 		};
 	}
 

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -204,6 +204,7 @@ class Main extends React.Component {
 		switch ( route ) {
 			case '/dashboard':
 			case '/reconnect':
+			case '/disconnect':
 				pageComponent = (
 					<AtAGlance
 						siteRawUrl={ this.props.siteRawUrl }

--- a/projects/plugins/jetpack/changelog/add-disconnect-route
+++ b/projects/plugins/jetpack/changelog/add-disconnect-route
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+New "disconnect" route to open the "Disconnect" modal.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* New `#/disconnect` route for the Jetpack plugin.
* The route shows the Jetpack Dashboard, and opens the "Disconnect" modal.

#### Jetpack product discussion
p1HpG7-chE-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

##### Before checking out the PR
1. Connect Jetpack if not connected.
2. Open the URL `/wp-admin/admin.php?page=jetpack#/disconnect`.
3. Confirm that you get redirected to `/wp-admin/admin.php?page=jetpack#/dashboard`, and Jetpack Dashboard loads.

##### After checking out the PR
1. Connect Jetpack if not connected.
2. Rebuild Jetpack if needed.
3. Open the URL `/wp-admin/admin.php?page=jetpack#/disconnect`.
4. Confirm that Jetpack Dashboard loads, and the "Disconnect" modal opens automatically.
5. Disconnect Jetpack, confirm that it went fine.
6. Reconnect Jetpack and load the URL `/wp-admin/admin.php?page=jetpack#/dashboard`.
7. Confirm that Jetpack Dashboard loads, but the "Disconnect" modal does not open automatically.
8. Click "Manage site connection", confirm that the "Disconnect" modal opens.