### PR TITLE
Jetpack Plan: filter video mime types

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-filter-mime-types
+++ b/projects/plugins/jetpack/changelog/update-videopress-filter-mime-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Filter video mime-types according to videopress feature

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -359,7 +359,7 @@ function jetpack_filter_mimetypes_by_modules_and_features( $mimes ) {
 	}
 
 	// `videopress` module is not active, Bail early.
-	if ( Jetpack::is_module_active( 'videopress' ) ) {
+	if ( ! Jetpack::is_module_active( 'videopress' ) ) {
 		return $mimes;
 	};
 

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -348,6 +348,9 @@ class Jetpack_Plan {
 /**
  * Modify the allowed mimes types when uploading files,
  * acoording to Jetpack module and/or feature.
+ *
+ * @param array Mime types provided by the `upload_mimes` filter.
+ * @return array Filtered mime types array.
  */
 function jetpack_filter_mimetypes_by_modules_and_features( $mimes ) {
 	// Not connected. Bail early.
@@ -361,15 +364,24 @@ function jetpack_filter_mimetypes_by_modules_and_features( $mimes ) {
 	};
 
 	// `videopress` feature is supported. Bail early.
-	if ( $support = Jetpack_Plan::supports( 'videopress' ) ) {
+	if ( Jetpack_Plan::supports( 'videopress' ) ) {
 		return $mimes;
 	};
 
 
 	// Remove `video/` mimes from the list.
-	return array_filter( $mimes, function ( $mime ) {
-		return ! preg_match( '@^video/@', $mime );
-	} );
+	return array_filter(
+		$mimes,
+		function ( $mime ) {
+			return ! preg_match(
+				'@^video/@',
+				$mime
+			);
+		}
+	);
 }
 
-add_filter( 'upload_mimes', 'jetpack_filter_mimetypes_by_modules_and_features' );
+add_filter(
+	'upload_mimes',
+	'jetpack_filter_mimetypes_by_modules_and_features'
+);

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -344,3 +344,32 @@ class Jetpack_Plan {
 		return false;
 	}
 }
+
+/**
+ * Modify the allowed mimes types when uploading files,
+ * acoording to Jetpack module and/or feature.
+ */
+function jetpack_filter_mimetypes_by_modules_and_features( $mimes ) {
+	// Not connected. Bail early.
+	if ( ! Jetpack::is_connection_ready() ) {
+		return $mimes;
+	}
+
+	// `videopress` module is not active, Bail early.
+	if ( Jetpack::is_module_active( 'videopress' ) ) {
+		return $mimes;
+	};
+
+	// `videopress` feature is supported. Bail early.
+	if ( $support = Jetpack_Plan::supports( 'videopress' ) ) {
+		return $mimes;
+	};
+
+
+	// Remove `video/` mimes from the list.
+	return array_filter( $mimes, function ( $mime ) {
+		return ! preg_match( '@^video/@', $mime );
+	} );
+}
+
+add_filter( 'upload_mimes', 'jetpack_filter_mimetypes_by_modules_and_features' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

This PR filters the video mime-types considering: the site type (Atomic or Jetpack), the `videopress` feature, and of course, it's also subject to the `videopress` module activation.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
