### PR TITLE
Carousel: prevent zoom transition slide

### DIFF
--- a/projects/plugins/jetpack/changelog/try-carousel-prevent-zoom-transition-slide
+++ b/projects/plugins/jetpack/changelog/try-carousel-prevent-zoom-transition-slide
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Disabling transitions on prev/next images to prevent flash effect on pinch, zoom and swipe.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -17,6 +17,17 @@
 	background-position: center;
 }
 
+/*
+    To prevent flash of prev/next image scale transition after pinch zoom we need to hide them.
+    Swiper does not add a class of `swiper-slide-zoomed` to slides on pinch and zoom
+    so we have to target all affected elements in touch devices.
+*/
+
+.swiper-slide.swiper-slide-prev .swiper-zoom-container img,
+.swiper-slide.swiper-slide-next .swiper-zoom-container img {
+    transition: none !important;
+}
+
 .jp-carousel-overlay .swiper-button-prev:after,
 .jp-carousel-overlay .swiper-button-next:after {
 	color: #cccccc;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -18,14 +18,14 @@
 }
 
 /*
-    To prevent flash of prev/next image scale transition after pinch zoom we need to hide them.
-    Swiper does not add a class of `swiper-slide-zoomed` to slides on pinch and zoom
-    so we have to target all affected elements in touch devices.
+To prevent flash of prev/next image scale transition after pinch zoom we need to hide them.
+Swiper does not add a class of `swiper-slide-zoomed` to slides on pinch and zoom
+so we have to target all affected elements in touch devices.
 */
 
 .swiper-slide.swiper-slide-prev .swiper-zoom-container img,
 .swiper-slide.swiper-slide-next .swiper-zoom-container img {
-    transition: none !important;
+	transition: none !important;
 }
 
 .jp-carousel-overlay .swiper-button-prev:after,


### PR DESCRIPTION
Maybe kinda hopefully Fixes https://github.com/Automattic/view-design/issues/294

#### Changes proposed in this Pull Request

This PR hides previous and next slides in touch devices to prevent the flying transition after pinch, zoom and slide described in https://github.com/Automattic/view-design/issues/309

Here's how it looks with the changes:

https://user-images.githubusercontent.com/6458278/123742819-a57abd80-d8ef-11eb-8531-67f29004d291.MP4


https://user-images.githubusercontent.com/6458278/123893696-39a45d80-d9a0-11eb-8257-ddc261db0fee.MP4



#### Jetpack product discussion
p9Jlb4-2cI-p2

#### Does this pull request change what data or activity we track or use?
Nah.

#### Testing instructions

1. Create a carousel gallery and preview it in a touch device
2. Check that swiping through images works
3. Pinch and zoom and image and slide to the next image, making sure you don't trigger an edge-swipe browser navigation (keep your pointer finger/thumb clear of the edge of your device)
4. You should not see the flying transition

