### PR TITLE
Refactored Carousel: set pagination font weight to normal

### DIFF
--- a/projects/plugins/jetpack/changelog/update-refactored-carousel-pagination-to-use-normal-font-weight
+++ b/projects/plugins/jetpack/changelog/update-refactored-carousel-pagination-to-use-normal-font-weight
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: Set pagination font weight to normal to avoid conflicts with theme styles.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -287,6 +287,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 .jp-carousel-pagination {
 	color: #fff;
 	font-size: 15px; /* same as .jp-carousel-info-footer .jp-carousel-photo-title  */
+	font-weight: normal;
 	white-space: nowrap;
 	display: none;
 	position: static !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This is a small change to ensure that font-weight from the current font doesn't leak into and affect the pagination in the bottom-left hand corner of the carousel

#### Screenshots

Testing with Maywood theme, which sets a font-weight of 300:

| Before (theme's 300 weight) | After (overridden normal weight) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/123755241-0cec3980-d8ff-11eb-9007-a8c2a71f5ec7.png) | ![image](https://user-images.githubusercontent.com/14988353/123755130-f1812e80-d8fe-11eb-85fe-affd14a9f3e2.png) |

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Switch on the Carousel module for you local environment
* Add a gallery block to a post, and include at least 6 images so that it shows the number-based pagination
* Switch to a theme that sets a light (or heavy) font weight for the `body` tag (e.g. Maywood theme)
* Load the post on the front end of your site. The pagination in the bottom left should have a normal font weight (e.g. 400) instead of being too light (300).
