### PR TITLE
Gardening: add E2E Tests label

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-gardening-e2e-tests-label
+++ b/projects/github-actions/repo-gardening/changelog/add-gardening-e2e-tests-label
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add E2E Tests label in gardening

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -208,6 +208,12 @@ async function getLabelsToAdd( octokit, owner, repo, number ) {
 		if ( compat ) {
 			keywords.add( 'Compatibility' );
 		}
+
+		// E2E tests.
+		const e2e = file.match( /^projects\/plugins\/jetpack\/tests\/e2e\// );
+		if ( e2e ) {
+			keywords.add( 'E2E Tests' );
+		}
 	} );
 
 	return [ ...keywords ];

--- a/projects/plugins/jetpack/tests/e2e/playwright.config.js
+++ b/projects/plugins/jetpack/tests/e2e/playwright.config.js
@@ -10,6 +10,7 @@ if ( HEADLESS !== 'false' && ! E2E_DEBUG ) {
 	};
 }
 
+// Comment to test PR gardening. Please remove me if you read me.
 module.exports = {
 	pwBrowserOptions: {
 		channel: '', // Leave blank for 'chromium'. For stock browsers: 'chrome', 'msedge'. See https://playwright.dev/docs/browsers/

--- a/projects/plugins/jetpack/tests/e2e/playwright.config.js
+++ b/projects/plugins/jetpack/tests/e2e/playwright.config.js
@@ -10,7 +10,6 @@ if ( HEADLESS !== 'false' && ! E2E_DEBUG ) {
 	};
 }
 
-// Comment to test PR gardening. Please remove me if you read me.
 module.exports = {
 	pwBrowserOptions: {
 		channel: '', // Leave blank for 'chromium'. For stock browsers: 'chrome', 'msedge'. See https://playwright.dev/docs/browsers/


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Automatically add label `E2E Tests` if PR changes e2e tests files.

#### Jetpack product discussion
1156386383419466-as-1200408419584765/f

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI green.
* If e2e tests files are changed E2E Tests label should be added by `Gardening / Manage labels and assignees` check.
* Tested with [81535a1](https://github.com/Automattic/jetpack/pull/20213/commits/81535a11a0ea174e557735f63161c4cc73712e85), see PR history.