### PR TITLE
pre-commit hook: Only lint changed PHP files

### DIFF
--- a/tools/git-hooks/pre-commit-hook.js
+++ b/tools/git-hooks/pre-commit-hook.js
@@ -211,7 +211,7 @@ function runPHPLinter( toLintFiles ) {
 		return;
 	}
 
-	const phpLintResult = spawnSync( 'composer', [ 'php:lint', '--files', ...toLintFiles ], {
+	const phpLintResult = spawnSync( 'composer', [ 'php:lint', '--', '--files', ...toLintFiles ], {
 		shell: true,
 		stdio: 'inherit',
 	} );

--- a/tools/git-hooks/pre-commit-hook.js
+++ b/tools/git-hooks/pre-commit-hook.js
@@ -211,7 +211,7 @@ function runPHPLinter( toLintFiles ) {
 		return;
 	}
 
-	const phpLintResult = spawnSync( 'composer', [ 'php:lint', ...toLintFiles ], {
+	const phpLintResult = spawnSync( 'composer', [ 'php:lint', '--files', ...toLintFiles ], {
 		shell: true,
 		stdio: 'inherit',
 	} );

--- a/tools/parallel-lint.sh
+++ b/tools/parallel-lint.sh
@@ -1,9 +1,35 @@
 #!/bin/bash
 
-find . \( \
-	-name .git \
-	-o -name vendor \
-	-o -name wordpress \
-	-o -name wordpress-develop \
-	-o -name node_modules \
-\) -prune -o -name '*.php' -print | vendor/bin/parallel-lint --stdin "$@"
+set -eo pipefail
+
+ARGS=()
+ALL=true
+while [[ $# -gt 0 ]]; do
+	arg="$1"
+	shift
+	case $arg in
+		--files)
+			ALL=false
+			;;
+		--stdin)
+			# I guess someone is planning to pipe files to us?
+			ALL=false
+			ARGS+=( "$arg" )
+			;;
+		*)
+			ARGS+=( "$arg" )
+			;;
+	esac
+done
+
+if $ALL; then
+	find . \( \
+		-name .git \
+		-o -name vendor \
+		-o -name wordpress \
+		-o -name wordpress-develop \
+		-o -name node_modules \
+	\) -prune -o -name '*.php' -print | vendor/bin/parallel-lint --stdin "${ARGS[@]}"
+else
+	exec vendor/bin/parallel-lint "${ARGS[@]}"
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
PR #19334 intended to add linting of changed PHP files in the pre-commit
hook, but the actual implementation linted all PHP files if any PHP file
is changed.

This fixes that, by enhancing our wrapper script to be able to be told
when files are being listed on the command line so it can avoid
processing all files.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None linkable.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `composer php:lint`. See that all files are linted.
* Edit some PHP files, then commit. See that only the edited files are linted by the pre-commit hook.