### PR TITLE
pre-commit hook: Remove package.json engines check

### DIFF
--- a/tools/check-copied-files.sh
+++ b/tools/check-copied-files.sh
@@ -75,70 +75,8 @@ compare () {
 	fi
 }
 
-# Compare objects in two JSON files
-# $1 - First file.
-# $2 - Second file.
-# $3 - jq style path expression.
-compareJSON () {
-	if ! command -v jq &> /dev/null; then
-		if [[ -z "$CI" ]]; then
-			$JQWARNED || warn "Command jq is not found, skipping checks for copied JSON paths."
-		else
-			$JQWARNED || error "Command jq is not found, cannot check for copied JSON paths."
-			EXIT=1
-		fi
-		JQWARNED=true
-		return
-	fi
-
-	local JSPATH=$(jq -n "path( $3 )" 2>/dev/null)
-	if [[ -z "$JSPATH" ]]; then
-		[[ -n "$CI" ]] && printf '::error::'
-		error "Invalid path expression \`$3\`."
-		EXIT=1
-		return
-	fi
-
-	local FAIL=
-	local A=$(jq --argjson path "$JSPATH" 'getpath( $path )' "$1" 2>/dev/null)
-	local LA=$(jq --stream --arg obj "$A" --argjson path "$JSPATH" 'if length == 1 then .[0][:-1] else .[0] end | if . == $path then input_line_number - ( $obj | gsub( "[^\n]"; "" ) | length ) else empty end' "$1")
-	if [[ -z "$LA" ]]; then
-		[[ -n "$CI" ]] && printf '::error file=%s::' "$1"
-		error "Did not find path \`$3\` in $1."
-		FAIL=1
-	fi
-	local B=$(jq --argjson path "$JSPATH" 'getpath( $path )' "$2" 2>/dev/null)
-	local LB=$(jq --stream --arg obj "$B" --argjson path "$JSPATH" 'if length == 1 then .[0][:-1] else .[0] end | if . == $path then input_line_number - ( $obj | gsub( "[^\n]"; "" ) | length ) else empty end' "$2")
-	if [[ -z "$LB" ]]; then
-		[[ -n "$CI" ]] && printf '::error file=%s::' "$2"
-		error "Did not find path \`$3\` in $2."
-		FAIL=1
-	fi
-	if [[ -n "$FAIL" ]]; then
-		EXIT=1
-		return
-	fi
-
-	if [[ "$A" != "$B" ]]; then
-		printf '\n'
-		local MSG="JSON values at \`$3\` in $1 and $2 must be identical."
-		if [[ -n "$CI" ]]; then
-			printf "::error file=%s,line=%d::%s\\n" "$1" "${LA}" "$MSG"
-			printf "::error file=%s,line=%d::%s\\n" "$2" "${LB}" "$MSG"
-		else
-			error "$MSG"
-		fi
-		diff -u /dev/fd/3 --label "$1" /dev/fd/4 --label "$2" 3<<<"$A" 4<<<"$B" || true
-		EXIT=1
-	fi
-}
-
 compare readme.md projects/plugins/jetpack/readme.md '^## Security' '^<!-- end sync section -->$'
 compare projects/packages/identity-crisis/src/scss/functions/colors.scss projects/plugins/jetpack/_inc/client/scss/functions/colors.scss
 compare projects/packages/identity-crisis/src/scss/variables/_colors.scss projects/plugins/jetpack/_inc/client/scss/variables/_colors.scss
-
-for f in $(git -c core.quotepath=off ls-files '**/package.json'); do
-	compareJSON package.json "$f" '.engines'
-done
 
 exit $EXIT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Remove the package.json engines check from the pre-commit hook.
It's slow, and package.json files aren't edited all that often.

Put the check into .github/files/lint-project-structure.sh instead.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None linkable.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit a package.json to change one of the entries in `.engines`, then commit. It shouldn't warn you about it.
* Run `.github/files/lint-project-structure.sh`. That should produce messages about the mismatch.