### PR TITLE
Carousel: Fix styling conflicts with Twenty Nineteen theme

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-to-avoid-twenty-nineteen-theme-heading-conflicts
+++ b/projects/plugins/jetpack/changelog/update-carousel-to-avoid-twenty-nineteen-theme-heading-conflicts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Carousel: Ensure refactored carousel is compatible with Twenty Nineteen theme styles.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -566,6 +566,8 @@ a.jp-carousel-image-download:hover {
 	border: none !important;
 	padding: 0 !important;
 	background-color: transparent !important;
+	min-width: 64px;
+	min-height: 64px;
 	width: 64px;
 	height: 64px;
 }

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -48,6 +48,14 @@
 	box-sizing: border-box;
 }
 
+/* Fix for Twenty Nineteen theme compatibility */
+.jp-carousel-overlay h1:before,
+.jp-carousel-overlay h2:before,
+.jp-carousel-overlay h3:before {
+	content: '';
+	display: none;
+}
+
 .swiper-container .swiper-button-prev {
 	left: 40px;
 }
@@ -558,7 +566,8 @@ a.jp-carousel-image-download:hover {
 	border: none !important;
 	padding: 0 !important;
 	background-color: transparent !important;
-	min-width: 64px;
+	width: 64px;
+	height: 64px;
 }
 
 .jp-carousel-comment .comment-date {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -52,7 +52,7 @@
 .jp-carousel-overlay h1:before,
 .jp-carousel-overlay h2:before,
 .jp-carousel-overlay h3:before {
-	content: '';
+	content: none;
 	display: none;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Twenty Nineteen theme causes a couple of styling issues with the refactored carousel introduced in #20107, this PR adds a couple of rules to ensure we're overriding styles from that theme.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Explicitly set the `before` pseudo element on headings to `none` and display `none` to prevent Twenty Nineteen's heading separator line from rendering
* Add explicit height and width to the avatar (locked to 64px since gravatars are always square) to prevent Twenty Nineteen from squishing the avatar height
* Add a minimum height of 64px just in case themes provide their own higher value

#### Screenshots

In the before and after screenshots, note the shape of the avatar images and the separator line above the heading (both should be fixed by this change).

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/123890292-50e04c80-d99a-11eb-82ea-1d4ccefd75a5.png) | ![image](https://user-images.githubusercontent.com/14988353/123890312-589ff100-d99a-11eb-96a4-495813eaae86.png) |

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In your local environment, activate the Carousel module in `/wp-admin/admin.php?page=jetpack#/writing`
* Install and activate the Twenty Nineteen theme
* Add an image gallery to a post, and ensure it has a title or caption
* View the post on the front end of your site and open up the carousel
* With this change applied, check that there isn't an extra line being drawn before the heading in the footer
* Open up the info panel and check that there isn't an extra line being drawn before the heading there
* Open up the comments panel and check that there isn't an extra line being drawn before the heading there
* Add a comment
* Check that the gravatar image (or placeholder) is being drawn at 64px by 64px.
