### PR TITLE
Update checksum query to use a distinct inner join

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-checksum-parent-join
+++ b/projects/packages/sync/changelog/fix-sync-checksum-parent-join
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Checksum parent_table joins need distinct selection to account for possibility of multiple rows.

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -486,7 +486,13 @@ class Table_Checksum {
 			$parent_filter_query = $parent_table_obj->build_filter_statement( null, null, null, 'parent_table' );
 
 			$join_statement = "
-				INNER JOIN {$parent_table_obj->table} as parent_table ON ({$this->table}.{$this->table_join_field} = parent_table.{$this->parent_join_field} AND {$parent_filter_query})
+				INNER JOIN
+				( 
+				  SELECT DISTINCT parent_table.{$this->parent_join_field}
+				  FROM {$parent_table_obj->table} as parent_table
+				  WHERE {$parent_filter_query}
+				)
+				AS parent_table ON {$this->table}.{$this->table_join_field} = parent_table.{$this->parent_join_field}
 			";
 		}
 

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -485,6 +485,8 @@ class Table_Checksum {
 			$parent_table_obj    = new Table_Checksum( $this->parent_table );
 			$parent_filter_query = $parent_table_obj->build_filter_statement( null, null, null, 'parent_table' );
 
+			// It is possible to have the GROUP By cause multiple rows to be returned for the same row.
+			// To get distinct entries we use a correlatd subquery back on the parent table using the primary key.
 			$join_statement = "
 			    INNER JOIN {$parent_table_obj->table} as parent_table
 			    ON (

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -486,13 +486,16 @@ class Table_Checksum {
 			$parent_filter_query = $parent_table_obj->build_filter_statement( null, null, null, 'parent_table' );
 
 			$join_statement = "
-				INNER JOIN
-				( 
-				  SELECT DISTINCT parent_table.{$this->parent_join_field}
-				  FROM {$parent_table_obj->table} as parent_table
-				  WHERE {$parent_filter_query}
-				)
-				AS parent_table ON {$this->table}.{$this->table_join_field} = parent_table.{$this->parent_join_field}
+			    INNER JOIN {$parent_table_obj->table} as parent_table
+			    ON (
+			        {$this->table}.{$this->table_join_field} = parent_table.{$this->parent_join_field}
+			        AND {$parent_filter_query}
+			        AND parent_table.{$parent_table_obj->range_field} = (
+			            SELECT min( parent_table_cs.{$parent_table_obj->range_field} )
+			            FROM {$parent_table_obj->table} as parent_table_cs
+			            WHERE parent_table_cs.{$this->parent_join_field} = {$this->table}.{$this->table_join_field}
+			        )
+			    )
 			";
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes:Checksum inconsistent terms

The checksum process is currently identifying terms as inconsistent when the Cache and remote db have the same data. Upon review it was determined that the issue was a parent join that caused multiple rows per term and so multiple values were included in the checksum.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Resolve discrepancy in terms checksum logic.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply Patch to your Jetpack Site / Checkout branch in beta tester
* Access the JP Debug tool for your site
* Click "Schedule Fix" from Sync Validation panel
* Wait for the fix to complete
* Click "Schedule Checksum" from Sync Validation panel
* Verify that terms align and that other tables align as well.

Alternatively from a WP.com sandbox you can run
switch_to_blog( --BLOG_ID-- );
$validator = new Jetpack_Sync_Validator( get_current_blog_id() );
$validator->perform_cache_site_audit( null, true );
