### PR TITLE
E2E checks: removed obsolete field sent to reporter workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -234,7 +234,6 @@ jobs:
           \"run_id\": \"$GITHUB_RUN_ID\",
           \"run_number\": \"$GITHUB_RUN_NUMBER\",
           \"branch\": \"$BRANCH\",
-          \"pr\": \"${{ github.event.pull_request.number }}\",
           \"pr_title\": \"${{ github.event.pull_request.title }}\",
           \"pr_number\": \"${{ github.event.pull_request.number }}\"
           }}"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Remove an unused field (`pr`) in payload sent to reporting workflow in jetpack-e2e-reports repo. This field was replaced by `pr_number` and was kept for a while for backwards compatibility.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI green
* Report successfully generated: https://automattic.github.io/jetpack-e2e-reports/20230/report/
