### PR TITLE
Update term_taxonomy checksum filter to an allow list.

### DIFF
--- a/projects/packages/sync/changelog/fix-checksum-invalid-term-in-term-relationship
+++ b/projects/packages/sync/changelog/fix-checksum-invalid-term-in-term-relationship
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update term_taxonomy checksum query to an allowed list vs disallowed

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -317,6 +317,27 @@ class Settings {
 	}
 
 	/**
+	 * Returns structured SQL clause for allowed taxonomies.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return array taxonomies filter values
+	 */
+	public static function get_allowed_taxonomies_structured() {
+		global $wp_taxonomies;
+
+		$allowed_taxonomies = array_keys( $wp_taxonomies );
+		$allowed_taxonomies = array_diff( $allowed_taxonomies, self::get_setting( 'taxonomies_blacklist' ) );
+		return array(
+			'taxonomy' => array(
+				'operator' => 'IN',
+				'values'   => array_map( 'esc_sql', $allowed_taxonomies ),
+			),
+		);
+	}
+
+	/**
 	 * Returns escaped SQL for blacklisted comment meta.
 	 * Can be injected directly into a WHERE clause.
 	 *

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -224,7 +224,7 @@ class Table_Checksum {
 				'range_field'     => 'term_taxonomy_id',
 				'key_fields'      => array( 'term_taxonomy_id' ),
 				'checksum_fields' => array( 'term_taxonomy_id', 'term_id', 'taxonomy', 'description', 'parent' ),
-				'filter_values'   => Sync\Settings::get_blacklisted_taxonomies_structured(),
+				'filter_values'   => Sync\Settings::get_allowed_taxonomies_structured(),
 			),
 			'links'              => $wpdb->links, // TODO describe in the array format or add exceptions.
 			'options'            => $wpdb->options, // TODO describe in the array format or add exceptions.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes Invalid Taxonomy being returned in a checksum.

Currently the Term_Taxonomy table is checksummed based on a disallow list. This implementation has a flaw in that any misc relationships that are not part of registered taxonomies get included in the checksum and lead to inconsistencies being identified that can not be resolved. To ensure only registered taxonomies are included in the checksum we are moving to an allowed (IN) query which has the benefit of being lower footprint as the majority of sites have less taxonomies then the disallow list we maintain.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix term_relationship data inconsistencies in checksum routine.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Access wp shell and run `Automattic\Jetpack\Sync\Settings::get_allowed_taxonomies_structured();` verify that it returns an array which includes registered taxonomies and nothing from the blacklisted_taxonomies list.
* You can register a blacklisted taxonomy on your site and verify it doesn't get included in the return value.
* Apply this patch to your jetpack site.
* From WP.com sandbox run the following commands in wp shell
* `switch_to_blog( BLOG_ID );`
* `$validator = new Jetpack_Sync_Validator( get_current_blog_id() );`
* `$validator->perform_cache_site_audit( null, false );` 
* Review the term_relationship output to see what was identified.
* Revert the patch on your Jetpack site
* run the same perform_cache_site_audit command on your WP.com sandbox
* Are the same discrepancies found? If not try running a fix by passing true as the 2nd parameter. does this fix the issue?

