### PR TITLE
Revert the carousel overlay z-index to previous settings

### DIFF
--- a/projects/plugins/jetpack/changelog/revert-carousel-z-index
+++ b/projects/plugins/jetpack/changelog/revert-carousel-z-index
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: A minor css change to revert carousel overlay z-index
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -43,7 +43,7 @@ so we have to target all affected elements in touch devices.
 
 .jp-carousel-overlay {
 	font-family: 'Helvetica Neue', sans-serif !important;
-	z-index: 10;
+	z-index: 2147483647;
 	overflow-x: hidden;
 	overflow-y: auto;
 	direction: ltr;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -230,10 +230,6 @@ div.jp-carousel-buttons a:hover {
 	color: #fff;
 }
 
-body.admin-bar .jp-carousel-close-hint {
-	top: 50px;
-}
-
 .jp-carousel-transitions .jp-carousel-close-hint {
 	-webkit-transition: color 200ms linear;
 	-moz-transition: color 200ms linear;


### PR DESCRIPTION
As crazy as the previous z-index is at least we shouldn't get any theme regressions if we keep it the same.

Fixes #20233

#### Changes proposed in this Pull Request:

* Reverts the carousel overlay z-index to the previous setting

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Check out PR and add gallery with carousel enabled
* Test that overlay displays as expected, including with Independent Publisher 2 theme installed.
