### PR TITLE
Carousel: Make sure zoom works on high PPI devices

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-image-zoom-on-mobile
+++ b/projects/plugins/jetpack/changelog/fix-carousel-image-zoom-on-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix image quality on carousel zoom.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -837,9 +837,9 @@
 			var mediumWidth = parseInt( mediumSizeParts[ 0 ], 10 );
 			var mediumHeight = parseInt( mediumSizeParts[ 1 ], 10 );
 
-			// Assign max width and height.
-			args.origMaxWidth = args.maxWidth;
-			args.origMaxHeight = args.maxHeight;
+			// Assign max width and height -- @3x to support hiPPI/Retina devices when zooming in.
+			args.origMaxWidth = args.maxWidth * 3;
+			args.origMaxHeight = args.maxHeight * 3;
 
 			// Give devices with a higher devicePixelRatio higher-res images (Retina display = 2, Android phones = 1.5, etc)
 			if ( typeof window.devicePixelRatio !== 'undefined' && window.devicePixelRatio > 1 ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/view-design/issues/299

| Before        | After           |
| ------------- |:-------------:| 
| ![IMG_1437](https://user-images.githubusercontent.com/1464705/123674104-16d64580-d7f6-11eb-922e-fbc6717863bb.PNG) |  ![IMG_1436](https://user-images.githubusercontent.com/1464705/123674110-18a00900-d7f6-11eb-80b4-8bab6334c95c.PNG) |


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When zooming in on images, make sure they stay high enough quality to look good on high PPI/Retina device screens.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open an image in the carousel, zoom in and make sure the image does not look pixelated.
* Check that this continues to work on desktop devices.