### PR TITLE
Fix/carousel light small screens

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-light-small-screens
+++ b/projects/plugins/jetpack/changelog/fix-carousel-light-small-screens
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Minor css fix on small screens for carousel
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -1172,6 +1172,10 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		background-color: #000;
 	}
 
+	.jp-carousel-light .jp-carousel-wrap {
+		background-color: #fff;
+	}
+
 	.jp-carousel-fadeaway {
 		display: none;
 	}


### PR DESCRIPTION
Fixes #20245

#### Changes proposed in this Pull Request:

* Add light theme option for background on small screens

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Check out PR and add gallery with Jetpack carousel enabled and White theme set
* Make sure background remains white on smaller screens

Before:
<img width="630" alt="Screen Shot 2021-07-02 at 9 19 42 AM" src="https://user-images.githubusercontent.com/3629020/124190807-fc161080-db16-11eb-85b8-779321adf670.png">

After:
<img width="628" alt="Screen Shot 2021-07-02 at 9 16 15 AM" src="https://user-images.githubusercontent.com/3629020/124190824-00422e00-db17-11eb-8a30-cc2319b73fc0.png">

