### PR TITLE
Carousel: Only upscale images if they are less than 1k px.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-better-carousel-upscaling
+++ b/projects/plugins/jetpack/changelog/add-better-carousel-upscaling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -837,9 +837,8 @@
 			var mediumWidth = parseInt( mediumSizeParts[ 0 ], 10 );
 			var mediumHeight = parseInt( mediumSizeParts[ 1 ], 10 );
 
-			// Assign max width and height -- @3x to support hiPPI/Retina devices when zooming in.
-			args.origMaxWidth = args.maxWidth * 3;
-			args.origMaxHeight = args.maxHeight * 3;
+			args.origMaxWidth = args.maxWidth;
+			args.origMaxHeight = args.maxHeight;
 
 			// Give devices with a higher devicePixelRatio higher-res images (Retina display = 2, Android phones = 1.5, etc)
 			if ( typeof window.devicePixelRatio !== 'undefined' && window.devicePixelRatio > 1 ) {
@@ -865,6 +864,13 @@
 					// If we have a really large image load a smaller version
 					// that is closer to the viewable size
 					if ( args.origWidth > args.maxWidth || args.origHeight > args.maxHeight ) {
+						// If the image is smaller than 1000px in width or height, @2x it so
+						// we get a high enough resolution for zooming.
+						if ( args.origMaxWidth < 1000 || args.origMaxWidth < 1000 ) {
+							args.origMaxWidth = args.maxWidth * 2;
+							args.origMaxHeight = args.maxHeight * 2;
+						}
+
 						origPhotonUrl += '?fit=' + args.origMaxWidth + '%2C' + args.origMaxHeight;
 					}
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Improves on https://github.com/Automattic/jetpack/pull/20244 after testing performance on Matt's site.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Only upscale images for zoom if they are less than 1000px in width or height. This prevents large images on desktop from being upscaled in photon and causing sluggish scrolling.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open a gallery and confirm you can scroll smoothly on mobile and desktop.
* Zoom in on an image on a mobile device and confirm the quality looks good (not fuzzy).
