### PR TITLE
Search: Add search admin page footer

### DIFF
--- a/projects/plugins/jetpack/_inc/client/search/dashboard/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/index.jsx
@@ -10,7 +10,6 @@ import { __ } from '@wordpress/i18n';
  */
 import { JetpackFooter } from '@automattic/jetpack-components';
 import restApi from 'rest-api';
-import getRedirectUrl from 'lib/jp-redirect';
 import Masthead from 'components/masthead';
 import LoadingPlaceHolder from 'components/loading-placeholder';
 import ModuleControl from './module-control';
@@ -22,7 +21,6 @@ import './style.scss';
  */
 import { isFetchingSitePurchases } from 'state/site';
 import { setInitialState, getApiNonce, getApiRootUrl, getSiteAdminUrl } from 'state/initial-state';
-import { getSiteConnectionStatus } from 'state/connection';
 
 const useComponentWillMount = func => {
 	// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -41,7 +39,6 @@ function SearchDashboard( props ) {
 		apiRootUrl,
 		apiNonce,
 		setInitialState: setSearchDashboardInitialState,
-		siteConnectionStatus,
 		siteAdminUrl,
 	} = props;
 
@@ -51,9 +48,7 @@ function SearchDashboard( props ) {
 		setSearchDashboardInitialState && setSearchDashboardInitialState();
 	} );
 
-	const aboutPageUrl = siteConnectionStatus
-		? siteAdminUrl + 'admin.php?page=jetpack_about'
-		: getRedirectUrl( 'jetpack' );
+	const aboutPageUrl = siteAdminUrl + 'admin.php?page=jetpack_about';
 
 	return (
 		<Fragment>
@@ -94,7 +89,6 @@ export default connect(
 			apiNonce: getApiNonce( state ),
 			isLoading: isFetchingSitePurchases( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
-			siteConnectionStatus: getSiteConnectionStatus( state ),
 		};
 	},
 	{ setInitialState }

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/index.jsx
@@ -8,7 +8,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { JetpackFooter } from '@automattic/jetpack-components';
 import restApi from 'rest-api';
+import getRedirectUrl from 'lib/jp-redirect';
 import Masthead from 'components/masthead';
 import LoadingPlaceHolder from 'components/loading-placeholder';
 import ModuleControl from './module-control';
@@ -19,7 +21,8 @@ import './style.scss';
  * State dependencies
  */
 import { isFetchingSitePurchases } from 'state/site';
-import { setInitialState, getApiNonce, getApiRootUrl } from 'state/initial-state';
+import { setInitialState, getApiNonce, getApiRootUrl, getSiteAdminUrl } from 'state/initial-state';
+import { getSiteConnectionStatus } from 'state/connection';
 
 const useComponentWillMount = func => {
 	// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -34,13 +37,23 @@ const useComponentWillMount = func => {
  */
 function SearchDashboard( props ) {
 	// NOTE: API root and nonce must be set before any components are mounted!
-	const { apiRootUrl, apiNonce, setInitialState: setSearchDashboardInitialState } = props;
+	const {
+		apiRootUrl,
+		apiNonce,
+		setInitialState: setSearchDashboardInitialState,
+		siteConnectionStatus,
+		siteAdminUrl,
+	} = props;
 
 	useComponentWillMount( () => {
 		apiRootUrl && restApi.setApiRoot( apiRootUrl );
 		apiNonce && restApi.setApiNonce( apiNonce );
 		setSearchDashboardInitialState && setSearchDashboardInitialState();
 	} );
+
+	const aboutPageUrl = siteConnectionStatus
+		? siteAdminUrl + 'admin.php?page=jetpack_about'
+		: getRedirectUrl( 'jetpack' );
 
 	return (
 		<Fragment>
@@ -63,6 +76,10 @@ function SearchDashboard( props ) {
 					</div>
 					<div className="jp-search-dashboard__bottom">
 						<ModuleControl />
+						<JetpackFooter
+							a8cLogoHref={ aboutPageUrl }
+							moduleName={ __( 'Jetpack Search', 'jetpack' ) }
+						/>
 					</div>
 				</Fragment>
 			) }
@@ -76,6 +93,8 @@ export default connect(
 			apiRootUrl: getApiRootUrl( state ),
 			apiNonce: getApiNonce( state ),
 			isLoading: isFetchingSitePurchases( state ),
+			siteAdminUrl: getSiteAdminUrl( state ),
+			siteConnectionStatus: getSiteConnectionStatus( state ),
 		};
 	},
 	{ setInitialState }

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-instant-search.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-instant-search.scss
@@ -14,7 +14,6 @@ $color-text-lighter: $studio-gray-50;
 	margin: 0 auto;
 	width: 100%;
 	height: 100%;
-	min-height: 25rem;
 	box-shadow: rgba( 0, 0, 0, 0.35 ) 0px 5px 25px;
 	user-select: none;
 	overflow: hidden;

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
@@ -36,7 +36,7 @@ $color-button-text-disabled: #a7aaad;
 p.jp-form-search-settings-group__toggle-explanation {
 	color: #2c3338;
 	font-weight: 250;
-	font-size: 0.75rem;
+	font-size: 0.875rem;
 }
 
 .jp-form-search-settings-group__buttons {

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/style.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/style.scss
@@ -42,7 +42,7 @@
 		justify-content: space-around;
 		align-items: center;
 		width: 100%;
-		min-height: 30rem;
+		min-height: 24rem;
 
 		background-color: $white;
 	}

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/style.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/style.scss
@@ -11,9 +11,10 @@
 		align-items: center;
 		flex-flow: column;
 
-		@media screen and ( min-width: 480px ) and ( min-height: 700px ) {
-			height: 55vh;
-		}
+		min-height: 300px;
+		max-height: 500px;
+		height: 45vh;
+		overflow: hidden;
 	}
 
 	.jp-search-dashboard__title {
@@ -40,19 +41,10 @@
 		flex-flow: column;
 		justify-content: space-around;
 		align-items: center;
-		position: absolute;
-		left: 0;
 		width: 100%;
-		top: 25rem;
-		min-height: 20rem;
+		min-height: 30rem;
 
 		background-color: $white;
-		z-index: 1;
-		// In order to show WP footer, we need to sync the breakpoint.
-		@media screen and ( min-width: 782px ) and ( min-height: 700px ) {
-			top: 50vh;
-			height: calc( 48vh - 51px );
-		}
 	}
 
 	@include breakpoint( '<480px' ) {

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/style.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/style.scss
@@ -46,12 +46,12 @@
 		top: 25rem;
 		min-height: 20rem;
 
-		background-color: #fff;
+		background-color: $white;
 		z-index: 1;
-
-		@media screen and ( min-width: 480px ) and ( min-height: 700px ) {
+		// In order to show WP footer, we need to sync the breakpoint.
+		@media screen and ( min-width: 782px ) and ( min-height: 700px ) {
 			top: 50vh;
-			height: 48vh;
+			height: calc( 48vh - 51px );
 		}
 	}
 

--- a/projects/plugins/jetpack/changelog/add-search-admin-page-footer
+++ b/projects/plugins/jetpack/changelog/add-search-admin-page-footer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: added footer for search dashboard


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This is a followup PR for #20224. Added footer branding for search admin page based on Jetpack RNA component add in #20287.

#### Jetpack product discussion
pcNPJE-7J#comment-161

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with Jetpack Instant Search subscription (enter URL directly `/wp-admin/admin.php?page=jetpack-search&a8ctest`)
* Ensure the footer looks good with both PC and mobile resolutions

![image](https://user-images.githubusercontent.com/1425433/124211128-bbcb8800-db40-11eb-9afa-be4a9de33650.png)


NOTE:

- The functionality is hidden, unless a a8ctest param is detected in URL, e.g. /wp-admin/admin.php?page=jetpack-search&a8ctest.
