### PR TITLE
Search: Add search admin page buttons for search/widget settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
@@ -85,26 +85,27 @@ function Search( props ) {
 	const togglingInstantSearch = !! props.isSavingAnyOption( 'instant_search_enabled' );
 	const isSavingEitherOption = togglingModule || togglingInstantSearch;
 
-	const isInstantSearchButtonDisabled =
+	const isInstantSearchCusomizeButtonDisabled =
 		isSavingEitherOption ||
 		! isModuleEnabled ||
 		! isInstantSearchEnabled ||
 		! hasActiveSearchPurchase;
+	const isWidgetsEditorButtonDisabled = isSavingEitherOption || ! isModuleEnabled;
 	const returnUrl = encodeURIComponent( siteAdminUrl + RETURN_PATH );
 	const renderInstantSearchButtons = () => {
 		return (
 			<div className="jp-form-search-settings-group__buttons">
 				<Button
 					className="jp-form-search-settings-group__button is-customize-search"
-					href={ ! isInstantSearchButtonDisabled && SEARCH_CUSTOMIZE_URL + returnUrl }
-					disabled={ isInstantSearchButtonDisabled }
+					href={ ! isInstantSearchCusomizeButtonDisabled && SEARCH_CUSTOMIZE_URL + returnUrl }
+					disabled={ isInstantSearchCusomizeButtonDisabled }
 				>
 					{ __( 'Customize search results', 'jetpack' ) }
 				</Button>
 				<Button
 					className="jp-form-search-settings-group__button is-widgets-editor"
-					href={ ! isInstantSearchButtonDisabled && WIDGETS_EDITOR_URL + returnUrl }
-					disabled={ isInstantSearchButtonDisabled }
+					href={ ! isWidgetsEditorButtonDisabled && WIDGETS_EDITOR_URL + returnUrl }
+					disabled={ isWidgetsEditorButtonDisabled }
 				>
 					{ __( 'Edit sidebar widgets', 'jetpack' ) }
 				</Button>

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
@@ -22,7 +22,7 @@ import './module-control.scss';
  * State dependencies
  */
 import { isOfflineMode } from 'state/connection';
-import { getUpgradeUrl } from 'state/initial-state';
+import { getUpgradeUrl, getSiteAdminUrl } from 'state/initial-state';
 import {
 	getSitePlan,
 	hasActiveSearchPurchase as selectHasActiveSearchPurchase,
@@ -40,8 +40,10 @@ const INSTANT_SEARCH_DESCRIPTION = __(
 	'jetpack'
 );
 const SEARCH_SUPPORT = __( 'Search supports many customizations. ', 'jetpack' );
-const SEARCH_CUSTOMIZE_URL = 'customize.php?autofocus[section]=jetpack_search';
-const WIDGETS_EDITOR_URL = 'customize.php?autofocus[panel]=widgets';
+// NOTE: remove a8ctest after all relative PRs merged.
+const RETURN_PATH = 'admin.php?page=jetpack-search&a8ctest';
+const SEARCH_CUSTOMIZE_URL = 'customize.php?autofocus[section]=jetpack_search&return=';
+const WIDGETS_EDITOR_URL = 'customize.php?autofocus[panel]=widgets&return=';
 
 /**
  * Search settings component to be used within the Performance section.
@@ -50,7 +52,7 @@ const WIDGETS_EDITOR_URL = 'customize.php?autofocus[panel]=widgets';
  * @returns {React.Component}	Search settings component.
  */
 function Search( props ) {
-	const { failedToEnableSearch, hasActiveSearchPurchase, updateOptions } = props;
+	const { failedToEnableSearch, hasActiveSearchPurchase, updateOptions, siteAdminUrl } = props;
 	const isModuleEnabled = props.getOptionValue( 'search' );
 	const isInstantSearchEnabled = props.getOptionValue( 'instant_search_enabled', 'search' );
 
@@ -88,20 +90,20 @@ function Search( props ) {
 		! isModuleEnabled ||
 		! isInstantSearchEnabled ||
 		! hasActiveSearchPurchase;
-
+	const returnUrl = encodeURIComponent( siteAdminUrl + RETURN_PATH );
 	const renderInstantSearchCFAButtons = () => {
 		return (
 			<div className="jp-form-search-cfa-buttons">
 				<Button
 					className="jp-form-search-cfa-button customize-search-button"
-					href={ ! isInstantSearchCFAButtonDisabled && SEARCH_CUSTOMIZE_URL }
+					href={ ! isInstantSearchCFAButtonDisabled && SEARCH_CUSTOMIZE_URL + returnUrl }
 					disabled={ isInstantSearchCFAButtonDisabled }
 				>
 					{ __( 'Customize search results', 'jetpack' ) }
 				</Button>
 				<Button
 					className="jp-form-search-cfa-button widgets-editor-button"
-					href={ ! isInstantSearchCFAButtonDisabled && WIDGETS_EDITOR_URL }
+					href={ ! isInstantSearchCFAButtonDisabled && WIDGETS_EDITOR_URL + returnUrl }
 					disabled={ isInstantSearchCFAButtonDisabled }
 				>
 					{ __( 'Edit sidebar widgets', 'jetpack' ) }
@@ -180,5 +182,6 @@ export default connect( state => {
 			false === hasUpdatedSetting( state, 'search' ),
 		siteID: getSiteID( state ),
 		upgradeUrl: getUpgradeUrl( state, 'jetpack-search' ),
+		siteAdminUrl: getSiteAdminUrl( state ),
 	};
 } )( withModuleSettingsFormHelpers( Search ) );

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
@@ -13,6 +13,7 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsGroup from 'components/settings-group';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import Button from 'components/button';
 import getRedirectUrl from 'lib/jp-redirect';
 import { getPlanClass } from 'lib/plans/constants';
 import './module-control.scss';
@@ -39,6 +40,8 @@ const INSTANT_SEARCH_DESCRIPTION = __(
 	'jetpack'
 );
 const SEARCH_SUPPORT = __( 'Search supports many customizations. ', 'jetpack' );
+const SEARCH_CUSTOMIZE_URL = 'customize.php?autofocus[section]=jetpack_search';
+const WIDGETS_EDITOR_URL = 'customize.php?autofocus[panel]=widgets';
 
 /**
  * Search settings component to be used within the Performance section.
@@ -79,6 +82,33 @@ function Search( props ) {
 	const togglingModule = !! props.isSavingAnyOption( 'search' );
 	const togglingInstantSearch = !! props.isSavingAnyOption( 'instant_search_enabled' );
 	const isSavingEitherOption = togglingModule || togglingInstantSearch;
+
+	const isInstantSearchCFAButtonDisabled =
+		isSavingEitherOption ||
+		! isModuleEnabled ||
+		! isInstantSearchEnabled ||
+		! hasActiveSearchPurchase;
+
+	const renderInstantSearchCFAButtons = () => {
+		return (
+			<div className="jp-form-search-cfa-buttons">
+				<Button
+					className="jp-form-search-cfa-button customize-search-button"
+					href={ ! isInstantSearchCFAButtonDisabled && SEARCH_CUSTOMIZE_URL }
+					disabled={ isInstantSearchCFAButtonDisabled }
+				>
+					{ __( 'Customize search results', 'jetpack' ) }
+				</Button>
+				<Button
+					className="jp-form-search-cfa-button widgets-editor-button"
+					href={ ! isInstantSearchCFAButtonDisabled && WIDGETS_EDITOR_URL }
+					disabled={ isInstantSearchCFAButtonDisabled }
+				>
+					{ __( 'Edit sidebar widgets', 'jetpack' ) }
+				</Button>
+			</div>
+		);
+	};
 
 	return (
 		<Fragment>
@@ -127,6 +157,7 @@ function Search( props ) {
 								<p className="jp-search-search-toggle__explanation">
 									{ INSTANT_SEARCH_DESCRIPTION }
 								</p>
+								{ renderInstantSearchCFAButtons() }
 							</div>
 						</div>
 					</Fragment>

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
@@ -85,26 +85,26 @@ function Search( props ) {
 	const togglingInstantSearch = !! props.isSavingAnyOption( 'instant_search_enabled' );
 	const isSavingEitherOption = togglingModule || togglingInstantSearch;
 
-	const isInstantSearchCFAButtonDisabled =
+	const isInstantSearchButtonDisabled =
 		isSavingEitherOption ||
 		! isModuleEnabled ||
 		! isInstantSearchEnabled ||
 		! hasActiveSearchPurchase;
 	const returnUrl = encodeURIComponent( siteAdminUrl + RETURN_PATH );
-	const renderInstantSearchCFAButtons = () => {
+	const renderInstantSearchButtons = () => {
 		return (
-			<div className="jp-form-search-cfa-buttons">
+			<div className="jp-form-search-settings-group__buttons">
 				<Button
-					className="jp-form-search-cfa-button customize-search-button"
-					href={ ! isInstantSearchCFAButtonDisabled && SEARCH_CUSTOMIZE_URL + returnUrl }
-					disabled={ isInstantSearchCFAButtonDisabled }
+					className="jp-form-search-settings-group__button is-customize-search"
+					href={ ! isInstantSearchButtonDisabled && SEARCH_CUSTOMIZE_URL + returnUrl }
+					disabled={ isInstantSearchButtonDisabled }
 				>
 					{ __( 'Customize search results', 'jetpack' ) }
 				</Button>
 				<Button
-					className="jp-form-search-cfa-button widgets-editor-button"
-					href={ ! isInstantSearchCFAButtonDisabled && WIDGETS_EDITOR_URL + returnUrl }
-					disabled={ isInstantSearchCFAButtonDisabled }
+					className="jp-form-search-settings-group__button is-widgets-editor"
+					href={ ! isInstantSearchButtonDisabled && WIDGETS_EDITOR_URL + returnUrl }
+					disabled={ isInstantSearchButtonDisabled }
 				>
 					{ __( 'Edit sidebar widgets', 'jetpack' ) }
 				</Button>
@@ -131,7 +131,7 @@ function Search( props ) {
 
 				{ ! props.isLoading && ( props.isBusinessPlan || props.hasActiveSearchPurchase ) && (
 					<Fragment>
-						<div className="jp-search-search-toggle jp-search-search-toggle--search">
+						<div className="jp-form-search-settings-group__toggle is-search">
 							<ModuleToggle
 								activated={ isModuleEnabled }
 								compact
@@ -142,11 +142,13 @@ function Search( props ) {
 							>
 								{ __( 'Enable Jetpack Search', 'jetpack' ) }
 							</ModuleToggle>
-							<div className="jp-search-search-toggle__description">
-								<p className="jp-search-search-toggle__explanation">{ SEARCH_DESCRIPTION }</p>
+							<div className="jp-form-search-settings-group__toggle-description">
+								<p className="jp-form-search-settings-group__toggle-explanation">
+									{ SEARCH_DESCRIPTION }
+								</p>
 							</div>
 						</div>
-						<div className="jp-search-search-toggle jp-search-search-toggle--instant-search">
+						<div className="jp-form-search-settings-group__toggle is-instant-search">
 							<CompactFormToggle
 								checked={ isModuleEnabled && isInstantSearchEnabled }
 								disabled={ isSavingEitherOption || ! props.hasActiveSearchPurchase }
@@ -155,11 +157,11 @@ function Search( props ) {
 							>
 								{ __( 'Enable instant search experience (recommended)', 'jetpack' ) }
 							</CompactFormToggle>
-							<div className="jp-search-search-toggle__description">
-								<p className="jp-search-search-toggle__explanation">
+							<div className="jp-form-search-settings-group__toggle-description">
+								<p className="jp-form-search-settings-group__toggle-explanation">
 									{ INSTANT_SEARCH_DESCRIPTION }
 								</p>
-								{ renderInstantSearchCFAButtons() }
+								{ renderInstantSearchButtons() }
 							</div>
 						</div>
 					</Fragment>

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment, useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -42,8 +42,8 @@ const INSTANT_SEARCH_DESCRIPTION = __(
 const SEARCH_SUPPORT = __( 'Search supports many customizations. ', 'jetpack' );
 // NOTE: remove a8ctest after all relative PRs merged.
 const RETURN_PATH = 'admin.php?page=jetpack-search&a8ctest';
-const SEARCH_CUSTOMIZE_URL = 'customize.php?autofocus[section]=jetpack_search&return=';
-const WIDGETS_EDITOR_URL = 'customize.php?autofocus[panel]=widgets&return=';
+const SEARCH_CUSTOMIZE_URL = 'customize.php?autofocus[section]=jetpack_search&return=%s';
+const WIDGETS_EDITOR_URL = 'customize.php?autofocus[panel]=widgets&return=%s';
 
 /**
  * Search settings component to be used within the Performance section.
@@ -97,14 +97,16 @@ function Search( props ) {
 			<div className="jp-form-search-settings-group__buttons">
 				<Button
 					className="jp-form-search-settings-group__button is-customize-search"
-					href={ ! isInstantSearchCustomizeButtonDisabled && SEARCH_CUSTOMIZE_URL + returnUrl }
+					href={
+						! isInstantSearchCustomizeButtonDisabled && sprintf( SEARCH_CUSTOMIZE_URL, returnUrl )
+					}
 					disabled={ isInstantSearchCustomizeButtonDisabled }
 				>
 					{ __( 'Customize search results', 'jetpack' ) }
 				</Button>
 				<Button
 					className="jp-form-search-settings-group__button is-widgets-editor"
-					href={ ! isWidgetsEditorButtonDisabled && WIDGETS_EDITOR_URL + returnUrl }
+					href={ ! isWidgetsEditorButtonDisabled && sprintf( WIDGETS_EDITOR_URL, returnUrl ) }
 					disabled={ isWidgetsEditorButtonDisabled }
 				>
 					{ __( 'Edit sidebar widgets', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
@@ -85,7 +85,7 @@ function Search( props ) {
 	const togglingInstantSearch = !! props.isSavingAnyOption( 'instant_search_enabled' );
 	const isSavingEitherOption = togglingModule || togglingInstantSearch;
 
-	const isInstantSearchCusomizeButtonDisabled =
+	const isInstantSearchCustomizeButtonDisabled =
 		isSavingEitherOption ||
 		! isModuleEnabled ||
 		! isInstantSearchEnabled ||
@@ -97,8 +97,8 @@ function Search( props ) {
 			<div className="jp-form-search-settings-group__buttons">
 				<Button
 					className="jp-form-search-settings-group__button is-customize-search"
-					href={ ! isInstantSearchCusomizeButtonDisabled && SEARCH_CUSTOMIZE_URL + returnUrl }
-					disabled={ isInstantSearchCusomizeButtonDisabled }
+					href={ ! isInstantSearchCustomizeButtonDisabled && SEARCH_CUSTOMIZE_URL + returnUrl }
+					disabled={ isInstantSearchCustomizeButtonDisabled }
 				>
 					{ __( 'Customize search results', 'jetpack' ) }
 				</Button>

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
@@ -1,5 +1,10 @@
 @import './_variables.scss';
 
+$color-button-background: $black;
+$color-button-text: $white;
+$color-button-background-disabled: #dcdcde;
+$color-button-text-disabled: #a7aaad;
+
 .jp-form-search-settings-group {
 	width: 100%;
 	max-width: 55rem;
@@ -34,4 +39,43 @@ p.jp-search-search-toggle__explanation {
 	color: #2c3338;
 	font-weight: 250;
 	font-size: 0.75rem;
+}
+
+.jp-form-search-cfa-buttons {
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: space-between;
+	margin-top: 1em;
+	width: 100%;
+	max-width: 450px;
+}
+
+.jp-form-search-cfa-button {
+	width: 15em;
+	margin: 0.25em;
+	text-align: center;
+	border-color: $color-button-background;
+
+	&.customize-search-button {
+		color: $color-button-text;
+		background-color: $color-button-background;
+	}
+
+	&:disabled,
+	&[disabled] {
+		background-color: $color-button-background-disabled;
+		border-color: $color-button-background-disabled;
+		color: $color-button-text-disabled;
+		cursor: not-allowed;
+	}
+
+	&.widgets-editor-button {
+		color: $color-button-background;
+		background: transparent;
+		&:disabled,
+		&[disabled] {
+			color: $color-button-text-disabled;
+			background: transparent;
+		}
+	}
 }

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
@@ -20,11 +20,9 @@ $color-button-text-disabled: #a7aaad;
 	.form-toggle__label-content {
 		font-weight: bold;
 	}
-
 	.form-toggle:checked + .form-toggle__label .form-toggle__switch {
 		background: $color-plan;
 	}
-
 	.form-toggle__switch:focus {
 		box-shadow: 0 0 0 2px $blue-medium;
 	}

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
@@ -13,7 +13,7 @@ $color-button-text-disabled: #a7aaad;
 	}
 }
 
-.jp-search-search-toggle {
+.jp-form-search-settings-group__toggle {
 	margin-top: 2em;
 	font-size: 1.5em;
 
@@ -30,18 +30,18 @@ $color-button-text-disabled: #a7aaad;
 	}
 }
 
-.jp-search-search-toggle__description {
+.jp-form-search-settings-group__toggle-description {
 	margin-left: 36px; // same as label
 	margin-top: 0.5em;
 }
 
-p.jp-search-search-toggle__explanation {
+p.jp-form-search-settings-group__toggle-explanation {
 	color: #2c3338;
 	font-weight: 250;
 	font-size: 0.75rem;
 }
 
-.jp-form-search-cfa-buttons {
+.jp-form-search-settings-group__buttons {
 	display: flex;
 	flex-flow: row wrap;
 	justify-content: space-between;
@@ -50,13 +50,13 @@ p.jp-search-search-toggle__explanation {
 	max-width: 450px;
 }
 
-.jp-form-search-cfa-button {
+.jp-form-search-settings-group__button {
 	width: 15em;
 	margin: 0.25em;
 	text-align: center;
 	border-color: $color-button-background;
 
-	&.customize-search-button {
+	&.is-customize-search {
 		color: $color-button-text;
 		background-color: $color-button-background;
 	}
@@ -69,7 +69,7 @@ p.jp-search-search-toggle__explanation {
 		cursor: not-allowed;
 	}
 
-	&.widgets-editor-button {
+	&.is-widgets-editor {
 		color: $color-button-background;
 		background: transparent;
 		&:disabled,

--- a/projects/plugins/jetpack/changelog/add-search-admin-page-buttons
+++ b/projects/plugins/jetpack/changelog/add-search-admin-page-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: Added widgets editor and search customizer buttons for search admin page


### PR DESCRIPTION
Changes proposed in this Pull Request:

This is a followup PR for #20224. Added buttons to link Search customizer and customizer widget editor. 

Jetpack product discussion
pcNPJE-7J#comment-161

Does this pull request change what data or activity we track or use?
no

Testing instructions:
- Go to a site with Jetpack Instant Search subscription (enter URL directly `/wp-admin/admin.php?page=jetpack-search&a8ctest`)
- Ensure buttons link to the right place when Instant Search is enabled
- Ensure customize button is disabled and not clickable when Search is enabled but Instant Search is disabled
- Ensure buttons are not available when Search is disabled.
- Ensure Edit widgets button is disabled only when Search is disabled.

![watch](https://user-images.githubusercontent.com/1425433/125005783-bb873b80-e0b0-11eb-84b5-cba9a30c7d9c.gif)



NOTE:

- The functionality is hidden, unless a a8ctest param is detected in URL, e.g. /wp-admin/admin.php?page=jetpack-search&a8ctest.

