### PR TITLE
Instant Search: fix visual glitch on breadcrumb in Firefox

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-instant-search-breadcrumb
+++ b/projects/plugins/jetpack/changelog/fix-instant-search-breadcrumb
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instant Search: fix visual glitch on breadcrumb in Firefox

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.scss
@@ -18,7 +18,6 @@ $image-square-size: 128px;
 	color: $color-text-lighter;
 	font-size: 0.9375em;
 	margin: 0 0 0.4em;
-	line-height: 1.3;
 }
 
 .jetpack-instant-search__search-result-expanded__copy-container {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result.scss
@@ -2,7 +2,7 @@
 
 //
 // Only add styles here that should be shared across different result types (minimal, expanded, product).
-// NOTE: Due to Webpack import order, this styles will apply AFTER minimal/expanded/product styles.
+// NOTE: Due to Webpack import order, these styles will apply AFTER minimal/expanded/product styles.
 //
 .jetpack-instant-search__search-result {
 	margin: 0 0 2em;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/20096.

#### Changes proposed in this Pull Request:
* Remove the line-height from the breadcrumb in search results. This fixes a visual glitch in Firefox caused by an overflow. It is only visible in certain themes (spotted here in Spearhead).

<img width="501" alt="122327674-5e510c00-cf82-11eb-8733-cb1801557c55" src="https://user-images.githubusercontent.com/17325/124221024-00601f00-db53-11eb-85f7-76e0acb4d48b.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Go to a test site with Instant Search enabled.
* Install the Spearhead theme.
* Set your search result type to "expanded".
* Check that the breadcrumb appears correctly in Firefox.
