### PR TITLE
Widget visibility: supporting load conditions for legacy widgets in gutenberg widgets screen

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-widget-visibility
+++ b/projects/plugins/jetpack/changelog/fix-widget-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Allow the use of widget visibility conditions in gutenberg based widget editing

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -12,7 +12,7 @@ class Jetpack_Widget_Conditions {
 	public static function init() {
 		global $pagenow;
 
-		if ( is_customize_preview() || 'widgets.php' === $pagenow || 'themes.php' === $pagenow ) {
+		if ( is_customize_preview() || 'widgets.php' === $pagenow || 'themes.php' === $pagenow || str_starts_with( $_SERVER['REQUEST_URI'], '/wp-json/wp/v2/widget-types' ) ) {
 			add_action( 'sidebar_admin_setup', array( __CLASS__, 'widget_admin_setup' ) );
 			add_filter( 'widget_update_callback', array( __CLASS__, 'widget_update' ), 10, 3 );
 			add_action( 'in_widget_form', array( __CLASS__, 'widget_conditions_admin' ), 10, 3 );

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -10,11 +10,13 @@ class Jetpack_Widget_Conditions {
 	static $passed_template_redirect = false;
 
 	public static function init() {
-		if ( is_admin() ) {
+		global $pagenow;
+
+		if ( is_customize_preview() || 'widgets.php' === $pagenow || 'themes.php' === $pagenow ) {
 			add_action( 'sidebar_admin_setup', array( __CLASS__, 'widget_admin_setup' ) );
 			add_filter( 'widget_update_callback', array( __CLASS__, 'widget_update' ), 10, 3 );
 			add_action( 'in_widget_form', array( __CLASS__, 'widget_conditions_admin' ), 10, 3 );
-		} elseif ( ! in_array( $GLOBALS['pagenow'], array( 'wp-login.php', 'wp-register.php' ) ) ) {
+		} elseif ( ! in_array( $pagenow, array( 'wp-login.php', 'wp-register.php' ), true ) ) {
 			add_filter( 'widget_display_callback', array( __CLASS__, 'filter_widget' ) );
 			add_filter( 'sidebars_widgets', array( __CLASS__, 'sidebars_widgets' ) );
 			add_action( 'template_redirect', array( __CLASS__, 'template_redirect' ) );
@@ -22,11 +24,6 @@ class Jetpack_Widget_Conditions {
 	}
 
 	public static function widget_admin_setup() {
-		// Return early if we are not in the block editor.
-		if ( wp_should_load_block_editor_scripts_and_styles() ) {
-			return;
-		}
-
 		wp_enqueue_style( 'widget-conditions', plugins_url( 'widget-conditions/widget-conditions.css', __FILE__ ) );
 		wp_style_add_data( 'widget-conditions', 'rtl', 'replace' );
 		wp_enqueue_script(

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -12,7 +12,9 @@ class Jetpack_Widget_Conditions {
 	public static function init() {
 		global $pagenow;
 
-		if ( is_customize_preview() || 'widgets.php' === $pagenow || 'themes.php' === $pagenow || str_starts_with( $_SERVER['REQUEST_URI'], '/wp-json/wp/v2/widget-types' ) ) {
+		if ( is_customize_preview() || 'widgets.php' === $pagenow || 'themes.php' === $pagenow ||
+			 str_starts_with( $_SERVER['REQUEST_URI'], '/wp-json/wp/v2/widget-types' ) ||	// Widget editing via API in gutenberg widgets
+			 str_starts_with($_SERVER['REQUEST_URI'], '/wp-json/batch/v1' )) {	// Saving widgets via API in gutenberg widgets
 			add_action( 'sidebar_admin_setup', array( __CLASS__, 'widget_admin_setup' ) );
 			add_filter( 'widget_update_callback', array( __CLASS__, 'widget_update' ), 10, 3 );
 			add_action( 'in_widget_form', array( __CLASS__, 'widget_conditions_admin' ), 10, 3 );
@@ -460,6 +462,7 @@ class Jetpack_Widget_Conditions {
 	/**
 	 * On an AJAX update of the widget settings, process the display conditions.
 	 *
+	 * @param array $instance The current instance's settings
 	 * @param array $new_instance New settings for this instance as input by the user.
 	 * @param array $old_instance Old settings for this instance.
 	 * @return array Modified settings.
@@ -484,7 +487,7 @@ class Jetpack_Widget_Conditions {
 
 		if ( ! empty( $conditions['rules'] ) ) {
 			$instance['conditions'] = $conditions;
-		} else {
+		} elseif ( empty( $new_instance['conditions']['rules'] ) ) {
 			unset( $instance['conditions'] );
 		}
 

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -327,6 +327,9 @@ class Jetpack_Widget_Conditions {
 			class="
 				widget-conditional
 				<?php
+				// $_POST['widget-conditions-visible'] is used in the classic widget experience to decide whether to
+				// display the visibility panel open, e.g. when saving. In the gutenberg widget experience the POST
+				// value will always be empty, but this is fine - it doesn't rerender the HTML when saving anyway.
 				if (
 						empty( $_POST['widget-conditions-visible'] )
 						|| $_POST['widget-conditions-visible'] == '0'

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -566,8 +566,8 @@ class Jetpack_Widget_Conditions {
 	 */
 	public static function widget_update( $instance, $new_instance, $old_instance ) {
 		$conditions              = array();
-		$conditions['action']    = $new_instance['conditions']['action'];
-		$conditions['match_all'] = ( isset( $new_instance['conditions']['match_all'] ) ? '1' : '0' );
+		$conditions['action']    = isset( $new_instance['conditions']['action'] ) ? $new_instance['conditions']['action'] : null;
+		$conditions['match_all'] = isset( $new_instance['conditions']['match_all'] ) ? '1' : '0';
 		$conditions['rules']     = isset( $new_instance['conditions']['rules'] ) ? $new_instance['conditions']['rules'] : array();
 
 		if ( isset( $new_instance['conditions']['rules_major'] ) ) {

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -292,7 +292,7 @@ class Jetpack_Widget_Conditions {
 	/**
 	 * Add the widget conditions to each widget in the admin.
 	 *
-	 * @param $widget unused.
+	 * @param WP_Widget $widget Widget to add conditions settings to.
 	 * @param $return unused.
 	 * @param array         $instance The widget settings.
 	 */
@@ -357,7 +357,7 @@ class Jetpack_Widget_Conditions {
 				<a href="#" class="button display-options"><?php _e( 'Visibility', 'jetpack' ); ?></a><?php } ?>
 			<div class="widget-conditional-inner">
 				<div class="condition-top">
-					<?php printf( _x( '%s if:', 'placeholder: dropdown menu to select widget visibility; hide if or show if', 'jetpack' ), '<select name="conditions[action]"><option value="show" ' . selected( $conditions['action'], 'show', false ) . '>' . esc_html_x( 'Show', 'Used in the "%s if:" translation for the widget visibility dropdown', 'jetpack' ) . '</option><option value="hide" ' . selected( $conditions['action'], 'hide', false ) . '>' . esc_html_x( 'Hide', 'Used in the "%s if:" translation for the widget visibility dropdown', 'jetpack' ) . '</option></select>' ); ?>
+					<?php printf( _x( '%s if:', 'placeholder: dropdown menu to select widget visibility; hide if or show if', 'jetpack' ), '<select name="' .  esc_attr( $widget->get_field_name( 'conditions[action]' ) ) . '"><option value="show" ' . selected( $conditions['action'], 'show', false ) . '>' . esc_html_x( 'Show', 'Used in the "%s if:" translation for the widget visibility dropdown', 'jetpack' ) . '</option><option value="hide" ' . selected( $conditions['action'], 'hide', false ) . '>' . esc_html_x( 'Hide', 'Used in the "%s if:" translation for the widget visibility dropdown', 'jetpack' ) . '</option></select>' ); ?>
 				</div><!-- .condition-top -->
 
 				<div class="conditions">
@@ -375,7 +375,7 @@ class Jetpack_Widget_Conditions {
 						?>
 						<div class="condition" data-rule-major="<?php echo esc_attr( $rule['major'] ); ?>" data-rule-minor="<?php echo esc_attr( $rule['minor'] ); ?>" data-rule-has-children="<?php echo esc_attr( $rule['has_children'] ); ?>">
 							<div class="selection alignleft">
-								<select class="conditions-rule-major" name="conditions[rules_major][]">
+								<select class="conditions-rule-major" name="<?php echo esc_attr( $widget->get_field_name( 'conditions[rules_major][]' ) ); ?>">
 									<option value="" <?php selected( '', $rule['major'] ); ?>><?php echo esc_html_x( '-- Select --', 'Used as the default option in a dropdown list', 'jetpack' ); ?></option>
 									<option value="category" <?php selected( 'category', $rule['major'] ); ?>><?php esc_html_e( 'Category', 'jetpack' ); ?></option>
 									<option value="author" <?php selected( 'author', $rule['major'] ); ?>><?php echo esc_html_x( 'Author', 'Noun, as in: "The author of this post is..."', 'jetpack' ); ?></option>
@@ -395,7 +395,7 @@ class Jetpack_Widget_Conditions {
 
 								<?php _ex( 'is', 'Widget Visibility: {Rule Major [Page]} is {Rule Minor [Search results]}', 'jetpack' ); ?>
 
-								<select class="conditions-rule-minor" name="conditions[rules_minor][]"
+								<select class="conditions-rule-minor" name="<?php echo esc_attr( $widget->get_field_name( 'conditions[rules_minor][]' ) ); ?>"
 								<?php
 								if ( ! $rule['major'] ) {
 									?>
@@ -415,7 +415,7 @@ class Jetpack_Widget_Conditions {
 									?>
 									 style="display: none;"<?php } ?>>
 									<label>
-										<input type="checkbox" name="conditions[page_children][<?php echo $rule_index; ?>]" value="has" <?php checked( $rule['has_children'], true ); ?> />
+										<input type="checkbox" name="<?php echo esc_attr( $widget->get_field_name( "conditions[page_children][$rule_index]" ) );?>" value="has" <?php checked( $rule['has_children'], true ); ?> />
 										<?php echo esc_html_x( 'Include children', 'Checkbox on Widget Visibility if children of the selected page should be included in the visibility rule.', 'jetpack' ); ?>
 									</label>
 								</span>
@@ -444,7 +444,7 @@ class Jetpack_Widget_Conditions {
 						<label>
 							<input
 								type="checkbox"
-								name="conditions[match_all]"
+								name="<?php echo esc_attr( $widget->get_field_name( 'conditions[match_all]' ) ); ?>"
 								value="1"
 								class="conditions-match-all"
 								<?php checked( $conditions['match_all'], '1' ); ?> />
@@ -465,24 +465,20 @@ class Jetpack_Widget_Conditions {
 	 * @return array Modified settings.
 	 */
 	public static function widget_update( $instance, $new_instance, $old_instance ) {
-		if ( empty( $_POST['conditions'] ) ) {
-			return $instance;
-		}
-
 		$conditions              = array();
-		$conditions['action']    = $_POST['conditions']['action'];
-		$conditions['match_all'] = ( isset( $_POST['conditions']['match_all'] ) ? '1' : '0' );
+		$conditions['action']    = $instance['conditions']['action'];
+		$conditions['match_all'] = ( isset( $instance['conditions']['match_all'] ) ? '1' : '0' );
 		$conditions['rules']     = array();
 
-		foreach ( $_POST['conditions']['rules_major'] as $index => $major_rule ) {
+		foreach ( $instance['conditions']['rules_major'] as $index => $major_rule ) {
 			if ( ! $major_rule ) {
 				continue;
 			}
 
 			$conditions['rules'][] = array(
 				'major'        => $major_rule,
-				'minor'        => isset( $_POST['conditions']['rules_minor'][ $index ] ) ? $_POST['conditions']['rules_minor'][ $index ] : '',
-				'has_children' => isset( $_POST['conditions']['page_children'][ $index ] ) ? true : false,
+				'minor'        => isset( $instance['conditions']['rules_minor'][ $index ] ) ? $instance['conditions']['rules_minor'][ $index ] : '',
+				'has_children' => isset( $instance['conditions']['page_children'][ $index ] ) ? true : false,
 			);
 		}
 

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -45,7 +45,7 @@ class Jetpack_Widget_Conditions {
 				'modules/widget-visibility/widget-conditions/widget-conditions.js'
 			),
 			array( 'jquery', 'jquery-ui-core' ),
-			20191128,
+			JETPACK__VERSION,
 			true
 		);
 

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -97,9 +97,7 @@ class Jetpack_Widget_Conditions {
 		}
 
 		if ( ! $add_html_to_form && ! $handle_widget_updates && ! $add_data_assets_to_page &&
-			! in_array( $pagenow, array( 'wp-login.php', 'wp-register.php' ), true ) &&
-			// Don't filter widgets when editing them - otherwise they could get filtered out and become impossible to edit.
-			( false === strpos( wp_get_raw_referer(), '/wp-admin/widgets.php' ) )
+			! in_array( $pagenow, array( 'wp-login.php', 'wp-register.php' ), true )
 		) {
 			// Not hit any known widget admin endpoint, register widget display hooks instead.
 			add_filter( 'widget_display_callback', array( __CLASS__, 'filter_widget' ) );
@@ -704,6 +702,12 @@ class Jetpack_Widget_Conditions {
 		global $wp_query;
 
 		if ( empty( $instance['conditions'] ) || empty( $instance['conditions']['rules'] ) ) {
+			return $instance;
+		}
+
+		// Don't filter widgets from the REST API when it's called via the widgets admin page - otherwise they could get
+		// filtered out and become impossible to edit.
+		if ( strpos( wp_get_raw_referer(), '/wp-admin/widgets.php' ) && false !== strpos( $_SERVER['REQUEST_URI'], '/wp-json/' ) ) {
 			return $instance;
 		}
 

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -32,9 +32,10 @@ class Jetpack_Widget_Conditions {
 			return;
 		}
 
-		// Not making use of the heartbeat functionality at all.
+		// If action is posted and it's save-widget then it's relevant to widget conditions, otherwise it's something
+		// else and it's not worth registering hooks.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		if ( isset( $_POST['action'] ) && 'heartbeat' === $_POST['action'] ) {
+		if ( isset( $_POST['action'] ) && ! in_array( $_POST['action'], array( 'save-widget', 'update-widget' ), true ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -27,7 +27,7 @@ class Jetpack_Widget_Conditions {
 	}
 
 	public static function widget_admin_setup() {
-		wp_enqueue_style( 'widget-conditions', plugins_url( 'widget-conditions/widget-conditions.css', __FILE__ ) );
+		wp_enqueue_style( 'widget-conditions', plugins_url( 'widget-conditions/widget-conditions.css', __FILE__ ), array( 'widgets' ), JETPACK__VERSION );
 		wp_style_add_data( 'widget-conditions', 'rtl', 'replace' );
 		wp_enqueue_script(
 			'widget-conditions',

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -87,7 +87,7 @@ class Jetpack_Widget_Conditions {
 			// Don't filter widgets when editing them - otherwise they could get filtered out and become impossible to edit.
 			( false === strpos( wp_get_raw_referer(), '/wp-admin/widgets.php' ) )
 		) {
-			// Not hit any known widget admin point, register widget display hooks instead.
+			// Not hit any known widget admin endpoint, register widget display hooks instead.
 			add_filter( 'widget_display_callback', array( __CLASS__, 'filter_widget' ) );
 			add_filter( 'sidebars_widgets', array( __CLASS__, 'sidebars_widgets' ) );
 			add_action( 'template_redirect', array( __CLASS__, 'template_redirect' ) );

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -3,17 +3,30 @@
 use Automattic\Jetpack\Assets;
 
 /**
- * Hide or show widgets conditionally.
+ * Hide or show legacy widgets conditionally.
+ *
+ * This class has two responsiblities - administrating the conditions in which legacy widgets may be hidden or shown
+ * and hiding/showing the legacy widgets on the front-end of the site, depending upon the evaluation of those conditions.
+ *
+ * Administrating the conditions can be done in one of four different WordPress screens, plus direct use of the API and
+ * is supplemented with a legacy widget preview screen. The four different admin screens are
+ *
+ * Gutenberg widget experience - widget admin (widgets.php + API + legacy widget preview)
+ * Gutenberg widget experience - Customizer (customizer screen/API + API + legacy widget preview)
+ * Classic widget experience - widget admin (widgets.php + admin-ajax XHR requests)
+ * Classic widget experience - Customizer (customizer screen/API)
+ *
+ * An introduction to the API endpoints can be found here: https://make.wordpress.org/core/2021/06/29/rest-api-changes-in-wordpress-5-8/
  */
-
 class Jetpack_Widget_Conditions {
 	static $passed_template_redirect = false;
 
 	public static function init() {
 		global $pagenow;
 
-		// Previews don't need widget editing loaded and also don't want to run the filter - it might mean the preview
-		// is empty which would be confusing.
+		// The Gutenberg based widget experience will show a preview of legacy widgets by including a URL beginning
+		// widgets.php?legacy-widget-preview inside an iframe. Previews don't need widget editing loaded and also don't
+		// want to run the filter - if the widget is filtered out it'll be empty, which would be confusing.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['legacy-widget-preview'] ) ) {
 			return;
@@ -46,7 +59,7 @@ class Jetpack_Widget_Conditions {
 			$add_html_to_form        = true;
 			$handle_widget_updates   = true;
 		} else {
-			// On a page that is hosting the API.
+			// On a screen that is hosting the API in the gutenberg editing experience.
 			if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
 				$add_data_assets_to_page = true;
 			}

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -439,7 +439,7 @@ class Jetpack_Widget_Conditions {
 									?>
 									 style="display: none;"<?php } ?>>
 									<label>
-										<input type="checkbox" name="<?php echo esc_attr( $widget->get_field_name( "conditions[page_children][$rule_index]" ) );?>" value="has" <?php checked( $rule['has_children'], true ); ?> />
+										<input type="checkbox" name="<?php echo esc_attr( $widget->get_field_name( "conditions[page_children][$rule_index]" ) ); ?>" value="has" <?php checked( $rule['has_children'], true ); ?> />
 										<?php echo esc_html_x( 'Include children', 'Checkbox on Widget Visibility if children of the selected page should be included in the visibility rule.', 'jetpack' ); ?>
 									</label>
 								</span>

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -13,9 +13,10 @@ class Jetpack_Widget_Conditions {
 		global $pagenow;
 
 		if ( is_customize_preview() || 'widgets.php' === $pagenow || 'themes.php' === $pagenow ||
-			 ('admin-ajax.php' === $pagenow && array_key_exists( 'action', $_POST ) && 'save-widget' === $_POST['action'] ) ||	// Saving widgets on classic widget admin
-			 str_starts_with( $_SERVER['REQUEST_URI'], '/wp-json/wp/v2/widget-types' ) ||	// Widget editing via API in gutenberg widgets
-			 str_starts_with($_SERVER['REQUEST_URI'], '/wp-json/batch/v1' )) {	// Saving widgets via API in gutenberg widgets
+			 // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			( 'admin-ajax.php' === $pagenow && array_key_exists( 'action', $_POST ) && 'save-widget' === $_POST['action'] ) || // Saving widgets on classic widget admin.
+			0 === strpos( $_SERVER['REQUEST_URI'], '/wp-json/wp/v2/widget-types' ) // Widget editing via API in gutenberg widgets.
+		) {
 			add_action( 'sidebar_admin_setup', array( __CLASS__, 'widget_admin_setup' ) );
 			add_filter( 'widget_update_callback', array( __CLASS__, 'widget_update' ), 10, 3 );
 			add_action( 'in_widget_form', array( __CLASS__, 'widget_conditions_admin' ), 10, 3 );
@@ -23,6 +24,11 @@ class Jetpack_Widget_Conditions {
 			add_filter( 'widget_display_callback', array( __CLASS__, 'filter_widget' ) );
 			add_filter( 'sidebars_widgets', array( __CLASS__, 'sidebars_widgets' ) );
 			add_action( 'template_redirect', array( __CLASS__, 'template_redirect' ) );
+		}
+
+		// Saving widgets via API in gutenberg widgets.
+		if ( 0 === strpos( $_SERVER['REQUEST_URI'], 'wp-json/batch/v1' ) ) {
+			add_filter( 'widget_update_callback', array( __CLASS__, 'widget_update' ), 10, 3 );
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -27,7 +27,7 @@ class Jetpack_Widget_Conditions {
 		}
 
 		// Saving widgets via API in gutenberg widgets.
-		if ( 0 === strpos( $_SERVER['REQUEST_URI'], 'wp-json/batch/v1' ) ) {
+		if ( 0 === strpos( $_SERVER['REQUEST_URI'], '/wp-json/batch/v1' ) ) {
 			add_filter( 'widget_update_callback', array( __CLASS__, 'widget_update' ), 10, 3 );
 		}
 	}

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -12,7 +12,7 @@ class Jetpack_Widget_Conditions {
 	public static function init() {
 		global $pagenow;
 
-		if ( is_customize_preview() || 'widgets.php' === $pagenow || 'themes.php' === $pagenow ||
+		if ( is_customize_preview() || 'widgets.php' === $pagenow ||
 			 // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			( 'admin-ajax.php' === $pagenow && array_key_exists( 'action', $_POST ) && 'save-widget' === $_POST['action'] ) || // Saving widgets on classic widget admin.
 			0 === strpos( $_SERVER['REQUEST_URI'], '/wp-json/wp/v2/widget-types' ) // Widget editing via API in gutenberg widgets.

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -32,6 +32,9 @@ class Jetpack_Widget_Conditions {
 		}
 	}
 
+	/**
+	 * Prepare the interface for editing widgets - loading css, javascript & data
+	 */
 	public static function widget_admin_setup() {
 		wp_enqueue_style( 'widget-conditions', plugins_url( 'widget-conditions/widget-conditions.css', __FILE__ ), array( 'widgets' ), JETPACK__VERSION );
 		wp_style_add_data( 'widget-conditions', 'rtl', 'replace' );
@@ -302,8 +305,8 @@ class Jetpack_Widget_Conditions {
 	 * Add the widget conditions to each widget in the admin.
 	 *
 	 * @param WP_Widget $widget Widget to add conditions settings to.
-	 * @param $return unused.
-	 * @param array         $instance The widget settings.
+	 * @param null      $return unused.
+	 * @param array     $instance The widget settings.
 	 */
 	public static function widget_conditions_admin( $widget, $return, $instance ) {
 		$conditions = array();
@@ -366,10 +369,19 @@ class Jetpack_Widget_Conditions {
 			<?php
 			if ( ! isset( $_POST['widget-conditions-visible'] ) ) {
 				?>
-				<a href="#" class="button display-options"><?php _e( 'Visibility', 'jetpack' ); ?></a><?php } ?>
+				<a href="#" class="button display-options"><?php esc_html_e( 'Visibility', 'jetpack' ); ?></a><?php } ?>
 			<div class="widget-conditional-inner">
 				<div class="condition-top">
-					<?php printf( _x( '%s if:', 'placeholder: dropdown menu to select widget visibility; hide if or show if', 'jetpack' ), '<select name="' .  esc_attr( $widget->get_field_name( 'conditions[action]' ) ) . '"><option value="show" ' . selected( $conditions['action'], 'show', false ) . '>' . esc_html_x( 'Show', 'Used in the "%s if:" translation for the widget visibility dropdown', 'jetpack' ) . '</option><option value="hide" ' . selected( $conditions['action'], 'hide', false ) . '>' . esc_html_x( 'Hide', 'Used in the "%s if:" translation for the widget visibility dropdown', 'jetpack' ) . '</option></select>' ); ?>
+					<?php
+						printf(
+							// translators: %s is a HTML select widget for widget visibility, 'show' and 'hide' are it's options. It will read like 'show if' or 'hide if'.
+							esc_html_x( '%s if:', 'placeholder: dropdown menu to select widget visibility; hide if or show if', 'jetpack' ),
+							'<select name="' . esc_attr( $widget->get_field_name( 'conditions[action]' ) ) . '">
+											<option value="show" ' . selected( $conditions['action'], 'show', false ) . '>' . esc_html_x( 'Show', 'Used in the "%s if:" translation for the widget visibility dropdown', 'jetpack' ) . '</option>
+											<option value="hide" ' . selected( $conditions['action'], 'hide', false ) . '>' . esc_html_x( 'Hide', 'Used in the "%s if:" translation for the widget visibility dropdown', 'jetpack' ) . '</option>
+										</select>'
+						);
+					?>
 				</div><!-- .condition-top -->
 
 				<div class="conditions">
@@ -472,7 +484,7 @@ class Jetpack_Widget_Conditions {
 	/**
 	 * On an AJAX update of the widget settings, process the display conditions.
 	 *
-	 * @param array $instance The current instance's settings
+	 * @param array $instance The current instance's settings.
 	 * @param array $new_instance New settings for this instance as input by the user.
 	 * @param array $old_instance Old settings for this instance.
 	 * @return array Modified settings.
@@ -490,9 +502,9 @@ class Jetpack_Widget_Conditions {
 				}
 
 				$conditions['rules'][] = array(
-						'major'        => $major_rule,
-						'minor'        => isset( $new_instance['conditions']['rules_minor'][ $index ] ) ? $new_instance['conditions']['rules_minor'][ $index ] : '',
-						'has_children' => isset( $new_instance['conditions']['page_children'][ $index ] ) ? true : false,
+					'major'        => $major_rule,
+					'minor'        => isset( $new_instance['conditions']['rules_minor'][ $index ] ) ? $new_instance['conditions']['rules_minor'][ $index ] : '',
+					'has_children' => isset( $new_instance['conditions']['page_children'][ $index ] ) ? true : false,
 				);
 			}
 		}

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.css
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.css
@@ -69,6 +69,11 @@
 	text-indent: -9999px;
 	z-index: 1;
 }
+
+.wp-block-legacy-widget__edit-form .widget-conditional .condition-control a {
+	top: 20px;
+}
+
 .widget-conditional .condition-control a:before {
 	position: absolute;
 	text-indent: 0;
@@ -86,10 +91,6 @@
 
 .wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional .widget-conditional-inner a.dashicons {
 	font-family: dashicons;
-}
-
-.wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional .widget-conditional-inner a {
-	top:1.5rem
 }
 
 .wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional-inner select {

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.css
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.css
@@ -23,6 +23,7 @@
 }
 .widget-conditional {
 	margin-bottom: 12px;
+	margin-top: 10px;
 }
 .widget-conditional .conditions{
 	margin-bottom: 12px;
@@ -74,7 +75,7 @@
 	top: 0;
 	left: 0;
 }
-.wp-block-legacy-widget .widget-conditional .condition-control .delete-condition,
+.wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional .condition-control .delete-condition,
 .widget-conditional .condition-control .delete-condition {
 	left: 0;
 	color: #f11;
@@ -83,22 +84,27 @@
 	right: 0;
 }
 
-
-.wp-block-legacy-widget .widget-conditional .widget-conditional-inner a.dashicons {
+.wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional .widget-conditional-inner a.dashicons {
 	font-family: dashicons;
 }
 
-.wp-block-legacy-widget .widget-conditional .widget-conditional-inner a {
+.wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional .widget-conditional-inner a {
 	top:1.5rem
 }
 
-
-.wp-block-legacy-widget .widget-conditional .widget-conditional-inner select {
+.wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional-inner select {
 	display:initial;
 	width:auto;
+	background-color: #fff;
 }
 
-.editor-styles-wrapper .wp-block-legacy-widget .widget-conditional  .alignleft {
+.wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional .widget-conditional-inner select:disabled {
+	color: #a7aaad;
+	border-color: #dcdcde;
+	background-color: #f6f7f7;
+}
+
+.editor-styles-wrapper .wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional  .alignleft {
 	margin-left:20px
 }
 
@@ -136,7 +142,7 @@
 	}
 }
 
-.wp-block-legacy-widget .widget-conditional-inner {
+.wp-block-legacy-widget__edit-form .widget-inside.widget-inside .widget-conditional-inner {
 	/*
 	 * fonts of labels are reset to 13px in gutenberg editor for legacy widgets, ensure a consistent look on non-labels
 	 */

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.css
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.css
@@ -74,12 +74,32 @@
 	top: 0;
 	left: 0;
 }
+.wp-block-legacy-widget .widget-conditional .condition-control .delete-condition,
 .widget-conditional .condition-control .delete-condition {
 	left: 0;
 	color: #f11;
 }
 .widget-conditional .condition-control .add-condition {
 	right: 0;
+}
+
+
+.wp-block-legacy-widget .widget-conditional .widget-conditional-inner a.dashicons {
+	font-family: dashicons;
+}
+
+.wp-block-legacy-widget .widget-conditional .widget-conditional-inner a {
+	top:1.5rem
+}
+
+
+.wp-block-legacy-widget .widget-conditional .widget-conditional-inner select {
+	display:initial;
+	width:auto;
+}
+
+.editor-styles-wrapper .wp-block-legacy-widget .widget-conditional  .alignleft {
+	margin-left:20px
 }
 
 .widget-conditional .condition:last-child .condition-conjunction,
@@ -114,4 +134,11 @@
 	.widget-conditional .condition-control a {
 		top: 20px;
 	}
+}
+
+.wp-block-legacy-widget .widget-conditional-inner {
+	/*
+	 * fonts of labels are reset to 13px in gutenberg editor for legacy widgets, ensure a consistent look on non-labels
+	 */
+	font-size: 13px;
 }

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -1,11 +1,11 @@
 /* global isRtl, widget_conditions_parent_pages, widget_conditions_data, jQuery */
 
 jQuery( function ( $ ) {
-	//  Gutenberg widgets screen.
+	//  Gutenberg 'widgets.php' screen.
 	var widgets_shell = $( '#widgets-editor' );
 
 	if ( 0 === widgets_shell.length ) {
-		// Gutenberg + classic customizer
+		// Legacy 'widgets.php' screen + customizer.
 		widgets_shell = $( 'div#widgets-right' );
 
 		// For backwards compatibility

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -1,14 +1,14 @@
 /* global isRtl, widget_conditions_parent_pages, widget_conditions_data, jQuery */
 
 jQuery( function ( $ ) {
-	//  Gutenberg widgets + customizer screen.
+	//  Gutenberg widgets screen.
 	var widgets_shell = $( '#widgets-editor' );
 
 	if ( 0 === widgets_shell.length ) {
-		// Pre-gutenberg widget screen.
+		// Gutenberg + classic customizer
 		widgets_shell = $( 'div#widgets-right' );
 
-		// Pre-gutenberg customizer screen.
+		// For backwards compatibility
 		if ( 0 === widgets_shell.length ) {
 			widgets_shell = $( 'form#customize-controls' );
 		}

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -1,10 +1,17 @@
 /* global isRtl, widget_conditions_parent_pages, widget_conditions_data, jQuery */
 
 jQuery( function ( $ ) {
-	var widgets_shell = $( 'div#widgets-right' );
+	//  Gutenberg widgets + customizer screen.
+	var widgets_shell = $( '#widgets-editor' );
 
-	if ( ! widgets_shell && ! widgets_shell.length ) {
-		widgets_shell = $( 'form#customize-controls' );
+	if ( 0 === widgets_shell.length ) {
+		// Pre-gutenberg widget screen.
+		widgets_shell = $( 'div#widgets-right' );
+
+		// Pre-gutenberg customizer screen.
+		if ( 0 === widgets_shell.length ) {
+			widgets_shell = $( 'form#customize-controls' );
+		}
 	}
 
 	function setWidgetMargin( $widget ) {
@@ -51,8 +58,15 @@ jQuery( function ( $ ) {
 	}
 
 	function moveWidgetVisibilityButton( $widget ) {
-		var $displayOptionsButton = $widget.find( 'a.display-options' ).first();
-		$displayOptionsButton.insertBefore( $widget.find( 'input.widget-control-save' ) );
+		var $displayOptionsButton = $widget.find( 'a.display-options' ).first(),
+			$relativeWidget = $widget.find( 'input.widget-control-save' );
+
+		if ( 0 === $relativeWidget.length ) {
+			// The save button doesn't exist in gutenberg widget editor, the conditional HTML ought to be displayed
+			// last inside the widget options, so display the button before that.
+			$relativeWidget = $widget.find( 'div.widget-conditional' );
+		}
+		$displayOptionsButton.insertBefore( $relativeWidget );
 
 		// Widgets with no configurable options don't show the Save button's container.
 		$displayOptionsButton


### PR DESCRIPTION
Lets the widget visibility conditions run using the new gutenberg based
widgets screen.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #20057 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Enables visibility conditions to be set on legacy widgets used within the block-based widget editor

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- Firstly, use a theme that supports widgets (you probably are already)
- To enable this feature, go to Jetpack → Settings → Writing, scroll down to the Widgets section, and toggle the switch labelled Enable widget visibility controls to display widgets only on particular posts or pages.

##### Gutenberg widget editor
 This requires testing on WordPress 5.8


###### Widgets admin
* Go to 'Appearance > Widgets'
* Press + inside the editor
* Press visibility, a form should appear
* Set some conditions, e.g. 'Hide if User is Logged Out'
* Press Update near the top of the screen
* Go to the front-end and look at the widget area, the widgets should appear, now logout, it should disappear.

Repeat again, this time set-up two widgets together before pressing update.

###### Customizer
As above but go to 'Appearance > Customizer' first and use the 'Publish' button rather than 'Update'


##### Classic widget editor
 * Install the classic-widgets plugin
 * Test the widgets admin and customizer as above



