### PR TITLE
[Slideshow]: Fix display of slideshow in widget editor

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/slideshow/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/view.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { forEach } from 'lodash';
 import domReady from '@wordpress/dom-ready';
 import ResizeObserver from 'resize-observer-polyfill';
 
@@ -18,8 +17,10 @@ import {
 
 if ( typeof window !== 'undefined' ) {
 	domReady( function () {
-		const slideshowBlocks = document.getElementsByClassName( 'wp-block-jetpack-slideshow' );
-		forEach( slideshowBlocks, slideshowBlock => {
+		const slideshowBlocks = Array.from(
+			document.getElementsByClassName( 'wp-block-jetpack-slideshow' )
+		);
+		slideshowBlocks.forEach( slideshowBlock => {
 			if ( slideshowBlock.getAttribute( 'data-jetpack-block-initialized' ) === 'true' ) {
 				return;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #19980

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The Slideshow block was broken in the widget editor. If you add a slideshow to the footer for example, it does not appear in the preview, nor on the frontend of the site.

TODO...

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TODO...
