### PR TITLE
Nav unification: create and use function setFocusOnActiveMenuItem

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-current-menu-item-focus
+++ b/projects/plugins/jetpack/changelog/fix-current-menu-item-focus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Ensure on pageload that the active menu item is keyboard focused in nav unification so its consistent with Calypso

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -18,6 +18,7 @@
 			}
 		}
 
+		setFocusOnActiveMenuItem();
 		setAriaExpanded( 'false' );
 
 		var adminbarBlog = adminbar.querySelector( '#wp-admin-bar-blog' );
@@ -93,6 +94,16 @@
 				jpAdminMenu.screen +
 				'&preferred-view=default'
 		);
+	}
+
+	function setFocusOnActiveMenuItem() {
+		var currentMenuItem = document.querySelector('.wp-submenu .current > a');
+
+		if ( ! currentMenuItem ) {
+			return;
+		}
+
+		currentMenuItem.focus();
 	}
 
 	if ( document.readyState === 'loading' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/51513

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* On page load, focus on the currently active menu item so it's behaviour is inline with Calypso

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
**Atomic**
* Install Jetpack Beta and activate this branch
* Navigate between WP Admin pages ensuring that on every new page you visit via the menu that your keyboard focus is active on the active menu item.

**Simple**
* Apply patch `D63692` on your Sandbox and Sandbox a simple site
* Navigate between WP Admin pages ensuring that on every new page you visit via the menu that your keyboard focus is active on the active menu item.