### PR TITLE
Search: Add search admin page upsell nudge for business plan

### DIFF
--- a/projects/plugins/jetpack/_inc/client/search/dashboard/instant-search-upsell-nudge.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/instant-search-upsell-nudge.jsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './instant-search-upsell-nudge.scss';
+
+const InstantSearchUpsellNudge = props => {
+	return (
+		<a className="jp-instant-search-upsell-nudge" href={ props.href }>
+			<span>
+				{ __(
+					'Offer instant search results to your visitors as soon as they start typing. ',
+					'jetpack'
+				) }
+				<b>{ __( 'Upgrade to Jetpack Instant Search now', 'jetpack' ) }</b>
+			</span>
+			<div className="jp-instant-search-upsell-nudge__button-arrow">&rarr;</div>
+		</a>
+	);
+};
+
+export default InstantSearchUpsellNudge;

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/instant-search-upsell-nudge.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/instant-search-upsell-nudge.scss
@@ -1,0 +1,35 @@
+@import './_variables.scss';
+
+$color-nudget-text: $black;
+
+.jp-instant-search-upsell-nudge {
+	display: flex;
+	flex-direction: row nowrap;
+	align-content: space-between;
+	width: 38em;
+	max-width: 90%;
+	padding: 1em;
+	border-radius: 5px;
+	border: 2px solid $color-plan;
+
+	color: $color-nudget-text;
+
+	font-size: 0.75em;
+	font-weight: normal;
+	text-decoration: none;
+	&:hover {
+		color: $color-nudget-text;
+	}
+
+	cursor: pointer;
+}
+.jp-instant-search-upsell-nudge__button-arrow {
+	display: flex;
+	align-items: center;
+	padding: 0.4em;
+
+	color: $color-plan;
+
+	font-size: 1.5em;
+	font-weight: bold;
+}

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
@@ -23,7 +23,7 @@ import './module-control.scss';
  * State dependencies
  */
 import { isOfflineMode } from 'state/connection';
-import { getUpgradeUrl, getSiteAdminUrl } from 'state/initial-state';
+import { getUpgradeUrl, getSiteAdminUrl, arePromotionsActive } from 'state/initial-state';
 import {
 	getSitePlan,
 	hasActiveSearchPurchase as selectHasActiveSearchPurchase,
@@ -53,7 +53,13 @@ const WIDGETS_EDITOR_URL = 'customize.php?autofocus[panel]=widgets&return=%s';
  * @returns {React.Component}	Search settings component.
  */
 function Search( props ) {
-	const { failedToEnableSearch, hasActiveSearchPurchase, updateOptions, siteAdminUrl } = props;
+	const {
+		failedToEnableSearch,
+		hasActiveSearchPurchase,
+		updateOptions,
+		siteAdminUrl,
+		isInstantSearchPromotionActive,
+	} = props;
 	const isModuleEnabled = props.getOptionValue( 'search' );
 	const isInstantSearchEnabled = props.getOptionValue( 'instant_search_enabled', 'search' );
 
@@ -172,7 +178,9 @@ function Search( props ) {
 										{ renderInstantSearchButtons() }
 									</Fragment>
 								) }
-								{ hasOnlyLegacySearch && <InstantSearchUpsellNudge href={ props.upgradeUrl } /> }
+								{ hasOnlyLegacySearch && isInstantSearchPromotionActive && (
+									<InstantSearchUpsellNudge href={ props.upgradeUrl } />
+								) }
 							</div>
 						</div>
 					</Fragment>
@@ -196,5 +204,6 @@ export default connect( state => {
 		siteID: getSiteID( state ),
 		upgradeUrl: getUpgradeUrl( state, 'jetpack-search' ),
 		siteAdminUrl: getSiteAdminUrl( state ),
+		isInstantSearchPromotionActive: arePromotionsActive( state ),
 	};
 } )( withModuleSettingsFormHelpers( Search ) );

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
@@ -16,6 +16,7 @@ import SettingsGroup from 'components/settings-group';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import Button from 'components/button';
 import { getPlanClass } from 'lib/plans/constants';
+import InstantSearchUpsellNudge from './instant-search-upsell-nudge';
 import './module-control.scss';
 
 /**
@@ -84,6 +85,7 @@ function Search( props ) {
 	const togglingModule = !! props.isSavingAnyOption( 'search' );
 	const togglingInstantSearch = !! props.isSavingAnyOption( 'instant_search_enabled' );
 	const isSavingEitherOption = togglingModule || togglingInstantSearch;
+	const hasOnlyLegacySearch = props.isBusinessPlan && ! props.hasActiveSearchPurchase;
 
 	const isInstantSearchCustomizeButtonDisabled =
 		isSavingEitherOption ||
@@ -161,10 +163,15 @@ function Search( props ) {
 								{ __( 'Enable instant search experience (recommended)', 'jetpack' ) }
 							</CompactFormToggle>
 							<div className="jp-form-search-settings-group__toggle-description">
-								<p className="jp-form-search-settings-group__toggle-explanation">
-									{ INSTANT_SEARCH_DESCRIPTION }
-								</p>
-								{ renderInstantSearchButtons() }
+								{ ! hasOnlyLegacySearch && (
+									<Fragment>
+										<p className="jp-form-search-settings-group__toggle-explanation">
+											{ INSTANT_SEARCH_DESCRIPTION }
+										</p>
+										{ renderInstantSearchButtons() }
+									</Fragment>
+								) }
+								{ hasOnlyLegacySearch && <InstantSearchUpsellNudge href={ props.upgradeUrl } /> }
 							</div>
 						</div>
 					</Fragment>

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.jsx
@@ -85,6 +85,7 @@ function Search( props ) {
 	const togglingModule = !! props.isSavingAnyOption( 'search' );
 	const togglingInstantSearch = !! props.isSavingAnyOption( 'instant_search_enabled' );
 	const isSavingEitherOption = togglingModule || togglingInstantSearch;
+	// Site has Legacy Search included in Business plan but doesn't have Jetpack Search subscription.
 	const hasOnlyLegacySearch = props.isBusinessPlan && ! props.hasActiveSearchPurchase;
 
 	const isInstantSearchCustomizeButtonDisabled =

--- a/projects/plugins/jetpack/changelog/add-search-admin-page-upsell-nudge
+++ b/projects/plugins/jetpack/changelog/add-search-admin-page-upsell-nudge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: add instant search upsell nudge for business plan.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This is a followup PR for #20224. 

Added upsell nudge for Legacy Business plan. If a site has business plan and doesn't have Jetpack Search purchase, the nudge will be shown.


#### Jetpack product discussion
pcNPJE-7J#comment-161

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with business plan but no Jetpack Search purchase (enter URL directly `/wp-admin/admin.php?page=jetpack-search&a8ctest`)
* Ensure the nudge will be shown.

![image](https://user-images.githubusercontent.com/1425433/124533720-fb5ae280-de66-11eb-9277-c51103b50a9b.png)
