### PR TITLE
Nav Unification: Register "Settings > Performance" submenu

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-register-performance-submenu
+++ b/projects/plugins/jetpack/changelog/fix-register-performance-submenu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Nav Unification bugfix, it only affects WP.com sites
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -419,6 +419,8 @@ class Admin_Menu extends Base_Admin_Menu {
 			$submenus_to_update['options-discussion.php'] = 'https://wordpress.com/settings/discussion/' . $this->domain;
 		}
 
+		add_submenu_page( 'options-general.php', esc_attr__( 'Performance', 'jetpack' ), __( 'Performance', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain, null, 1 );
+
 		$this->update_submenus( 'options-general.php', $submenus_to_update );
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -419,9 +419,9 @@ class Admin_Menu extends Base_Admin_Menu {
 			$submenus_to_update['options-discussion.php'] = 'https://wordpress.com/settings/discussion/' . $this->domain;
 		}
 
-		add_submenu_page( 'options-general.php', esc_attr__( 'Performance', 'jetpack' ), __( 'Performance', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain, null, 1 );
-
 		$this->update_submenus( 'options-general.php', $submenus_to_update );
+
+		add_submenu_page( 'options-general.php', esc_attr__( 'Performance', 'jetpack' ), __( 'Performance', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain, null, 1 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/54220

#### Changes proposed in this Pull Request:

Fixes a regression introduced in https://github.com/Automattic/jetpack/pull/20147, where we mistakenly removed the "Settings > Performance" menu that we added in https://github.com/Automattic/jetpack/pull/20100.

Before | After
--- | ---
<img width="277" alt="Screen Shot 2021-07-06 at 11 31 37" src="https://user-images.githubusercontent.com/1233880/124577949-0a816680-de4e-11eb-8372-d78cc39d34e4.png"> | <img width="277" alt="Screen Shot 2021-07-06 at 11 33 05" src="https://user-images.githubusercontent.com/1233880/124577999-179e5580-de4e-11eb-828b-66a823e0210b.png">

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Set up the testing environment:
  - Simple sites: Apply D63721-code to your WP.com sandbox, and sandbox both the API and a Simple site.
  - Atomic sites: Install Jetpack Beta and activate the `fix/register-performance-submenu` branch.
- Go to https://wordpress.com and switch to your test site.
- Make sure the "Settings" menu contains a "Performance" submenu.
