### PR TITLE
Adds admin / frontend CSS files to the build watcher.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-watch_css_files
+++ b/projects/plugins/jetpack/changelog/fix-watch_css_files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Adds admin / frontend CSS files to the build watcher.

--- a/projects/plugins/jetpack/gulpfile.babel.js
+++ b/projects/plugins/jetpack/gulpfile.babel.js
@@ -8,8 +8,11 @@ import { spawn } from 'child_process';
 /**
  * Internal dependencies
  */
-import frontendcss from './tools/builder/frontend-css';
-import admincss from './tools/builder/admin-css';
+import frontendcss, {
+	frontendCSSSeparateFilesList,
+	frontendCSSConcatFilesList,
+} from './tools/builder/frontend-css';
+import admincss, { adminCSSFiles } from './tools/builder/admin-css';
 import { watch as react_watch, build as react_build } from './tools/builder/react';
 import {
 	watch as sass_watch,
@@ -18,7 +21,15 @@ import {
 } from './tools/builder/sass';
 
 gulp.task( 'old-styles:watch', function () {
-	return gulp.watch( 'scss/**/*.scss', gulp.parallel( 'old-styles' ) );
+	return gulp.watch(
+		[
+			'scss/**/*.scss',
+			...adminCSSFiles,
+			...frontendCSSSeparateFilesList,
+			...frontendCSSConcatFilesList,
+		],
+		gulp.parallel( 'old-styles' )
+	);
 } );
 
 gulp.task( 'blocks:watch', function () {

--- a/projects/plugins/jetpack/tools/builder/admin-css.js
+++ b/projects/plugins/jetpack/tools/builder/admin-css.js
@@ -11,7 +11,7 @@ import rename from 'gulp-rename';
 import rtlcss from 'gulp-rtlcss';
 import log from 'fancy-log';
 
-const admincss = [
+export const adminCSSFiles = [
 	// Non-concatenated, non-admin styles to be processed
 	'modules/custom-post-types/comics/comics.css',
 	'modules/shortcodes/css/recipes.css',
@@ -40,7 +40,7 @@ const admincss = [
 // Minimizes admin css for modules.  Outputs to same folder as min.css
 gulp.task( 'admincss', function () {
 	return gulp
-		.src( admincss, { base: './' } )
+		.src( adminCSSFiles, { base: './' } )
 		.pipe( autoprefixer() )
 		.pipe( cleanCSS() )
 		.pipe( rename( { suffix: '.min' } ) )
@@ -58,7 +58,7 @@ gulp.task( 'admincss', function () {
 // Admin RTL CSS for modules.  Auto-prefix, RTL, Minify, RTL the minimized version.
 gulp.task( 'admincss:rtl', function () {
 	return gulp
-		.src( admincss, { base: './' } )
+		.src( adminCSSFiles, { base: './' } )
 		.pipe( autoprefixer() )
 		.pipe( rtlcss() )
 		.pipe( rename( { suffix: '-rtl' } ) )

--- a/projects/plugins/jetpack/tools/builder/frontend-css.js
+++ b/projects/plugins/jetpack/tools/builder/frontend-css.js
@@ -22,7 +22,7 @@ import { transformRelativePath } from './transform-relative-paths';
  *
  * When making changes to that list, you must also update $concatenated_style_handles in class.jetpack.php.
  */
-const concat_list = [
+export const frontendCSSSeparateFilesList = [
 	'modules/carousel/jetpack-carousel.css',
 	'modules/carousel/swiper-bundle.css',
 	'modules/contact-form/css/grunion.css',
@@ -58,7 +58,7 @@ const concat_list = [
  * Front end CSS that needs separate minified and RTL styles.
  * This list will need to have files added as we move to the add_style RTL approach.
  */
-const separate_list = [
+export const frontendCSSConcatFilesList = [
 	'modules/carousel/jetpack-carousel.css',
 	'modules/contact-form/css/grunion.css',
 	'modules/related-posts/related-posts.css',
@@ -80,7 +80,7 @@ const pathModifier = function ( url, filePath ) {
 // Frontend CSS.  Auto-prefix and minimize.
 gulp.task( 'frontendcss', function () {
 	return gulp
-		.src( concat_list )
+		.src( frontendCSSSeparateFilesList )
 		.pipe( modifyCssUrls( { modify: pathModifier } ) )
 		.pipe( autoprefixer() )
 		.pipe( cleanCSS() )
@@ -103,7 +103,7 @@ gulp.task( 'frontendcss', function () {
 
 gulp.task( 'frontendcss:separate', function () {
 	return gulp
-		.src( separate_list )
+		.src( frontendCSSConcatFilesList )
 		.pipe( modifyCssUrls( { modify: pathModifier } ) )
 		.pipe( autoprefixer() )
 		.pipe( cleanCSS() )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

While working on some CSS issues on the Jetpack plugin I noticed that styles are not generated automatically while running either `jetpack watch` or `cd projects/plugins/jetpack && pnpm watch`. In particular the following files were not triggering a build step:
https://github.com/Automattic/jetpack/blob/12c1ec934857a0c0fa2afe2ddecbddb7cdbf2e4e/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.css#L0-L1
https://github.com/Automattic/jetpack/blob/dd9bf5dd1629a42d8407bd514c7a6256ede96606/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css#L0-L1

The above files are built as part of 
https://github.com/Automattic/jetpack/blob/d19207606cb70859f6c617ecd46c5f32c6927ad0/projects/plugins/jetpack/tools/builder/admin-css.js#L34
https://github.com/Automattic/jetpack/blob/d19207606cb70859f6c617ecd46c5f32c6927ad0/projects/plugins/jetpack/tools/builder/frontend-css.js#L62

It seems like the watcher was only looking for `'scss/**/*.scss',`, adding the explicit list of files worked for me. I tried also using a pattern `modules/**/*.css` but I ran into infinite loops.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `cd projects/plugins/jetpack`
* `pnpm watch`
* Make a change to either 
https://github.com/Automattic/jetpack/blob/12c1ec934857a0c0fa2afe2ddecbddb7cdbf2e4e/projects/plugins/jetpack/modules/widget-visibility/widget-conditions/widget-conditions.css#L0-L1
https://github.com/Automattic/jetpack/blob/dd9bf5dd1629a42d8407bd514c7a6256ede96606/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css#L0-L1
* observe that the builder is running and your changes are reflected to the page after a refresh