### PR TITLE
Carousel: Update icons to match original designs

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-icon-weight
+++ b/projects/plugins/jetpack/changelog/fix-carousel-icon-weight
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve carousel icons.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -48,14 +48,10 @@ so we have to target all affected elements in touch devices.
 
 .jp-carousel-overlay .swiper-button-prev svg,
 .jp-carousel-overlay .swiper-button-next svg {
-	height: 40px;
-	width: 40px;
-	fill: #ccc;
-}
-
-.jp-carousel-overlay .swiper-button-prev svg:hover,
-.jp-carousel-overlay .swiper-button-next svg:hover {
-	fill: #fff;
+	height: 30px;
+	width: 28px;
+	background: #000;
+	border-radius: 4px;
 }
 
 .jp-carousel-overlay {
@@ -148,12 +144,12 @@ so we have to target all affected elements in touch devices.
 }
 
 .jp-carousel-info ::selection {
-	background: #68c9e8; /* Safari */
+	background: #fff; /* Safari */
 	color: #fff;
 }
 
 .jp-carousel-info ::-moz-selection {
-	background: #68c9e8; /* Firefox */
+	background: #fff; /* Firefox */
 	color: #fff;
 }
 
@@ -212,7 +208,7 @@ div.jp-carousel-buttons a {
 }
 
 div.jp-carousel-buttons a:hover {
-	color: #68c9e8;
+	color: #fff;
 	border: none !important;
 }
 
@@ -239,12 +235,14 @@ div.jp-carousel-buttons a:hover {
 	letter-spacing: 0 !important;
 	position: fixed;
 	top: 20px;
-	right: 25px;
+	right: 30px;
+	padding: 10px;
 	text-align: right;
 	width: 45px;
 	height: 45px;
 	z-index: 15;
 	color: #fff;
+	cursor: pointer;
 }
 
 .jp-carousel-transitions .jp-carousel-close-hint {
@@ -254,32 +252,13 @@ div.jp-carousel-buttons a:hover {
 	transition: color 200ms linear;
 }
 
-.jp-carousel-close-hint span {
-	cursor: pointer;
-	background-color: transparent;
-	display: inline-block;
-	font: 400 36px/1 'Helvetica Neue', sans-serif !important;
-	line-height: 22px;
-	margin: 0;
-	text-align: center;
-	vertical-align: middle;
-	-moz-border-radius: 4px;
-	-webkit-border-radius: 4px;
+.jp-carousel-close-hint svg {
+	padding: 3px 2px;
+	background: #000;
 	border-radius: 4px;
-	font-size: 36px !important;
-	height: 44px;
-	width: 44px;
-}
-
-.jp-carousel-transitions .jp-carousel-close-hint span {
-	-webkit-transition: border-color 200ms linear;
-	-moz-transition: border-color 200ms linear;
-	-o-transition: border-color 200ms linear;
-	transition: border-color 200ms linear;
 }
 
 .jp-carousel-close-hint:hover {
-	cursor: default;
 	color: #fff;
 }
 
@@ -288,11 +267,6 @@ div.jp-carousel-buttons a:hover {
 }
 
 div.jp-carousel-buttons a.jp-carousel-commentlink,
-a.jp-carousel-image-download {
-	background: url( ./images/carousel-sprite.png?5 ) no-repeat;
-	background-size: 16px 200px;
-}
-
 div.jp-carousel-buttons a.jp-carousel-commentlink {
 	margin: 0 14px 0 0 !important;
 	background-position: 0px -156px;
@@ -303,8 +277,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 	only screen and ( -o-min-device-pixel-ratio: 3/2 ),
 	only screen and ( min--moz-device-pixel-ratio: 1.5 ),
 	only screen and ( min-device-pixel-ratio: 1.5 ) {
-	div.jp-carousel-buttons a.jp-carousel-commentlink,
-	a.jp-carousel-image-download {
+	div.jp-carousel-buttons a.jp-carousel-commentlink {
 		background-image: url( ./images/carousel-sprite-2x.png?5 );
 	}
 }
@@ -426,7 +399,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 .jp-carousel-photo-description p a:hover,
 .jp-carousel-comments p a:hover,
 .jp-carousel-info h2 a:hover {
-	color: #68c9e8 !important;
+	color: #fff !important;
 }
 
 .jp-carousel-photo-description p:empty {
@@ -498,9 +471,15 @@ a.jp-carousel-image-download {
 	color: #999;
 	line-height: 1;
 	font-weight: 400;
-	font-size: 13px;
+	font-size: 14px;
 	text-decoration: none;
-	background-position: 0 -82px;
+}
+
+a.jp-carousel-image-download svg {
+	display: inline-block;
+	vertical-align: middle;
+	margin: 0 3px;
+	padding-bottom: 2px;
 }
 
 a.jp-carousel-image-download span.photo-size {
@@ -516,7 +495,7 @@ a.jp-carousel-image-download span.photo-size-times {
 
 a.jp-carousel-image-download:hover {
 	background-position: 0 -122px;
-	color: #68c9e8;
+	color: #fff;
 	border: none !important;
 }
 
@@ -535,7 +514,7 @@ a.jp-carousel-image-download:hover {
 .jp-carousel-comments p a:hover,
 .jp-carousel-comments p a:focus,
 .jp-carousel-comments p a:active {
-	color: #68c9e8 !important;
+	color: #fff !important;
 }
 
 .jp-carousel-comment {
@@ -864,23 +843,24 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 /* ----- Light variant ----- */
 
-.jp-carousel-light.jp-carousel-overlay {
+.jp-carousel-light.jp-carousel-overlay svg {
 	background: #fff;
 }
 
-.jp-carousel-light.jp-carousel-overlay .swiper-button-prev,
-.jp-carousel-light.jp-carousel-overlay .swiper-button-next {
-	opacity: 1;
-}
-
-.jp-carousel-light.jp-carousel-overlay .swiper-button-prev:hover,
-.jp-carousel-light.jp-carousel-overlay .swiper-button-next:hover {
-	opacity: 0.5;
-}
-
-.jp-carousel-light.jp-carousel-overlay .swiper-button-prev svg,
-.jp-carousel-light.jp-carousel-overlay .swiper-button-next svg {
+.jp-carousel-light.jp-carousel-overlay rect {
 	fill: #000;
+}
+
+.jp-carousel-light.jp-carousel-overlay .jp-carousel-selected .jp-carousel-icon,
+.jp-carousel-light.jp-carousel-overlay .jp-carousel-selected .jp-carousel-icon svg {
+	background: #000;
+}
+.jp-carousel-light.jp-carousel-overlay .jp-carousel-selected rect {
+	fill: #fff;
+}
+
+.jp-carousel-light.jp-carousel-overlay {
+	background: #fff;
 }
 
 .jp-carousel-light .jp-carousel-close-hint:hover,
@@ -894,7 +874,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 .jp-carousel-light .jp-carousel-photo-description p a,
 .jp-carousel-light .jp-carousel-comments p a,
 .jp-carousel-light .jp-carousel-info h2 a {
-	color: #4f94d4 !important;
+	color: #000 !important;
 }
 
 .jp-carousel-light .jp-carousel-comments p a:hover,
@@ -903,7 +883,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 .jp-carousel-light .jp-carousel-photo-description p a:hover,
 .jp-carousel-light .jp-carousel-comments p a:hover,
 .jp-carousel-light .jp-carousel-info h2 a:hover {
-	color: #f1831e !important;
+	color: #000 !important;
 }
 
 .jp-carousel-light .jp-carousel-info h2,
@@ -1033,18 +1013,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 .jp-carousel-light .jp-carousel-info-extra {
 	background-color: #fff;
-}
-
-.jp-carousel-light .jp-carousel-icon {
-	color: #000;
-	fill: #000;
-	background-color: #fff;
-}
-
-.jp-carousel-light .jp-carousel-icon-btn.jp-carousel-selected .jp-carousel-icon {
-	color: #fff;
-	fill: #fff;
-	background-color: #000;
+	border-color: #ddd;
 }
 
 .jp-carousel-light .jp-carousel-pagination {
@@ -1081,30 +1050,25 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 }
 
 .jp-carousel-icon {
-	color: #fff;
-	fill: #fff;
-	background-color: #000;
 	border: none;
-	border-radius: 2px;
 	pointer-events: none;
-	font-family: dashicons;
 	display: inline-block;
-	width: 32px;
-	height: 32px;
-	font-size: 30px;
-	line-height: 1;
+	line-height: 0;
 	font-weight: 400;
 	font-style: normal;
+	border-radius: 4px;
+	padding: 4px 3px 3px;
 }
 
 .jp-carousel-icon svg {
 	display: inline-block;
 }
 
-.jp-carousel-icon-btn.jp-carousel-selected .jp-carousel-icon {
-	color: #000;
+.jp-carousel-selected .jp-carousel-icon {
+	background: #fff;
+}
+.jp-carousel-selected rect {
 	fill: #000;
-	background-color: #fff;
 }
 
 .jp-carousel-icon-comments.jp-carousel-show {
@@ -1160,7 +1124,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 		font-size: 26px !important;
 		position: fixed !important;
 		top: 10px;
-		right: 15px;
+		right: 10px;
 	}
 
 	/* The admin bar is fixed at top: 0*/
@@ -1201,7 +1165,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	}
 
 	.jp-carousel-photo-icons-container {
-		margin: 0 15px 0 0;
+		margin: 0 10px 0 0;
 		white-space: nowrap;
 	}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1027,8 +1027,10 @@
 				original = currentSlide.attrs.origFile.replace( /\?.+$/, '' );
 			}
 
+			var downloadText = carousel.info.querySelector( '.jp-carousel-download-text' );
 			var permalink = carousel.info.querySelector( '.jp-carousel-image-download' );
-			permalink.innerHTML = util.applyReplacements(
+
+			downloadText.innerHTML = util.applyReplacements(
 				jetpackCarouselStrings.download_original,
 				origSize
 			);

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -385,18 +385,37 @@ class Jetpack_Carousel {
 				itemtype="https://schema.org/ImageGallery">
 				<div class="jp-carousel swiper-wrapper"></div>
 				<div class="jp-swiper-button-prev swiper-button-prev">
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-						<path d="M10.4772727,0.477272727 C10.7408632,0.740863176 10.7408632,1.16822773 10.4772727,1.43181818 L1.90909091,10 L10.4772727,18.5681818 C10.7408632,18.8317723 10.7408632,19.2591368 10.4772727,19.5227273 C10.2136823,19.7863177 9.78631772,19.7863177 9.52272727,19.5227273 L0.707106781,10.7071068 C0.316582489,10.3165825 0.316582489,9.68341751 0.707106781,9.29289322 L9.52272727,0.477272727 C9.78631772,0.213682278 10.2136823,0.213682278 10.4772727,0.477272727 Z" transform="translate(4)"/>
+					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<mask id="maskPrev" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="9" height="12">
+							<path d="M16.2072 16.59L11.6496 12L16.2072 7.41L14.8041 6L8.8335 12L14.8041 18L16.2072 16.59Z" fill="white"/>
+						</mask>
+						<g mask="url(#maskPrev)">
+							<rect x="0.579102" width="23.8823" height="24" fill="#FFFFFF"/>
+						</g>
 					</svg>
 				</div>
 				<div class="jp-swiper-button-next swiper-button-next">
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-						<path d="M1.37727273,19.5227273 C1.11368228,19.2591368 1.11368228,18.8317723 1.37727273,18.5681818 L9.94545455,10 L1.37727273,1.43181818 C1.11368228,1.16822773 1.11368228,0.740863176 1.37727273,0.477272727 C1.64086318,0.213682278 2.06822773,0.213682278 2.33181818,0.477272727 L11.1474387,9.29289322 C11.537963,9.68341751 11.537963,10.3165825 11.1474387,10.7071068 L2.33181818,19.5227273 C2.06822773,19.7863177 1.64086318,19.7863177 1.37727273,19.5227273 Z" transform="translate(4)"/>
+					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<mask id="maskNext" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="8" height="12">
+							<path d="M8.59814 16.59L13.1557 12L8.59814 7.41L10.0012 6L15.9718 12L10.0012 18L8.59814 16.59Z" fill="white"/>
+						</mask>
+						<g mask="url(#maskNext)">
+							<rect x="0.34375" width="23.8822" height="24" fill="#FFFFFF"/>
+						</g>
 					</svg>
 				</div>
 			</div>
 			<!-- The main close buton -->
-			<div class="jp-carousel-close-hint"><span>&times;</span></div>
+			<div class="jp-carousel-close-hint">
+				<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<mask id="maskClose" mask-type="alpha" maskUnits="userSpaceOnUse" x="5" y="5" width="15" height="14">
+						<path d="M19.3166 6.41L17.9135 5L12.3509 10.59L6.78834 5L5.38525 6.41L10.9478 12L5.38525 17.59L6.78834 19L12.3509 13.41L17.9135 19L19.3166 17.59L13.754 12L19.3166 6.41Z" fill="white"/>
+					</mask>
+					<g mask="url(#maskClose)">
+						<rect x="0.409668" width="23.8823" height="24" fill="#FFFFFF"/>
+					</g>
+				</svg>
+			</div>
 			<!-- Image info, comments and meta -->
 			<div class="jp-carousel-info">
 				<div class="jp-carousel-info-footer">
@@ -411,14 +430,29 @@ class Jetpack_Carousel {
 						<?php if ( $localize_strings['display_exif'] ) : ?>
 							<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
 								<span class="jp-carousel-icon">
-									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path></svg>
+									<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+										<mask id="maskInfo" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="20">
+											<path fill-rule="evenodd" clip-rule="evenodd" d="M12.7537 2C7.26076 2 2.80273 6.48 2.80273 12C2.80273 17.52 7.26076 22 12.7537 22C18.2466 22 22.7046 17.52 22.7046 12C22.7046 6.48 18.2466 2 12.7537 2ZM11.7586 7V9H13.7488V7H11.7586ZM11.7586 11V17H13.7488V11H11.7586ZM4.79292 12C4.79292 16.41 8.36531 20 12.7537 20C17.142 20 20.7144 16.41 20.7144 12C20.7144 7.59 17.142 4 12.7537 4C8.36531 4 4.79292 7.59 4.79292 12Z" fill="white"/>
+										</mask>
+										<g mask="url(#maskInfo)">
+											<rect x="0.8125" width="23.8823" height="24" fill="#FFFFFF"/>
+										</g>
+									</svg>
 								</span>
 							</a>
 						<?php endif; ?>
 						<?php if ( $localize_strings['display_comments'] ) : ?>
 						<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
 							<span class="jp-carousel-icon">
-								<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="32" height="32" role="img" aria-hidden="true" focusable="false"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"></path></svg>
+								<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+									<mask id="maskComments" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="20">
+										<path fill-rule="evenodd" clip-rule="evenodd" d="M4.3271 2H20.2486C21.3432 2 22.2388 2.9 22.2388 4V16C22.2388 17.1 21.3432 18 20.2486 18H6.31729L2.33691 22V4C2.33691 2.9 3.2325 2 4.3271 2ZM6.31729 16H20.2486V4H4.3271V18L6.31729 16Z" fill="white"/>
+									</mask>
+									<g mask="url(#maskComments)">
+										<rect x="0.34668" width="23.8823" height="24" fill="#FFFFFF"/>
+									</g>
+								</svg>
+
 								<span class="jp-carousel-has-comments-indicator" aria-label="<?php esc_attr_e( 'This image has comments.', 'jetpack' ); ?>"></span>
 							</span>
 						</a>
@@ -513,7 +547,17 @@ class Jetpack_Carousel {
 								</div>
 							</div>
 							<ul class="jp-carousel-image-exif" style="display: none;"></ul>
-							<a class="jp-carousel-image-download" target="_blank" style="display: none;"></a>
+							<a class="jp-carousel-image-download" target="_blank" style="display: none;">
+								<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+									<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="3" y="3" width="19" height="18">
+										<path fill-rule="evenodd" clip-rule="evenodd" d="M5.84615 5V19H19.7775V12H21.7677V19C21.7677 20.1 20.8721 21 19.7775 21H5.84615C4.74159 21 3.85596 20.1 3.85596 19V5C3.85596 3.9 4.74159 3 5.84615 3H12.8118V5H5.84615ZM14.802 5V3H21.7677V10H19.7775V6.41L9.99569 16.24L8.59261 14.83L18.3744 5H14.802Z" fill="white"/>
+									</mask>
+									<g mask="url(#mask0)">
+										<rect x="0.870605" width="23.8823" height="24" fill="#FFFFFF"/>
+									</g>
+								</svg>
+								<span class="jp-carousel-download-text"></span>
+							</a>
 							<div class="jp-carousel-image-map" style="display: none;"></div>
 						</div>
 					</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/20266

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix the icons to perfectly match the original designs. This includes updated prev/next icons, close button icon, and external link icon.

<img width="1354" alt="Screen Shot 2021-07-06 at 1 15 13 PM" src="https://user-images.githubusercontent.com/1464705/124663485-027df280-de5f-11eb-9fea-e8b84c0dcf89.png">


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the carousel, confirm all icons work on desktop and mobile.
* Confirm the icons look correct in light mode.
