### PR TITLE
Sync: Add note to use new deleted_theme hook

### DIFF
--- a/projects/packages/sync/changelog/add-inline-note-re-new-sync-action
+++ b/projects/packages/sync/changelog/add-inline-note-re-new-sync-action
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just an inline doc to track a future change needed.
+
+

--- a/projects/packages/sync/src/modules/class-themes.php
+++ b/projects/packages/sync/src/modules/class-themes.php
@@ -35,14 +35,16 @@ class Themes extends Module {
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader' ), 10, 2 );
 		add_action( 'jetpack_installed_theme', $callable, 10, 2 );
 		add_action( 'jetpack_updated_themes', $callable, 10, 2 );
-		add_action( 'delete_site_transient_update_themes', array( $this, 'detect_theme_deletion' ) );
-		add_action( 'jetpack_deleted_theme', $callable, 10, 2 );
 		add_filter( 'wp_redirect', array( $this, 'detect_theme_edit' ) );
 		add_action( 'jetpack_edited_theme', $callable, 10, 2 );
 		add_action( 'wp_ajax_edit-theme-plugin-file', array( $this, 'theme_edit_ajax' ), 0 );
 		add_action( 'update_site_option_allowedthemes', array( $this, 'sync_network_allowed_themes_change' ), 10, 4 );
 		add_action( 'jetpack_network_disabled_themes', $callable, 10, 2 );
 		add_action( 'jetpack_network_enabled_themes', $callable, 10, 2 );
+
+		// @todo Switch to use the new `deleted_theme` hook once WP 5.8 is the minimum version. See https://core.trac.wordpress.org/changeset/50826
+		add_action( 'delete_site_transient_update_themes', array( $this, 'detect_theme_deletion' ) );
+		add_action( 'jetpack_deleted_theme', $callable, 10, 2 );
 
 		// Sidebar updates.
 		add_action( 'update_option_sidebars_widgets', array( $this, 'sync_sidebar_widgets_actions' ), 10, 2 );


### PR DESCRIPTION
fixes #20261 

There are new `delete_theme` and `deleted_theme` hooks in WordPress 5.8. We may want to switch to it once WP 5.8 is our minimum version.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* We don't want to switch to the new hook yet, must wait for WP 5.8 to be our minimum version.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None needed for this PR.
*
