### PR TITLE
Carousel  - Namespace all swiper css overrides to stop clashes with other plugins

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-corousel-css-leakage-bug
+++ b/projects/plugins/jetpack/changelog/fix-corousel-css-leakage-bug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Fix namespacing of carousel swiper css overrides
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -1,3 +1,17 @@
+/* 
+ * Temporary fix below for issue introduced to Newspack blocks, can be removed once
+ * once Newspack blocks includes this override
+*/
+.wp-block-newspack-blocks-carousel .swiper-button-prev:after,
+.swiper-container-rtl .swiper-button-next:after {
+	content: none;
+}
+.wp-block-newspack-blocks-carousel .swiper-button-next:after,
+.swiper-container-rtl .swiper-button-prev:after {
+	content: none;
+}
+/* end of temporary fix */
+
 [data-carousel-extra]:not( .jp-carousel-wrap ) {
 	cursor: pointer;
 }

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -6,7 +6,7 @@
 	line-height: inherit;
 }
 
-.swiper-container {
+.jp-carousel-wrap.swiper-container {
 	height: auto;
 	width: 100vw;
 }
@@ -22,8 +22,8 @@ To prevent flash of prev/next image scale transition after pinch zoom we need to
 Swiper does not add a class of `swiper-slide-zoomed` to slides on pinch and zoom
 so we have to target all affected elements in touch devices.
 */
-.swiper-slide.swiper-slide-prev .swiper-zoom-container img,
-.swiper-slide.swiper-slide-next .swiper-zoom-container img {
+.jp-carousel-overlay .swiper-slide.swiper-slide-prev .swiper-zoom-container img,
+.jp-carousel-overlay .swiper-slide.swiper-slide-next .swiper-zoom-container img {
 	transition: none !important;
 }
 
@@ -34,6 +34,7 @@ so we have to target all affected elements in touch devices.
 	height: initial;
 	width: initial;
 	padding: 20px 40px;
+	background-image: none;
 }
 
 .jp-carousel-overlay .swiper-button-prev:hover,
@@ -84,10 +85,10 @@ so we have to target all affected elements in touch devices.
 	display: none;
 }
 
-.swiper-container .swiper-button-prev {
+.jp-carousel-overlay .swiper-container .swiper-button-prev {
 	left: 0px;
 }
-.swiper-container .swiper-button-next {
+.jp-carousel-overlay .swiper-container .swiper-button-next {
 	right: 0px;
 }
 
@@ -1138,8 +1139,8 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 /* Small screens */
 @media only screen and ( max-width: 760px ) {
-	.swiper-container .swiper-button-next,
-	.swiper-container .swiper-button-prev {
+	.jp-carousel-overlay .swiper-container .swiper-button-next,
+	.jp-carousel-overlay .swiper-container .swiper-button-prev {
 		display: none !important;
 	}
 


### PR DESCRIPTION
Fixes: #20289

#### Changes proposed in this Pull Request:

* Adds a jp-carousel class to all swiper.js css overrides

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

- On a local test site install newspack blocks and jetpack
- Turn on jetpack carousel and add a page with the Post Carousel block and a gallery
- In frontend notice make sure that both the  Post carousel and the gallery carousel display as expected

Before:
<img width="1919" alt="Screen Shot 2021-07-07 at 4 37 38 PM" src="https://user-images.githubusercontent.com/3629020/124702597-b4dbb580-df44-11eb-904e-c3277f00fb75.png">

After:
<img width="677" alt="Screen Shot 2021-07-07 at 5 15 51 PM" src="https://user-images.githubusercontent.com/3629020/124703844-24eb3b00-df47-11eb-841f-284925fa2354.png">


