### PR TITLE
Update requested jetpack components version number

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
   projects/packages/connection-ui:
     specifiers:
       '@automattic/calypso-build': 6.5.0
-      '@automattic/jetpack-components': workspace:^0.1.0-alpha
+      '@automattic/jetpack-components': workspace:^0.2.0-alpha
       '@automattic/jetpack-connection': workspace:^0.4.0-alpha
       '@babel/core': 7.12.10
       '@babel/helper-module-imports': 7.12.5
@@ -287,7 +287,7 @@ importers:
       '@automattic/color-studio': 2.5.0
       '@automattic/components': 1.0.0-alpha.3
       '@automattic/format-currency': 1.0.0-alpha.0
-      '@automattic/jetpack-components': workspace:^0.1.0-alpha
+      '@automattic/jetpack-components': workspace:^0.2.0-alpha
       '@automattic/jetpack-connection': workspace:^0.4.0-alpha
       '@automattic/popup-monitor': 1.0.0
       '@automattic/request-external-access': 1.0.0
@@ -633,7 +633,7 @@ importers:
       eslint-plugin-jsdoc: 32.3.3_eslint@7.25.0
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.25.0
       eslint-plugin-lodash: 7.2.0_eslint@7.25.0
-      eslint-plugin-prettier: 3.4.0_e9d1ac6628d83db1359573269b37032a
+      eslint-plugin-prettier: 3.4.0_29601d46fa20d533a3a9bdbfa88bed36
       eslint-plugin-react: 7.23.2_eslint@7.25.0
       eslint-plugin-wpcalypso: 5.0.0_eslint@7.25.0
 
@@ -5324,7 +5324,7 @@ packages:
       eslint-plugin-jest: 23.20.0_eslint@7.25.0
       eslint-plugin-jsdoc: 30.7.13_eslint@7.25.0
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.25.0
-      eslint-plugin-prettier: 3.4.0_78f889a4d298e472d2ac774dc8d2052c
+      eslint-plugin-prettier: 3.4.0_106fe4c2d8b17897212c9dcbb448a167
       eslint-plugin-react: 7.23.2_eslint@7.25.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.25.0
       globals: 12.4.0
@@ -9255,7 +9255,7 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /eslint-plugin-prettier/3.4.0_78f889a4d298e472d2ac774dc8d2052c:
+  /eslint-plugin-prettier/3.4.0_106fe4c2d8b17897212c9dcbb448a167:
     resolution: {integrity: sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -9272,7 +9272,7 @@ packages:
       prettier-linter-helpers: 1.0.0
     dev: true
 
-  /eslint-plugin-prettier/3.4.0_e9d1ac6628d83db1359573269b37032a:
+  /eslint-plugin-prettier/3.4.0_29601d46fa20d533a3a9bdbfa88bed36:
     resolution: {integrity: sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -9285,6 +9285,7 @@ packages:
     dependencies:
       eslint: 7.25.0
       eslint-config-prettier: 8.3.0_eslint@7.25.0
+      prettier: /wp-prettier/2.0.5
       prettier-linter-helpers: 1.0.0
     dev: true
 

--- a/projects/packages/connection-ui/changelog/fix-update-requested-components-version-number
+++ b/projects/packages/connection-ui/changelog/fix-update-requested-components-version-number
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Bugfix to build process.
+
+

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -15,7 +15,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-build": "6.5.0",
-		"@automattic/jetpack-components": "workspace:^0.1.0-alpha",
+		"@automattic/jetpack-components": "workspace:^0.2.0-alpha",
 		"@automattic/jetpack-connection": "workspace:^0.4.0-alpha",
 		"@babel/core": "7.12.10",
 		"@babel/helper-module-imports": "7.12.5",

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "1.2.0",
+	"version": "1.2.1-alpha",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-connection-ui",

--- a/projects/plugins/jetpack/changelog/fix-update-requested-components-version-number
+++ b/projects/plugins/jetpack/changelog/fix-update-requested-components-version-number
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Build process bugfix.
+
+

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -59,7 +59,7 @@
 		"@automattic/calypso-color-schemes": "2.1.1",
 		"@automattic/components": "1.0.0-alpha.3",
 		"@automattic/format-currency": "1.0.0-alpha.0",
-		"@automattic/jetpack-components": "workspace:^0.1.0-alpha",
+		"@automattic/jetpack-components": "workspace:^0.2.0-alpha",
 		"@automattic/jetpack-connection": "workspace:^0.4.0-alpha",
 		"@automattic/popup-monitor": "1.0.0",
 		"@automattic/request-external-access": "1.0.0",


### PR DESCRIPTION
The repo currently doesn't build because of a version mismatch in `jetpack-components`.

Fixes bug introduced in #20288.

#### Changes proposed in this Pull Request:
* Match requested `jetpack-components` version to available version.

#### Jetpack product discussion
None.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Check out the branch
* Run `pnpm i`
* Ensure it works correctly, without complaining about missing dependencies
