### PR TITLE
tools: Make "check-composer-deps" into "check-intra-monorepo-deps"

### DIFF
--- a/.github/files/renovate-helper.sh
+++ b/.github/files/renovate-helper.sh
@@ -121,7 +121,7 @@ fi
 
 # Update deps and lock files.
 echo "::group::Updating dependencies on changed packages"
-tools/check-composer-deps.sh -uv
+tools/check-intra-monorepo-deps.sh -uv
 echo "::endgroup::"
 
 # Create and push the commit.

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -783,7 +783,7 @@ jobs:
       - run: .github/files/check-lock-files.sh
 
   ### Check that monorepo packages are correctly referenced.
-  # Local equivalent: tools/check-composer-deps.sh -v && .github/files/check-monorepo-package-repos.sh
+  # Local equivalent: tools/check-intra-monorepo-deps.sh -v && .github/files/check-monorepo-package-repos.sh
   monorepo_package_refs:
     name: Monorepo package version refs
     runs-on: ubuntu-latest
@@ -796,7 +796,7 @@ jobs:
         run: |
           which jq
           jq --version
-      - run: tools/check-composer-deps.sh -v
+      - run: tools/check-intra-monorepo-deps.sh -v
       - run: .github/files/check-monorepo-package-repos.sh
 
   ### Checks against project structure, e.g. that composer.json exists.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,7 @@ importers:
     specifiers:
       '@automattic/calypso-build': 6.5.0
       '@automattic/jetpack-components': workspace:^0.2.0-alpha
-      '@automattic/jetpack-connection': workspace:^0.4.0-alpha
+      '@automattic/jetpack-connection': workspace:^0.4.0
       '@babel/core': 7.12.10
       '@babel/helper-module-imports': 7.12.5
       '@babel/preset-env': 7.12.11
@@ -244,7 +244,7 @@ importers:
   projects/plugins/backup:
     specifiers:
       '@automattic/calypso-build': 7.0.0
-      '@automattic/jetpack-connection': workspace:^0.4.0-alpha
+      '@automattic/jetpack-connection': workspace:^0.4.0
       '@babel/core': 7.13.14
       '@babel/helper-module-imports': 7.13.12
       '@babel/preset-env': 7.13.12
@@ -288,7 +288,7 @@ importers:
       '@automattic/components': 1.0.0-alpha.3
       '@automattic/format-currency': 1.0.0-alpha.0
       '@automattic/jetpack-components': workspace:^0.2.0-alpha
-      '@automattic/jetpack-connection': workspace:^0.4.0-alpha
+      '@automattic/jetpack-connection': workspace:^0.4.0
       '@automattic/popup-monitor': 1.0.0
       '@automattic/request-external-access': 1.0.0
       '@automattic/social-previews': 1.1.1

--- a/projects/packages/connection-ui/changelog/add-check-intra-monorepo-deps
+++ b/projects/packages/connection-ui/changelog/add-check-intra-monorepo-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"@automattic/calypso-build": "6.5.0",
 		"@automattic/jetpack-components": "workspace:^0.2.0-alpha",
-		"@automattic/jetpack-connection": "workspace:^0.4.0-alpha",
+		"@automattic/jetpack-connection": "workspace:^0.4.0",
 		"@babel/core": "7.12.10",
 		"@babel/helper-module-imports": "7.12.5",
 		"@babel/preset-env": "7.12.11",

--- a/projects/plugins/backup/changelog/add-check-intra-monorepo-deps
+++ b/projects/plugins/backup/changelog/add-check-intra-monorepo-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/package.json
+++ b/projects/plugins/backup/package.json
@@ -27,7 +27,7 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
-		"@automattic/jetpack-connection": "workspace:^0.4.0-alpha",
+		"@automattic/jetpack-connection": "workspace:^0.4.0",
 		"@wordpress/data": "4.27.3",
 		"@wordpress/i18n": "3.20.0",
 		"react": "16.14.0",

--- a/projects/plugins/jetpack/changelog/add-check-intra-monorepo-deps
+++ b/projects/plugins/jetpack/changelog/add-check-intra-monorepo-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -60,7 +60,7 @@
 		"@automattic/components": "1.0.0-alpha.3",
 		"@automattic/format-currency": "1.0.0-alpha.0",
 		"@automattic/jetpack-components": "workspace:^0.2.0-alpha",
-		"@automattic/jetpack-connection": "workspace:^0.4.0-alpha",
+		"@automattic/jetpack-connection": "workspace:^0.4.0",
 		"@automattic/popup-monitor": "1.0.0",
 		"@automattic/request-external-access": "1.0.0",
 		"@automattic/social-previews": "1.1.1",

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -12,7 +12,7 @@ function usage {
 	cat <<-EOH
 		usage: $0 [-u] [-v]
 
-		Check that all composer dependencies between monorepo projects are up to date.
+		Check that all composer and pnpm dependencies between monorepo projects are up to date.
 
 		If \`-u\` is passed, update any that aren't and add changelogger change files
 		for the updates.
@@ -60,12 +60,14 @@ fi
 function get_packages {
 	PACKAGES1=$(jq -nc 'reduce inputs as $in ({}; .[$in.name] |= if $in.extra["branch-alias"]["dev-master"] then [ $in.extra["branch-alias"]["dev-master"], ( $in.extra["branch-alias"]["dev-master"] | sub( "^(?<v>\\d+\\.\\d+)\\.x-dev$"; "^\(.v)" ) ) ] else [ "@dev" ] end )' "$BASE"/projects/packages/*/composer.json)
 	PACKAGES2=$(jq -c '( .[][0] | select( . != "@dev" ) ) |= empty' <<<"$PACKAGES1")
+	JSPACKAGES=$(jq -nc 'reduce inputs as $in ({}; if $in.name then .[$in.name] |= [ "workspace:^\($in.version)", "workspace:\($in.version)" ] else . end )' "$BASE"/projects/js-packages/*/package.json)
 }
 
 get_packages
 
 # Use a temp variable so pipefail works
 TMP="$(tools/get-build-order.php 2>/dev/null)"
+TMP=monorepo$'\n'"$TMP"
 SLUGS=()
 mapfile -t SLUGS <<<"$TMP"
 
@@ -111,50 +113,84 @@ for SLUG in "${SLUGS[@]}"; do
 	else
 		PACKAGES="$PACKAGES1"
 	fi
-	FILE="projects/$SLUG/composer.json"
+	if [[ "$SLUG" == monorepo ]]; then
+		DOCL=false
+		DIR=.
+		PHPFILE=composer.json
+		JSFILE=package.json
+	else
+		DOCL=true
+		DIR="projects/$SLUG"
+		PHPFILE="projects/$SLUG/composer.json"
+		JSFILE="projects/$SLUG/package.json"
+	fi
 	if $UPDATE; then
-		JSON=$(jq --argjson packages "$PACKAGES" -r 'def ver(e): if $packages[e.key] then if e.value[0:1] == "^" then $packages[e.key][1] else null end // $packages[e.key][0] else e.value end; if .require then .require |= with_entries( .value = ver(.) ) else . end | if .["require-dev"] then .["require-dev"] |= with_entries( .value = ver(.) ) else . end' "$FILE" | tools/prettier --parser=json-stringify)
-		DIDCL=false
-		if [[ "$JSON" != "$(<"$FILE")" ]]; then
-			info "Dependencies of $SLUG changed!"
-			echo "$JSON" > "$FILE"
+		JSON=$(jq --argjson packages "$PACKAGES" -r 'def ver(e): if $packages[e.key] then if e.value[0:1] == "^" then $packages[e.key][1] else null end // $packages[e.key][0] else e.value end; if .require then .require |= with_entries( .value = ver(.) ) else . end | if .["require-dev"] then .["require-dev"] |= with_entries( .value = ver(.) ) else . end' "$PHPFILE" | tools/prettier --parser=json-stringify)
+		if [[ "$JSON" != "$(<"$PHPFILE")" ]]; then
+			info "PHP dependencies of $SLUG changed!"
+			echo "$JSON" > "$PHPFILE"
 
-			info "Creating changelog entry for $SLUG"
-			changelogger "$SLUG" 'Updated package dependencies.'
-			DIDCL=true
+			if $DOCL; then
+				info "Creating changelog entry for $SLUG"
+				changelogger "$SLUG" 'Updated package dependencies.'
+				DOCL=false
+			fi
 		fi
-		if [[ -n "$(git -c core.quotepath=off ls-files "projects/$SLUG/composer.lock")" ]]; then
-			PROJECTFOLDER="$BASE/projects/$SLUG"
+		if [[ -e "$JSFILE" ]]; then
+			JSON=$(jq --argjson packages "$JSPACKAGES" -r 'def ver(e): if $packages[e.key] then if e.value[0:1] == "^" then $packages[e.key][1] else null end // $packages[e.key][0] else e.value end; def proc(k): if .[k] then .[k] |= with_entries( .value = ver(.) ) else . end; proc("dependencies") | proc("devDependencies") | proc("peerDependencies") | proc("optionalDependencies")' "$JSFILE" | tools/prettier --parser=json-stringify)
+			if [[ "$JSON" != "$(<"$JSFILE")" ]]; then
+				info "JS dependencies of $SLUG changed!"
+				echo "$JSON" > "$JSFILE"
+
+				if $DOCL; then
+					info "Creating changelog entry for $SLUG"
+					changelogger "$SLUG" 'Updated package dependencies.'
+					DOCL=false
+				fi
+			fi
+		fi
+		if [[ -n "$(git -c core.quotepath=off ls-files "$DIR/composer.lock")" ]]; then
+			PROJECTFOLDER="$BASE/$DIR"
 			cd "$PROJECTFOLDER"
 			debug "Updating $SLUG composer.lock"
 			OLD="$(<composer.lock)"
 			"$BASE/tools/composer-update-monorepo.sh" --quiet "$PROJECTFOLDER"
-			if [[ "$OLD" != "$(<composer.lock)" ]] && ! $DIDCL; then
+			if [[ "$OLD" != "$(<composer.lock)" ]] && $DOCL; then
 				info "Creating changelog entry for $SLUG composer.lock update"
 				changelogger "$SLUG" '' 'Updated composer.lock.'
-				DIDCL=true
+				DOCL=false
 			fi
 			cd "$BASE"
 		fi
 	else
-		while IFS=" " read -r PKG VER; do
+		while IFS=$'\t' read -r FILE PKG VER; do
 			EXIT=1
 			LINE=$(grep --line-number --fixed-strings --max-count=1 "$PKG" "$FILE")
 			if [[ -n "$CI" ]]; then
 				M="::error file=$FILE"
 				[[ -n "$LINE" ]] && M="$M,line=${LINE%%:*}"
-				echo "$M::Must depend on monorepo package $PKG version $VER%0AYou might use \`tools/check-composer-deps.sh -u\` to fix this."
+				echo "$M::Must depend on monorepo package $PKG version $VER%0AYou might use \`tools/check-intra-monorepo-deps.sh -u\` to fix this."
 			else
 				M="$FILE"
 				[[ -n "$LINE" ]] && M="$M:${LINE%%:*}"
 				error "$M: Must depend on monorepo package $PKG version $VER"
 			fi
-		done < <( jq --argjson packages "$PACKAGES" -r '.require // {}, .["require-dev"] // {} | to_entries[] | select( $packages[.key] as $vals | $vals and ( [ .value ] | inside( $vals ) | not ) ) | .key + " " + ( $packages[.key] | join( " or " ) )' "$FILE" )
+		done < <(
+			jq --argjson packages "$PACKAGES" -r '.require // {}, .["require-dev"] // {} | to_entries[] | select( $packages[.key] as $vals | $vals and ( [ .value ] | inside( $vals ) | not ) ) | [ input_filename, .key, ( $packages[.key] | join( " or " ) ) ] | @tsv' "$PHPFILE"
+			if [[ -e "$JSFILE" ]]; then
+				jq --argjson packages "$JSPACKAGES" -r '.dependencies // {}, .devDependencies // {}, .peerDependencies // {}, .optionalDependencies // {} | to_entries[] | select( $packages[.key] as $vals | $vals and ( [ .value ] | inside( $vals ) | not ) ) | [ input_filename, .key, ( $packages[.key] | join( " or " ) ) ] | @tsv' "$JSFILE"
+			fi
+		)
 	fi
 done
 
+if $UPDATE; then
+	debug "Updating pnpm-lock.yaml"
+	pnpm install --silent
+fi
+
 if ! $UPDATE && [[ "$EXIT" != "0" ]]; then
-	jetpackGreen 'You might use `tools/check-composer-deps.sh -u` to fix these errors.'
+	jetpackGreen 'You might use `tools/check-intra-monorepo-deps.sh -u` to fix these errors.'
 fi
 
 exit $EXIT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In other words, have it also check intra-monorepo JS package
dependencies.
    
And while I'm at it, have it check the monorepo root composer.json too.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1625657891311300-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test 1:
* Check out the first commit of this PR.
* Run `tools/check-intra-monorepo-deps.sh`, see it complain about `@automattic/jetpack-connection` deps that weren't updated in #20214.
* Run `tools/check-intra-monorepo-deps.sh -u`, see it reproduce the second commit of this PR.

Test 2:
* Edit the monorepo root composer.json to depend on a wrong version of `automattic/jetpack-codesniffer`.
* Run `tools/check-intra-monorepo-deps.sh`, see it complain about that.
* Run `tools/check-intra-monorepo-deps.sh -u`, see it fix it (and not try to create a change entry for the monorepo root).

Test 3:
* Edit `projects/plugins/backup/package.json` to change the version of `@automattic/jetpack-connection`, and `projects/plugins/backup/composer.json` to change the version of one of the monorepo PHP packages.
* Run `tools/check-intra-monorepo-deps.sh`, see it complain about both.
* Run `tools/check-intra-monorepo-deps.sh -u`, see it fix both but only create one change entry.
