### PR TITLE
ci: When checking lock files, run pnpm in non-CI mode

### DIFF
--- a/.github/files/check-lock-files.sh
+++ b/.github/files/check-lock-files.sh
@@ -37,4 +37,9 @@ for FILE in $(git -c core.quotepath=off ls-files 'pnpm-lock.yaml' '**/pnpm-lock.
 	cd "$BASE"
 done
 
+# XXX
+pnpm add --workspace-root ci-info
+node -e 'const x = require( "ci-info" ); console.log( x );'
+CI= GITHUB_ACTIONS= node -e 'const x = require( "ci-info" ); console.log( x );'
+
 exit $EXIT

--- a/.github/files/check-lock-files.sh
+++ b/.github/files/check-lock-files.sh
@@ -26,7 +26,7 @@ done
 for FILE in $(git -c core.quotepath=off ls-files 'pnpm-lock.yaml' '**/pnpm-lock.yaml'); do
 	cd $(dirname "$FILE")
 	echo "::group::$FILE - pnpm install"
-	pnpm install
+	CI= GITHUB_ACTIONS= pnpm install
 	echo "::endgroup::"
 	if ! git diff --exit-code pnpm-lock.yaml; then
 		echo "---" # Bracket message containing newlines for better visibility in GH's logs.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/jetpack-monorepo",
-	"description": "Monorepo for the Jetpack ecosystem",
+	"description": "Monorepo for the Jetpack ecosystem!",
 	"homepage": "https://jetpack.com/",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Apparently pnpm looks for `CI=1` and changes its behavior when
processing the lockfile. For the lock file check, we want the non-CI
behavior.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1625657891311300-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 