### PR TITLE
E2E tests: listeners for page error and request failed

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-page-listeners
+++ b/projects/plugins/jetpack/changelog/e2e-page-listeners
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+E2E tests: add listeners for page errors and request failed

--- a/projects/plugins/jetpack/tests/e2e/lib/env/playwright-environment.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/env/playwright-environment.js
@@ -158,7 +158,7 @@ class PlaywrightEnvironment extends AllureNodeEnvironment {
 		} );
 
 		page.on( 'pageerror', exception => {
-			logger.error( `Page error: Uncaught exception: "${ exception }"` );
+			logger.error( `Page error: "${ exception }"` );
 		} );
 
 		page.on( 'requestfailed', request => {

--- a/projects/plugins/jetpack/tests/e2e/lib/env/playwright-environment.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/env/playwright-environment.js
@@ -156,6 +156,14 @@ class PlaywrightEnvironment extends AllureNodeEnvironment {
 
 			logger.debug( `CONSOLE: ${ type.toUpperCase() }: ${ text }` );
 		} );
+
+		page.on( 'pageerror', exception => {
+			logger.error( `Page error: Uncaught exception: "${ exception }"` );
+		} );
+
+		page.on( 'requestfailed', request => {
+			logger.error( `Request failed: ${ request.url() }  ${ request.failure().errorText }` );
+		} );
 	}
 
 	async closePage( eventName, saveVideo = true ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Listen and log `pageerror` and `requestfailed` page events.

#### Jetpack product discussion
1156386383419466-as-1200559827847720

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI green
* Page events of type `pageerror` and `requestfailed` should be logged in console and log file.