### PR TITLE
build: Don't publish the wrong plugin's releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,13 @@ jobs:
       - name: Extract build archive
         run: tar --xz -xvvf build.tar.xz
 
+      - name: Filter mirror list for release branch
+        if: contains( github.ref, '/branch-' )
+        working-directory: monorepo
+        env:
+          BUILD_BASE: ${{ github.workspace }}/build
+        run: .github/files/filter-mirrors-for-release-branch.sh
+
       - name: Determine plugins
         run: |
           jq -r 'if .extra["mirror-repo"] and .extra["wp-plugin-slug"] then [ ( input_filename | sub( "/composer\\.json$"; "" ) ), .extra["mirror-repo"], .extra["wp-plugin-slug"] ] else empty end | @tsv' monorepo/projects/plugins/*/composer.json > plugins.tsv
@@ -145,6 +152,12 @@ jobs:
               continue
             fi
 
+            if ! grep -q --fixed-strings --line-regexp "$MIRROR" build/mirrors.txt; then
+              echo "Plugin is not being mirrored in this build, skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
             # The Jetpack Beta Tester plugin needs the base directory name to be like "${SLUG}-dev", so copy it over.
             mv "build/$MIRROR" "work/${SLUG}-dev"
 
@@ -171,13 +184,13 @@ jobs:
             echo "::endgroup::"
           done < plugins.tsv
           if [[ "$PLUGIN_DATA" == "{}" ]]; then
-            echo "No plugins were built?!"
-            exit 1
+            echo "No plugins were built"
           fi
           echo "::set-output name=plugin-data::$PLUGIN_DATA"
 
       - name: Create plugins artifact
         uses: actions/upload-artifact@v2
+        if: steps.prepare.outputs.plugin-data != '{}'
         with:
           name: plugins
           path: zips
@@ -185,6 +198,7 @@ jobs:
           retention-days: 1
 
       - name: Inform Beta Download webhook
+        if: steps.prepare.outputs.plugin-data != '{}'
         env:
           SECRET: ${{ secrets.JPBETA_SECRET }}
           PLUGIN_DATA: ${{ steps.prepare.outputs.plugin-data }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We should not be publishing a release candidate for VaultPress from
jetpack/branch-9.9, for example.

FYI, I already manually deleted the bogus rc entry from https://betadownload.jetpack.me/vaultpress-branches.json.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure this PR still is published to both https://betadownload.jetpack.me/jetpack-branches.json and https://betadownload.jetpack.me/vaultpress-branches.json (under "pr", of course).
* Cherry pick this to jetpack/branch-9.9 and see that it doesn't re-publish an "rc" entry to https://betadownload.jetpack.me/vaultpress-branches.json.