### PR TITLE
packages/connection: Fix test after WorDBless change

### DIFF
--- a/projects/packages/connection/changelog/fix-packages-connection-test-broken-by-wordbless
+++ b/projects/packages/connection/changelog/fix-packages-connection-test-broken-by-wordbless
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix a test broken by a WorDBless change.
+
+

--- a/projects/packages/connection/tests/php/test-class-webhooks.php
+++ b/projects/packages/connection/tests/php/test-class-webhooks.php
@@ -84,7 +84,7 @@ class Test_Webhooks extends TestCase {
 		remove_action( 'jetpack_client_authorize_processing', $processing_handler );
 
 		static::assertInstanceOf( WP_Error::class, $error_result );
-		static::assertEquals( array( '/wp-admin/' ), $this->redirect_stack );
+		static::assertEquals( array( 'http://example.org/wp-admin/' ), $this->redirect_stack );
 
 		static::assertTrue( $processing_started, 'The `jetpack_client_authorize_processing` hook was not executed.' );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
https://github.com/Automattic/wordbless/pull/44 started setting the
correct "siteurl" option, which changed the redirect path returned by
one of the tests here.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy? Particularly the Code Coverage job, which had been failing due to this.