### PR TITLE
Add package version constants to the Sync, Connection, and Backup packages

### DIFF
--- a/projects/packages/backup/changelog/update-add_package_versions
+++ b/projects/packages/backup/changelog/update-add_package_versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a package version constant.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -48,6 +48,9 @@
 	"extra": {
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-backup",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-package-version.php"
+		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
 		},

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * The Package_Version class.
+ *
+ * @package automattic/jetpack-backup
+ */
+
+namespace Automattic\Jetpack\Backup;
+
+/**
+ * The Package_Version class.
+ */
+class Package_Version {
+
+	const PACKAGE_VERSION = '1.1.1-alpha';
+
+}

--- a/projects/packages/connection/changelog/update-add_package_versions
+++ b/projects/packages/connection/changelog/update-add_package_versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a package version constant.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -57,6 +57,9 @@
 	"extra": {
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-connection",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-package-version.php"
+		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * The Package_Version class.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+/**
+ * The Package_Version class.
+ */
+class Package_Version {
+
+	const PACKAGE_VERSION = '1.29.1-alpha';
+}

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.29.1-alpha';
+	const PACKAGE_VERSION = '1.30.1-alpha';
 }

--- a/projects/packages/sync/changelog/update-add_package_versions
+++ b/projects/packages/sync/changelog/update-add_package_versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a package version constant.

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -51,6 +51,9 @@
 	"extra": {
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-sync",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-package-version.php"
+		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * The Package_Version class.
+ *
+ * @package automattic/jetpack-sync
+ */
+
+namespace Automattic\Jetpack\Sync;
+
+/**
+ * The Package_Version class.
+ */
+class Package_Version {
+
+	const PACKAGE_VERSION = '1.24.0-alpha';
+}

--- a/projects/plugins/backup/changelog/update-add_package_versions
+++ b/projects/plugins/backup/changelog/update-add_package_versions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -174,7 +174,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "3e79b8bd187df4a2659726affb0612c39fc1c05d"
+                "reference": "4a7ba20b295ba7a7a0f0a26a14db346236ddb029"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.30",
@@ -189,6 +189,9 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-backup",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
                 },
@@ -271,7 +274,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "08957565f80c421bd110242c5730f3d7c170b272"
+                "reference": "be4296dc62f27520d9b2443114c4b60605f73829"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -294,6 +297,9 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-connection",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
@@ -906,7 +912,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "4276591594f079897e4a9b3387ddeed76a21d4b6"
+                "reference": "ba7c56236e958b56c0e6aebc47d2a742306b443b"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.30",
@@ -927,6 +933,9 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-sync",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },

--- a/projects/plugins/jetpack/changelog/update-add_package_versions
+++ b/projects/plugins/jetpack/changelog/update-add_package_versions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -232,7 +232,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "3e79b8bd187df4a2659726affb0612c39fc1c05d"
+                "reference": "4a7ba20b295ba7a7a0f0a26a14db346236ddb029"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.30",
@@ -247,6 +247,9 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-backup",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
                 },
@@ -423,7 +426,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "08957565f80c421bd110242c5730f3d7c170b272"
+                "reference": "be4296dc62f27520d9b2443114c4b60605f73829"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -446,6 +449,9 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-connection",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
@@ -1357,7 +1363,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "4276591594f079897e4a9b3387ddeed76a21d4b6"
+                "reference": "ba7c56236e958b56c0e6aebc47d2a742306b443b"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.30",
@@ -1378,6 +1384,9 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-sync",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add new classes, `Package_Version`, to the Sync, Connection, and Backup packages.
* Add a constant that contains the package version string to the new `Package_Version` classes.
* Update the packages' `composer.json` files to include the `version-constants` extra value.

#### Jetpack product discussion
* p9dueE-3b1-p2

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* n/a