### PR TITLE
Search: make sure ?s= is set when using filter links

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-filter-links-path
+++ b/projects/plugins/jetpack/changelog/fix-search-filter-links-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instant Search: make sure ?s= is set when using filter links

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -99,6 +99,7 @@ export default class DomEventHandler extends Component {
 				);
 			}
 		}
+		this.props.setSearchQuery( '' );
 		this.props.showResults();
 	};
 


### PR DESCRIPTION
Fixes #20250.

#### Changes proposed in this Pull Request:
It's possible for the Instant Search overlay to be opened via a custom link with the class `jetpack-search-filter__link`. More details under 'Opening the Search Overlay from a link' here:

https://jetpack.com/support/search/install-search-on-your-site/

In p4Kr4c-3OV-p2#comment-18701 we discovered that opening an overlay in this way does not set the search query in the URL (`/?s=`). As a side effect, this means that the "Showing popular results" header is not displayed as expected.

This PR ensures that the `/?s=` query string is set even when the overlay has been opened via filter link.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On a test site with Instant Search enabled, create a link with the classname `jetpack-search-filter__link` and no data- attributes:

```
<a class="jetpack-search-filter__link" href="#">Open search</a>
```

Click the link and ensure the search overlay:
* Opens with the URL `/?s=`
* Displays 'Showing popular results' header

<img width="512" alt="Screen Shot 2021-07-09 at 14 45 49" src="https://user-images.githubusercontent.com/17325/125015839-681ee880-e0c4-11eb-962b-b9a7280b513d.png">
