### PR TITLE
Carousel: Add JS-based smooth scrolling on footer area open/hide

### DIFF
--- a/projects/plugins/jetpack/changelog/try-carousel-add-js-smooth-scroll
+++ b/projects/plugins/jetpack/changelog/try-carousel-add-js-smooth-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Carousel: Add JS-based smooth scroll behaviour to the footer buttons.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -171,20 +171,12 @@
 			el.dispatchEvent( e );
 		}
 
-		function scrollToElement( el ) {
-			if ( ! el || typeof el.scrollIntoView !== 'function' ) {
-				return;
-			}
-
-			if ( 'scrollBehavior' in document.documentElement.style ) {
-				el.scrollIntoView( { behavior: 'smooth' } );
-			} else {
-				el.scrollIntoView();
-			}
+		// From: https://easings.net/#easeInOutQuad
+		function easeInOutQuad( num ) {
+			return num < 0.5 ? 2 * num * num : 1 - Math.pow( -2 * num + 2, 2 ) / 2;
 		}
 
-		// TODO: This should ultimately replace scrollToElement.
-		function scrollToThen( el, container, callback ) {
+		function scrollToElement( el, container, callback ) {
 			if ( ! el || ! container ) {
 				if ( callback ) {
 					return callback();
@@ -192,33 +184,18 @@
 				return;
 			}
 
-			// TODO: Remove this if not used.
-			// From: https://easings.net/#easeInOutSine
-			function easeInOutSine( num ) {
-				return -( Math.cos( Math.PI * num ) - 1 ) / 2;
-			}
-
-			// From: https://easings.net/#easeInOutQuad
-			function easeInOutQuad( num ) {
-				return num < 0.5 ? 2 * num * num : 1 - Math.pow( -2 * num + 2, 2 ) / 2;
-			}
-
 			var startTime = Date.now();
 			var duration = 500;
-
+			var originalPosition = container.scrollTop;
 			var distance = el.offsetTop - container.scrollTop;
 			distance = Math.min( distance, container.scrollHeight - window.innerHeight );
 
-			var originalPosition = container.scrollTop;
-
 			function runScroll() {
 				var now = Date.now();
-
 				var progress = easeInOutQuad( ( now - startTime ) / duration );
 
 				progress = progress > 1 ? 1 : progress;
 				var newVal = progress * distance;
-
 				container.scrollTop = originalPosition + newVal;
 
 				if ( now <= startTime + duration ) {
@@ -262,7 +239,6 @@
 			fadeIn: fadeIn,
 			fadeOut: fadeOut,
 			scrollToElement: scrollToElement,
-			scrollToThen: scrollToThen,
 			getJSONAttribute: getJSONAttribute,
 			convertToPlainText: convertToPlainText,
 			stripHTML: stripHTML,
@@ -643,19 +619,19 @@
 				target.classList.contains( 'jp-carousel-photo-title' )
 			) {
 				if ( photoMetaContainer && photoMetaContainer.classList.contains( 'jp-carousel-show' ) ) {
-					domUtil.scrollToThen( carousel.overlay, carousel.overlay, handleInfoToggle );
+					domUtil.scrollToElement( carousel.overlay, carousel.overlay, handleInfoToggle );
 				} else {
 					handleInfoToggle();
-					domUtil.scrollToThen( extraInfoContainer, carousel.overlay );
+					domUtil.scrollToElement( carousel.info, carousel.overlay );
 				}
 			}
 
 			if ( domUtil.closest( target, '.jp-carousel-icon-comments' ) ) {
 				if ( commentsContainer && commentsContainer.classList.contains( 'jp-carousel-show' ) ) {
-					domUtil.scrollToThen( carousel.overlay, carousel.overlay, handleCommentToggle );
+					domUtil.scrollToElement( carousel.overlay, carousel.overlay, handleCommentToggle );
 				} else {
 					handleCommentToggle();
-					domUtil.scrollToThen( extraInfoContainer, carousel.overlay );
+					domUtil.scrollToElement( carousel.info, carousel.overlay );
 				}
 			}
 		}

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -176,6 +176,20 @@
 			return num < 0.5 ? 2 * num * num : 1 - Math.pow( -2 * num + 2, 2 ) / 2;
 		}
 
+		function getFooterClearance( container ) {
+			var footer = container.querySelector( '.jp-carousel-info-footer' );
+			var infoArea = container.querySelector( '.jp-carousel-info-extra' );
+			var contentArea = container.querySelector( '.jp-carousel-info-content-wrapper' );
+
+			if ( footer && infoArea && contentArea ) {
+				var styles = window.getComputedStyle( infoArea );
+				var padding = parseInt( styles.paddingTop, 10 ) + parseInt( styles.paddingBottom, 10 );
+				padding = isNaN( padding ) ? 0 : padding;
+				return contentArea.offsetHeight + footer.offsetHeight + padding;
+			}
+			return 0;
+		}
+
 		function scrollToElement( el, container, callback ) {
 			if ( ! el || ! container ) {
 				if ( callback ) {
@@ -185,14 +199,10 @@
 			}
 
 			// For iOS Safari compatibility, use JS to set the minimum height.
-			var extraInfoArea = container.querySelector( '.jp-carousel-info-extra' );
-			if ( extraInfoArea ) {
-				extraInfoArea.style.minHeight = window.innerHeight - 64 + 'px';
+			var infoArea = container.querySelector( '.jp-carousel-info-extra' );
+			if ( infoArea ) {
+				infoArea.style.minHeight = window.innerHeight - 64 + 'px';
 			}
-			var extraInfoContentArea = container.querySelector( '.jp-carousel-info-content-wrapper' );
-			var extraInfoContentAreaHeight = extraInfoContentArea
-				? extraInfoContentArea.offsetHeight
-				: window.innerHeight;
 
 			var isScrolling = true;
 			var startTime = Date.now();
@@ -200,8 +210,7 @@
 			var originalPosition = container.scrollTop;
 			var targetPosition = Math.max(
 				0,
-				el.offsetTop -
-					Math.max( 0, window.innerHeight - ( extraInfoContentAreaHeight + 64 + 35 + 35 ) ) // Subtract footer height plus content area padding.
+				el.offsetTop - Math.max( 0, window.innerHeight - getFooterClearance( container ) )
 			);
 			var distance = targetPosition - container.scrollTop;
 			distance = Math.min( distance, container.scrollHeight - window.innerHeight );
@@ -224,10 +233,10 @@
 				if ( callback ) {
 					callback();
 				}
-				isScrolling = false;
-				if ( extraInfoArea ) {
-					extraInfoArea.style.minHeight = '';
+				if ( infoArea ) {
+					infoArea.style.minHeight = '';
 				}
+				isScrolling = false;
 				container.removeEventListener( 'wheel', stopScroll );
 			}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -201,7 +201,7 @@
 			var targetPosition = Math.max(
 				0,
 				el.offsetTop -
-					Math.max( 0, window.innerHeight - ( extraInfoContentAreaHeight + 64 + 15 + 35 ) ) // Subtract footer height plus content area padding.
+					Math.max( 0, window.innerHeight - ( extraInfoContentAreaHeight + 64 + 35 + 35 ) ) // Subtract footer height plus content area padding.
 			);
 			var distance = targetPosition - container.scrollTop;
 			distance = Math.min( distance, container.scrollHeight - window.innerHeight );
@@ -225,6 +225,9 @@
 					callback();
 				}
 				isScrolling = false;
+				if ( extraInfoArea ) {
+					extraInfoArea.style.minHeight = '';
+				}
 				container.removeEventListener( 'wheel', stopScroll );
 			}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -201,6 +201,7 @@
 			// For iOS Safari compatibility, use JS to set the minimum height.
 			var infoArea = container.querySelector( '.jp-carousel-info-extra' );
 			if ( infoArea ) {
+				// 64px is the same height as `.jp-carousel-info-footer` in the CSS.
 				infoArea.style.minHeight = window.innerHeight - 64 + 'px';
 			}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -196,7 +196,7 @@
 
 			var isScrolling = true;
 			var startTime = Date.now();
-			var duration = 500;
+			var duration = 300;
 			var originalPosition = container.scrollTop;
 			var targetPosition = Math.max(
 				0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes: https://github.com/Automattic/jetpack/issues/20251

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The objective is to add JS-based smooth scroll for the icon buttons in the footer of the Carousel. This needs to be done in JS so that devices that don't support smooth scroll behaviour can still have it (e.g. iOS Safari), and so that on all devices (including desktop) we can scroll to top _before_ hiding the comments area, otherwise we effectively snap scroll to the top when the comments area is hidden.
* The scroll duration is currently set to 300ms.
* For the easing algorithm, I used the `easeInOutQuad` from https://easings.net/#easeInOutQuad — also happy to try one of the other easings if folks prefer an alternative.

#### Screenshots

Desktop:

https://user-images.githubusercontent.com/14988353/125039351-bb4f6600-e0d9-11eb-90ed-ce257d8d4a18.mp4

Mobile:

https://user-images.githubusercontent.com/14988353/125221207-3ea3ce00-e30b-11eb-882f-3d63b7e6e539.mov

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

There are much more complex polyfills and libraries we could use instead of this added function (e.g. https://github.com/iamdustan/smoothscroll), however to try to keep this lightweight, I thought I'd see if we can keep the function as simple as possible rather than pulling in anything extra.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With the Jetpack Carousel module switched on, add an image gallery to a post and view it on the front end of the site
* Open up the carousel.
* Click or tap on the buttons in the footer to slide out the extra footer area
* (NEW) On desktop, clicking the button again should smooth scroll the viewport back to the top and then hide the extra footer area
* On mobile (e.g. iOS Safari) there should now be smooth scrolling when showing/hiding the extra footer area where there was none before

I have tested this on desktop Safari, FF, Chrome, and Edge (on Mac), and on a real iOS device (iPhone 8, Safari + Chrome).

I'm curious if someone can test this on a real android device, and on any device see if we run into any edge cases or issues with this JS-based approach.
