### PR TITLE
Carousel: Prevent comments indicator from bumping icon width of comments button

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-comments-icon-jump-when-comments-loaded
+++ b/projects/plugins/jetpack/changelog/fix-carousel-comments-icon-jump-when-comments-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: Prevent comments indicator from bumping icon width of comments button.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -1,4 +1,4 @@
-/* 
+/*
  * Temporary fix below for issue introduced to Newspack blocks, can be removed once
  * once Newspack blocks includes this override
 */
@@ -1072,6 +1072,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	font-weight: 400;
 	font-style: normal;
 	border-radius: 4px;
+	width: 31px; /* Prevent comments indicator from changing icon width */
 	padding: 4px 3px 3px;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a specific width to the Carousel footer icons, to ensure that the presence of the comments indicator doesn't affect the width of the icon (and thereby affect the horizontal position of the button).

#### Screenshots

##### Before

https://user-images.githubusercontent.com/14988353/125237072-6fdec700-e328-11eb-8f58-33cd3109aeb6.mp4

##### After

https://user-images.githubusercontent.com/14988353/125237085-740ae480-e328-11eb-89c1-4c2cee109f9d.mp4

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a post containing an image gallery block, and with the Jetpack Carousel module switched on, open up the carousel on the front end of a site
* Add a comment to an image if there isn't one already, then scroll back and forth through the gallery, paying close attention to the position of the comments icon
* With this PR applied, the horizontal position of the comments icon should not move when the comments indicator number is displayed over the top
