### PR TITLE
Publicize: avoid PHP notices when $post isn't defined yet.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-php-notice-enhanced-opengraph
+++ b/projects/plugins/jetpack/changelog/fix-php-notice-enhanced-opengraph
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Publicize: avoid PHP notices in edge-cases where no info about a post can be found.

--- a/projects/plugins/jetpack/modules/publicize/enhanced-open-graph.php
+++ b/projects/plugins/jetpack/modules/publicize/enhanced-open-graph.php
@@ -17,7 +17,7 @@ function enhanced_og_image( $tags ) {
 	global $post;
 
 	// Bail if we do not have info about the post.
-	if ( empty( $post ) || ! is_a( $post, 'WP_Post' ) ) {
+	if ( ! $post instanceof WP_Post ) {
 		return $tags;
 	}
 
@@ -47,7 +47,7 @@ function enhanced_og_gallery( $tags ) {
 	global $post;
 
 	// Bail if we do not have info about the post.
-	if ( empty( $post ) || ! is_a( $post, 'WP_Post' ) ) {
+	if ( ! $post instanceof WP_Post ) {
 		return $tags;
 	}
 
@@ -86,7 +86,7 @@ function enhanced_og_video( $tags ) {
 	global $post;
 
 	// Bail if we do not have info about the post.
-	if ( empty( $post ) || ! is_a( $post, 'WP_Post' ) ) {
+	if ( ! $post instanceof WP_Post ) {
 		return $tags;
 	}
 

--- a/projects/plugins/jetpack/modules/publicize/enhanced-open-graph.php
+++ b/projects/plugins/jetpack/modules/publicize/enhanced-open-graph.php
@@ -16,6 +16,11 @@ function enhanced_og_image( $tags ) {
 
 	global $post;
 
+	// Bail if we do not have info about the post.
+	if ( empty( $post ) || ! is_a( $post, 'WP_Post' ) ) {
+		return $tags;
+	}
+
 	// Always favor featured images.
 	if ( enhanced_og_has_featured_image( $post->ID ) )
 		return $tags;
@@ -40,6 +45,11 @@ function enhanced_og_gallery( $tags ) {
 		return $tags;
 
 	global $post;
+
+	// Bail if we do not have info about the post.
+	if ( empty( $post ) || ! is_a( $post, 'WP_Post' ) ) {
+		return $tags;
+	}
 
 	// Always favor featured images.
 	if ( enhanced_og_has_featured_image( $post->ID ) )
@@ -74,6 +84,11 @@ function enhanced_og_video( $tags ) {
 		return $tags;
 
 	global $post;
+
+	// Bail if we do not have info about the post.
+	if ( empty( $post ) || ! is_a( $post, 'WP_Post' ) ) {
+		return $tags;
+	}
 
 	// Always favor featured images.
 	if ( enhanced_og_has_featured_image( $post->ID ) )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix PHP notices where no $post information is available.

The notices are visible on WordCamp sites.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

Not sure to be honest. I wasn't able to reproduce the notice on my own site.
