### PR TITLE
linting: Do pnpm install in Jetpack E2E dir before eslint

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -453,7 +453,11 @@ jobs:
           which jq
           jq --version
 
-      - run: pnpm install
+      - name: Monorepo pnpm install
+        run: pnpm install
+      - name: Jetpack E2E tests pnpm install
+        working-directory: projects/plugins/jetpack/tests/e2e
+        run: pnpm install
       - run: pnpx jetpack install --all -v # Ensure there are no unresolved import errors.
       - run: pnpm run lint-required
 
@@ -533,7 +537,11 @@ jobs:
           which jq
           jq --version
 
-      - run: pnpm install
+      - name: Monorepo pnpm install
+        run: pnpm install
+      - name: Jetpack E2E tests pnpm install
+        working-directory: projects/plugins/jetpack/tests/e2e
+        run: pnpm install
       - run: pnpx jetpack install --all -v # Ensure there are no unresolved import errors.
       - name: Run eslint-changed
         env:
@@ -665,7 +673,11 @@ jobs:
           jq --version
 
       - run: composer install
-      - run: pnpm install
+      - name: Monorepo pnpm install
+        run: pnpm install
+      - name: Jetpack E2E tests pnpm install
+        working-directory: projects/plugins/jetpack/tests/e2e
+        run: pnpm install
       - run: pnpx jetpack install --all -v # Ensure there are no unresolved import errors.
 
       - name: Cleanup excludelists


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We don't include that as part of the workspace so normal development
doesn't need to install all of playwright and so on. But that also means
the root-level `pnpm install` doesn't process it, which can make eslint
be unable to resolve imports.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Came up in code review on #20326

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this, then have renovate regenerate #19328, then rebase #20326. See if that fixes the "Linting / ESLint (non-excluded files only)" job.
