### PR TITLE
Fix/allow check for single connected user

### DIFF
--- a/projects/packages/connection/changelog/fix-allow-check-for-single-connected-user
+++ b/projects/packages/connection/changelog/fix-allow-check-for-single-connected-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added second parameter to Tokens::get_connected_users to allow any connected user to be returned.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -567,7 +567,7 @@ class Manager {
 	 * @return bool
 	 */
 	public function has_connected_user() {
-		return (bool) count( $this->get_tokens()->get_connected_users( 'any', true ) );
+		return (bool) count( $this->get_tokens()->get_connected_users( 'any', 1 ) );
 	}
 
 	/**

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -567,18 +567,21 @@ class Manager {
 	 * @return bool
 	 */
 	public function has_connected_user() {
-		return (bool) count( $this->get_tokens()->get_connected_users( 'any', 1 ) );
+		return (bool) count( $this->get_connected_users( 'any', 1 ) );
 	}
 
 	/**
 	 * Returns an array of user_id's that have user tokens for communicating with wpcom.
 	 * Able to select by specific capability.
 	 *
-	 * @param string $capability The capability of the user.
+	 * @since 9.9.1 Added $limit parameter.
+	 *
+	 * @param string   $capability The capability of the user.
+	 * @param int|null $limit How many connected users to get before returning.
 	 * @return array Array of WP_User objects if found.
 	 */
-	public function get_connected_users( $capability = 'any' ) {
-		return $this->get_tokens()->get_connected_users( $capability );
+	public function get_connected_users( $capability = 'any', $limit = null ) {
+		return $this->get_tokens()->get_connected_users( $capability, $limit );
 	}
 
 	/**

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -567,7 +567,7 @@ class Manager {
 	 * @return bool
 	 */
 	public function has_connected_user() {
-		return (bool) count( $this->get_connected_users() );
+		return (bool) count( $this->get_tokens()->get_connected_users( 'any', true ) );
 	}
 
 	/**

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -498,8 +498,8 @@ class Tokens {
 	 * Returns an array of user_id's that have user tokens for communicating with wpcom.
 	 * Able to select by specific capability.
 	 *
-	 * @param string $capability The capability of the user.
-	 * @param int|null   $limit How many connected users to get before returning. 
+	 * @param string   $capability The capability of the user.
+	 * @param int|null $limit How many connected users to get before returning.
 	 * @return array Array of WP_User objects if found.
 	 */
 	public function get_connected_users( $capability = 'any', $limit = null ) {

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -499,9 +499,10 @@ class Tokens {
 	 * Able to select by specific capability.
 	 *
 	 * @param string $capability The capability of the user.
+	 * @param bool $is_any_user_connected Set to true to return when a single connected user is found
 	 * @return array Array of WP_User objects if found.
 	 */
-	public function get_connected_users( $capability = 'any' ) {
+	public function get_connected_users( $capability = 'any', $is_any_user_connected = false ) {
 		$connected_users = array();
 		$user_tokens     = Jetpack_Options::get_option( 'user_tokens' );
 
@@ -520,6 +521,9 @@ class Tokens {
 				$user_data = get_userdata( $id );
 				if ( $user_data instanceof \WP_User ) {
 					$connected_users[] = $user_data;
+					if ( $is_any_user_connected ) {
+						return $connected_users;
+					}
 				}
 			}
 		}

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -499,7 +499,7 @@ class Tokens {
 	 * Able to select by specific capability.
 	 *
 	 * @param string $capability The capability of the user.
-	 * @param bool $is_any_user_connected Set to true to return when a single connected user is found
+	 * @param bool   $is_any_user_connected Set to true to return when a single connected user is found.
 	 * @return array Array of WP_User objects if found.
 	 */
 	public function get_connected_users( $capability = 'any', $is_any_user_connected = false ) {

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -498,6 +498,8 @@ class Tokens {
 	 * Returns an array of user_id's that have user tokens for communicating with wpcom.
 	 * Able to select by specific capability.
 	 *
+	 * @since 9.9.1 Added $limit parameter.
+	 *
 	 * @param string   $capability The capability of the user.
 	 * @param int|null $limit How many connected users to get before returning.
 	 * @return array Array of WP_User objects if found.

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -499,10 +499,10 @@ class Tokens {
 	 * Able to select by specific capability.
 	 *
 	 * @param string $capability The capability of the user.
-	 * @param bool   $is_any_user_connected Set to true to return when a single connected user is found.
+	 * @param int|null   $limit How many connected users to get before returning. 
 	 * @return array Array of WP_User objects if found.
 	 */
-	public function get_connected_users( $capability = 'any', $is_any_user_connected = false ) {
+	public function get_connected_users( $capability = 'any', $limit = null ) {
 		$connected_users = array();
 		$user_tokens     = Jetpack_Options::get_option( 'user_tokens' );
 
@@ -521,7 +521,7 @@ class Tokens {
 				$user_data = get_userdata( $id );
 				if ( $user_data instanceof \WP_User ) {
 					$connected_users[] = $user_data;
-					if ( $is_any_user_connected ) {
+					if ( $limit && count( $connected_users ) >= $limit ) {
 						return $connected_users;
 					}
 				}

--- a/projects/packages/connection/tests/php/test_Manager_integration.php
+++ b/projects/packages/connection/tests/php/test_Manager_integration.php
@@ -104,9 +104,11 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 
 		$all_users = $this->manager->get_connected_users();
 		$admins    = $this->manager->get_connected_users( 'manage_options' );
+		$limited   = $this->manager->get_connected_users( 'any', 1 );
 
 		$this->assertCount( 2, $all_users );
 		$this->assertCount( 1, $admins );
+		$this->assertCount( 1, $limited );
 		$this->assertSame( $id_admin, $admins[0]->ID );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

### Description
Fixes 6755-gh-Automattic/jpop-issues

Methods such as Manager->has_connected_user() doesn't need to loop through and check all connected Jetpack users from Tokens->get_connected_users().

By adding this second param, the $connected_users param will return once a single connected user was found and validated, allowing the foreach loop to close early.

When a larger site has over 100 users and has memcache enabled, this loop was causing an additional 200 memcache GET calls per request.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add second param to Tokens::get_connected_users
* Use this method with second param set to true in Manager::has_connected_user

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Issue created here: 
> 6755-gh-Automattic/jpop-issues

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Can run existing test_Manager_integration test.
* Specifically the method: `test_has_connected_user_and_has_connected_admin()`