### PR TITLE
Backup Plugin: Reorganize Admin.js to facilitate integration

### DIFF
--- a/projects/plugins/backup/changelog/reorganize-admin-js
+++ b/projects/plugins/backup/changelog/reorganize-admin-js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reorganized Admin.js to facilitate integration

--- a/projects/plugins/backup/src/js/components/Admin.js
+++ b/projects/plugins/backup/src/js/components/Admin.js
@@ -85,11 +85,34 @@ const Admin = () => {
 		return <div>No Backup Capabilities</div>;
 	};
 
-	return (
-		<div id="jetpack-backup-admin-container" className="jp-content">
+	const renderHeader = () => {
+		// TODO: Integrate Jetpack Header
+		return (
 			<div className="jp-header">
 				<h1>Jetpack Backup Plugin - Placeholder Header</h1>
 			</div>
+		);
+	};
+
+	const renderFooter = () => {
+		// TODO: Integrate Jetpack Footer
+		return <div className="jp-footer">Jetpack Backup 1.0 - Placeholder Footer</div>;
+	};
+
+	const renderManageConnection = () => {
+		// TODO: Integrate connection management from Connection Package
+		return (
+			<Fragment>
+				<h2>{ __( 'Manage your connection', 'jetpack-backup' ) }</h2>
+				<p className="notice notice-success">
+					{ __( 'Site and User Connected.', 'jetpack-backup' ) }
+				</p>
+			</Fragment>
+		);
+	};
+
+	const renderContent = () => {
+		return (
 			<div className="content">
 				<div>
 					<div className="jp-hero">{ renderLoadedState() }</div>
@@ -143,25 +166,29 @@ const Admin = () => {
 									</p>
 								</div>
 							</div>
-							<div className="jp-row">
-								<div class="lg-col-span-6 md-col-span-4 sm-col-span-4"></div>
-								<div class="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
-								<div class="lg-col-span-5 md-col-span-3 sm-col-span-4">
-									{ /* This should be replaced by "Manage Connection" Block from Connection Package */ }
-									{ connectionLoaded &&
-										connectionStatus.isUserConnected &&
-										connectionStatus.isRegistered && (
-											<p className="notice notice-success">
-												{ __( 'Site and User Connected.', 'jetpack-backup' ) }
-											</p>
-										) }
-								</div>
-							</div>
+							{ connectionLoaded &&
+								connectionStatus.isUserConnected &&
+								connectionStatus.isRegistered && (
+									<div className="jp-row">
+										<div class="lg-col-span-6 md-col-span-4 sm-col-span-4"></div>
+										<div class="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
+										<div class="lg-col-span-5 md-col-span-3 sm-col-span-4">
+											{ renderManageConnection() }
+										</div>
+									</div>
+								) }
 						</div>
 					</div>
 				</div>
 			</div>
-			<div className="jp-footer">Jetpack Backup 1.0 - Placeholder Footer</div>
+		);
+	};
+
+	return (
+		<div id="jetpack-backup-admin-container" className="jp-content">
+			{ renderHeader() }
+			{ renderContent() }
+			{ renderFooter() }
 		</div>
 	);
 };

--- a/projects/plugins/backup/src/js/components/Backups.js
+++ b/projects/plugins/backup/src/js/components/Backups.js
@@ -65,14 +65,14 @@ const Backups = () => {
 						return;
 					}
 
-					if ( 'finished' === backup.status ) {
+					if ( 'finished' === backup.status && backup.stats ) {
 						latestBackup = backup;
 						setBackupState( BACKUP_STATE.COMPLETE );
 					}
 				} );
 
 				// Only the first backup can be in progress.
-				if ( 0 === res.length && 'started' === res[ 0 ].status ) {
+				if ( null === latestBackup && 'started' === res[ 0 ].status ) {
 					latestBackup = res[ 0 ];
 					setBackupState( BACKUP_STATE.IN_PROGRESS );
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* A minor change to the way the backups array is parsed to handle a case where backups are deleted but still appear in the activity log.  This is a very rare case in the wild GDPR mostly, but is useful for testing sites without backups.
* Reorganized the Admin.js to make it more obvious where we'll integrate the Manage Connection, Header and Footer segments.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Install plugin and ensure placeholder header / footer / manage connection blocks continue to appear in their designated spaces.