### PR TITLE
Restrict correlated subquery to term_taxonomy joins only

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-checksum-performance
+++ b/projects/packages/sync/changelog/fix-sync-checksum-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Performance of Sync checksums degraded with the update to correlated subquery. This restricts its usage to term_taxonomy joins only."


### PR DESCRIPTION
Monitoring the checksum performance post the 9.9 release we noticed a 50% reduction in performance. Checksums taking 40 seconds on average instead of 20 seconds. To address the performance decrease we are restricting the correlated subquery to the taxonomy table as other joins are on the primary and won't have the same issue.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Restricted correlated subquery to term_taxonomy joins.


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* NO

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Apply Patch to your Jetpack Site / Checkout branch in beta tester
- Access the JP Debug tool for your site
- Click "Schedule Fix" from Sync Validation panel
- Wait for the fix to complete
- Click "Schedule Checksum" from Sync Validation panel
- Verify that terms align and that other tables align as well.

Alternatively from a WP.com sandbox you can run

- switch_to_blog( --BLOG_ID-- );
- $validator = new Jetpack_Sync_Validator( get_current_blog_id() );
- $validator->perform_cache_site_audit( null, true );
