### PR TITLE
Fixes broken comments with social login

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-comments-break-social-login
+++ b/projects/plugins/jetpack/changelog/fix-comments-break-social-login
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Comments: fix subsequent commenting when using a social profile.

--- a/projects/plugins/jetpack/modules/comments/base.php
+++ b/projects/plugins/jetpack/modules/comments/base.php
@@ -195,6 +195,7 @@ class Highlander_Comments_Base {
 		}
 
 		add_filter( 'pre_option_comment_registration', '__return_zero' );
+		add_filter( 'pre_option_require_name_email', '__return_zero' );
 	}
 
 	/**


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Commenting on a post after a social login is broken, if the user tries to post comments after their first comment. After connecting a social profile, the first comment is correctly published. But from the second comment onwards, the user will see an error on the page after posting a comment, preventing them from posting any further comments. Here's an example:

![CommentTwbug](https://user-images.githubusercontent.com/1269602/125424009-9fbbec60-eca2-4621-a7b4-af89328fd7e5.gif)

To reproduce this issue, try the following steps:

1. Go to any public Jetpack blog and comment on an article after connecting via Twitter or Facebook.
2. After the page reloads, either on the same article or any other article on the same site, post a comment and see the error message shown in the GIF above.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pd2HMz-27-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. On a JP connected site, enable commenting with social options by enabling the following option in WP.com in https://wordpress.com/settings/discussion/:

<img width="769" alt="Screenshot 2021-07-13 at 1 16 21 PM" src="https://user-images.githubusercontent.com/1269602/125426020-d22e73ec-b4a9-4aaf-962e-2699149c5c6e.png">

2. Visit any public blog article on that JP connected site.
2. Comment on that article by connecting a social profile like Twitter or FB
3. Now, after the page loads with the comment posted successfully, post a second comment on the same article or any other article in the site.
4. Ensure that the subsequent comments are posted successfully.
