### PR TITLE
OpenTable Block: Fix the min width on small widths so it fits on small width viewports.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-open-table-block-widget
+++ b/projects/plugins/jetpack/changelog/fix-open-table-block-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix Opentable block input width when used in block editor.

--- a/projects/plugins/jetpack/extensions/blocks/opentable/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/editor.scss
@@ -41,9 +41,7 @@
 			.components-form-token-field__input-container {
 				width: 100%;
 				@media screen and ( min-width: 480px ) {
-					width: 327px;
-
-					input[type=text].components-form-token-field__input {
+					input[type='text'].components-form-token-field__input {
 						min-height: 32px;
 					}
 				}
@@ -137,7 +135,7 @@
 	}
 }
 
-.wp-block[data-type="jetpack/opentable"] {
+.wp-block[data-type='jetpack/opentable'] {
 	.components-notice__content {
 		text-align: left;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/19979

| Before        | After           |
| ------------- |:-------------:| 
|  <img width="371" alt="Screen Shot 2021-07-13 at 1 30 48 PM" src="https://user-images.githubusercontent.com/1464705/125520613-685157a1-3e71-4406-b3a8-5036d163cde7.png"> | <img width="359" alt="Screen Shot 2021-07-13 at 1 26 10 PM" src="https://user-images.githubusercontent.com/1464705/125520540-ee16a6e9-db3e-4859-87ef-f5c966bde686.png">  |

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Don't set a min width on small viewports for the input field, because this breaks very small width viewports. Just use the percentage width.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the widget editor in the customizer in WP 5.8
* Insert an Open Table block
* Confirm that the width of the form is correct.
