### PR TITLE
Carousel: CSS tweaks to ensure WPCOM compatibility

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-css-tweaks
+++ b/projects/plugins/jetpack/changelog/update-carousel-css-tweaks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Carousel CSS tweaks to ensure text and comment loader spinners dislay correctly in dark and light theme views.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -807,7 +807,6 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 #jp-carousel-comment-form-container {
 	margin-bottom: 15px;
-	overflow: auto;
 	width: 100%;
 	margin-top: 20px;
 	color: #999;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -1043,6 +1043,13 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	opacity: 0.5;
 }
 
+.jp-carousel-light #jp-carousel-comment-form-spinner {
+	border-top: 4px solid rgba( 0, 0, 0, 0.2 );
+	border-right: 4px solid rgba( 0, 0, 0, 0.2 );
+	border-bottom: 4px solid rgba( 0, 0, 0, 0.2 );
+	border-left: 4px solid #000000;
+}
+
 /** Icons Start **/
 .jp-carousel-photo-icons-container {
 	flex: 1;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -796,6 +796,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	border-radius: 3px;
 	padding: 8px 16px;
 	font-size: 14px;
+	color: white;
 }
 
 #jp-carousel-comment-form-button-submit:active,
@@ -811,6 +812,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	margin-top: 20px;
 	color: #999;
 	position: relative;
+	overflow: hidden;
 }
 
 #jp-carousel-comment-post-results {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -708,7 +708,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	-webkit-animation: load8 1.1s infinite linear;
 	animation: load8 1.1s infinite linear;
 	margin: 0 auto;
-	top: 40%;
+	top: calc( 50% - 15px );
 	left: 0;
 	bottom: 0;
 	right: 0;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -102,13 +102,13 @@ so we have to target all affected elements in touch devices.
 }
 
 .jp-carousel-overlay .swiper-container .swiper-button-prev {
-	right: 0;
-	left: auto;
+	left: 0;
+	right: auto;
 }
 
 .jp-carousel-overlay .swiper-container .swiper-button-next {
-	left: 0;
-	right: auto;
+	right: 0;
+	left: auto;
 }
 
 .jp-carousel-overlay .swiper-container.swiper-container-rtl .swiper-button-prev,

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -10,6 +10,10 @@
 .swiper-container-rtl .swiper-button-prev:after {
 	content: none;
 }
+.jp-carousel-overlay .swiper-button-prev, .jp-carousel-overlay .swiper-container-rtl .swiper-button-next,
+.jp-carousel-overlay .swiper-button-next, .jp-carousel-overlay .swiper-container-rtl .swiper-button-prev {
+	background-image: none;
+}
 /* end of temporary fix */
 
 [data-carousel-extra]:not( .jp-carousel-wrap ) {
@@ -98,11 +102,13 @@ so we have to target all affected elements in touch devices.
 }
 
 .jp-carousel-overlay .swiper-container .swiper-button-prev {
-	left: 0;
+	right: 0;
+	left: auto;
 }
 
 .jp-carousel-overlay .swiper-container .swiper-button-next {
-	right: 0;
+	left: 0;
+	right: auto;
 }
 
 .jp-carousel-overlay .swiper-container.swiper-container-rtl .swiper-button-prev,

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -327,13 +327,13 @@ class Jetpack_Carousel {
 			 */
 			$localize_strings = apply_filters( 'jp_carousel_localize_strings', $localize_strings );
 			wp_localize_script( 'jetpack-carousel', 'jetpackCarouselStrings', $localize_strings );
-			wp_enqueue_style( 'jetpack-carousel', plugins_url( 'jetpack-carousel.css', __FILE__ ), array(), $this->asset_version( JETPACK__VERSION ) );
 			wp_enqueue_style(
 				'jetpack-carousel-swiper-css',
 				plugins_url( 'swiper-bundle.css', __FILE__ ),
 				array(),
 				$this->asset_version( JETPACK__VERSION )
 			);
+			wp_enqueue_style( 'jetpack-carousel', plugins_url( 'jetpack-carousel.css', __FILE__ ), array(), $this->asset_version( JETPACK__VERSION ) );
 			wp_style_add_data( 'jetpack-carousel', 'rtl', 'replace' );
 
 			/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While testing D63016-code, we noticed a couple of minor UI irregularities:

**1. Font color is missing on the default post comment button**
<img width="905" alt="Screen Shot 2021-07-14 at 9 13 52 am" src="https://user-images.githubusercontent.com/6458278/125541876-8f45ae45-a4bc-43e3-9f77-aefbd1a1ecdf.png">

**2. The comment loading spinner border flows over the comment container**

![comment-overflow](https://user-images.githubusercontent.com/6458278/125541883-a75e8c7b-910c-490a-9903-0a145f2944f6.gif)

**3. The comment loading spinner isn't visible in the light theme**

This PR addresses these issues.

ℹ️  **The changes in this PR have been migrated to D63016-code**

#### Does this pull request change what data or activity we track or use?
Nup.

#### Testing instructions:
1. Check that the comment button displays correctly in both dark and light carousel views
2. Submit a comment and ensure the spinner border doesn't overflow. Check in both light and dark themes that the spinner displays correctly.
3.  Add a newspack post carousel to the same page as the gallery and make sure that the next and previous buttons look correct on both ltr and rtl languages.


![light-theme-comment-spinner](https://user-images.githubusercontent.com/6458278/125542455-e3fc8456-35e1-4798-bfa8-67acc56e582b.gif)

