### PR TITLE
Fix/nav unification disable function

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nav-unification-disable-function
+++ b/projects/plugins/jetpack/changelog/fix-nav-unification-disable-function
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed the condition that disables Nav-unification when SSO is disabled and the admin-menu class is overriden in jetpack_admin_menu_class filter.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -22,12 +22,12 @@ function should_customize_nav( $admin_menu_class ) {
 	$is_api_request = defined( 'REST_REQUEST' ) && REST_REQUEST || 0 === strpos( $_SERVER['REQUEST_URI'], '/?rest_route=%2Fwpcom%2Fv2%2Fadmin-menu' );
 
 	// No nav customizations on WP Admin of Atomic sites when SSO is disabled.
-	if ( is_subclass_of( $admin_menu_class, Atomic_Admin_Menu::class ) && ! $is_api_request && ! \Jetpack::is_module_active( 'sso' ) ) {
+	if ( is_a( $admin_menu_class, Atomic_Admin_Menu::class, true ) && ! $is_api_request && ! \Jetpack::is_module_active( 'sso' ) ) {
 		return false;
 	}
 
 	// No nav customizations on WP Admin of Jetpack sites.
-	if ( is_subclass_of( $admin_menu_class, Jetpack_Admin_Menu::class ) && ! $is_api_request ) {
+	if ( is_a( $admin_menu_class, Jetpack_Admin_Menu::class, true ) && ! $is_api_request ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -22,12 +22,12 @@ function should_customize_nav( $admin_menu_class ) {
 	$is_api_request = defined( 'REST_REQUEST' ) && REST_REQUEST || 0 === strpos( $_SERVER['REQUEST_URI'], '/?rest_route=%2Fwpcom%2Fv2%2Fadmin-menu' );
 
 	// No nav customizations on WP Admin of Atomic sites when SSO is disabled.
-	if ( Atomic_Admin_Menu::class === $admin_menu_class && ! $is_api_request && ! \Jetpack::is_module_active( 'sso' ) ) {
+	if ( is_subclass_of( $admin_menu_class, Atomic_Admin_Menu::class ) && ! $is_api_request && ! \Jetpack::is_module_active( 'sso' ) ) {
 		return false;
 	}
 
 	// No nav customizations on WP Admin of Jetpack sites.
-	if ( Jetpack_Admin_Menu::class === $admin_menu_class && ! $is_api_request ) {
+	if ( is_subclass_of( $admin_menu_class, Jetpack_Admin_Menu::class ) && ! $is_api_request ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/54544

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make sure that when we override the admin-menu class we are checking if the new class is a subclass of Atomic_Admin_Menu. Otherwise, nav-unification will not be disabled when Jetpack SSO is disabled.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Atomic
* Use Jetpack Beta and switch to this branch.
* Go to WP-Admin > Jetpack > Dashboard > Settings and disable SSO (WordPress Login)
* Make sure that the Core menu is loaded instead of Nav-unification