### PR TITLE
RNA Connection: hide connection screen while loading the status

### DIFF
--- a/projects/js-packages/connection/changelog/fix-rna-connection-screen-loading
+++ b/projects/js-packages/connection/changelog/fix-rna-connection-screen-loading
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Hide the connection screen while connection status is loading.
+
+

--- a/projects/js-packages/connection/components/connect-screen/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import { JetpackLogo, getRedirectUrl } from '@automattic/jetpack-components';
@@ -46,10 +46,25 @@ const ConnectScreen = props => {
 
 	const showImageSlider = images.length && assetBaseUrl;
 
+	const [ connectionStatus, setConnectionStatus ] = useState( {} );
+
+	const statusHandler = useCallback(
+		status => {
+			setConnectionStatus( status );
+
+			if ( statusCallback && {}.toString.call( statusCallback ) === '[object Function]' ) {
+				return statusCallback( status );
+			}
+		},
+		[ statusCallback, setConnectionStatus ]
+	);
+
 	return (
 		<div
 			className={
-				'jp-connect-screen' + ( showImageSlider ? ' jp-connect-screen--two-columns' : '' )
+				'jp-connect-screen' +
+				( showImageSlider ? ' jp-connect-screen--two-columns' : '' ) +
+				( connectionStatus.hasOwnProperty( 'isRegistered' ) ? '' : ' jp-connect-screen--loading' )
 			}
 		>
 			<div className="jp-connect-screen--left">
@@ -65,7 +80,7 @@ const ConnectScreen = props => {
 					registrationNonce={ registrationNonce }
 					from={ from }
 					redirectUri={ redirectUri }
-					statusCallback={ statusCallback }
+					statusCallback={ statusHandler }
 					connectLabel={ __( 'Set up Jetpack', 'jetpack' ) }
 				/>
 

--- a/projects/js-packages/connection/components/connect-screen/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/style.scss
@@ -4,6 +4,10 @@
 	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 	border-radius: 4px;
 
+	&.jp-connect-screen--loading {
+		display: none;
+	}
+
 	.jp-connect-screen--left, .jp-connect-screen--right {
 		box-sizing: border-box;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* hide connection screen while loading the connection status

#### Jetpack product discussion
Related to #20167

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
_If you're using a JN site, you need to install [this plugin](https://gist.github.com/sergeymitr/bc005e1b893e778c03e4f43debb91c30) to activate the Connection Manager page._

1. Disconnect Jetpack.
2. Go to "Tools -> Connection Manager".
3. Fully connect, you should be taken back to the Connection Manager.
4. Reload the Connection Manager page. Confirm that the page is empty, then the line "Site and User Connected" appears. The connection screen layout should not appear even for a moment while the page is loading if the connection is fully established.