### PR TITLE
WordPress.com Block Editor: do not use in the upcoming Block-based Widgets Editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-widget-wpcom-block-editor
+++ b/projects/plugins/jetpack/changelog/fix-widget-wpcom-block-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WordPress.com Block Editor: do not use in the upcoming Block-based Widgets Editor

--- a/projects/plugins/jetpack/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/projects/plugins/jetpack/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -304,6 +304,13 @@ class Jetpack_WPCOM_Block_Editor {
 	 * Enqueues the WordPress.com block editor integration assets for the editor.
 	 */
 	public function enqueue_block_editor_assets() {
+		global $pagenow;
+
+		// Bail if we're not in the post editor, but on the widget settings screen.
+		if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
+			return;
+		}
+
 		$debug   = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 		$version = gmdate( 'Ymd' );
 


### PR DESCRIPTION
Related: #20357

#### Changes proposed in this Pull Request:

Since the WordPress.com Block editor relies on wp-editor, and since that dependency cannot be used in the widget editor (see https://core.trac.wordpress.org/changeset/51393 ), let's not load the WordPress.com editor scripts in the widget editor.

#### Jetpack product discussion

* Primary issue: #20357

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a site where Jetpack is connected to WordPress.com and where you are running WordPress 5.8 RC.
* Go to Appearance > Widgets.
* The `wpcom-block-editor` scripts should not be enqueued.
