### PR TITLE
My Plan: Recognize and display details for new Backup, Security plans

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -418,7 +418,9 @@ class MyPlanBody extends React.Component {
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Activity', 'jetpack' ) }</h3>
+								<h3 className="jp-landing__plan-features-title">
+									{ __( 'Site activity', 'jetpack' ) }
+								</h3>
 								<p>
 									{ __(
 										'View a chronological list of all the changes and updates to your site in an organized, readable way.',

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -80,9 +80,14 @@ class MyPlanBody extends React.Component {
 			[
 				'is-premium-plan',
 				'is-business-plan',
+				'is-security-plan',
+				'is-security-pro-plan',
+				'is-complete-plan',
+
+				// DEPRECATED: Daily and Real-time variations are no longer sold.
+				// Remove after all customers are migrated to new products.
 				'is-daily-security-plan',
 				'is-realtime-security-plan',
-				'is-complete-plan',
 			],
 			planClass
 		);
@@ -217,6 +222,9 @@ class MyPlanBody extends React.Component {
 		};
 
 		let jetpackBackupCard;
+
+		// DEPRECATED: Daily and Real-time variations are no longer sold.
+		// Remove after all customers are migrated to new products.
 		if ( 'is-daily-backup-plan' === planClass ) {
 			jetpackBackupCard = getJetpackBackupCard( {
 				title: __( 'Automated Daily Backups', 'jetpack' ),
@@ -227,7 +235,16 @@ class MyPlanBody extends React.Component {
 			} );
 		}
 
-		if ( 'is-realtime-backup-plan' === planClass ) {
+		if (
+			[
+				'is-backup-plan',
+				'is-backup-pro-plan',
+
+				// DEPRECATED: Daily and Real-time variations are no longer sold.
+				// Remove after all customers are migrated to new products.
+				'is-realtime-backup-plan',
+			].includes( planClass )
+		) {
 			jetpackBackupCard = getJetpackBackupCard( {
 				title: __( 'Automated Real-time Backups', 'jetpack' ),
 				description: __(
@@ -271,10 +288,14 @@ class MyPlanBody extends React.Component {
 		switch ( planClass ) {
 			case 'is-personal-plan':
 			case 'is-premium-plan':
-			case 'is-daily-security-plan':
-			case 'is-realtime-security-plan':
+			case 'is-security-plan':
+			case 'is-security-pro-plan':
 			case 'is-business-plan':
 			case 'is-complete-plan':
+			// DEPRECATED: Daily and Real-time variations are no longer sold.
+			// Remove after all customers are migrated to new products.
+			case 'is-daily-security-plan':
+			case 'is-realtime-security-plan':
 				planCard = (
 					<div className="jp-landing__plan-features">
 						{ 'is-personal-plan' === planClass && getRewindVaultPressCard() }
@@ -541,10 +562,14 @@ class MyPlanBody extends React.Component {
 				break;
 
 			case 'is-free-plan':
-			case 'is-daily-backup-plan':
-			case 'is-realtime-backup-plan':
+			case 'is-backup-plan':
+			case 'is-backup-pro-plan':
 			case 'is-search-plan':
 			case 'offline':
+			// DEPRECATED: Daily and Real-time variations are no longer sold.
+			// Remove after all customers are migrated to new products.
+			case 'is-daily-backup-plan':
+			case 'is-realtime-backup-plan':
 				planCard = (
 					<div className="jp-landing__plan-features">
 						{ jetpackBackupCard }

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -115,7 +115,7 @@ class MyPlanBody extends React.Component {
 							onClick={ this.handleButtonClickForTracking( 'view_backup_dash' ) }
 							href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
 						>
-							{ __( 'View Your Backups', 'jetpack' ) }
+							{ __( 'View your backups', 'jetpack' ) }
 						</Button>
 					</div>
 				</div>
@@ -139,7 +139,7 @@ class MyPlanBody extends React.Component {
 						</div>
 						<div className="jp-landing__plan-features-text">
 							<h3 className="jp-landing__plan-features-title">
-								{ __( 'Site Backups', 'jetpack' ) }
+								{ __( 'Site backups', 'jetpack' ) }
 							</h3>
 							<p>
 								{ __(
@@ -194,7 +194,7 @@ class MyPlanBody extends React.Component {
 					</div>
 					<div className="jp-landing__plan-features-text">
 						<h3 className="jp-landing__plan-features-title">
-							{ __( 'Site Security', 'jetpack' ) }
+							{ __( 'Site security', 'jetpack' ) }
 						</h3>
 						<p>{ description + __( ' (powered by VaultPress).', 'jetpack' ) }</p>
 						{ this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) &&
@@ -246,7 +246,7 @@ class MyPlanBody extends React.Component {
 			].includes( planClass )
 		) {
 			jetpackBackupCard = getJetpackBackupCard( {
-				title: __( 'Automated Real-time Backups', 'jetpack' ),
+				title: __( 'Automated real-time backups', 'jetpack' ),
 				description: __(
 					'We back up your website with every change you make, making it easy to fix your mistakes.',
 					'jetpack'
@@ -379,7 +379,7 @@ class MyPlanBody extends React.Component {
 									</div>
 									<div className="jp-landing__plan-features-text">
 										<h3 className="jp-landing__plan-features-title">
-											{ __( 'Video Hosting', 'jetpack' ) }
+											{ __( 'Video hosting', 'jetpack' ) }
 										</h3>
 										<p>
 											{ __(
@@ -529,7 +529,7 @@ class MyPlanBody extends React.Component {
 								</div>
 								<div className="jp-landing__plan-features-text">
 									<h3 className="jp-landing__plan-features-title">
-										{ __( 'Marketing Automation', 'jetpack' ) }
+										{ __( 'Marketing automation', 'jetpack' ) }
 									</h3>
 									<p>
 										{ __(

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -10,7 +10,7 @@ import { find, isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -30,6 +30,9 @@ import {
 } from 'state/initial-state';
 import License from './license';
 import MyPlanCard from '../my-plan-card';
+
+const BACKUP_STORAGE_GB = 200;
+const BACKUP_PRO_STORAGE_TB = 2;
 
 class MyPlanHeader extends React.Component {
 	getProductProps( productSlug ) {
@@ -134,11 +137,32 @@ class MyPlanHeader extends React.Component {
 				};
 
 			case 'is-backup-plan':
+				return {
+					...productProps,
+					details: expiration,
+					tagLine: sprintf(
+						/* translators: %1$d is the number of gigabytes of storage space the the site has. */
+						__(
+							'Your data is being securely backed up as you edit. You have %1$dGB of storage space.',
+							'jetpack'
+						),
+						BACKUP_STORAGE_GB
+					),
+					title: __( 'Jetpack Backup', 'jetpack' ),
+				};
+
 			case 'is-backup-pro-plan':
 				return {
 					...productProps,
 					details: expiration,
-					tagLine: __( 'Your data is being securely backed up as you edit.', 'jetpack' ),
+					tagLine: sprintf(
+						/* translators: %1$d is the number of terabytes of storage space the the site has. */
+						__(
+							'Your data is being securely backed up as you edit. You have %1$dTB of storage space.',
+							'jetpack'
+						),
+						BACKUP_PRO_STORAGE_TB
+					),
 					title: __( 'Jetpack Backup', 'jetpack' ),
 				};
 

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -113,26 +113,13 @@ class MyPlanHeader extends React.Component {
 					title: __( 'Jetpack Professional', 'jetpack' ),
 				};
 
-			case 'is-daily-security-plan':
+			case 'is-security-plan':
+			case 'is-security-pro-plan':
 				return {
 					...productProps,
 					details: expiration,
-					tagLine: __(
-						'Enjoy the peace of mind of complete site protection. Great for brochure sites, restaurants, blogs, and resume sites.',
-						'jetpack'
-					),
-					title: __( 'Jetpack Security Daily', 'jetpack' ),
-				};
-
-			case 'is-realtime-security-plan':
-				return {
-					...productProps,
-					details: expiration,
-					tagLine: __(
-						'Additional security for sites with 24/7 activity. Recommended for eCommerce stores, news organizations, and online forums.',
-						'jetpack'
-					),
-					title: __( 'Jetpack Security Real-Time', 'jetpack' ),
+					tagLine: __( 'Enjoy the peace of mind of complete site protection.', 'jetpack' ),
+					title: __( 'Jetpack Security', 'jetpack' ),
 				};
 
 			case 'is-complete-plan':
@@ -146,27 +133,13 @@ class MyPlanHeader extends React.Component {
 					title: __( 'Jetpack Complete', 'jetpack' ),
 				};
 
-			case 'is-daily-backup-plan':
-				return {
-					...productProps,
-					details: expiration,
-					tagLine: __(
-						'Your data is being securely backed up every day with a 30-day archive.',
-						'jetpack'
-					),
-					title: createInterpolateElement( __( 'Jetpack Backup <em>Daily</em>', 'jetpack' ), {
-						em: <em />,
-					} ),
-				};
-
-			case 'is-realtime-backup-plan':
+			case 'is-backup-plan':
+			case 'is-backup-pro-plan':
 				return {
 					...productProps,
 					details: expiration,
 					tagLine: __( 'Your data is being securely backed up as you edit.', 'jetpack' ),
-					title: createInterpolateElement( __( 'Jetpack Backup <em>Real-Time</em>', 'jetpack' ), {
-						em: <em />,
-					} ),
+					title: __( 'Jetpack Backup', 'jetpack' ),
 				};
 
 			case 'is-search-plan':
@@ -199,6 +172,50 @@ class MyPlanHeader extends React.Component {
 						'jetpack'
 					),
 					title: __( 'Jetpack Anti-Spam', 'jetpack' ),
+				};
+
+			// DEPRECATED: Daily and Real-time variations are no longer sold.
+			// Remove after all customers are migrated to new products.
+			case 'is-daily-security-plan':
+				return {
+					...productProps,
+					details: expiration,
+					tagLine: __(
+						'Enjoy the peace of mind of complete site protection. Great for brochure sites, restaurants, blogs, and resume sites.',
+						'jetpack'
+					),
+					title: __( 'Jetpack Security Daily', 'jetpack' ),
+				};
+			case 'is-realtime-security-plan':
+				return {
+					...productProps,
+					details: expiration,
+					tagLine: __(
+						'Additional security for sites with 24/7 activity. Recommended for eCommerce stores, news organizations, and online forums.',
+						'jetpack'
+					),
+					title: __( 'Jetpack Security Real-Time', 'jetpack' ),
+				};
+			case 'is-daily-backup-plan':
+				return {
+					...productProps,
+					details: expiration,
+					tagLine: __(
+						'Your data is being securely backed up every day with a 30-day archive.',
+						'jetpack'
+					),
+					title: createInterpolateElement( __( 'Jetpack Backup <em>Daily</em>', 'jetpack' ), {
+						em: <em />,
+					} ),
+				};
+			case 'is-realtime-backup-plan':
+				return {
+					...productProps,
+					details: expiration,
+					tagLine: __( 'Your data is being securely backed up as you edit.', 'jetpack' ),
+					title: createInterpolateElement( __( 'Jetpack Backup <em>Real-Time</em>', 'jetpack' ), {
+						em: <em />,
+					} ),
 				};
 
 			default:

--- a/projects/plugins/jetpack/changelog/add-my-plan-for-new-backup-security-products
+++ b/projects/plugins/jetpack/changelog/add-my-plan-for-new-backup-security-products
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+My Plan: Recognize and display new Backup, Security plans.

--- a/projects/plugins/jetpack/tests/e2e/lib/plan-helper.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/plan-helper.js
@@ -336,11 +336,17 @@ function getPlan( type ) {
 							'jetpack_premium_monthly',
 							'jetpack_business_monthly',
 							'jetpack_personal_monthly',
+							'jetpack_security',
+							'jetpack_security_monthly',
+							'jetpack_security_pro',
+							'jetpack_security_pro_monthly',
+							'jetpack_complete_monthly',
+							// DEPRECATED: Daily and Real-time variations are no longer sold.
+							// Remove after all customers are migrated to new products.
 							'jetpack_security_daily',
 							'jetpack_security_daily_monthly',
 							'jetpack_security_realtime',
 							'jetpack_security_realtime_monthly',
-							'jetpack_complete_monthly',
 						],
 						'send-a-message': [
 							'jetpack_free',
@@ -350,11 +356,17 @@ function getPlan( type ) {
 							'jetpack_premium_monthly',
 							'jetpack_business_monthly',
 							'jetpack_personal_monthly',
+							'jetpack_security',
+							'jetpack_security_monthly',
+							'jetpack_security_pro',
+							'jetpack_security_pro_monthly',
+							'jetpack_complete_monthly',
+							// DEPRECATED: Daily and Real-time variations are no longer sold.
+							// Remove after all customers are migrated to new products.
 							'jetpack_security_daily',
 							'jetpack_security_daily_monthly',
 							'jetpack_security_realtime',
 							'jetpack_security_realtime_monthly',
-							'jetpack_complete_monthly',
 						],
 						'social-previews': [
 							'jetpack_free',
@@ -364,11 +376,17 @@ function getPlan( type ) {
 							'jetpack_premium_monthly',
 							'jetpack_business_monthly',
 							'jetpack_personal_monthly',
+							'jetpack_security',
+							'jetpack_security_monthly',
+							'jetpack_security_pro',
+							'jetpack_security_pro_monthly',
+							'jetpack_complete_monthly',
+							// DEPRECATED: Daily and Real-time variations are no longer sold.
+							// Remove after all customers are migrated to new products.
 							'jetpack_security_daily',
 							'jetpack_security_daily_monthly',
 							'jetpack_security_realtime',
 							'jetpack_security_realtime_monthly',
-							'jetpack_complete_monthly',
 						],
 						'vaultpress-backups': [
 							'jetpack_premium',
@@ -419,11 +437,17 @@ function getPlan( type ) {
 							'jetpack_premium_monthly',
 							'jetpack_business_monthly',
 							'jetpack_personal_monthly',
+							'jetpack_security',
+							'jetpack_security_monthly',
+							'jetpack_security_pro',
+							'jetpack_security_pro_monthly',
+							'jetpack_complete_monthly',
+							// DEPRECATED: Daily and Real-time variations are no longer sold.
+							// Remove after all customers are migrated to new products.
 							'jetpack_security_daily',
 							'jetpack_security_daily_monthly',
 							'jetpack_security_realtime',
 							'jetpack_security_realtime_monthly',
-							'jetpack_complete_monthly',
 						],
 						'core/video': [
 							'jetpack_premium',
@@ -444,11 +468,17 @@ function getPlan( type ) {
 							'jetpack_premium_monthly',
 							'jetpack_business_monthly',
 							'jetpack_personal_monthly',
+							'jetpack_security',
+							'jetpack_security_monthly',
+							'jetpack_security_pro',
+							'jetpack_security_pro_monthly',
+							'jetpack_complete_monthly',
+							// DEPRECATED: Daily and Real-time variations are no longer sold.
+							// Remove after all customers are migrated to new products.
 							'jetpack_security_daily',
 							'jetpack_security_daily_monthly',
 							'jetpack_security_realtime',
 							'jetpack_security_realtime_monthly',
-							'jetpack_complete_monthly',
 						],
 						'premium-content/container': [
 							'jetpack_premium',
@@ -457,11 +487,17 @@ function getPlan( type ) {
 							'jetpack_premium_monthly',
 							'jetpack_business_monthly',
 							'jetpack_personal_monthly',
+							'jetpack_security',
+							'jetpack_security_monthly',
+							'jetpack_security_pro',
+							'jetpack_security_pro_monthly',
+							'jetpack_complete_monthly',
+							// DEPRECATED: Daily and Real-time variations are no longer sold.
+							// Remove after all customers are migrated to new products.
 							'jetpack_security_daily',
 							'jetpack_security_daily_monthly',
 							'jetpack_security_realtime',
 							'jetpack_security_realtime_monthly',
-							'jetpack_complete_monthly',
 						],
 						support: [
 							'jetpack_premium',
@@ -470,11 +506,17 @@ function getPlan( type ) {
 							'jetpack_premium_monthly',
 							'jetpack_business_monthly',
 							'jetpack_personal_monthly',
+							'jetpack_security',
+							'jetpack_security_monthly',
+							'jetpack_security_pro',
+							'jetpack_security_pro_monthly',
+							'jetpack_complete_monthly',
+							// DEPRECATED: Daily and Real-time variations are no longer sold.
+							// Remove after all customers are migrated to new products.
 							'jetpack_security_daily',
 							'jetpack_security_daily_monthly',
 							'jetpack_security_realtime',
 							'jetpack_security_realtime_monthly',
-							'jetpack_complete_monthly',
 						],
 						'premium-themes': [ 'jetpack_business', 'jetpack_business_monthly' ],
 						'vaultpress-security-scanning': [ 'jetpack_business', 'jetpack_business_monthly' ],


### PR DESCRIPTION
Partially addresses `1200412004370260-as-1200532973279687`.

#### Changes proposed in this Pull Request:

* Add My Plan cards for new Backup and Security plans.
* Update behavior of the My Plan card body, so that new Backup and Security plans function the same as existing Backup and Security plans.
* Add new Backup and Security plan information to the e2e test helper `plan-helper.js`.

#### Jetpack product discussion

`pbtFFM-XN-p2`

#### Does this pull request change what data or activity we track or use?

No 👍 

#### Testing instructions:

1. Apply this PR to your Jetpack plug-in testing environment.
2. Ensure all tests pass (e.g., `pnpm test-adminpage`).
3. Visit the Jetpack > Dashboard > My Plan page.
4. Open the Dev Tools by clicking on the Dev Tools link in the page footer.
5. Select the new Backup and Security plans, ensuring that the My Plan card changes in appearance to correspond with the plan you select.
6. Verify that when other (pre-existing) plans are selected, they appear normally and without changes.

##### Design

* Be advised:
  * In the initial upload of this PR, the lower and higher plan tiers display identically to each other; I'm happy to change this if desired.
  * I haven't yet updated the plan icons -- that will come soon as a separate PR.
* Review and give feedback on the following, in the context of new Backup and Security plans on the My Plan page (see screenshots below):
  * plan title and description; and
  * upsell/feature cards below the My Plan card.

#### Reference screenshots

<img width="325" alt="image" src="https://user-images.githubusercontent.com/670067/125650743-ecceedd2-876b-4fd7-a5f0-2febeb8e3fa6.png"> <img width="325" alt="image" src="https://user-images.githubusercontent.com/670067/125650615-196124a2-ed36-4419-bcea-a3701f969402.png">