### PR TITLE
Search: Add mocked legacy search interface for business plan without search subscription

### DIFF
--- a/projects/plugins/jetpack/_inc/client/search/dashboard/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/index.jsx
@@ -13,7 +13,7 @@ import restApi from 'rest-api';
 import Masthead from 'components/masthead';
 import LoadingPlaceHolder from 'components/loading-placeholder';
 import ModuleControl from './module-control';
-import MockedInstantSearch from './mocked-instant-search';
+import MockedSearch from './mocked-search';
 import './style.scss';
 
 /**
@@ -66,7 +66,7 @@ function SearchDashboard( props ) {
 							</h1>
 						</div>
 						<div className="jp-search-dashboard__mocked-search-interface">
-							<MockedInstantSearch />
+							<MockedSearch />
 						</div>
 					</div>
 					<div className="jp-search-dashboard__bottom">

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-instant-search.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-instant-search.jsx
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import React from 'react';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { __ } from '@wordpress/i18n';
 import Gridicon from 'components/gridicon';
 import TextRowPlaceHolder from './placeholder';
 import './mocked-instant-search.scss';

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-legacy-search.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-legacy-search.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from '../../../../modules/search/instant-search/components/gridicon';
+import TextRowPlaceHolder from './placeholder';
+import './mocked-legacy-search.scss';
+
+/**
+ * Generate mocked search dialog
+ *
+ * @returns {React.Component}	Mocked Search dialog component.
+ */
+export default function MockedSearch() {
+	return (
+		<div className="jp-mocked-legacy-search">
+			<div className="jp-mocked-legacy-search__search-controls">
+				<div className="jp-mocked-legacy-search__search-icon">
+					<Gridicon icon="search" size={ 24 } />
+				</div>
+				<div className="jp-mocked-legacy-search__search-input">
+					<TextRowPlaceHolder style={ { height: '50px', width: '80%' } } />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-legacy-search.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-legacy-search.jsx
@@ -15,7 +15,7 @@ import './mocked-legacy-search.scss';
  *
  * @returns {React.Component}	Mocked Search dialog component.
  */
-export default function MockedSearch() {
+export default function MockedLegacySearch() {
 	return (
 		<div className="jp-mocked-legacy-search">
 			<div className="jp-mocked-legacy-search__search-controls">

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-legacy-search.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-legacy-search.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Gridicon from '../../../../modules/search/instant-search/components/gridicon';
+import Gridicon from 'components/gridicon';
 import TextRowPlaceHolder from './placeholder';
 import './mocked-legacy-search.scss';
 

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-legacy-search.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-legacy-search.scss
@@ -1,0 +1,31 @@
+@import './_variables.scss';
+
+$color-modal-background: $studio-white;
+$search-box-size: 60px;
+
+.jp-mocked-legacy-search {
+	border-radius: 3px;
+	margin: 0 auto;
+	width: 100%;
+
+	user-select: none;
+}
+.jp-mocked-legacy-search__search-controls {
+	display: flex;
+	flex-flow: row nowrap;
+	width: 100%;
+	background: $color-modal-background;
+	box-shadow: rgba( 0, 0, 0, 0.35 ) 0px 5px 25px;
+}
+.jp-mocked-legacy-search__search-icon {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: $search-box-size;
+	height: $search-box-size;
+}
+.jp-mocked-legacy-search__search-input {
+	width: 100%;
+	display: flex;
+	align-items: center;
+}

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-search.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-search.jsx
@@ -24,12 +24,14 @@ import { getSitePlan, hasActiveSearchPurchase as selectHasActiveSearchPurchase }
  */
 function MockedSearch( props ) {
 	const { hasActiveSearchPurchase, isBusinessPlan } = props;
-	const shouldShowMockedInstantSearch = ! isBusinessPlan || hasActiveSearchPurchase;
+	// We only want to show the legacy search mock to users with bussiness plan but no search subscription.
+	// For all other cases, we show our Instant Search experience mock.
+	const shouldShowMockedLegacySearch = isBusinessPlan && ! hasActiveSearchPurchase;
 
 	return (
 		<Fragment>
-			{ shouldShowMockedInstantSearch && <MockedInstantSearch /> }
-			{ ! shouldShowMockedInstantSearch && <MockedLegacySearch /> }
+			{ shouldShowMockedLegacySearch && <MockedLegacySearch /> }
+			{ ! shouldShowMockedLegacySearch && <MockedInstantSearch /> }
 		</Fragment>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-search.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-search.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import MockedInstantSearch from './mocked-instant-search';
+import MockedLegacySearch from './mocked-legacy-search';
+import { getPlanClass } from 'lib/plans/constants';
+
+/**
+ * State dependencies
+ */
+import { getSitePlan, hasActiveSearchPurchase as selectHasActiveSearchPurchase } from 'state/site';
+
+/**
+ *Mocked Search component, which shows mocked Instant Search or legacy Search interface.
+ *
+ * @param {object} props - Component properties.
+ * @returns {React.Component} Mocked Search interface component.
+ */
+function MockedSearch( props ) {
+	const { hasActiveSearchPurchase, isBusinessPlan } = props;
+	const shouldShowMockedInstantSearch = ! isBusinessPlan || hasActiveSearchPurchase;
+
+	return (
+		<Fragment>
+			{ shouldShowMockedInstantSearch && <MockedInstantSearch /> }
+			{ ! shouldShowMockedInstantSearch && <MockedLegacySearch /> }
+		</Fragment>
+	);
+}
+
+export default connect( state => {
+	const planClass = getPlanClass( getSitePlan( state ).product_slug );
+	return {
+		hasActiveSearchPurchase: selectHasActiveSearchPurchase( state ),
+		isBusinessPlan: 'is-business-plan' === planClass,
+	};
+} )( MockedSearch );

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-search.jsx
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/mocked-search.jsx
@@ -17,7 +17,7 @@ import { getPlanClass } from 'lib/plans/constants';
 import { getSitePlan, hasActiveSearchPurchase as selectHasActiveSearchPurchase } from 'state/site';
 
 /**
- *Mocked Search component, which shows mocked Instant Search or legacy Search interface.
+ * Mocked Search component, which shows mocked Instant Search or legacy Search interface.
  *
  * @param {object} props - Component properties.
  * @returns {React.Component} Mocked Search interface component.

--- a/projects/plugins/jetpack/_inc/client/search/dashboard/style.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/style.scss
@@ -34,6 +34,11 @@
 		width: 90%;
 		max-width: 60rem;
 		height: 100%;
+
+		display: flex;
+		flex-flow: column;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.jp-search-dashboard__bottom {

--- a/projects/plugins/jetpack/changelog/add-search-admin-page-mocked-legacy-search
+++ b/projects/plugins/jetpack/changelog/add-search-admin-page-mocked-legacy-search
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: added mocked legacy search interface for admin page


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This is a followup PR for #20224. Added a mocked search interface for Business plan without search subscription.

#### Jetpack product discussion
pcNPJE-7J#comment-161

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with business plan but no Jetpack Search purchase (enter URL directly `/wp-admin/admin.php?page=jetpack-search&a8ctest`)
* Ensure the legacy search mock is shown.

![image](https://user-images.githubusercontent.com/1425433/125723638-96134cc3-9bd4-4ee3-b048-b75e665329f9.png)


Related: #20269