### PR TITLE
Map block: show preview not available in customizer to prevent js error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mapblock-customizer-widget
+++ b/projects/plugins/jetpack/changelog/fix-mapblock-customizer-widget
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Map block widget can't be loaded dynamically in customizer so display message instead
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -626,7 +626,13 @@ class Jetpack_Gutenberg {
 			// If this is a customizer preview, enqueue the dependencies and render the script directly to the preview after autosave.
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( is_customize_preview() && ! empty( $_GET['customize_autosaved'] ) ) {
-				echo '<script id="jetpack-block-' . esc_attr( $type ) . '" src="' . esc_attr( $view_script ) . '?ver=' . esc_attr( $script_version ) . '" defer></script>';
+				// The Map block is dependent on wp-element, and it doesn't appear to to be possible to load
+				// this dynamically into the customizer iframe currently.
+				if ( 'map' === $type ) {
+					echo '<div>' . __( 'No preview available. Publish and refresh to see this widget', 'jetpack' ) . '</div>';
+				} else {
+					echo '<script id="jetpack-block-' . esc_attr( $type ) . '" src="' . esc_attr( $view_script ) . '?ver=' . esc_attr( $script_version ) . '"></script>';
+				}
 			}
 		}
 

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -629,7 +629,7 @@ class Jetpack_Gutenberg {
 				// The Map block is dependent on wp-element, and it doesn't appear to to be possible to load
 				// this dynamically into the customizer iframe currently.
 				if ( 'map' === $type ) {
-					echo '<div>' . __( 'No preview available. Publish and refresh to see this widget', 'jetpack' ) . '</div>';
+					echo '<div>' . esc_html_e( 'No preview available. Publish and refresh to see this widget', 'jetpack' ) . '</div>';
 				} else {
 					echo '<script id="jetpack-block-' . esc_attr( $type ) . '" src="' . esc_attr( $view_script ) . '?ver=' . esc_attr( $script_version ) . '"></script>';
 				}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -629,7 +629,10 @@ class Jetpack_Gutenberg {
 				// The Map block is dependent on wp-element, and it doesn't appear to to be possible to load
 				// this dynamically into the customizer iframe currently.
 				if ( 'map' === $type ) {
-					echo '<div>' . esc_html_e( 'No preview available. Publish and refresh to see this widget', 'jetpack' ) . '</div>';
+					echo '<div>' . esc_html_e( 'No map preview available. Publish and refresh to see this widget.', 'jetpack' ) . '</div>';
+					echo '<script>';
+					echo 'Array.from(document.getElementsByClassName(\'wp-block-jetpack-map\')).forEach(function(element){element.style.display = \'none\';})';
+					echo '</script>';
 				} else {
 					echo '<script id="jetpack-block-' . esc_attr( $type ) . '" src="' . esc_attr( $view_script ) . '?ver=' . esc_attr( $script_version ) . '"></script>';
 				}


### PR DESCRIPTION
Fixes #19976

#### Changes proposed in this Pull Request:

* If the Map block is added as a widget to the customizer it fails to load and causes an exception in the console. This is because the `wp-element` dependency is not loaded by default in the customizer, and it doesn't see possible to get these dependencies loaded dynamically in the customizer iframe. This PR instead indicates to the user that a preview is not available for that widget.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Check out this PR and run locally with latest Gutenberg and latest WP dev build
* In customizer add a map widget and check there are no errors in console and that the 'no preview' message displays

Before:
![before](https://user-images.githubusercontent.com/3629020/125725337-da3395a4-a239-4fb1-8702-349d65c8a288.gif)

After:
![after](https://user-images.githubusercontent.com/3629020/125725347-fd2436b2-5a2d-4d08-b240-d5b1ab0139cb.gif)

