### PR TITLE
Move Dashboard Quick Switcher outside of admin menu classes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-refactor-dashboard-switcher
+++ b/projects/plugins/jetpack/changelog/fix-refactor-dashboard-switcher
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Refactored the dashboard quick switcher in order to load it for sites with SSO disabled.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -482,35 +482,4 @@ class Admin_Menu extends Base_Admin_Menu {
 			61 // Just under Appearance.
 		);
 	}
-
-	/**
-	 * Prepend a dashboard swithcer to the "Screen Options" box of the current page.
-	 * Callback for the 'screen_settings' filter (available in WP 3.0 and up).
-	 *
-	 * @param string $current The currently added panels in screen options.
-	 *
-	 * @return string The HTML code to append to "Screen Options"
-	 */
-	public function register_dashboard_switcher( $current ) {
-		$menu_mappings = require __DIR__ . '/menu-mappings.php';
-		$screen        = $this->get_current_screen();
-
-		// Let's show the switcher only in screens that we have a Calypso mapping to switch to.
-		if ( ! isset( $menu_mappings[ $screen ] ) ) {
-			return;
-		}
-
-		$contents = sprintf(
-			'<div id="dashboard-switcher"><h5>%s</h5><p class="dashboard-switcher-text">%s</p><a class="button button-primary dashboard-switcher-button" href="%s">%s</a></div>',
-			__( 'Screen features', 'jetpack' ),
-			__( 'Currently you are seeing the classic WP-Admin view of this page. Would you like to see the default WordPress.com view?', 'jetpack' ),
-			$menu_mappings[ $screen ] . $this->domain,
-			__( 'Use WordPress.com view', 'jetpack' )
-		);
-
-		// Prepend the Dashboard swither to the other custom panels.
-		$current = $contents . $current;
-
-		return $current;
-	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-dashboard-switcher.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-dashboard-switcher.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Dashboard_Switcher class file
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Dashboard_Customizations;
+
+/**
+ * Class Dashboard_Switcher
+ *
+ * Handles Calypso to WP-Admin quick switcher
+ *
+ * @package Automattic\Jetpack\Dashboard_Customizations
+ */
+class Dashboard_Switcher {
+
+	/**
+	 * Site's domain
+	 *
+	 * @var string.
+	 */
+	private $domain;
+
+	/**
+	 * Dashboard_Switcher constructor.
+	 *
+	 * @param string $domain Site's domain.
+	 */
+	public function __construct( $domain ) {
+		$this->domain = $domain;
+	}
+
+	/**
+	 * Prepend a dashboard switcher to the "Screen Options" box of the current page.
+	 * Callback for the 'screen_settings' filter (available in WP 3.0 and up).
+	 *
+	 * @param string $current The currently added panels in screen options.
+	 *
+	 * @return string|void The HTML code to append to "Screen Options"
+	 */
+	public function register_dashboard_switcher( $current ) {
+		$menu_mappings = require __DIR__ . '/menu-mappings.php';
+		$screen        = $this->get_current_screen();
+
+		// Let's show the switcher only in screens that we have a Calypso mapping to switch to.
+		if ( ! isset( $menu_mappings[ $screen ] ) ) {
+			return;
+		}
+
+		$contents = sprintf(
+			'<div id="dashboard-switcher"><h5>%s</h5><p class="dashboard-switcher-text">%s</p><a class="button button-primary dashboard-switcher-button" href="%s">%s</a></div>',
+			__( 'Screen features', 'jetpack' ),
+			__( 'Currently you are seeing the classic WP-Admin view of this page. Would you like to see the default WordPress.com view?', 'jetpack' ),
+			$menu_mappings[ $screen ] . $this->domain,
+			__( 'Use WordPress.com view', 'jetpack' )
+		);
+
+		// Prepend the Dashboard switcher to the other custom panels.
+		return $contents . $current;
+	}
+
+	/**
+	 * Gets the identifier of the current screen.
+	 *
+	 * @return string
+	 */
+	public function get_current_screen() {
+		// phpcs:disable WordPress.Security.NonceVerification
+		global $pagenow;
+
+		$screen = isset( $_REQUEST['screen'] ) ? $_REQUEST['screen'] : $pagenow;
+		if ( isset( $_GET['post_type'] ) ) {
+			$screen = add_query_arg( 'post_type', $_GET['post_type'], $screen );
+		}
+		if ( isset( $_GET['taxonomy'] ) ) {
+			$screen = add_query_arg( 'taxonomy', $_GET['taxonomy'], $screen );
+		}
+		if ( isset( $_GET['page'] ) ) {
+			$screen = add_query_arg( 'page', $_GET['page'], $screen );
+		}
+
+		return $screen;
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Dashboard_Customizations\Base_Admin_Menu;
 use Automattic\Jetpack\Status;
 
 require_jetpack_file( 'modules/masterbar/admin-menu/class-admin-menu.php' );
+require_jetpack_file( 'modules/masterbar/admin-menu/class-dashboard-switcher.php' );
 require_jetpack_file( 'tests/php/modules/masterbar/data/admin-menu.php' );
 
 /**
@@ -560,37 +561,5 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 				array( '', 'read', 'test-slug', '', Base_Admin_Menu::HIDE_CSS_CLASS ),
 			),
 		);
-	}
-
-	/**
-	 * Check if the dashboard switcher is registered correctly.
-	 */
-	public function test_register_dashboard_switcher() {
-		global $pagenow;
-		$pagenow = 'edit.php?post_type=feedback';
-
-		$output = static::$admin_menu->register_dashboard_switcher( '' );
-		$this->assertNull( $output );
-
-		$screens = array(
-			'edit.php'                             => 'https://wordpress.com/posts/',
-			'edit.php?post_type=page'              => 'https://wordpress.com/pages/',
-			'edit.php?post_type=jetpack-portfolio' => 'https://wordpress.com/types/jetpack-portfolio/',
-			'edit-tags.php?taxonomy=category'      => 'https://wordpress.com/settings/taxonomies/category/',
-		);
-
-		foreach ( $screens as $screen => $mapping ) {
-			$pagenow  = $screen;
-			$output   = static::$admin_menu->register_dashboard_switcher( '' );
-			$expected = sprintf(
-				'<div id="dashboard-switcher"><h5>%s</h5><p class="dashboard-switcher-text">%s</p><a class="button button-primary dashboard-switcher-button" href="%s">%s</a></div>',
-				__( 'Screen features', 'jetpack' ),
-				__( 'Currently you are seeing the classic WP-Admin view of this page. Would you like to see the default WordPress.com view?', 'jetpack' ),
-				$mapping . static::$domain,
-				__( 'Use WordPress.com view', 'jetpack' )
-			);
-
-			$this->assertEquals( $expected, $output );
-		}
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Status;
 
 require_jetpack_file( 'modules/masterbar/admin-menu/class-atomic-admin-menu.php' );
 require_jetpack_file( 'tests/php/modules/masterbar/data/admin-menu.php' );
+require_jetpack_file( 'modules/masterbar/admin-menu/class-dashboard-switcher.php' );
 
 /**
  * Class Test_Atomic_Admin_Menu.

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-dashboard-switcher.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-dashboard-switcher.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tests for Dashboard_Switcher
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Dashboard_Customizations\Dashboard_Switcher;
+
+require_jetpack_file( 'modules/masterbar/admin-menu/class-dashboard-switcher.php' );
+
+/**
+ * Class Test_Admin_Menu
+ *
+ * @coversDefaultClass Automattic\Jetpack\Dashboard_Customizations\Admin_Menu
+ */
+class Test_Dashboard_Switcher extends WP_UnitTestCase {
+
+	/**
+	 * A site domain.
+	 *
+	 * @var string
+	 */
+	public static $domain = 'test.com';
+
+	/**
+	 * Check if the dashboard switcher is registered correctly.
+	 */
+	public function test_register_dashboard_switcher() {
+		global $pagenow;
+		$pagenow = 'edit.php?post_type=feedback';
+
+		$output = ( new Dashboard_Switcher( self::$domain ) )->register_dashboard_switcher( '' );
+		$this->assertNull( $output );
+
+		$screens = array(
+			'edit.php'                             => 'https://wordpress.com/posts/',
+			'edit.php?post_type=page'              => 'https://wordpress.com/pages/',
+			'edit.php?post_type=jetpack-portfolio' => 'https://wordpress.com/types/jetpack-portfolio/',
+			'edit-tags.php?taxonomy=category'      => 'https://wordpress.com/settings/taxonomies/category/',
+		);
+
+		foreach ( $screens as $screen => $mapping ) {
+			$pagenow  = $screen;
+			$output   = ( new Dashboard_Switcher( self::$domain ) )->register_dashboard_switcher( '' );
+			$expected = sprintf(
+				'<div id="dashboard-switcher"><h5>%s</h5><p class="dashboard-switcher-text">%s</p><a class="button button-primary dashboard-switcher-button" href="%s">%s</a></div>',
+				__( 'Screen features', 'jetpack' ),
+				__( 'Currently you are seeing the classic WP-Admin view of this page. Would you like to see the default WordPress.com view?', 'jetpack' ),
+				$mapping . static::$domain,
+				__( 'Use WordPress.com view', 'jetpack' )
+			);
+
+			$this->assertEquals( $expected, $output );
+		}
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-domain-only-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-domain-only-admin-menu.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Status;
 
 require_jetpack_file( 'modules/masterbar/admin-menu/class-domain-only-admin-menu.php' );
 require_jetpack_file( 'tests/php/modules/masterbar/data/admin-menu.php' );
+require_jetpack_file( 'modules/masterbar/admin-menu/class-dashboard-switcher.php' );
 
 /**
  * Class Test_Domain_Only_Admin_Menu.

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Status;
 
 require_jetpack_file( 'modules/masterbar/admin-menu/class-jetpack-admin-menu.php' );
 require_jetpack_file( 'tests/php/modules/masterbar/data/admin-menu.php' );
+require_jetpack_file( 'modules/masterbar/admin-menu/class-dashboard-switcher.php' );
 
 /**
  * Class Test_Jetpack_Admin_Menu.

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Status;
 
 require_jetpack_file( 'modules/masterbar/admin-menu/class-wpcom-admin-menu.php' );
 require_jetpack_file( 'tests/php/modules/masterbar/data/admin-menu.php' );
+require_jetpack_file( 'modules/masterbar/admin-menu/class-dashboard-switcher.php' );
 
 /**
  * Class Test_WPcom_Admin_Menu.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/54499

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moved the logic that displays the Dashboard Quick switcher outside of Base_Admin_Menu class in order to be able to load it even if nav-unification is disabled in WP-Admin side.


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Atomic:
* Go to WP-Admin > Jetpack > Dashboard > Settings and disable SSO (WordPress Login)
* Go to Posts > All posts
* Use the switcher to land in WP-Admin
