### PR TITLE
[Carousel]: Reenable background color

### DIFF
--- a/projects/packages/sync/changelog/update-carousel-add-option-to-toggle-background-image
+++ b/projects/packages/sync/changelog/update-carousel-add-option-to-toggle-background-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync option for the Carousel to display colorized slide background.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -33,6 +33,7 @@ class Defaults {
 		'carousel_background_color',
 		'carousel_display_exif',
 		'carousel_display_comments',
+		'carousel_display_slide_background',
 		'category_base',
 		'ce4wp_referred_by', // Creative Mail. See pbtFPC-H5-p2.
 		'close_comments_days_old',

--- a/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
@@ -35,7 +35,15 @@ function WritingMedia( props ) {
 
 	const displayComments = props.getOptionValue( 'carousel_display_comments', 'carousel' );
 	const displayExif = props.getOptionValue( 'carousel_display_exif', 'carousel' );
+	const displaySlideBackground = props.getOptionValue(
+		'carousel_display_slide_background',
+		'carousel'
+	);
 	const isCarouselActive = props.getOptionValue( 'carousel' );
+
+	const handleCarouselDisplaySlideBackgroundChange = () => {
+		props.updateFormStateModuleOption( 'carousel', 'carousel_display_slide_background' );
+	};
 
 	const handleCarouselDisplayExifChange = () => {
 		props.updateFormStateModuleOption( 'carousel', 'carousel_display_exif' );
@@ -108,6 +116,12 @@ function WritingMedia( props ) {
 						'carousel_display_comments',
 						handleCarouselDisplayCommentsChange,
 						__( 'Show comments area in carousel', 'jetpack' )
+					) }
+					{ renderToggle(
+						displaySlideBackground,
+						'carousel_display_slide_background',
+						handleCarouselDisplaySlideBackgroundChange,
+						__( 'Display colorized slide backgrounds', 'jetpack' )
 					) }
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2168,6 +2168,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'carousel',
 			),
+			'carousel_display_slide_background'    => array(
+				'description'       => esc_html__( 'Display colorized slide backgrounds', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'carousel',
+			),
 
 			// Comments
 			'highlander_comment_form_prompt'       => array(

--- a/projects/plugins/jetpack/changelog/update-carousel-add-option-to-toggle-background-image
+++ b/projects/plugins/jetpack/changelog/update-carousel-add-option-to-toggle-background-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Carousel: Add settings toggle to control display of colorized slide background.

--- a/projects/plugins/jetpack/changelog/update-fix-and-reenable-carousel-background
+++ b/projects/plugins/jetpack/changelog/update-fix-and-reenable-carousel-background
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Carousel: Enabled blurred background images, fixed bug with missing background when reversing swipe direction.

--- a/projects/plugins/jetpack/changelog/update-fix-and-reenable-carousel-background
+++ b/projects/plugins/jetpack/changelog/update-fix-and-reenable-carousel-background
@@ -1,4 +1,4 @@
 Significance: minor
 Type: bugfix
 
-Carousel: Enabled blurred background images, fixed bug with missing background when reversing swipe direction.
+Carousel: Enabled background colors, fixed bug with missing background when reversing swipe direction.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -31,12 +31,6 @@
 	width: 100vw;
 }
 
-.jp-carousel-overlay .swiper-zoom-container {
-	background-size: 200%;
-	background-repeat: no-repeat;
-	background-position: center;
-}
-
 /*
 To prevent flash of prev/next image scale transition after pinch zoom we need to hide them.
 Swiper does not add a class of `swiper-slide-zoomed` to slides on pinch and zoom
@@ -93,19 +87,6 @@ so we have to target all affected elements in touch devices.
 
 .jp-carousel-overlay * {
 	box-sizing: border-box;
-}
-
-/*
-Blurred background images: apply blur with CSS if browser does not have
-support via the Canvas 2D API
-*/
-.jp-carousel-overlay .jp-carousel-canvas-blur-unsupported .swiper-zoom-container {
-	transform: translate3d( 0, 0, 0 );
-	transform: translateZ( 0 );
-
-	backdrop-filter: blur( 20px );
-	-webkit-backdrop-filter: blur( 20px );
-	will-change: transform;
 }
 
 /* Fix for Twenty Nineteen theme compatibility */

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -94,24 +94,14 @@ so we have to target all affected elements in touch devices.
 }
 
 /* Blurred background images */
-.jp-carousel-overlay .swiper-zoom-container {
+.jp-carousel-overlay .jp-carousel-blurred-image .swiper-zoom-container {
 	transform: translate3d(0,0,0);
 	transform: translateZ(0);
 
-	background-size: 200%;
-	background-repeat: no-repeat;
-	background-position: center;
-	backdrop-filter: blur( 75px );
-	-webkit-backdrop-filter: blur( 75px ) saturate( 50% );
+	backdrop-filter: blur( 20px );
+	-webkit-backdrop-filter: blur( 20px );
 	will-change: transform;
 }
-
-/* Blurred background image support for Firefox */
-@supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
-	.jp-carousel-overlay .swiper-zoom-container::before  {
-	  filter: blur(75px);
-	  filter: url(#gaussian-blur-18);
-	  filter: progid:DXImageTransform.Microsoft.Blur(PixelRadius='75'); } }
 
 /* Fix for Twenty Nineteen theme compatibility */
 .jp-carousel-overlay h1:before,

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -89,6 +89,12 @@ so we have to target all affected elements in touch devices.
 	box-sizing: border-box;
 }
 
+/* Prevent flickering of the background in Safari */
+.jp-carousel-overlay .swiper-slide {
+	transform: translateZ( 0 );
+	-webkit-transform: translateZ( 0 );
+}
+
 /* Fix for Twenty Nineteen theme compatibility */
 .jp-carousel-overlay h1:before,
 .jp-carousel-overlay h2:before,

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -93,8 +93,11 @@ so we have to target all affected elements in touch devices.
 	box-sizing: border-box;
 }
 
-/* Blurred background images */
-.jp-carousel-overlay .jp-carousel-blurred-image .swiper-zoom-container {
+/*
+Blurred background images: apply blur with CSS if browser does not have
+support via the Canvas 2D API
+*/
+.jp-carousel-overlay .jp-carousel-canvas-blur-unsupported .swiper-zoom-container {
 	transform: translate3d(0,0,0);
 	transform: translateZ(0);
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -10,8 +10,10 @@
 .swiper-container-rtl .swiper-button-prev:after {
 	content: none;
 }
-.jp-carousel-overlay .swiper-button-prev, .jp-carousel-overlay .swiper-container-rtl .swiper-button-next,
-.jp-carousel-overlay .swiper-button-next, .jp-carousel-overlay .swiper-container-rtl .swiper-button-prev {
+.jp-carousel-overlay .swiper-button-prev,
+.jp-carousel-overlay .swiper-container-rtl .swiper-button-next,
+.jp-carousel-overlay .swiper-button-next,
+.jp-carousel-overlay .swiper-container-rtl .swiper-button-prev {
 	background-image: none;
 }
 /* end of temporary fix */
@@ -98,8 +100,8 @@ Blurred background images: apply blur with CSS if browser does not have
 support via the Canvas 2D API
 */
 .jp-carousel-overlay .jp-carousel-canvas-blur-unsupported .swiper-zoom-container {
-	transform: translate3d(0,0,0);
-	transform: translateZ(0);
+	transform: translate3d( 0, 0, 0 );
+	transform: translateZ( 0 );
 
 	backdrop-filter: blur( 20px );
 	-webkit-backdrop-filter: blur( 20px );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -93,6 +93,26 @@ so we have to target all affected elements in touch devices.
 	box-sizing: border-box;
 }
 
+/* Blurred background images */
+.jp-carousel-overlay .swiper-zoom-container {
+	transform: translate3d(0,0,0);
+	transform: translateZ(0);
+
+	background-size: 200%;
+	background-repeat: no-repeat;
+	background-position: center;
+	backdrop-filter: blur( 75px );
+	-webkit-backdrop-filter: blur( 75px ) saturate( 50% );
+	will-change: transform;
+}
+
+/* Blurred background image support for Firefox */
+@supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
+	.jp-carousel-overlay .swiper-zoom-container::before  {
+	  filter: blur(75px);
+	  filter: url(#gaussian-blur-18);
+	  filter: progid:DXImageTransform.Microsoft.Blur(PixelRadius='75'); } }
+
 /* Fix for Twenty Nineteen theme compatibility */
 .jp-carousel-overlay h1:before,
 .jp-carousel-overlay h2:before,

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -768,13 +768,7 @@
 			}
 
 			loadFullImage( carousel.slides[ index ] );
-
-			if (
-				Number( jetpackCarouselStrings.display_background_image ) === 1 &&
-				! carousel.slides[ index ].backgroundImage
-			) {
-				loadBackgroundImage( carousel.slides[ index ] );
-			}
+			loadBackgroundImage( carousel.slides[ index ] );
 
 			domUtil.hide( carousel.caption );
 			updateTitleCaptionAndDesc( {
@@ -1277,7 +1271,7 @@
 		}
 
 		function applyBackgroundImage( slide, currentSlide, image ) {
-			var url = util.getBackgroundImage( image );
+			var url = slide.backgroundImage ? slide.backgroundImage : util.getBackgroundImage( image );
 			slide.backgroundImage = url;
 			currentSlide.style.backgroundImage = 'url(' + url + ')';
 			currentSlide.style.backgroundSize = 'cover';

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -61,7 +61,7 @@
 
 			// Apply image blur.
 			if ( context.filter !== undefined ) {
-				context.filter = 'blur(20px) ';
+				context.globalAlpha = 0.3;
 			} else {
 				// Class used to apply CSS blur on Safari, where it is not supported by the canvas.
 				// Canvas blur is preferred for performance reasons on Chrome.
@@ -70,7 +70,7 @@
 					.classList.add( 'jp-carousel-canvas-blur-unsupported' );
 			}
 
-			context.filter = 'blur(20px) ';
+			context.filter = 'blur(30px) ';
 			context.drawImage(
 				imgEl,
 				( imgEl.naturalWidth - imageWidth ) * 0.5,
@@ -1311,7 +1311,8 @@
 			var url = slide.backgroundImage ? slide.backgroundImage : util.getBackgroundImage( image );
 			slide.backgroundImage = url;
 			currentSlide.style.backgroundImage = 'url(' + url + ')';
-			currentSlide.style.backgroundSize = 'cover';
+			currentSlide.style.backgroundPosition = 'center center';
+			currentSlide.style.backgroundSize = '150% 150%';
 		}
 
 		function clearCommentTextAreaValue() {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -38,29 +38,21 @@
 		function getAverageColor( imgEl ) {
 			var canvas = document.createElement( 'canvas' ),
 				context = canvas.getContext && canvas.getContext( '2d' ),
-				imgData,
-				width,
-				height,
-				length,
-				rgb = { r: 0, g: 0, b: 0 },
-				count = 0;
+				rgb = { r: 0, g: 0, b: 0 };
+
 			if ( ! imgEl ) {
 				return rgb;
 			}
-			height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
-			width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
-			context.drawImage( imgEl, 0, 0 );
-			imgData = context.getImageData( 0, 0, width, height );
-			length = imgData.data.length;
-			for ( var i = 0; i < length; i += 4 ) {
-				rgb.r += imgData.data[ i ];
-				rgb.g += imgData.data[ i + 1 ];
-				rgb.b += imgData.data[ i + 2 ];
-				count++;
-			}
-			rgb.r = Math.floor( rgb.r / count );
-			rgb.g = Math.floor( rgb.g / count );
-			rgb.b = Math.floor( rgb.b / count );
+
+			canvas.width = 1;
+			canvas.height = 1;
+			context.drawImage( imgEl, 0, 0, 1, 1 );
+			var i = context.getImageData( 0, 0, 1, 1 ).data;
+
+			rgb.r = i[ 0 ];
+			rgb.g = i[ 1 ];
+			rgb.b = i[ 2 ];
+
 			return rgb;
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -35,7 +35,7 @@
 			} );
 		}
 
-		function getBackgroundImage( imgEl ) {
+		function getBackgroundImage( slideEl, imgEl ) {
 			var canvas = document.createElement( 'canvas' ),
 				context = canvas.getContext && canvas.getContext( '2d' );
 
@@ -57,6 +57,15 @@
 				imageHeight = imgEl.naturalWidth * winRatio;
 			} else {
 				imageWidth = imgEl.naturalHeight / winRatio;
+			}
+
+			// Apply image blur.
+			if ( context.filter !== undefined ) {
+				context.filter = 'blur(20px) ';
+			} else {
+				// Class used to apply CSS blur on Safari, where it is not supported by the canvas.
+				// Canvas blur is preferred for performance reasons on Chrome.
+				slideEl.classList.add( 'jp-carousel-blurred-image' );
 			}
 
 			context.filter = 'blur(20px) ';
@@ -1297,7 +1306,9 @@
 		}
 
 		function applyBackgroundImage( slide, currentSlide, image ) {
-			var url = slide.backgroundImage ? slide.backgroundImage : util.getBackgroundImage( image );
+			var url = slide.backgroundImage
+				? slide.backgroundImage
+				: util.getBackgroundImage( currentSlide, image );
 			slide.backgroundImage = url;
 			currentSlide.style.backgroundImage = 'url(' + url + ')';
 			currentSlide.style.backgroundSize = 'cover';

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -35,27 +35,10 @@
 			} );
 		}
 
-		function getBackgroundImage( imgEl ) {
-			var canvas = document.createElement( 'canvas' ),
-				context = canvas.getContext && canvas.getContext( '2d' );
-
-			if ( ! imgEl ) {
-				return;
-			}
-
-			context.filter = 'blur(20px) ';
-			context.drawImage( imgEl, 0, 0 );
-			var url = canvas.toDataURL( 'image/png' );
-			canvas = null;
-
-			return url;
-		}
-
 		return {
 			noop: noop,
 			texturize: texturize,
 			applyReplacements: applyReplacements,
-			getBackgroundImage: getBackgroundImage,
 		};
 	} )();
 
@@ -1270,10 +1253,8 @@
 			};
 		}
 
-		function applyBackgroundImage( slide, currentSlide, image ) {
-			var url = slide.backgroundImage ? slide.backgroundImage : util.getBackgroundImage( image );
-			slide.backgroundImage = url;
-			currentSlide.style.backgroundImage = 'url(' + url + ')';
+		function applyBackgroundImage( slide, currentSlide ) {
+			currentSlide.style.backgroundImage = 'url(' + slide.attrs.mediumFile + ')';
 			currentSlide.style.backgroundSize = 'cover';
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -61,7 +61,7 @@
 
 			// Apply image blur.
 			if ( context.filter !== undefined ) {
-				context.globalAlpha = 0.3;
+				context.filter = 'blur(30px) ';
 			} else {
 				// Class used to apply CSS blur on Safari, where it is not supported by the canvas.
 				// Canvas blur is preferred for performance reasons on Chrome.
@@ -70,7 +70,7 @@
 					.classList.add( 'jp-carousel-canvas-blur-unsupported' );
 			}
 
-			context.filter = 'blur(30px) ';
+			context.globalAlpha = 0.3;
 			context.drawImage(
 				imgEl,
 				( imgEl.naturalWidth - imageWidth ) * 0.5,

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -788,7 +788,7 @@
 			}
 
 			loadFullImage( carousel.slides[ index ] );
-			loadBackgroundImage( carousel.slides[ index ] );
+			loadSlideBackgrounds();
 
 			domUtil.hide( carousel.caption );
 			updateTitleCaptionAndDesc( {
@@ -1270,31 +1270,46 @@
 			}
 		}
 
-		function loadBackgroundImage( slide ) {
-			var currentSlide = slide.el;
+		function loadSlideBackgrounds() {
+			applySlideBackground( '.swiper-slide-active' );
 
-			if ( swiper && swiper.slides ) {
-				currentSlide = swiper.slides[ swiper.activeIndex ];
+			setTimeout( function () {
+				applySlideBackground( '.swiper-slide-prev' );
+				applySlideBackground( '.swiper-slide-next' );
+			}, 200 );
+		}
+
+		function applySlideBackground( slideClass ) {
+			var slideEl = carousel.container.querySelector( slideClass );
+
+			if ( ! slideEl ) {
+				return;
 			}
 
-			var image = carousel.container.querySelector(
-				'.swiper-slide[data-attachment-id="' + slide.attrs.attachmentId + '"] img'
-			);
-			var isLoaded = image.complete && image.naturalHeight !== 0;
+			// We're done if there's already a background image set.
+			if ( slideEl.style.backgroundImage ) {
+				return;
+			}
 
+			var image = slideEl.querySelector( 'img' );
+			if ( ! image ) {
+				return;
+			}
+
+			var isLoaded = image.complete && image.naturalHeight !== 0;
 			if ( isLoaded ) {
-				applyBackgroundImage( currentSlide, image );
+				calculateSlideBackgroundCss( slideEl, image );
 				return;
 			}
 
 			image.onload = function () {
-				applyBackgroundImage( currentSlide, image );
+				calculateSlideBackgroundCss( slideEl, image );
 			};
 		}
 
-		function applyBackgroundImage( currentSlide, image ) {
+		function calculateSlideBackgroundCss( slideEl, image ) {
 			var rgb = util.getAverageColor( image );
-			currentSlide.style.backgroundImage =
+			slideEl.style.backgroundImage =
 				'linear-gradient( to bottom, rgba(' +
 				rgb.r +
 				',' +

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -38,20 +38,36 @@
 		function getAverageColor( imgEl ) {
 			var canvas = document.createElement( 'canvas' ),
 				context = canvas.getContext && canvas.getContext( '2d' ),
-				rgb = { r: 0, g: 0, b: 0 };
+				imgData,
+				width,
+				height,
+				length,
+				rgb = { r: 0, g: 0, b: 0 },
+				count = 0;
 
 			if ( ! imgEl ) {
 				return rgb;
 			}
 
-			canvas.width = 1;
-			canvas.height = 1;
-			context.drawImage( imgEl, 0, 0, 1, 1 );
-			var i = context.getImageData( 0, 0, 1, 1 ).data;
+			height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
 
-			rgb.r = i[ 0 ];
-			rgb.g = i[ 1 ];
-			rgb.b = i[ 2 ];
+			width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
+
+			context.drawImage( imgEl, 0, 0 );
+			imgData = context.getImageData( 0, 0, width, height );
+
+			length = imgData.data.length;
+
+			for ( var i = 0; i < length; i += 4 ) {
+				rgb.r += imgData.data[ i ];
+				rgb.g += imgData.data[ i + 1 ];
+				rgb.b += imgData.data[ i + 2 ];
+				count++;
+			}
+
+			rgb.r = Math.floor( rgb.r / count );
+			rgb.g = Math.floor( rgb.g / count );
+			rgb.b = Math.floor( rgb.b / count );
 
 			return rgb;
 		}

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1261,18 +1261,18 @@
 				currentSlide = swiper.slides[ swiper.activeIndex ];
 			}
 
-			var imgEl = new Image();
-			imgEl.setAttribute( 'crossOrigin', '' );
-			imgEl.src = slide.attrs.mediumFile;
-			var isLoaded = imgEl.complete && imgEl.naturalHeight !== 0;
+			var image = carousel.container.querySelector(
+				'.swiper-slide[data-attachment-id="' + slide.attrs.attachmentId + '"] img'
+			);
+			var isLoaded = image.complete && image.naturalHeight !== 0;
 
 			if ( isLoaded ) {
-				applyBackgroundImage( currentSlide, imgEl );
+				applyBackgroundImage( currentSlide, image );
 				return;
 			}
 
-			imgEl.onload = function () {
-				applyBackgroundImage( currentSlide, imgEl );
+			image.onload = function () {
+				applyBackgroundImage( currentSlide, image );
 			};
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -788,7 +788,10 @@
 			}
 
 			loadFullImage( carousel.slides[ index ] );
-			loadSlideBackgrounds();
+
+			if ( Number( jetpackCarouselStrings.display_slide_background ) === 1 ) {
+				loadSlideBackgrounds();
+			}
 
 			domUtil.hide( carousel.caption );
 			updateTitleCaptionAndDesc( {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -35,7 +35,7 @@
 			} );
 		}
 
-		function getBackgroundImage( slideEl, imgEl ) {
+		function getBackgroundImage( imgEl ) {
 			var canvas = document.createElement( 'canvas' ),
 				context = canvas.getContext && canvas.getContext( '2d' );
 
@@ -65,7 +65,9 @@
 			} else {
 				// Class used to apply CSS blur on Safari, where it is not supported by the canvas.
 				// Canvas blur is preferred for performance reasons on Chrome.
-				slideEl.classList.add( 'jp-carousel-blurred-image' );
+				document
+					.querySelector( '.jp-carousel' )
+					.classList.add( 'jp-carousel-canvas-blur-unsupported' );
 			}
 
 			context.filter = 'blur(20px) ';
@@ -1306,9 +1308,7 @@
 		}
 
 		function applyBackgroundImage( slide, currentSlide, image ) {
-			var url = slide.backgroundImage
-				? slide.backgroundImage
-				: util.getBackgroundImage( currentSlide, image );
+			var url = slide.backgroundImage ? slide.backgroundImage : util.getBackgroundImage( image );
 			slide.backgroundImage = url;
 			currentSlide.style.backgroundImage = 'url(' + url + ')';
 			currentSlide.style.backgroundSize = 'cover';

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -39,18 +39,34 @@
 			var canvas = document.createElement( 'canvas' ),
 				context = canvas.getContext && canvas.getContext( '2d' ),
 				imgData,
-				rgb = { r: 0, g: 0, b: 0 };
+				width,
+				height,
+				length,
+				rgb = { r: 0, g: 0, b: 0 },
+				count = 0;
 
 			if ( ! imgEl ) {
 				return rgb;
 			}
 
-			context.drawImage( imgEl, 0, 0 );
-			imgData = context.getImageData( 0, 0, 1, 1 );
+			height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
+			width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
 
-			rgb.r = imgData.data[ 0 ];
-			rgb.g = imgData.data[ 1 ];
-			rgb.b = imgData.data[ 2 ];
+			context.drawImage( imgEl, 0, 0 );
+			imgData = context.getImageData( 0, 0, width, height );
+
+			length = imgData.data.length;
+
+			for ( var i = 0; i < length; i += 4 ) {
+				rgb.r += imgData.data[ i ];
+				rgb.g += imgData.data[ i + 1 ];
+				rgb.b += imgData.data[ i + 2 ];
+				count++;
+			}
+
+			rgb.r = Math.floor( rgb.r / count );
+			rgb.g = Math.floor( rgb.g / count );
+			rgb.b = Math.floor( rgb.b / count );
 
 			return rgb;
 		}

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -35,10 +35,53 @@
 			} );
 		}
 
+		function getBackgroundImage( imgEl ) {
+			var canvas = document.createElement( 'canvas' ),
+				context = canvas.getContext && canvas.getContext( '2d' );
+
+			if ( ! imgEl ) {
+				return;
+			}
+
+			// Adjust the canvas size.
+			canvas.width = window.innerWidth;
+			canvas.height = window.innerHeight;
+
+			var imageRatio = imgEl.naturalHeight / imgEl.naturalWidth;
+			var winRatio = window.innerHeight / window.innerWidth;
+
+			// Calculate adjusted image dimensions to cover the canvas.
+			var imageHeight = imgEl.naturalHeight;
+			var imageWidth = imgEl.naturalWidth;
+			if ( imageRatio > winRatio ) {
+				imageHeight = imgEl.naturalWidth * winRatio;
+			} else {
+				imageWidth = imgEl.naturalHeight / winRatio;
+			}
+
+			context.filter = 'blur(20px) ';
+			context.drawImage(
+				imgEl,
+				( imgEl.naturalWidth - imageWidth ) * 0.5,
+				( imgEl.naturalHeight - imageHeight ) * 0.5,
+				imageWidth,
+				imageHeight,
+				0,
+				0,
+				window.innerWidth,
+				window.innerHeight
+			);
+			var url = canvas.toDataURL( 'image/png' );
+			canvas = null;
+
+			return url;
+		}
+
 		return {
 			noop: noop,
 			texturize: texturize,
 			applyReplacements: applyReplacements,
+			getBackgroundImage: getBackgroundImage,
 		};
 	} )();
 
@@ -1253,8 +1296,10 @@
 			};
 		}
 
-		function applyBackgroundImage( slide, currentSlide ) {
-			currentSlide.style.backgroundImage = 'url(' + slide.attrs.mediumFile + ')';
+		function applyBackgroundImage( slide, currentSlide, image ) {
+			var url = slide.backgroundImage ? slide.backgroundImage : util.getBackgroundImage( image );
+			slide.backgroundImage = url;
+			currentSlide.style.backgroundImage = 'url(' + url + ')';
 			currentSlide.style.backgroundSize = 'cover';
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -39,35 +39,18 @@
 			var canvas = document.createElement( 'canvas' ),
 				context = canvas.getContext && canvas.getContext( '2d' ),
 				imgData,
-				width,
-				height,
-				length,
-				rgb = { r: 0, g: 0, b: 0 },
-				count = 0;
+				rgb = { r: 0, g: 0, b: 0 };
 
 			if ( ! imgEl ) {
 				return rgb;
 			}
 
-			height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
-
-			width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
-
 			context.drawImage( imgEl, 0, 0 );
-			imgData = context.getImageData( 0, 0, width, height );
+			imgData = context.getImageData( 0, 0, 1, 1 );
 
-			length = imgData.data.length;
-
-			for ( var i = 0; i < length; i += 4 ) {
-				rgb.r += imgData.data[ i ];
-				rgb.g += imgData.data[ i + 1 ];
-				rgb.b += imgData.data[ i + 2 ];
-				count++;
-			}
-
-			rgb.r = Math.floor( rgb.r / count );
-			rgb.g = Math.floor( rgb.g / count );
-			rgb.b = Math.floor( rgb.b / count );
+			rgb.r = imgData.data[ 0 ];
+			rgb.g = imgData.data[ 1 ];
+			rgb.b = imgData.data[ 2 ];
 
 			return rgb;
 		}
@@ -1278,16 +1261,18 @@
 				currentSlide = swiper.slides[ swiper.activeIndex ];
 			}
 
-			var image = slide.attrs.originalElement;
-			var isLoaded = image.complete && image.naturalHeight !== 0;
+			var imgEl = new Image();
+			imgEl.setAttribute( 'crossOrigin', '' );
+			imgEl.src = slide.attrs.mediumFile;
+			var isLoaded = imgEl.complete && imgEl.naturalHeight !== 0;
 
 			if ( isLoaded ) {
-				applyBackgroundImage( currentSlide, image );
+				applyBackgroundImage( currentSlide, imgEl );
 				return;
 			}
 
-			image.onload = function () {
-				applyBackgroundImage( currentSlide, image );
+			imgEl.onload = function () {
+				applyBackgroundImage( currentSlide, imgEl );
 			};
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -261,6 +261,7 @@ class Jetpack_Carousel {
 				'display_exif'                    => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', true ) ),
 				'display_comments'                => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_comments', true ) ),
 				'display_geo'                     => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_geo', true ) ),
+				'display_slide_background'        => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_slide_background', false ), false ),
 				'single_image_gallery'            => $this->single_image_gallery_enabled,
 				'single_image_gallery_media_file' => $this->single_image_gallery_enabled_media_file,
 				'background_color'                => $this->carousel_background_color_sanitize( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_background_color', '' ) ),
@@ -1065,6 +1066,9 @@ class Jetpack_Carousel {
 		add_settings_field( 'carousel_display_comments', __( 'Comments', 'jetpack' ), array( $this, 'carousel_display_comments_callback' ), 'media', 'carousel_section' );
 		register_setting( 'media', 'carousel_display_comments', array( $this, 'carousel_display_comments_sanitize' ) );
 
+		add_settings_field( 'carousel_display_slide_background', __( 'Slide background', 'jetpack' ), array( $this, 'carousel_display_slide_background_callback' ), 'media', 'carousel_section' );
+		register_setting( 'media', 'carousel_display_slide_background', array( $this, 'carousel_display_slide_background_sanitize' ) );
+
 		// No geo setting yet, need to "fuzzify" data first, for privacy
 		// add_settings_field('carousel_display_geo', __( 'Geolocation', 'jetpack' ), array( $this, 'carousel_display_geo_callback' ), 'media', 'carousel_section' );
 		// register_setting( 'media', 'carousel_display_geo', array( $this, 'carousel_display_geo_sanitize' ) );
@@ -1135,6 +1139,24 @@ class Jetpack_Carousel {
 	}
 
 	function carousel_display_exif_sanitize( $value ) {
+		return $this->sanitize_1or0_option( $value );
+	}
+
+	/**
+	 * Callback for checkbox and label of field that toggles slide background color.
+	 */
+	public function carousel_display_slide_background_callback() {
+		$this->settings_checkbox( 'carousel_display_slide_background', esc_html__( 'Display colorized slide backgrounds', 'jetpack' ), '', false );
+	}
+
+	/**
+	 * Return sanitized option for value that controls whether the slide background color is displayed.
+	 *
+	 * @param number $value Value to sanitize.
+	 *
+	 * @return number Sanitized value, only 1 or 0.
+	 */
+	public function carousel_display_slide_background_sanitize( $value ) {
 		return $this->sanitize_1or0_option( $value );
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -142,6 +142,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'carousel_background_color'                    => 'pineapple',
 			'carousel_display_exif'                        => 'pineapple',
 			'carousel_display_comments'                    => 'pineapple',
+			'carousel_display_slide_background'            => 'pineapple',
 			'jetpack_portfolio'                            => 'pineapple',
 			'jetpack_portfolio_posts_per_page'             => 'pineapple',
 			'jetpack_testimonial'                          => 'pineapple',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes 290-gh-Automattic/view-design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Re-enables solid background colors using the average color of the image, with a gradient in opacity from 0.5 to 0.25
* Fixes a bug where the background image of the first & last slides would sometimes disappear when swiping backwards
* ~~Re-enables blurred background images in the carousel, which were previously hidden behind a flag~~
* ~~Fixes a bug where the background image was not sized/centered properly, so the background image would be "zoomed in" to the top left corner. Now the image is centered and scaled to best fit~~
* ~~Since the Canvas 2D API [does not have browser support for Safari on desktop or iOS](https://developer.mozilla.org/en-US/docs/Web/CSS/filter#browser_compatibility), we detect when the feature is unsupported and fallback to the original CSS blur, and attempt to optimize performance by forcing GPU composition [as described in this article](https://www.smashingmagazine.com/2016/12/gpu-animation-doing-it-right/). This should only apply to Safari, where the performance is testing well for me.~~
* Add an admin option to toggle this feature (more details in https://github.com/Automattic/jetpack/pull/20447)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

For each test, make sure to do a hard refresh first 👍 
* Enable the slide background feature in `/wp-admin/admin.php?page=jetpack#/writing`
* Publish a post with a gallery
* Open the post in a new browser tab and click an image to load it in the carousel
* Swipe through the carousel and verify you see the background on each image and that performance still feels smooth
* Once you've swiped through all the images, start swiping again in the other direction. Swipe backwards and forwards through the entire gallery and make sure you do not see the background image disappear.
* Open the inspector and verify that the `.jp-carousel-canvas-blur-unsupported` is only being added on Safari.

Test across browsers and on mobile devices.


https://user-images.githubusercontent.com/63313398/126559968-cfedf594-e53a-49ae-8cf3-906dd67409dd.mov


