### PR TITLE
Map Block: Ensure theme styles do not override map button background colors

### DIFF
--- a/projects/plugins/jetpack/changelog/update-map-block-fullscreen-button-color-on-front-end
+++ b/projects/plugins/jetpack/changelog/update-map-block-fullscreen-button-color-on-front-end
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Map Block: Ensure theme styles do not override map button background colors.

--- a/projects/plugins/jetpack/extensions/blocks/map/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/map/style.scss
@@ -22,5 +22,7 @@
 	.mapboxgl-ctrl-group button {
 		// Prevents theme styles adding a border radius to all buttons affecting the Map block controls too.
 		border-radius: 0;
+		// Prevents theme styles from affecting the background color of the button.
+		background-color: transparent !important;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

While testing #20371, I noticed that Twenty Twenty One theme is overriding the background color of buttons in the Map block on the front end of the site. This was also mentioned in #15701. Also, in #14080 it was suggested that we might add in more specific CSS rules for the Map block to be a bit more opinionated about keeping themes from affecting the block's styles.

While there's more that we can do to harden the Map block's CSS, I thought in the short-term it could be good to add this simple change to at least fix the more obvious issue with a theme affecting the button colors.

Note: this change doesn't fix the marker styling issues reported in #14080.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `!important` rule to the Map block's button background color to ensure that it isn't overridden by themes.

#### Screenshots

This is on the front end of a site running Twenty Twenty One theme

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/125877748-87e25830-5f51-4959-8491-ef80dd7d6e75.png) | ![image](https://user-images.githubusercontent.com/14988353/125877765-1c228398-9cba-4f8d-8b21-b4091df349bf.png) | 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate the Twenty Twenty One theme
* Add a Map block to a post or page and add a Mapbox token if you need to
* Publish the map and view on the front end of the site
* With this PR applied, the buttons should render as expected, with a transparent / white background color instead of the Twenty Twenty One theme's dark background color

