### PR TITLE
Site Editor: Hide on universal themes unless a user opts in to the core site editor

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -99,6 +99,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	public function prepare_menu_for_response( array $menu ) {
 		global $submenu;
 
+		do_action( 'admin_menu_rest_api' );
+		global $menu;
 		$data = array();
 
 		/**

--- a/projects/plugins/jetpack/changelog/fusion-sync-scruffian-r228671-wpcom-1626420316
+++ b/projects/plugins/jetpack/changelog/fusion-sync-scruffian-r228671-wpcom-1626420316
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Added an action to the Admin Menu endpoint so that it can be modified by a hook


### PR DESCRIPTION
Summary: Unless the user has opted in to the core Site Editor, we hide the Site Editor menu and show the customizer and widget menus for universal themes.

Test Plan: See associated PR: https://github.com/Automattic/themes/pull/4206

Tags: #touches_jetpack_files

Differential Revision: D63947-code

This commit syncs r228671-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
