### PR TITLE
Carousel: Try using settimeout for finishing fade instead of transitionend in case it doesn't fire

### DIFF
--- a/projects/plugins/jetpack/changelog/try-carousel-swap-transitionend-for-set-timeout
+++ b/projects/plugins/jetpack/changelog/try-carousel-swap-transitionend-for-set-timeout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Carousel: Replace transitionend with settimeout for fade to improve compatibility in low framerate environments

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -139,24 +139,19 @@
 			el.style.transition = 'opacity 0.2s';
 			el.style.pointerEvents = 'none';
 
-			var finished = function ( e ) {
-				if ( e.target === el && e.propertyName === 'opacity' ) {
-					el.style.removeProperty( 'transition' );
-					el.style.removeProperty( 'opacity' );
-					el.style.removeProperty( 'pointer-events' );
-					el.removeEventListener( 'transitionend', finished );
-					el.removeEventListener( 'transitioncancel', finished );
-					callback();
-				}
+			var finished = function () {
+				el.style.removeProperty( 'transition' );
+				el.style.removeProperty( 'opacity' );
+				el.style.removeProperty( 'pointer-events' );
+				callback();
 			};
 
 			requestAnimationFrame( function () {
 				// Double rAF for browser compatibility.
 				requestAnimationFrame( function () {
-					el.addEventListener( 'transitionend', finished );
-					el.addEventListener( 'transitioncancel', finished );
 					// Trigger transition.
 					el.style.opacity = end;
+					setTimeout( finished, 200 );
 				} );
 			} );
 		}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

This is an exploratory PR that came out of feedback from @ramonjd while testing the Carousel using Browserstack. We noticed while testing the Carousel in Windows 10 + Edge that sometimes the carousel would be unresponsive to clicks after opening it.

My hunch is that in environments like Browserstack, where the browser has an extraordinarily low frame-rate, it's possible that the `transitionend` event might not fire, which could result in `pointerevents` not being restored, and therefor the Carousel becoming unusable.

More reading on `transitionend` here: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ontransitionend — the comment seems to suggest that there are circumstances where it might not fire?

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Try replacing `transitionend` and `transitioncancel` with a `setTimeout` for restoring click behaviour after `fade` has finished

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With the Carousel module enabled, publish a post containing a gallery block
* Before applying this PR, open the post on the front end of your site via Browserstack, selecting Windows 10 + Edge
* See if you can open up the Carousel and then swipe between slides
* If you can't (which is the issue we ran into), try applying this PR and see if you are now able to
* See if the footer buttons correctly open / close the footer areas
* Note that the next / prev buttons didn't appear to work for me via Browserstack — perhaps a similar `transitionend` issue is at play?
