### PR TITLE
Sync: remove the arrays_are_similar helper method from WP_Test_iJetpack_Sync_Replicastore

### DIFF
--- a/projects/plugins/jetpack/changelog/update-arrays_are_similar
+++ b/projects/plugins/jetpack/changelog/update-arrays_are_similar
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove the arrays_are_similar method and use PHPUnit's assertEquals method.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -707,35 +707,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		$color_meta = $store->get_metadata( 'post', 1, 'colors' );
 
-		$this->assertTrue( $this->arrays_are_similar( $meta_array, $color_meta[0] ) );
-	}
-
-	/**
-	 * Determine if two associative arrays are similar
-	 *
-	 * Both arrays must have the same indexes with identical values
-	 * without respect to key ordering
-	 *
-	 * @param array $a
-	 * @param array $b
-	 *
-	 * @return bool
-	 */
-	function arrays_are_similar( $a, $b ) {
-		// if the indexes don't match, return immediately
-		if ( count( array_diff_assoc( $a, $b ) ) ) {
-			return false;
-		}
-		// we know that the indexes, but maybe not values, match.
-		// compare the values between the two arrays
-		foreach ( $a as $k => $v ) {
-			if ( $v !== $b[ $k ] ) {
-				return false;
-			}
-		}
-
-		// we have identical indexes, and no unequal values
-		return true;
+		$this->assertEquals( $meta_array, $color_meta[0] );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The `WP_Test_iJetpack_Sync_Replicastore::arrays_are_similar` method isn't needed. Just use PHPUnit's `assertEquals` method instead.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Verify that the unit tests are passing.
