### PR TITLE
Update Options module to return jetpack_sync_settings_* options from Settings class

### DIFF
--- a/projects/packages/sync/changelog/fix-return-setting-value-of-jetpack-sync-settings-options
+++ b/projects/packages/sync/changelog/fix-return-setting-value-of-jetpack-sync-settings-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update Options module to return jetpack_sync_settings_* values from the Settings class vs direct option lookup.

--- a/projects/packages/sync/src/modules/class-options.php
+++ b/projects/packages/sync/src/modules/class-options.php
@@ -218,9 +218,14 @@ class Options extends Module {
 		$options       = array();
 		$random_string = wp_generate_password();
 		foreach ( $this->options_whitelist as $option ) {
-			$option_value = get_option( $option, $random_string );
-			if ( $option_value !== $random_string ) {
+			if ( 0 === strpos( $option, Settings::SETTINGS_OPTION_PREFIX ) ) {
+				$option_value       = Settings::get_setting( str_replace( Settings::SETTINGS_OPTION_PREFIX, '', $option ) );
 				$options[ $option ] = $option_value;
+			} else {
+				$option_value = get_option( $option, $random_string );
+				if ( $option_value !== $random_string ) {
+					$options[ $option ] = $option_value;
+				}
 			}
 		}
 
@@ -454,9 +459,14 @@ class Options extends Module {
 			$random_string = wp_generate_password();
 			// Only whitelisted options can be returned.
 			if ( in_array( $id, $this->options_whitelist, true ) ) {
-				$option_value = get_option( $id, $random_string );
-				if ( $option_value !== $random_string ) {
+				if ( 0 === strpos( $id, Settings::SETTINGS_OPTION_PREFIX ) ) {
+					$option_value = Settings::get_setting( str_replace( Settings::SETTINGS_OPTION_PREFIX, '', $id ) );
 					return $option_value;
+				} else {
+					$option_value = get_option( $id, $random_string );
+					if ( $option_value !== $random_string ) {
+						return $option_value;
+					}
 				}
 			} elseif ( 'all' === $id ) {
 				return $this->get_all_options();

--- a/projects/packages/sync/src/modules/class-options.php
+++ b/projects/packages/sync/src/modules/class-options.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Settings;
 
 /**
  * Class to handle sync for options.

--- a/projects/plugins/jetpack/changelog/fix-return-setting-value-of-jetpack-sync-settings-options
+++ b/projects/plugins/jetpack/changelog/fix-return-setting-value-of-jetpack-sync-settings-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Update Sync tests to include case for jetpack_sync_settings options.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Settings;
 
 /**
  * Testing CRUD on Options
@@ -311,12 +312,22 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	/**
-	 * Verify that get_object_by_id returns a allowed option
+	 * Verify that get_object_by_id returns a allowed option.
 	 */
 	public function test_get_objects_by_id_singular() {
 		$module      = Modules::get_module( 'options' );
 		$options     = $module->get_all_options();
 		$get_options = $module->get_objects_by_id( 'option', array( 'test_option' ) );
 		$this->assertEquals( $options['test_option'], $get_options['test_option'] );
+	}
+
+	/**
+	 * Verify that get_object_by_id returns settings logic for jetpack_sync_settings_* options.
+	 */
+	public function test_get_objects_by_id_sync_settings() {
+		$module      = Modules::get_module( 'options' );
+		$settings    = Settings::get_settings();
+		$get_options = $module->get_objects_by_id( 'option', array( 'jetpack_sync_settings_post_meta_whitelist' ) );
+		$this->assertEquals( $settings['post_meta_whitelist'], $get_options['jetpack_sync_settings_post_meta_whitelist'] );
 	}
 }


### PR DESCRIPTION
Jetpack Sync Settings have a custom Settings class that integrated option values with various filters. When options are synced to WP.com we need to ensure the Settings logic is used so that the correct values are persisted to allow for proper functionality of cache based functionality.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Options module updated to use Settings class for jetpack_sync_settings_* options

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Unit testing is included in the PR

To manually test perform the following actions

1) delete_option( 'jetpack_sync_settings_post_meta_whitelist' );
2) $module  = Automattic\Jetpack\Sync\Modules::get_module( 'options' );
3) $module->get_all_options();
4) Verify that the jetpack_sync_settings_post_meta_whitelist is not empty but an array that matches
Automattic\Jetpack\Sync\Settings::get_setting( 'post_meta_whitelist' );
5)  $module->get_objects_by_id( 'option', array( 'jetpack_sync_settings_post_meta_whitelist' ) );
6) Verify that the return value matches Automattic\Jetpack\Sync\Settings::get_setting( 'post_meta_whitelist' );
