### PR TITLE
Atomic admin menu: Only show security nav item if site has security settings feature

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-hide-security-settings-menu
+++ b/projects/plugins/jetpack/changelog/fix-hide-security-settings-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Only adds the security nav item to the Atomic admin menu if the site has the security-settings feature.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -268,7 +268,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_options_menu() {
 		parent::add_options_menu();
 
-		add_submenu_page( 'options-general.php', esc_attr__( 'Security', 'jetpack' ), __( 'Security', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/security/' . $this->domain, null, 2 );
+		$show_security_nav_item = Jetpack_Plan::supports( 'security-settings' );
+
+		if ( $show_security_nav_item ) {
+			add_submenu_page( 'options-general.php', esc_attr__( 'Security', 'jetpack' ), __( 'Security', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/security/' . $this->domain, null, 2 );
+		}
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 11 );
 		add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 12 );
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -271,7 +271,15 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$show_security_nav_item = Jetpack_Plan::supports( 'security-settings' );
 
 		if ( $show_security_nav_item ) {
-			add_submenu_page( 'options-general.php', esc_attr__( 'Security', 'jetpack' ), __( 'Security', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/security/' . $this->domain, null, 2 );
+			add_submenu_page(
+				'options-general.php',
+				esc_attr__( 'Security', 'jetpack' ),
+				__( 'Security', 'jetpack' ),
+				'manage_options',
+				'https://wordpress.com/settings/security/' . $this->domain,
+				null,
+				2
+			);
 		}
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 11 );
 		add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 12 );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -268,9 +268,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_options_menu() {
 		parent::add_options_menu();
 
-		$show_security_nav_item = Jetpack_Plan::supports( 'security-settings' );
-
-		if ( $show_security_nav_item ) {
+		if ( Jetpack_Plan::supports( 'security-settings' ) ) {
 			add_submenu_page(
 				'options-general.php',
 				esc_attr__( 'Security', 'jetpack' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Part of a fix for https://github.com/Automattic/wp-calypso/issues/51820

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Only adds the security nav item to the Atomic admin menu if the site has the `security-settings` feature added in D63248-code
* This is necessary because not all Atomic sites will have access to the `security-settings` modules (Jetpack monitor, protect, sso) going forward

<img width="570" alt="Screen Shot 2021-07-16 at 10 42 50 AM" src="https://user-images.githubusercontent.com/1689238/125965633-964635f0-8c06-4a49-a66b-f089a0ac5f0b.png">


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Nope!

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to an Atomic site that does not have the `security-settings` feature, e.g. an Atomic site with the Business plan removed or a free / personal / premium Atomic site with a marketplace subscription
* Verify that the Settings > Security nav item isn't there
* Regression: Go to an Atomic site that does have the `security-settings` feature, e.g. an Atomic site with a Business plan
* Verify that the Settings > Security nav item is there