### PR TITLE
Beta plugin: Recognize releases with tags prefixed with "v"

### DIFF
--- a/projects/plugins/beta/changelog/fix-beta-tag-with-v
+++ b/projects/plugins/beta/changelog/fix-beta-tag-with-v
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Correctly handle self-autoupgrades when the release tag begins with "v".

--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -49,7 +49,7 @@
 	"prefer-stable": true,
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_0_0"
+		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_0_1_alpha"
 	},
 	"extra": {
 		"autotagger": true,

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 3.0.0
+ * Version: 3.0.1-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'JPBETA__PLUGIN_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
-define( 'JPBETA_VERSION', '3.0.0' );
+define( 'JPBETA_VERSION', '3.0.1-alpha' );
 
 define( 'JETPACK_BETA_PLUGINS_URL', 'https://betadownload.jetpack.me/plugins.json' );
 

--- a/projects/plugins/beta/src/class-autoupdateself.php
+++ b/projects/plugins/beta/src/class-autoupdateself.php
@@ -98,7 +98,7 @@ class AutoupdateSelf {
 				foreach ( $releases as $release ) {
 					// Since 2.2, so that we don't have to maker the Jetpack Beta 2.0.3 as prerelease.
 					if ( ! $release->prerelease ) {
-						$tagged_version = $release->tag_name;
+						$tagged_version = ltrim( $release->tag_name, 'v' );
 						break;
 					}
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We'll also want to replace the autotagger's tags when making releases
for a few months, so people using older versions get prompted to
upgrade.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1626385556043300-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ???