### PR TITLE
tools: Add the ability to do `@since $$next-version$$`

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -116,6 +116,15 @@ for SLUG in "${SLUGS[@]}"; do
 				continue
 			fi
 			echo "::endgroup::"
+			echo '::group::Updating $$next-version$$'
+			VER="$($CHANGELOGGER version current)"
+			if ! "$BASE"/tools/replace-next-version-tag.sh -v "$SLUG" "$VER"; then
+				EXIT=1
+				echo "::endgroup::"
+				echo "::error::\$\$next-version\$\$ update for ${SLUG} failed"
+				continue
+			fi
+			echo "::endgroup::"
 		else
 			echo "Not updating changelog, there are no change files."
 		fi

--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -13,6 +13,7 @@ function usage {
 
 		Prepare a release of the specified project and everything it depends on.
 		 - Run \`changelogger write\`
+		 - Run \`tools/replace-next-version-tag.sh\`
 		 - Run \`tools/project-version.sh\`
 
 		Pass \`-b\` to prepare a beta release by passing \`--prerelease=beta\` to changelogger.
@@ -123,6 +124,9 @@ function releaseProject {
 	# Fetch version from changelogger.
 	debug "${I}  $CL version current"
 	local VER=$($CL version current)
+
+	# Replace $$next-version$$
+	"$BASE"/tools/replace-next-version-tag.sh "$SLUG" "${VER%-beta}"
 
 	# Update versions.
 	ARGS=()

--- a/tools/replace-next-version-tag.sh
+++ b/tools/replace-next-version-tag.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+BASE=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+. "$BASE/tools/includes/check-osx-bash-version.sh"
+. "$BASE/tools/includes/chalk-lite.sh"
+. "$BASE/tools/includes/proceed_p.sh"
+
+# Print help and exit.
+function usage {
+	cat <<-'EOH'
+		usage: $0 [-v] <slug> <version>
+
+		Replace the `$$next-version$$` token in doc tags with the specified version.
+		Recognized patterns:
+		 - `@since $$next-version$$`
+		 - `@deprecated $$next-version$$`
+		 - `@deprecated since $$next-version$$`
+	EOH
+	exit 1
+}
+
+if [[ $# -eq 0 ]]; then
+	usage
+fi
+
+# Sets options.
+VERBOSE=
+while getopts ":vh" opt; do
+	case ${opt} in
+		v)
+			if [[ -n "$VERBOSE" ]]; then
+				VERBOSE="${VERBOSE}v"
+			else
+				VERBOSE="-v"
+			fi
+			;;
+		h)
+			usage
+			;;
+		:)
+			die "Argument -$OPTARG requires a value."
+			;;
+		?)
+			error "Invalid argument: -$OPTARG"
+			echo ""
+			usage
+			;;
+	esac
+done
+shift "$(($OPTIND - 1))"
+
+if [[ -z "$VERBOSE" ]]; then
+	function debug {
+		:
+	}
+fi
+
+# Determine the project
+[[ -z "$1" ]] && die "A project slug must be specified."
+SLUG="${1#projects/}" # DWIM
+SLUG="${SLUG%/}" # Sanitize
+if [[ ! -e "$BASE/projects/$SLUG/composer.json" ]]; then
+	die "Project $SLUG does not exist."
+fi
+
+# Determine the version
+[[ -z "$2" ]] && die "A version must be specified."
+VERSION="$2"
+if ! grep -E -q '^[0-9]+(\.[0-9]+)+(-(alpha|beta)([-.]?[0-9]+)?)?$' <<<"$VERSION"; then
+	proceed_p "Version $VERSION does not seem to be a valid version number." "Continue?"
+fi
+VE=$(sed 's/[&\\/]/\\&/g' <<<"$VERSION")
+
+cd "$BASE"
+EXIT=0
+for FILE in $(git ls-files "projects/$SLUG/"); do
+	grep -F -q '$$next-version$$' "$FILE" || continue
+	debug "Processing $FILE"
+
+	sed -i.bak -E -e 's!(@since|@deprecated( [sS]ince)?) \$\$next-version\$\$!\1 '"$VE"'!g' "$FILE"
+	rm "$FILE.bak" # We need a backup file because macOS requires it.
+
+	if grep -F -q '$$next-version$$' "$FILE"; then
+		EXIT=1
+		while IFS=':' read -r LINE DUMMY; do
+			if [[ -n "$CI" ]]; then
+				echo "::error file=$FILE,line=$LINE::"'Unexpected `$$next-version$$` token.'
+			else
+				error "$FILE:$LINE:"' Unexpected `$$next-version$$` token.'
+			fi
+		done < <( grep --line-number -F '$$next-version$$' "$FILE" || echo "" )
+	fi
+done
+
+exit $EXIT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
And similarly for `@deprecated`. More specifically, if you write any of

- `@since $$next-version$$`
- `@deprecated $$next-version$$`
- `@deprecated since $$next-version$$`

then the `$$next-version$$` will be replaced with the appropriate
version number on release (using `tools/changelogger-release.sh`).

The appropriate alpha version will also be used when for the mirror repo
(via `.github/files/build-all-projects.sh`).

Using the string `$$next-version$$` elsewhere will result in an error during the
build.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-2zB-p2
p9dueE-3cJ-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See that the build on this PR is happy.
* Make a PR based on this that uses the relevant constructs. Check that the artifacts from the Build workflow show the constructs replaced.
* Run `tools/changelogger-release.sh` where the released packages use the relevant constructs. See that the constructs are replaced as part of the changes to be committed for the release.
* Check that I didn't forget any other code paths where we'd want the replacement to happen.