### PR TITLE
Development: Soft-fail if Jetpack is not built

### DIFF
--- a/projects/plugins/jetpack/changelog/add-soft-fail-modules
+++ b/projects/plugins/jetpack/changelog/add-soft-fail-modules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Development: Soft-fail if Jetpack is not built.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -136,10 +136,9 @@ if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' )
  *   and where we add on to various hooks that we expect to always run.
  */
 $jetpack_autoloader           = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
-$jetpack_module_headings_file = JETPACK__PLUGIN_DIR . 'modules/module-headings.php';
+$jetpack_module_headings_file = JETPACK__PLUGIN_DIR . 'modules/module-headings.php'; // This file is loaded later in load-jetpack.php, but let's check here to pause before half-loading Jetpack.
 if ( is_readable( $jetpack_autoloader ) && is_readable( $jetpack_module_headings_file ) ) {
 	require_once $jetpack_autoloader;
-	require_once $jetpack_module_headings_file;
 } else {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -135,9 +135,11 @@ if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' )
  * - If it succeeds, we require load-jetpack.php, where all legacy files are required,
  *   and where we add on to various hooks that we expect to always run.
  */
-$jetpack_autoloader = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
-if ( is_readable( $jetpack_autoloader ) ) {
-	require $jetpack_autoloader;
+$jetpack_autoloader           = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
+$jetpack_module_headings_file = JETPACK__PLUGIN_DIR . 'modules/module-headings.php';
+if ( is_readable( $jetpack_autoloader ) && is_readable( $jetpack_module_headings_file ) ) {
+	require_once $jetpack_autoloader;
+	require_once $jetpack_module_headings_file;
 } else {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
@@ -154,7 +156,7 @@ if ( is_readable( $jetpack_autoloader ) ) {
 	 *
 	 * @since 7.4.0
 	 */
-	function jetpack_admin_missing_autoloader() {
+	function jetpack_admin_missing_files() {
 		?>
 		<div class="notice notice-error is-dismissible">
 			<p>
@@ -162,7 +164,7 @@ if ( is_readable( $jetpack_autoloader ) ) {
 				printf(
 					wp_kses(
 						/* translators: Placeholder is a link to a support document. */
-						__( 'Your installation of Jetpack is incomplete. If you installed Jetpack from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment.', 'jetpack' ),
+						__( 'Your installation of Jetpack is incomplete. If you installed Jetpack from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack must have Composer dependencies installed and built via the build command.', 'jetpack' ),
 						array(
 							'a' => array(
 								'href'   => array(),
@@ -179,7 +181,7 @@ if ( is_readable( $jetpack_autoloader ) ) {
 		<?php
 	}
 
-	add_action( 'admin_notices', 'jetpack_admin_missing_autoloader' );
+	add_action( 'admin_notices', 'jetpack_admin_missing_files' );
 	return;
 }
 

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -53,6 +53,7 @@ require_once JETPACK__PLUGIN_DIR . 'functions.cookies.php';
 require_once JETPACK__PLUGIN_DIR . 'require-lib.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php';
 require_once JETPACK__PLUGIN_DIR . 'class.frame-nonce-preview.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/module-headings.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
 

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -53,7 +53,6 @@ require_once JETPACK__PLUGIN_DIR . 'functions.cookies.php';
 require_once JETPACK__PLUGIN_DIR . 'require-lib.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php';
 require_once JETPACK__PLUGIN_DIR . 'class.frame-nonce-preview.php';
-require_once JETPACK__PLUGIN_DIR . 'modules/module-headings.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
 

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -53,6 +53,16 @@ if ( ! isset( $test_root ) || ! file_exists( $test_root . '/includes/bootstrap.p
 
 echo "Using test root $test_root\n";
 
+$jp_autoloader = __DIR__ . '/../../vendor/autoload.php';
+
+if ( ! is_readable( $jp_autoloader ) || ! is_readable( __DIR__ . '/../../modules/module-headings.php' ) ) {
+	echo 'Jetpack is not ready for testing.' . PHP_EOL;
+	echo PHP_EOL;
+	echo 'Jetpack must have Composer dependencies installed and be built.' . PHP_EOL;
+	echo 'If developing in the Jetpack monorepo, try running: jetpack build plugins/jetpack' . PHP_EOL;
+	exit( 1 );
+}
+
 // WordPress requires PHPUnit 7.5 or earlier and hacks around a few things to
 // make it work with PHP 8. Unfortunately for MockObjects they do it via
 // composer.json rather than bootstrap.php, so we have to manually do it here.
@@ -176,7 +186,7 @@ function in_running_uninstall_group() {
 	return is_array( $argv ) && in_array( '--group=uninstall', $argv );
 }
 
-require __DIR__ . '/../../vendor/autoload.php';
+require $jp_autoloader;
 
 // Using the Speed Trap Listener provided by WordPress Core testing suite to expose
 // slowest running tests. See the configuration in phpunit.xml.dist


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

After #20367, the modules/module-headings.php file is not always in the development environment (unbuilt version Jetpack), but load-jetpack.php required it.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Soft-fail if modules/module-headings.php is not present in a similar way as it does if our autoloader is not present.
* Update the admin_notice message to add that building Jetpack is required.
* Add autoloader and module-headings.php check to unit test bootstrap and have an informative failure if not built (previously, would just exit without outputting the error).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1626455992369100-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `jetpack clean plugins/jetpack` and select vendor and "other ignored files"
* Run `jetpack docker up`
* Load docker instance and visit wp-admin. If Jetpack isn't active, try to activate it.
* Before patch: If JP is already active, hard fatal on the site. If it isn't, it won't activate due to causing a fatal error.
* After patch: An admin notice will display.
* Run `jetpack docker phpunit`
* Before patch: Exit after initial load without error message.
* After patch: Output error that Jetpack must be installed and built.