### PR TITLE
Beta: add breadcrumb link back to main selection screen

### DIFF
--- a/projects/plugins/beta/changelog/add-beta-breadcrumb-menu
+++ b/projects/plugins/beta/changelog/add-beta-breadcrumb-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add small breadcrumb link to get back to the main plugin selection screen.

--- a/projects/plugins/beta/changelog/add-beta-breadcrumb-menu
+++ b/projects/plugins/beta/changelog/add-beta-breadcrumb-menu
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Add small breadcrumb link to get back to the main plugin selection screen.

--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -49,7 +49,7 @@
 	"prefer-stable": true,
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_1_0_alpha"
+		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_0_1_alpha"
 	},
 	"extra": {
 		"autotagger": true,

--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -49,7 +49,7 @@
 	"prefer-stable": true,
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_0_0"
+		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_1_0_alpha"
 	},
 	"extra": {
 		"autotagger": true,

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 3.1.0-alpha
+ * Version: 3.0.1-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'JPBETA__PLUGIN_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
-define( 'JPBETA_VERSION', '3.1.0-alpha' );
+define( 'JPBETA_VERSION', '3.0.1-alpha' );
 
 define( 'JETPACK_BETA_PLUGINS_URL', 'https://betadownload.jetpack.me/plugins.json' );
 

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 3.0.0
+ * Version: 3.1.0-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'JPBETA__PLUGIN_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
-define( 'JPBETA_VERSION', '3.0.0' );
+define( 'JPBETA_VERSION', '3.1.0-alpha' );
 
 define( 'JETPACK_BETA_PLUGINS_URL', 'https://betadownload.jetpack.me/plugins.json' );
 

--- a/projects/plugins/beta/src/admin/notice.template.php
+++ b/projects/plugins/beta/src/admin/notice.template.php
@@ -39,19 +39,6 @@ $is_notice = ( 'plugins' === $current_screen->base ? true : false );
 				margin-bottom:1em;
 			}
 		</style>
-
-		<?php
-		if ( isset( $plugin ) ) {
-			$plugin = $plugin; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			?>
-			<div id="jetpack-beta-tester__breadcrumb">
-				<a href="<?php echo esc_url( Utils::admin_url() ); ?>">
-					<?php esc_html_e( 'Jetpack Beta Tester Home', 'jetpack-beta' ); ?>
-				</a>
-				<span>&nbsp;&gt; <?php echo esc_html( $plugin->get_name() ); ?></span>
-			</div>
-		<?php } ?>
-
 		<div id="jetpack-beta-tester__start" class="<?php echo ( $is_notice ? 'notice notice-updated' : 'dops-card' ); ?>">
 			<h1><?php esc_html_e( 'Welcome to Jetpack Beta Tester', 'jetpack-beta' ); ?></h1>
 			<p><?php esc_html_e( 'Thank you for helping to test our plugins!  We appreciate your time and effort.', 'jetpack-beta' ); ?></p>

--- a/projects/plugins/beta/src/admin/notice.template.php
+++ b/projects/plugins/beta/src/admin/notice.template.php
@@ -39,6 +39,19 @@ $is_notice = ( 'plugins' === $current_screen->base ? true : false );
 				margin-bottom:1em;
 			}
 		</style>
+
+		<?php
+		if ( isset( $plugin ) ) {
+			$plugin = $plugin; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			?>
+			<div id="jetpack-beta-tester__breadcrumb">
+				<a href="<?php echo esc_url( Utils::admin_url() ); ?>">
+					<?php esc_html_e( 'Jetpack Beta Tester Home', 'jetpack-beta' ); ?>
+				</a>
+				<span>&nbsp;&gt; <?php echo esc_html( $plugin->get_name() ); ?></span>
+			</div>
+		<?php } ?>
+
 		<div id="jetpack-beta-tester__start" class="<?php echo ( $is_notice ? 'notice notice-updated' : 'dops-card' ); ?>">
 			<h1><?php esc_html_e( 'Welcome to Jetpack Beta Tester', 'jetpack-beta' ); ?></h1>
 			<p><?php esc_html_e( 'Thank you for helping to test our plugins!  We appreciate your time and effort.', 'jetpack-beta' ); ?></p>

--- a/projects/plugins/beta/src/admin/plugin-manage.template.php
+++ b/projects/plugins/beta/src/admin/plugin-manage.template.php
@@ -67,6 +67,12 @@ if ( is_plugin_active( $plugin->plugin_file() ) ) {
 ?>
 <?php require __DIR__ . '/header.template.php'; ?>
 <div class="jetpack-beta-container" >
+	<div id="jetpack-beta-tester__breadcrumb">
+		<a href="<?php echo esc_url( Utils::admin_url() ); ?>">
+			<?php esc_html_e( 'Jetpack Beta Tester Home', 'jetpack-beta' ); ?>
+		</a>
+		<span>&nbsp;&gt; <?php echo esc_html( $plugin->get_name() ); ?></span>
+	</div>
 	<?php
 	if ( ! Utils::has_been_used() ) {
 		require __DIR__ . '/notice.template.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When navigating to a plugin to manage, users may be confused on how to get back home to the main plugin selection screen. They could click the Jetpack Beta Tester logo in the header, but that might not be fully apparent. This PR adds a small breadcrumb link to get back home.

![Markup on 2021-07-16 at 14:13:46](https://user-images.githubusercontent.com/15803018/126004169-582a96ab-e9d2-42d4-bf6b-ce787b8c6faf.png)

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

* After pulling down changes, navigate between the specific plugin management screens (e.g. `/wp-admin/admin.php?page=jetpack-beta&plugin=vaultpress`).
* The `Jetpack Beta Tester Home` link should take you back to the main selection screen.
