### PR TITLE
Fixed Back-end tracking on Atomic sites by using the same method that checks if a user should be tracked

### DIFF
--- a/projects/packages/tracking/changelog/fix-jetpack-tracking-atomic
+++ b/projects/packages/tracking/changelog/fix-jetpack-tracking-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed back-end tracking on Atomic sites

--- a/projects/packages/tracking/legacy/class-jetpack-tracks-client.php
+++ b/projects/packages/tracking/legacy/class-jetpack-tracks-client.php
@@ -59,6 +59,20 @@ class Jetpack_Tracks_Client {
 	private static $terms_of_service = null;
 
 	/**
+	 * Stores the Jetpack Status object.
+	 *
+	 * @var null | \Automattic\Jetpack\Status
+	 */
+	private static $status = null;
+
+	/**
+	 * Store the Jetpack Tracking object.
+	 *
+	 * @var null | \Automattic\Jetpack\Tracking
+	 */
+	private static $tracks = null;
+
+	/**
 	 * Record an event.
 	 *
 	 * @param  mixed $event Event object to send to Tracks. An array will be cast to object. Required.
@@ -70,8 +84,16 @@ class Jetpack_Tracks_Client {
 			self::$terms_of_service = new \Automattic\Jetpack\Terms_Of_Service();
 		}
 
+		if ( null === self::$status ) {
+			self::$status = new \Automattic\Jetpack\Status();
+		}
+
+		if ( null === self::$tracks ) {
+			self::$tracks = new \Automattic\Jetpack\Tracking();
+		}
+
 		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
-		if ( ! self::$terms_of_service->has_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) ) {
+		if ( ! empty( $_COOKIE['tk_opt-out'] ) || ! self::$tracks->should_enable_tracking( self::$terms_of_service, self::$status ) ) {
 			return false;
 		}
 

--- a/projects/packages/tracking/src/class-tracking.php
+++ b/projects/packages/tracking/src/class-tracking.php
@@ -211,8 +211,8 @@ class Tracking {
 	/**
 	 * Determines whether tracking should be enabled.
 	 *
-	 * @param Automattic\Jetpack\Terms_Of_Service $terms_of_service A Terms_Of_Service object.
-	 * @param Automattic\Jetpack\Status           $status A Status object.
+	 * @param \Automattic\Jetpack\Terms_Of_Service $terms_of_service A Terms_Of_Service object.
+	 * @param \Automattic\Jetpack\Status           $status A Status object.
 	 *
 	 * @return boolean True if tracking should be enabled, else false.
 	 */


### PR DESCRIPTION
On Atomic sites, we don't have the Jetpack option "tos_agreed", because of this, tracking events are not fired even though in Tracking class we already check to see if a user should be tracked or not.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/20401

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Instead of having a duplicate condition, we can use the existing condition from the Tracking class that checks if a user should be tracked or not.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- On Atomic, perform an action that with an event triggered on the back-end side (e.g. deactivate plugin).
- Go to Live tracks and make sure that the event appears (usually after 5-6 minutes). 

Note: Please be aware that this a **high impact change** since we are changing the logic that determines if users should be tracked for all events triggered on the back-end side. 
