### PR TITLE
Force Calypso interfaces when sso is disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-force-calypso-links-when-sso-is-disabled
+++ b/projects/plugins/jetpack/changelog/fix-force-calypso-links-when-sso-is-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Force Calypso interfaces for Atomic sites that have Jetpack SSO disabled.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -89,6 +89,14 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * @return string
 	 */
 	public function get_preferred_view( $screen, $fallback_global_preference = true ) {
+		/**
+		 * When Jetpack SSO is disabled, we need to force Calypso because it might create confusion to be redirected to WP-Admin.
+		 * Furthermore, because we don't display the quick switcher, users having an WP-Admin interface by default won't be able to go back to the Calyso version.
+		 */
+		if ( ! \Jetpack::is_module_active( 'sso' ) ) {
+			return self::DEFAULT_VIEW;
+		}
+
 		// Plugins, Export, and Customize on Atomic sites are always managed on WP Admin.
 		if ( in_array( $screen, array( 'plugins.php', 'export.php', 'customize.php' ), true ) ) {
 			return self::CLASSIC_VIEW;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -89,17 +89,17 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * @return string
 	 */
 	public function get_preferred_view( $screen, $fallback_global_preference = true ) {
+		// Plugins, Export, and Customize on Atomic sites are always managed on WP Admin.
+		if ( in_array( $screen, array( 'plugins.php', 'export.php', 'customize.php' ), true ) ) {
+			return self::CLASSIC_VIEW;
+		}
+
 		/**
 		 * When Jetpack SSO is disabled, we need to force Calypso because it might create confusion to be redirected to WP-Admin.
 		 * Furthermore, because we don't display the quick switcher, users having an WP-Admin interface by default won't be able to go back to the Calyso version.
 		 */
 		if ( ! \Jetpack::is_module_active( 'sso' ) ) {
 			return self::DEFAULT_VIEW;
-		}
-
-		// Plugins, Export, and Customize on Atomic sites are always managed on WP Admin.
-		if ( in_array( $screen, array( 'plugins.php', 'export.php', 'customize.php' ), true ) ) {
-			return self::CLASSIC_VIEW;
 		}
 
 		return parent::get_preferred_view( $screen, $fallback_global_preference );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/54499

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Instead of relying on the global wp-admin toggle and on Dashboard Quick switcher preferences, we should force Calypso interfaces in the menu for Atomic sites that have Jetpack SSO disabled. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Switch to this branch using Jetpack Beta
* Make sure you have the wp-admin toggle turned on in me/account
* Make sure that you have a quick switcher preference for a page.
* Go to an Atomic site and disable SSO.
* Make sure that all links that should have a WP-Admin page and a Calypso page are always pointing to the Calypso interface.
