### PR TITLE
Jetpack: Change the GH link in the incomplete Jetpack notice.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-build_message
+++ b/projects/plugins/jetpack/changelog/update-build_message
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Change the GitHub link in the incomplete Jetpack notice.
+
+

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -172,7 +172,7 @@ if ( is_readable( $jetpack_autoloader ) && is_readable( $jetpack_module_headings
 							),
 						)
 					),
-					'https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md'
+					'https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md#building-your-project'
 				);
 				?>
 			</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* An incomplete Jetpack installation in a development environment is most likely caused by Jetpack being activated before it has been built, and the solution is to build Jetpack. The `Development Environment` document is large, so let's take the developer directly to the `Building your project` section of the document. I think this change makes the notice more useful, especially to new contributors who may be unfamiliar with setting up and working in the Jetpack development environment.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Delete the vendor files and `modules/module-headings.php` file. You can use this command: `jetpack clean plugins/jetpack` and select vendor and "other ignored files".

2. Navigate to a `wp-admin` page. You should see the incomplete Jetpack notice with the following text:
> Your installation of Jetpack is incomplete. If you installed Jetpack from GitHub, please refer to this document to set up your development environment. Jetpack must have Composer dependencies installed and built via the build command.

3. Click the link in the notice and verify that it opens the the "Building your project" section of the monorepo's Development Environment document: https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md#building-your-project