### PR TITLE
API: Add File Attachment & Parent Details to Media Endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/update-media-api-details
+++ b/projects/plugins/jetpack/changelog/update-media-api-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+API: Include details about where the file has been attached and its parent to the Media endpoint.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -390,36 +390,32 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		return $return;
 	}
-	
-	/**
-	 * Queries attachments to see where they have been used on the site.
-	 *
-	 * Returns the title and link of places where the file has been attached.
-	 */
+
+	// Queries attachments to see where they have been used on the site.
 	function query_attachment_id( $attachment_id ) {
 		$queries = array( wp_get_attachment_url( $attachment_id ) );
 
 		if ( wp_attachment_is_image( $attachment_id ) ) {
 			$meta = wp_get_attachment_metadata( $attachment_id );
-			
-			foreach ( $meta['sizes'] as $name => $info ) {
+
+			foreach ( $meta['sizes'] as $info ) {
 				$queries[] = wp_upload_dir()['url'] . '/' . $info['file'];
 			}
 		}
 
 		$content_ids = array();
-
 		foreach ( $queries as $query ) {
 			$args = array(
-				's'            => $query,
-				'fields'       => 'ids',
-				'post_type'    => 'any',
+				's'         => $query,
+				'fields'    => 'ids',
+				'post_type' => 'any',
 			);
-			
+
 			$content_query = new WP_Query( $args );
-			$content_ids = array_merge( $content_query->posts, $content_ids );
+			$content_ids   = array_merge( $content_query->posts, $content_ids );
 		}
 
+		$data = array();
 		foreach ( $content_ids as $id ) {
 			$data[] = array(
 				'title' => get_the_title( $id ),

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
@@ -31,6 +31,7 @@ new WPCOM_JSON_API_List_Media_v1_1_Endpoint( array(
 		'mime_type' => "(string) Default is empty. Filter by mime type (e.g., 'image/jpeg', 'application/pdf'). Partial searches also work (e.g. passing 'image' will search for all image files).",
 		'after'     => '(ISO 8601 datetime) Return media items uploaded after the specified datetime.',
 		'before'    => '(ISO 8601 datetime) Return media items uploaded before the specified datetime.',
+		'query_attached_files' => '(bool=false) If should perform a search to see where the content has been attached to.',
 	),
 
 	'response_format' => array(
@@ -145,8 +146,10 @@ class WPCOM_JSON_API_List_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		$response = array();
 
+		$should_query_attached_files = $args['query_attached_files'];
+
 		foreach ( $media->posts as $item ) {
-			$response[] = $this->get_media_item_v1_1( $item->ID );
+			$response[] = $this->get_media_item_v1_1( $item->ID, null, null, $should_query_attached_files );
 		}
 
 		$return = array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Required for Automattic/wp-calypso#54691

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds two pieces of information to the Media endpoint:
* Details from the "Uploaded to" section (it already exists in WP-Admin, so this is part of the effort for it to mirror Calypso)
* Details about where the file has been attached

#### Jetpack product discussion
* N/A - all in Calypso.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* I don't think so, this is just a change needed for Calypso

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Add a file from a specific post, and include that file into various other posts
- Inspect the call to the media endpoint
- Verify the response includes the correct data relating to this

<img width="986" alt="Screenshot 2021-07-19 at 17 32 57" src="https://user-images.githubusercontent.com/43215253/126194998-92c4ff4d-0a76-4c2e-9676-91a2437714d9.png">

