### PR TITLE
SEO: Earlier load of functions

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-seo-load-order
+++ b/projects/plugins/jetpack/changelog/improve-seo-load-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO Tools: Ensure functions are loaded before API endpoint attempts to use them.

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -56,6 +56,11 @@ require_once JETPACK__PLUGIN_DIR . 'class.frame-nonce-preview.php';
 require_once JETPACK__PLUGIN_DIR . 'modules/module-headings.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
+// Used by the API endpoints.
+require_once JETPACK__PLUGIN_DIR . 'modules/seo-tools/jetpack-seo-utils.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/seo-tools/jetpack-seo-titles.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/seo-tools/jetpack-seo-posts.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/verification-tools/verification-tools-utils.php';
 
 require_once JETPACK__PLUGIN_DIR . 'class-jetpack-xmlrpc-methods.php';
 Jetpack_XMLRPC_Methods::init();

--- a/projects/plugins/jetpack/modules/module-extras.php
+++ b/projects/plugins/jetpack/modules/module-extras.php
@@ -33,11 +33,6 @@ $tools = array(
 	'theme-tools/social-menu.php',
 	'theme-tools/content-options.php',
 	'theme-tools/devicepx.php',
-	// Needed for SEO Tools.
-	'seo-tools/jetpack-seo-utils.php',
-	'seo-tools/jetpack-seo-titles.php',
-	'seo-tools/jetpack-seo-posts.php',
-	'verification-tools/verification-tools-utils.php',
 	// Needed for VideoPress, so videos keep working in existing posts/pages when the module is deactivated.
 	'videopress/utility-functions.php',
 	'videopress/class.videopress-gutenberg.php',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #19511

I didn't track down quite what was causing it, but improving the load order should take care of it.
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Load files that only define functions (not call them) to earlier in the process.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not sure how to reproduce, so not sure how to test. 
* Ensure nothing breaks in the unit test?
