### PR TITLE
Fix "My Sites" navigation in WP-Admin on Atomic sites  with SSO disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-my-sites-on-atomic-without-sso
+++ b/projects/plugins/jetpack/changelog/fix-my-sites-on-atomic-without-sso
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix My Sites navigation in WP-Admin for Atomic sites with SSO disabled (and nav-unification disabled).

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -87,4 +87,6 @@ function get_admin_menu_class() {
 $admin_menu_class = apply_filters( 'jetpack_admin_menu_class', get_admin_menu_class() );
 if ( should_customize_nav( $admin_menu_class ) ) {
 	$admin_menu_class::get_instance();
+} else {
+	\add_filter( 'jetpack_load_admin_menu_class', '__return_false' );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
This PR fixes the scenario in which My Sites navigation displays an empty slider that happens when the Nav-unification is disabled on Atomic sites with SSO disabled.

Fixes https://github.com/Automattic/wp-calypso/issues/54502

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* We rely on the `jetpack_load_admin_menu_class` filter to disable the My Sites navigation for sites with nav-unification enabled. However, there's a case when the filter still returns a class even though the nav-unification is disabled. In this case, the `My Sites` navigation from masterbar remains disabled. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to an Atomic site and switch to this branch using Jetpack Beta.
* Go to Jetpack > Dashboard > Settings and disable SSO.
* Go to WP-Admin and click on the `My Sites` link.
* You should be able to see the old navigation opening using the slider.
