### PR TITLE
Tiled gallery: Don't swap width and height in srcset

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-srcset-width
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-srcset-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Tiled Gallery: Fix blurry display of images much wider than they are high.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -78,8 +78,8 @@ class Tiled_Gallery {
 
 			foreach ( $images[0] as $image_html ) {
 				if (
-					preg_match( '/data-width="([0-9]+)"/', $image_html, $img_height )
-					&& preg_match( '/data-height="([0-9]+)"/', $image_html, $img_width )
+					preg_match( '/data-width="([0-9]+)"/', $image_html, $img_width )
+					&& preg_match( '/data-height="([0-9]+)"/', $image_html, $img_height )
 					&& preg_match( '/src="([^"]+)"/', $image_html, $img_src )
 				) {
 					// Drop img src query string so it can be used as a base to add photon params


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It had the width and height swapped when processing images to generate
the srcset attribute. This is most noticeable when the gallery contains
images that are much wider than they are high, resulting in ridiculously
small images in the srcset that the browser then scales up into a blurry
mess.

Fixes Automattic/jpop-issues#6772

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
6772-gh-Automattic/jpop-issues

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a tiled gallery where the images are much wider than they are high. Use the default layout.
* See if the images look normalish, or if they're a blurry mess.