### PR TITLE
Jetpack: Fail build if the php:module-heading step fails

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-build-module-header-step-fail
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-build-module-header-step-fail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fail build if the php:module-headings step fails.

--- a/projects/plugins/jetpack/gulpfile.babel.js
+++ b/projects/plugins/jetpack/gulpfile.babel.js
@@ -65,7 +65,7 @@ gulp.task( 'search-configure:watch', function () {
 	child.stdout.on( 'data', data => log( data.toString() ) );
 } );
 
-gulp.task( 'php:module-headings', function ( callback ) {
+gulp.task( 'php:module-headings', function () {
 	const process = spawn( 'php', [ 'tools/build-module-headings-translations.php' ] );
 	process.stderr.on( 'data', function ( data ) {
 		log( data.toString() );
@@ -73,12 +73,7 @@ gulp.task( 'php:module-headings', function ( callback ) {
 	process.stdout.on( 'data', function ( data ) {
 		log( data.toString() );
 	} );
-	process.on( 'exit', function ( code ) {
-		if ( 0 !== code ) {
-			log( 'Failed building module headings translations: process exited with code ', code );
-		}
-		callback();
-	} );
+	return process;
 } );
 
 gulp.task( 'old-styles', gulp.parallel( frontendcss, admincss, 'sass:old', 'sass:packages' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Gulp does the right thing if we return the "child_process" object from
the task function, so let's just do that.

https://gulpjs.com/docs/en/getting-started/async-completion/

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
I saw this during discussion of p1626874210189400-slack-CBG1CP4EN, but probably not actually the cause of the problem there.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit `projects/plugins/jetpack/tools/build-module-headings-translations.php` to error out, e.g. by adding `exit(1);` at the end.
* See if `jetpack build plugins/jetpack` properly fails.