### PR TITLE
Force local node version to match expected

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,7 @@
 save-exact = true
 prefer-workspace-packages = true
+# Force node version
+engine-strict = true
 
 # Default, minus eslint.
 public-hoist-pattern=['*types*', '@prettier/plugin-*', '*prettier-plugin-*']

--- a/projects/plugins/jetpack/changelog/add-force-node-version-match
+++ b/projects/plugins/jetpack/changelog/add-force-node-version-match
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Require local node to match one defined in package.json

--- a/projects/plugins/jetpack/changelog/add-force-node-version-match
+++ b/projects/plugins/jetpack/changelog/add-force-node-version-match
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Require local node to match one defined in package.json
+E2E tests: Require local node to match one defined in package.json

--- a/projects/plugins/jetpack/tests/e2e/.npmrc
+++ b/projects/plugins/jetpack/tests/e2e/.npmrc
@@ -1,0 +1,2 @@
+# Force node version
+engine-strict = true


### PR DESCRIPTION
Throws error if locally installed node version is not matching one defined in package.json

Fixes #20428


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* switch to older node version: `nvm use 14.16.0`
* run any `pnpm` command: `pnpm lint`

error example:

```
✗ pnpm lint
 ERROR  Your Node version is incompatible with "/Users/brbrr/Developer/a8c/jetpack".

Expected version: ^14.16.1
Got: v14.16.0

This is happening because the package's manifest has an engines.node field specified.
To fix this issue, install the required Node version.
```
