### PR TITLE
[Plugin] Backup: Updated links and changed to use Jetpack Redirect service

### DIFF
--- a/projects/plugins/backup/changelog/update-backup-plugin-links
+++ b/projects/plugins/backup/changelog/update-backup-plugin-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated all external links to use redirect service

--- a/projects/plugins/backup/src/js/components/Admin.js
+++ b/projects/plugins/backup/src/js/components/Admin.js
@@ -5,7 +5,7 @@ import { Fragment, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useSelect } from '@wordpress/data';
-import { JetpackFooter, JetpackLogo } from '@automattic/jetpack-components';
+import { JetpackFooter, JetpackLogo, getRedirectUrl } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -70,7 +70,7 @@ const Admin = () => {
 						</p>
 						<a
 							class="button"
-							href={ `https://wordpress.com/plans/${ domain }` }
+							href={ getRedirectUrl( 'backup-plugin-upgrade' ) }
 							target="_blank"
 							rel="noreferrer"
 						>
@@ -187,7 +187,7 @@ const Admin = () => {
 					{ ! capabilities.includes( 'backup-realtime' ) && (
 						<a
 							class="jp-cut"
-							href={ 'https://wordpress.com/checkout/' + domain + '/jetpack_backup_realtime' }
+							href={ getRedirectUrl( 'backup-plugin-realtime-upgrade', { site: domain } ) }
 						>
 							<span>
 								{ __(
@@ -210,7 +210,7 @@ const Admin = () => {
 					</p>
 					<p>
 						<a
-							href={ 'https://cloud.jetpack.com/activity-log/' + domain }
+							href={ getRedirectUrl( 'backup-plugin-activity-log', { site: domain } ) }
 							target="_blank"
 							rel="noreferrer"
 						>

--- a/projects/plugins/backup/src/js/components/Backups.js
+++ b/projects/plugins/backup/src/js/components/Backups.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { createInterpolateElement, useState, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -139,7 +140,7 @@ const Backups = () => {
 							{
 								a: (
 									<a
-										href={ `https://cloud.jetpack.com/backup/${ domain }` }
+										href={ getRedirectUrl( 'jetpack-backup', { site: domain } ) }
 										target="_blank"
 										rel="noreferrer"
 									/>
@@ -181,7 +182,7 @@ const Backups = () => {
 					<h1>{ formatDateString( latestTime ) }</h1>
 					<a
 						class="button is-full-width"
-						href={ `https://cloud.jetpack.com/backup/${ domain }` }
+						href={ getRedirectUrl( 'jetpack-backup', { site: domain } ) }
 						target="_blank"
 						rel="noreferrer"
 					>
@@ -235,7 +236,7 @@ const Backups = () => {
 							{
 								a: (
 									<a
-										href={ `https://tools.jetpack.com/debug/?url=${ domain }` }
+										href={ getRedirectUrl( 'backup-plugin-debug', { site: domain } ) }
 										target="_blank"
 										rel="noreferrer"
 									/>
@@ -252,7 +253,7 @@ const Backups = () => {
 							{
 								a: (
 									<a
-										href={ `https://cloud.jetpack.com/backup/${ domain }` }
+										href={ getRedirectUrl( 'jetpack-backup', { site: domain } ) }
 										target="_blank"
 										rel="noreferrer"
 									/>


### PR DESCRIPTION
Fixes #20356

#### Changes proposed in this Pull Request:
* Updated all external links to use getRedirectUrl
* Updated the 'Upgrade Now' button (visible when a site has no backup capabilities) to go to jetpack.com/upgrade/backup
* All non-dashboard links use new `backup-plugin-` prefixed redirect sources.

#### Jetpack product discussion
1200631314158697-as

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Install the Backup Plugin
* 7 links were updated to use redirect
 * Upgrade Now is visible if you have no plan on the site (remove plan from Store Admin and you may need to wait up to 15min for cache)
 * The Real-time upgrade CTA is only visible if you don't have Real-time but do have backup, so when adding a new plan, just add Backup Daily so this will be visible
 * `See your site's activity` link is visible with a backup plan
 * `See your backups` link is visible with a successful backup
 * The dashboard link (which is the same as the See your backups) and debugger link is available only if you have no backups and none in progress.  This state is hard to check naturally without breaking backups somehow or truncating them.  You can fake this by setting `setBackupState( BACKUP_STATE.NO_BACKUPS );` in the Backup.js apiFetch `then()` and returning early.
