### PR TITLE
Widget Visibility - rename taxonomy label "All Pages" in dropdown

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-20439
+++ b/projects/plugins/jetpack/changelog/fix-20439
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Widget Visibility - rename taxonomy label "All Pages" in dropdown

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -289,7 +289,7 @@ class Jetpack_Widget_Conditions {
 			);
 
 			$widget_conditions_terms   = array();
-			$widget_conditions_terms[] = array( $taxonomy->name, __( 'All pages', 'jetpack' ) );
+			$widget_conditions_terms[] = array( $taxonomy->name, $taxonomy->labels->all_items );
 
 			foreach ( $taxonomy_terms as $term ) {
 				$widget_conditions_terms[] = array( $taxonomy->name . '_tax_' . $term->term_id, $term->name );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change "All Pages" label in dropdown to those one saved as "all_items" in taxonomy configuration

#### Testing instructions:

* Go to Widgets settings
* Open Widget Visibility
* Choose "Show if" taxonomy
* Instead of "All Pages" see taxonomy translation for this label
