### PR TITLE
Backup plugin: Integrate ConnectionStatusCard RNA component

### DIFF
--- a/projects/plugins/backup/changelog/update-integrate-connection-status-card-in-backup-plugin
+++ b/projects/plugins/backup/changelog/update-integrate-connection-status-card-in-backup-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Integrate ConnectionStatusCard component for managing the site/user connection.

--- a/projects/plugins/backup/src/js/components/Admin.js
+++ b/projects/plugins/backup/src/js/components/Admin.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Fragment, useState, useEffect } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useSelect } from '@wordpress/data';
@@ -18,7 +18,7 @@ import { STORE_ID } from '../store';
 
 /* eslint react/react-in-jsx-scope: 0 */
 const Admin = () => {
-	const [ connectionStatus, renderConnectScreen ] = useConnection();
+	const [ connectionStatus, renderConnectScreen, renderConnectionStatusCard ] = useConnection();
 	const [ capabilities, setCapabilities ] = useState( null );
 	const [ capabilitiesError, setCapabilitiesError ] = useState( null );
 	const [ connectionLoaded, setConnectionLoaded ] = useState( false );
@@ -161,15 +161,7 @@ const Admin = () => {
 	};
 
 	const renderManageConnection = () => {
-		// TODO: Integrate connection management from Connection Package
-		return (
-			<Fragment>
-				<h2>{ __( 'Manage your connection', 'jetpack-backup' ) }</h2>
-				<p className="notice notice-success">
-					{ __( 'Site and User Connected.', 'jetpack-backup' ) }
-				</p>
-			</Fragment>
-		);
+		return renderConnectionStatusCard();
 	};
 
 	// Renders additional segments under the jp-hero area condition on having a backup plan

--- a/projects/plugins/backup/src/js/hooks/useConnection.js
+++ b/projects/plugins/backup/src/js/hooks/useConnection.js
@@ -3,7 +3,7 @@
  */
 import React, { useCallback } from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { ConnectScreen } from '@automattic/jetpack-connection';
+import { ConnectScreen, ConnectionStatusCard } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -32,6 +32,10 @@ export default function useConnection() {
 		[ setConnectionStatus ]
 	);
 
+	const onDisconnectedCallback = useCallback( () => {
+		setConnectionStatus( { isActive: false, isRegistered: false, isUserConnected: false } );
+	}, [ setConnectionStatus ] );
+
 	const renderConnectScreen = () => {
 		return (
 			<ConnectScreen
@@ -53,5 +57,18 @@ export default function useConnection() {
 		);
 	};
 
-	return [ connectionStatus, renderConnectScreen ];
+	const renderConnectionStatusCard = () => {
+		return (
+			<ConnectionStatusCard
+				isRegistered={ connectionStatus.isRegistered }
+				isUserConnected={ connectionStatus.isUserConnected }
+				apiRoot={ APIRoot }
+				apiNonce={ APINonce }
+				onDisconnected={ onDisconnectedCallback }
+				redirectUri="admin.php?page=jetpack-backup"
+			/>
+		);
+	};
+
+	return [ connectionStatus, renderConnectScreen, renderConnectionStatusCard ];
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Integrates the `ConnectionStatusCard` RNA component into the Backup Plugin.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Replaces the current Connection Management section with the `ConnectionStatusCard`component.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbuNQi-1w3-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
**Important:** Unfortunately, until we get [this PR](https://github.com/Automattic/jetpack/pull/20440) merged we can't test with standalone Backup plugin.

- Spin up a new JN site or test locally with Jetpack active
- Activate the Backup Plugin
- Navigate to `/wp-admin/admin.php?page=jetpack-backup`
- Fully connect by clicking the `Set up Jetpack` button 
- Confirm that you see your WPCOM user info as displayed below:
<img width="470" alt="Screenshot 2021-07-22 at 5 34 10 PM" src="https://user-images.githubusercontent.com/1758399/126799547-49ffe518-3dcc-4a65-973a-7b7fb2ca288c.png">

- Try disconnecting by clicking the `Disconnect` link

- After successful disconnection you should be presented with the `ConnectScreen` again

#### Important Notes
- We have already requested and got review from Design for the  `ConnectionStatusCard` RNA component. There's an existing issue that tracks a few suggested changes we'll need to implement. internal: 1199658893173824-as-1200636806056127/f
- This PR focuses on integrating the component. This is why it's not touching the existing logic on what to display depending on whether the site is fully connected. Right now we display the `ConnectScreen` even if the site connection is already established, however we might want to consider only showing it when the site is not registered and let the `ConnectionStatusCard` component handle connected/not-connected user.