### PR TITLE
Identity Crisis: remove unneeded test helper method return_example_url

### DIFF
--- a/projects/packages/identity-crisis/changelog/update-remove_example_url
+++ b/projects/packages/identity-crisis/changelog/update-remove_example_url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove the unneeded return_example_url method.
+
+

--- a/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
+++ b/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
@@ -330,11 +330,4 @@ class Test_Identity_Crisis extends BaseTestCase {
 	public function return_string_1() {
 		return '1';
 	}
-
-	/**
-	 * Return string 'example.org'.
-	 */
-	public function return_example_url() {
-		return 'https://example.org';
-	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The `return_example_url` method is not needed, so remove it.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Verify that the tests pass.
