### PR TITLE
Heartbeat: Include media library size

### DIFF
--- a/projects/plugins/jetpack/changelog/add-media-library-size
+++ b/projects/plugins/jetpack/changelog/add-media-library-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Heartbeat: Calculate media library size

--- a/projects/plugins/jetpack/class.jetpack-heartbeat.php
+++ b/projects/plugins/jetpack/class.jetpack-heartbeat.php
@@ -91,6 +91,16 @@ class Jetpack_Heartbeat {
 		}
 		$return[ "{$prefix}manage-enabled" ] = true;
 
+		if ( function_exists( 'get_space_used' ) ) { // Only available in multisite.
+			$space_used = get_space_used();
+		} else {
+			// This is the same as `get_space_used`, except it does not apply the short-circuit filter.
+			$upload_dir = wp_upload_dir();
+			$space_used = get_dirsize( $upload_dir['basedir'] ) / MB_IN_BYTES;
+		}
+
+		$return[ "{$prefix}space-used" ] = $space_used;
+
 		$xmlrpc_errors = Jetpack_Options::get_option( 'xmlrpc_errors', array() );
 		if ( $xmlrpc_errors ) {
 			$return[ "{$prefix}xmlrpc-errors" ] = implode( ',', array_keys( $xmlrpc_errors ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Includes output of `get_space_used` or shim code as part of the heartbeat array.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
To be used to help us determine the general sizes of the media library on sites.
p1HpG7-cyv-p2#comment-47782

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* We would add tracking the size of the media library as a discreet item. We could calculate something close to this with existing data.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with this PR, run the debugger. See the new value as part of the heartbeat.