### PR TITLE
Fix bug where strlen is being called on the raw unencoded items

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-sender-upload-size
+++ b/projects/packages/sync/changelog/fix-sync-sender-upload-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update Sender so it adheres to max upload bytes when not encoding items.

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -436,12 +436,12 @@ class Sender {
 				$skipped_items_ids[] = $key;
 				continue;
 			}
-			$encoded_item = $encode ? $this->codec->encode( $item ) : $item;
+			$encoded_item = $this->codec->encode( $item );
 			$upload_size += strlen( $encoded_item );
 			if ( $upload_size > $this->upload_max_bytes && count( $items_to_send ) > 0 ) {
 				break;
 			}
-			$items_to_send[ $key ] = $encoded_item;
+			$items_to_send[ $key ] = $encode ? $encoded_item : $item;
 			if ( microtime( true ) - $start_time > $this->max_dequeue_time ) {
 				break;
 			}


### PR DESCRIPTION
To reduce OOM an other errors we enforce a maximum size on the data sent to WP.com for processing. This check makes use of strlen however if encoding is disabled it attempts to run strlen on an array which causes php warnings and also bypasses the content limit. This update ensures the encoded object is used in the strlen check.

Fixes # https://wp.me/p9F6qB-7bJ

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Sync Sender - resolve strlen usage that causes php warnings

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:

Changes are covered by unit/integration tests.
Modify content on a Jetpack connected site and verify it Syncs and is persisted to the cache.
