### PR TITLE
Carousel: Add admin option to toggle whether or not to display blurred background image.

### DIFF
--- a/projects/packages/sync/changelog/update-carousel-add-option-to-toggle-background-image
+++ b/projects/packages/sync/changelog/update-carousel-add-option-to-toggle-background-image
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Sync option for the Carousel to display blurred background image behind focused image.
+Sync option for the Carousel to display colorized slide background.

--- a/projects/packages/sync/changelog/update-carousel-add-option-to-toggle-background-image
+++ b/projects/packages/sync/changelog/update-carousel-add-option-to-toggle-background-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync option for the Carousel to display blurred background image behind focused image.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -33,7 +33,7 @@ class Defaults {
 		'carousel_background_color',
 		'carousel_display_exif',
 		'carousel_display_comments',
-		'carousel_display_background_image',
+		'carousel_display_slide_background',
 		'category_base',
 		'ce4wp_referred_by', // Creative Mail. See pbtFPC-H5-p2.
 		'close_comments_days_old',

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -33,6 +33,7 @@ class Defaults {
 		'carousel_background_color',
 		'carousel_display_exif',
 		'carousel_display_comments',
+		'carousel_display_background_image',
 		'category_base',
 		'ce4wp_referred_by', // Creative Mail. See pbtFPC-H5-p2.
 		'close_comments_days_old',

--- a/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
@@ -35,7 +35,15 @@ function WritingMedia( props ) {
 
 	const displayComments = props.getOptionValue( 'carousel_display_comments', 'carousel' );
 	const displayExif = props.getOptionValue( 'carousel_display_exif', 'carousel' );
+	const displayBackgroundImage = props.getOptionValue(
+		'carousel_display_background_image',
+		'carousel'
+	);
 	const isCarouselActive = props.getOptionValue( 'carousel' );
+
+	const handleCarouselDisplayBackgroundImageChange = () => {
+		props.updateFormStateModuleOption( 'carousel', 'carousel_display_background_image' );
+	};
 
 	const handleCarouselDisplayExifChange = () => {
 		props.updateFormStateModuleOption( 'carousel', 'carousel_display_exif' );
@@ -108,6 +116,12 @@ function WritingMedia( props ) {
 						'carousel_display_comments',
 						handleCarouselDisplayCommentsChange,
 						__( 'Show comments area in carousel', 'jetpack' )
+					) }
+					{ renderToggle(
+						displayBackgroundImage,
+						'carousel_display_background_image',
+						handleCarouselDisplayBackgroundImageChange,
+						__( 'Display blurred background behind focused image', 'jetpack' )
 					) }
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">

--- a/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
@@ -35,14 +35,14 @@ function WritingMedia( props ) {
 
 	const displayComments = props.getOptionValue( 'carousel_display_comments', 'carousel' );
 	const displayExif = props.getOptionValue( 'carousel_display_exif', 'carousel' );
-	const displayBackgroundImage = props.getOptionValue(
-		'carousel_display_background_image',
+	const displaySlideBackground = props.getOptionValue(
+		'carousel_display_slide_background',
 		'carousel'
 	);
 	const isCarouselActive = props.getOptionValue( 'carousel' );
 
-	const handleCarouselDisplayBackgroundImageChange = () => {
-		props.updateFormStateModuleOption( 'carousel', 'carousel_display_background_image' );
+	const handleCarouselDisplaySlideBackgroundChange = () => {
+		props.updateFormStateModuleOption( 'carousel', 'carousel_display_slide_background' );
 	};
 
 	const handleCarouselDisplayExifChange = () => {
@@ -118,10 +118,10 @@ function WritingMedia( props ) {
 						__( 'Show comments area in carousel', 'jetpack' )
 					) }
 					{ renderToggle(
-						displayBackgroundImage,
-						'carousel_display_background_image',
-						handleCarouselDisplayBackgroundImageChange,
-						__( 'Display blurred background behind focused image', 'jetpack' )
+						displaySlideBackground,
+						'carousel_display_slide_background',
+						handleCarouselDisplaySlideBackgroundChange,
+						__( 'Display colorized slide backgrounds', 'jetpack' )
 					) }
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2168,10 +2168,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'carousel',
 			),
-			'carousel_display_background_image'    => array(
-				'description'       => esc_html__( 'Display blurred background behind focused image', 'jetpack' ),
+			'carousel_display_slide_background'    => array(
+				'description'       => esc_html__( 'Display colorized slide backgrounds', 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => 1,
+				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'carousel',
 			),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2168,6 +2168,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'carousel',
 			),
+			'carousel_display_background_image'    => array(
+				'description'       => esc_html__( 'Display blurred background behind focused image', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 1,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'carousel',
+			),
 
 			// Comments
 			'highlander_comment_form_prompt'       => array(

--- a/projects/plugins/jetpack/changelog/update-carousel-add-option-to-toggle-background-image
+++ b/projects/plugins/jetpack/changelog/update-carousel-add-option-to-toggle-background-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Carousel: Add settings toggle to make the blurred background image optional.

--- a/projects/plugins/jetpack/changelog/update-carousel-add-option-to-toggle-background-image
+++ b/projects/plugins/jetpack/changelog/update-carousel-add-option-to-toggle-background-image
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Carousel: Add settings toggle to make the blurred background image optional.
+Carousel: Add settings toggle to control display of colorized slide background.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -789,7 +789,7 @@
 
 			loadFullImage( carousel.slides[ index ] );
 
-			if ( Number( jetpackCarouselStrings.display_background_image ) === 1 ) {
+			if ( Number( jetpackCarouselStrings.display_slide_background ) === 1 ) {
 				loadSlideBackgrounds();
 			}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -788,7 +788,10 @@
 			}
 
 			loadFullImage( carousel.slides[ index ] );
-			loadSlideBackgrounds();
+
+			if ( Number( jetpackCarouselStrings.display_background_image ) === 1 ) {
+				loadSlideBackgrounds();
+			}
 
 			domUtil.hide( carousel.caption );
 			updateTitleCaptionAndDesc( {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -261,7 +261,7 @@ class Jetpack_Carousel {
 				'display_exif'                    => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', true ) ),
 				'display_comments'                => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_comments', true ) ),
 				'display_geo'                     => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_geo', true ) ),
-				'display_background_image'        => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_background_image', true ) ),
+				'display_slide_background'        => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_slide_background', false ), false ),
 				'single_image_gallery'            => $this->single_image_gallery_enabled,
 				'single_image_gallery_media_file' => $this->single_image_gallery_enabled_media_file,
 				'background_color'                => $this->carousel_background_color_sanitize( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_background_color', '' ) ),
@@ -1066,8 +1066,8 @@ class Jetpack_Carousel {
 		add_settings_field( 'carousel_display_comments', __( 'Comments', 'jetpack' ), array( $this, 'carousel_display_comments_callback' ), 'media', 'carousel_section' );
 		register_setting( 'media', 'carousel_display_comments', array( $this, 'carousel_display_comments_sanitize' ) );
 
-		add_settings_field( 'carousel_display_background_image', __( 'Background image', 'jetpack' ), array( $this, 'carousel_display_background_image_callback' ), 'media', 'carousel_section' );
-		register_setting( 'media', 'carousel_display_background_image', array( $this, 'carousel_display_background_image_sanitize' ) );
+		add_settings_field( 'carousel_display_slide_background', __( 'Slide background', 'jetpack' ), array( $this, 'carousel_display_slide_background_callback' ), 'media', 'carousel_section' );
+		register_setting( 'media', 'carousel_display_slide_background', array( $this, 'carousel_display_slide_background_sanitize' ) );
 
 		// No geo setting yet, need to "fuzzify" data first, for privacy
 		// add_settings_field('carousel_display_geo', __( 'Geolocation', 'jetpack' ), array( $this, 'carousel_display_geo_callback' ), 'media', 'carousel_section' );
@@ -1143,20 +1143,20 @@ class Jetpack_Carousel {
 	}
 
 	/**
-	 * Callback for checkbox and label of field that toggles background image.
+	 * Callback for checkbox and label of field that toggles slide background color.
 	 */
-	public function carousel_display_background_image_callback() {
-		$this->settings_checkbox( 'carousel_display_background_image', esc_html__( 'Show blurred background image behind focused image', 'jetpack' ) );
+	public function carousel_display_slide_background_callback() {
+		$this->settings_checkbox( 'carousel_display_slide_background', esc_html__( 'Display colorized slide backgrounds', 'jetpack' ), '', false );
 	}
 
 	/**
-	 * Return sanitized option for value that controls whether the blurred background image is displayed.
+	 * Return sanitized option for value that controls whether the slide background color is displayed.
 	 *
 	 * @param number $value Value to sanitize.
 	 *
 	 * @return number Sanitized value, only 1 or 0.
 	 */
-	public function carousel_display_background_image_sanitize( $value ) {
+	public function carousel_display_slide_background_sanitize( $value ) {
 		return $this->sanitize_1or0_option( $value );
 	}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -261,6 +261,7 @@ class Jetpack_Carousel {
 				'display_exif'                    => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', true ) ),
 				'display_comments'                => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_comments', true ) ),
 				'display_geo'                     => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_geo', true ) ),
+				'display_background_image'        => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_background_image', true ) ),
 				'single_image_gallery'            => $this->single_image_gallery_enabled,
 				'single_image_gallery_media_file' => $this->single_image_gallery_enabled_media_file,
 				'background_color'                => $this->carousel_background_color_sanitize( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_background_color', '' ) ),
@@ -1065,6 +1066,9 @@ class Jetpack_Carousel {
 		add_settings_field( 'carousel_display_comments', __( 'Comments', 'jetpack' ), array( $this, 'carousel_display_comments_callback' ), 'media', 'carousel_section' );
 		register_setting( 'media', 'carousel_display_comments', array( $this, 'carousel_display_comments_sanitize' ) );
 
+		add_settings_field( 'carousel_display_background_image', __( 'Background image', 'jetpack' ), array( $this, 'carousel_display_background_image_callback' ), 'media', 'carousel_section' );
+		register_setting( 'media', 'carousel_display_background_image', array( $this, 'carousel_display_background_image_sanitize' ) );
+
 		// No geo setting yet, need to "fuzzify" data first, for privacy
 		// add_settings_field('carousel_display_geo', __( 'Geolocation', 'jetpack' ), array( $this, 'carousel_display_geo_callback' ), 'media', 'carousel_section' );
 		// register_setting( 'media', 'carousel_display_geo', array( $this, 'carousel_display_geo_sanitize' ) );
@@ -1135,6 +1139,24 @@ class Jetpack_Carousel {
 	}
 
 	function carousel_display_exif_sanitize( $value ) {
+		return $this->sanitize_1or0_option( $value );
+	}
+
+	/**
+	 * Callback for checkbox and label of field that toggles background image.
+	 */
+	public function carousel_display_background_image_callback() {
+		$this->settings_checkbox( 'carousel_display_background_image', esc_html__( 'Show blurred background image behind focused image', 'jetpack' ) );
+	}
+
+	/**
+	 * Return sanitized option for value that controls whether the blurred background image is displayed.
+	 *
+	 * @param number $value Value to sanitize.
+	 *
+	 * @return number Sanitized value, only 1 or 0.
+	 */
+	public function carousel_display_background_image_sanitize( $value ) {
 		return $this->sanitize_1or0_option( $value );
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -142,7 +142,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'carousel_background_color'                    => 'pineapple',
 			'carousel_display_exif'                        => 'pineapple',
 			'carousel_display_comments'                    => 'pineapple',
-			'carousel_display_background_image'            => 'pineapple',
+			'carousel_display_slide_background'            => 'pineapple',
 			'jetpack_portfolio'                            => 'pineapple',
 			'jetpack_portfolio_posts_per_page'             => 'pineapple',
 			'jetpack_testimonial'                          => 'pineapple',

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -142,6 +142,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'carousel_background_color'                    => 'pineapple',
 			'carousel_display_exif'                        => 'pineapple',
 			'carousel_display_comments'                    => 'pineapple',
+			'carousel_display_background_image'            => 'pineapple',
 			'jetpack_portfolio'                            => 'pineapple',
 			'jetpack_portfolio_posts_per_page'             => 'pineapple',
 			'jetpack_testimonial'                          => 'pineapple',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

This PR is split out from #20377, to explore putting the feature behind an admin toggle. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add an option to toggle the background color display for the Carousel (the feature introduced in #20377)
* Currently this defaults to off if no option is present — should it instead default to being switched on?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See #20377 for more on the background color feature

#### Screenshots

From options screen (`/wp-admin/options-media.php`):

![image](https://user-images.githubusercontent.com/14988353/127081044-7fec80d1-c873-4746-b258-076c69307847.png)

From Jetpack settings screen (`/wp-admin/admin.php?page=jetpack#/writing`):

![image](https://user-images.githubusercontent.com/14988353/127081153-bc89ebf6-1c83-4cb7-872a-57247b7b8b5c.png)

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before testing the below steps, run the following (assuming you're using `wp-env`) to ensure you do not already have a value set for the option — this will help test that the default behaviour is for the feature to be switched off:

```
wp-env run cli wp option delete carousel_display_slide_background
wp-env run cli wp option get carousel_display_slide_background
```

* With the Carousel module enabled go to `/wp-admin/admin.php?page=jetpack#/writing` and you should see an option to toggle the blurred background image
* With the option switched off, the feature introduced in #20377 should not be present
* With the option switched on, the background color / blurred background image should be displayed
* From the Media options screen (`/wp-admin/options-media.php`) repeat the above steps to toggle the feature and ensure it works as expected

