### PR TITLE
Add badge to admin menus endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -158,6 +158,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 					'description' => 'Additional text to be added inline with the menu title.',
 					'type'        => 'string',
 				),
+				'badge'      => array(
+					'description' => 'Badge to be added inline with the menu title.',
+					'type'        => 'string',
+				),
 				'slug'       => array(
 					'type' => 'string',
 				),
@@ -413,6 +417,19 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			if ( $text ) {
 				// Keep the text in the item array.
 				$item['inlineText'] = $text;
+			}
+
+			// Finally remove the markup.
+			$title = trim( str_replace( $matches[0], '', $title ) );
+		}
+
+		if ( false !== strpos( $title, 'awaiting-mod' ) ) {
+			preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches );
+
+			$text = $matches[1];
+			if ( $text ) {
+				// Keep the text in the item array.
+				$item['badge'] = $text;
 			}
 
 			// Finally remove the markup.

--- a/projects/plugins/jetpack/changelog/add-admin-menu-rest-api-badge
+++ b/projects/plugins/jetpack/changelog/add-admin-menu-rest-api-badge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add badge to admin menus endpoint

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -568,9 +568,16 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				),
 			),
 			array(
-				'<span class="unexpected-classname">badge name</span> Unexpected <font style="vertical-align: inherit;"><font style="vertical-align: inherit;">markup</font></font><span class="awaiting-mod"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;"></font></font></span> <span class="unexpected-classname">badge name</span>',
+				'<span class="unexpected-classname">badge name</span> Unexpected <font style="vertical-align: inherit;"><font style="vertical-align: inherit;">markup</font></font><font style="vertical-align: inherit;"><font style="vertical-align: inherit;"></font></font> <span class="unexpected-classname">badge name</span>',
 				array(
 					'title' => 'Badge name Unexpected markup badge name',
+				),
+			),
+			array(
+				'Comments <span class="awaiting-mod">new feature</span>more title',
+				array(
+					'badge' => 'new feature',
+					'title' => 'Comments more title',
 				),
 			),
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Related https://github.com/Automattic/wp-calypso/issues/54464

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add badge to the JetPack admin menus endpoint. We use this to ensure we have a beta badge for the Site Editor menu.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply diff
* Sandbox public-api
* Open the Calypso admin of one of your sites with site editor enabled
* Open inspector and find this request: https://public-api.wordpress.com/wpcom/v2/sites/_YOUR_SITE_ID_/admin-menu/?_envelope=1
* Confirm response contains the site editor with a badge property. (badge = "beta")
