### PR TITLE
Stats: add rel attribute to Learn More links

### DIFF
--- a/projects/plugins/jetpack/changelog/update-learn_more_rel
+++ b/projects/plugins/jetpack/changelog/update-learn_more_rel
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add rel="noopener noreferrer" to Learn More links.
+
+

--- a/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
+++ b/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
@@ -230,7 +230,7 @@ class Jetpack_Stats_Upgrade_Nudges {
 	 * @param string  $icon The path of the icon, relative to Jetpack images folder.
 	 * @param string  $link The link of the button.
 	 * @param string  $tracks_id The id used to identify the tracks event. Automatically prefixed with "jetpack_stats_nudges_".
-	 * @param string  $learn_more_link The target of the "Lear more" link.
+	 * @param string  $learn_more_link The target of the "Learn more" link.
 	 * @param boolean $subitem Whether it is a subitem or not.
 	 * @param string  $button_label The button label.
 	 * @return void
@@ -251,7 +251,7 @@ class Jetpack_Stats_Upgrade_Nudges {
 							<?php echo esc_html( $title ); ?>
 							<p>
 								<?php echo esc_html( $text ); ?>
-								<a href="<?php echo esc_attr( $learn_more_link ); ?>" target="_blank">
+								<a href="<?php echo esc_attr( $learn_more_link ); ?>" target="_blank" rel="noopener noreferrer">
 									<?php esc_html_e( 'Learn more', 'jetpack' ); ?>
 								</a>
 							</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add the `rel="noopener noreferrer"` attribute to the Learn More links in the nudge items.
Reference: https://web.dev/external-anchors-use-rel-noopener/
* This is a follow-up to PR #20436.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Edit your `wp-config.php` and add `define( 'JETPACK_DEV_TEST_STATS_UPGRADE_NUDGES', true );`
2. Install and activate this branch. Connect Jetpack.
3. In wp-admin, navigate to Jetpack -> Site Stats.
4. Confirm that the Learn More links in the nudges include the `rel` attribute.
