### PR TITLE
track events when nudges are displayed

### DIFF
--- a/projects/plugins/jetpack/changelog/update-stats-nudges-view-events
+++ b/projects/plugins/jetpack/changelog/update-stats-nudges-view-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add tracks event when the Stats page upgrade nudges are displayed

--- a/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
+++ b/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Jetpack_CRM_Data;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Tracking;
 
 jetpack_require_lib( 'plugins' );
 
@@ -223,13 +224,30 @@ class Jetpack_Stats_Upgrade_Nudges {
 	}
 
 	/**
+	 * Tracks an event in Tracks
+	 *
+	 * @param string $event_name The event name.
+	 * @return void
+	 */
+	private static function track_event( $event_name ) {
+		$connection_manager = new Manager( 'jetpack' );
+		$tracking           = new Tracking( 'jetpack', $connection_manager );
+		$tracking->record_user_event(
+			$event_name,
+			array(
+				'has_connected_owner' => $connection_manager->has_connected_owner(),
+			)
+		);
+	}
+
+	/**
 	 * Outputs one Upgrade item
 	 *
 	 * @param string  $title The title of the item.
 	 * @param string  $text The description of the item.
 	 * @param string  $icon The path of the icon, relative to Jetpack images folder.
 	 * @param string  $link The link of the button.
-	 * @param string  $tracks_id The id used to identify the tracks event. Automatically prefixed with "jetpack_stats_nudges_".
+	 * @param string  $tracks_id The id used to identify the tracks events. Automatically prefixed with "jetpack_stats_nudges_{view|click}_".
 	 * @param string  $learn_more_link The target of the "Learn more" link.
 	 * @param boolean $subitem Whether it is a subitem or not.
 	 * @param string  $button_label The button label.
@@ -240,6 +258,9 @@ class Jetpack_Stats_Upgrade_Nudges {
 		$button_class       = $subitem ? 'is-secondary' : 'is-primary';
 		$icon_url           = plugins_url( '', JETPACK__PLUGIN_FILE ) . '/images/products/' . $icon;
 		$button_label       = is_null( $button_label ) ? __( 'Upgrade', 'jetpack' ) : $button_label;
+		$view_event         = "stats_nudges_view_$tracks_id";
+		$click_event        = "stats_nudges_click_$tracks_id";
+		self::track_event( $view_event );
 		?>
 			<div class="dops-card dops-banner has-call-to-action is-product jp-stats-report-upgrade-item <?php echo esc_attr( $additional_classes ); ?>">
 				<div class="dops-banner__icon-plan">
@@ -258,7 +279,7 @@ class Jetpack_Stats_Upgrade_Nudges {
 						</div>
 					</div>
 					<div class="dops-banner__action">
-						<a href="<?php echo esc_attr( $link ); ?>" type="button" class="jptracks dops-button is-compact <?php echo esc_attr( $button_class ); ?>" data-jptracks-name="stats_nudges_<?php echo esc_attr( $tracks_id ); ?>">
+						<a href="<?php echo esc_attr( $link ); ?>" type="button" class="jptracks dops-button is-compact <?php echo esc_attr( $button_class ); ?>" data-jptracks-name="<?php echo esc_attr( $click_event ); ?>">
 						<?php echo esc_html( $button_label ); ?>
 						</a>
 					</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Add a tracking event when the Stats page upgrade Nudges are displayed and rename the click event for consistency.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* tracks when the stats page upgrade nudges are displayed

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1200651327748745-as-1200651327748784

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect Jetpack
* Add `define( 'JETPACK_DEV_TEST_STATS_UPGRADE_NUDGES', true );` to `wp-config.php`
* Go to Jetpack -> Site Stats
* Go to tracks live view and look for events `jetpack_stats_nudges_%`
* Make sure the `view` events are recorded
* On your site Activate Boost or CRM / and or buy a plan - something that will make some Nudgets disappear.
* Load the page again
* Make sure only events from the visible nudges are recorded in Tracks.