### PR TITLE
Remove stats page Upgrade nudges feature flag and activate it for everyone

### DIFF
--- a/projects/plugins/jetpack/changelog/activate-stats-upgrade-nudges
+++ b/projects/plugins/jetpack/changelog/activate-stats-upgrade-nudges
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Remove feature flag and activate the Stats page Upgrade Nudges for eveyone

--- a/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
+++ b/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
@@ -393,10 +393,6 @@ class Jetpack_Stats_Upgrade_Nudges {
 			return;
 		}
 
-		if ( ! defined( 'JETPACK_DEV_TEST_STATS_UPGRADE_NUDGES' ) || ! JETPACK_DEV_TEST_STATS_UPGRADE_NUDGES ) {
-			return;
-		}
-
 		if ( self::has_complete_plan() ) {
 			return;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove stats page Upgrade nudges feature flag and activate it for everyone

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1200651327748745-as-1200651327748779

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect Jetpack
* Make sure the `JETPACK_DEV_TEST_STATS_UPGRADE_NUDGES` constant is NOT set in you wp-config
* Go to Jetpack > Site Stats
* Confirm the Upgrade Nudges are displayed at the bottom of the page