### PR TITLE
Select Dropdown Component: Fix box sizing issue that affects the height of the button

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/select-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/select-dropdown/style.scss
@@ -52,6 +52,7 @@
 }
 
 .dops-select-dropdown__header {
+	box-sizing: content-box;
 	padding: 11px 44px 11px 16px; // 44 = padding (16) + arrow width (20) + arrow margin (8)
 	border-style: solid;
 	border-color: lighten( $gray, 20% );

--- a/projects/plugins/jetpack/changelog/update-select-dropdown-styling-to-use-content-box-sizing
+++ b/projects/plugins/jetpack/changelog/update-select-dropdown-styling-to-use-content-box-sizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Select Dropdown Component: Add content-box box sizing to prevent global box-sizing settings from affecting dropdown size.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

While working on #20447 we noticed that the SelectDropdown component in the Carousel settings wasn't being rendered with the correct height. After running a `git bisect` it looks like the change that introduced the styling issue was likely #20402, where a global `box-sizing: border-box` was added. It seems that the SelectDropdown component's CSS has been written expecting `content-box` sizing instead.

In this change, we're manually specifying the SelectDropdown component to use `content-box` sizing so that the existing padding calculations are factored into the height of the component.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `box-sizing: content-box` to the SelectDropdown component's header class to ensure it has the correct height if a global `box-sizing: border-box` setting is being used elsewhere

#### Screenshots

Viewing the Carousel color scheme dropdown setting at: `/wp-admin/admin.php?page=jetpack#/writing`

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/127102351-cb6a0226-4aa4-4a2b-8bbc-f0d3bce92da9.png) | ![image](https://user-images.githubusercontent.com/14988353/127102357-dd35a452-fecc-4358-8d5c-6b963f616839.png) |

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Noticed during testing of #20447

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Before applying this change, go to `/wp-admin/admin.php?page=jetpack#/writing` and notice that the height of the Carousel color scheme dropdown is incorrect (also affects the color scheme dropdown in `/wp-admin/admin.php?page=jetpack#/discussion`
* With this change applied, the height of the dropdown components should look like the After screenshot above
