### PR TITLE
Slideshow Block: Fix intermittent issue with unresponsive next/prev button clicks

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-block-back-button-clicks
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-block-back-button-clicks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Slideshow Block: Fix intermittent issue where next/prev buttons sometimes don't respond to clicks.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/create-swiper.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/create-swiper.js
@@ -32,8 +32,8 @@ export default async function createSwiper(
 		preventClicksPropagation: false, // Necessary for normal block operations.
 		releaseFormElements: false,
 		setWrapperSize: true,
-		touchStartPreventDefault: false,
 		threshold: 5, // This value helps avoid clicks being treated as swipe actions.
+		touchStartPreventDefault: false,
 		on: mapValues(
 			callbacks,
 			callback =>

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/create-swiper.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/create-swiper.js
@@ -28,10 +28,12 @@ export default async function createSwiper(
 			el: '.swiper-pagination',
 			type: 'bullets',
 		},
-		preventClicksPropagation: false /* Necessary for normal block interactions */,
+		preventClicks: false,
+		preventClicksPropagation: false, // Necessary for normal block operations.
 		releaseFormElements: false,
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
+		threshold: 5, // This value helps avoid clicks being treated as swipe actions.
 		on: mapValues(
 			callbacks,
 			callback =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

This change rolls out the Swiper settings used in the Carousel to fix an intermittent issue with unresponsive next/prev button clicks in the Slideshow block.

As with the issue encountered with the Carousel, the bug appears to be that without setting a `threshold` value, individual clicks on the `next` and `prev` buttons that sit over the top of the swiper container are sometimes treated as the beginning of a swipe gesture, resulting in the buttons appearing to be unresponsive some of the time.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a threshold value of `5` to the Slideshow block's Swiper settings to ensure that a single click with no (or very little movement) is treated as a click, and not as the beginning of a swiper gesture

#### Screenshots

Note that this is an intermittent issue, so it can take a bit of clicking back and forth before you see the issue. In the "before" screenshot below, one of the clicks fails, but the next click works.

| Before | After |
| --- | --- |
| ![slideshow-back-button-intermittent-issue-small](https://user-images.githubusercontent.com/14988353/127254120-641fe98e-e085-45c8-9da7-fc38a99d21d4.gif) | ![slideshow-back-button-intermittent-fix-small](https://user-images.githubusercontent.com/14988353/127254142-156f96e6-0617-4283-b435-01ad2a86cd18.gif) |

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Before applying this change, add a Slideshow block to a post and add a few images to it.
* Publish the post and view on the front end of your site. Click the next/prev buttons quite quickly and notice that some of the time, the buttons are _sometimes_ unresponsive to a click.
* Apply this change
* On the front end of your site, the next/prev buttons should always be responsive to clicks
* View on a mobile device and try swiping the slideshow block. The threshold of 5 pixels should be nearly imperceptible — swiping should still feel natural
