### PR TITLE
Carousel: add opacity transition to carousel when opening

### DIFF
--- a/projects/plugins/jetpack/changelog/add-carousel-image-fadein-onload
+++ b/projects/plugins/jetpack/changelog/add-carousel-image-fadein-onload
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adding a fade in effect that waits for the carousel image to load before activating

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -89,7 +89,7 @@ so we have to target all affected elements in touch devices.
 
 .jp-carousel-overlay {
 	font-family: 'Helvetica Neue', sans-serif !important;
-	z-index: 2147483646;
+	z-index: 2147483647;
 	overflow-x: hidden;
 	overflow-y: auto;
 	direction: ltr;
@@ -177,7 +177,7 @@ so we have to target all affected elements in touch devices.
 	z-index: 100;
 	background-color: #000;
 	transition: opacity 200ms ease-out;
-	opacity: 1;
+	opacity: 0;
 }
 
 .jp-carousel-hide-controls .jp-carousel-info {
@@ -688,7 +688,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	bottom: 0;
 	left: 0;
 	right: 0;
-	z-index: 2147483647;
+	z-index: 14;
 }
 
 #jp-carousel-loading-wrapper {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -33,11 +33,8 @@
 }
 
 .jp-carousel-fade-in-image {
-	animation: fadeInOpacity ease-in 0.5s 1 normal forwards;
-	-webkit-animation: fadeInOpacity ease-in 0.5s 1 normal forwards;
-	-moz-animation: fadeInOpacity ease-in 0.5s 1 normal forwards;
-	-o-animation: fadeInOpacity ease-in 0.5s 1 normal forwards;
-
+	animation: fadeInOpacity ease-in 0.25s 1 normal forwards;
+	-webkit-animation: fadeInOpacity ease-in 0.25s 1 normal forwards;
 }
 
 @keyframes fadeInOpacity {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -29,6 +29,25 @@
 .jp-carousel-wrap.swiper-container {
 	height: auto;
 	width: 100vw;
+	opacity: 0;
+}
+
+.jp-carousel-fade-in-image {
+	animation: fadeInOpacity ease-in 0.5s 1 normal forwards;
+	-webkit-animation: fadeInOpacity ease-in 0.5s 1 normal forwards;
+	-moz-animation: fadeInOpacity ease-in 0.5s 1 normal forwards;
+	-o-animation: fadeInOpacity ease-in 0.5s 1 normal forwards;
+
+}
+
+@keyframes fadeInOpacity {
+	0% { opacity: 0; }
+	100% { opacity: 1; }
+}
+
+@-webkit-keyframes fadeInOpacity {
+	0% { opacity: 0; }
+	100% { opacity: 1; }
 }
 
 /*
@@ -73,7 +92,7 @@ so we have to target all affected elements in touch devices.
 
 .jp-carousel-overlay {
 	font-family: 'Helvetica Neue', sans-serif !important;
-	z-index: 2147483647;
+	z-index: 2147483646;
 	overflow-x: hidden;
 	overflow-y: auto;
 	direction: ltr;
@@ -672,6 +691,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	bottom: 0;
 	left: 0;
 	right: 0;
+	z-index: 2147483647;
 }
 
 #jp-carousel-loading-wrapper {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -33,8 +33,8 @@
 }
 
 .jp-carousel-fade-in-image {
-	animation: fadeInOpacity ease-in 0.25s 1 normal forwards;
-	-webkit-animation: fadeInOpacity ease-in 0.25s 1 normal forwards;
+	animation: fadeInOpacity ease-in 0.2s 1 normal forwards;
+	-webkit-animation: fadeInOpacity ease-in 0.2s 1 normal forwards;
 }
 
 @keyframes fadeInOpacity {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1600,7 +1600,7 @@
 					}, 150 );
 				}
 			} );
-			var currentSlideObj = carousel.slides[ options.startIndex ];
+			var currentSlideObj = options.startIndex > 0 ? carousel.slides[ options.startIndex ] : carousel.slides[ 0 ];
 			var currentSlideImage =
 				currentSlideObj && currentSlideObj.el ? currentSlideObj.el.querySelector( 'img' ) : null;
 			var isCurrentSlideImageLoaded =

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1601,7 +1601,8 @@
 				}
 			} );
 			var currentSlideObj = carousel.slides[ options.startIndex ];
-			var currentSlideImage = currentSlideObj.el ? currentSlideObj.el.querySelector( 'img' ) : null;
+			var currentSlideImage =
+				currentSlideObj && currentSlideObj.el ? currentSlideObj.el.querySelector( 'img' ) : null;
 			var isCurrentSlideImageLoaded =
 				currentSlideImage && currentSlideImage.complete && currentSlideImage.naturalHeight !== 0;
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1473,7 +1473,7 @@
 					openCarousel( gallery, options );
 				};
 				jsScript.onerror = function () {
-					toggleLoader();
+					toggleLoader( false );
 				};
 				document.head.appendChild( jsScript );
 				return;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1602,28 +1602,29 @@
 			} );
 			var currentSlideObj = carousel.slides[ options.startIndex ];
 			var currentSlideImage = currentSlideObj.el ? currentSlideObj.el.querySelector( 'img' ) : null;
-			var iscurrentSlideImageLoaded =
+			var isCurrentSlideImageLoaded =
 				currentSlideImage && currentSlideImage.complete && currentSlideImage.naturalHeight !== 0;
 
 			domUtil.fadeIn( carousel.overlay );
 
-			if ( iscurrentSlideImageLoaded ) {
-				toggleLoader();
+			if ( isCurrentSlideImageLoaded ) {
+				toggleLoader( false );
 				carousel.container.classList.add( 'jp-carousel-fade-in-image' );
 				domUtil.emitEvent( carousel.overlay, 'jp_carousel.afterOpen' );
 				return;
 			}
 
 			toggleLoader( true );
+			// Grab the selected image and preload it before fading it in.
 			var newImage = new Image();
+
 			newImage.onload = function () {
-				toggleLoader();
-				carousel.overlay.style.visibility = 'visible';
+				toggleLoader( false );
 				carousel.container.classList.add( 'jp-carousel-fade-in-image' );
 				domUtil.emitEvent( carousel.overlay, 'jp_carousel.afterOpen' );
 			};
 			newImage.onerror = function () {
-				toggleLoader();
+				toggleLoader( false );
 				carousel.container.classList.add( 'jp-carousel-fade-in-image' );
 				domUtil.emitEvent( carousel.overlay, 'jp_carousel.afterOpen' );
 			};

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -371,39 +371,10 @@ class Jetpack_Carousel {
 		/* translators: %s is replaced with a field name in the form, e.g. "Email" */
 		$required = ( $require_name_email ) ? __( '%s (Required)', 'jetpack' ) : '%s';
 		?>
-		<div id="jp-carousel-loading-overlay">
-			<div id="jp-carousel-loading-wrapper">
-				<span id="jp-carousel-library-loading">&nbsp;</span>
-			</div>
-		</div>
 		<div class="jp-carousel-overlay<?php echo( $is_light ? ' jp-carousel-light' : '' ); ?>" style="display: none;">
-
-		<div class="jp-carousel-container<?php echo( $is_light ? ' jp-carousel-light' : '' ); ?>">
-			<!-- The Carousel Swiper -->
-			<div
-				class="jp-carousel-wrap swiper-container jp-carousel-swiper-container jp-carousel-transitions"
-				itemscope
-				itemtype="https://schema.org/ImageGallery">
-				<div class="jp-carousel swiper-wrapper"></div>
-				<div class="jp-swiper-button-prev swiper-button-prev">
-					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-						<mask id="maskPrev" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="9" height="12">
-							<path d="M16.2072 16.59L11.6496 12L16.2072 7.41L14.8041 6L8.8335 12L14.8041 18L16.2072 16.59Z" fill="white"/>
-						</mask>
-						<g mask="url(#maskPrev)">
-							<rect x="0.579102" width="23.8823" height="24" fill="#FFFFFF"/>
-						</g>
-					</svg>
-				</div>
-				<div class="jp-swiper-button-next swiper-button-next">
-					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-						<mask id="maskNext" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="8" height="12">
-							<path d="M8.59814 16.59L13.1557 12L8.59814 7.41L10.0012 6L15.9718 12L10.0012 18L8.59814 16.59Z" fill="white"/>
-						</mask>
-						<g mask="url(#maskNext)">
-							<rect x="0.34375" width="23.8822" height="24" fill="#FFFFFF"/>
-						</g>
-					</svg>
+			<div id="jp-carousel-loading-overlay">
+				<div id="jp-carousel-loading-wrapper">
+					<span id="jp-carousel-library-loading">&nbsp;</span>
 				</div>
 			</div>
 			<!-- The main close buton -->
@@ -417,156 +388,183 @@ class Jetpack_Carousel {
 					</g>
 				</svg>
 			</div>
-			<!-- Image info, comments and meta -->
-			<div class="jp-carousel-info">
-				<div class="jp-carousel-info-footer">
-					<div class="jp-carousel-pagination-container">
-						<div class="jp-swiper-pagination swiper-pagination"></div>
-						<div class="jp-carousel-pagination"></div>
+			<div class="jp-carousel-container<?php echo( $is_light ? ' jp-carousel-light' : '' ); ?>">
+				<!-- The Carousel Swiper -->
+				<div
+					class="jp-carousel-wrap swiper-container jp-carousel-swiper-container jp-carousel-transitions"
+					itemscope
+					itemtype="https://schema.org/ImageGallery">
+					<div class="jp-carousel swiper-wrapper"></div>
+					<div class="jp-swiper-button-prev swiper-button-prev">
+						<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<mask id="maskPrev" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="9" height="12">
+								<path d="M16.2072 16.59L11.6496 12L16.2072 7.41L14.8041 6L8.8335 12L14.8041 18L16.2072 16.59Z" fill="white"/>
+							</mask>
+							<g mask="url(#maskPrev)">
+								<rect x="0.579102" width="23.8823" height="24" fill="#FFFFFF"/>
+							</g>
+						</svg>
 					</div>
-					<div class="jp-carousel-photo-title-container">
-						<h2 class="jp-carousel-photo-caption"></h2>
-					</div>
-					<div class="jp-carousel-photo-icons-container">
-						<?php if ( $localize_strings['display_exif'] ) : ?>
-							<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
-								<span class="jp-carousel-icon">
-									<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-										<mask id="maskInfo" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="20">
-											<path fill-rule="evenodd" clip-rule="evenodd" d="M12.7537 2C7.26076 2 2.80273 6.48 2.80273 12C2.80273 17.52 7.26076 22 12.7537 22C18.2466 22 22.7046 17.52 22.7046 12C22.7046 6.48 18.2466 2 12.7537 2ZM11.7586 7V9H13.7488V7H11.7586ZM11.7586 11V17H13.7488V11H11.7586ZM4.79292 12C4.79292 16.41 8.36531 20 12.7537 20C17.142 20 20.7144 16.41 20.7144 12C20.7144 7.59 17.142 4 12.7537 4C8.36531 4 4.79292 7.59 4.79292 12Z" fill="white"/>
-										</mask>
-										<g mask="url(#maskInfo)">
-											<rect x="0.8125" width="23.8823" height="24" fill="#FFFFFF"/>
-										</g>
-									</svg>
-								</span>
-							</a>
-						<?php endif; ?>
-						<?php if ( $localize_strings['display_comments'] ) : ?>
-						<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
-							<span class="jp-carousel-icon">
-								<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-									<mask id="maskComments" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="20">
-										<path fill-rule="evenodd" clip-rule="evenodd" d="M4.3271 2H20.2486C21.3432 2 22.2388 2.9 22.2388 4V16C22.2388 17.1 21.3432 18 20.2486 18H6.31729L2.33691 22V4C2.33691 2.9 3.2325 2 4.3271 2ZM6.31729 16H20.2486V4H4.3271V18L6.31729 16Z" fill="white"/>
-									</mask>
-									<g mask="url(#maskComments)">
-										<rect x="0.34668" width="23.8823" height="24" fill="#FFFFFF"/>
-									</g>
-								</svg>
-
-								<span class="jp-carousel-has-comments-indicator" aria-label="<?php esc_attr_e( 'This image has comments.', 'jetpack' ); ?>"></span>
-							</span>
-						</a>
-						<?php endif; ?>
+					<div class="jp-swiper-button-next swiper-button-next">
+						<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<mask id="maskNext" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="8" height="12">
+								<path d="M8.59814 16.59L13.1557 12L8.59814 7.41L10.0012 6L15.9718 12L10.0012 18L8.59814 16.59Z" fill="white"/>
+							</mask>
+							<g mask="url(#maskNext)">
+								<rect x="0.34375" width="23.8822" height="24" fill="#FFFFFF"/>
+							</g>
+						</svg>
 					</div>
 				</div>
-				<div class="jp-carousel-info-extra">
-					<div class="jp-carousel-info-content-wrapper">
+				<!-- Image info, comments and meta -->
+				<div class="jp-carousel-info">
+					<div class="jp-carousel-info-footer">
+						<div class="jp-carousel-pagination-container">
+							<div class="jp-swiper-pagination swiper-pagination"></div>
+							<div class="jp-carousel-pagination"></div>
+						</div>
 						<div class="jp-carousel-photo-title-container">
-							<h2 class="jp-carousel-photo-title"></h2>
+							<h2 class="jp-carousel-photo-caption"></h2>
 						</div>
-						<div class="jp-carousel-comments-wrapper">
+						<div class="jp-carousel-photo-icons-container">
+							<?php if ( $localize_strings['display_exif'] ) : ?>
+								<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-info" aria-label="<?php esc_attr_e( 'Toggle photo metadata visibility', 'jetpack' ); ?>">
+									<span class="jp-carousel-icon">
+										<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+											<mask id="maskInfo" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="20">
+												<path fill-rule="evenodd" clip-rule="evenodd" d="M12.7537 2C7.26076 2 2.80273 6.48 2.80273 12C2.80273 17.52 7.26076 22 12.7537 22C18.2466 22 22.7046 17.52 22.7046 12C22.7046 6.48 18.2466 2 12.7537 2ZM11.7586 7V9H13.7488V7H11.7586ZM11.7586 11V17H13.7488V11H11.7586ZM4.79292 12C4.79292 16.41 8.36531 20 12.7537 20C17.142 20 20.7144 16.41 20.7144 12C20.7144 7.59 17.142 4 12.7537 4C8.36531 4 4.79292 7.59 4.79292 12Z" fill="white"/>
+											</mask>
+											<g mask="url(#maskInfo)">
+												<rect x="0.8125" width="23.8823" height="24" fill="#FFFFFF"/>
+											</g>
+										</svg>
+									</span>
+								</a>
+							<?php endif; ?>
 							<?php if ( $localize_strings['display_comments'] ) : ?>
-								<div id="jp-carousel-comments-loading">
-									<span><?php echo esc_html( $localize_strings['loading_comments'] ); ?></span>
-								</div>
-								<div class="jp-carousel-comments"></div>
-								<div id="jp-carousel-comment-form-container">
-									<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
-									<div id="jp-carousel-comment-post-results"></div>
-									<?php if ( $use_local_comments ) : ?>
-										<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
-											<div id="jp-carousel-comment-form-commenting-as">
-												<p id="jp-carousel-commenting-as">
-													<?php
-														echo wp_kses(
-															__( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ),
-															array(
-																'a' => array(
-																	'href'  => array(),
-																	'class' => array(),
-																),
-															)
-														);
-													?>
-												</p>
-											</div>
-										<?php else : ?>
-											<form id="jp-carousel-comment-form">
-												<label for="jp-carousel-comment-form-comment-field" class="screen-reader-text"><?php echo esc_attr( $localize_strings['write_comment'] ); ?></label>
-												<textarea
-													name="comment"
-													class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"
-													id="jp-carousel-comment-form-comment-field"
-													placeholder="<?php echo esc_attr( $localize_strings['write_comment'] ); ?>"
-												></textarea>
-												<div id="jp-carousel-comment-form-submit-and-info-wrapper">
-													<div id="jp-carousel-comment-form-commenting-as">
-														<?php if ( $localize_strings['is_logged_in'] ) : ?>
-															<p id="jp-carousel-commenting-as">
-																<?php
-																	printf(
-																		/* translators: %s is replaced with the user's display name */
-																		esc_html__( 'Commenting as %s', 'jetpack' ),
-																		esc_html( $current_user->data->display_name )
-																	);
-																?>
-															</p>
-														<?php else : ?>
-															<fieldset>
-																<label for="jp-carousel-comment-form-email-field"><?php echo esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ); ?></label>
-																<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
-															</fieldset>
-															<fieldset>
-																<label for="jp-carousel-comment-form-author-field"><?php echo esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ); ?></label>
-																<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
-															</fieldset>
-															<fieldset>
-																<label for="jp-carousel-comment-form-url-field"><?php esc_html_e( 'Website', 'jetpack' ); ?></label>
-																<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" />
-															</fieldset>
-														<?php endif ?>
-													</div>
-													<input
-														type="submit"
-														name="submit"
-														class="jp-carousel-comment-form-button"
-														id="jp-carousel-comment-form-button-submit"
-														value="<?php echo esc_attr( $localize_strings['post_comment'] ); ?>" />
-												</div>
-											</form>
-										<?php endif ?>
-									<?php endif ?>
-								</div>
-							<?php endif ?>
-						</div>
-						<div class="jp-carousel-image-meta">
-							<div class="jp-carousel-title-and-caption">
-								<div class="jp-carousel-photo-info">
-									<h3 class="jp-carousel-caption" itemprop="caption description"></h3>
-								</div>
+							<a href="#" class="jp-carousel-icon-btn jp-carousel-icon-comments" aria-label="<?php esc_attr_e( 'Toggle photo comments visibility', 'jetpack' ); ?>">
+								<span class="jp-carousel-icon">
+									<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+										<mask id="maskComments" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="20">
+											<path fill-rule="evenodd" clip-rule="evenodd" d="M4.3271 2H20.2486C21.3432 2 22.2388 2.9 22.2388 4V16C22.2388 17.1 21.3432 18 20.2486 18H6.31729L2.33691 22V4C2.33691 2.9 3.2325 2 4.3271 2ZM6.31729 16H20.2486V4H4.3271V18L6.31729 16Z" fill="white"/>
+										</mask>
+										<g mask="url(#maskComments)">
+											<rect x="0.34668" width="23.8823" height="24" fill="#FFFFFF"/>
+										</g>
+									</svg>
 
-								<div class="jp-carousel-photo-description"></div>
-							</div>
-							<ul class="jp-carousel-image-exif" style="display: none;"></ul>
-							<a class="jp-carousel-image-download" target="_blank" style="display: none;">
-								<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-									<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="3" y="3" width="19" height="18">
-										<path fill-rule="evenodd" clip-rule="evenodd" d="M5.84615 5V19H19.7775V12H21.7677V19C21.7677 20.1 20.8721 21 19.7775 21H5.84615C4.74159 21 3.85596 20.1 3.85596 19V5C3.85596 3.9 4.74159 3 5.84615 3H12.8118V5H5.84615ZM14.802 5V3H21.7677V10H19.7775V6.41L9.99569 16.24L8.59261 14.83L18.3744 5H14.802Z" fill="white"/>
-									</mask>
-									<g mask="url(#mask0)">
-										<rect x="0.870605" width="23.8823" height="24" fill="#FFFFFF"/>
-									</g>
-								</svg>
-								<span class="jp-carousel-download-text"></span>
+									<span class="jp-carousel-has-comments-indicator" aria-label="<?php esc_attr_e( 'This image has comments.', 'jetpack' ); ?>"></span>
+								</span>
 							</a>
-							<div class="jp-carousel-image-map" style="display: none;"></div>
+							<?php endif; ?>
+						</div>
+					</div>
+					<div class="jp-carousel-info-extra">
+						<div class="jp-carousel-info-content-wrapper">
+							<div class="jp-carousel-photo-title-container">
+								<h2 class="jp-carousel-photo-title"></h2>
+							</div>
+							<div class="jp-carousel-comments-wrapper">
+								<?php if ( $localize_strings['display_comments'] ) : ?>
+									<div id="jp-carousel-comments-loading">
+										<span><?php echo esc_html( $localize_strings['loading_comments'] ); ?></span>
+									</div>
+									<div class="jp-carousel-comments"></div>
+									<div id="jp-carousel-comment-form-container">
+										<span id="jp-carousel-comment-form-spinner">&nbsp;</span>
+										<div id="jp-carousel-comment-post-results"></div>
+										<?php if ( $use_local_comments ) : ?>
+											<?php if ( ! $localize_strings['is_logged_in'] && $localize_strings['comment_registration'] ) : ?>
+												<div id="jp-carousel-comment-form-commenting-as">
+													<p id="jp-carousel-commenting-as">
+														<?php
+															echo wp_kses(
+																__( 'You must be <a href="#" class="jp-carousel-comment-login">logged in</a> to post a comment.', 'jetpack' ),
+																array(
+																	'a' => array(
+																		'href'  => array(),
+																		'class' => array(),
+																	),
+																)
+															);
+														?>
+													</p>
+												</div>
+											<?php else : ?>
+												<form id="jp-carousel-comment-form">
+													<label for="jp-carousel-comment-form-comment-field" class="screen-reader-text"><?php echo esc_attr( $localize_strings['write_comment'] ); ?></label>
+													<textarea
+														name="comment"
+														class="jp-carousel-comment-form-field jp-carousel-comment-form-textarea"
+														id="jp-carousel-comment-form-comment-field"
+														placeholder="<?php echo esc_attr( $localize_strings['write_comment'] ); ?>"
+													></textarea>
+													<div id="jp-carousel-comment-form-submit-and-info-wrapper">
+														<div id="jp-carousel-comment-form-commenting-as">
+															<?php if ( $localize_strings['is_logged_in'] ) : ?>
+																<p id="jp-carousel-commenting-as">
+																	<?php
+																		printf(
+																			/* translators: %s is replaced with the user's display name */
+																			esc_html__( 'Commenting as %s', 'jetpack' ),
+																			esc_html( $current_user->data->display_name )
+																		);
+																	?>
+																</p>
+															<?php else : ?>
+																<fieldset>
+																	<label for="jp-carousel-comment-form-email-field"><?php echo esc_html( sprintf( $required, __( 'Email', 'jetpack' ) ) ); ?></label>
+																	<input type="text" name="email" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-email-field" />
+																</fieldset>
+																<fieldset>
+																	<label for="jp-carousel-comment-form-author-field"><?php echo esc_html( sprintf( $required, __( 'Name', 'jetpack' ) ) ); ?></label>
+																	<input type="text" name="author" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-author-field" />
+																</fieldset>
+																<fieldset>
+																	<label for="jp-carousel-comment-form-url-field"><?php esc_html_e( 'Website', 'jetpack' ); ?></label>
+																	<input type="text" name="url" class="jp-carousel-comment-form-field jp-carousel-comment-form-text-field" id="jp-carousel-comment-form-url-field" />
+																</fieldset>
+															<?php endif ?>
+														</div>
+														<input
+															type="submit"
+															name="submit"
+															class="jp-carousel-comment-form-button"
+															id="jp-carousel-comment-form-button-submit"
+															value="<?php echo esc_attr( $localize_strings['post_comment'] ); ?>" />
+													</div>
+												</form>
+											<?php endif ?>
+										<?php endif ?>
+									</div>
+								<?php endif ?>
+							</div>
+							<div class="jp-carousel-image-meta">
+								<div class="jp-carousel-title-and-caption">
+									<div class="jp-carousel-photo-info">
+										<h3 class="jp-carousel-caption" itemprop="caption description"></h3>
+									</div>
+
+									<div class="jp-carousel-photo-description"></div>
+								</div>
+								<ul class="jp-carousel-image-exif" style="display: none;"></ul>
+								<a class="jp-carousel-image-download" target="_blank" style="display: none;">
+									<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+										<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="3" y="3" width="19" height="18">
+											<path fill-rule="evenodd" clip-rule="evenodd" d="M5.84615 5V19H19.7775V12H21.7677V19C21.7677 20.1 20.8721 21 19.7775 21H5.84615C4.74159 21 3.85596 20.1 3.85596 19V5C3.85596 3.9 4.74159 3 5.84615 3H12.8118V5H5.84615ZM14.802 5V3H21.7677V10H19.7775V6.41L9.99569 16.24L8.59261 14.83L18.3744 5H14.802Z" fill="white"/>
+										</mask>
+										<g mask="url(#mask0)">
+											<rect x="0.870605" width="23.8823" height="24" fill="#FFFFFF"/>
+										</g>
+									</svg>
+									<span class="jp-carousel-download-text"></span>
+								</a>
+								<div class="jp-carousel-image-map" style="display: none;"></div>
+							</div>
 						</div>
 					</div>
 				</div>
 			</div>
-		</div>
-
 		</div>
 		<?php
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

An alternative to https://github.com/Automattic/jetpack/pull/20373
Fixes https://github.com/Automattic/view-design/issues/324

## Changes proposed in this Pull Request

Hi!

This PR adds an opacity transition effect when opening a carousel slide. 🎉 

**Before** 

The slide is blank and the image appears with no fade in effect until it's loaded.

<img src="https://user-images.githubusercontent.com/6458278/127262823-740bd8ee-83cd-44bb-9f34-b3982de1c99b.gif" width="300" />


**After**

The image should fade in. 


https://user-images.githubusercontent.com/6458278/127428373-969c5f46-668e-4217-b384-83efa0e33b66.mp4


If the image hasn't loaded yet, you should see the loading spinner.

#### Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Open images with cache enabled and disabled. Try throttling the network. 

Check in mobile browsers. 

Take a deep breath between tasks.

- [ ] The carousel overlay and loading spinner should appear immediately, even when loading Swiper JS for the first time
- [ ] The info UI should only appear once the carousel is initialized.
- [ ] The current slide's image should fade in both when you click on an image in the gallery, and when you reload page with a carousel hash, e.g., `/?p=7#jp-carousel-9`
- [ ] You should be able to exit the load screen by hitting the Esc key and by clicking on the close button.

Thank you!
