### PR TITLE
Plans: check Atomic and Jetpack through plans

### DIFF
--- a/projects/plugins/jetpack/changelog/update-checking-atomic-plans
+++ b/projects/plugins/jetpack/changelog/update-checking-atomic-plans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Use Jetpack Plan class to check features for Atomic sites

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1075,31 +1075,20 @@ class Jetpack_Gutenberg {
 		$slug           = self::remove_extension_prefix( $slug );
 		$features_data  = array();
 		$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$is_atomic_site = jetpack_is_atomic_site();
 
 		// Check feature availability for Simple and Atomic sites.
-		if ( $is_simple_site || $is_atomic_site ) {
-
-			// Simple sites.
-			if ( $is_simple_site ) {
-				if ( ! class_exists( 'Store_Product_List' ) ) {
-					require WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/store-product-list.php';
-				}
-				$features_data = Store_Product_List::get_site_specific_features_data();
-			} else {
-				// Atomic sites.
-				$option = get_option( 'jetpack_active_plan' );
-				if ( isset( $option['features'] ) ) {
-					$features_data = $option['features'];
-				}
+		if ( $is_simple_site ) {
+			if ( ! class_exists( 'Store_Product_List' ) ) {
+				require WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/store-product-list.php';
 			}
+			$features_data = Store_Product_List::get_site_specific_features_data();
 
 			$is_available = isset( $features_data['active'] ) && in_array( $slug, $features_data['active'], true );
 			if ( ! empty( $features_data['available'][ $slug ] ) ) {
 				$plan = $features_data['available'][ $slug ][0];
 			}
 		} else {
-			// Jetpack sites.
+			// Atomic / Jetpack sites.
 			$is_available = Jetpack_Plan::supports( $slug );
 			$plan         = Jetpack_Plan::get_minimum_plan_for_feature( $slug );
 		}

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -40,17 +40,7 @@ class Jetpack_Plan {
 			'plans'    => array(
 				'jetpack_free',
 			),
-			'supports' => array(
-				'opentable',
-				'calendly',
-				'send-a-message',
-				'whatsapp-button',
-				'social-previews',
-
-				'core/video',
-				'core/cover',
-				'core/audio',
-			),
+			'supports' => array(),
 		),
 		'personal' => array(
 			'plans'    => array(
@@ -60,11 +50,7 @@ class Jetpack_Plan {
 				'personal-bundle-monthly',
 				'personal-bundle-2y',
 			),
-			'supports' => array(
-				'akismet',
-				'recurring-payments',
-				'premium-content/container',
-			),
+			'supports' => array(),
 		),
 		'premium'  => array(
 			'plans'    => array(
@@ -74,12 +60,7 @@ class Jetpack_Plan {
 				'value_bundle-monthly',
 				'value_bundle-2y',
 			),
-			'supports' => array(
-				'donations',
-				'simple-payments',
-				'vaultpress',
-				'videopress',
-			),
+			'supports' => array(),
 		),
 		'security' => array(
 			'plans'    => array(
@@ -321,7 +302,6 @@ class Jetpack_Plan {
 		}
 
 		$plan = self::get();
-
 		if ( in_array( $feature, $plan['features']['active'], true ) ) {
 			return true;
 		}

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -322,22 +322,7 @@ class Jetpack_Plan {
 
 		$plan = self::get();
 
-		// Manually mapping WordPress.com features to Jetpack module slugs.
-		foreach ( $plan['features']['active'] as $wpcom_feature ) {
-			switch ( $wpcom_feature ) {
-				case 'wordads-jetpack':
-					// WordAds are supported for this site.
-					if ( 'wordads' === $feature ) {
-						return true;
-					}
-					break;
-			}
-		}
-
-		if (
-			in_array( $feature, $plan['supports'], true )
-			|| in_array( $feature, $plan['features']['active'], true )
-		) {
+		if ( in_array( $feature, $plan['features']['active'], true ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

This PR changes the way about how the site features are checked for Atomic sites. In short, it uses the same logic used for Jetpack sites. In the end, the data is provided by the same source ( WordPress.com features data)

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Check features for Atomic sites using Plan class

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes to Atomic sites
* Confirm that all features are consistent according to the testing site and its current plan.
