### PR TITLE
Sync: Utilize import for WP_Error

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-wp-error
+++ b/projects/packages/sync/changelog/fix-sync-wp-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed unqualified WP_Error use in the Rest_Sender class.

--- a/projects/packages/sync/changelog/fix-sync-wp-error-1
+++ b/projects/packages/sync/changelog/fix-sync-wp-error-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Utilize an import for WP_Error in all instances.

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Connection\Urls;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Identity_Crisis;
 use Automattic\Jetpack\Status;
+use WP_Error;
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
@@ -395,7 +396,7 @@ class Actions {
 		// If we're currently updating to Jetpack 7.7, the IXR client may be missing briefly
 		// because since 7.7 it's being autoloaded with Composer.
 		if ( ! class_exists( '\\Jetpack_IXR_Client' ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'ixr_client_missing',
 				esc_html__( 'Sync has been aborted because the IXR client is missing.', 'jetpack' )
 			);
@@ -447,7 +448,7 @@ class Actions {
 				);
 			}
 
-			return new \WP_Error(
+			return new WP_Error(
 				'sync_error_idc',
 				esc_html__( 'Sync has been blocked from WordPress.com because it would cause an identity crisis', 'jetpack' )
 			);

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.24.0';
+	const PACKAGE_VERSION = '1.24.1-alpha';
 }

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use WP_Error;
+
 /**
  * A persistent queue that can be flushed in increments of N items,
  * and which blocks reads until checked-out buffers are checked in or
@@ -98,7 +100,7 @@ class Queue {
 		$rows_added = $wpdb->query( $query . join( ',', $rows ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( count( $items ) !== $rows_added ) {
-			return new \WP_Error( 'row_count_mismatch', "The number of rows inserted didn't match the size of the input array" );
+			return new WP_Error( 'row_count_mismatch', "The number of rows inserted didn't match the size of the input array" );
 		}
 		return true;
 	}
@@ -229,7 +231,7 @@ class Queue {
 	 */
 	public function checkout( $buffer_size ) {
 		if ( $this->get_checkout_id() ) {
-			return new \WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
+			return new WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
 		}
 
 		$buffer_id = uniqid();
@@ -300,7 +302,7 @@ class Queue {
 	 */
 	public function checkout_with_memory_limit( $max_memory, $max_buffer_size = 500 ) {
 		if ( $this->get_checkout_id() ) {
-			return new \WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
+			return new WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
 		}
 
 		$buffer_id = uniqid();
@@ -481,11 +483,11 @@ class Queue {
 		}
 
 		if ( 30 === $tries ) {
-			return new \WP_Error( 'lock_timeout', 'Timeout waiting for sync queue to empty' );
+			return new WP_Error( 'lock_timeout', 'Timeout waiting for sync queue to empty' );
 		}
 
 		if ( $this->get_checkout_id() ) {
-			return new \WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
+			return new WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
 		}
 
 		// Hopefully this means we can acquire a checkout?
@@ -706,22 +708,22 @@ class Queue {
 	 *
 	 * @param Automattic\Jetpack\Sync\Queue_Buffer $buffer The Queue_Buffer.
 	 *
-	 * @return bool|\WP_Error
+	 * @return bool|WP_Error
 	 */
 	private function validate_checkout( $buffer ) {
 		if ( ! $buffer instanceof Queue_Buffer ) {
-			return new \WP_Error( 'not_a_buffer', 'You must checkin an instance of Automattic\\Jetpack\\Sync\\Queue_Buffer' );
+			return new WP_Error( 'not_a_buffer', 'You must checkin an instance of Automattic\\Jetpack\\Sync\\Queue_Buffer' );
 		}
 
 		$checkout_id = $this->get_checkout_id();
 
 		if ( ! $checkout_id ) {
-			return new \WP_Error( 'buffer_not_checked_out', 'There are no checked out buffers' );
+			return new WP_Error( 'buffer_not_checked_out', 'There are no checked out buffers' );
 		}
 
 		// TODO: change to strict comparison.
 		if ( $checkout_id != $buffer->id ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-			return new \WP_Error( 'buffer_mismatch', 'The buffer you checked in was not checked out' );
+			return new WP_Error( 'buffer_mismatch', 'The buffer you checked in was not checked out' );
 		}
 
 		return true;

--- a/projects/packages/sync/src/class-replicastore.php
+++ b/projects/packages/sync/src/class-replicastore.php
@@ -856,7 +856,8 @@ class Replicastore implements Replicastore_Interface {
 	 * @access public
 	 *
 	 * @param string $taxonomy Taxonomy slug.
-	 * @return array|\WP_Error Array of terms or WP_Error object on failure.
+	 *
+	 * @return array|WP_Error Array of terms or WP_Error object on failure.
 	 */
 	public function get_terms( $taxonomy ) {
 		$t = $this->ensure_taxonomy( $taxonomy );
@@ -874,7 +875,8 @@ class Replicastore implements Replicastore_Interface {
 	 * @param string $taxonomy   Taxonomy slug.
 	 * @param int    $term_id    ID of the term.
 	 * @param string $term_key   ID Field `term_id` or `term_taxonomy_id`.
-	 * @return \WP_Term|\WP_Error Term object on success, \WP_Error object on failure.
+	 *
+	 * @return \WP_Term|WP_Error Term object on success, \WP_Error object on failure.
 	 */
 	public function get_term( $taxonomy, $term_id, $term_key = 'term_id' ) {
 
@@ -897,7 +899,8 @@ class Replicastore implements Replicastore_Interface {
 	 * @access private
 	 *
 	 * @param string $taxonomy Taxonomy slug.
-	 * @return bool|void|\WP_Error True if already exists; void if it was registered; \WP_Error on error.
+	 *
+	 * @return bool|void|WP_Error True if already exists; void if it was registered; \WP_Error on error.
 	 */
 	private function ensure_taxonomy( $taxonomy ) {
 		if ( ! taxonomy_exists( $taxonomy ) ) {
@@ -905,7 +908,7 @@ class Replicastore implements Replicastore_Interface {
 			$taxonomies = $this->get_callable( 'taxonomies' );
 			if ( ! isset( $taxonomies[ $taxonomy ] ) ) {
 				// Doesn't exist, or somehow hasn't been synced.
-				return new \WP_Error( 'invalid_taxonomy', "The taxonomy '$taxonomy' doesn't exist" );
+				return new WP_Error( 'invalid_taxonomy', "The taxonomy '$taxonomy' doesn't exist" );
 			}
 			$t = $taxonomies[ $taxonomy ];
 
@@ -926,7 +929,8 @@ class Replicastore implements Replicastore_Interface {
 	 *
 	 * @param int    $object_id Object ID.
 	 * @param string $taxonomy  Taxonomy slug.
-	 * @return array|bool|\WP_Error Array of terms on success, `false` if no terms or post doesn't exist, \WP_Error on failure.
+	 *
+	 * @return array|bool|WP_Error Array of terms on success, `false` if no terms or post doesn't exist, \WP_Error on failure.
 	 */
 	public function get_the_terms( $object_id, $taxonomy ) {
 		return get_the_terms( $object_id, $taxonomy );
@@ -938,7 +942,8 @@ class Replicastore implements Replicastore_Interface {
 	 * @access public
 	 *
 	 * @param \WP_Term $term_object Term object.
-	 * @return array|bool|\WP_Error Array of term_id and term_taxonomy_id if updated, true if inserted, \WP_Error on failure.
+	 *
+	 * @return array|bool|WP_Error Array of term_id and term_taxonomy_id if updated, true if inserted, \WP_Error on failure.
 	 */
 	public function update_term( $term_object ) {
 		$taxonomy = $term_object->taxonomy;
@@ -981,7 +986,8 @@ class Replicastore implements Replicastore_Interface {
 	 *
 	 * @param int    $term_id  Term ID.
 	 * @param string $taxonomy Taxonomy slug.
-	 * @return bool|int|\WP_Error True on success, false if term doesn't exist. Zero if trying with default category. \WP_Error on invalid taxonomy.
+	 *
+	 * @return bool|int|WP_Error True on success, false if term doesn't exist. Zero if trying with default category. \WP_Error on invalid taxonomy.
 	 */
 	public function delete_term( $term_id, $taxonomy ) {
 		$this->ensure_taxonomy( $taxonomy );

--- a/projects/packages/sync/src/class-rest-sender.php
+++ b/projects/packages/sync/src/class-rest-sender.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use WP_Error;
+
 /**
  * This class will handle checkout of Sync queues for REST Endpoints.
  *

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Constants;
+use WP_Error;
 
 /**
  * This class grabs pending actions from the queue and sends them
@@ -253,7 +254,7 @@ class Sender {
 	 *
 	 * @access public
 	 *
-	 * @return boolean|\WP_Error True if this sync sending was successful, error object otherwise.
+	 * @return boolean|WP_Error True if this sync sending was successful, error object otherwise.
 	 */
 	public function do_full_sync() {
 		$sync_module = Modules::get_module( 'full-sync' );
@@ -267,7 +268,7 @@ class Sender {
 
 		// Don't sync if request is marked as read only.
 		if ( Constants::is_true( 'JETPACK_SYNC_READ_ONLY' ) ) {
-			return new \WP_Error( 'jetpack_sync_read_only' );
+			return new WP_Error( 'jetpack_sync_read_only' );
 		}
 
 		// Sync not started or Sync finished.
@@ -317,7 +318,7 @@ class Sender {
 	 *
 	 * @access public
 	 *
-	 * @return boolean|\WP_Error True if this sync sending was successful, error object otherwise.
+	 * @return boolean|WP_Error True if this sync sending was successful, error object otherwise.
 	 */
 	public function do_sync() {
 		return $this->do_sync_and_set_delays( $this->sync_queue );
@@ -332,21 +333,22 @@ class Sender {
 	 * @access public
 	 *
 	 * @param Automattic\Jetpack\Sync\Queue $queue Queue object.
-	 * @return boolean|\WP_Error True if this sync sending was successful, error object otherwise.
+	 *
+	 * @return boolean|WP_Error True if this sync sending was successful, error object otherwise.
 	 */
 	public function do_sync_and_set_delays( $queue ) {
 		// Don't sync if importing.
 		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
-			return new \WP_Error( 'is_importing' );
+			return new WP_Error( 'is_importing' );
 		}
 
 		// Don't sync if request is marked as read only.
 		if ( Constants::is_true( 'JETPACK_SYNC_READ_ONLY' ) ) {
-			return new \WP_Error( 'jetpack_sync_read_only' );
+			return new WP_Error( 'jetpack_sync_read_only' );
 		}
 
 		if ( ! Settings::is_sender_enabled( $queue->id ) ) {
-			return new \WP_Error( 'sender_disabled_for_queue_' . $queue->id );
+			return new WP_Error( 'sender_disabled_for_queue_' . $queue->id );
 		}
 
 		// Return early if we've gotten a retry-after header response.
@@ -356,12 +358,12 @@ class Sender {
 			if ( microtime( true ) > $retry_time ) {
 				update_option( Actions::RETRY_AFTER_PREFIX . $queue->id, false, false );
 			}
-			return new \WP_Error( 'retry_after' );
+			return new WP_Error( 'retry_after' );
 		}
 
 		// Don't sync if we are throttled.
 		if ( $this->get_next_sync_time( $queue->id ) > microtime( true ) ) {
-			return new \WP_Error( 'sync_throttled' );
+			return new WP_Error( 'sync_throttled' );
 		}
 
 		$start_time = microtime( true );
@@ -468,12 +470,13 @@ class Sender {
 	 * @access public
 	 *
 	 * @param Automattic\Jetpack\Sync\Queue $queue Queue object.
-	 * @return boolean|\WP_Error True if this sync sending was successful, error object otherwise.
+	 *
+	 * @return boolean|WP_Error True if this sync sending was successful, error object otherwise.
 	 */
 	public function do_sync_for_queue( $queue ) {
 		do_action( 'jetpack_sync_before_send_queue_' . $queue->id );
 		if ( $queue->size() === 0 ) {
-			return new \WP_Error( 'empty_queue_' . $queue->id );
+			return new WP_Error( 'empty_queue_' . $queue->id );
 		}
 
 		/**
@@ -495,7 +498,7 @@ class Sender {
 
 		if ( ! $buffer ) {
 			// Buffer has no items.
-			return new \WP_Error( 'empty_buffer' );
+			return new WP_Error( 'empty_buffer' );
 		}
 
 		if ( is_wp_error( $buffer ) ) {
@@ -538,11 +541,11 @@ class Sender {
 					$queue->force_checkin();
 				}
 				if ( is_wp_error( $processed_item_ids ) ) {
-					return new \WP_Error( 'wpcom_error', $processed_item_ids->get_error_code() );
+					return new WP_Error( 'wpcom_error', $processed_item_ids->get_error_code() );
 				}
 
 				// Returning a wpcom_error is a sign to the caller that we should wait a while before syncing again.
-				return new \WP_Error( 'wpcom_error', 'jetpack_sync_send_data_false' );
+				return new WP_Error( 'wpcom_error', 'jetpack_sync_send_data_false' );
 			} else {
 				// Detect if the last item ID was an error.
 				$had_wp_error = is_wp_error( end( $processed_item_ids ) );
@@ -566,7 +569,7 @@ class Sender {
 				$queue->close( $buffer, $processed_item_ids );
 				// Returning a WP_Error is a sign to the caller that we should wait a while before syncing again.
 				if ( $had_wp_error ) {
-					return new \WP_Error( 'wpcom_error', $wp_error->get_error_code() );
+					return new WP_Error( 'wpcom_error', $wp_error->get_error_code() );
 				}
 			}
 		}

--- a/projects/packages/sync/src/class-server.php
+++ b/projects/packages/sync/src/class-server.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use WP_Error;
+
 /**
  * Simple version of a Jetpack Sync Server - just receives arrays of events and
  * issues them locally with the 'jetpack_sync_remote_action' action.
@@ -127,7 +129,7 @@ class Server {
 	public function receive( $data, $token = null, $sent_timestamp = null, $queue_id = null ) {
 		$start_time = microtime( true );
 		if ( ! is_array( $data ) ) {
-			return new \WP_Error( 'action_decoder_error', 'Events must be an array' );
+			return new WP_Error( 'action_decoder_error', 'Events must be an array' );
 		}
 
 		if ( $token && ! $this->attempt_request_lock( $token->blog_id ) ) {
@@ -140,7 +142,7 @@ class Server {
 			 */
 			do_action( 'jetpack_sync_multi_request_fail', $token );
 
-			return new \WP_Error( 'concurrent_request_error', 'There is another request running for the same blog ID' );
+			return new WP_Error( 'concurrent_request_error', 'There is another request running for the same blog ID' );
 		}
 
 		$events           = wp_unslash( array_map( array( $this->codec, 'decode' ), $data ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes issue reported from WordCamp.org:
Uncaught Error: Class 'Automattic\Jetpack\Sync\WP_Error' not found in /.../wp-content/plugins/jetpack/vendor/automattic/jetpack-sync/src/class-rest-sender.php:37

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* For the Rest_Sender class, add `use WP_Error` to resolve the fatal.
* Added `use WP_Error` to other files that previously used \WP_Error so all are they same now.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None. It's a syntax error really.
