### PR TITLE
Carousel: Strip html from carousel title instead of converting to plain text so that quotes are correctly converted

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-title-formatting
+++ b/projects/plugins/jetpack/changelog/fix-carousel-title-formatting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Minor change to carousel title formatting to prevent issues with quote conversion
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1048,7 +1048,7 @@
 				}
 
 				if ( title ) {
-					var plainTitle = domUtil.convertToPlainText( title );
+					var plainTitle = domUtil.stripHTML( title );
 					titleElement.innerHTML = plainTitle;
 
 					if ( ! caption ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Changes the title parsing from converting to plain text to stripHtml so that all quotes are correctly displayed in carousel.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Check out PR and turn on jetpack carousel option
* Add a gallery and set a title for an image with double quotes, eg. `"This is my title"` and make sure quotes show properly on frontend. Make sure you don't have a caption with exactly the same text otherwise this will show correctly instead of the broken title.

Before:
<img width="416" alt="Screen Shot 2021-07-29 at 11 26 01 AM" src="https://user-images.githubusercontent.com/3629020/127408856-2e2818fb-2760-4313-badd-71c627b70430.png">

After:
<img width="441" alt="Screen Shot 2021-07-29 at 11 15 07 AM" src="https://user-images.githubusercontent.com/3629020/127408870-1e78c82b-8b5a-4e9e-8672-d1db8abf6395.png">

