### PR TITLE
Carousel: Use existing gallery image to get background colour

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-background-load
+++ b/projects/plugins/jetpack/changelog/fix-carousel-background-load
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Fixes issues with cross origin exceptions when adding background colours to carousel and also fixes issue with adding background to first and last slides when looping
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -35,15 +35,18 @@
 			} );
 		}
 
-		function getAverageColor( imgEl ) {
+		function getAverageColor( slideEl, imgEl ) {
 			var canvas = document.createElement( 'canvas' ),
 				context = canvas.getContext && canvas.getContext( '2d' ),
 				imgData,
 				width,
 				height,
 				length,
-				rgb = { r: 0, g: 0, b: 0 },
 				count = 0;
+
+			var rgb = slideEl.closest( '.jp-carousel-light' )
+				? { r: 255, g: 255, b: 255 }
+				: { r: 0, g: 0, b: 0 };
 
 			if ( ! imgEl ) {
 				return rgb;
@@ -1308,7 +1311,7 @@
 		}
 
 		function calculateSlideBackgroundCss( slideEl, image ) {
-			var rgb = util.getAverageColor( image );
+			var rgb = util.getAverageColor( slideEl, image );
 			slideEl.style.backgroundImage =
 				'linear-gradient( to bottom, rgba(' +
 				rgb.r +

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -38,19 +38,41 @@
 		function getAverageColor( imgEl ) {
 			var canvas = document.createElement( 'canvas' ),
 				context = canvas.getContext && canvas.getContext( '2d' ),
-				rgb = { r: 0, g: 0, b: 0 };
+				imgData,
+				width,
+				height,
+				length,
+				rgb = { r: 0, g: 0, b: 0 },
+				count = 0;
 
 			if ( ! imgEl ) {
 				return rgb;
 			}
-			imgEl.crossOrigin = 'Anonymous';
-			canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
-			canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
+			try {
+				imgEl.crossOrigin = 'Anonymous';
+			} catch ( e ) {
+				return rgb;
+			}
+
+			height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
+			width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
+
 			context.drawImage( imgEl, 0, 0 );
-			const average = context.getImageData( 0, 0, 1, 1 ).data.slice( 0, 3 );
-			rgb.r = average[ 0 ];
-			rgb.g = average[ 1 ];
-			rgb.b = average[ 2 ];
+
+			imgData = context.getImageData( 0, 0, width, height );
+
+			length = imgData.data.length;
+
+			for ( var i = 0; i < length; i += 4 ) {
+				rgb.r += imgData.data[ i ];
+				rgb.g += imgData.data[ i + 1 ];
+				rgb.b += imgData.data[ i + 2 ];
+				count++;
+			}
+
+			rgb.r = Math.floor( rgb.r / count );
+			rgb.g = Math.floor( rgb.g / count );
+			rgb.b = Math.floor( rgb.b / count );
 
 			return rgb;
 		}
@@ -1267,7 +1289,7 @@
 			}
 			var isLoaded = image.complete && image.naturalHeight !== 0;
 			if ( isLoaded ) {
-				const rgb = calculateSlideBackgroundCss( slideEl, image );
+				var rgb = calculateSlideBackgroundCss( slideEl, image );
 				// For some reason in some instances, although showing as loaded, a black background
 				// is returned, and image.onload still fires and gives a correct background, so only
 				// return here if we have something other than black.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1258,11 +1258,11 @@
 			}
 		}
 
-		function applySlideBackground( image, slideEl ) {
+		function applySlideBackground( image, slideEl, duplicate ) {
 			if ( ! slideEl || ! image ) {
 				return;
 			}
-			if ( slideEl.style.backgroundImage ) {
+			if ( slideEl.style.backgroundImage && ! duplicate ) {
 				return;
 			}
 			var isLoaded = image.complete && image.naturalHeight !== 0;
@@ -1303,11 +1303,18 @@
 		function addBackgroundToDuplicateSlides( swiper ) {
 			const slideCount = swiper.slides.length;
 			if ( slideCount > 0 ) {
-				swiper.slides[ 0 ].style.backgroundImage =
-					swiper.slides[ slideCount - 2 ].style.backgroundImage;
-
-				swiper.slides[ slideCount - 1 ].style.backgroundImage =
-					swiper.slides[ 1 ].style.backgroundImage;
+				setTimeout( function () {
+					applySlideBackground(
+						carousel.slides[ carousel.slides.length - 1 ].attrs.originalElement,
+						swiper.slides[ 0 ],
+						true
+					);
+					applySlideBackground(
+						carousel.slides[ 0 ].attrs.originalElement,
+						swiper.slides[ slideCount - 1 ],
+						true
+					);
+				}, 500 );
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1304,16 +1304,10 @@
 			const slideCount = swiper.slides.length;
 			if ( slideCount > 0 ) {
 				setTimeout( function () {
-					applySlideBackground(
-						carousel.slides[ carousel.slides.length - 1 ].attrs.originalElement,
-						swiper.slides[ 0 ],
-						true
-					);
-					applySlideBackground(
-						carousel.slides[ 0 ].attrs.originalElement,
-						swiper.slides[ slideCount - 1 ],
-						true
-					);
+					swiper.slides[ 0 ].style.backgroundImage =
+						swiper.slides[ slideCount - 2 ].style.backgroundImage;
+					swiper.slides[ slideCount - 1 ].style.backgroundImage =
+						swiper.slides[ 1 ].style.backgroundImage;
 				}, 500 );
 			}
 		}

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -51,33 +51,33 @@
 			if ( ! imgEl ) {
 				return rgb;
 			}
+
 			try {
 				imgEl.crossOrigin = 'Anonymous';
+
+				height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
+				width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
+
+				context.drawImage( imgEl, 0, 0 );
+
+				imgData = context.getImageData( 0, 0, width, height );
+
+				length = imgData.data.length;
+
+				for ( var i = 0; i < length; i += 4 ) {
+					rgb.r += imgData.data[ i ];
+					rgb.g += imgData.data[ i + 1 ];
+					rgb.b += imgData.data[ i + 2 ];
+					count++;
+				}
+
+				rgb.r = Math.floor( rgb.r / count );
+				rgb.g = Math.floor( rgb.g / count );
+				rgb.b = Math.floor( rgb.b / count );
+				return rgb;
 			} catch ( e ) {
 				return rgb;
 			}
-
-			height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
-			width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
-
-			context.drawImage( imgEl, 0, 0 );
-
-			imgData = context.getImageData( 0, 0, width, height );
-
-			length = imgData.data.length;
-
-			for ( var i = 0; i < length; i += 4 ) {
-				rgb.r += imgData.data[ i ];
-				rgb.g += imgData.data[ i + 1 ];
-				rgb.b += imgData.data[ i + 2 ];
-				count++;
-			}
-
-			rgb.r = Math.floor( rgb.r / count );
-			rgb.g = Math.floor( rgb.g / count );
-			rgb.b = Math.floor( rgb.b / count );
-
-			return rgb;
 		}
 
 		return {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1275,23 +1275,13 @@
 		}
 
 		function applySlideBackground( image, slideEl ) {
-			if ( ! slideEl ) {
-				return;
-			}
-
-			// We're done if there's already a background image set.
-			if ( slideEl.style.backgroundImage ) {
-				return;
-			}
-
-			if ( ! image ) {
+			if ( ! slideEl || ! image ) {
 				return;
 			}
 
 			var isLoaded = image.complete && image.naturalHeight !== 0;
 			if ( isLoaded ) {
 				calculateSlideBackgroundCss( slideEl, image );
-				return;
 			}
 
 			image.onload = function () {
@@ -1446,9 +1436,9 @@
 					}
 
 					if ( Number( jetpackCarouselStrings.display_slide_background ) === 1 ) {
-						applySlideBackground(item, slideEl);
+						applySlideBackground( item, slideEl );
 					}
-					
+
 					var slide = { el: slideEl, attrs: attrs, index: i };
 
 					carousel.slides.push( slide );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -794,10 +794,6 @@
 
 			loadFullImage( carousel.slides[ index ] );
 
-			if ( Number( jetpackCarouselStrings.display_slide_background ) === 1 ) {
-				loadSlideBackgrounds();
-			}
-
 			domUtil.hide( carousel.caption );
 			updateTitleCaptionAndDesc( {
 				caption: current.attrs.caption,
@@ -1278,18 +1274,7 @@
 			}
 		}
 
-		function loadSlideBackgrounds() {
-			applySlideBackground( '.swiper-slide-active' );
-
-			setTimeout( function () {
-				applySlideBackground( '.swiper-slide-prev' );
-				applySlideBackground( '.swiper-slide-next' );
-			}, 200 );
-		}
-
-		function applySlideBackground( slideClass ) {
-			var slideEl = carousel.container.querySelector( slideClass );
-
+		function applySlideBackground( image, slideEl ) {
 			if ( ! slideEl ) {
 				return;
 			}
@@ -1299,7 +1284,6 @@
 				return;
 			}
 
-			var image = slideEl.querySelector( 'img' );
 			if ( ! image ) {
 				return;
 			}
@@ -1461,7 +1445,12 @@
 						attrs.previewImage = attrs.src;
 					}
 
+					if ( Number( jetpackCarouselStrings.display_slide_background ) === 1 ) {
+						applySlideBackground(item, slideEl);
+					}
+					
 					var slide = { el: slideEl, attrs: attrs, index: i };
+
 					carousel.slides.push( slide );
 				}
 			} );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1277,6 +1277,10 @@
 			}
 
 			image.onload = function () {
+				slideEl.backgroundLoaded = true;
+				if ( carousel.slides.filter( slide => slide.el.backgroundLoaded !== true ).length === 0 ) {
+					domUtil.emitEvent( carousel.overlay, 'background-images-loaded' );
+				}
 				calculateSlideBackgroundCss( slideEl, image );
 			};
 		}
@@ -1303,12 +1307,12 @@
 		function addBackgroundToDuplicateSlides( swiper ) {
 			const slideCount = swiper.slides.length;
 			if ( slideCount > 0 ) {
-				setTimeout( function () {
+				carousel.overlay.addEventListener( 'background-images-loaded', function () {
 					swiper.slides[ 0 ].style.backgroundImage =
 						swiper.slides[ slideCount - 2 ].style.backgroundImage;
 					swiper.slides[ slideCount - 1 ].style.backgroundImage =
 						swiper.slides[ 1 ].style.backgroundImage;
-				}, 500 );
+				} );
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds a cross origin setting to fix security exception on background colour extraction from canvas
* Uses the existing image in the gallery for the generation of the background colour
* Sets background image on the swiper virtual start and finish slides


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Checkout PR to local test env and enable the carousel slide background colour option under jetpack 'Writing' settings
- Add a gallery and open in frontend and make sure the background colour shows correctly on all slides looping forwards and backwards
- Also test on WPcom and Atomic