### PR TITLE
Update editor.scss - Fix form button alignment

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -23,6 +23,7 @@ div[data-type="jetpack/button"]:not([data-align='left']):not([data-align='right'
 
 div[data-type="jetpack/button"][data-align] {
 	z-index: 1;
+	width: 100%;
 
 	.wp-block > div {
 		max-width: 100%;


### PR DESCRIPTION
The button alignment options, Left - Center - Right, have an issue while in the editor to not display the buttons alignment correctly.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #18933

Able to replicate the issue for Right alignment only.  The Left and Center alignment worked while using the editor to align a forms button. (Tested on themes: Twenty Twenty One and Storefront)

**Note**: Although the editor for alignment may be off, on the live site is was working to align the button. 

------------
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

To fix the issue within the editor, with alignment of buttons, we need to set a width for Jetpacks `data-align` class.

**editor.scss**
- **Add** `width` and set to `100%`

```
div[data-type="jetpack/button"][data-align] {
    z-index: 1;
    width: 100%;
}
```

------------

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a new 'Post'
* Make a new block for a form, select Contact Form or Newsletter Sign-up
* Edit the new form
* Click on the submit button for the form you selected
* Align the button left/center/right

![align-editor](https://user-images.githubusercontent.com/11654917/126931832-c2c6e5c2-8a89-4c2e-a15a-ae24480d51b4.gif)


