### PR TITLE
Plans: Improve registering paid blocks process

### DIFF
--- a/projects/plugins/jetpack/changelog/update-refact-core-video-upgrade-handling
+++ b/projects/plugins/jetpack/changelog/update-refact-core-video-upgrade-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Try a new way to set paid blocks availability

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1120,7 +1120,7 @@ class Jetpack_Gutenberg {
 
 	/**
 	 * Set the block availability according to the given features.
-	 * 
+	 *
 	 * @param string $block_slug Block slug.
 	 * @param array  $features Features list that defines when the block active and/or available.
 	 */
@@ -1128,7 +1128,7 @@ class Jetpack_Gutenberg {
 		$features             = (array) array_values( $features );
 		$unsupported_features = array();
 
-		foreach( $features as $feature ) {
+		foreach ( $features as $feature ) {
 			if ( ! Jetpack_Plan::has_active_feature( $feature ) ) {
 				$unsupported_features[] = $feature;
 			}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1119,6 +1119,36 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
+	 * Set the block availability according to the given features.
+	 * 
+	 * @param string $block_slug Block slug.
+	 * @param array  $features Features list that defines when the block active and/or available.
+	 */
+	public static function set_block_availability( $block_slug, $features ) {
+		$features             = (array) array_values( $features );
+		$unsupported_features = array();
+
+		foreach( $features as $feature ) {
+			if ( ! Jetpack_Plan::has_active_feature( $feature ) ) {
+				$unsupported_features[] = $feature;
+			}
+		}
+
+		if ( empty( $unsupported_features ) ) {
+			return self::set_extension_available( $block_slug );
+		}
+
+		self::set_extension_unavailable(
+			$block_slug,
+			'missing_plan',
+			array(
+				'required_feature' => $unsupported_features,
+				'required_plan'    => Jetpack_Plan::get_minimum_plan_for_feature( $unsupported_features ),
+			)
+		);
+	}
+
+	/**
 	 * Wraps the suplied render_callback in a function to check
 	 * the availability of the block before rendering it.
 	 *

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1123,6 +1123,7 @@ class Jetpack_Gutenberg {
 	 * $features is an associative array that expect two keys:
 	 * - sufficient: an array of features where ONE of them is sufficient to enable the block.
 	 * - necessary: an array of features where ALL of them are necessary to enable the block.
+	 *
 	 * @param string $block_slug Block slug.
 	 * @param array  $features Features list that defines when the block active and/or available.
 	 */
@@ -1146,7 +1147,7 @@ class Jetpack_Gutenberg {
 			$sufficient_features_required[] = $sufficient;
 		}
 
-		// neccesary: ALL of them are required to enable the block.		
+		// neccesary: ALL of them are required to enable the block.
 		foreach ( $necessary_features as $necessary ) {
 			if ( ! Jetpack_Plan::has_active_feature( $necessary ) ) {
 				$necessary_features_required[] = $necessary;

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1121,18 +1121,19 @@ class Jetpack_Gutenberg {
 	/**
 	 * Set the block availability according to the given features.
 	 * $features is an associative array that expect two keys:
-	 * - sufficient: an array of features where ONE of them is sufficient to enable the block.
-	 * - necessary: an array of features where ALL of them are necessary to enable the block.
+	 * - sufficient: an array/itemitem of features where ONE of them is sufficient to enable the block.
+	 * - necessary: an array/item of features where ALL of them are necessary to enable the block.
 	 *
 	 * @param string $block_slug Block slug.
 	 * @param array  $features Features list that defines when the block active and/or available.
 	 */
 	public static function set_block_availability( $block_slug, $features = array() ) {
 		$sufficient_features = isset( $features['sufficient'] )
-			? (array) array_values( $features['sufficient'] )
+			? array_values( (array) $features['sufficient'] )
 			: array();
-		$necessary_features  = isset( $features['necessary'] )
-			? (array) array_values( $features['necessary'] )
+
+		$necessary_features = isset( $features['necessary'] )
+			? array_values( (array) $features['necessary'] )
 			: array();
 
 		$sufficient_features_required = array();
@@ -1154,11 +1155,11 @@ class Jetpack_Gutenberg {
 			}
 		}
 
-		if ( empty( $necessary_features_required ) ) {
+		// Combine sufficient and necessary required features.
+		$unsupported_features = array_merge( $sufficient_features_required, $necessary_features_required );
+		if ( empty( $unsupported_features ) ) {
 			return self::set_extension_available( $block_slug );
 		}
-
-		$unsupported_features = array_merge( $sufficient_features_required, $necessary_features_required );
 
 		self::set_extension_unavailable(
 			$block_slug,

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -42,7 +42,6 @@ class Jetpack_Plan {
 			),
 			'supports' => array(
 				'opentable',
-				'calendly',
 				'send-a-message',
 				'whatsapp-button',
 				'social-previews',
@@ -366,7 +365,7 @@ class Jetpack_Plan {
 	 * Check whether the given feature is active.
 	 *
 	 * @param String $feature  The feature slug to check.
-	 * @return Boolean           True whether the feature is active. Otherwise, False.
+	 * @return Boolean         True when the feature is active. Otherwise, False.
 	 */
 	public static function has_active_feature( $feature ) {
 		if ( ! isset( $feature ) ) {

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -365,7 +365,7 @@ class Jetpack_Plan {
 	/**
 	 * Check whether the given feature is active.
 	 *
-	 * @param String   $feature  The feature slug to check.
+	 * @param String $feature  The feature slug to check.
 	 * @return Boolean           True whether the feature is active. Otherwise, False.
 	 */
 	public static function has_active_feature( $feature ) {

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -42,6 +42,7 @@ class Jetpack_Plan {
 			),
 			'supports' => array(
 				'opentable',
+				'calendly',
 				'send-a-message',
 				'whatsapp-button',
 				'social-previews',

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -292,8 +292,8 @@ class Jetpack_Plan {
 	 * @return string|bool The slug for the minimum plan that supports the feature, or False if not found.
 	 */
 	public static function get_minimum_plan_for_feature( $feature_slug ) {
-		$feature_slug = is_array( $feature_slug ) ? $feature_slug[ 0 ] : $feature_slug;
-		$features = self::get_features();
+		$feature_slug = is_array( $feature_slug ) ? $feature_slug[0] : $feature_slug;
+		$features     = self::get_features();
 
 		if ( isset( $features['available'][ $feature_slug ][0] ) ) {
 			return $features['available'][ $feature_slug ][0];
@@ -344,6 +344,12 @@ class Jetpack_Plan {
 		return false;
 	}
 
+	/**
+	 * Get a list of all available features for the site.
+	 * It supports site type.
+	 *
+	 * @return object Site features object.
+	 */
 	public static function get_features() {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			if ( ! class_exists( 'Store_Product_List' ) ) {
@@ -359,7 +365,7 @@ class Jetpack_Plan {
 	/**
 	 * Check whether the given feature is active.
 	 *
-	 * @param  String  $feature  The feature slug to check.
+	 * @param String   $feature  The feature slug to check.
 	 * @return Boolean           True whether the feature is active. Otherwise, False.
 	 */
 	public static function has_active_feature( $feature ) {
@@ -368,11 +374,10 @@ class Jetpack_Plan {
 		}
 
 		$features = self::get_features();
-		error_log( '$features: ' . print_r( $features, true ) );
 		if ( ! isset( $features['active'] ) ) {
 			return false;
 		}
 
-		return in_array( $feature, $features['active'] );
+		return in_array( $feature, $features['active'], true );
 	}
 }

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -322,21 +322,24 @@ class Jetpack_Plan {
 
 		$plan = self::get();
 
-		// Manually mapping WordPress.com features to Jetpack module slugs.
-		foreach ( $plan['features']['active'] as $wpcom_feature ) {
-			switch ( $wpcom_feature ) {
-				case 'wordads-jetpack':
-					// WordAds are supported for this site.
-					if ( 'wordads' === $feature ) {
-						return true;
-					}
-					break;
-			}
-		}
+		// @TODO: ensure setting `wordads-jetpack` in dotcom.
+		/*
+		//Manually mapping WordPress.com features to Jetpack module slugs.
+		// foreach ( $plan['features']['active'] as $wpcom_feature ) {
+		// 	switch ( $wpcom_feature ) {
+		// 		case 'wordads-jetpack':
+		// 			// WordAds are supported for this site.
+		// 			if ( 'wordads' === $feature ) {
+		// 				return true;
+		// 			}
+		// 			break;
+		// 	}
+		// }
+		*/
 
 		if (
-			in_array( $feature, $plan['supports'], true )
-			|| in_array( $feature, $plan['features']['active'], true )
+			in_array( $feature, $plan['supports'], true )  // <- Feature supported by Jetpack PLAN_DATA. Consider removing it?. 
+			|| self::has_active_feature( $feature )        // <- Feature supported by dotcom features.
 		) {
 			return true;
 		}

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
@@ -25,7 +25,7 @@ add_action(
 		\Jetpack_Gutenberg::set_block_availability(
 			'core/video',
 			array(
-				'sufficient' => 'upload-video-files'
+				'sufficient' => 'upload-video-files',
 			)
 		);
 	}

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
@@ -22,10 +22,13 @@ add_filter(
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
-		\Jetpack_Gutenberg::set_block_availability( 'core/video', array(
-			'upload-video-files',
-			'polldaddy',
-			'premium-themes',
-		) );
+		\Jetpack_Gutenberg::set_block_availability(
+			'core/video',
+			array(
+				'upload-video-files',
+				'polldaddy',
+				'premium-themes',
+			)
+		);
 	}
 );

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
@@ -26,8 +26,6 @@ add_action(
 			'core/video',
 			array(
 				'upload-video-files',
-				'polldaddy',
-				'premium-themes',
 			)
 		);
 	}

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
@@ -25,7 +25,9 @@ add_action(
 		\Jetpack_Gutenberg::set_block_availability(
 			'core/video',
 			array(
-				'upload-video-files',
+				'sufficient' => array(
+					'upload-video-files',
+				),
 			)
 		);
 	}

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
@@ -22,6 +22,10 @@ add_filter(
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
-		\Jetpack_Gutenberg::set_availability_for_plan( 'core/video' );
+		\Jetpack_Gutenberg::set_block_availability( 'core/video', array(
+			'upload-video-files',
+			'polldaddy',
+			'premium-themes',
+		) );
 	}
 );

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
@@ -25,9 +25,7 @@ add_action(
 		\Jetpack_Gutenberg::set_block_availability(
 			'core/video',
 			array(
-				'sufficient' => array(
-					'upload-video-files',
-				),
+				'sufficient' => 'upload-video-files'
 			)
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

This PR tries to improve the way of registering paid blocks. For this purpose, it adds some helper methods to the Plan and Gutenberg classes. The final goal is to be able to define the block availability according to the site features in a flexible way.

## Jetpack_Plan::get_features()

This method returns all features for the site. It can be Simple, Atomic, or Jetpack site type.

```php
$features = Jetpack_Plan::get_features();
error_log( $features['active'] );
```

```stdout
[29-Jul-2021 19:01:55 UTC] Array
(
	[0] => google-analytics
	[1] => security-settings
	[2] => advanced-seo
	[3] => upload-video-files
	[4] => video-hosting
	[5] => akismet
	[6] => simple-payments
	[7] => send-a-message
	[8] => whatsapp-button
	[9] => social-previews
	[10] => donations
	[11] => core/audio
	[12] => premium-content/container
	[13] => support
	[14] => wordads-jetpack
)
```

## Jetpack_Plan::has_active_feature( $slug );

Check whether the given feature is active.

```php
if ( Jetpack_Plan::has_active_feature( 'calendly' ) ) {
    echo "Calendly is active on this site!";
}
```

## Jetpack_Gutenberg::set_block_availability( $block_slug, $features )

Set the block availability according to the given features. `$features` is an associative array that expects two keys:
- `sufficient`: an array/item of features where ONE of them is sufficient to enable the block.
- `necessary`: an array/item of features where ALL of them are necessary to enable the block.

## Example. Setting `core/video` block availability.

Once the block (extension) is added, it's possible to define its availability. The extension name is totally arbitrary, but in this case, it makes sense to use the block name.
To define when or how the block will be available we can pass features that define this condition. For this purpose, the API changes suggest setting the feature in two different groups:

- `sufficient`: an array/item of features where ONE of them is sufficient to enable the block.
- `necessary`: an array/item of features where ALL of them are necessary to enable the block.

To enable `code/video` block, we can do something like the following:

```php
add_action(
    'jetpack_register_gutenberg_extensions',
    function () {
        \Jetpack_Gutenberg::set_block_availability(
            'core/video',
            array(
                'sufficient' => 'upload-video-files',
            )
        );
    }
);

```

Defining the `upload-video-files` feature as _sufficient_ for this block will make that the availability will depend on only this feature. Pretty simple.

It's possible to combine and/or add more features per block:

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Plans: Improve registering paid blocks process

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes to your testing site
* Check that the core/video block availability is consistent with the site type  and the site plan
