### PR TITLE
Sync: backport new package version from 10.0-beta

### DIFF
--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2021-07-29
+### Changed
+- Utilize an import for WP_Error in all instances.
+
+### Fixed
+- Fixed unqualified WP_Error use in the Rest_Sender class.
+
 ## [1.24.0] - 2021-07-27
 ### Added
 - Add a package version constant.
@@ -433,6 +440,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.24.1]: https://github.com/Automattic/jetpack-sync/compare/v1.24.0...v1.24.1
 [1.24.0]: https://github.com/Automattic/jetpack-sync/compare/v1.23.3...v1.24.0
 [1.23.3]: https://github.com/Automattic/jetpack-sync/compare/v1.23.2...v1.23.3
 [1.23.2]: https://github.com/Automattic/jetpack-sync/compare/v1.23.1...v1.23.2

--- a/projects/packages/sync/changelog/fix-sync-wp-error
+++ b/projects/packages/sync/changelog/fix-sync-wp-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed unqualified WP_Error use in the Rest_Sender class.

--- a/projects/packages/sync/changelog/fix-sync-wp-error-1
+++ b/projects/packages/sync/changelog/fix-sync-wp-error-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Utilize an import for WP_Error in all instances.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.24.1-alpha';
+	const PACKAGE_VERSION = '1.24.1';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Backport new version release from 10.0 beta: https://github.com/Automattic/jetpack/commit/a632065f5617394514c07ef680a6658370bfa778

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

* Proofread