### PR TITLE
Jetpack: Rename a JS file to avoid an outdated wpcom minifier

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-workaround-bad-wpcom-minifier-part-1
+++ b/projects/plugins/jetpack/changelog/fix-workaround-bad-wpcom-minifier-part-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Rename a generated js file to avoid triggering an outdated minifier on wpcom's cdn.

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -33,7 +33,7 @@ const baseWebpackConfig = getBaseWebpackConfig(
 				require.resolve( 'abortcontroller-polyfill/dist/polyfill-patch-fetch' ),
 			],
 		},
-		'output-chunk-filename': 'jp-search.chunk-[name]-[hash].js',
+		'output-chunk-filename': 'jp-search.chunk-[name]-[hash].min.js',
 		'output-filename': 'jp-search-[name].bundle.js',
 		'output-path': path.join( __dirname, '../_inc/build/instant-search' ),
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The minifier seems to choke on newer JS, but we can avoid it by naming
the file to end in ".min.js".

At some point we'll probably need to do this to more files too.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1627570375202400-slack-C025Q5RK2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load onto wpcom infrastructure somehow, and see if the built file avoids being broken without having to include `?minify=no` in the URL.