### PR TITLE
[Carousel] Prevent cross origin errors

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-cross-origin-issue
+++ b/projects/plugins/jetpack/changelog/fix-carousel-cross-origin-issue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: [Carousel] Fix cross origin error on simple sites.
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -49,10 +49,15 @@
 				return rgb;
 			}
 
+			try {
+				imgEl.crossOrigin = 'Anonymous';
+			} catch ( e ) {
+				return { r: 0, g: 0, b: 0 };
+			}
+
 			height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
 			width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
 
-			imgEl.crossOrigin = 'Anonymous';
 			context.drawImage( imgEl, 0, 0 );
 			imgData = context.getImageData( 0, 0, width, height );
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -52,6 +52,7 @@
 			height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
 			width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
 
+			imgEl.crossOrigin = 'Anonymous';
 			context.drawImage( imgEl, 0, 0 );
 			imgData = context.getImageData( 0, 0, width, height );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates GH to the background image diff D64175-code by preventing cross-origin errors on simple sites.

This may just be rolled in with other background changes in #20476.


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync D64175-code to your sandbox to get background colors working on simple sites.
* Make sure to enable the colorized backgrounds in the carousel settings under Settings -> Media
* Add a Gallery to a post and view on the frontend.
* Click on an image to open the carousel and verify that you do not receive any console errors. You should be able to swipe back and forth through images and exit the carousel without issue. Note that the colorized backgrounds will not be working consistently; this is being addressed in another PR. This PR just prevents the page from crashing.
* Test the carousel on a local jetpack site via jurassic.tube to make sure it functions well there as well.