### PR TITLE
[Carousel]: Stop gallery from being treated as single image when linking to attachment page

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-images-with-attachment-page-link
+++ b/projects/plugins/jetpack/changelog/fix-carousel-images-with-attachment-page-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+[Carousel]: Fix bug preventing user from swiping in gallery when images are configured to link to Attachment Page.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -307,9 +307,12 @@
 			'div.gallery, div.tiled-gallery, ul.wp-block-gallery, ul.blocks-gallery-grid, ' +
 			'figure.blocks-gallery-grid, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery';
 
-		var itemSelector =
-			'.gallery-item, .tiled-gallery-item, .blocks-gallery-item, ' +
-			' .tiled-gallery__item, .wp-block-image';
+		// Selector for items within a gallery or tiled gallery.
+		var galleryItemSelector =
+			'.gallery-item, .tiled-gallery-item, .blocks-gallery-item, ' + ' .tiled-gallery__item';
+
+		// Selector for all items including single images.
+		var itemSelector = galleryItemSelector + ', .wp-block-image';
 
 		var carousel = {};
 
@@ -690,7 +693,7 @@
 				}
 
 				// Skip if image is part of a gallery.
-				if ( container.parentElement.classList.contains( 'blocks-gallery-item' ) ) {
+				if ( domUtil.closest( container, galleryItemSelector ) ) {
 					return;
 				}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -681,15 +681,21 @@
 		function processSingleImageGallery() {
 			var images = document.querySelectorAll( 'a img[data-attachment-id]' );
 			Array.prototype.forEach.call( images, function ( image ) {
-				var container = image.parentElement;
+				var link = image.parentElement;
+				var container = link.parentElement;
 
 				// Skip if image was already added to gallery by shortcode.
-				if ( container.parentElement.classList.contains( 'gallery-icon' ) ) {
+				if ( container.classList.contains( 'gallery-icon' ) ) {
 					return;
 				}
 
-				// Skip if the container is not a link.
-				if ( ! container.hasAttribute( 'href' ) ) {
+				// Skip if image is part of a gallery.
+				if ( container.parentElement.classList.contains( 'blocks-gallery-item' ) ) {
+					return;
+				}
+
+				// Skip if the parent is not actually a link.
+				if ( ! link.hasAttribute( 'href' ) ) {
 					return;
 				}
 
@@ -697,7 +703,7 @@
 
 				// If link points to 'Media File' (ignoring GET parameters) and flag is set, allow it.
 				if (
-					container.getAttribute( 'href' ).split( '?' )[ 0 ] ===
+					link.getAttribute( 'href' ).split( '?' )[ 0 ] ===
 						image.getAttribute( 'data-orig-file' ).split( '?' )[ 0 ] &&
 					Number( jetpackCarouselStrings.single_image_gallery_media_file ) === 1
 				) {
@@ -705,7 +711,7 @@
 				}
 
 				// If link points to 'Attachment Page', allow it.
-				if ( container.getAttribute( 'href' ) === image.getAttribute( 'data-permalink' ) ) {
+				if ( link.getAttribute( 'href' ) === image.getAttribute( 'data-permalink' ) ) {
 					valid = true;
 				}
 
@@ -715,9 +721,9 @@
 				}
 
 				// Make this node a gallery recognizable by event listener above.
-				container.classList.add( 'single-image-gallery' );
+				link.classList.add( 'single-image-gallery' );
 				// blog_id is needed to allow posting comments to correct blog.
-				container.setAttribute(
+				link.setAttribute(
 					'data-carousel-extra',
 					JSON.stringify( {
 						blog_id: Number( jetpackCarouselStrings.blog_id ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #20490

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When a gallery is configured in the block settings to link to Attachment Page, it was being treated by the Carousel like a single image -- meaning the carousel would open to the clicked image, but the next/prev buttons would be disabled and the user is unable to swipe through the gallery.

This PR adds a check to the lightbox code to return early when the image is part of a gallery.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test Bug Fix
* Add a gallery with at least a few images to a new post.
* Publish the post and view on the frontend.
* Click one of the images. The carousel should open.
* Test swiping back and forth; you should be able to move from slide to slide. Test the next/prev buttons as well.
* In the Gallery Settings in the Inspector Controls panel, set the "link" type to "Attachment Page":
<img width="275" alt="Screen Shot 2021-07-29 at 2 48 39 PM" src="https://user-images.githubusercontent.com/63313398/127570286-a4003780-e4ad-4dd6-bc71-13aecab0a2a8.png">
* Publish the post and test on the frontend to make sure that swiping and the next/prev buttons still work.

Test Single Image Carousel
* Add a single Image block to your post and set the Link type to "Attachment Page" in the block toolbar:
<img width="513" alt="Screen Shot 2021-07-29 at 2 50 23 PM" src="https://user-images.githubusercontent.com/63313398/127570398-49e37c03-3130-4116-99d1-c88087981e73.png">
* Publish the post and view on the frontend.
* Click on the single image. It should open in the carousel view. You should not be able to swipe back and forth to additional images; the next/prev buttons should do nothing.
