### PR TITLE
Search: Remove IE11 polyfill mechanism

### DIFF
--- a/projects/plugins/jetpack/.size-limit.js
+++ b/projects/plugins/jetpack/.size-limit.js
@@ -1,6 +1,6 @@
 module.exports = [
 	{
-		path: '_inc/build/instant-search/jp-search-main.bundle.js',
+		path: '_inc/build/instant-search/jp-search-main.min.js',
 		running: false,
 		limit: '4 KiB',
 	},

--- a/projects/plugins/jetpack/changelog/remove-ie11-support-for-search
+++ b/projects/plugins/jetpack/changelog/remove-ie11-support-for-search
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+Search: Remove IE11 polyfill mechanism

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -115,24 +115,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @param string $plugin_base_path - Base path for use in plugins_url.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
-		$polyfill_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-ie11-polyfill-loader.bundle.js';
-		$script_relative_path   = $path_prefix . '_inc/build/instant-search/jp-search-main.bundle.js';
-
-		if (
-			! file_exists( JETPACK__PLUGIN_DIR . $polyfill_relative_path ) ||
-			! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path )
-		) {
-			return;
-		}
-
-		$polyfill_version = Jetpack_Search_Helpers::get_asset_version( $polyfill_relative_path );
-		$polyfill_path    = plugins_url( $polyfill_relative_path, $plugin_base_path );
-		wp_enqueue_script( 'jetpack-instant-search-ie11', $polyfill_path, array(), $polyfill_version, true );
-		$polyfill_payload_path = plugins_url(
-			$path_prefix . '_inc/build/instant-search/jp-search-ie11-polyfill-payload.bundle.js',
-			$plugin_base_path
-		);
-		$this->inject_polyfill_js_options( $polyfill_payload_path );
+		$script_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-main.min.js';
 
 		$script_version = Jetpack_Search_Helpers::get_asset_version( $script_relative_path );
 		$script_path    = plugins_url( $script_relative_path, $plugin_base_path );
@@ -149,15 +132,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$options = Jetpack_Search_Helpers::generate_initial_javascript_state();
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
 		wp_add_inline_script( 'jetpack-instant-search', 'var JetpackInstantSearchOptions=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $options ) ) . '"));', 'before' );
-	}
-
-	/**
-	 * Passes options to the polyfill loader script.
-	 *
-	 * @param string $polyfill_payload_path - Absolute path to the IE11 polyfill payload.
-	 */
-	protected function inject_polyfill_js_options( $polyfill_payload_path ) {
-		wp_add_inline_script( 'jetpack-instant-search-ie11', 'var JetpackInstantSearchIe11PolyfillPath=decodeURIComponent("' . rawurlencode( $polyfill_payload_path ) . '");', 'before' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -22,19 +22,9 @@ const baseWebpackConfig = getBaseWebpackConfig(
 	{
 		entry: {
 			main: path.join( __dirname, '../modules/search/instant-search/loader.js' ),
-			'ie11-polyfill-loader': path.join(
-				__dirname,
-				'../modules/search/instant-search/ie11-polyfill.js'
-			),
-			'ie11-polyfill-payload': [
-				require.resolve( 'core-js' ),
-				require.resolve( 'regenerator-runtime/runtime' ),
-				require.resolve( 'whatwg-fetch' ),
-				require.resolve( 'abortcontroller-polyfill/dist/polyfill-patch-fetch' ),
-			],
 		},
 		'output-chunk-filename': 'jp-search.chunk-[name]-[hash].min.js',
-		'output-filename': 'jp-search-[name].bundle.js',
+		'output-filename': 'jp-search-[name].min.js',
 		'output-path': path.join( __dirname, '../_inc/build/instant-search' ),
 	}
 );


### PR DESCRIPTION
Fixes #19223.

#### Changes proposed in this Pull Request:
* Removes Search's custom IE11 polyfilling mechanism.
* Changes asset suffix to `min.(js|css)` for improved compatibility with WPCOM.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply these changes to your site with a Jetpack Search subscription.
* Ensure that Instant Search works as expected on one of our supported browsers (Chrome, Firefox, Safari, etc.)
