### PR TITLE
Search: Remove forward slash from search homepage breadcrumb when empty.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-homepage-breadcrumb
+++ b/projects/plugins/jetpack/changelog/fix-search-homepage-breadcrumb
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: removes forward slash from empty breadcrumb display

--- a/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.jsx
@@ -8,7 +8,7 @@ import './path-breadcrumbs.scss';
 function splitDomainPath( path ) {
 	const splits = path.split( '/' ).filter( piece => piece.length > 0 );
 	splits.shift(); // Removes domain name from splits; e.g. 'jetpack.com'
-	return splits.length === 0 ? [] : splits;
+	return splits;
 }
 
 const PathBreadcrumbs = ( { className, onClick, url } ) => {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.jsx
@@ -8,10 +8,16 @@ import './path-breadcrumbs.scss';
 function splitDomainPath( path ) {
 	const splits = path.split( '/' ).filter( piece => piece.length > 0 );
 	splits.shift(); // Removes domain name from splits; e.g. 'jetpack.com'
-	return splits.length === 0 ? [ '/' ] : splits;
+	return splits.length === 0 ? [] : splits;
 }
 
 const PathBreadcrumbs = ( { className, onClick, url } ) => {
+	const breadcrumbPieces = splitDomainPath( url );
+
+	if ( breadcrumbPieces.length < 1 ) {
+		return null;
+	}
+
 	return (
 		<div className={ `jetpack-instant-search__path-breadcrumb ${ className ? className : '' }` }>
 			<a

--- a/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.jsx
@@ -25,7 +25,7 @@ const PathBreadcrumbs = ( { className, onClick, url } ) => {
 				href={ `//${ url }` }
 				onClick={ onClick }
 			>
-				{ splitDomainPath( url ).map( ( piece, index, pieces ) => (
+				{ breadcrumbPieces.map( ( piece, index, pieces ) => (
 					<span className="jetpack-instant-search__path-breadcrumb-piece">
 						{ decodeURIComponent( piece ) }
 						{ index !== pieces.length - 1 ? ' › ' : '' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This PR fixes the homepage breadcrumb display when no breadcrumb is available by removing the forward slash displayed.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Go to a site with Jetpack Instant Search subscription.
* Search for a keyword which will result in a homepage without a breadcrumb (searching by site title should work)
* Check that there is no forward slash where the breadcrumb is usually displayed.

Before: 

![image](https://user-images.githubusercontent.com/30754158/127587395-1bab7ce3-5964-4654-bc69-77fefa3f47c2.png)


After: 
![image](https://user-images.githubusercontent.com/30754158/127587327-ffca39d8-2818-43b1-8d12-102141e39ab7.png)
