### PR TITLE
[Carousel] Invert colors of comments indicator when icon selected

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-comments-icon-when-selected
+++ b/projects/plugins/jetpack/changelog/update-carousel-comments-icon-when-selected
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Minor CSS change
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -1135,6 +1135,16 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	color: #fff;
 }
 
+.jp-carousel-selected .jp-carousel-icon .jp-carousel-has-comments-indicator {
+	background: #000;
+	color: #fff;
+}
+
+.jp-carousel-light .jp-carousel-selected .jp-carousel-icon .jp-carousel-has-comments-indicator {
+	background: #fff;
+	color: #000;
+}
+
 .jp-carousel-has-comments-indicator.jp-carousel-show {
 	display: inline-block;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The comment icon in the carousel includes a comments indicator to display the number of comments on the image. When the icon is not selected/the panel isn't open, the colors of this indicator contrast with the background -- so in dark mode for example the indicator appears as a white bubble with black text:
<img width="125" alt="Screen Shot 2021-07-30 at 1 41 49 PM" src="https://user-images.githubusercontent.com/63313398/127709507-fbfbe25f-0aa9-4adc-b774-b26a5ac9f727.png">

When the icon is selected in order to open the panel, the entire icon receives a white background, but the indicators colors remain the same, so it bleeds into the background:
<img width="116" alt="Screen Shot 2021-07-30 at 1 22 37 PM" src="https://user-images.githubusercontent.com/63313398/127709607-acaa61a5-e35e-4ec1-931c-d308f3e76c50.png">

This PR inverts the colors of the indicator when the icon is selected.
|  | Before | After |
| --- | --- | --- |
| Light Mode | <img width="133" alt="Screen Shot 2021-07-30 at 1 22 16 PM" src="https://user-images.githubusercontent.com/63313398/127709671-7e12f64d-114d-4938-8192-df18be299761.png"> | <img width="126" alt="Screen Shot 2021-07-30 at 1 23 22 PM" src="https://user-images.githubusercontent.com/63313398/127709704-1605fc28-103b-4954-8d2d-106882c7888b.png"> |
| Dark Mode | <img width="116" alt="Screen Shot 2021-07-30 at 1 22 37 PM" src="https://user-images.githubusercontent.com/63313398/127709757-7df3176c-4021-473f-8eba-a62d9d1fcdd4.png"> | <img width="124" alt="Screen Shot 2021-07-30 at 1 23 00 PM" src="https://user-images.githubusercontent.com/63313398/127709816-696e93e2-9512-4eea-bd63-6adfc11c2acb.png"> | 


This is a good example of some CSS that could benefit from the CSS variables introduced to simplify Light Mode in #20503 :)


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Publish a post with a gallery block.
* Add some comments to one of the gallery images.
* View the image in the carousel and verify that the comments indicator looks correct, ie the colors contrast with the background (see screenshots)
* Click the comments icon to open the comments panel. Verify that the colors on the comment indicator invert/match screenshots.

Test in light mode and dark mode.