### PR TITLE
Carousel: disable UI controls for single image

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-hide-ui-controls-for-single-image
+++ b/projects/plugins/jetpack/changelog/update-carousel-hide-ui-controls-for-single-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Hide UI controls in the carousel for single images.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -441,8 +441,6 @@
 
 					// Don't show navigation if there's only one image.
 					if ( carousel.slides.length <= 1 ) {
-						domUtil.hide( carousel.overlay.querySelector( '.jp-swiper-button-prev' ) );
-						domUtil.hide( carousel.overlay.querySelector( '.jp-swiper-button-next' ) );
 						return;
 					}
 					// Show dot pagination if slide count is <= 5, otherwise show n/total.
@@ -459,9 +457,12 @@
 					// Fixes some themes where closing carousel brings view back to top.
 					document.documentElement.style.removeProperty( 'height' );
 
-					// Show the navigation arrows if we hid them for single images.
-					domUtil.show( carousel.overlay.querySelector( '.jp-swiper-button-prev' ) );
-					domUtil.show( carousel.overlay.querySelector( '.jp-swiper-button-next' ) );
+					// If we disable the swiper (because there's only one image)
+					// we have to re-enable it here again as Swiper doesn't, for some reason,
+					// Show the navigation buttons again after reinitialization.
+					if ( swiper ) {
+						swiper.enable();
+					}
 
 					// Hide pagination.
 					domUtil.hide( carousel.info.querySelector( '.jp-swiper-pagination' ) );
@@ -1509,7 +1510,9 @@
 			swiper = new window.Swiper( '.jp-carousel-swiper-container', {
 				centeredSlides: true,
 				zoom: true,
-				loop: carousel.slides.length > 1 ? true : false,
+				loop: carousel.slides.length > 1,
+				// Turn off interactions and hide navigation arrows if there is only one slide.
+				enabled: carousel.slides.length > 1,
 				pagination: {
 					el: '.jp-swiper-pagination',
 					clickable: true,

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -459,7 +459,7 @@
 					// Fixes some themes where closing carousel brings view back to top.
 					document.documentElement.style.removeProperty( 'height' );
 
-					// Should the navigation arrows if we hid them for single images.
+					// Show the navigation arrows if we hid them for single images.
 					domUtil.show( carousel.overlay.querySelector( '.jp-swiper-button-prev' ) );
 					domUtil.show( carousel.overlay.querySelector( '.jp-swiper-button-next' ) );
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -438,6 +438,13 @@
 
 				carousel.overlay.addEventListener( 'jp_carousel.afterOpen', function () {
 					enableKeyboardNavigation();
+
+					// Don't show navigation if there's only one image.
+					if ( carousel.slides.length <= 1 ) {
+						domUtil.hide( carousel.overlay.querySelector( '.jp-swiper-button-prev' ) );
+						domUtil.hide( carousel.overlay.querySelector( '.jp-swiper-button-next' ) );
+						return;
+					}
 					// Show dot pagination if slide count is <= 5, otherwise show n/total.
 					if ( carousel.slides.length <= 5 ) {
 						domUtil.show( carousel.info.querySelector( '.jp-swiper-pagination' ) );
@@ -451,6 +458,10 @@
 
 					// Fixes some themes where closing carousel brings view back to top.
 					document.documentElement.style.removeProperty( 'height' );
+
+					// Should the navigation arrows if we hid them for single images.
+					domUtil.show( carousel.overlay.querySelector( '.jp-swiper-button-prev' ) );
+					domUtil.show( carousel.overlay.querySelector( '.jp-swiper-button-next' ) );
 
 					// Hide pagination.
 					domUtil.hide( carousel.info.querySelector( '.jp-swiper-pagination' ) );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -459,7 +459,7 @@
 
 					// If we disable the swiper (because there's only one image)
 					// we have to re-enable it here again as Swiper doesn't, for some reason,
-					// Show the navigation buttons again after reinitialization.
+					// show the navigation buttons again after reinitialization.
 					if ( swiper ) {
 						swiper.enable();
 					}


### PR DESCRIPTION

Fixes https://github.com/Automattic/jetpack/issues/20267

#### Changes proposed in this Pull Request

This PR:

- hides navigation arrows and pagination UI if there's only one image.
- disables swipe interaction if there's only one image.
- sets swiper to `enabled` before close. We have to do this because, after testing, it seems as if Swiper doesn't re-enable the navigation arrows on reinitialization.


**Before**

<img width="500" alt="single-image" src="https://user-images.githubusercontent.com/6458278/127795393-aed572ba-fe2c-4523-8c5e-9f7390b5fd0d.png">

**After**
<img width="500" alt="Screen Shot 2021-08-02 at 12 10 10 pm" src="https://user-images.githubusercontent.com/6458278/127795386-558356cd-611c-4ae1-8683-089589e1abe1.png">

#### Does this pull request change what data or activity we track or use?
Nope.

#### Testing instructions:

Create 2 x galleries on the same post: one with several images and one with only 1 image.

Publish them and checkout the frontend.

You should see and be able to use the navigation arrows and pagination UI for the gallery with several images.

The gallery with one image shouldn't display any UI controls. You shouldn't be able to slide it or interact with the image.

Open one, then the other to make sure we're enabling/disabling the UI correctly.



