### PR TITLE
Revert "[Carousel]: Reenable background color"

### DIFF
--- a/projects/packages/sync/changelog/revert-20377-update-fix-and-reenable-carousel-background
+++ b/projects/packages/sync/changelog/revert-20377-update-fix-and-reenable-carousel-background
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Revert: Sync option for the Carousel to display colorized slide background.
+
+

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -33,7 +33,6 @@ class Defaults {
 		'carousel_background_color',
 		'carousel_display_exif',
 		'carousel_display_comments',
-		'carousel_display_slide_background',
 		'category_base',
 		'ce4wp_referred_by', // Creative Mail. See pbtFPC-H5-p2.
 		'close_comments_days_old',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.24.1';
+	const PACKAGE_VERSION = '1.24.2-alpha';
 }

--- a/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
@@ -34,15 +34,7 @@ function WritingMedia( props ) {
 
 	const displayComments = props.getOptionValue( 'carousel_display_comments', 'carousel' );
 	const displayExif = props.getOptionValue( 'carousel_display_exif', 'carousel' );
-	const displaySlideBackground = props.getOptionValue(
-		'carousel_display_slide_background',
-		'carousel'
-	);
 	const isCarouselActive = props.getOptionValue( 'carousel' );
-
-	const handleCarouselDisplaySlideBackgroundChange = () => {
-		props.updateFormStateModuleOption( 'carousel', 'carousel_display_slide_background' );
-	};
 
 	const handleCarouselDisplayExifChange = () => {
 		props.updateFormStateModuleOption( 'carousel', 'carousel_display_exif' );
@@ -114,12 +106,6 @@ function WritingMedia( props ) {
 						'carousel_display_comments',
 						handleCarouselDisplayCommentsChange,
 						__( 'Show comments area in carousel', 'jetpack' )
-					) }
-					{ renderToggle(
-						displaySlideBackground,
-						'carousel_display_slide_background',
-						handleCarouselDisplaySlideBackgroundChange,
-						__( 'Display colorized slide backgrounds', 'jetpack' )
 					) }
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2137,13 +2137,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'carousel',
 			),
-			'carousel_display_slide_background'    => array(
-				'description'       => esc_html__( 'Display colorized slide backgrounds', 'jetpack' ),
-				'type'              => 'boolean',
-				'default'           => 0,
-				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'jp_group'          => 'carousel',
-			),
 
 			// Comments
 			'highlander_comment_form_prompt'       => array(

--- a/projects/plugins/jetpack/changelog/revert-20377-update-fix-and-reenable-carousel-background
+++ b/projects/plugins/jetpack/changelog/revert-20377-update-fix-and-reenable-carousel-background
@@ -1,0 +1,6 @@
+Significance: patch
+Type: other
+Comment: Revert: Carousel: Add settings toggle to control display of colorized slide background., Carousel: Enabled background colors, fixed bug with missing background when reversing swipe direction.
+
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -31,6 +31,12 @@
 	width: 100vw;
 }
 
+.jp-carousel-overlay .swiper-zoom-container {
+	background-size: 200%;
+	background-repeat: no-repeat;
+	background-position: center;
+}
+
 /*
 To prevent flash of prev/next image scale transition after pinch zoom we need to hide them.
 Swiper does not add a class of `swiper-slide-zoomed` to slides on pinch and zoom
@@ -87,12 +93,6 @@ so we have to target all affected elements in touch devices.
 
 .jp-carousel-overlay * {
 	box-sizing: border-box;
-}
-
-/* Prevent flickering of the background in Safari */
-.jp-carousel-overlay .swiper-slide {
-	transform: translateZ( 0 );
-	-webkit-transform: translateZ( 0 );
 }
 
 /* Fix for Twenty Nineteen theme compatibility */

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -35,47 +35,27 @@
 			} );
 		}
 
-		function getAverageColor( imgEl ) {
+		function getBackgroundImage( imgEl ) {
 			var canvas = document.createElement( 'canvas' ),
-				context = canvas.getContext && canvas.getContext( '2d' ),
-				imgData,
-				width,
-				height,
-				length,
-				rgb = { r: 0, g: 0, b: 0 },
-				count = 0;
+				context = canvas.getContext && canvas.getContext( '2d' );
 
 			if ( ! imgEl ) {
-				return rgb;
+				return;
 			}
 
-			height = canvas.height = imgEl.naturalHeight || imgEl.offsetHeight || imgEl.height;
-			width = canvas.width = imgEl.naturalWidth || imgEl.offsetWidth || imgEl.width;
-
+			context.filter = 'blur(20px) ';
 			context.drawImage( imgEl, 0, 0 );
-			imgData = context.getImageData( 0, 0, width, height );
+			var url = canvas.toDataURL( 'image/png' );
+			canvas = null;
 
-			length = imgData.data.length;
-
-			for ( var i = 0; i < length; i += 4 ) {
-				rgb.r += imgData.data[ i ];
-				rgb.g += imgData.data[ i + 1 ];
-				rgb.b += imgData.data[ i + 2 ];
-				count++;
-			}
-
-			rgb.r = Math.floor( rgb.r / count );
-			rgb.g = Math.floor( rgb.g / count );
-			rgb.b = Math.floor( rgb.b / count );
-
-			return rgb;
+			return url;
 		}
 
 		return {
 			noop: noop,
 			texturize: texturize,
 			applyReplacements: applyReplacements,
-			getAverageColor: getAverageColor,
+			getBackgroundImage: getBackgroundImage,
 		};
 	} )();
 
@@ -794,8 +774,11 @@
 
 			loadFullImage( carousel.slides[ index ] );
 
-			if ( Number( jetpackCarouselStrings.display_slide_background ) === 1 ) {
-				loadSlideBackgrounds();
+			if (
+				Number( jetpackCarouselStrings.display_background_image ) === 1 &&
+				! carousel.slides[ index ].backgroundImage
+			) {
+				loadBackgroundImage( carousel.slides[ index ] );
 			}
 
 			domUtil.hide( carousel.caption );
@@ -1278,59 +1261,31 @@
 			}
 		}
 
-		function loadSlideBackgrounds() {
-			applySlideBackground( '.swiper-slide-active' );
+		function loadBackgroundImage( slide ) {
+			var currentSlide = slide.el;
 
-			setTimeout( function () {
-				applySlideBackground( '.swiper-slide-prev' );
-				applySlideBackground( '.swiper-slide-next' );
-			}, 200 );
-		}
-
-		function applySlideBackground( slideClass ) {
-			var slideEl = carousel.container.querySelector( slideClass );
-
-			if ( ! slideEl ) {
-				return;
+			if ( swiper && swiper.slides ) {
+				currentSlide = swiper.slides[ swiper.activeIndex ];
 			}
 
-			// We're done if there's already a background image set.
-			if ( slideEl.style.backgroundImage ) {
-				return;
-			}
-
-			var image = slideEl.querySelector( 'img' );
-			if ( ! image ) {
-				return;
-			}
-
+			var image = slide.attrs.originalElement;
 			var isLoaded = image.complete && image.naturalHeight !== 0;
+
 			if ( isLoaded ) {
-				calculateSlideBackgroundCss( slideEl, image );
+				applyBackgroundImage( slide, currentSlide, image );
 				return;
 			}
 
 			image.onload = function () {
-				calculateSlideBackgroundCss( slideEl, image );
+				applyBackgroundImage( slide, currentSlide, image );
 			};
 		}
 
-		function calculateSlideBackgroundCss( slideEl, image ) {
-			var rgb = util.getAverageColor( image );
-			slideEl.style.backgroundImage =
-				'linear-gradient( to bottom, rgba(' +
-				rgb.r +
-				',' +
-				rgb.g +
-				',' +
-				rgb.b +
-				', 0.5 ), rgba(' +
-				rgb.r +
-				', ' +
-				rgb.g +
-				', ' +
-				rgb.b +
-				', 0.25 ';
+		function applyBackgroundImage( slide, currentSlide, image ) {
+			var url = util.getBackgroundImage( image );
+			slide.backgroundImage = url;
+			currentSlide.style.backgroundImage = 'url(' + url + ')';
+			currentSlide.style.backgroundSize = 'cover';
 		}
 
 		function clearCommentTextAreaValue() {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -261,7 +261,6 @@ class Jetpack_Carousel {
 				'display_exif'                    => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', true ) ),
 				'display_comments'                => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_comments', true ) ),
 				'display_geo'                     => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_geo', true ) ),
-				'display_slide_background'        => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_slide_background', false ), false ),
 				'single_image_gallery'            => $this->single_image_gallery_enabled,
 				'single_image_gallery_media_file' => $this->single_image_gallery_enabled_media_file,
 				'background_color'                => $this->carousel_background_color_sanitize( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_background_color', '' ) ),
@@ -1066,9 +1065,6 @@ class Jetpack_Carousel {
 		add_settings_field( 'carousel_display_comments', __( 'Comments', 'jetpack' ), array( $this, 'carousel_display_comments_callback' ), 'media', 'carousel_section' );
 		register_setting( 'media', 'carousel_display_comments', array( $this, 'carousel_display_comments_sanitize' ) );
 
-		add_settings_field( 'carousel_display_slide_background', __( 'Slide background', 'jetpack' ), array( $this, 'carousel_display_slide_background_callback' ), 'media', 'carousel_section' );
-		register_setting( 'media', 'carousel_display_slide_background', array( $this, 'carousel_display_slide_background_sanitize' ) );
-
 		// No geo setting yet, need to "fuzzify" data first, for privacy
 		// add_settings_field('carousel_display_geo', __( 'Geolocation', 'jetpack' ), array( $this, 'carousel_display_geo_callback' ), 'media', 'carousel_section' );
 		// register_setting( 'media', 'carousel_display_geo', array( $this, 'carousel_display_geo_sanitize' ) );
@@ -1139,24 +1135,6 @@ class Jetpack_Carousel {
 	}
 
 	function carousel_display_exif_sanitize( $value ) {
-		return $this->sanitize_1or0_option( $value );
-	}
-
-	/**
-	 * Callback for checkbox and label of field that toggles slide background color.
-	 */
-	public function carousel_display_slide_background_callback() {
-		$this->settings_checkbox( 'carousel_display_slide_background', esc_html__( 'Display colorized slide backgrounds', 'jetpack' ), '', false );
-	}
-
-	/**
-	 * Return sanitized option for value that controls whether the slide background color is displayed.
-	 *
-	 * @param number $value Value to sanitize.
-	 *
-	 * @return number Sanitized value, only 1 or 0.
-	 */
-	public function carousel_display_slide_background_sanitize( $value ) {
 		return $this->sanitize_1or0_option( $value );
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -142,7 +142,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'carousel_background_color'                    => 'pineapple',
 			'carousel_display_exif'                        => 'pineapple',
 			'carousel_display_comments'                    => 'pineapple',
-			'carousel_display_slide_background'            => 'pineapple',
 			'jetpack_portfolio'                            => 'pineapple',
 			'jetpack_portfolio_posts_per_page'             => 'pineapple',
 			'jetpack_testimonial'                          => 'pineapple',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Reverts the colorized background feature for the carousel for the time being; the feature will be revisited in the next release cycle when there is time for sufficient testing. (JP 10.1)

Discussion: https://github.com/Automattic/jetpack/pull/20476#issuecomment-891162815

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Checkout PR to local test env.
View the carousel settings under Jetpack Settings -> Writing and verify that the setting for colorized backgrounds no longer appears.
Add a gallery to a post and open in frontend and make sure the background is solid black/white (depending on Light Mode/ Dark mode settings)


This should not require a diff as the diff for #20377 (D64175-code) was not merged.

Reverts Automattic/jetpack#20377