### PR TITLE
Sync: backport v1.24.2 from JP 10.0-beta

### DIFF
--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2021-08-02
+- Reverted: Sync option for the Carousel to display colorized slide background.
+
 ## [1.24.1] - 2021-07-29
 ### Changed
 - Utilize an import for WP_Error in all instances.
@@ -440,6 +443,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.24.2]: https://github.com/Automattic/jetpack-sync/compare/v1.24.1...v1.24.2
 [1.24.1]: https://github.com/Automattic/jetpack-sync/compare/v1.24.0...v1.24.1
 [1.24.0]: https://github.com/Automattic/jetpack-sync/compare/v1.23.3...v1.24.0
 [1.23.3]: https://github.com/Automattic/jetpack-sync/compare/v1.23.2...v1.23.3

--- a/projects/packages/sync/changelog/revert-20377-update-fix-and-reenable-carousel-background
+++ b/projects/packages/sync/changelog/revert-20377-update-fix-and-reenable-carousel-background
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Revert: Sync option for the Carousel to display colorized slide background.
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.24.2-alpha';
+	const PACKAGE_VERSION = '1.24.2';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Backport new version release from 10.0 beta: https://github.com/Automattic/jetpack/commit/4056eedcc8d9825eb8a5dfcf8608d9457067780f

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.