### PR TITLE
Search: Fixed Instant Search does not work when home_url() and the actual page URL do not match

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-relative-home-url
+++ b/projects/plugins/jetpack/changelog/fix-relative-home-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fixed search blocked by Same Origin Policy when home_url() does not match the actual home URL usually caused by reverse proxying requests

--- a/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
+++ b/projects/plugins/jetpack/modules/search/class.jetpack-search-helpers.php
@@ -859,7 +859,7 @@ class Jetpack_Search_Helpers {
 			),
 
 			// core config.
-			'homeUrl'               => home_url(),
+			'homeUrl'               => home_url( '/', 'relative' ),
 			'locale'                => str_replace( '_', '-', self::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
 			'postsPerPage'          => $posts_per_page,
 			'siteId'                => class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'get_option' ) ? Jetpack::get_option( 'id' ) : get_current_blog_id(),

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -38,7 +38,7 @@ function pushQueryString( queryString ) {
 	if ( history.pushState ) {
 		const url = new window.URL( window.location.href );
 		if ( window[ SERVER_OBJECT_NAME ] && 'homeUrl' in window[ SERVER_OBJECT_NAME ] ) {
-			url.href = window[ SERVER_OBJECT_NAME ].homeUrl;
+			url.pathname = window[ SERVER_OBJECT_NAME ].homeUrl;
 		}
 		url.search = queryString;
 		window.history.pushState( null, null, url.toString() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Changed the home URL used by `pushState` to relative aka only the path name.
Instant Search gets the home URL for the use of putting query string in the URL without refreshing the page using `pushState`. When the backend is sitting behind a server with server name / protocol not the same as the public facing one, `home_url` would return the internal server name / protocol. In this case, the backend gets `http://test.jetpack.com` instead of the actual `https://test.jetpack.com`, causing `pushState` blocked by Same Origin Policy.

![image](https://user-images.githubusercontent.com/1425433/127964488-0b9a32dd-10ea-471e-a780-d2e92b02baba.png)


#### Jetpack product discussion
p1627862549015600-slack-p2
p9lV3a-2JW-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Go to a site with Jetpack Search subscription
- Make sure Instant Search works as expected and the query string in the URL changes on user input.
