### PR TITLE
Repo Gardening: update paths used for label detection for the Boost plugin

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-boost
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-boost
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Labels task: update paths to support new location of the Boost plugin.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -150,7 +150,7 @@ async function getLabelsToAdd( octokit, owner, repo, number ) {
 		}
 
 		// Docker.
-		const docker = file.match( /^(docker|tools\/docker)\// );
+		const docker = file.match( /^(projects\/plugins\/boost\/docker|tools\/docker)\// );
 		if ( docker !== null ) {
 			keywords.add( 'Docker' );
 		}
@@ -175,7 +175,9 @@ async function getLabelsToAdd( octokit, owner, repo, number ) {
 		}
 
 		// React Dashboard and Boost Admin.
-		const reactAdmin = file.match( /^(app\/admin|projects\/plugins\/jetpack\/_inc\/client)\// );
+		const reactAdmin = file.match(
+			/^(projects\/plugins\/boost\/app\/admin|projects\/plugins\/jetpack\/_inc\/client)\//
+		);
 		if ( reactAdmin !== null ) {
 			keywords.add( 'Admin Page' );
 		}
@@ -195,14 +197,18 @@ async function getLabelsToAdd( octokit, owner, repo, number ) {
 		}
 
 		// Boost Critical CSS.
-		const boostModules = file.match( /^app\/modules\/(?<boostModule>[^/]*)\// );
+		const boostModules = file.match(
+			/^projects\/plugins\/boost\/app\/modules\/(?<boostModule>[^/]*)\//
+		);
 		const boostModuleName = boostModules && boostModules.groups.boostModule;
 		if ( boostModuleName ) {
 			keywords.add( `${ cleanName( boostModuleName ) }` );
 		}
 
 		// Compatibility with 3rd party tools (Boost and Jetpack).
-		const compat = file.match( /^(compatibility|projects\/plugins\/jetpack\/3rd-party)\// );
+		const compat = file.match(
+			/^(projects\/plugins\/boost\/compatibility|projects\/plugins\/jetpack\/3rd-party)\//
+		);
 		if ( compat ) {
 			keywords.add( 'Compatibility' );
 		}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Follow-up from #19891

Now that Boost is in the monorepo, its paths have changed. Our action should be updated accordingly.
    
#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* In Boost PRs, module names should be automatically labeled from now on. You should be able to test that by opening a PR against this branch, that makes changes to `projects/plugins/boost/app/admin/index.php`, or `projects/plugins/boost/compatibility/`, or `projects/plugins/boost/app/modules`.
