### PR TITLE
Boost: Add watch entry in composer for compatibility with "jetpack watch" cli 

### DIFF
--- a/projects/plugins/boost/changelog/add-jetpack-watch-cli-for-boost
+++ b/projects/plugins/boost/changelog/add-jetpack-watch-cli-for-boost
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Watch command in Composer to allow Jetpack watch CLI command working for Boost

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -55,6 +55,10 @@
 			"Composer\\Config::disableProcessTimeout",
 			"pnpm run build-development"
 		],
+	  	"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run dev"
+	  	],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
 	},
 	"autoload-dev": {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -61,7 +61,7 @@
 		"build-production-php": "rm -rf vendor/ && COMPOSER_MIRROR_PATH_REPOS=1 COMPOSER_ROOT_VERSION=dev-master composer install -o --no-dev --classmap-authoritative --prefer-dist",
 		"install-if-deps-outdated": "pnpm install --no-prod --frozen-lockfile",
 		"dev-serve": "rollup -c -w --environment SERVE",
-		"dev": "npm run clear-dist && rollup -c -w",
+		"dev": "pnpm run clear-dist && rollup -c -w",
 		"validate": "svelte-check --ignore docker",
 		"lint": "npm-run-all --parallel lint:js lint:php",
 		"lint:fix": "npm-run-all --parallel lint:js:fix lint:php:fix",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add watch entry in composer for compatibility with "jetpack watch" cli 

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
* Run `jetpack watch plugins/boost` and it should run the Jetpack Boost plugin watch process
