### PR TITLE
REST API: Adds 'i_replied' field to comments in comments endpoint responses

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-aerych-r229758-wpcom-1628006252
+++ b/projects/plugins/jetpack/changelog/fusion-sync-aerych-r229758-wpcom-1628006252
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+WordPress.com REST API: Add new field to comment endpoint response.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -29,6 +29,7 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'i_like'       => '(bool) Does the current user like this comment?',
 		'meta'         => '(object) Meta data',
 		'can_moderate' => '(bool) Whether current user can moderate the comment.',
+		'i_replied'    => '(bool) Has the current user replied to this comment?',
 	);
 
 	// public $response_format =& $this->comment_object_format;
@@ -197,6 +198,15 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'can_moderate':
 				$response[ $key ] = (bool) current_user_can( 'edit_comment', $comment_id );
 				break;
+				case 'i_replied':
+					$response[ $key ] = (bool) 0 < get_comments(
+						array(
+							'user_id' => get_current_user_id(),
+							'parent'  => $comment->comment_ID,
+							'count'   => true,
+						)
+					);
+					break;
 			}
 		}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This adds a new field to comments returned by comments endpoints.  The new field indicates whether the current user has replied to a specific comment.
The field is a simple bool rather than an int for the ID of the reply since there could be more than one.

#### Jetpack product discussion

* Differential Revision: D64353-code
* This commit syncs r229758-wpcom.
* More context in this thread: pbArwn-2ks-p2#comment-3471

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

Sandbox this change and visit the following endpoints for sites where you have replied to comments.  Confirm that `i_replied` is `true` for comments to which you have replied and is `false` otherwise.

/sites/%s/comments
/sites/%s/comments/%d
/sites/%s/posts/%d/replies

