### PR TITLE
Search: improves handling of really long breadcrumbs

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-handling-long-breadcrumbs
+++ b/projects/plugins/jetpack/changelog/fix-search-handling-long-breadcrumbs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: improves handling of really long breadcrumbs

--- a/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.scss
@@ -11,9 +11,9 @@
 .jetpack-instant-search__path-breadcrumb-link {
 	text-decoration: none;
 	-webkit-line-clamp: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 
 	&:hover,
 	&:focus {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.scss
@@ -10,6 +10,10 @@
 
 .jetpack-instant-search__path-breadcrumb-link {
 	text-decoration: none;
+	-webkit-line-clamp: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
 	&:hover,
 	&:focus {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/path-breadcrumbs.scss
@@ -10,7 +10,7 @@
 
 .jetpack-instant-search__path-breadcrumb-link {
 	text-decoration: none;
-	-webkit-line-clamp: 1;
+	max-width: 100%;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-result-expanded.scss
@@ -24,7 +24,7 @@ $image-square-size: 128px;
 	max-width: 100%;
 
 	@include break-small-up() {
-		width: 100%;
+		width: calc(100% - #{$image-square-size} - 1em);
 	}
 
 	.jetpack-instant-search__search-result-expanded--no-image & {


### PR DESCRIPTION
Fixes #20501

#### Changes proposed in this Pull Request:

This PR restricts breadcrumbs to a single line, with an ellipsis at the end if the breadcrumb is longer than the single line

#### Jetpack product discussion

Discussed in p9MPsk-X5-p2#comment-10092.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Go to a site with Jetpack Instant Search subscription.
* Search for a keyword which will display a result with a really long breadcrumb, due to a deep hierarchy or a really long page slug
* Check that the breadcrumb occupies only one line, and any overflow text is replaced with an ellipsis at the end
* Test resizing the window for responsiveness, and checking on a mobile browser (or mobile browser simulator) 

**A really long breadcrumb viewed in a web browser (before):**
![image](https://user-images.githubusercontent.com/30754158/128121998-69792a1d-d500-422a-bf49-c0912309ad2d.png)

**A really long breadcrumb viewed in a web browser (after):**
![image](https://user-images.githubusercontent.com/30754158/128121707-92a9ff07-e26d-4a7e-8e14-11f131fb866d.png)
| Mobile view before  | Mobile view after |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/128123285-2dbf5eae-d868-4d0c-9de9-51634d4f4649.png)  | ![image](https://user-images.githubusercontent.com/30754158/128123450-9393cd91-a07d-4fc4-87cd-3a6dca43ae37.png)  |
