### PR TITLE
E2E tests: fix for mailchimp test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-e2e-mailchimp-test
+++ b/projects/plugins/jetpack/changelog/fix-e2e-mailchimp-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: fixed mailchimp tests failing after a button label change

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/mailchimp.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/mailchimp.js
@@ -31,7 +31,7 @@ export default class MailchimpBlock extends PageActions {
 	}
 
 	get joinBtnSel() {
-		return `${ this.blockSelector } div >> text="Join my email list"`;
+		return `${ this.blockSelector } div >> text="Join my Mailchimp audience"`;
 	}
 
 	//endregion


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix for Mailchimp e2e test that started failing after the text of a button was changed.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* E2E tests should pass