### PR TITLE
RNA: bring back the missing API pieces

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,7 @@ importers:
   projects/packages/connection-ui:
     specifiers:
       '@automattic/calypso-build': 6.5.0
+      '@automattic/jetpack-api': workspace:^0.1.0-alpha
       '@automattic/jetpack-connection': workspace:^0.5.1-alpha
       '@babel/core': 7.12.10
       '@babel/helper-module-imports': 7.12.5
@@ -168,6 +169,7 @@ importers:
       webpack: 4.46.0
     dependencies:
       '@automattic/calypso-build': 6.5.0_54255fe29db862e741e1a266e6029402
+      '@automattic/jetpack-api': link:../../js-packages/api
       '@automattic/jetpack-connection': link:../../js-packages/connection
       '@babel/core': 7.12.10
       '@babel/helper-module-imports': 7.12.5
@@ -253,6 +255,7 @@ importers:
   projects/plugins/backup:
     specifiers:
       '@automattic/calypso-build': 7.0.0
+      '@automattic/jetpack-api': workspace:^0.1.0-alpha
       '@automattic/jetpack-components': workspace:^0.2.1-alpha
       '@automattic/jetpack-connection': workspace:^0.5.1-alpha
       '@babel/core': 7.13.14
@@ -274,6 +277,7 @@ importers:
       react-dom: 17.0.2
       webpack: 5.31.0
     dependencies:
+      '@automattic/jetpack-api': link:../../js-packages/api
       '@automattic/jetpack-components': link:../../js-packages/components
       '@automattic/jetpack-connection': link:../../js-packages/connection
       '@wordpress/api-fetch': 5.2.0
@@ -13962,7 +13966,7 @@ packages:
   /isomorphic-fetch/2.2.1:
     resolution: {integrity: sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=}
     dependencies:
-      node-fetch: 1.7.3
+      node-fetch: 2.6.1
       whatwg-fetch: 3.6.2
     dev: false
 
@@ -16392,13 +16396,6 @@ packages:
 
   /node-contains/1.0.0:
     resolution: {integrity: sha1-0sJzUkU22jtWGvBTnjM0T3yQLLg=}
-    dev: false
-
-  /node-fetch/1.7.3:
-    resolution: {integrity: sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==}
-    dependencies:
-      encoding: 0.1.13
-      is-stream: 1.1.0
     dev: false
 
   /node-fetch/2.6.1:
@@ -20508,7 +20505,7 @@ packages:
       find-cache-dir: 2.1.0
       is-wsl: 1.1.0
       schema-utils: 1.0.0
-      serialize-javascript: 4.0.0
+      serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 4.8.0
       webpack: 4.45.0
@@ -20526,7 +20523,7 @@ packages:
       find-cache-dir: 2.1.0
       is-wsl: 1.1.0
       schema-utils: 1.0.0
-      serialize-javascript: 4.0.0
+      serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 4.8.0
       webpack: 4.46.0_webpack-cli@4.5.0
@@ -22007,12 +22004,6 @@ packages:
     resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
     engines: {node: '>=10'}
 
-  /yargs-parser/5.0.1:
-    resolution: {integrity: sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==}
-    dependencies:
-      camelcase: 3.0.0
-      object.assign: 4.1.2
-
   /yargs-unparser/2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
@@ -22107,7 +22098,7 @@ packages:
       string-width: 1.0.2
       which-module: 1.0.0
       y18n: 3.2.2
-      yargs-parser: 5.0.1
+      yargs-parser: 20.2.4
 
   /yauzl/2.10.0:
     resolution: {integrity: sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=}

--- a/projects/js-packages/api/changelog/fix-rna-api-dependency
+++ b/projects/js-packages/api/changelog/fix-rna-api-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the API methods left behind by the previous PR.

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -73,6 +73,30 @@ function JetpackRestApiClient( root, nonce ) {
 			cacheBusterCallback = callback;
 		},
 
+		registerSite: ( registrationNonce, redirectUri ) =>
+			postRequest( `${ apiRoot }jetpack/v4/connection/register`, postParams, {
+				body: JSON.stringify( {
+					registration_nonce: registrationNonce,
+					no_iframe: true,
+					redirect_uri: redirectUri,
+				} ),
+			} )
+				.then( checkStatus )
+				.then( parseJsonResponse ),
+
+		fetchAuthorizationUrl: redirectUri =>
+			getRequest(
+				`${ apiRoot }jetpack/v4/connection/authorize_url?no_iframe=1&redirect_uri=${ encodeURIComponent(
+					redirectUri
+				) }`,
+				getParams
+			)
+				.then( checkStatus )
+				.then( parseJsonResponse ),
+
+		fetchSiteConnectionData: () =>
+			getRequest( `${ apiRoot }jetpack/v4/connection/data`, getParams ).then( parseJsonResponse ),
+
 		fetchSiteConnectionStatus: () =>
 			getRequest( `${ apiRoot }jetpack/v4/connection`, getParams ).then( parseJsonResponse ),
 

--- a/projects/packages/connection-ui/changelog/fix-rna-api-dependency
+++ b/projects/packages/connection-ui/changelog/fix-rna-api-dependency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add a missing dependency to fix the build.
+
+

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -15,6 +15,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-build": "6.5.0",
+		"@automattic/jetpack-api": "workspace:^0.1.0-alpha",
 		"@automattic/jetpack-connection": "workspace:^0.5.1-alpha",
 		"@babel/core": "7.12.10",
 		"@babel/helper-module-imports": "7.12.5",

--- a/projects/plugins/backup/changelog/fix-rna-api-dependency
+++ b/projects/plugins/backup/changelog/fix-rna-api-dependency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing dependency to fix the build.
+
+

--- a/projects/plugins/backup/package.json
+++ b/projects/plugins/backup/package.json
@@ -27,6 +27,7 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
+		"@automattic/jetpack-api": "workspace:^0.1.0-alpha",
 		"@automattic/jetpack-connection": "workspace:^0.5.1-alpha",
 		"@automattic/jetpack-components": "workspace:^0.2.1-alpha",
 		"@wordpress/api-fetch": "5.2.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Add missing `@automattic/jetpack-api` dependency to the Backup and Connection UI.
- Add back the API methods accidentally left behind

Related to #20531

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Build Backup and Connection UI.
2. Confirm that "Backup" and "Tools -> Connection Manager" pages load well with no JS errors.
3. Disconnect Jetpack, go to "Backup" and go through the connection flow. Confirm that it went fine.