### PR TITLE
Publicize: do not show Twitter annotations on published posts

### DIFF
--- a/projects/plugins/jetpack/changelog/update-publicize-threads-hide
+++ b/projects/plugins/jetpack/changelog/update-publicize-threads-hide
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Publicize / Twitter Threads: din the block editor, do not display indicators of where a post will be divided into tweets once you have published your post.

--- a/projects/plugins/jetpack/extensions/blocks/publicize/store/selectors.js
+++ b/projects/plugins/jetpack/extensions/blocks/publicize/store/selectors.js
@@ -288,6 +288,18 @@ export function isTweetStorm() {
 }
 
 /**
+ * Check to see if a post is published.
+ *
+ * @returns {boolean} Is the post published?
+ */
+export function isPublished() {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const status = getEditedPostAttribute( 'status' );
+
+	return 'publish' === status;
+}
+
+/**
  * Finds the boundary definitions for a given block.
  *
  * @param {object} state - State object.

--- a/projects/plugins/jetpack/extensions/blocks/publicize/twitter/tweet-divider.js
+++ b/projects/plugins/jetpack/extensions/blocks/publicize/twitter/tweet-divider.js
@@ -34,6 +34,7 @@ class TweetDivider extends Component {
 			boundaries,
 			childProps,
 			currentAnnotations,
+			isPublished,
 			isTweetStorm,
 			updateAnnotations,
 			updateTweets,
@@ -46,6 +47,10 @@ class TweetDivider extends Component {
 		}
 
 		if ( ! supportedBlockType ) {
+			return;
+		}
+
+		if ( isPublished ) {
 			return;
 		}
 
@@ -67,13 +72,14 @@ class TweetDivider extends Component {
 		const {
 			ChildEdit,
 			childProps,
+			isPublished,
 			isTweetStorm,
 			isSelectedTweetBoundary,
 			boundaryStylesSelectors,
 			popoverWarnings,
 		} = this.props;
 
-		if ( ! isTweetStorm ) {
+		if ( ! isTweetStorm || isPublished ) {
 			return <ChildEdit { ...childProps } />;
 		}
 
@@ -129,6 +135,7 @@ class TweetDivider extends Component {
 export default compose( [
 	withSelect( ( select, { childProps } ) => {
 		const {
+			isPublished,
 			isTweetStorm,
 			getPopoverWarnings,
 			getBoundariesForBlock,
@@ -143,6 +150,7 @@ export default compose( [
 		);
 
 		return {
+			isPublished: isPublished(),
 			isTweetStorm: isTweetStorm(),
 			isSelectedTweetBoundary: isSelectedTweetBoundary( childProps ),
 			boundaries: getBoundariesForBlock( childProps.clientId ),


### PR DESCRIPTION
Fixes #20446

#### Changes proposed in this Pull Request:

When a post has already been published, there is no need to display annotations that show where the post will be divided into tweets, since that has already happened.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a site that's connected to WordPress.com, where Publicize is active, and where you've connected your Twitter account.
* Create a new post.
* Pick the Twitter Thread option in the Jetpack sidebar.
* You should see annotations (pipes, separator between blocks) appear where your post will be divided into tweets.
* Publish that post; it should be published properly and you should see the tweet publicized.
* Go back to edit that post again; the annotations should not be visible anymore.
