### PR TITLE
Autoloader: update readme

### DIFF
--- a/projects/packages/autoloader/README.md
+++ b/projects/packages/autoloader/README.md
@@ -11,8 +11,7 @@ It diverges from the default Composer autoloader setup in the following ways:
 
 * It creates `jetpack_autoload_classmap.php` and `jetpack_autoload_filemap.php` files in the `vendor/composer` directory.
 * This file includes the version numbers from each package that is used. 
-* The autoloader will only load the latest version of the library no matter what plugin loads the library. 
-
+* The autoloader will only load the latest version of the package no matter what plugin loads the package. This behavior is guaranteed only when every plugin that uses the package uses this autoloader. If any plugin that requires the package uses a different autoloader, this autoloader may not be able to control which version of the package is loaded.
 
 Usage
 -----

--- a/projects/packages/autoloader/changelog/update-autoloader_readme
+++ b/projects/packages/autoloader/changelog/update-autoloader_readme
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update the readme file.
+
+


### PR DESCRIPTION
Fixes #20546

#### Changes proposed in this Pull Request:
* Update the README file to specify that the autoloader can only control which version of a package is loaded if all plugins that use the package use this autoloader.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* n/a