### PR TITLE
Boost: Implement the feature to clear dismissed Critical CSS recommendations

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
@@ -8,8 +8,6 @@
 		activeRecommendations,
 		dismissedRecommendations,
 		clearDismissedRecommendations,
-		resetDismissals,
-		updateDismissedRecommendations,
 	} from '../../../stores/critical-css-recommendations.ts';
 	import InfoIcon from '../../../svg/info.svg';
 	import generateCriticalCss from '../../../utils/generate-critical-css';
@@ -18,11 +16,29 @@
 	import { writable } from 'svelte/store';
 	import CriticalCssErrorDescription from '../elements/CriticalCssErrorDescription.svelte';
 	import { isFinished } from '../../../stores/critical-css-status';
+
 	function onRetry() {
 		generateCriticalCss();
 		navigateTo();
 	}
+
 	const dismissalError = writable( null );
+
+	/**
+	 * Set the dismissal error if something wrong occurred
+	 * during the event to dismiss a recommendation or the event
+	 * to clear the dismissed recommendations.
+	 *
+	 * @param {string} title.
+	 * @param {object} error.
+	 */
+	function setDismissalError( title, error ) {
+		dismissalError.set( {
+			title,
+			error,
+		} );
+	}
+
 	/**
 	 * Dismisses a recommendation by key.
 	 *
@@ -31,15 +47,11 @@
 	async function dismiss( key ) {
 		try {
 			await dismissRecommendation( key );
-			updateDismissedRecommendations( key );
 		} catch ( error ) {
-			dismissalError.set( {
-				title: __(
-					'Failed to dismiss recommendation',
-					'jetpack-boost'
-				),
-				error,
-			} );
+			setDismissalError(
+				__( 'Failed to dismiss recommendation', 'jetpack-boost' ),
+				error
+			);
 		}
 	}
 	/**
@@ -48,17 +60,17 @@
 	async function showDismissedRecommendations() {
 		try {
 			await clearDismissedRecommendations();
-			resetDismissals();
 		} catch ( error ) {
-			dismissalError.set( {
-				title: __(
+			setDismissalError(
+				__(
 					'Failed to show the dismissed recommendations',
 					'jetpack-boost'
 				),
-				error,
-			} );
+				error
+			);
 		}
 	}
+
 	/**
 	 * Figure out heading based on state.
 	 */

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
@@ -8,35 +8,19 @@
 		activeRecommendations,
 		dismissedRecommendations,
 		clearDismissedRecommendations,
+		dismissalError,
+		setDismissalError,
 	} from '../../../stores/critical-css-recommendations.ts';
 	import InfoIcon from '../../../svg/info.svg';
 	import generateCriticalCss from '../../../utils/generate-critical-css';
 	import CloseButton from '../../../elements/CloseButton.svelte';
 	import ErrorNotice from '../../../elements/ErrorNotice.svelte';
-	import { writable } from 'svelte/store';
 	import CriticalCssErrorDescription from '../elements/CriticalCssErrorDescription.svelte';
 	import { isFinished } from '../../../stores/critical-css-status';
 
 	function onRetry() {
 		generateCriticalCss();
 		navigateTo();
-	}
-
-	const dismissalError = writable( null );
-
-	/**
-	 * Set the dismissal error if something wrong occurred
-	 * during the event to dismiss a recommendation or the event
-	 * to clear the dismissed recommendations.
-	 *
-	 * @param {string} title.
-	 * @param {object} error.
-	 */
-	function setDismissalError( title, error ) {
-		dismissalError.set( {
-			title,
-			error,
-		} );
 	}
 
 	/**

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-recommendations.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-recommendations.ts
@@ -106,7 +106,23 @@ export async function dismissRecommendation( key: string ): Promise< void > {
 		action: 'dismiss_recommendations',
 		providerKey: key,
 	} );
+}
 
+/**
+ * Clear all the dismissed recommendations.
+ */
+export async function clearDismissedRecommendations(): Promise< void > {
+	await makeAdminAjaxRequest( {
+		action: 'reset_dismissed_recommendations',
+	} );
+}
+
+/**
+ * Update dismissed recommendation.
+ *
+ * @param {string} key Key of recommendation to dismiss.
+ */
+export function updateDismissedRecommendations( key ): void {
 	dismissed.update( ( keys ) => [ ...keys, key ] );
 }
 

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-recommendations.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-recommendations.ts
@@ -96,6 +96,26 @@ export const primaryErrorSet = derived( recommendations, ( recommends ) => {
 } );
 
 /**
+ * Store used to track Critical CSS Recommendations dismissal error.
+ */
+export const dismissalError = writable( null );
+
+/**
+ * Set the dismissal error if something wrong occurred
+ * during the event to dismiss a recommendation or the event
+ * to clear the dismissed recommendations.
+ *
+ * @param {string} title Error display title.
+ * @param {Object} error Error.
+ */
+export function setDismissalError( title, error ) {
+	dismissalError.set( {
+		title,
+		error,
+	} );
+}
+
+/**
  * Dismiss the recommendation associated with the given provider key. Calls the
  * API to update the back end in lock-step.
  *

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-recommendations.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-recommendations.ts
@@ -106,6 +106,7 @@ export async function dismissRecommendation( key: string ): Promise< void > {
 		action: 'dismiss_recommendations',
 		providerKey: key,
 	} );
+	dismissed.update( ( keys ) => [ ...keys, key ] );
 }
 
 /**
@@ -115,21 +116,6 @@ export async function clearDismissedRecommendations(): Promise< void > {
 	await makeAdminAjaxRequest( {
 		action: 'reset_dismissed_recommendations',
 	} );
-}
-
-/**
- * Update dismissed recommendation.
- *
- * @param {string} key Key of recommendation to dismiss.
- */
-export function updateDismissedRecommendations( key ): void {
-	dismissed.update( ( keys ) => [ ...keys, key ] );
-}
-
-/**
- * Clear all dismissed recommendations.
- */
-export function resetDismissals(): void {
 	dismissed.set( [] );
 }
 

--- a/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
@@ -17,7 +17,7 @@ import type { Viewport } from './types';
 import { isEnabled } from '../stores/modules';
 import { loadCriticalCssLibrary } from './load-critical-css-library';
 import { removeShownAdminNotices } from './remove-admin-notices';
-import { resetDismissals } from '../stores/critical-css-recommendations';
+import { clearDismissedRecommendations } from '../stores/critical-css-recommendations';
 
 export type ProviderKeyUrls = {
 	[ providerKey: string ]: string[];
@@ -63,7 +63,7 @@ export default async function generateCriticalCss(
 	let cancelling = false;
 
 	if ( reset ) {
-		resetDismissals();
+		clearDismissedRecommendations();
 		updateGenerateStatus( true, 0 );
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
@@ -1,13 +1,25 @@
 /**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type { JSONObject } from './json-types';
 
 declare const ajaxurl: string;
 
-export async function makeAdminAjaxRequest(
+class AdminAjaxError extends Error {
+	constructor( message ) {
+		super( message );
+		this.name = 'AdminAjaxError';
+	}
+}
+
+export async function makeAdminAjaxRequest< T = JSONObject >(
 	payload: JSONObject
-): Promise< Response > {
+): Promise< T > {
 	const args = {
 		method: 'post',
 		body: new URLSearchParams( {
@@ -19,5 +31,35 @@ export async function makeAdminAjaxRequest(
 		},
 	};
 
-	return fetch( ajaxurl, args );
+	const response = await fetch( ajaxurl, args );
+
+	let jsonBody: JSONObject;
+	try {
+		jsonBody = await response.json();
+	} catch ( error ) {
+		throw new AdminAjaxError(
+			sprintf(
+				/* Translators: %s refers to a browser-supplied error message (hopefully already in the right language) */
+				__(
+					'Received invalid response while communicating with your WordPress site: %s',
+					'jetpack-boost'
+				),
+				error.message
+			)
+		);
+	}
+	if ( ! response.ok ) {
+		throw new AdminAjaxError(
+			sprintf(
+				/* Translators: %d refers to numeric HTTP error code */
+				__(
+					'HTTP %d error received while communicating with the server.',
+					'jetpack-boost'
+				),
+				response.status
+			)
+		);
+	}
+
+	return jsonBody as any;
 }

--- a/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
+++ b/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
@@ -167,6 +167,7 @@ class Critical_CSS extends Module {
 
 		if ( is_admin() ) {
 			add_action( 'wp_ajax_dismiss_recommendations', array( $this, 'dismiss_recommendations' ) );
+			add_action( 'wp_ajax_reset_dismissed_recommendations', array( $this, 'reset_dismissed_recommendations' ) );
 		}
 
 		return true;
@@ -986,6 +987,21 @@ class Critical_CSS extends Module {
 			$dismissed_recommendations[] = $provider_key;
 			\update_option( self::DISMISSED_RECOMMENDATIONS_STORAGE_KEY, $dismissed_recommendations );
 		}
+
+		echo wp_json_encode( $response );
+		wp_die();
+	}
+
+	/**
+	 * Reset dismissed Critical CSS recommendations.
+	 */
+	public function reset_dismissed_recommendations() {
+		check_ajax_referer( self::AJAX_NONCE, 'nonce' );
+		$response = array(
+			'status' => 'ok',
+		);
+
+		self::clear_dismissed_recommendations();
 
 		echo wp_json_encode( $response );
 		wp_die();

--- a/projects/plugins/boost/changelog/add-jetpack-boost-clear-dismissed-recommendations
+++ b/projects/plugins/boost/changelog/add-jetpack-boost-clear-dismissed-recommendations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Implement the feature to clear dismissed Critical CSS recommendations


### PR DESCRIPTION
This is a port of the PR from the Legacy Jetpack Boost repository

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Allow to clear dismissed Critical CSS recommendations.

See the demo video below:


https://user-images.githubusercontent.com/927932/128448056-d2420d56-b15f-4091-b5f9-a0dd7328fce9.mov



#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
* Refer to the demo video above.
