### PR TITLE
Jetpack Sync: Add /sync/object endpoint access via POST

### DIFF
--- a/projects/packages/sync/changelog/fix-jetpack-sync-get-sync-objects-post
+++ b/projects/packages/sync/changelog/fix-jetpack-sync-get-sync-objects-post
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Made /sync/object endpoint accessible over POST, not only GET, to allow fetching more items inn a single request.
+Made /sync/object endpoint accessible over POST, not only GET, to allow fetching more items in a single request.

--- a/projects/packages/sync/changelog/fix-jetpack-sync-get-sync-objects-post
+++ b/projects/packages/sync/changelog/fix-jetpack-sync-get-sync-objects-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Made /sync/object endpoint accessible over POST, not only GET, to allow fetching more items inn a single request.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.24.2';
+	const PACKAGE_VERSION = '1.24.3-alpha';
 }

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -121,7 +121,7 @@ class REST_Endpoints {
 			'jetpack/v4',
 			'/sync/object',
 			array(
-				'methods'             => WP_REST_Server::READABLE,
+				'methods'             => WP_REST_Server::ALLMETHODS,
 				'callback'            => __CLASS__ . '::get_sync_objects',
 				'permission_callback' => __CLASS__ . '::verify_default_permissions',
 				'args'                => array(

--- a/projects/plugins/boost/changelog/fix-jetpack-sync-get-sync-objects-post
+++ b/projects/plugins/boost/changelog/fix-jetpack-sync-get-sync-objects-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -55,10 +55,10 @@
 			"Composer\\Config::disableProcessTimeout",
 			"pnpm run build-development"
 		],
-	  	"watch": [
+		"watch": [
 			"Composer\\Config::disableProcessTimeout",
 			"pnpm run dev"
-	  	],
+		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
 	},
 	"autoload-dev": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make `/sync/object/get_sync_objects` endpoint accessible via `POST`. Retain `GET` as backwards-compatibility. 

#### Jetpack product discussion
N/a

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* To be specified later as it needs a WPCOM change.
