### PR TITLE
E2E tests: Fix selector for block editor search field

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-e2e-block-search-input-selector
+++ b/projects/plugins/jetpack/changelog/fix-e2e-block-search-input-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: fix selector for block editor search field

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
@@ -18,7 +18,7 @@ export default class BlockEditorPage extends WpPage {
 	}
 
 	get searchBlockFldSel() {
-		return '.block-editor-inserter__search-input';
+		return '.components-search-control__input,.block-editor-inserter__search-input';
 	}
 
 	blockSel( blockName ) {

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
@@ -19,7 +19,7 @@ export default class BlockEditorPage extends WpPage {
 
 	get searchBlockFldSel() {
 		// There are 2 classes here because the class changed in Gutenberg 11.2 but is not yet in the WP bundled version.
-		//todo to remove .block-editor-inserter__search-input once WP will include GB version 11.2
+		//TODO: to remove .block-editor-inserter__search-input once WP will include GB version 11.2
 		return '.components-search-control__input,.block-editor-inserter__search-input';
 	}
 

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
@@ -18,6 +18,8 @@ export default class BlockEditorPage extends WpPage {
 	}
 
 	get searchBlockFldSel() {
+		// There are 2 classes here because the class changed in Gutenberg 11.2 but is not yet in the WP bundled version.
+		//todo to remove .block-editor-inserter__search-input once WP will include GB version 11.2
 		return '.components-search-control__input,.block-editor-inserter__search-input';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The selector for block search input field changed in Gutenberg standalone version and this fails out scheduled blocks tests with standalone Gutenberg.

#### Jetpack product discussion
p1628253905220700-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* E2E tests should pass