### PR TITLE
Instant Search: Improves formatting of search filter checkboxes on Flatsome theme

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-form-label-alignment
+++ b/projects/plugins/jetpack/changelog/fix-search-form-label-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: improve checkbox alignment by removing custom checkbox margins added by some themes

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
@@ -46,6 +46,7 @@
 		top: 0; // Ensures align-items: center; works as expected.
 
 		// Remove any custom checkbox styling
+		margin: 0;
 		appearance: checkbox;
 		background: none;
 		border: none;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
@@ -46,11 +46,11 @@
 		top: 0; // Ensures align-items: center; works as expected.
 
 		// Remove any custom checkbox styling
-		margin: 0;
 		appearance: checkbox;
 		background: none;
 		border: none;
 		height: initial;
+		margin: 0;
 		width: initial;
 		&::after,
 		&::before {


### PR DESCRIPTION
Fixes #20548 

#### Changes proposed in this Pull Request:

* This PR removes custom checkbox styling margins which are being added by the Flatsome theme and causing the checkboxes & labels to become misaligned. 

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Go to a site with Jetpack Instant Search subscription and the [Flatsome theme](https://themeforest.net/item/flatsome-multipurpose-responsive-woocommerce-theme/5484319) active. 
* Open up the instant search overlay
* Check the alignment of the checkboxes and labels, and that the checkbox elements maintain a margin:0
* Test resizing the window for responsiveness across different browsers, and checking on a mobile browser, as well as with other themes active aside from Flatsome.

Before:
![image](https://user-images.githubusercontent.com/30754158/128650495-f38a6add-225f-49cb-a4ae-71efc9248bfc.png)

After:
![image](https://user-images.githubusercontent.com/30754158/128650502-bb8efd97-bd63-43ee-88bf-beda0e55b0a5.png)
