### PR TITLE
Reviews: allow teams to approve changes to monorepo's lock file

### DIFF
--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -13,19 +13,23 @@
   teams:
    - jetpack-approvers
 
-# The Backup team reviews changes to the VaultPress and Backup plugin.
+# The Backup team reviews changes to the VaultPress and Backup plugin,
+# and can add dependencies to the monorepo's lock file.
 - name: VaultPress and Backup
   paths:
    - 'projects/plugins/vaultpress/**'
    - 'projects/plugins/backup/**'
+   - 'pnpm-lock.yaml'
   teams:
    - yamato-backup-and-security
    - jetpack-approvers
 
-# The Backup team reviews changes to the Boost plugin.
+# The Boost team reviews changes to the Boost plugin,
+# and can add dependencies to the monorepo's lock file.
 - name: Boost
   paths:
    - 'projects/plugins/boost/**'
+   - 'pnpm-lock.yaml'
   teams:
    - heart-of-gold
    - jetpack-approvers


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
﻿Since that lock file gets modified when they add new dependencies in their plugin's dependencies, let's not block them for that.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here. This should unblock things for Boost and Backup teams in the future.
