### PR TITLE
Boost: Refactor CSS to Improve UI on small devices - Re-submitted for approval workflow

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/critical-css.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/critical-css.scss
@@ -57,6 +57,10 @@
 		border-radius: 4px;
 		padding: 24px 69px 0 27px;
 
+		li {
+			@include word-wrap();
+		}
+
 		h4 {
 			font-size: 20px;
 			margin-bottom: 1rem;

--- a/projects/plugins/boost/app/assets/src/css/components/error-message.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/error-message.scss
@@ -1,12 +1,15 @@
 .jb-error {
 	position: relative;
 	color: #d63638;
-	display: flex;
-	align-items: flex-start;
-	justify-content: left;
-	text-align: left;
+	display: block;
 	margin: 0;
 	padding: 0;
+
+	@include breakpoint(sm) {
+		display: flex;
+		align-items: flex-start;
+		justify-content: left;
+	}
 
 	p {
 		margin: .25em 0;
@@ -14,7 +17,13 @@
 	}
 
 	.jb-error__main-action:not( :empty ) {
-		margin-left: 20px;
+		margin-left: auto;
+		button {
+			margin-left: 0;
+			@include breakpoint(sm) {
+				margin-left: 20px;
+			}
+		}
 	}
 
 	svg.icon {
@@ -45,6 +54,10 @@
 			color: $primary-black;
 			font-size: 16px;
 			margin: 16px auto;
+		}
+
+		li {
+			@include word-wrap();
 		}
 	}
 

--- a/projects/plugins/boost/app/assets/src/css/main/mixins.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/mixins.scss
@@ -2,20 +2,29 @@
 	@if $class == xs {
 		@media (max-width: 767px) { @content; }
 	}
-	
+
 	@else if $class == sm {
 		@media (min-width: 768px) { @content; }
 	}
-	
+
 	@else if $class == md {
 		@media (min-width: 992px) { @content; }
 	}
-	
+
 	@else if $class == lg {
 		@media (min-width: 1200px) { @content; }
 	}
-	
+
 	@else {
 		@warn "Breakpoint mixin supports: xs, sm, md, lg";
 	}
+}
+
+// The following is partly taken from https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+@mixin word-wrap() {
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+	-ms-word-break: break-all;
+	word-break: break-all;
+	word-break: break-word;
 }

--- a/projects/plugins/boost/changelog/update-boost-css-error-mobile-styles
+++ b/projects/plugins/boost/changelog/update-boost-css-error-mobile-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved Critical CSS showstopper error display on small screens


### PR DESCRIPTION
NOTE: This is replacing https://github.com/Automattic/jetpack/pull/20603 in order to fix a temporary workflow issue. Even though I approved the PR, it could not get merged because I am not belonging to the correct Github group. After discussion with @thingalon we decided to raise a new PR that he could approve and merge.

Below is the original PR description:

_______________ 

This PR was "left behind" when Jetpack Boost was migrated to the Jetpack Monorepo: 1059-gh-Automattic/jetpack-boost

This PR fixes a couple of issue with the design on mobile:

- Issue with long URLs breaking the design as they were overflowing their containers. I have added some logic to wrap them.
- issue with the Refresh/Contact Support buttons squashing to much the left hand side paragraph. I have made some changes to have the button sections as a block for small devices and flex on larger displays.

#### Changes proposed in this Pull Request:
* Improve display of Critical CSS showstopper errors on small screens

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1. Cause Critical CSS Generation to fail with a showstopper (e.g.: throw a 500 error on every page)
2. Check out the error display on small screens, make sure it doesn't run off the display or look weird.