### PR TITLE
Boost: Show standard Critical CSS showstopper flow when 0 files successfully - Re-submitted for approval workflow

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/critical-css.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/critical-css.scss
@@ -1,5 +1,6 @@
 .jb-critical-css__error-description {
 	line-height: 1.5rem;
+	color: $primary-black;
 
 	a, h5, a.action {
 		color: inherit;
@@ -34,6 +35,7 @@
 	}
 
 	p.suggestion, p.raw-error {
+		color: $primary-black;
 		margin-top: 8px;
 		margin-bottom: 24px;
 	}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
@@ -22,6 +22,9 @@
 
 	const dispatch = createEventDispatcher();
 
+	export let showSuggestion = true;
+	export let foldRawErrors = true;
+
 	/**
 	 * @var {ErrorSet} errorSet Error Set to display a description of, from a Recommendation or CriticalCssStatus.
 	 */
@@ -52,15 +55,19 @@
 		</a>
 	</MoreList>
 
-	<h5>
-		{__( 'What to do', 'jetpack-boost' )}
-	</h5>
+	{#if showSuggestion}
+		<h5>
+			{__( 'What to do', 'jetpack-boost' )}
+		</h5>
 
-	<p class="suggestion">
-		<TemplatedString template={textSuggestion( errorSet )} vars={templateVars} />
-	</p>
+		<p class="suggestion">
+			<TemplatedString template={textSuggestion( errorSet )} vars={templateVars} />
+		</p>
 
-	{#if rawError( errorSet )}
+		<svelte:component this={footerComponent( errorSet )} />
+	{/if}
+
+	{#if foldRawErrors}
 		<FoldingElement
 			showLabel={__( 'See error message', 'jetpack-boost' )}
 			hideLabel={__( 'Hide error message', 'jetpack-boost' )}
@@ -69,7 +76,9 @@
 				{rawError( errorSet )}
 			</p>
 		</FoldingElement>
+	{:else}
+		<p class="raw-error" transition:slide|local>
+			{rawError( errorSet )}
+		</p>
 	{/if}
-
-	<svelte:component this={footerComponent( errorSet )} />
 </div>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
@@ -23,47 +23,50 @@
 	}
 </script>
 
-{#if showingProviderError}
-	<ErrorNotice {title}>
-		<CriticalCssErrorDescription errorSet={$primaryErrorSet} on:retry={generateCriticalCss} />
-	</ErrorNotice>
-{:else}
-	<ErrorNotice {title}>
-		<p>
-			{$criticalCssStatus.retriedShowstopper
-				? __(
-						"Hmm, looks like something went wrong. We're still seeing an unexpected error. Please reach out to our support to get help.",
-						'jetpack-boost'
-				  )
-				: __(
-						'An unexpected error has occurred. As this error may be temporary, please try and refresh the Critical CSS.',
-						'jetpack-boost'
-				  )}
-		</p>
+<ErrorNotice {title}>
+	<p>
+		{$criticalCssStatus.retriedShowstopper
+			? __(
+					"Hmm, looks like something went wrong. We're still seeing an unexpected error. Please reach out to our support to get help.",
+					'jetpack-boost'
+			  )
+			: __(
+					'An unexpected error has occurred. As this error may be temporary, please try and refresh the Critical CSS.',
+					'jetpack-boost'
+			  )}
+	</p>
 
-		<FoldingElement
-			showLabel={__( 'See error message', 'jetpack-boost' )}
-			hideLabel={__( 'Hide error message', 'jetpack-boost' )}
-		>
-			<p class="status-error" transition:slide|local>
-				{$criticalCssStatus.status_error}
-			</p>
-		</FoldingElement>
-
-		<div slot="actionButton">
-			{#if $criticalCssStatus.retriedShowstopper}
-				<a
-					class="button button-secondary"
-					href="https://wordpress.org/support/plugin/jetpack-boost/"
-					target="_blank"
-				>
-					{__( 'Contact Support', 'jetpack-boost' )}
-				</a>
+	<FoldingElement
+		showLabel={__( 'See error message', 'jetpack-boost' )}
+		hideLabel={__( 'Hide error message', 'jetpack-boost' )}
+	>
+		<div transition:slide|local>
+			{#if showingProviderError}
+				<CriticalCssErrorDescription
+					errorSet={$primaryErrorSet}
+					showSuggestion={false}
+					foldRawErrors={false}
+					on:retry={generateCriticalCss}
+				/>
 			{:else}
-				<button class="secondary" on:click={retryShowstopper}>
-					{__( 'Refresh', 'jetpack-boost' )}
-				</button>
+				{$criticalCssStatus.status_error}
 			{/if}
 		</div>
-	</ErrorNotice>
-{/if}
+	</FoldingElement>
+
+	<div slot="actionButton">
+		{#if $criticalCssStatus.retriedShowstopper}
+			<a
+				class="button button-secondary"
+				href="https://wordpress.org/support/plugin/jetpack-boost/"
+				target="_blank"
+			>
+				{__( 'Contact Support', 'jetpack-boost' )}
+			</a>
+		{:else}
+			<button class="secondary" on:click={retryShowstopper}>
+				{__( 'Refresh', 'jetpack-boost' )}
+			</button>
+		{/if}
+	</div>
+</ErrorNotice>

--- a/projects/plugins/boost/changelog/update-boost-css-showstopper-design
+++ b/projects/plugins/boost/changelog/update-boost-css-showstopper-design
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Unify Critical CSS Showstopper error design - show consistent styling and options for all cases.


### PR DESCRIPTION
**NOTE**: This is replacing https://github.com/Automattic/jetpack/pull/20602 in order to fix a temporary workflow issue. Even though I approved the PR, it could not get merged because I am not belonging to the correct Github group. After discussion with @thingalon we decided to raise a new PR that he could approve and merge.

Below is the original PR description
______________________________

This PR was "left behind" when Jetpack Boost was migrated to the Jetpack Monorepo: 1057-gh-Automattic/jetpack-boost

This PR migrates the original changes to the Monorepo, but also adds a couple of minor tweaks:

- When an `UknownError` occurred on all pages in a site, its error message was hidden in the showstopper view, because the `rawError` information was hidden along with the suggestion. This PR separates the raw error info from the suggestion so it can be shown even in Showstoppers.
- Consistent `transition:slide` rules used for all see | hide error links.

#### Changes proposed in this Pull Request:
* Updates display of "0 CSS files generated" error to match other showstopper errors, including the "Retry / Contact Support" flow.

#### Does this pull request change what data or activity we track or use?
no.

#### Testing instructions:
1. Break Critical CSS Generation in such a way as to cause a showstopper error. e.g.: cause a 500 error if the `jb-generate-critical-css` GET parameter exists.
2. Generate Critical CSS, and view the showstopper error.
3. Click Retry, and verify that it shows an option to contact support.