### PR TITLE
Boost: Fix some minor UI issues with Critical CSS Showstopper error

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/error-message.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/error-message.scss
@@ -61,6 +61,10 @@
 		}
 	}
 
+	.raw-error {
+		color: $primary-black;
+	}
+
 	.action {
 		color: $gray_90;
 		font-weight: bold;

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
@@ -67,18 +67,20 @@
 		<svelte:component this={footerComponent( errorSet )} />
 	{/if}
 
-	{#if foldRawErrors}
-		<FoldingElement
-			showLabel={__( 'See error message', 'jetpack-boost' )}
-			hideLabel={__( 'Hide error message', 'jetpack-boost' )}
-		>
+	{#if rawError( errorSet )}
+		{#if foldRawErrors}
+			<FoldingElement
+				showLabel={__( 'See error message', 'jetpack-boost' )}
+				hideLabel={__( 'Hide error message', 'jetpack-boost' )}
+			>
+				<p class="raw-error" transition:slide|local>
+					{rawError( errorSet )}
+				</p>
+			</FoldingElement>
+		{:else}
 			<p class="raw-error" transition:slide|local>
 				{rawError( errorSet )}
 			</p>
-		</FoldingElement>
-	{:else}
-		<p class="raw-error" transition:slide|local>
-			{rawError( errorSet )}
-		</p>
+		{/if}
 	{/if}
 </div>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
@@ -40,7 +40,7 @@
 		showLabel={__( 'See error message', 'jetpack-boost' )}
 		hideLabel={__( 'Hide error message', 'jetpack-boost' )}
 	>
-		<div transition:slide|local>
+		<div class="raw-error" transition:slide|local>
 			{#if showingProviderError}
 				<CriticalCssErrorDescription
 					errorSet={$primaryErrorSet}

--- a/projects/plugins/boost/changelog/fix-critical-css-details
+++ b/projects/plugins/boost/changelog/fix-critical-css-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed minor styling and display issues around Critical CSS Showstopper errors


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add logic to not show 'See Error Message' text if no details are available.
* Ensure that the correct error message details are in the correct colour.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Force to generate a Showstopper error and:
- Make sure that correct error message details are displayed in black color.
- Make sure that the 'See Error Message' text is not showing if no error details are available.
