### PR TITLE
Fix relative path in intra-deps checker tool

### DIFF
--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -97,7 +97,7 @@ if $UPDATE; then
 
 		if ! $DID_CL_INSTALL; then
 			debug "Making sure changelogger is runnable"
-			(cd projects/packages/changelogger && composer update --quiet)
+			(cd "$BASE/projects/packages/changelogger" && composer update --quiet)
 			DID_CL_INSTALL=true
 		fi
 


### PR DESCRIPTION
When using `tools/changelogger-release.sh` to update changelogs for release, I hit ran into a path error:

```
Processing plugins/boost...
  Processing packages/autoloader...
There are no changes with content for this write. Proceed? [y/N] y
  Processing packages/lazy-images...
  Processing packages/tracking...
Updating dependencies...
Creating changelog entry for plugins/debug-helper composer.lock update
tools/check-intra-monorepo-deps.sh: line 100: cd: projects/packages/changelogger: No such file or directory
```

This PR fixes the issue by changing to the `changelogger` directory using an absolute path, care of `$BASE` instead of using a relative path.

#### Changes proposed in this Pull Request:
* Use an absolute path when changing directory in `check-intra-monorepo-deps.sh`.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1. Try using `tools/changelogger-release.sh` to prepare a beta release as per the beta release instructions
2. See that it can now complete successfully. :)