### PR TITLE
Boost: start new release cycle

### DIFF
--- a/projects/plugins/boost/changelog/update-boost-release-cycle
+++ b/projects/plugins/boost/changelog/update-boost-release-cycle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+General: start new release cycle

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "1.2.0-beta",
+	"version": "1.3.0-alpha",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -76,7 +76,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ1_2_0_beta"
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ1_3_0_alpha"
 	},
 	"repositories": [
 		{

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2939275c7257ed83821ace6888c20231",
+    "content-hash": "2c021556c2b3661ee8f34faa07285333",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 1.2.0-beta
+ * Version: 1.3.0-alpha
  * Author:            Automattic
  * Author URI:        https://automattic.com
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'JETPACK_BOOST_VERSION', '1.2.0-beta' );
+define( 'JETPACK_BOOST_VERSION', '1.3.0-alpha' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-boost",
-	"version": "1.2.0-beta",
+	"version": "1.3.0-alpha",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"directories": {
 		"test": "tests"


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Start the new release cycle for the Boost plugin after releasing 1.2.0 Beta.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Is CI happy?
