### PR TITLE
Boost: Prevent display issues / crashes from leftover Critical CSS Error data

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
@@ -36,23 +36,25 @@
 			  )}
 	</p>
 
-	<FoldingElement
-		showLabel={__( 'See error message', 'jetpack-boost' )}
-		hideLabel={__( 'Hide error message', 'jetpack-boost' )}
-	>
-		<div class="raw-error" transition:slide|local>
-			{#if showingProviderError}
-				<CriticalCssErrorDescription
-					errorSet={$primaryErrorSet}
-					showSuggestion={false}
-					foldRawErrors={false}
-					on:retry={generateCriticalCss}
-				/>
-			{:else}
-				{$criticalCssStatus.status_error}
-			{/if}
-		</div>
-	</FoldingElement>
+	{#if showingProviderError || $criticalCssStatus.status_error}
+		<FoldingElement
+			showLabel={__( 'See error message', 'jetpack-boost' )}
+			hideLabel={__( 'Hide error message', 'jetpack-boost' )}
+		>
+			<div class="raw-error" transition:slide|local>
+				{#if showingProviderError}
+					<CriticalCssErrorDescription
+						errorSet={$primaryErrorSet}
+						showSuggestion={false}
+						foldRawErrors={false}
+						on:retry={generateCriticalCss}
+					/>
+				{:else}
+					{$criticalCssStatus.status_error}
+				{/if}
+			</div>
+		</FoldingElement>
+	{/if}
 
 	<div slot="actionButton">
 		{#if $criticalCssStatus.retriedShowstopper}

--- a/projects/plugins/boost/changelog/fix-boost-backwards-compatibility
+++ b/projects/plugins/boost/changelog/fix-boost-backwards-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed backwards compatibility for leftover past Critical CSS generation failure data


### PR DESCRIPTION
Jetpack Boost 1.2.0 changes the way that Critical CSS errors are raised and stored, making them more consistent and appropriate for display in the new UI.

However, if there is old error data left in the database from a previous version, it can cause crashes or display issues in the current beta. 

This PR fixes the issue by filtering out old Critical CSS failure information, instead showing a very generic error message for these cases: 

![image](https://user-images.githubusercontent.com/1369626/128856283-3acda710-7f26-4266-9cea-e0c42cab81e0.png)

This will only affect users who have previously had issues generating Critical CSS, and have since upgraded to 1.2.0. It will encourage them to try again, and they will then receive the updated error flow. 

#### Changes proposed in this Pull Request:
* Filter out invalid Critical CSS error data, ensuring leftover old errors from previous versions do not cause crashes or display issues.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1. Install Jetpack Boost 1.1.1 on a test site.
2. Ensure that Critical CSS generation will fail by causing errors in core pages. (e.g.: 500 error on front page)
3. Attempt Critical CSS generation, leaving errors in the system. 
4. Upgrade to 1.2.0 and try to view the Jetpack Boost dashboard.

It should not generate any PHP or JavaScript warnings. The dashboard should clearly show that Critical CSS generation was not successful last time, and encourage users to try again. 

*Also, importantly:* Successful Critical CSS results should not be removed or affected when upgrading from 1.1.1 to 1.2.0.