### PR TITLE
Boost: Update WordPress tested up to version in the readme file

### DIFF
--- a/projects/plugins/boost/changelog/add-boost-wp-tested-version
+++ b/projects/plugins/boost/changelog/add-boost-wp-tested-version
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update the WordPress tested up to version in the readme file

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, xwp, thingalon, pyronaur, davidlonjon, danwalmsley, lu
 Donate link: https://automattic.com
 Tags: performance, speed, pagespeed, web vitals, critical css, optimize, defer
 Requires at least: 5.5
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 7.0
 Stable tag: 1.1.1
 License: GPLv2 or later


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* I am not entirely sure if this can be done the release process so I am putting forward this PR to update the WordPress tested up to version in the readme file. Otherwise for WordPress 5.8, Jetpack Boost plugin in the Plugin search area comes with the test "Untested with your version of WordPress".

<img width="689" alt="Screen Shot 2021-08-10 at 8 41 17 PM" src="https://user-images.githubusercontent.com/927932/128876587-19db9003-813f-4827-b2d4-3833a31a3bbf.png">


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
- Once release, Jetpack Boost will show with the wording "Compatible with your version of WordPress" like in the screenshot below for the Jetpack plugin:

![image](https://user-images.githubusercontent.com/927932/128877100-3e0ddd39-ffa8-4d9f-8537-19ee8420fd91.png)
