### PR TITLE
E2E tests: Fix Paypal block fields not getting filled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-e2e-fix-paypal-block-no-fill
+++ b/projects/plugins/jetpack/changelog/fix-e2e-fix-paypal-block-no-fill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+E2E tests: fixed PayPal block fields not getting filled

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/jetpack-connect/site-topic.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/jetpack-connect/site-topic.js
@@ -14,7 +14,7 @@ export default class JetpackSiteTopicPage extends WpPage {
 		const siteTopicSpinnerSelector = '.suggestion-search .spinner';
 
 		await this.click( siteTopicInputSelector, { clickCount: 3 } );
-		await this.type( siteTopicInputSelector, siteTopic );
+		await this.fill( siteTopicInputSelector, siteTopic );
 
 		await this.waitForElementToBeHidden( siteTopicSpinnerSelector );
 		await this.click( siteTopicButtonSelector );

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/page-actions.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/page-actions.js
@@ -190,7 +190,8 @@ export default class PageActions {
 	}
 
 	/**
-	 * Types text in an element in page
+	 * Types text in an element in page, can be used to send fine-grained keyboard events.
+	 * Do not used for form filling. See `fill` method for that.
 	 *
 	 * @param {string} selector the element's selector
 	 * @param {string} text     to be typed
@@ -204,7 +205,8 @@ export default class PageActions {
 	}
 
 	/**
-	 * Fills an editable text type element
+	 * Fills an editable text type element.
+	 * It waits for actionability checks before filling
 	 *
 	 * @param {string} selector the element's selector
 	 * @param {string} text     to be filled in
@@ -217,7 +219,7 @@ export default class PageActions {
 	}
 
 	/**
-	 * Focus an element in page
+	 * Focus an element in page.
 	 *
 	 * @param {string} selector the element's selector
 	 * @param {Object} options  see: https://playwright.dev/docs/api/class-page?_highlight=focus#pagefocusselector-options

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/block-editor.js
@@ -72,7 +72,7 @@ export default class BlockEditorPage extends WpPage {
 		await testStep( `Search for block: ${ searchTerm }`, async () => {
 			logger.step( `Search block: '${ searchTerm }'` );
 			await this.click( this.insertBlockBtnSel );
-			await this.type( this.searchBlockFldSel, searchTerm );
+			await this.fill( this.searchBlockFldSel, searchTerm );
 		} );
 	}
 

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/eventbrite.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/eventbrite.js
@@ -24,7 +24,7 @@ export default class EventbriteBlock extends PageActions {
 		const inputSelector = this.getSelector( '.components-placeholder__input' );
 		const descriptionSelector = this.getSelector( "button[type='submit']" );
 
-		await this.type( inputSelector, this.embedUrl() );
+		await this.fill( inputSelector, this.embedUrl() );
 		await this.click( descriptionSelector );
 		await this.waitForElementToBeVisible( '.wp-block-jetpack-eventbrite .components-sandbox' );
 	}

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/pinterest.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/pinterest.js
@@ -25,7 +25,7 @@ export default class PinterestBlock extends PageActions {
 		const inputSelector = this.getSelector( '.components-placeholder__input' );
 		const descriptionSelector = this.getSelector( "button[type='submit']" );
 
-		await this.type( inputSelector, this.embedUrl() );
+		await this.fill( inputSelector, this.embedUrl() );
 		await this.click( descriptionSelector );
 		await this.waitForElementToBeVisible( '.wp-block-jetpack-pinterest .components-sandbox' );
 	}

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/simple-payments.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/simple-payments.js
@@ -22,15 +22,15 @@ export default class SimplePaymentBlock extends PageActions {
 		price = '23.42',
 		email = 'test@example.com',
 	} = {} ) {
-		const titleSelector = this.getSelector( '.simple-payments__field-title' );
-		const descriptionSelector = this.getSelector( '.simple-payments__field-content' );
-		const priceSelector = this.getSelector( '.simple-payments__field-price' );
-		const emailSelector = this.getSelector( '.simple-payments__field-email' );
+		const titleSelector = this.getSelector( '.simple-payments__field-title input' );
+		const descriptionSelector = this.getSelector( '.simple-payments__field-content textarea' );
+		const priceSelector = this.getSelector( '.simple-payments__field-price input' );
+		const emailSelector = this.getSelector( '.simple-payments__field-email input' );
 
-		await this.type( titleSelector, title );
-		await this.type( descriptionSelector, description );
-		await this.type( priceSelector, price );
-		await this.type( emailSelector, email );
+		await this.fill( titleSelector, title );
+		await this.fill( descriptionSelector, description );
+		await this.fill( priceSelector, price );
+		await this.fill( emailSelector, email );
 	}
 
 	getSelector( selector ) {

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wpcom/checkout.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wpcom/checkout.js
@@ -11,7 +11,7 @@ export default class CheckoutPage extends WpPage {
 	async processPurchase( cardCredentials ) {
 		// Enter billing info
 		await this.selectOption( `select#country-selector`, cardCredentials.cardCountryCode );
-		await this.type( '#contact-postal-code', cardCredentials.cardPostCode, {
+		await this.fill( '#contact-postal-code', cardCredentials.cardPostCode, {
 			delay: 10,
 		} );
 		await this.click( '.checkout-step.is-active .checkout-button' );
@@ -29,7 +29,7 @@ export default class CheckoutPage extends WpPage {
 	}
 
 	async enterTestCreditCardDetails( { cardHolder, cardNumber, cardExpiry, cardCVV } ) {
-		await this.type( '#cardholder-name', cardHolder, { delay: 10 } );
+		await this.fill( '#cardholder-name', cardHolder, { delay: 10 } );
 
 		await this.waitAndTypeInIframe( '.number', "input[name='cardnumber']", cardNumber );
 		await this.waitAndTypeInIframe( '.cvv', "input[name='cvc']", cardCVV );
@@ -63,6 +63,6 @@ export default class CheckoutPage extends WpPage {
 		const iframeElement = await this.page.$( fullSelector );
 		const iframe = await iframeElement.contentFrame();
 
-		return await iframe.type( what, value, { delay: 10 } );
+		return await iframe.fill( what, value, { delay: 10 } );
 	}
 }

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wpcom/connections.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wpcom/connections.js
@@ -42,9 +42,9 @@ export default class ConnectionsPage extends WpPage {
 		const mcPasswordSelector = '#login #password';
 		const mcSubmitSelector = "#login input[type='submit']";
 
-		await mcPopupPage.type( mcUsernameSelector, mcLogin );
-		await mcPopupPage.type( mcPasswordSelector, mcPassword );
-		await mcPopupPage.type( mcSubmitSelector );
+		await mcPopupPage.fill( mcUsernameSelector, mcLogin );
+		await mcPopupPage.fill( mcPasswordSelector, mcPassword );
+		await mcPopupPage.fill( mcSubmitSelector );
 		await this.page.bringToFront();
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* The mandatory fields in PayPal blocks are not getting filled, leading to occasional PayPal test failure. Why occasional? Apparently if you're fast enough, which Playwright is, you can publish the post before the fields are validated and errors are thrown.
* Fixed the selectors so that fields are no properly filled.
* Replaced `page.type` with `page.fill` everywhere we're filling forms, as `fill` method is the recommended one because it also checks for fields being editable before filling them with text.

#### Jetpack product discussion
1156386383419466-as-1200757549786732

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* E2E tests need to pass