### PR TITLE
JetpackFooter: add default a8cLogoHref prop value

### DIFF
--- a/projects/js-packages/components/changelog/fix-jetpack-footer-default-prop
+++ b/projects/js-packages/components/changelog/fix-jetpack-footer-default-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JetpackFooter: add default a8cLogoHref prop value

--- a/projects/js-packages/components/components/jetpack-footer/index.jsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.jsx
@@ -22,7 +22,7 @@ import JetpackLogo from '../jetpack-logo';
  * @returns {React.Component} JetpackFooter component.
  */
 export default function JetpackFooter( {
-	a8cLogoHref,
+	a8cLogoHref = 'https://www.jetpack.com',
 	moduleName = __( 'Jetpack', 'jetpack' ),
 	className = '',
 	...otherProps

--- a/projects/js-packages/components/components/jetpack-footer/index.jsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.jsx
@@ -22,7 +22,7 @@ import JetpackLogo from '../jetpack-logo';
  * @returns {React.Component} JetpackFooter component.
  */
 export default function JetpackFooter( {
-	a8cLogoHref = 'https://www.jetpack.com',
+	a8cLogoHref = 'https://jetpack.com',
 	moduleName = __( 'Jetpack', 'jetpack' ),
 	className = '',
 	...otherProps


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds a default value for the `a8cLogoHref` URL prop; previously was blank.
  * The `/wp-admin/admin.php?page=jetpack_about` page would only be available if Jetpack was activated, which won't always be the case (e.g. standalone Backup plugin). We could consider linking by default to an `automattic.com` page or maybe a new `jetpack.com` page with similar content as the `jetpack_about` page.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* After pulling down these changes to local dev, adding a `<JetpackFooter />` with no `a8cLogoHref` prop value provided should default to: https://www.jetpack.com
