### PR TITLE
Add support for specifying individual users as required reviewers

### DIFF
--- a/projects/github-actions/required-review/README.md
+++ b/projects/github-actions/required-review/README.md
@@ -81,6 +81,9 @@ The requirements consist of an array of requirement objects. A requirement objec
   from every team (but if a person is a member of multiple teams, they can satisfy multiple
   requirements). When it's `any-of`, one review from any team is needed.
 
+  Additionally, you can specify a single user by prefixing their username with `@`. For example,
+  `@example` will be treated as a virtual team with one member; `example`.
+
 Paths are matched using the [picomatch](https://www.npmjs.com/package/picomatch#globbing-features) library.
 
 Every requirement object that applies must have appropriate reviews, it's not "first match". Thus,

--- a/projects/github-actions/required-review/changelog/add-single-user-review-support
+++ b/projects/github-actions/required-review/changelog/add-single-user-review-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added support for naming individual users as required reviewers

--- a/projects/github-actions/required-review/package.json
+++ b/projects/github-actions/required-review/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "required-review",
-	"version": "2.0.1-alpha",
+	"version": "2.1.0-alpha",
 	"description": "Check that a PR has reviews from required teams.",
 	"main": "index.js",
 	"author": "Automattic",

--- a/projects/github-actions/required-review/src/team-members.js
+++ b/projects/github-actions/required-review/src/team-members.js
@@ -5,12 +5,18 @@ const { WError } = require( 'error' );
 const cache = {};
 
 /**
- * Fetch the members of a team.
+ * Fetch the members of a team for the purpose of verifying a review Requirement.
+ * Special case: Named prefixed with @ are considered to be a one-member team with the named GitHub user.
  *
- * @param {string} team - GitHub team slug.
+ * @param {string} team - GitHub team slug, or @ followed by a GitHub user name.
  * @returns {string[]} Team members.
  */
 async function fetchTeamMembers( team ) {
+	// Handle @singleuser virtual teams.
+	if ( team.startsWith( '@' ) ) {
+		return [ team.slice( 1 ) ];
+	}
+
 	if ( cache[ team ] ) {
 		return cache[ team ];
 	}

--- a/projects/github-actions/required-review/src/team-members.js
+++ b/projects/github-actions/required-review/src/team-members.js
@@ -6,7 +6,7 @@ const cache = {};
 
 /**
  * Fetch the members of a team for the purpose of verifying a review Requirement.
- * Special case: Named prefixed with @ are considered to be a one-member team with the named GitHub user.
+ * Special case: Names prefixed with @ are considered to be a one-member team with the named GitHub user.
  *
  * @param {string} team - GitHub team slug, or @ followed by a GitHub user name.
  * @returns {string[]} Team members.


### PR DESCRIPTION
This PR adds support for specifying individual users in the required-review config.

When a team name is prefixed with `@`, it is treated as a single-user team containing the named GitHub user. For example, `@thingalon` would be treated as a virtual team with one (utterly amazing 😉 ) team member.

For example:
```
# The Boost team reviews changes to the Boost plugin,
# and can add dependencies to the monorepo's lock file.
- name: Boost
  paths:
   - 'projects/plugins/boost/**'
   - 'pnpm-lock.yaml'
  teams:
   - heart-of-gold
   - jetpack-approvers
   - '@davidlonjon'
```

It should happily work with the existing `any-of` and `all-of` features.

Fixes #20610 

#### Changes proposed in this Pull Request:
* Add support for naming individuals in required reviewers config, by using an `@` prefix.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1. Check out this branch, then modify `.github/files/required-review.yaml` to add a user (e.g.: `'@davidlonjon'`) to the list of Boost reviewers. See above example.
2. Run the test utility in the `required-review` tool directory to verify that it matches successfully, using a PR reviewed by the user you named. e.g.:
```
INPUT_TOKEN=[github api token here] ./projects/github-actions/required-review/test.sh 20621
```

Here, I used #20621, which at the time of writing this, has been approved by David.

3. Check the output includes acknowledgement that the Boost requirement has been met. e.g.:
```
::group::Checking requirement "Boost"...
Matches the following files:
   - projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
   - projects/plugins/boost/app/modules/critical-css/class-critical-css-state.php
   - projects/plugins/boost/changelog/fix-boost-backwards-compatibility
Checking reviewers...
  Union of these:
    Members of @davidlonjon: davidlonjon
    Members of heart-of-gold: <empty set>
    Members of jetpack-approvers: <empty set>
  => davidlonjon
::endgroup::
Requirement "Boost" is satisfied by the existing reviews.
```