### PR TITLE
Related Posts: process content in post titles

### DIFF
--- a/projects/plugins/jetpack/changelog/update-related-posts-stripped-titles
+++ b/projects/plugins/jetpack/changelog/update-related-posts-stripped-titles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Related Posts: allow shortcodes in Related Posts titles, to allow third-party plugins processing shortcodes in post titles to work.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1148,7 +1148,7 @@ EOT;
 			foreach ( array_merge( $with_post_thumbnails, $no_post_thumbnails ) as $index => $real_post ) {
 				$related_posts[ $index ]['id']      = $real_post->ID;
 				$related_posts[ $index ]['url']     = esc_url( get_permalink( $real_post ) );
-				$related_posts[ $index ]['title']   = $this->_to_utf8( $this->_get_title( $real_post->post_title, $real_post->post_content ) );
+				$related_posts[ $index ]['title']   = $this->_to_utf8( $this->get_title( $real_post->post_title, $real_post->post_content ) );
 				$related_posts[ $index ]['date']    = get_the_date( '', $real_post );
 				$related_posts[ $index ]['excerpt'] = html_entity_decode( $this->_to_utf8( $this->_get_excerpt( $real_post->post_excerpt, $real_post->post_content ) ), ENT_QUOTES, 'UTF-8' );
 				$related_posts[ $index ]['img']     = $this->_generate_related_post_image_params( $real_post->ID );
@@ -1194,13 +1194,16 @@ EOT;
 		$post = get_post( $post_id );
 
 		return array(
-			'id' => $post->ID,
-			'url' => get_permalink( $post->ID ),
-			'url_meta' => array( 'origin' => $origin, 'position' => $position ),
-			'title' => $this->_to_utf8( $this->_get_title( $post->post_title, $post->post_content ) ),
-			'date' => get_the_date( '', $post->ID ),
-			'format' => get_post_format( $post->ID ),
-			'excerpt' => html_entity_decode( $this->_to_utf8( $this->_get_excerpt( $post->post_excerpt, $post->post_content ) ), ENT_QUOTES, 'UTF-8' ),
+			'id'       => $post->ID,
+			'url'      => get_permalink( $post->ID ),
+			'url_meta' => array(
+				'origin'   => $origin,
+				'position' => $position,
+			),
+			'title'    => $this->_to_utf8( $this->get_title( $post->post_title, $post->post_content ) ),
+			'date'     => get_the_date( '', $post->ID ),
+			'format'   => get_post_format( $post->ID ),
+			'excerpt'  => html_entity_decode( $this->_to_utf8( $this->_get_excerpt( $post->post_excerpt, $post->post_content ) ), ENT_QUOTES, 'UTF-8' ),
 			/**
 			 * Filters the rel attribute for the Related Posts' links.
 			 *
@@ -1250,14 +1253,19 @@ EOT;
 	/**
 	 * Returns either the title or a small excerpt to use as title for post.
 	 *
-	 * @param string $post_title
-	 * @param string $post_content
-	 * @uses strip_shortcodes, wp_trim_words, __
+	 * @uses strip_shortcodes, wp_trim_words, __, apply_filters
+	 *
+	 * @param string $post_title   Post title.
+	 * @param string $post_content Post content.
+	 *
 	 * @return string
 	 */
-	protected function _get_title( $post_title, $post_content ) {
+	protected function get_title( $post_title, $post_content ) {
 		if ( ! empty( $post_title ) ) {
-			return wp_strip_all_tags( $post_title );
+			return wp_strip_all_tags(
+				/** This filter is documented in core/src/wp-includes/post-template.php */
+				apply_filters( 'the_title', $post_title )
+			);
 		}
 
 		$post_title = wp_trim_words( wp_strip_all_tags( strip_shortcodes( $post_content ) ), 5, '…' );


### PR DESCRIPTION
Fixes #20551

#### Changes proposed in this Pull Request:

Related Posts' titles need to be quite simple, to avoid display issues in the Related Post grid and to avoid displaying HTML tags in the title attribute used in the related posts anchor. That said, we should be able to allow shortcodes that add simple text to post titles to work.

Let's consequently continue to strip all tags, but let's process the post titles through the the_title filter so third-party plugins can use it.

This may also address #2535.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site connected to WordPress.com, with related posts on, and with some related posts appearing under your posts.
* Install and activate [the Dynamic Month & Year into Posts plugin](https://wordpress.org/plugins/dynamic-month-year-into-posts/).
* Edit one of the posts you see as related post under one of your posts.
* Add `[year]` to the post title.
* Save your changes.
* Refresh the page where that post was displayed as related post.
* You should now see the year instead of just `[year]` (as with currently on `master`).
* Edit that same post again, and try adding other things, such as `<script>alert(1);</script>`
* Save your changes
* Ensure that is not displayed in the related post grid.
