### PR TITLE
SSO: remove Jetpack.com redirect during login process

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sso-redirect
+++ b/projects/plugins/jetpack/changelog/update-sso-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Secure Sign On: remove additional redirect during sign in process.

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -1,7 +1,6 @@
 <?php
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
@@ -952,7 +951,7 @@ class Jetpack_SSO {
 	 */
 	public function build_sso_url( $args = array() ) {
 		$sso_nonce = ! empty( $args['sso_nonce'] ) ? $args['sso_nonce'] : self::request_initial_nonce();
-		$defaults = array(
+		$defaults  = array(
 			'action'       => 'jetpack-sso',
 			'site_id'      => Jetpack_Options::get_option( 'id' ),
 			'sso_nonce'    => $sso_nonce,
@@ -965,17 +964,7 @@ class Jetpack_SSO {
 			return $args['sso_nonce'];
 		}
 
-		$query = add_query_arg( $args, '' );
-		$query = trim( $query, '?' );
-
-		$url = Redirect::get_url(
-			'wpcom-login',
-			array(
-				'query' => $query,
-			)
-		);
-
-		return $url;
+		return add_query_arg( $args, 'https://wordpress.com/wp-login.php' );
 	}
 
 	/**
@@ -1009,17 +998,7 @@ class Jetpack_SSO {
 			return $args['sso_nonce'];
 		}
 
-		$query = add_query_arg( $args, '' );
-		$query = trim( $query, '?' );
-
-		$url = Redirect::get_url(
-			'wpcom-login',
-			array(
-				'query' => $query,
-			)
-		);
-
-		return $url;
+		return add_query_arg( $args, 'https://wordpress.com/wp-login.php' );
 	}
 
 	/**


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

﻿This was added in #15140. Removing it means making the log in process a bit faster.


#### Jetpack product discussion

* Internal reference: p55Cj4-1bO-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a site with SSO enabled, log out and log back in.
* You should be redirected to WordPress.com and then back to your site, without going through jetpack.com.
