### PR TITLE
Fix/nav unification submenu positioning

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nav-unification-submenu-positioning
+++ b/projects/plugins/jetpack/changelog/fix-nav-unification-submenu-positioning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed submenu positioning issue for Nav-Unification in WP-Admin

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -218,7 +218,7 @@ abstract class Base_Admin_Menu {
 				isset( $submenu_item[1] ) ? $submenu_item[1] : 'read',
 				$submenus_to_update[ $submenu_item[2] ],
 				'',
-				$i
+				0 === $i ? 0 : $i + 1
 			);
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #https://github.com/Automattic/wp-calypso/issues/55369

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixed the order for the submenu items when updating them to use the Calypso versions using the update_submenus method.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- On Atomic, use Jetpack Beta and switch to this branch
- On Simple Site, apply AAA-code patch on your sandbox.

Please follow these steps:
- Go to WP-Admin and Calypso
- Make sure that Appearance > Customize is after `Themes` menu
- Make sure that we haven't introduced any obvious regressions (e.g. go to Settings menu and check that General submenu is the first submenu)
