### PR TITLE
Widget visibility: Make request paths work on wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-widget-visibility-on-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-widget-visibility-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Correct REQUEST_URI checking to work for wp.com as well as .org endpoints

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -40,7 +40,7 @@ class Jetpack_Widget_Conditions {
 		}
 
 		// API call to *list* the widget types doesn't use editing visibility or display widgets.
-		if ( false !== strpos( $_SERVER['REQUEST_URI'], '/wp-json/wp/v2/widget-types?' ) ) {
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], '/widget-types?' ) ) {
 			return;
 		}
 
@@ -66,7 +66,7 @@ class Jetpack_Widget_Conditions {
 			}
 
 			// Encoding for a particular widget end point.
-			if ( 1 === preg_match( '|/wp-json/wp/v2/widget-types/.*/encode|', $_SERVER['REQUEST_URI'] ) ) {
+			if ( 1 === preg_match( '|/widget-types/.*/encode|', $_SERVER['REQUEST_URI'] ) ) {
 				$add_html_to_form      = true;
 				$handle_widget_updates = true;
 			}


### PR DESCRIPTION
This plugin checks the current REQUEST_URI to decide whether or not to
register hooks. The REQUEST_URI it checked against was correct for
WordPress.org sites but not for WordPress.com sites.

These have now been updated to work in both cases.

Builds on #20255 which doesn't work on wp.com simple sites, this has been discussed at p7DVsv-cqD-p2#comment-37158

#### Changes proposed in this Pull Request:
Made the URL check for when to register hooks weaker.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


#### Testing instructions:
1. Create a wordpress.com simple site
2. Click on Appearance then widgets in the right hand menu
3. Add a legacy widget


#### What I expected
A button to control conditional widget visibility as part of the widget form

![image](https://user-images.githubusercontent.com/93301/129059369-cd7a9310-c6bf-4262-bc87-a2dde7095815.png)


#### What happened instead
The widget form without widget visibility button
