### PR TITLE
Fix broken SSO tests

### DIFF
--- a/projects/plugins/jetpack/changelog/try-fix-sso-tests
+++ b/projects/plugins/jetpack/changelog/try-fix-sso-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix broken SSO sync test

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sso.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sso.php
@@ -6,9 +6,10 @@
 class WP_Test_Jetpack_Sync_SSO extends WP_Test_Jetpack_Sync_Base {
 	public function setUp() {
 		parent::setUp();
+		$this->sender->do_sync();
 		$this->resetCallableAndConstantTimeouts();
 	}
-	
+
 	function test_sync_sso_is_two_step_required_filter_true() {
 		add_filter( 'jetpack_sso_require_two_step', '__return_true' );
 		$this->sender->do_sync();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

SSO tests were failing because not enough data was synchronized to return the callables.

This patch is a naive fixed based on patterns seen in other tests - run do_sync() in the before block so that exists stuff is already synced.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix broken SSO tests

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

```sh
jetpack docker phpunit -- --testdox --filter=Jetpack_Sync_SSO
```