### PR TITLE
Add davidlonjon as a reviewer on the Boost project

### DIFF
--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -33,6 +33,7 @@
   teams:
    - heart-of-gold
    - jetpack-approvers
+   - '@davidlonjon'
 
 # Jetpack Approvers review everything that hasn't been specifically assigned above.
 # This needs to be last.


### PR DESCRIPTION
Add @davidlonjon to the list of reviewers for the Boost project.

Now that https://github.com/Automattic/jetpack/pull/20633 has merged, we can give David the ability to approve patches which only affect Boost's files.

#### Changes proposed in this Pull Request:
* Add @davidlonjon to the list of reviewers for Boost.

#### Jetpack product discussion
p1628562101034800-slack-C019N9JKKM5

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1. Read the config, and make sure you're happy with the change. :)