### PR TITLE
Restore the 'safecss_embed_style' filter from the pre-4.7 Custom CSS

### DIFF
--- a/projects/plugins/jetpack/modules/custom-css/custom-css-4.7.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css-4.7.php
@@ -199,16 +199,23 @@ class Jetpack_Custom_CSS_Enhancements {
 	 */
 	public static function wp_custom_css_cb() {
 		$styles = wp_get_custom_css();
-		if ( strlen( $styles ) > 2000 && ! is_customize_preview() ) :
+		if ( ! $styles ) {
+			return;
+		}
+
+		$should_embed = strlen( $styles ) < 2000;
+		$should_embed = apply_filters( 'safecss_embed_style', $should_embed, $styles );
+
+		if ( $should_embed || is_customize_preview() ) : ?>
+			<style type="text/css" id="wp-custom-css">
+				<?php echo strip_tags( $styles ); // Note that esc_html() cannot be used because `div &gt; span` is not interpreted properly. ?>
+			</style>
+		<?php else:
 			// Add a cache buster to the url.
 			$url = home_url( '/' );
 			$url = add_query_arg( 'custom-css', substr( md5( $styles ), -10 ), $url );
 			?>
 			<link rel="stylesheet" type="text/css" id="wp-custom-css" href="<?php echo esc_url( $url ); ?>" />
-		<?php elseif ( $styles || is_customize_preview() ) : ?>
-			<style type="text/css" id="wp-custom-css">
-				<?php echo strip_tags( $styles ); // Note that esc_html() cannot be used because `div &gt; span` is not interpreted properly. ?>
-			</style>
 		<?php endif;
 	}
 


### PR DESCRIPTION
Restore the 'safecss_embed_style' filter from the pre-4.7 Custom CSS module into the new Custom CSS Module.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #20653

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Includes the filter from the old custom css module into the new custom css module.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add `add_filter( 'safecss_embed_style', '__return_true' );` to a custom plugin
* Add Custom CSS > 2000 Char
* View front-end, admire the Custom CSS inserted inline
