### PR TITLE
Boost: Ignore the Docker folder from being added into production release

### DIFF
--- a/projects/plugins/boost/.gitattributes
+++ b/projects/plugins/boost/.gitattributes
@@ -16,6 +16,7 @@ vendor/tedivm/** 			  production-include
 /app/assets/src/**                         production-exclude
 /app/assets/dist/**/*.js.map               production-exclude
 /changelog/**                              production-exclude
+/docker/**                                 production-exclude
 /docs/**                                   production-exclude
 /node_modules/**                           production-exclude
 /tests/**                                  production-exclude

--- a/projects/plugins/boost/changelog/fix-boost-ignore-docker-folder-for-release
+++ b/projects/plugins/boost/changelog/fix-boost-ignore-docker-folder-for-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ignore the Docker folder from being added into production release


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Ignore the Docker folder from being added into production release

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* Make sure that the `docker` folder does not appear in the https://github.com/Automattic/jetpack-boost-production repo
