### PR TITLE
Boost: Add versioning to the loading of the Critical CSS Gen library

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/utils/load-critical-css-library.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/load-critical-css-library.ts
@@ -14,7 +14,8 @@ export async function loadCriticalCssLibrary(): Promise< void > {
 	}
 
 	loadLibraryPromise = new Promise< void >( ( resolve, reject ) => {
-		const scriptUrl = Jetpack_Boost.site.assetPath + '/critical-css-gen.js';
+		const scriptUrl =
+			Jetpack_Boost.site.assetPath + '/critical-css-gen.js?ver=' + Jetpack_Boost.version;
 		const scriptTag = document.createElement( 'script' );
 		scriptTag.src = scriptUrl;
 

--- a/projects/plugins/boost/changelog/fix-boost-load-gen-library-with-version
+++ b/projects/plugins/boost/changelog/fix-boost-load-gen-library-with-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use version GET parameter when loading Critical CSS lib to ensure cache busted on upgrade


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Include Boost version as GET parameter when loading gen library to avoid caching issues

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Generate Critical CSS with Boost plugin version 1.1.1 with errors
* Upgrade to Jetpack Boost version 1.2.0 (Do not clear browser cache) and make sure that the UI is presenting error correctly.
