### PR TITLE
Connection: Remove tracked DNA packages on disconnect

### DIFF
--- a/projects/packages/connection/changelog/update-remove_tracked_packages_on_disconnect
+++ b/projects/packages/connection/changelog/update-remove_tracked_packages_on_disconnect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove tracked package versions when disconnecting the site.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1980,6 +1980,9 @@ class Manager {
 
 		$this->delete_all_connection_tokens( true );
 
+		// Remove tracked package versions, since they depend on the Jetpack Connection.
+		delete_option( Package_Version_Tracker::PACKAGE_VERSION_OPTION );
+
 		$jetpack_unique_connection = \Jetpack_Options::get_option( 'unique_connection' );
 		if ( $jetpack_unique_connection ) {
 			// Check then record unique disconnection if site has never been disconnected previously.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.2';
+	const PACKAGE_VERSION = '1.30.3-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 


### PR DESCRIPTION
Upon disconnecting a site, the `jetpack_package_versions` option should be removed as it depends on the Jetpack Connection.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates `disconnect_site` method in `Jetpack\Connection\Manager` to remove the stored package versions.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1200561894344934-as-1200719679037708/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
D65339-code