### PR TITLE
Content Options: add missing textdomain for core string

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-missing-textdomain-content-options
+++ b/projects/plugins/jetpack/changelog/fix-missing-textdomain-content-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Content Options: add missing textdomain for core string.
+
+

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/blog-display.php
@@ -63,7 +63,7 @@ function jetpack_blog_display_custom_excerpt( $content = '' ) {
 		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 		 * Do not translate into your own language.
 		 */
-		if ( strpos( _x( 'words', 'Word count type. Do not translate!' ), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
+		if ( strpos( _x( 'words', 'Word count type. Do not translate!', 'jetpack' ), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
 			$text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $text ), ' ' );
 			preg_match_all( '/./u', $text, $words );
 			$words = array_slice( $words[0], 0, $excerpt_length + 1 );


### PR DESCRIPTION
Fixes #20664

#### Changes proposed in this Pull Request:
Let's use our own textdomain for now.

See this trac ticket for more info:
https://core.trac.wordpress.org/ticket/47511#comment:19

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here, the string should not change.
