### PR TITLE
Make sure generated secrets have the required length

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-secrets-length
+++ b/projects/packages/connection/changelog/fix-connection-secrets-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make sure generated secrets have the required length

--- a/projects/packages/connection/src/class-secrets.php
+++ b/projects/packages/connection/src/class-secrets.php
@@ -44,7 +44,7 @@ class Secrets {
 			$secret       .= wp_generate_password( 32, false );
 			$secret_length = strlen( $secret );
 		}
-		return substr( $secret, 0, 32 );
+		return (string) substr( $secret, 0, 32 );
 	}
 
 	/**

--- a/projects/packages/connection/src/class-secrets.php
+++ b/projects/packages/connection/src/class-secrets.php
@@ -37,10 +37,12 @@ class Secrets {
 		$secret = wp_generate_password( 32, false );
 
 		// Some sites may hook into the random_password filter and make the password shorter, let's make sure our secret has the required length.
-		$attempts = 1;
-		while( strlen( $secret ) < 32 && $attempts < 32 ) {
+		$attempts      = 1;
+		$secret_length = strlen( $secret );
+		while ( $secret_length < 32 && $attempts < 32 ) {
 			$attempts++;
-			$secret .= wp_generate_password( 32, false );
+			$secret       .= wp_generate_password( 32, false );
+			$secret_length = strlen( $secret );
 		}
 		return substr( $secret, 0, 32 );
 	}

--- a/projects/packages/connection/src/class-secrets.php
+++ b/projects/packages/connection/src/class-secrets.php
@@ -34,7 +34,15 @@ class Secrets {
 	 * @return String $secret value.
 	 */
 	private function secret_callable_method() {
-		return wp_generate_password( 32, false );
+		$secret = wp_generate_password( 32, false );
+
+		// Some sites may hook into the random_password filter and make the password shorter, let's make sure our secret has the required length.
+		$attempts = 1;
+		while( strlen( $secret ) < 32 && $attempts < 32 ) {
+			$attempts++;
+			$secret .= wp_generate_password( 32, false );
+		}
+		return substr( $secret, 0, 32 );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test_Secrets.php
+++ b/projects/packages/connection/tests/php/test_Secrets.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Connection;
 
-use Automattic\Jetpack\Connection\Secrets;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/projects/packages/connection/tests/php/test_Secrets.php
+++ b/projects/packages/connection/tests/php/test_Secrets.php
@@ -1,0 +1,110 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * Secrets functionality testing.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Connection\Secrets;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Secrets functionality testing.
+ */
+class SecretsTest extends TestCase {
+
+	/**
+	 * Calls the private Secrets::secret_callable_method method
+	 */
+	public function call_private_secret_callable_method() {
+		$method = new \ReflectionMethod( 'Automattic\Jetpack\Connection\Secrets', 'secret_callable_method' );
+		$method->setAccessible( true );
+		return $method->invoke( new Secrets() );
+	}
+
+	/**
+	 * Asserts that secret_callable_method returns the correct string length
+	 */
+	public function assert_generate_secrets_length() {
+		$secret = $this->call_private_secret_callable_method();
+		return $this->assertSame( 32, strlen( $secret ) );
+	}
+
+	/**
+	 * Cuts the string and returns only the first 16 characters
+	 *
+	 * @param string $string The string.
+	 * @return string
+	 */
+	public function trim_string_to_16( $string ) {
+		return substr( $string, 0, 16 );
+	}
+
+	/**
+	 * Cuts the string and returns only the first 7 characters
+	 *
+	 * @param string $string The string.
+	 * @return string
+	 */
+	public function trim_string_to_7( $string ) {
+		return substr( $string, 0, 7 );
+	}
+
+	/**
+	 * Cuts the string and returns only the first character
+	 *
+	 * @param string $string The string.
+	 * @return string
+	 */
+	public function trim_string_to_1( $string ) {
+		return substr( $string, 0, 1 );
+	}
+
+	/**
+	 * Test secret_callable_method default behavior
+	 */
+	public function test_generate_secrets_length() {
+		$secret = $this->call_private_secret_callable_method();
+		$this->assertSame( 32, strlen( $secret ) );
+	}
+
+	/**
+	 * Test secret_callable_method with filter 16
+	 */
+	public function test_generate_secrets_length_16() {
+		add_filter( 'random_password', array( $this, 'trim_string_to_16' ) );
+		$this->assert_generate_secrets_length();
+		remove_filter( 'random_password', array( $this, 'trim_string_to_16' ) );
+	}
+
+	/**
+	 * Test secret_callable_method with filter 7
+	 */
+	public function test_generate_secrets_length_7() {
+		add_filter( 'random_password', array( $this, 'trim_string_to_7' ) );
+		$this->assert_generate_secrets_length();
+		remove_filter( 'random_password', array( $this, 'trim_string_to_7' ) );
+	}
+
+	/**
+	 * Test secret_callable_method with filter 1
+	 */
+	public function test_generate_secrets_length_1() {
+		add_filter( 'random_password', array( $this, 'trim_string_to_1' ) );
+		$this->assert_generate_secrets_length();
+		remove_filter( 'random_password', array( $this, 'trim_string_to_1' ) );
+	}
+
+	/**
+	 * Test secret_callable_method with filter that returns an empty string
+	 */
+	public function test_generate_secrets_length_empty_string() {
+		add_filter( 'random_password', '__return_empty_string' );
+		$secret = $this->call_private_secret_callable_method();
+		$this->assertSame( '', $secret ); // We are just assuring that we are not entering an infinite loop. In a situation like this, the site would be broken.
+		remove_filter( 'random_password', '__return_empty_string' );
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #20672


Jetpack connection requires that the secrets generated are 32 characters long. However, if a theme or plugin hooks into the `random_password` filter they can mess things up and return a shorter password, thus not allowing the site to connect.

This PR assures that the secrets generated have the right length in `Automattic\Jetpack\Connection\Secrets::secret_callable_method()`

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Connection: Make sure generated secrets have the required length

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/20672

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* kick off a new site on `master`
* Add the following code to your themes's `function.php` or as a mu-plugin

```PHP
add_filter( 'random_password', function( $pass ) { return substr($pass, 0, 6); } );
```

* Try to Connect Jetpack and confirm it fails (secret_1 is malformed)
* checkout this branch
* clear the secrets with `wp option delete jetpack_secrets`
* Try to connect again and confirm it works
