### PR TITLE
Search: fix allowing scrolling behind the modal when it is open

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-touchmove-thru-overlay
+++ b/projects/plugins/jetpack/changelog/fix-touchmove-thru-overlay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fix allowing scrolling behind the modal when it is open on mobile devices

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -131,11 +131,15 @@ class SearchApp extends Component {
 	}
 
 	preventBodyScroll() {
+		document.body.style.position = 'fixed';
+		document.body.style.height = '100%';
 		document.body.style.overflowY = 'hidden';
 	}
 
 	restoreBodyScroll() {
-		document.body.style.overflowY = null;
+		document.body.style.position = '';
+		document.body.style.height = '';
+		document.body.style.overflowY = '';
 	}
 
 	getResultFormat = () => {
@@ -194,12 +198,13 @@ class SearchApp extends Component {
 		isVisible && this.initializeStaticFilters();
 
 		this.setState( { isVisible }, () => {
-			if ( isVisible ) {
-				this.preventBodyScroll();
-			} else {
-				// This codepath will only be executed in the Customizer.
-				this.restoreBodyScroll();
-			}
+			// if ( isVisible ) {
+			this.preventBodyScroll();
+			// window.scrollTo(0,0);
+			// } else {
+			// 	// This codepath will only be executed in the Customizer.
+			// 	this.restoreBodyScroll();
+			// }
 		} );
 	};
 

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -198,13 +198,12 @@ class SearchApp extends Component {
 		isVisible && this.initializeStaticFilters();
 
 		this.setState( { isVisible }, () => {
-			// if ( isVisible ) {
-			this.preventBodyScroll();
-			// window.scrollTo(0,0);
-			// } else {
-			// 	// This codepath will only be executed in the Customizer.
-			// 	this.restoreBodyScroll();
-			// }
+			if ( isVisible ) {
+				this.preventBodyScroll();
+			} else {
+				// This codepath will only be executed in the Customizer.
+				this.restoreBodyScroll();
+			}
 		} );
 	};
 


### PR DESCRIPTION
Fixes #20271 

#### Changes proposed in this Pull Request:
On desktop browsers, it works fine. But for mobile device, the touch events would bubble up to body. We could either disable touch events for body, or easier, jut set body not scroll-able, which is proposed in the PR.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with Jetpack Search subscription on iPad or iPhone
* Perform a search and try to scroll
* Ensure the document body in the background doesn't scroll

* Close the overlay
* Ensure the document could scroll normally


