### PR TITLE
Search: Fix overlay not scrolled to top on mobile

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-overlay-scroll-to-top-on-mobile
+++ b/projects/plugins/jetpack/changelog/fix-overlay-scroll-to-top-on-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fixed modal not scrolling to top when keyboard is opened on mobile devices

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -187,13 +187,8 @@ export default class DomEventHandler extends Component {
 		if ( event?.propertyName !== 'opacity' ) {
 			return;
 		}
-		// NOTE: IE11 doesn't support scrollTo. Manually set overlay element's scrollTop.
-		if ( window.scrollTo ) {
-			// @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
-			window.scrollTo( 0, 0 );
-		} else {
-			window.scrollTop = 0;
-		}
+		// @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
+		window?.scrollTo( 0, 0 );
 	};
 
 	render() {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -7,6 +7,11 @@ import { Component } from 'react';
 // eslint-disable-next-line lodash/import-scope
 import debounce from 'lodash/debounce';
 
+/**
+ * Internal dependencies
+ */
+import { OVERLAY_CLASS_NAME } from '../lib/constants';
+
 // This component is used primarily to bind DOM event handlers to elements outside of the Jetpack Search overlay.
 export default class DomEventHandler extends Component {
 	constructor() {
@@ -63,6 +68,10 @@ export default class DomEventHandler extends Component {
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.addEventListener( 'click', this.handleFilterInputClick );
 		} );
+
+		document.querySelectorAll( `.${ OVERLAY_CLASS_NAME }` ).forEach( element => {
+			element.addEventListener( 'transitionend', this.scrollOverlayToTop );
+		} );
 	}
 
 	removeEventListeners() {
@@ -82,6 +91,10 @@ export default class DomEventHandler extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.removeEventListener( 'click', this.handleFilterInputClick );
+		} );
+
+		document.querySelectorAll( `.${ OVERLAY_CLASS_NAME }` ).forEach( element => {
+			element.removeEventListener( 'transitionend', this.scrollOverlayToTop );
 		} );
 	}
 
@@ -166,6 +179,20 @@ export default class DomEventHandler extends Component {
 			// Don't do a falsy check; empty string is an allowed value.
 			typeof value === 'string' && this.props.setSearchQuery( value );
 			this.props.showResults();
+		}
+	};
+
+	scrollOverlayToTop = event => {
+		// NOTE: the propertyName need to be aligned with the animation
+		if ( event?.propertyName !== 'opacity' ) {
+			return;
+		}
+		// NOTE: IE11 doesn't support scrollTo. Manually set overlay element's scrollTop.
+		if ( window.scrollTo ) {
+			// @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
+			window.scrollTo( 0, 0 );
+		} else {
+			window.scrollTop = 0;
 		}
 	};
 


### PR DESCRIPTION
Fixes #19882 

#### Changes proposed in this Pull Request:
Scroll window to the top for the for the visibility of the search input. I guess the problem is the browser tries still to focus on the search input in the body (on the page), and when the search input is on the lower position, the search input on the overlay would be scrolled away. When the search input is on top of the page, it actually works fine.

So this PR basically brings back the scrollTo functionality but with different propertyName to listen on which based on what the overlay animation uses.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with Jetpack Search on iPad or iPhone and perform a search
* Ensure the search input of the overlay is visible

Like this,
![Simulator Screen Shot - iPad (8th generation) - 2021-08-13 at 13 44 21](https://user-images.githubusercontent.com/1425433/129293427-da83c941-84cf-4438-8eb2-20671a839067.png)


NOT like this,
![Simulator Screen Shot - iPad (8th generation) - 2021-08-13 at 13 45 32](https://user-images.githubusercontent.com/1425433/129293434-2183fb52-96cc-4d7c-be2c-2a4776b374af.png)

