### PR TITLE
GitHub actions: add pipe to allow for multiline script run

### DIFF
--- a/.github/files/gh-autotagger/workflows/autotagger.yml
+++ b/.github/files/gh-autotagger/workflows/autotagger.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check that the secret is set
         env:
           TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
-        run:
+        run: |
           if [[ -z "$TOKEN" ]]; then
             echo '::error::The secret API_TOKEN_GITHUB must be set.'
             exit 1

--- a/.github/files/gh-npmjs-autopublisher/workflows/npmjs-autopublisher.yml
+++ b/.github/files/gh-npmjs-autopublisher/workflows/npmjs-autopublisher.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check that the secret is set
         env:
           TOKEN: ${{ secrets.NPMJS_AUTOMATION_TOKEN }}
-        run:
+        run: |
           if [[ -z "$TOKEN" ]]; then
             echo '::error::The secret NPMJS_AUTOMATION_TOKEN must be set.'
             exit 1


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This was added in #20454 and #20455, but is causing issues when trying to run those actions in the mirror repos:

```
 [36;1mif [[ -z "$TOKEN" ]]; then echo '::error::The secret API_TOKEN_GITHUB must be set.' exit 1 fi[0m
 shell: /usr/bin/bash -e {0}
 env:
   TOKEN:
 line 2: syntax error: unexpected end of file
```

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Nothing will change in the monorepo, we'll only see the result in the mirror repos once we merge this.
