### PR TITLE
TT | 3471 | "Introduce allow-list and disallow-list for blocks."

### DIFF
--- a/projects/plugins/jetpack/extensions/editor.native.js
+++ b/projects/plugins/jetpack/extensions/editor.native.js
@@ -3,6 +3,5 @@
  */
 import './shared/block-category';
 
-// Register blocks
-import './blocks/contact-info/editor';
-import './blocks/story/editor';
+export const registerContactInfoBlock = () => require( './blocks/contact-info/editor' );
+export const registerStoryBlock = () => require( './blocks/story/editor' );


### PR DESCRIPTION
Updating the entry point for the registration of `jetpack/contact-info` and `jetpack/story` block types to export `register*Block` functions to allow for them to be conditionally registered independently of each other on demand instead of implicitly when this module is imported in `gutenberg-mobile`.

This is a supplementary change for the primary work being done in [gutenberg mobile #3811](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3811)

### Fixes
[Gutenberg Mobile Issue 3471](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3471)

Cc, @fluiddot