### PR TITLE
Carousel: fix issue with image quality

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-image-sizing-issue
+++ b/projects/plugins/jetpack/changelog/fix-carousel-image-sizing-issue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Apply the 2x of max image size to all images, not just those smaller than 1000px
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -935,13 +935,9 @@
 					// If we have a really large image load a smaller version
 					// that is closer to the viewable size
 					if ( args.origWidth > args.maxWidth || args.origHeight > args.maxHeight ) {
-						// If the image is smaller than 1000px in width or height, @2x it so
-						// we get a high enough resolution for zooming.
-						if ( args.origMaxWidth < 1000 || args.origMaxWidth < 1000 ) {
-							args.origMaxWidth = args.maxWidth * 2;
-							args.origMaxHeight = args.maxHeight * 2;
-						}
-
+						// @2x the max sizes so we get a high enough resolution for zooming.
+						args.origMaxWidth = args.maxWidth * 2;
+						args.origMaxHeight = args.maxHeight * 2;
 						origPhotonUrl += '?fit=' + args.origMaxWidth + '%2C' + args.origMaxHeight;
 					}
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Increase image max sizes for all images, not just those below 1000px to prevent reported issues with image quality when large images are downsized with photon. (issue reported at p9F6qB-7kv-p2)

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Check out PR in local dev and run with external domain name so jetpack can be fully connected
* Turn on image optimisation and carousel
* Upload a very hi res image to gallery, eg. 5000px/10MB + and view in Carousel and make sure resized quality is acceptable

Before:
image reduced from 10MB to 67KB
![Collingwood-Model-3-1-3-scaled before](https://user-images.githubusercontent.com/3629020/129497140-1fd198be-85fe-41b1-9ffa-efa064063b74.jpeg)

After:
Image reduced from 10MB to 531KB
![Collingwood-Model-3-1-3-scaled after](https://user-images.githubusercontent.com/3629020/129497158-dd71db10-e154-442e-8cf2-4b5908072490.jpeg)