### PR TITLE
Search: Fix dark mode label text colours being overridden

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-filter-label-darkmode
+++ b/projects/plugins/jetpack/changelog/fix-search-filter-label-darkmode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: fix label coloring in dark mode with some themes

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
@@ -61,6 +61,7 @@
 	.jetpack-instant-search__search-filter-list-label,
 	// Extra specific to override in some themes
 	.widget_search .jetpack-instant-search__search-filter-list-label {
+		color: inherit;
 		cursor: pointer;
 		display: inline-block;
 		font-weight: normal;


### PR DESCRIPTION
Fixes #20697 

#### Changes proposed in this Pull Request:

* Sets an inherited color setting for the search filter label text, so as not to be overridden by specific theme styles _(such as Flatsome)_ when in dark mode. Note: I went with `inherit` to be minimally invasive, but it would also be possible to set this with one of the `$color-text` variables if that would be preferable for any reason?

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Install and activate the Flatsome theme on a site with Instant Search enabled.

* From the **Customizer -> Jetpack Search** set the theme to dark mode

* Try searching and look at the color of the search filter label text to check for readability.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/129506471-cec7573f-3f39-4bf0-8aff-6eea6244e2dd.png) | ![image](https://user-images.githubusercontent.com/30754158/129506447-30c1d8d1-8b10-4126-9ac0-bb584882269f.png) |
