### PR TITLE
Make Beta Testing link appear on Atomic but not on P2

### DIFF
--- a/projects/plugins/jetpack/changelog/adjust-where-beta-testing-is-shown
+++ b/projects/plugins/jetpack/changelog/adjust-where-beta-testing-is-shown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Masterbar: show Beta Testing link on Atomic Sites and hide it on P2

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -461,6 +461,14 @@ class Admin_Menu extends Base_Admin_Menu {
 	}
 
 	/**
+	 * Adds Beta Testing link.
+	 */
+	public function add_beta_testing_menu() {
+		$icon = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxOCAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE1LjE5MDEgMTAuODU2N0MxNC45NTc0IDEwLjYyNCAxNC42NjExIDEwLjQ2NTQgMTQuMzM4NCAxMC40MDA4TDEyLjM0OTMgMTAuMDAzM0MxMS4yNTkgOS43ODUzIDEwLjEyNzEgOS45MzY5IDkuMTMyNjIgMTAuNDM0Mkw4Ljg2NzYxIDEwLjU2NThDNy44NzMxMiAxMS4wNjMxIDYuNzQxMjUgMTEuMjE0NyA1LjY1MDk1IDEwLjk5NjdMNC4wNDE3OCAxMC42NzVDMy43NzI3OCAxMC42MjEzIDMuNDk0NjggMTAuNjM0OCAzLjIzMjE0IDEwLjcxNDNDMi45Njk2MSAxMC43OTM4IDIuNzMwNzYgMTAuOTM2OSAyLjUzNjc4IDExLjEzMDhNNC42NjY3OCAxLjMzMzM0SDEzLjMzMzRMMTEuNTAwMSAyLjE2NjY4VjYuNDc2NjhDMTEuNTAwMiA2LjkxODY3IDExLjY3NTkgNy4zNDI1MiAxMS45ODg0IDcuNjU1MDFMMTYuMTU1MSAxMS44MjE3QzE3LjIwNTEgMTIuODcxNyAxNi40NjA5IDE0LjY2NjcgMTQuOTc1OSAxNC42NjY3SDMuMDIzNDVDMS41Mzg0NSAxNC42NjY3IDAuNzk1MTE2IDEyLjg3MTcgMS44NDUxMiAxMS44MjE3TDYuMDExNzggNy42NTUwMUM2LjMyNDM2IDcuMzQyNTIgNi41MDAwMiA2LjkxODY3IDYuNTAwMTEgNi40NzY2OFYyLjE2NjY4TDQuNjY2NzggMS4zMzMzNFoiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIgc3Ryb2tlLWxpbmVqb2luPSJiZXZlbCIvPgo8cmVjdCB4PSIxLjcyNzU0IiB5PSIxMC43MjczIiB3aWR0aD0iMTQuNTQ1NSIgaGVpZ2h0PSIzLjYzNjM2IiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K';
+		add_menu_page( 'beta-testing', __( 'Beta Testing', 'jetpack' ), 'manage_options', 'https://wordpress.com/beta-testing/' . $this->domain, null, $icon, null );
+	}
+
+	/**
 	 * Prepend a dashboard swithcer to the "Screen Options" box of the current page.
 	 * Callback for the 'screen_settings' filter (available in WP 3.0 and up).
 	 *

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -76,6 +76,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$this->add_new_site_link();
 		}
 
+		$this->add_beta_testing_menu();
+
 		ksort( $GLOBALS['menu'] );
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
@@ -142,6 +142,7 @@ class P2_Admin_Menu extends WPcom_Admin_Menu {
 		// The following menu items are hidden for both hubs and P2 sites.
 		remove_menu_page( 'link-manager.php' );
 		remove_menu_page( 'feedback' );
+		remove_menu_page( 'https://wordpress.com/beta-testing/' . $this->domain );
 		remove_menu_page( $this->plugins_slug );
 		remove_menu_page( 'https://wordpress.com/plugins/' . $this->domain );
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -358,14 +358,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
-	 * Adds Beta Testing link.
-	 */
-	public function add_beta_testing_menu() {
-		$icon = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxOCAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE1LjE5MDEgMTAuODU2N0MxNC45NTc0IDEwLjYyNCAxNC42NjExIDEwLjQ2NTQgMTQuMzM4NCAxMC40MDA4TDEyLjM0OTMgMTAuMDAzM0MxMS4yNTkgOS43ODUzIDEwLjEyNzEgOS45MzY5IDkuMTMyNjIgMTAuNDM0Mkw4Ljg2NzYxIDEwLjU2NThDNy44NzMxMiAxMS4wNjMxIDYuNzQxMjUgMTEuMjE0NyA1LjY1MDk1IDEwLjk5NjdMNC4wNDE3OCAxMC42NzVDMy43NzI3OCAxMC42MjEzIDMuNDk0NjggMTAuNjM0OCAzLjIzMjE0IDEwLjcxNDNDMi45Njk2MSAxMC43OTM4IDIuNzMwNzYgMTAuOTM2OSAyLjUzNjc4IDExLjEzMDhNNC42NjY3OCAxLjMzMzM0SDEzLjMzMzRMMTEuNTAwMSAyLjE2NjY4VjYuNDc2NjhDMTEuNTAwMiA2LjkxODY3IDExLjY3NTkgNy4zNDI1MiAxMS45ODg0IDcuNjU1MDFMMTYuMTU1MSAxMS44MjE3QzE3LjIwNTEgMTIuODcxNyAxNi40NjA5IDE0LjY2NjcgMTQuOTc1OSAxNC42NjY3SDMuMDIzNDVDMS41Mzg0NSAxNC42NjY3IDAuNzk1MTE2IDEyLjg3MTcgMS44NDUxMiAxMS44MjE3TDYuMDExNzggNy42NTUwMUM2LjMyNDM2IDcuMzQyNTIgNi41MDAwMiA2LjkxODY3IDYuNTAwMTEgNi40NzY2OFYyLjE2NjY4TDQuNjY2NzggMS4zMzMzNFoiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIgc3Ryb2tlLWxpbmVqb2luPSJiZXZlbCIvPgo8cmVjdCB4PSIxLjcyNzU0IiB5PSIxMC43MjczIiB3aWR0aD0iMTQuNTQ1NSIgaGVpZ2h0PSIzLjYzNjM2IiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K';
-		add_menu_page( 'beta-testing', __( 'Beta Testing', 'jetpack' ), 'manage_options', 'https://wordpress.com/beta-testing/' . $this->domain, null, $icon, null );
-	}
-
-	/**
 	 * Saves the sidebar state ( expanded / collapsed ) via an ajax request.
 	 */
 	public function ajax_sidebar_state() {


### PR DESCRIPTION
Summary:
This is a follow-up to D63456 where the Beta Testing link was added to WPCOM.
This diff includes the following:
- adds it to Atomic sites
- removes the link from P2 sites

Test Plan:
* Sandbox `[private link]`
* Apply this patch
* Go to a P2 page (ex. https://wordpress.com/home/[private link])
* Delete the calypso IndexedDB database to ensure the latest menu items will be shown
* There **should not** be Beta Testing link in the sidebar menu
{F8980610}

Testing for Atomic is a bit trickier:
* Set up an ephemeral site [[ https://[private link] | here ]] and connect it to your WordPress account
* You'll need ssh into the site and copy the changed files into `~/wp-content/plugins/jetpack/modules/masterbar/admin-menu`
* Go to the site's Calypso dashboard (ex. https://wordpress.com/home/ephemeral-claudiuthefilip-20210813.atomicsites.blog)
* Delete the calypso IndexedDB database to ensure the latest menu items will be shown
* There **should be** a Beta Testing link in the sidebar menu
{F8986598}

* Check that the link still appears for non-Atomic and non-P2 sites
* Check for related PHP errors

Reviewers: migueluy, undemian, danielwrobert

Reviewed By: danielwrobert

Tags: #touches_jetpack_files

Differential Revision: D65361-code

This commit syncs r230303-wpcom.

#### Changes proposed in this Pull Request:
- adds it to Atomic sites. This was mentioned in the initial PR (#20620) where the Link was added but only on Simple Sites.
- removes the link from P2 sites. This is from a request in P2 (3513-gh-Automattic/p2) to avoid showing Beta Testing on this platform.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- See D65361-code
