### PR TITLE
Lightweight HTML stories for component prototyping

### DIFF
--- a/projects/js-packages/base-styles/changelog/try-html-only-stories
+++ b/projects/js-packages/base-styles/changelog/try-html-only-stories
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Example story with a button

--- a/projects/js-packages/base-styles/stories/button.scss
+++ b/projects/js-packages/base-styles/stories/button.scss
@@ -1,0 +1,3 @@
+/**
+ * Custom SCSS goes here
+ */

--- a/projects/js-packages/base-styles/stories/button.stories.mdx
+++ b/projects/js-packages/base-styles/stories/button.stories.mdx
@@ -1,0 +1,29 @@
+import { Meta, Source, Story, Canvas } from '@storybook/addon-docs';
+import './button.scss';
+
+<Meta title="Examples/HTML" />
+
+# HTML-only story
+
+This is an example of a HTML-only story that a designer or front-end developer might use to establish the HTML
+and CSS structure to render an element properly.
+
+The file you are looking at lives in js-packages/base-styles/stories/button.stories.mdx. If you edit that file you will see your changes live.
+
+<Canvas>
+	<Story name="Plain button">
+		<button type="button" className="components-button is-small">Button</button>
+	</Story>
+</Canvas>
+
+<Canvas>
+	<Story name="Primary button">
+		<button type="button" className="components-button is-primary is-small">Primary Button</button>
+	</Story>
+</Canvas>
+
+<Canvas>
+	<Story name="Secondary button">
+		<button type="button" className="components-button is-secondary is-small">Secondary Button</button>
+	</Story>
+</Canvas>

--- a/projects/js-packages/storybook/changelog/try-html-only-stories
+++ b/projects/js-packages/storybook/changelog/try-html-only-stories
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for base-style stories

--- a/projects/js-packages/storybook/storybook/main.js
+++ b/projects/js-packages/storybook/storybook/main.js
@@ -12,6 +12,7 @@ const modulesDir = path.join( __dirname, '../node_modules' );
 const stories = [
 	process.env.NODE_ENV !== 'test' && './stories/**/*.@(js|jsx|mdx)',
 	path.join( modulesDir, '@automattic/jetpack-components/components/**/stories/*.@(js|jsx|mdx)' ),
+	path.join( modulesDir, '@automattic/jetpack-base-styles/stories/*.@(js|jsx|mdx)' ),
 ].filter( Boolean );
 
 const customEnvVariables = {};

--- a/projects/js-packages/storybook/storybook/stories/docs/howto.story.mdx
+++ b/projects/js-packages/storybook/storybook/stories/docs/howto.story.mdx
@@ -1,0 +1,66 @@
+import { Meta, Source, Story, Canvas } from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+
+<Meta title="Docs/HowTo" />
+
+# How to use this tool
+
+The Jetpack Components Library allows you to discover, test and live-edit Jetpack visual component.
+
+## Publish component stories
+
+Anywhere in a supported package, create one or more directories called `stories` (e.g. src/components/my-component/stories).
+
+In that directory, create an index.js or index.jsx file, like this:
+
+<Source
+	language='jsx'
+	code={dedent`
+		/**
+		 * Internal dependencies
+		 */
+		import MyComponent from '../index.jsx';
+		// the default export is metadata about the component
+		export default {
+			title: 'Components/My Component',
+		};
+		// the export called __default is the default state of the component
+		export const _default = () => {
+			return <MyComponent foo="bar"/>;
+		};
+	`}
+/>
+
+Or, create a file in MDX format, which combines docbook and "live" code:
+
+<Source
+	language='jsx'
+	code={dedent`
+		import { Meta, Source, Story, Canvas } from '@storybook/addon-docs';
+		import MyComponent from '../index.jsx';
+		<Meta title="Components/My Component"/>
+		# Some Title
+		export const Template = (args) => <MyComponent {...args} />
+		<Canvas>
+			<Story name="Example 1" args={{ label: 'foo' }}>
+				{Template.bind({})}
+			</Story>
+			<Story name="Example 2" args={{ label: 'bar' }}>
+				{Template.bind({})}
+			</Story>
+		</Canvas>
+	`}
+/>
+
+You can read more about writing stories in the [Storybook JS docs](https://storybook.js.org/docs/react/writing-stories/introduction)
+
+## Edit components live
+
+To run this locally, just run:
+
+```
+pnpm run storybook:dev
+```
+
+Any edits to SCSS, HTML, JSX or other files should be hot-loaded so you can see changes to styles or components.
+

--- a/projects/js-packages/storybook/storybook/style.scss
+++ b/projects/js-packages/storybook/storybook/style.scss
@@ -8,6 +8,7 @@
 @import "~@wordpress/base-styles/mixins";
 @import "~@wordpress/base-styles/variables";
 @import "~@wordpress/base-styles/z-index";
+@import "~@wordpress/base-styles/default-custom-properties";
 
 // @wordpress package styles
 @import "~@wordpress/components/src/style.scss";

--- a/projects/js-packages/storybook/storybook/webpack.config.js
+++ b/projects/js-packages/storybook/storybook/webpack.config.js
@@ -31,7 +31,11 @@ module.exports = ( { config } ) => {
 				},
 				'sass-loader',
 			],
-			include: [ path.resolve( __dirname ), path.join( __dirname, '../../components/components' ) ],
+			include: [
+				path.resolve( __dirname ),
+				path.join( __dirname, '../../components/components' ),
+				path.join( __dirname, '../../base-styles/stories' ),
+			],
 		}
 	);
 


### PR DESCRIPTION
Adds an example Storybook.JS story in the base-styles package to show how we can sketch out components in this way.

#### Changes proposed in this Pull Request:
* Add html-only storybook stories in the base-styles package

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

```
cd projects/js-packages/storybook
pnpm run storybook:dev
```

Confirm that there is an Example/HTML story present in the sidebar, and that it shows three button states.

<img width="1264" alt="html-only-story" src="https://user-images.githubusercontent.com/51896/129629457-34e1866b-a8de-4a44-9ac5-4eb31315d6bc.png">
