### PR TITLE
Boost: Explicit help for 418 errors

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/utils/describe-critical-css-recommendations.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/describe-critical-css-recommendations.ts
@@ -99,6 +99,12 @@ function httpErrorSuggestion( code: number, count: number ): string {
 				'jetpack-boost'
 			);
 
+		case 418:
+			return __(
+				'Your WordPress site returned a 418 error which many web hosts use to indicate they rejected your request due to security rules. Please contact your hosting provider for more information.',
+				'jetpack-boost'
+			);
+
 		case 500:
 			return _n(
 				'Your WordPress site encountered an error while trying to load the above page. Please check your server logs or contact your hosting provider for help to investigate the issue, and <retry>try again</retry>.',

--- a/projects/plugins/boost/changelog/add-critical-css-418-error
+++ b/projects/plugins/boost/changelog/add-critical-css-418-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added a message in case a 418 error occured during critical CSS generation


### PR DESCRIPTION
Fixes #20696

#### Changes proposed in this Pull Request:
Added a new HTTP error suggestion in case of 418 errors.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Force a 418 error (You can do it by targeting `$_GET['jb-generate-critical-css']` in an mu file). 
```
<?php
if ( ! empty( $_GET['jb-generate-critical-css' ] ) ) {
	if ( strpos( $_SERVER['REQUEST_URI'], 'sample-page' ) !== false ) {
		header("HTTP/1.0 418 I'm A Teapot");
		die();
	}
}
```
* Try to regenerate critical CSS and check the message.

#### Before
<img width="814" alt="Before" src="https://user-images.githubusercontent.com/3737780/129675508-328ffadc-1d43-4148-85c3-9599c173d89d.png">

#### After
<img width="808" alt="After" src="https://user-images.githubusercontent.com/3737780/129675436-7a7eff04-3bd3-47bd-bcb9-f8f7e14693a2.png">
