### PR TITLE
Remove `@composer update` from package test preconditions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Packages install
         run: |
           echo "::group::Packages"
-          jetpack install --all
+          pnpx jetpack install --all -v
           echo "::endgroup::"
 
       - name: Run project tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,12 @@ jobs:
           pnpm install
           echo "::endgroup::"
 
+      - name: Packages install
+        run: |
+          echo "::group::Packages"
+          jetpack install --all
+          echo "::endgroup::"
+
       - name: Run project tests
         env:
           CHANGED: ${{ steps.changed.outputs.projects }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,12 +139,6 @@ jobs:
           pnpm install
           echo "::endgroup::"
 
-      - name: Packages install
-        run: |
-          echo "::group::Packages"
-          pnpx jetpack install --all -v --exclude packages/analyzer
-          echo "::endgroup::"
-
       - name: Run project tests
         env:
           CHANGED: ${{ steps.changed.outputs.projects }}
@@ -183,6 +177,7 @@ jobs:
                 mkdir -p "coverage/$SLUG"
                 export COVERAGE_DIR="$GITHUB_WORKSPACE/coverage/$SLUG"
               fi
+              composer update
               FAIL=false
               if ! composer run --timeout=0 --working-dir="$DIR" "$TEST_SCRIPT"; then
                 FAIL=true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Packages install
         run: |
           echo "::group::Packages"
-          pnpx jetpack install --all -v
+          pnpx jetpack install --all -v --exclude packages/analyzer
           echo "::endgroup::"
 
       - name: Run project tests

--- a/projects/packages/a8c-mc-stats/changelog/try-remove-composer-update
+++ b/projects/packages/a8c-mc-stats/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/a8c-mc-stats/changelog/try-remove-composer-update
+++ b/projects/packages/a8c-mc-stats/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/a8c-mc-stats/composer.json
+++ b/projects/packages/a8c-mc-stats/composer.json
@@ -15,11 +15,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/abtest/changelog/try-remove-composer-update
+++ b/projects/packages/abtest/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/abtest/changelog/try-remove-composer-update
+++ b/projects/packages/abtest/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/abtest/composer.json
+++ b/projects/packages/abtest/composer.json
@@ -19,12 +19,10 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/assets/changelog/try-remove-composer-update
+++ b/projects/packages/assets/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/assets/changelog/try-remove-composer-update
+++ b/projects/packages/assets/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/assets/composer.json
+++ b/projects/packages/assets/composer.json
@@ -18,11 +18,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/autoloader/changelog/try-remove-composer-update
+++ b/projects/packages/autoloader/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/autoloader/changelog/try-remove-composer-update
+++ b/projects/packages/autoloader/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/autoloader/composer.json
+++ b/projects/packages/autoloader/composer.json
@@ -20,11 +20,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-php \"./tests/php/tmp/coverage-report.php\"",
 			"php ./tests/php/bin/test-coverage.php \"$COVERAGE_DIR/clover.xml\""
 		],

--- a/projects/packages/blocks/changelog/try-remove-composer-update
+++ b/projects/packages/blocks/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/blocks/changelog/try-remove-composer-update
+++ b/projects/packages/blocks/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/blocks/composer.json
+++ b/projects/packages/blocks/composer.json
@@ -17,12 +17,10 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/changelogger/changelog/try-remove-composer-update
+++ b/projects/packages/changelogger/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/changelogger/changelog/try-remove-composer-update
+++ b/projects/packages/changelogger/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/changelogger/composer.json
+++ b/projects/packages/changelogger/composer.json
@@ -30,11 +30,9 @@
 	],
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '1.2.0';
+	const VERSION = '1.2.1-alpha';
 
 	/**
 	 * Constructor.

--- a/projects/packages/codesniffer/changelog/try-remove-composer-update
+++ b/projects/packages/codesniffer/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/codesniffer/changelog/try-remove-composer-update
+++ b/projects/packages/codesniffer/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -24,11 +24,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": "./tests/action-test-php.sh"

--- a/projects/packages/connection/changelog/try-remove-composer-update
+++ b/projects/packages/connection/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/connection/changelog/try-remove-composer-update
+++ b/projects/packages/connection/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -31,12 +31,10 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/constants/changelog/try-remove-composer-update
+++ b/projects/packages/constants/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/constants/changelog/try-remove-composer-update
+++ b/projects/packages/constants/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/constants/composer.json
+++ b/projects/packages/constants/composer.json
@@ -16,11 +16,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/constants/tests/php/test-constants.php
+++ b/projects/packages/constants/tests/php/test-constants.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Constants;
 use Brain\Monkey;
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
 
@@ -95,11 +96,7 @@ class Test_Constants extends TestCase {
 	public function test_jetpack_constants_get_constant_null_when_not_set() {
 		$test_constant_name = 'UNDEFINED';
 
-		Functions\expect( 'apply_filters' )->once()->with(
-			'jetpack_constant_default_value',
-			null,
-			$test_constant_name
-		)->andReturn( null );
+		Filters\expectApplied( 'jetpack_constant_default_value' )->once()->with( null, $test_constant_name )->andReturn( null );
 
 		$actual_output = Constants::get_constant( $test_constant_name );
 
@@ -142,11 +139,7 @@ class Test_Constants extends TestCase {
 		$test_constant_name  = 'TEST_CONSTANT';
 		$test_constant_value = 'test value';
 
-		Functions\expect( 'apply_filters' )->once()->with(
-			'jetpack_constant_default_value',
-			null,
-			$test_constant_name
-		)->andReturn( $test_constant_value );
+		Filters\expectApplied( 'jetpack_constant_default_value' )->once()->with( null, $test_constant_name )->andReturn( $test_constant_value );
 
 		$actual_output = Constants::get_constant( $test_constant_name );
 

--- a/projects/packages/device-detection/changelog/try-remove-composer-update
+++ b/projects/packages/device-detection/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/device-detection/changelog/try-remove-composer-update
+++ b/projects/packages/device-detection/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/device-detection/composer.json
+++ b/projects/packages/device-detection/composer.json
@@ -15,11 +15,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/error/changelog/try-remove-composer-update
+++ b/projects/packages/error/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/error/changelog/try-remove-composer-update
+++ b/projects/packages/error/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/error/composer.json
+++ b/projects/packages/error/composer.json
@@ -15,11 +15,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/jitm/changelog/try-remove-composer-update
+++ b/projects/packages/jitm/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/jitm/changelog/try-remove-composer-update
+++ b/projects/packages/jitm/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -44,11 +44,9 @@
 			"pnpm run build"
 		],
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/lazy-images/changelog/try-remove-composer-update
+++ b/projects/packages/lazy-images/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/lazy-images/changelog/try-remove-composer-update
+++ b/projects/packages/lazy-images/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/lazy-images/composer.json
+++ b/projects/packages/lazy-images/composer.json
@@ -27,12 +27,10 @@
 			"pnpm run build"
 		],
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/licensing/changelog/try-remove-composer-update
+++ b/projects/packages/licensing/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/licensing/changelog/try-remove-composer-update
+++ b/projects/packages/licensing/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/licensing/composer.json
+++ b/projects/packages/licensing/composer.json
@@ -19,12 +19,10 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/logo/changelog/try-remove-composer-update
+++ b/projects/packages/logo/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/logo/changelog/try-remove-composer-update
+++ b/projects/packages/logo/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/logo/composer.json
+++ b/projects/packages/logo/composer.json
@@ -15,11 +15,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/partner/changelog/try-remove-composer-update
+++ b/projects/packages/partner/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/partner/changelog/try-remove-composer-update
+++ b/projects/packages/partner/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/partner/composer.json
+++ b/projects/packages/partner/composer.json
@@ -16,11 +16,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/password-checker/changelog/try-remove-composer-update
+++ b/projects/packages/password-checker/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/password-checker/changelog/try-remove-composer-update
+++ b/projects/packages/password-checker/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/password-checker/composer.json
+++ b/projects/packages/password-checker/composer.json
@@ -16,11 +16,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/redirect/changelog/try-remove-composer-update
+++ b/projects/packages/redirect/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/redirect/changelog/try-remove-composer-update
+++ b/projects/packages/redirect/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/redirect/composer.json
+++ b/projects/packages/redirect/composer.json
@@ -18,11 +18,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/roles/changelog/try-remove-composer-update
+++ b/projects/packages/roles/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/roles/changelog/try-remove-composer-update
+++ b/projects/packages/roles/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/roles/composer.json
+++ b/projects/packages/roles/composer.json
@@ -16,11 +16,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/status/changelog/try-remove-composer-update
+++ b/projects/packages/status/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/status/changelog/try-remove-composer-update
+++ b/projects/packages/status/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -16,11 +16,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/terms-of-service/changelog/try-remove-composer-update
+++ b/projects/packages/terms-of-service/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/terms-of-service/changelog/try-remove-composer-update
+++ b/projects/packages/terms-of-service/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/terms-of-service/composer.json
+++ b/projects/packages/terms-of-service/composer.json
@@ -19,11 +19,9 @@
 	},
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/projects/packages/tracking/changelog/try-remove-composer-update
+++ b/projects/packages/tracking/changelog/try-remove-composer-update
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: removed
 
 Remove composer update prior to test runs

--- a/projects/packages/tracking/changelog/try-remove-composer-update
+++ b/projects/packages/tracking/changelog/try-remove-composer-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove composer update prior to test runs

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -30,11 +30,9 @@
 	],
 	"scripts": {
 		"phpunit": [
-			"@composer update",
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],
 		"test-coverage": [
-			"@composer update",
 			"phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
 		],
 		"test-php": [

--- a/tools/cli/commands/install.js
+++ b/tools/cli/commands/install.js
@@ -21,16 +21,10 @@ import listrOpts from '../helpers/tasks/listrOpts';
 export async function install( argv ) {
 	argv = normalizeInstallArgv( argv );
 
-	const exclude = Array.isArray( argv.exclude ) ? argv.exclude : [ argv.exclude ];
-
 	let tasks = [];
 	if ( argv.all ) {
 		allProjects().forEach( item => {
 			argv.project = item;
-			if ( exclude.includes( item ) ) {
-				console.warn( `Skipping '${ item }' by user request` );
-				return;
-			}
 			tasks.push( installProjectTask( argv ) );
 		} );
 		// Reset.

--- a/tools/cli/commands/install.js
+++ b/tools/cli/commands/install.js
@@ -21,10 +21,16 @@ import listrOpts from '../helpers/tasks/listrOpts';
 export async function install( argv ) {
 	argv = normalizeInstallArgv( argv );
 
+	const exclude = Array.isArray( argv.exclude ) ? argv.exclude : [ argv.exclude ];
+
 	let tasks = [];
 	if ( argv.all ) {
 		allProjects().forEach( item => {
 			argv.project = item;
+			if ( exclude.includes( item ) ) {
+				console.warn( `Skipping '${ item }' by user request` );
+				return;
+			}
 			tasks.push( installProjectTask( argv ) );
 		} );
 		// Reset.


### PR DESCRIPTION
Running `composer update` takes 7-10 seconds on my machine. It was run before almost all our tests as a way of ensuring the software is up to date before running, but it's overkill, costing everyone lots of waiting around in return for saving one person 30 seconds occasionally.

This PR removes this check to see what breaks.

#### Changes proposed in this Pull Request:
* Only run composer update when necessary for tests to work in CI

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* `cd projects/packages/constants`
* `composer run phpunit`

This should execute in < 1 second, vs 8-11 seconds before.