### PR TITLE
Add instructions for downgrading composer

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -127,6 +127,16 @@ You'll need all the tools below to work in the Jetpack monorepo.
 		brew install composer
 		```
 
+		The latest composer in Homebrew at the time of writing is 2.1.x, but we currently require 2.0.x. If you need to downgrade to a specific version, we suggest these instructions:
+
+		```sh
+		brew tap-new $USER/local-composer
+		brew extract --version 2.0.14 composer $USER/local-composer
+		brew install composer@2.0.14
+		brew unlink composer # if you have 2.1 installed
+		brew link composer@2.0.14
+		```
+
 	 * ##### Installing Composer on other systems
 
 		We recommend visiting the [official Composer download instructions](https://getcomposer.org/download/) to install composer on other operating systems.
@@ -194,7 +204,7 @@ There are different types of builds:
 
 * ### Draft Mode
 	This is an experimental feature as of August 2021.
-	
+
 	Are pre-commit and pre-push hooks slowing down a major refactor or draft PR? Run `jetpack draft enable` to make them less aggressive (they will still run, but won't block for warnings), and `jetpack draft disable` when you're ready for them again.
 
 ---

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -130,11 +130,7 @@ You'll need all the tools below to work in the Jetpack monorepo.
 		The latest composer in Homebrew at the time of writing is 2.1.x, but we currently require 2.0.x. If you need to downgrade to a specific version, we suggest these instructions:
 
 		```sh
-		brew tap-new $USER/local-composer
-		brew extract --version 2.0.14 composer $USER/local-composer
-		brew install composer@2.0.14
-		brew unlink composer # if you have 2.1 installed
-		brew link composer@2.0.14
+		composer self-update 2.0.14
 		```
 
 	 * ##### Installing Composer on other systems


### PR DESCRIPTION
I kept getting plugin API version bumps in my generated composer files due to running 2.1.x instead of 2.0.x.

Then when I went to downgrade composer I couldn't find good instructions, so I created some.

#### Changes proposed in this Pull Request:
* Add instructions for downgrading Composer on Homebrew systems.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Update to composer 2.1.x by running `brew install composer@2.1` 
* Verify 2.1.x using `composer --version`
* Downgrade to composer 2.0.x by following the instructions in `docs/development-environment.md`
* Verify 2.0.x using `composer --version`