### PR TITLE
Search: Fix body scroll for overlay open/close

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mobile-page-scrolled-on-close
+++ b/projects/plugins/jetpack/changelog/fix-mobile-page-scrolled-on-close
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Search: fixed overlay is also scrolled to top on close
+Search: fixed body and overlay scroll position issue

--- a/projects/plugins/jetpack/changelog/fix-mobile-page-scrolled-on-close
+++ b/projects/plugins/jetpack/changelog/fix-mobile-page-scrolled-on-close
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fixed overlay is also scrolled to top on close

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -183,11 +183,13 @@ export default class DomEventHandler extends Component {
 	};
 
 	scrollOverlayToTop = event => {
-		// NOTE: the propertyName need to be aligned with the animation
-		if ( event?.propertyName !== 'opacity' ) {
+		// NOTE: the propertyName need to be aligned with the animation: instant-search/components/overlay.scss.
+		// We don't scroll the overlay on overlay close.
+		if ( event.propertyName !== 'opacity' || ! this.props.isVisible ) {
 			return;
 		}
-		// @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
+
+		// @see https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo
 		window?.scrollTo( 0, 0 );
 	};
 

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -188,6 +188,11 @@ export default class DomEventHandler extends Component {
 		}
 	};
 
+	/**
+	 * 1) When the overlay is open, we set body to fixed position.
+	 * 2) Body would be scrolled to top, so we need to set top to where the scroll position was.
+	 * 3) And we remember the body postition is `this.top`
+	 */
 	preventBodyScroll() {
 		this.top = parseInt( window.scrollY ) || 0;
 		/**
@@ -204,6 +209,11 @@ export default class DomEventHandler extends Component {
 		document.body.style.position = 'fixed';
 	}
 
+	/**
+	 * 1) Unset body fixed postion
+	 * 2) Scroll back to the position
+	 * 3) Reset `this.top` to `0`
+	 */
 	restoreBodyScroll() {
 		// Restore body scroll.
 		document.body.style.top = '';

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -17,7 +17,7 @@ export default class DomEventHandler extends Component {
 			// We toggle isComposing on compositionstart and compositionend events.
 			// (CJK = Chinese, Japanese, Korean; see https://en.wikipedia.org/wiki/CJK_characters)
 			isComposing: false,
-			// `bodyScrollTop` remebers the body scroll position.
+			// `bodyScrollTop` remembers the body scroll position.
 			bodyScrollTop: 0,
 			previousStyle: null,
 			previousBodyStyleAttribute: '',

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -215,7 +215,7 @@ export default class DomEventHandler extends Component {
 				 */
 				const scrollYOffset =
 					document.documentElement?.scrollHeight - document.body?.scrollHeight || 0;
-				// This is really important.
+				// This is really important - e.g. `twentytwenty` set an important style to body which we'd need to override.
 				// Make body not scrollable.
 				document.body.setAttribute( 'style', 'position: fixed !important' );
 

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -7,11 +7,6 @@ import { Component } from 'react';
 // eslint-disable-next-line lodash/import-scope
 import debounce from 'lodash/debounce';
 
-/**
- * Internal dependencies
- */
-import { OVERLAY_CLASS_NAME } from '../lib/constants';
-
 // This component is used primarily to bind DOM event handlers to elements outside of the Jetpack Search overlay.
 export default class DomEventHandler extends Component {
 	constructor() {
@@ -76,10 +71,6 @@ export default class DomEventHandler extends Component {
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.addEventListener( 'click', this.handleFilterInputClick );
 		} );
-
-		document.querySelectorAll( `.${ OVERLAY_CLASS_NAME }` ).forEach( element => {
-			element.addEventListener( 'transitionend', this.fixBodyScroll );
-		} );
 	}
 
 	removeEventListeners() {
@@ -99,10 +90,6 @@ export default class DomEventHandler extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.removeEventListener( 'click', this.handleFilterInputClick );
-		} );
-
-		document.querySelectorAll( `.${ OVERLAY_CLASS_NAME }` ).forEach( element => {
-			element.removeEventListener( 'transitionend', this.fixBodyScroll );
 		} );
 	}
 
@@ -191,9 +178,6 @@ export default class DomEventHandler extends Component {
 	};
 
 	fixBodyScroll = () => {
-		/**
-		 * The method could be called multiple times but we only want to run it once.
-		 */
 		if ( this.props.isVisible ) {
 			this.preventBodyScroll();
 			// This ensures the search input is visible on mobile devices.

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -191,7 +191,7 @@ export default class DomEventHandler extends Component {
 
 		if ( this.props.isVisible ) {
 			this.preventBodyScroll();
-			// This is to fix search input on the overlay is not visible on mobile devices.
+			// This ensures the search input is visible on mobile devices.
 			// @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
 			window?.scrollTo( 0, 0 );
 		} else {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -191,7 +191,7 @@ export default class DomEventHandler extends Component {
 	/**
 	 * 1) When the overlay is open, we set body to fixed position.
 	 * 2) Body would be scrolled to top, so we need to set top to where the scroll position was.
-	 * 3) And we remember the body postition is `this.top`
+	 * 3) And we remember the body postition in `this.top`
 	 */
 	preventBodyScroll() {
 		this.top = parseInt( window.scrollY ) || 0;
@@ -211,7 +211,7 @@ export default class DomEventHandler extends Component {
 
 	/**
 	 * 1) Unset body fixed postion
-	 * 2) Scroll back to the position
+	 * 2) Scroll back to the `this.top`
 	 * 3) Reset `this.top` to `0`
 	 */
 	restoreBodyScroll() {

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -199,7 +199,7 @@ export default class DomEventHandler extends Component {
 		 * For logged-in user, there's a WP Admin Bar which is made sticky by adding `margin-top` to the document (the old way of `position: sticky;`).
 		 * So we need to fix the offset of scrollY for fixed positioned body.
 		 */
-		const scrollYOffset = document.documentElement.scrollHeight - document.body.scrollHeight;
+		const scrollYOffset = document.documentElement?.scrollHeight - document.body?.scrollHeight || 0;
 		// Keep body at the same position when overlay is open.
 		document.body.style.top = `-${ this.top - scrollYOffset }px`;
 		// Make body in the center.

--- a/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/dom-event-handler.jsx
@@ -192,7 +192,7 @@ export default class DomEventHandler extends Component {
 	/**
 	 * 1) When the overlay is open, we set body to fixed position.
 	 * 2) Body would be scrolled to top, so we need to set top to where the scroll position was.
-	 * 3) And we remember the body postition in `this.state.bodyscrolltop`
+	 * 3) And we remember the body postition in `this.state.bodyScrollTop`
 	 */
 	preventBodyScroll() {
 		this.setState( { bodyScrollTop: parseInt( window.scrollY ) || 0 }, () => {
@@ -203,7 +203,7 @@ export default class DomEventHandler extends Component {
 			const scrollYOffset =
 				document.documentElement?.scrollHeight - document.body?.scrollHeight || 0;
 			// Keep body at the same position when overlay is open.
-			document.body.style.top = `-${ this.state.bodyscrolltop - scrollYOffset }px`;
+			document.body.style.top = `-${ this.state.bodyScrollTop - scrollYOffset }px`;
 			// Make body in the center.
 			document.body.style.left = 0;
 			document.body.style.right = 0;
@@ -214,8 +214,8 @@ export default class DomEventHandler extends Component {
 
 	/**
 	 * 1) Unset body fixed postion
-	 * 2) Scroll back to the `this.state.bodyscrolltop`
-	 * 3) Reset `this.state.bodyscrolltop` to `0`
+	 * 2) Scroll back to the `this.state.bodyScrollTop`
+	 * 3) Reset `this.state.bodyScrollTop` to `0`
 	 */
 	restoreBodyScroll() {
 		// Restore body scroll.
@@ -224,7 +224,7 @@ export default class DomEventHandler extends Component {
 		document.body.style.right = '';
 		document.body.style.position = '';
 		// Restore body position.
-		this.state.bodyscrolltop > 0 && window.scrollTo( 0, this.state.bodyscrolltop );
+		this.state.bodyScrollTop > 0 && window.scrollTo( 0, this.state.bodyScrollTop );
 		this.setState( { bodyScrollTop: 0 } );
 	}
 

--- a/projects/plugins/jetpack/modules/search/instant-search/components/overlay.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/overlay.scss
@@ -22,7 +22,6 @@ $overlay-horizontal-padding-lg: 3em;
 	overflow-x: hidden;
 	overflow-y: auto;
 
-	// If the animation is to be changed, please do change the `propertyName` in function `fixBodyScroll` too.
 	transition: opacity 0.1s ease-in;
 
 	z-index: 9999999999999;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/overlay.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/overlay.scss
@@ -22,7 +22,7 @@ $overlay-horizontal-padding-lg: 3em;
 	overflow-x: hidden;
 	overflow-y: auto;
 
-	// If the animation is to be changed, please do change the `propertyName` in function `scrollOverlayToTop` too.
+	// If the animation is to be changed, please do change the `propertyName` in function `fixBodyScroll` too.
 	transition: opacity 0.1s ease-in;
 
 	z-index: 9999999999999;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/overlay.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/overlay.scss
@@ -21,7 +21,8 @@ $overlay-horizontal-padding-lg: 3em;
 	opacity: 1;
 	overflow-x: hidden;
 	overflow-y: auto;
-	
+
+	// If the animation is to be changed, please do change the `propertyName` in function `scrollOverlayToTop` too.
 	transition: opacity 0.1s ease-in;
 
 	z-index: 9999999999999;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -120,10 +120,6 @@ class SearchApp extends Component {
 		}
 	}
 
-	componentWillUnmount() {
-		this.restoreBodyScroll();
-	}
-
 	initializeAnalytics() {
 		initializeTracks();
 		resetTrackingCookies();

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-app.jsx
@@ -130,18 +130,6 @@ class SearchApp extends Component {
 		identifySite( this.props.options.siteId );
 	}
 
-	preventBodyScroll() {
-		document.body.style.position = 'fixed';
-		document.body.style.height = '100%';
-		document.body.style.overflowY = 'hidden';
-	}
-
-	restoreBodyScroll() {
-		document.body.style.position = '';
-		document.body.style.height = '';
-		document.body.style.overflowY = '';
-	}
-
 	getResultFormat = () => {
 		// Override the result format from the query string if result_format= is specified
 		const resultFormatQuery = getResultFormatQuery();
@@ -178,7 +166,7 @@ class SearchApp extends Component {
 		if ( ! this.props.shouldIntegrateWithDom ) {
 			return;
 		}
-		this.restoreBodyScroll();
+
 		restorePreviousHref(
 			this.props.initialHref,
 			() => {
@@ -205,14 +193,7 @@ class SearchApp extends Component {
 		// If there are static filters available, but they are not part of the url/state, we will set their default value
 		isVisible && this.initializeStaticFilters();
 
-		this.setState( { isVisible }, () => {
-			if ( isVisible ) {
-				this.preventBodyScroll();
-			} else {
-				// This codepath will only be executed in the Customizer.
-				this.restoreBodyScroll();
-			}
-		} );
+		this.setState( { isVisible } );
 	};
 
 	showResults = this.toggleResults.bind( this, true );

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/constants.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/constants.js
@@ -7,7 +7,6 @@ export const MULTISITE_NO_GROUP_VALUE = '__NO_GROUP__';
 
 export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';
 export const OVERLAY_CLASS_NAME = 'jetpack-instant-search__overlay';
-export const WP_ADMIN_BAR_ID = 'wpadminbar';
 export const SORT_DIRECTION_ASC = 'ASC';
 export const SORT_DIRECTION_DESC = 'DESC';
 export const RESULT_FORMAT_EXPANDED = 'expanded';

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/constants.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/constants.js
@@ -7,6 +7,7 @@ export const MULTISITE_NO_GROUP_VALUE = '__NO_GROUP__';
 
 export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';
 export const OVERLAY_CLASS_NAME = 'jetpack-instant-search__overlay';
+export const WP_ADMIN_BAR_ID = 'wpadminbar';
 export const SORT_DIRECTION_ASC = 'ASC';
 export const SORT_DIRECTION_DESC = 'DESC';
 export const RESULT_FORMAT_EXPANDED = 'expanded';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR fixed an issue when user closes overlay the page scrolls to the top introduced by #20678. And it also includes some refactoring, which extracted some more dom integration functionalities.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with Jetpack Search subscription on mobile device
* Perform a search, make sure the search input is visible 
* Ensure the body in the background is not scrollable
* Ensure body is not scrolled to the top

* Close the overlay
* Ensure the page is not scrolled to the top

Known issue: if the overlay is triggered by submit, the search input on the page would lose focus after closing the overlay.
