### PR TITLE
Issue templates: remove extra link to security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Ask a support question
     url: http://jetpack.com/contact-support/
     about: This issue tracker is not for support. If you have questions about one of our plugins, you can contact us here.
-  - name: Security Policy guidelines
-    url: https://github.com/Automattic/jetpack/security/policy
-    about: Do not report potential security vulnerabilities here. For responsible disclosure of security issues and to be eligible for our bug bounty program, please review the guidelines here.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
﻿See discussion at https://github.com/Automattic/jetpack/pull/20726#issuecomment-900899508

#### Jetpack product discussion

No

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* This cannot be tested before merging, but this will basically remove the last item here:
https://github.com/Automattic/jetpack/issues/new/choose
