### PR TITLE
Related Posts: fix shortcode

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-shortcode
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Related Posts: fix issue with assets not loading for shortcode

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1656,19 +1656,6 @@ EOT;
 	}
 
 	/**
-	 * Determines if the scripts need be enqueued.
-	 *
-	 * @return bool
-	 */
-	protected function requires_scripts() {
-		return (
-			! ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) &&
-			! has_block( 'jetpack/related-posts' ) &&
-			! Blocks::is_fse_theme()
-		);
-	}
-
-	/**
 	 * Enqueues assets needed to do async loading of related posts.
 	 *
 	 * @uses wp_enqueue_script, wp_enqueue_style, plugins_url
@@ -1676,8 +1663,7 @@ EOT;
 	 */
 	protected function _enqueue_assets( $script, $style ) {
 		$dependencies = is_customize_preview() ? array( 'customize-base' ) : array();
-		// Do not enqueue scripts unless they are required.
-		if ( $script && $this->requires_scripts() ) {
+		if ( $script ) {
 			wp_enqueue_script(
 				'jetpack_related-posts',
 				Assets::get_file_url_for_environment(

--- a/projects/plugins/jetpack/modules/related-posts/related-posts.js
+++ b/projects/plugins/jetpack/modules/related-posts/related-posts.js
@@ -289,12 +289,8 @@
 	function startRelatedPosts() {
 		jprp.cleanupTrackedUrl();
 
-		var relatedPosts = document.querySelector( '#jp-relatedposts' );
-		if ( ! relatedPosts ) {
-			return;
-		}
-
 		var endpointURL = jprp.getEndpointURL();
+		var relatedPosts = document.querySelector( '#jp-relatedposts' );
 
 		if ( document.querySelectorAll( '#jp-relatedposts .jp-relatedposts-post' ).length ) {
 			afterPostsHaveLoaded();

--- a/projects/plugins/jetpack/modules/related-posts/related-posts.js
+++ b/projects/plugins/jetpack/modules/related-posts/related-posts.js
@@ -289,8 +289,12 @@
 	function startRelatedPosts() {
 		jprp.cleanupTrackedUrl();
 
-		var endpointURL = jprp.getEndpointURL();
 		var relatedPosts = document.querySelector( '#jp-relatedposts' );
+		if ( ! relatedPosts ) {
+			return;
+		}
+
+		var endpointURL = jprp.getEndpointURL();
 
 		if ( document.querySelectorAll( '#jp-relatedposts .jp-relatedposts-post' ).length ) {
 			afterPostsHaveLoaded();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
_The Problem_
 #20338 modifies the Related Posts feature to enqueue assets as early as possible, so that they can be dequeued by users who want to load in their own scripts. The scripts are only needed for the client-rendered version of the automatically inserted feature, and for the shortcode. To prevent console errors caused by the scripts being loaded when they're not needed, #20338 introduced a [method](https://github.com/Automattic/jetpack/blob/8f0818f661436c7e85cb525ed9393413cf8ed8e4/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php#L1663) to check when the scripts are required.

This method fails to account for the shortcode, so assets may not be enqueued, causing the shortcode to break.

_Solution_
This PR removes all attempts to check whether the script is required and just enqueues them no matter what. Instead it prevents the console errors within the script itself, by returning early if the `#jetpack-relatedposts` div is not present.

We do this because it's not possible at the time of asset enqueueing to know whether the shortcode is present, but if we move the enqueue step to later in the flow we would reintroduce the problem solved by #20338, where users are unable to dequeue.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

We should test all the ways the Related Posts feature can be inserted. Enable the feature via `Settings -> Reading` (or via the Jetpack settings on a Jetpack site) and make sure your test site has at least ten published posts.

**These changes include manual changes to the diff and are applied on top of the diff for #20338. To test wpcom, apply the D63970-code to your sandbox rather than syncing.**

In each case keep the console open and check for errors. **There should be no console errors if the script is loaded when it is not needed.**

* Enable an FSE theme such as TT1 blocks. View a post that does NOT contain the Related Posts block on the frontend. You should not see the feature added automatically.
* Edit the site in the site editor and add a Related Posts block to the single post template. View a post on the frontend and verify you can see the feature where you inserted it.
* Edit the post and add a Related Posts block. View on the frontend and verify you can see the block in the content, as well as the block from the template.
* Enable a non-FSE theme such as TT1. View the post on the frontend and verify you can see the block in the content, and the feature was not added automatically to the footer. **Pay special attention to console errors. If the code is working, you should not see the `Uncaught TypeError: Cannot read property 'hasAttribute' of null` error.**
* Remove the Related Posts block from the post and view on the frontend again. You should see the feature added automatically.
* On a non-FSE site, add the block via a shortcode (`[jetpack-related-posts]`) and verify that you see it on the frontend and that the feature is not added automatically.
* Test the shortcode on an FSE site as well.

To test dequeueing the script, I first verified I could see the related posts automatically being added to my Jurassic.tube site. Then I created and installed a minimal plugin for dequeuing, and verified that the Related Posts are no longer visible. 
* Verify that the Related posts div was still inserted into the page (open Inspector and find the `<div id="jp-relatedposts">`, but is empty (because the scripts that populate it were not loaded)
* Verify in the Inspector that the scripts were not loaded

Sample code for dequeueing:
```
<?php
/*
Plugin Name: My Test Plugin
*/
 
function wpdocs_dequeue_script() {
    wp_dequeue_script( 'jetpack_related-posts' );
}
add_action( 'wp_print_scripts', 'wpdocs_dequeue_script', 100 );
```
