### PR TITLE
required-review: Fix handling of multiple paths and negation

### DIFF
--- a/projects/github-actions/required-review/changelog/fix-required-reviews-multiple-paths-and-negation
+++ b/projects/github-actions/required-review/changelog/fix-required-reviews-multiple-paths-and-negation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+A negated pattern (other than the first) now removes previously-matched paths, rather than unexpectedly adding _all_ the paths that don't match the pattern.

--- a/projects/github-actions/required-review/package.json
+++ b/projects/github-actions/required-review/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "required-review",
-	"version": "2.1.0",
+	"version": "2.2.0-alpha",
 	"description": "Check that a PR has reviews from required teams.",
 	"main": "index.js",
 	"author": "Automattic",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Passing multiple path-patterns with some of the non-first patterns being
negated gave unexpected results. For example,

    paths:
      - '!a'
      - '!b'

would match everything including `a` and `b`, since the `!a` matches `b`
and the `!b` matches `a`.

What we want is for a non-first negated pattern to only exclude paths
that were matched by an earlier pattern, it should not add new paths.
That's the behavior already implied by README.md.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out this, then cherry pick #20749 too, then try `projects/github-actions/required-review/test.sh 20518` and examine the output to see that all the "Checking reviewers" in the output include "Members of heart-of-gold" as an option.