### PR TITLE
Search: Update Jetpack footer accessibility and layout

### DIFF
--- a/projects/js-packages/components/changelog/update-jp-footer-accessibility
+++ b/projects/js-packages/components/changelog/update-jp-footer-accessibility
@@ -1,4 +1,4 @@
-Significance: minor
-Type: changed
+Significance: patch
+Type: fixed
 
-Added accessibility label and adjusted footer style per design
+Added accessibility label and fixed footer style per design

--- a/projects/js-packages/components/changelog/update-jp-footer-accessibility
+++ b/projects/js-packages/components/changelog/update-jp-footer-accessibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added accessibility label and adjusted footer style per design

--- a/projects/js-packages/components/components/jetpack-footer/index.jsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.jsx
@@ -35,11 +35,12 @@ export default function JetpackFooter( {
 					showText={ false }
 					height="16"
 					className="jp-dashboard-footer__jetpack-symbol"
+					aria-label={ __( 'Jetpack Logo', 'jetpack' ) }
 				/>
 				<span className="jp-dashboard-footer__module-name">{ moduleName }</span>
 			</div>
 			<div className="jp-dashboard-footer__footer-right">
-				<a href={ a8cLogoHref }>
+				<a href={ a8cLogoHref } aria-label={ __( 'An Automattic Airline', 'jetpack' ) }>
 					<AutomatticBylineLogo />
 				</a>
 			</div>

--- a/projects/js-packages/components/components/jetpack-footer/index.jsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.jsx
@@ -35,7 +35,7 @@ export default function JetpackFooter( {
 					showText={ false }
 					height="16"
 					className="jp-dashboard-footer__jetpack-symbol"
-					aria-label={ __( 'Jetpack Logo', 'jetpack' ) }
+					aria-label={ __( 'Jetpack logo', 'jetpack' ) }
 				/>
 				<span className="jp-dashboard-footer__module-name">{ moduleName }</span>
 			</div>

--- a/projects/js-packages/components/components/jetpack-footer/style.scss
+++ b/projects/js-packages/components/components/jetpack-footer/style.scss
@@ -4,17 +4,9 @@
 	justify-content: space-between;
 	align-items: center;
 	width: 100%;
-	max-width: 65rem;
+	max-width: 1128px;
 
 	color: #000;
-
-	// Align with header.
-	@media ( max-width: 1250px ) {
-		width: 95%;
-	}
-	@media ( max-width: 480px ) {
-		justify-content: space-around;
-	}
 }
 .jp-dashboard-footer__module-name,
 .jp-dashboard-footer__jetpack-symbol {
@@ -23,4 +15,6 @@
 }
 .jp-dashboard-footer__module-name {
 	margin-left: 5px;
+	font-size: 12px;
+	font-weight: 600;
 }

--- a/projects/js-packages/components/components/jetpack-logo/index.jsx
+++ b/projects/js-packages/components/components/jetpack-logo/index.jsx
@@ -5,6 +5,11 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import classnames from 'classnames';
 
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 class JetpackLogo extends React.Component {
 	static propTypes = {
 		className: PropTypes.string,
@@ -35,7 +40,7 @@ class JetpackLogo extends React.Component {
 				aria-labelledby="jetpack-logo-title"
 				{ ...otherProps }
 			>
-				<title id="jetpack-logo-title">Jetpack Logo</title>
+				<title id="jetpack-logo-title">{ __( 'Jetpack Logo', 'jetpack' ) }</title>
 				<path
 					fill={ logoColor }
 					d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"

--- a/projects/js-packages/components/components/jetpack-logo/index.jsx
+++ b/projects/js-packages/components/components/jetpack-logo/index.jsx
@@ -32,8 +32,10 @@ class JetpackLogo extends React.Component {
 				y="0px"
 				viewBox={ viewBox }
 				className={ classnames( 'jetpack-logo', className ) }
+				aria-labelledby="jetpack-logo-title"
 				{ ...otherProps }
 			>
+				<title id="jetpack-logo-title">Jetpack Logo</title>
 				<path
 					fill={ logoColor }
 					d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"


### PR DESCRIPTION
Partially Fixes #20734

#### Changes proposed in this Pull Request:
Changes footer max width according to RNA design. Added accessibility label for Jetpack Logo.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Go to a site with Jetpack Search subscription, enter URL directly: `/wp-admin/admin.php?page=jetpack-search`
- Ensure Jetpack Logo in footer has aria-labelledby attribute
- Ensure the footer aligns with the rest of the page
- Ensure `Jetpack Search` text in the footer font weight 600, font size 12px

![image](https://user-images.githubusercontent.com/1425433/129980046-e39c8d82-220b-4a5c-b7a7-d93c09f90a83.png)
