### PR TITLE
Search: fix search widget not saving for block widget editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-widget-not-saving-for-block-editor
+++ b/projects/plugins/jetpack/changelog/fix-widget-not-saving-for-block-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fixed search widgets not saving for block widget editor

--- a/projects/plugins/jetpack/modules/widgets/search.php
+++ b/projects/plugins/jetpack/modules/widgets/search.php
@@ -686,18 +686,18 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @return array - The widget instance of JP search format.
 	 */
 	protected function maybe_new_block_widget_to_jp_search_format( $new_instance ) {
-		if ( isset( $new_instance['filter_type'] ) || ! is_array( $new_instance['filters'] ) ) {
+		if ( isset( $new_instance['filter_type'] ) || ! isset( $new_instance['filters'] ) || ! is_array( $new_instance['filters'] ) ) {
 			return $new_instance;
 		}
 
 		$instance = $new_instance;
 		foreach ( $new_instance['filters'] as $filter ) {
-			$instance['filter_type'][]             = $filter['type'];
-			$instance['taxonomy_type'][]           = $filter['taxonomy'];
-			$instance['filter_name'][]             = $filter['name'];
-			$instance['num_filters'][]             = $filter['count'];
-			$instance['date_histogram_field'][]    = $filter['field'];
-			$instance['date_histogram_interval'][] = $filter['interval'];
+			$instance['filter_type'][]             = isset( $filter['type'] ) ? $filter['type'] : '';
+			$instance['taxonomy_type'][]           = isset( $filter['type'] ) ? $filter['taxonomy'] : '';
+			$instance['filter_name'][]             = isset( $filter['type'] ) ? $filter['name'] : '';
+			$instance['num_filters'][]             = isset( $filter['type'] ) ? $filter['count'] : 5;
+			$instance['date_histogram_field'][]    = isset( $filter['type'] ) ? $filter['field'] : '';
+			$instance['date_histogram_interval'][] = isset( $filter['type'] ) ? $filter['interval'] : '';
 		}
 		unset( $instance['filters'] );
 		return $instance;

--- a/projects/plugins/jetpack/modules/widgets/search.php
+++ b/projects/plugins/jetpack/modules/widgets/search.php
@@ -624,7 +624,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @return array Settings to save.
 	 */
 	public function update( $new_instance, $old_instance ) {
-		$new_instance = $this->maybe_new_block_widget_to_jp_search_format( $new_instance );
+		$new_instance = $this->maybe_reformat_widget( $new_instance );
 		$instance     = array();
 
 		$instance['title']              = sanitize_text_field( $new_instance['title'] );
@@ -679,7 +679,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Reformats the widget instance array to one that is recognized by the `update` function. 
+	 * Reformats the widget instance array to one that is recognized by the `update` function.
 	 * This is only necessary when handling changes from the block-based widget editor.
 	 *
 	 * @param array $widget_instance - Jetpack Search widget instance.
@@ -687,12 +687,12 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @return array - Potentially reformatted instance compatible with the save function.
 	 */
 	protected function maybe_reformat_widget( $widget_instance ) {
-		if ( isset( $new_instance['filter_type'] ) || ! isset( $new_instance['filters'] ) || ! is_array( $new_instance['filters'] ) ) {
-			return $new_instance;
+		if ( isset( $widget_instance['filter_type'] ) || ! isset( $widget_instance['filters'] ) || ! is_array( $widget_instance['filters'] ) ) {
+			return $widget_instance;
 		}
 
-		$instance = $new_instance;
-		foreach ( $new_instance['filters'] as $filter ) {
+		$instance = $widget_instance;
+		foreach ( $widget_instance['filters'] as $filter ) {
 			$instance['filter_type'][]             = isset( $filter['type'] ) ? $filter['type'] : '';
 			$instance['taxonomy_type'][]           = isset( $filter['taxonomy'] ) ? $filter['taxonomy'] : '';
 			$instance['filter_name'][]             = isset( $filter['name'] ) ? $filter['name'] : '';

--- a/projects/plugins/jetpack/modules/widgets/search.php
+++ b/projects/plugins/jetpack/modules/widgets/search.php
@@ -7,9 +7,8 @@
  * @since      5.0.0
  */
 
-use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
 
 add_action( 'widgets_init', 'jetpack_search_widget_init' );
@@ -138,7 +137,9 @@ class Jetpack_Search_Widget extends WP_Widget {
 		);
 
 		wp_localize_script(
-			'jetpack-search-widget-admin', 'jetpack_search_filter_admin', array(
+			'jetpack-search-widget-admin',
+			'jetpack_search_filter_admin',
+			array(
 				'defaultFilterCount' => self::DEFAULT_FILTER_COUNT,
 				'tracksUserData'     => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 				'tracksEventData'    => array(
@@ -238,7 +239,8 @@ class Jetpack_Search_Widget extends WP_Widget {
 
 	public function jetpack_search_populate_defaults( $instance ) {
 		$instance = wp_parse_args(
-			(array) $instance, array(
+			(array) $instance,
+			array(
 				'title'              => '',
 				'search_box_enabled' => true,
 				'user_sort_enabled'  => true,
@@ -287,7 +289,8 @@ class Jetpack_Search_Widget extends WP_Widget {
 						<?php esc_html_e( 'Jetpack Search not supported in Offline Mode', 'jetpack' ); ?>
 					</label>
 				</div>
-			</div><?php
+			</div>
+			<?php
 			echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return;
 		}
@@ -370,7 +373,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		}
 
 		if ( ! empty( $instance['search_box_enabled'] ) && ! empty( $instance['user_sort_enabled'] ) ) :
-				?>
+			?>
 					<div class="jetpack-search-sort-wrapper">
 				<label>
 					<?php esc_html_e( 'Sort by', 'jetpack' ); ?>
@@ -383,7 +386,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 					</select>
 				</label>
 			</div>
-		<?php
+			<?php
 		endif;
 
 		if ( $display_filters ) {
@@ -521,7 +524,6 @@ class Jetpack_Search_Widget extends WP_Widget {
 		echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
-
 	/**
 	 * Renders JavaScript for the sorting controls on the frontend.
 	 *
@@ -542,7 +544,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		}
 
 		if ( ! empty( $instance['user_sort_enabled'] ) ) :
-		?>
+			?>
 		<script type="text/javascript">
 			var jetpackSearchModuleSorting = function() {
 				var orderByDefault = '<?php echo 'date' === $orderby ? 'date' : 'relevance'; ?>',
@@ -585,7 +587,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 				document.addEventListener( 'DOMContentLoaded', jetpackSearchModuleSorting );
 			}
 			</script>
-		<?php
+			<?php
 		endif;
 	}
 
@@ -622,7 +624,8 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @return array Settings to save.
 	 */
 	public function update( $new_instance, $old_instance ) {
-		$instance = array();
+		$new_instance = $this->maybe_new_block_widget_to_jp_search_format( $new_instance );
+		$instance     = array();
 
 		$instance['title']              = sanitize_text_field( $new_instance['title'] );
 		$instance['search_box_enabled'] = empty( $new_instance['search_box_enabled'] ) ? '0' : '1';
@@ -672,6 +675,31 @@ class Jetpack_Search_Widget extends WP_Widget {
 			$instance['filters'] = $filters;
 		}
 
+		return $instance;
+	}
+
+	/**
+	 * Covert the format of new widget to search widget format when appropriate.
+	 *
+	 * @param array $new_instance - The updated widget instance.
+	 *
+	 * @return array - The widget instance of JP search format.
+	 */
+	protected function maybe_new_block_widget_to_jp_search_format( $new_instance ) {
+		if ( isset( $new_instance['filter_type'] ) || ! is_array( $new_instance['filters'] ) ) {
+			return $new_instance;
+		}
+
+		$instance = $new_instance;
+		foreach ( $new_instance['filters'] as $filter ) {
+			$instance['filter_type'][]             = $filter['type'];
+			$instance['taxonomy_type'][]           = $filter['taxonomy'];
+			$instance['filter_name'][]             = $filter['name'];
+			$instance['num_filters'][]             = $filter['count'];
+			$instance['date_histogram_field'][]    = $filter['field'];
+			$instance['date_histogram_interval'][] = $filter['interval'];
+		}
+		unset( $instance['filters'] );
 		return $instance;
 	}
 
@@ -896,7 +924,8 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 */
 	public function render_widget_edit_filter( $filter, $is_template = false ) {
 		$args = wp_parse_args(
-			$filter, array(
+			$filter,
+			array(
 				'name'      => '',
 				'type'      => 'taxonomy',
 				'taxonomy'  => '',
@@ -1022,6 +1051,6 @@ class Jetpack_Search_Widget extends WP_Widget {
 				<a href="#" class="delete"><?php esc_html_e( 'Remove', 'jetpack' ); ?></a>
 			</p>
 		</div>
-	<?php
+		<?php
 	}
 }

--- a/projects/plugins/jetpack/modules/widgets/search.php
+++ b/projects/plugins/jetpack/modules/widgets/search.php
@@ -693,11 +693,11 @@ class Jetpack_Search_Widget extends WP_Widget {
 		$instance = $new_instance;
 		foreach ( $new_instance['filters'] as $filter ) {
 			$instance['filter_type'][]             = isset( $filter['type'] ) ? $filter['type'] : '';
-			$instance['taxonomy_type'][]           = isset( $filter['type'] ) ? $filter['taxonomy'] : '';
-			$instance['filter_name'][]             = isset( $filter['type'] ) ? $filter['name'] : '';
-			$instance['num_filters'][]             = isset( $filter['type'] ) ? $filter['count'] : 5;
-			$instance['date_histogram_field'][]    = isset( $filter['type'] ) ? $filter['field'] : '';
-			$instance['date_histogram_interval'][] = isset( $filter['type'] ) ? $filter['interval'] : '';
+			$instance['taxonomy_type'][]           = isset( $filter['taxonomy'] ) ? $filter['taxonomy'] : '';
+			$instance['filter_name'][]             = isset( $filter['name'] ) ? $filter['name'] : '';
+			$instance['num_filters'][]             = isset( $filter['count'] ) ? $filter['count'] : 5;
+			$instance['date_histogram_field'][]    = isset( $filter['field'] ) ? $filter['field'] : '';
+			$instance['date_histogram_interval'][] = isset( $filter['interval'] ) ? $filter['interval'] : '';
 		}
 		unset( $instance['filters'] );
 		return $instance;

--- a/projects/plugins/jetpack/modules/widgets/search.php
+++ b/projects/plugins/jetpack/modules/widgets/search.php
@@ -679,13 +679,14 @@ class Jetpack_Search_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Covert the format of new widget to search widget format when appropriate.
+	 * Reformats the widget instance array to one that is recognized by the `update` function. 
+	 * This is only necessary when handling changes from the block-based widget editor.
 	 *
-	 * @param array $new_instance - The updated widget instance.
+	 * @param array $widget_instance - Jetpack Search widget instance.
 	 *
-	 * @return array - The widget instance of JP search format.
+	 * @return array - Potentially reformatted instance compatible with the save function.
 	 */
-	protected function maybe_new_block_widget_to_jp_search_format( $new_instance ) {
+	protected function maybe_reformat_widget( $widget_instance ) {
 		if ( isset( $new_instance['filter_type'] ) || ! isset( $new_instance['filters'] ) || ! is_array( $new_instance['filters'] ) ) {
 			return $new_instance;
 		}


### PR DESCRIPTION
Fixes #20755 

#### Changes proposed in this Pull Request:
The problem is that for the block widget editor, the frontend passed the widget instance in another format (I would say a better format) the same as how the widget is saved in the db, but unfortunately our search widget save function only deals with its own format. 

| New  | Old |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1425433/130009367-75b3c5ef-168f-4b18-894d-2a2d3af8665d.png) | ![image](https://user-images.githubusercontent.com/1425433/130009486-5fe12a20-cdfb-4f5a-a094-795900f399db.png)|


The PR proposes a function to convert the format to the the format which Jetpack Search could consume.

We could potentially change the search widget form format, but that would require quite a few changes, and would likely break if not tested thoroughly. And also the widget is a legacy one, we'll probably create a block one in the future, so we'd better not put too much time in it.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Add a Jetpack Search widget to the Jetpack Search Sidebar area using the _NEW_ widget editor.
* Add filters to the widget from.
* Save your changes.
* Refresh the page.
* Ensure filter options stick.

-------------
* Disable the new widget editor by adding `add_filter( 'use_widgets_block_editor', '__return_false' );`
* Add a Jetpack Search widget to the Jetpack Search Sidebar area using the _OLD_ widget editor.
* Add filters to the widget from.
* Save your changes.
* Refresh the page.
* Ensure filter options stick.