### PR TITLE
CLI: Warn before cleaning a checked-in composer.lock

### DIFF
--- a/tools/cli/commands/clean.js
+++ b/tools/cli/commands/clean.js
@@ -223,18 +223,38 @@ async function collectAllFiles( toClean, argv ) {
 
 	// If we want to clean up a checked in composer.lock file, ls-files won't work and we have to filter the files manually.
 	if ( toClean.includes( 'composer.lock' ) && argv.project.startsWith( 'projects/plugins' ) ) {
-		let composerLockFiles = child_process.execSync(
-			`git -c core.quotepath=off ls-files projects/plugins/*/composer.lock`
+		console.log(
+			chalk.black.bgYellow(
+				' Deleting a checked-in composer.lock file is probably not what you want to do! '
+			)
 		);
-		composerLockFiles = composerLockFiles.toString().trim().split( '\n' );
+		console.log(
+			chalk.yellow(
+				`It's likely you want to use \`tools/composer-update-monorepo.sh --root-reqs ${
+					argv.project === 'projects/plugins' ? argv.project + '/[name]' : argv.project
+				}\` instead.`
+			)
+		);
+		const response = await inquirer.prompt( {
+			type: 'confirm',
+			name: 'confirm',
+			message: 'Delete checked in composer.lock files anyway?',
+			default: false,
+		} );
+		if ( response.confirm ) {
+			let composerLockFiles = child_process.execSync(
+				`git -c core.quotepath=off ls-files projects/plugins/*/composer.lock`
+			);
+			composerLockFiles = composerLockFiles.toString().trim().split( '\n' );
 
-		if ( argv.project !== 'projects/plugins' ) {
-			composerLockFiles = composerLockFiles.filter( file => {
-				return file === `${ argv.project }/composer.lock`;
-			} );
+			if ( argv.project !== 'projects/plugins' ) {
+				composerLockFiles = composerLockFiles.filter( file => {
+					return file === `${ argv.project }/composer.lock`;
+				} );
+			}
+
+			allFiles.composerLock.push( ...composerLockFiles );
 		}
-
-		allFiles.composerLock.push( ...composerLockFiles );
 	}
 
 	for ( const file of allFiles.combined ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Chances are they really want to use `tools/composer-update-monorepo.sh`,
so point them in that direction.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1629214200024600/1628610161.316400-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test 1:

* Run `jetpack clean` and choose a plugin.
* Choose the option to delete `composer.lock`.
* See that it prompts you to confirm, with a suggestion to use `tools/composer-update-monorepo.sh` instead.

Test 2:

* Run `jetpack clean plugins composer.lock`.
* See that it prompts you to confirm, with a suggestion to use `tools/composer-update-monorepo.sh` instead.