### PR TITLE
Carousel: fix element null ref

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-null-ref
+++ b/projects/plugins/jetpack/changelog/fix-carousel-null-ref
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Carousel: fix element null reference
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -775,8 +775,8 @@
 
 			// If the comment/info section is toggled open, it's kept open, but scroll to top of the next slide.
 			if (
-				infoIcon.classList.contains( 'jp-carousel-selected' ) ||
-				commentsIcon.classList.contains( 'jp-carousel-selected' )
+				( infoIcon && infoIcon.classList.contains( 'jp-carousel-selected' ) ) ||
+				( commentsIcon && commentsIcon.classList.contains( 'jp-carousel-selected' ) )
 			) {
 				if ( carousel.overlay.scrollTop !== 0 ) {
 					domUtil.scrollToElement( carousel.overlay, carousel.overlay );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* The `commentsIcon` may be null if user has "Show comments area in carousel" option turned off, so check that the element reference is not null first.

#### Jetpack product discussion:

Internal: p1629487288195100-slack-CB0B2G43X

Patch already applied to wpcom: r230597-wpcom

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Apply changes, and in `/wp-admin/options-media.php` make sure the carousel is enabled, but `Show comments area in carousel` is turned off.
* Open a gallery and make sure you don't receive any JS errors, and that the carousel functions as expected.