### PR TITLE
storybook: Change build dir to make GH happy

### DIFF
--- a/projects/js-packages/storybook/.gitattributes
+++ b/projects/js-packages/storybook/.gitattributes
@@ -10,4 +10,4 @@ node_modules      export-ignore
 /storybook/**     production-exclude
 
 # Files to include in the mirror repo
-/storybook/build/**  production-include -production-exclude
+/docs/**          production-include

--- a/projects/js-packages/storybook/.gitignore
+++ b/projects/js-packages/storybook/.gitignore
@@ -1,3 +1,3 @@
-vendor/
-node_modules/
-build/
+/vendor/
+/node_modules/
+/docs/

--- a/projects/js-packages/storybook/changelog/fix-storybook-in-mirror-repo
+++ b/projects/js-packages/storybook/changelog/fix-storybook-in-mirror-repo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+GH only allows pages to be in `/` or `/docs`, so build to `/docs`.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -22,7 +22,7 @@
 		"distclean": "rm -rf node_modules && pnpm run clean",
 		"install-if-deps-outdated": "pnpm install --no-prod --frozen-lockfile",
 		"validate-es5": "eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore",
-		"storybook:build": "build-storybook -c ./storybook -o ./storybook/build",
+		"storybook:build": "build-storybook -c ./storybook -o ./docs",
 		"dev:packages": "echo 'TODO dev:packages'",
 		"storybook:dev": "concurrently \"pnpm run dev:packages\" \"start-storybook -c ./storybook -p 50240\""
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
GH only allows pages to be in `/` or `/docs`, so build to `/docs`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See #20778

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the jetpack-build artifact produced by the "Build" workflow. See that Automattic/jetpack-storybook is present in the archive, with the appropriate contents.
* Merge this, wait for the publish, configure Pages in the mirror repo, and see that the content shows properly at https://automattic.github.io/jetpack-storybook/.
