### PR TITLE
update versions in annotations

### DIFF
--- a/projects/packages/constants/changelog/update-small-packages-annotations
+++ b/projects/packages/constants/changelog/update-small-packages-annotations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated versions in annotations

--- a/projects/packages/constants/src/class-constants.php
+++ b/projects/packages/constants/src/class-constants.php
@@ -80,7 +80,7 @@ class Constants {
 		/**
 		 * Filters the value of the constant.
 		 *
-		 * @since 8.5.0
+		 * @since 1.2.0
 		 *
 		 * @param null The constant value to be filtered. The default is null.
 		 * @param String $name The constant name.

--- a/projects/packages/device-detection/changelog/update-small-packages-annotations
+++ b/projects/packages/device-detection/changelog/update-small-packages-annotations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated versions in annotations

--- a/projects/packages/device-detection/src/class-device-detection.php
+++ b/projects/packages/device-detection/src/class-device-detection.php
@@ -52,7 +52,6 @@ class Device_Detection {
 			 * Filter the value of Device_Detection::get_info.
 			 *
 			 * @since 1.0.0
-			 * @since-jetpack 8.7.0
 			 *
 			 * @param array           $info    Array of device information.
 			 * @param string          $ua      User agent string passed to Device_Detection::get_info.

--- a/projects/packages/device-detection/src/class-device-detection.php
+++ b/projects/packages/device-detection/src/class-device-detection.php
@@ -51,7 +51,8 @@ class Device_Detection {
 			/**
 			 * Filter the value of Device_Detection::get_info.
 			 *
-			 * @since  8.7.0
+			 * @since 1.0.0
+			 * @since-jetpack 8.7.0
 			 *
 			 * @param array           $info    Array of device information.
 			 * @param string          $ua      User agent string passed to Device_Detection::get_info.

--- a/projects/packages/heartbeat/changelog/update-small-packages-annotations
+++ b/projects/packages/heartbeat/changelog/update-small-packages-annotations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated versions in annotations

--- a/projects/packages/heartbeat/src/class-heartbeat.php
+++ b/projects/packages/heartbeat/src/class-heartbeat.php
@@ -18,7 +18,8 @@ class Heartbeat {
 	/**
 	 * Holds the singleton instance of this class
 	 *
-	 * @since 2.3.3
+	 * @since 1.0.0
+	 * @since-jetpack 2.3.3
 	 * @var Heartbeat
 	 */
 	private static $instance = false;
@@ -33,7 +34,8 @@ class Heartbeat {
 	/**
 	 * Singleton
 	 *
-	 * @since 2.3.3
+	 * @since 1.0.0
+	 * @since-jetpack 2.3.3
 	 * @static
 	 * @return Heartbeat
 	 */
@@ -48,7 +50,8 @@ class Heartbeat {
 	/**
 	 * Constructor for singleton
 	 *
-	 * @since 2.3.3
+	 * @since 1.0.0
+	 * @since-jetpack 2.3.3
 	 */
 	private function __construct() {
 
@@ -75,7 +78,8 @@ class Heartbeat {
 	/**
 	 * Method that gets executed on the wp-cron call
 	 *
-	 * @since 2.3.3
+	 * @since 1.0.0
+	 * @since-jetpack 2.3.3
 	 * @global string $wp_version
 	 */
 	public function cron_exec() {

--- a/projects/packages/licensing/changelog/update-small-packages-annotations
+++ b/projects/packages/licensing/changelog/update-small-packages-annotations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated versions in annotations

--- a/projects/packages/licensing/src/class-licensing.php
+++ b/projects/packages/licensing/src/class-licensing.php
@@ -16,7 +16,7 @@ use WP_Error;
  * Class Licensing.
  * Helper class that is responsible for attaching licenses to the current site.
  *
- * @since 9.0.0
+ * @since 1.1.1
  */
 class Licensing {
 	/**
@@ -236,14 +236,14 @@ class Licensing {
 	/**
 	 * Is the current user allowed to use the Licensing Input UI?
 	 *
-	 * @since 9.6.0
+	 * @since 1.4.0
 	 * @return bool
 	 */
 	public static function is_licensing_input_enabled() {
 		/**
 		 * Filter that checks if the user is allowed to see the Licensing UI. `true` enables it.
 		 *
-		 * @since 9.6.0
+		 * @since 1.4.0
 		 *
 		 * @param bool False by default.
 		 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

This PR updates the package annotation to match them with the package verison instead of the Jetpack version.

When the annotation refers to a feature that existed before the package was created we are going to change it to the first released version of the package and add a new annotation (eg. `@since-jetpack`) to register when this was first added to the Jetpack plugin

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the annotation versions to match the package version

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-3cJ-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Look at the code
* Check if the versions changed match the conversion table in p9dueE-3cJ-p2
