### PR TITLE
Bugfix/20687 sites listed from other networks

### DIFF
--- a/projects/plugins/jetpack/changelog/bugfix-20687-sites-listed-from-other-networks
+++ b/projects/plugins/jetpack/changelog/bugfix-20687-sites-listed-from-other-networks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+In mutlti-site, list sites will show based on current network id

--- a/projects/plugins/jetpack/class.jetpack-network-sites-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-network-sites-list-table.php
@@ -30,6 +30,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 				'site__not_in' => array( get_current_blog_id() ),
 				'archived'     => false,
 				'number'       => 0,
+
 			)
 		);
 

--- a/projects/plugins/jetpack/class.jetpack-network-sites-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-network-sites-list-table.php
@@ -30,7 +30,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 				'site__not_in' => array( get_current_blog_id() ),
 				'archived'     => false,
 				'number'       => 0,
-
+				'network_id'   => get_current_network_id(),
 			)
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #20687
Closes #20687

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* I have added `network_id => get_current_network_id() argument` as a part of changes. https://github.com/Automattic/jetpack/blob/f8969425fdf4fe2aa08a797ea86d321238436ba4/projects/plugins/jetpack/class.jetpack-network-sites-list-table.php#L28-L33

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use? NO
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup (or find) a multi-network Multisite installation (e.g., wordpress.org)
* Visit https://example.org/wp-admin/network/admin.php?page=jetpack
* Visit https://sub-network.example.org/wp-admin/network/admin.php?page=jetpack
* We should not see other sites after making changes.

cc: @jeherve 
