### PR TITLE
No need for a versioned dep from js-tools to eslint-changed

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,7 +845,7 @@ importers:
 
   tools/js-tools:
     specifiers:
-      '@automattic/eslint-changed': workspace:1.0.1
+      '@automattic/eslint-changed': workspace:*
       '@babel/core': 7.14.6
       '@babel/eslint-parser': 7.14.5
       '@octokit/auth-token': 2.4.5

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -10,7 +10,7 @@
 		"sort-package-json": "sort-package-json"
 	},
 	"devDependencies": {
-		"@automattic/eslint-changed": "workspace:1.0.1",
+		"@automattic/eslint-changed": "workspace:*",
 		"@babel/core": "7.14.6",
 		"@babel/eslint-parser": "7.14.5",
 		"@octokit/auth-token": "2.4.5",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We always want the monorepo version, and js-tools is private so no need
to really declare the dep.

This will avoid a repeat of the need for #20688.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1628868885472200/1628868742.471100-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Change the version in `projects/js-packages/eslint-changed/package.json` to something like "2.0.0".
* Run `pnpm install`. It should work without error.