### PR TITLE
Custom CSS: Remove placeholder text to sync with wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-custom-css-placeholder-text
+++ b/projects/plugins/jetpack/changelog/remove-custom-css-placeholder-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove Custom CSS placeholder text to stay in sync with wpcom. The placeholder was only displaying on Simple Sites.

--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -629,29 +629,6 @@ class Jetpack_Custom_CSS {
 
 		$css = str_replace( array( '\\\00BB \\\0020', '\0BB \020', '0BB 020' ), '\00BB \0020', $css );
 
-		if ( empty( $css ) ) {
-			$css = "/*\n"
-				. wordwrap(
-					/**
-					 * Filter the default message displayed in the Custom CSS editor.
-					 *
-					 * @module custom-css
-					 *
-					 * @since 1.7.0
-					 *
-					 * @param string $str Default Custom CSS editor content.
-					 */
-					apply_filters(
-						'safecss_default_css',
-						__(
-							"Welcome to Custom CSS!\n\nTo learn how this works, see https://wp.me/PEmnE-Bt",
-							'jetpack'
-						)
-					)
-				)
-				. "\n*/";
-		}
-
 		/**
 		 * Filter the Custom CSS returned from the editor.
 		 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes placeholder text from the Custom CSS module. This change was already made on wpcom as part of other changes to align the "Additional CSS" area on Simple Sites with Jetpack/Atomic: r230650-wpcom
This text was not previously visible on Jetpack sites.
<img width="321" alt="screen-shot-2021-08-20-at-1 31 43-pm" src="https://user-images.githubusercontent.com/1689238/130512540-861d75d6-14dc-44d3-a932-605c5c252374.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

I was notified when commiting D65448-code

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Appearance > Additional CSS or the Customizer > Additional CSS
* Check that there is no change and the area works as expected.
* Go to Jetpack > Settings > Writing and enable the Jetpack module:
<img width="1049" alt="Screen Shot 2021-08-24 at 12 15 16 PM" src="https://user-images.githubusercontent.com/1689238/130663704-a9f213f6-dc8c-47a1-9608-aeb6fa6185b6.png">
* Check that additional options show up and work as expected.
