### PR TITLE
Changelogger: Add Example to Prompt if Adding to Plugin

### DIFF
--- a/projects/packages/changelogger/changelog/add-cli-changelog-example
+++ b/projects/packages/changelogger/changelog/add-cli-changelog-example
@@ -1,0 +1,4 @@
+Significance: major
+Type: added
+
+Adds additional formatting suggestions if the changelogger is being adde to a plugin.

--- a/projects/packages/changelogger/src/AddCommand.php
+++ b/projects/packages/changelogger/src/AddCommand.php
@@ -266,10 +266,15 @@ EOF
 			// Determine the changelog entry and add to the file contents.
 			$entry = $input->getOption( 'entry' );
 			if ( $isInteractive ) {
-				if ( 'patch' === $significance ) {
-					$question = new Question( "Changelog entry. Please use the format 'Feature: Description' e.g. 'Stats: Fixes funny errors.' \nMay be left empty if this change is particularly insignificant.\n > ", (string) $entry );
+				if ( str_contains( getcwd(), '/projects/plugins/' ) ) {
+					$formatNeeded = "Please use the format 'Feature: Description' e.g. 'Stats: Fixes funny errors.'\n";
 				} else {
-					$question = new Question( "Changelog entry. May not be empty. \nPlease use the format 'Feature: Description' e.g. 'Stats: Fixes funny errors.' \n > ", $entry );
+					$formatNeeded = '';
+				}
+				if ( 'patch' === $significance ) {
+						$question = new Question( 'Changelog entry.' . $formatNeeded . "May be left empty if this change is particularly insignificant.\n > ", (string) $entry );
+				} else {
+					$question = new Question( "Changelog entry. May not be empty. \n" . $formatNeeded . ' > ', $entry );
 					$question->setValidator(
 						function ( $v ) {
 							if ( trim( $v ) === '' ) {

--- a/projects/packages/changelogger/src/AddCommand.php
+++ b/projects/packages/changelogger/src/AddCommand.php
@@ -266,6 +266,7 @@ EOF
 			// Determine the changelog entry and add to the file contents.
 			$entry = $input->getOption( 'entry' );
 			if ( $isInteractive ) {
+				// Additional formatting info if we're adding the changelog to a plugin.
 				if ( str_contains( getcwd(), '/projects/plugins/' ) ) {
 					$formatNeeded = "Please use the format 'Feature: Description' e.g. 'Stats: Fixes funny errors.'\n";
 				} else {

--- a/projects/packages/changelogger/src/AddCommand.php
+++ b/projects/packages/changelogger/src/AddCommand.php
@@ -267,9 +267,9 @@ EOF
 			$entry = $input->getOption( 'entry' );
 			if ( $isInteractive ) {
 				if ( 'patch' === $significance ) {
-					$question = new Question( "Changelog entry. May be left empty if this change is particularly insignificant.\n > ", (string) $entry );
+					$question = new Question( "Changelog entry. Please use the format 'Feature: Description' e.g. 'Stats: Fixes funny errors.' \nMay be left empty if this change is particularly insignificant.\n > ", (string) $entry );
 				} else {
-					$question = new Question( "Changelog entry. May not be empty.\n > ", $entry );
+					$question = new Question( "Changelog entry. May not be empty. \nPlease use the format 'Feature: Description' e.g. 'Stats: Fixes funny errors.' \n > ", $entry );
 					$question->setValidator(
 						function ( $v ) {
 							if ( trim( $v ) === '' ) {

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -636,7 +636,8 @@ async function promptChangelog( argv, needChangelog ) {
 		{
 			type: 'string',
 			name: 'entry',
-			message: 'Changelog entry. May be left empty if this change is particularly insignificant.',
+			message:
+				'Changelog entry. Please use the format "Feature: Description" e.g. "Stats: Fixes funny errors." \nMay be left empty if this change is particularly insignificant.',
 			when: answers => answers.significance === 'patch',
 		},
 		{
@@ -649,7 +650,8 @@ async function promptChangelog( argv, needChangelog ) {
 		{
 			type: 'string',
 			name: 'entry',
-			message: 'Changelog entry. May not be empty.',
+			message:
+				'Changelog entry. May not be empty!. \nPlease use the format "Feature: Description" e.g. "Stats: Fixes funny errors."\n',
 			when: answers => answers.significance === 'minor' || 'major',
 			validate: input => {
 				if ( ! input || ! input.trim() ) {

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -565,7 +565,6 @@ async function promptVersion( argv ) {
  */
 async function checkForPlugin( projects ) {
 	for ( const proj of projects ) {
-		console.log( proj );
 		if ( proj.startsWith( 'plugins/' ) ) {
 			return 'Please use the format "Feature: Description" e.g. "Stats: Fixes funny errors." \n';
 		}

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -558,6 +558,22 @@ async function promptVersion( argv ) {
 }
 
 /**
+ * Checks if we're adding a changelog file to a plugin.
+ *
+ * @param {Array} projects - Projects that need a changelog.
+ * @returns {string} what we want to add.
+ */
+async function checkForPlugin( projects ) {
+	for ( const proj of projects ) {
+		console.log( proj );
+		if ( proj.startsWith( 'plugins/' ) ) {
+			return 'Please use the format "Feature: Description" e.g. "Stats: Fixes funny errors." \n';
+		}
+	}
+	return '';
+}
+
+/**
  * Prompts for changelog options.
  *
  * @param {object} argv - the arguments passed.
@@ -568,6 +584,7 @@ async function promptChangelog( argv, needChangelog ) {
 	const git = simpleGit();
 	const gitStatus = await git.status();
 	const gitBranch = gitStatus.current.replace( /\//g, '-' );
+	const formatPrompt = await checkForPlugin( needChangelog );
 
 	const commands = await inquirer.prompt( [
 		{
@@ -637,7 +654,9 @@ async function promptChangelog( argv, needChangelog ) {
 			type: 'string',
 			name: 'entry',
 			message:
-				'Changelog entry. Please use the format "Feature: Description" e.g. "Stats: Fixes funny errors." \nMay be left empty if this change is particularly insignificant.',
+				'Changelog entry. ' +
+				formatPrompt +
+				'May be left empty if this change is particularly insignificant.\n',
 			when: answers => answers.significance === 'patch',
 		},
 		{
@@ -650,8 +669,7 @@ async function promptChangelog( argv, needChangelog ) {
 		{
 			type: 'string',
 			name: 'entry',
-			message:
-				'Changelog entry. May not be empty!. \nPlease use the format "Feature: Description" e.g. "Stats: Fixes funny errors."\n',
+			message: 'Changelog entry. May not be empty! \n' + formatPrompt,
 			when: answers => answers.significance === 'minor' || 'major',
 			validate: input => {
 				if ( ! input || ! input.trim() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When we format the changelog file for a plugin release, we format them in the form of "Feature: Description". This PR nudges the user to format the changelog in that manner to encourage people to standardize changelog entries.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the changelogger for a plugin. You should see the prompt on how we would like the changelog formatted.
* Run the prompt for another project, like a package. The prompt shouldn't appear. 

Do we need to standardize anything for packages instead? 

