### PR TITLE
When computing the is_coming_soon flag on Atomic site, detect if ETK is disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-jsnajdr-r230729-wpcom-1629890303
+++ b/projects/plugins/jetpack/changelog/fusion-sync-jsnajdr-r230729-wpcom-1629890303
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Added support for editing_toolkit_is_active site option

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -146,6 +146,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'signup_is_store',
 		'has_pending_automated_transfer',
 		'woocommerce_is_active',
+		'editing_toolkit_is_active',
 		'design_type',
 		'site_goals',
 		'site_segment',
@@ -177,6 +178,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_atomic',
 		'is_wpcom_store',
 		'woocommerce_is_active',
+		'editing_toolkit_is_active',
 		'frame_nonce',
 		'jetpack_frame_nonce',
 		'design_type',
@@ -627,6 +629,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'woocommerce_is_active':
 					$options[ $key ] = $site->woocommerce_is_active();
+					break;
+				case 'editing_toolkit_is_active':
+					$options[ $key ] = $site->editing_toolkit_is_active();
 					break;
 				case 'design_type':
 					$options[ $key ] = $site->get_design_type();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -184,6 +184,10 @@ abstract class SAL_Site {
 		return false;
 	}
 
+	public function editing_toolkit_is_active() {
+		return true;
+	}
+
 	public function is_cloud_eligible() {
 		return false;
 	}


### PR DESCRIPTION
Syncing the D65864-code diff from wpcom to Jetpack. Original diff summary:

> This patch moves logic for displaying a "Coming Soon" badge for Atomic sites and setting the "Coming Soon" privacy option in settings from Calypso to server.
>
> The `is_coming_soon` flag for Atomic sites is now true only when the ETK plugin is not disabled. Calypso did this additional check by downloading the list of active plugins through REST API. Now the `is_coming_soon` value is correct right from the server.
>
> This patch also adds a new `editing_toolkit_is_active` site option that Calypso uses to show or hide a "Coming Soon" privacy option in settings. The implementation is a straightforward copy of `woocommerce_is_active` which also checks if a plugin is active on an Atomic site.

On the Jetpack site itself, the `editing_toolkit_is_active` flag will always be `true` no matter what the actual status of the ETK plugin is. Only wpcom servers read the real value from the shadow data. The `woocommerce_is_active` flag behaves similarly -- always `false` even if Woo is active -- so I guess it's OK and this sync PR is just a formality.

Differential Revision: D65864-code
This commit syncs r230729-wpcom.

#### Testing instructions:
The wpcom change has a companion Calypso PR at https://github.com/Automattic/wp-calypso/pull/55681, but the Jetpack version of the patch is basically a noop.
