### PR TITLE
Disable plugin updater test

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-disable-updater-test
+++ b/projects/plugins/jetpack/changelog/e2e-disable-updater-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+E2E tests: temporarily disable plugin updater test

--- a/projects/plugins/jetpack/tests/e2e/.eslintrc.js
+++ b/projects/plugins/jetpack/tests/e2e/.eslintrc.js
@@ -29,5 +29,6 @@ module.exports = {
 		'arrow-parens': [ 0, 'as-needed' ],
 		'no-console': 0,
 		'jsdoc/check-tag-names': [ 'error', { definedTags: [ 'group' ] } ],
+		'jest/no-disabled-tests': 0,
 	},
 };

--- a/projects/plugins/jetpack/tests/e2e/specs/plugin-updater.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/plugin-updater.test.js
@@ -49,7 +49,7 @@ describe( 'Jetpack updater', () => {
 		await DashboardPage.visit( page );
 	} );
 
-	it( 'Plugin updater', async () => {
+	it.skip( 'Plugin updater', async () => {
 		await testStep( 'Can login and navigate to Plugins page', async () => {
 			await ( await Sidebar.init( page ) ).selectInstalledPlugins();
 			await PluginsPage.init( page );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Temporarily disable plugin updater test until it can be brought to a more stable version.

#### Jetpack product discussion
pd5faL-1m-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* E2e test pass
* Plugin updater test is skipped