### PR TITLE
CLI Generate: Add release-branch-prefix automatically to plugins

### DIFF
--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -353,10 +353,16 @@ async function createComposerJson( composerJson, answers ) {
 		// Since we're catching an errors here, it'll continue executing.
 	}
 
-	if ( answers.type === 'package' ) {
-		composerJson.extra = composerJson.extra || {};
-		composerJson.extra[ 'branch-alias' ] = composerJson.extra[ 'branch-alias' ] || {};
-		composerJson.extra[ 'branch-alias' ][ 'dev-master' ] = '0.1.x-dev';
+	switch ( answers.type ) {
+		case 'package':
+			composerJson.extra = composerJson.extra || {};
+			composerJson.extra[ 'branch-alias' ] = composerJson.extra[ 'branch-alias' ] || {};
+			composerJson.extra[ 'branch-alias' ][ 'dev-master' ] = '0.1.x-dev';
+			break;
+		case 'plugin':
+			composerJson.extra = composerJson.extra || {};
+			composerJson.extra[ 'release-branch-prefix' ] = answers.name;
+			break;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

See https://github.com/Automattic/jetpack/pull/20811/commits/1115d089a1f77aa6d9a88922bb2a3eb697ce9294

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Automatically adds the "release-branch-prefix" to composer.json for plugins generated via the CLI.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `jetpack generate plugin` and confirm that composer.json now has `extra.release-branch-prefix`
