### PR TITLE
Remove unnecessary use of `prettier` on JSON data

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -60,7 +60,7 @@ for SLUG in "${SLUGS[@]}"; do
 	# That allows us to pick up the built version for plugins like Jetpack.
 	# Also save the old contents to restore post-build to help with local testing.
 	OLDJSON=$(<composer.json)
-	JSON=$(jq --argjson repo "$REPO" '( .repositories // [] | map( .options.monorepo or false ) | index(true) ) as $i | if $i != null then .repositories[$i:$i] |= [ $repo ] else . end' composer.json | "$BASE/tools/prettier" --parser=json-stringify)
+	JSON=$(jq --tab --argjson repo "$REPO" '( .repositories // [] | map( .options.monorepo or false ) | index(true) ) as $i | if $i != null then .repositories[$i:$i] |= [ $repo ] else . end' composer.json)
 	if [[ "$JSON" != "$OLDJSON" ]]; then
 		echo "$JSON" > composer.json
 		if [[ -e "composer.lock" ]]; then
@@ -185,14 +185,14 @@ for SLUG in "${SLUGS[@]}"; do
 		xargs cp --parents --target-directory="$BUILD_DIR"
 
 	# Remove monorepo repos from composer.json
-	JSON=$(jq 'if .repositories then .repositories |= map( select( .options.monorepo | not ) ) else . end' "$BUILD_DIR/composer.json" | "$BASE/tools/prettier" --parser=json-stringify)
+	JSON=$(jq --tab 'if .repositories then .repositories |= map( select( .options.monorepo | not ) ) else . end' "$BUILD_DIR/composer.json")
 	if [[ "$JSON" != "$(<"$BUILD_DIR/composer.json")" ]]; then
 		echo "$JSON" > "$BUILD_DIR/composer.json"
 	fi
 
 	# Remove engines from package.json
 	if [[ -e "$BUILD_DIR/package.json" ]]; then
-		JSON=$(jq 'if .publish_engines then .engines = .publish_engines | .publish_engines |= empty else .engines |= empty end' "$BUILD_DIR/package.json" | "$BASE/tools/prettier" --parser=json-stringify)
+		JSON=$(jq --tab 'if .publish_engines then .engines = .publish_engines | .publish_engines |= empty else .engines |= empty end' "$BUILD_DIR/package.json")
 		if [[ "$JSON" != "$(<"$BUILD_DIR/package.json")" ]]; then
 			echo "$JSON" > "$BUILD_DIR/package.json"
 		fi

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -155,7 +155,7 @@ for SLUG in "${SLUGS[@]}"; do
 		JSFILE="projects/$SLUG/package.json"
 	fi
 	if $UPDATE; then
-		JSON=$(jq --argjson packages "$PACKAGES" -r 'def ver(e): if $packages[e.key] then if e.value[0:1] == "^" then $packages[e.key][1] else null end // $packages[e.key][0] else e.value end; if .require then .require |= with_entries( .value = ver(.) ) else . end | if .["require-dev"] then .["require-dev"] |= with_entries( .value = ver(.) ) else . end' "$PHPFILE" | tools/prettier --parser=json-stringify)
+		JSON=$(jq --tab --argjson packages "$PACKAGES" -r 'def ver(e): if $packages[e.key] then if e.value[0:1] == "^" then $packages[e.key][1] else null end // $packages[e.key][0] else e.value end; if .require then .require |= with_entries( .value = ver(.) ) else . end | if .["require-dev"] then .["require-dev"] |= with_entries( .value = ver(.) ) else . end' "$PHPFILE")
 		if [[ "$JSON" != "$(<"$PHPFILE")" ]]; then
 			info "PHP dependencies of $SLUG changed!"
 			echo "$JSON" > "$PHPFILE"
@@ -167,7 +167,7 @@ for SLUG in "${SLUGS[@]}"; do
 			fi
 		fi
 		if [[ -e "$JSFILE" ]]; then
-			JSON=$(jq --argjson packages "$JSPACKAGES" -r 'def ver(e): if $packages[e.key] then if e.value[0:1] == "^" then $packages[e.key][1] else null end // $packages[e.key][0] else e.value end; def proc(k): if .[k] then .[k] |= with_entries( .value = ver(.) ) else . end; proc("dependencies") | proc("devDependencies") | proc("peerDependencies") | proc("optionalDependencies")' "$JSFILE" | tools/prettier --parser=json-stringify)
+			JSON=$(jq --tab --argjson packages "$JSPACKAGES" -r 'def ver(e): if $packages[e.key] then if e.value[0:1] == "^" then $packages[e.key][1] else null end // $packages[e.key][0] else e.value end; def proc(k): if .[k] then .[k] |= with_entries( .value = ver(.) ) else . end; proc("dependencies") | proc("devDependencies") | proc("peerDependencies") | proc("optionalDependencies")' "$JSFILE")
 			if [[ "$JSON" != "$(<"$JSFILE")" ]]; then
 				info "JS dependencies of $SLUG changed!"
 				echo "$JSON" > "$JSFILE"

--- a/tools/cleanup-excludelists.sh
+++ b/tools/cleanup-excludelists.sh
@@ -15,11 +15,11 @@ trap "rm \"$TEMP\"" EXIT
 : > "$TEMP"
 pnpm run lint-file -- --max-warnings=0 --format=json --output-file="$TEMP" $(for f in $(jq -r '.[]' tools/eslint-excludelist.json); do [[ -e "$f" ]] && echo $f; done) || true
 [[ -s "$TEMP" ]] && jq -e '.' < "$TEMP" >/dev/null || die "No JSON data found"
-jq -r --arg pwd "$PWD/" '[ .[] | select( .messages[0] ) | .filePath | ltrimstr($pwd) ] | sort' "$TEMP" | tools/prettier --parser=json > tools/eslint-excludelist.json
+jq --tab -r --arg pwd "$PWD/" '[ .[] | select( .messages[0] ) | .filePath | ltrimstr($pwd) ] | sort' "$TEMP" > tools/eslint-excludelist.json
 
 : > "$TEMP"
 composer phpcs:lint -- -m --file-list=<(for f in $(jq -r '.[]' tools/phpcs-excludelist.json); do [[ -e "$f" ]] && echo $f; done) --report=json --report-file="$TEMP" || true
 [[ -s "$TEMP" ]] && jq -e '.' < "$TEMP" >/dev/null || die "No JSON data found"
-jq -r --arg pwd "$PWD/" '[ .files | to_entries | .[] | select( .value.errors > 0 or .value.warnings > 0 ) | .key | ltrimstr($pwd) ] | sort' "$TEMP" | tools/prettier --parser=json > tools/phpcs-excludelist.json
+jq --tab -r --arg pwd "$PWD/" '[ .files | to_entries | .[] | select( .value.errors > 0 or .value.warnings > 0 ) | .key | ltrimstr($pwd) ] | sort' "$TEMP" > tools/phpcs-excludelist.json
 
 git diff tools/eslint-excludelist.json tools/phpcs-excludelist.json

--- a/tools/js-tools/git-hooks/pre-commit-hook.js
+++ b/tools/js-tools/git-hooks/pre-commit-hook.js
@@ -392,7 +392,11 @@ const toPrettify = jsFiles.filter( file => checkFileAgainstDirtyList( file, dirt
 toPrettify.forEach( file => console.log( `Prettier formatting staged file: ${ file }` ) );
 
 if ( toPrettify.length ) {
-	execSync( `tools/prettier --ignore-path .eslintignore --write ${ toPrettify.join( ' ' ) }` );
+	execSync(
+		`pnpx prettier --config .prettierrc.js --ignore-path .eslintignore --write ${ toPrettify.join(
+			' '
+		) }`
+	);
 	execSync( `git add ${ toPrettify.join( ' ' ) }` );
 }
 

--- a/tools/prettier
+++ b/tools/prettier
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eo pipefail
-
-cd "$( dirname "${BASH_SOURCE[0]}" )/.."
-exec pnpx --no prettier --config .prettierrc.js "$@"

--- a/tools/project-version.sh
+++ b/tools/project-version.sh
@@ -139,7 +139,7 @@ function sedver {
 #  - $4: What is being looked for, if not finding it is a problem.
 function jsver {
 	if [[ "$OP" == "update" ]]; then
-		JSON=$(jq --arg v "$3" "if $2 then $2 |= \$v else . end" "$1" | "$BASE/tools/prettier" --parser=json-stringify)
+		JSON=$(jq --tab --arg v "$3" "if $2 then $2 |= \$v else . end" "$1")
 		if [[ "$JSON" != "$(<"$FILE")" ]]; then
 			echo "$JSON" > "$FILE"
 		fi

--- a/tools/version-packages.sh
+++ b/tools/version-packages.sh
@@ -73,7 +73,7 @@ if [[ -z "$DIR" ]]; then
 fi
 
 # Remove the monorepo repo from composer.json.
-JSON=$(jq 'if .repositories then .repositories |= map( select( .options.monorepo | not ) ) else . end' "$DIR/composer.json" | "$BASE/tools/prettier" --parser=json-stringify)
+JSON=$(jq --tab 'if .repositories then .repositories |= map( select( .options.monorepo | not ) ) else . end' "$DIR/composer.json")
 echo "$JSON" > "$DIR/composer.json"
 
 # Get the list of package names to update.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The only difference between `jq`'s pretty-printed JSON and the
`prettier`'s pretty-printed JSON is that the former uses two spaces for
indenting while the latter uses tabs.

But `jq` has a `--tab` option, which lets us then skip invoking
`prettier` all over the place. That turns out to be a pretty good time
savings.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that nothing changed, other than various scripts now being faster.