### PR TITLE
push-to-mirrors: fix auth for "mirror repo exists" check

### DIFF
--- a/projects/github-actions/push-to-mirrors/changelog/update-push-to-mirrors-remote-auth
+++ b/projects/github-actions/push-to-mirrors/changelog/update-push-to-mirrors-remote-auth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make auth more reliable when checking whether the mirror repo exists.

--- a/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
+++ b/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
@@ -67,18 +67,18 @@ while read -r GIT_SLUG; do
 	CLONE_DIR="${BUILD_BASE}/${GIT_SLUG}"
 	cd "${CLONE_DIR}"
 
-	# Check if a remote exists for that mirror.
-	if ! git ls-remote -h "https://$API_TOKEN_GITHUB@github.com/${GIT_SLUG}.git" >/dev/null 2>&1; then
-		echo "Mirror repo for ${GIT_SLUG} does not exist. Skipping."
-		continue
-	fi
-
 	# Initialize the directory as a git repo, and set the remote
-	echo "::group::Fetching ${GIT_SLUG}"
 	git init -b "$BRANCH" .
 	git remote add origin "https://github.com/${GIT_SLUG}"
 	git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf "x-access-token:%s" "$API_TOKEN_GITHUB" | base64)"
 
+	# Check if a remote exists for that mirror.
+	if ! git ls-remote -h origin >/dev/null 2>&1; then
+		echo "Mirror repo for ${GIT_SLUG} does not exist. Skipping."
+		continue
+	fi
+
+	echo "::group::Fetching ${GIT_SLUG}"
 	FORCE_COMMIT=
 	if git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin "$BRANCH"; then
 		git reset --soft FETCH_HEAD


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Instead of trying to use the HTTP userinfo, configure the remote first
so we can use the `Authorization` header.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test 1

* Download and extract the "jetpack-build" artifact from a Build workflow run.
* Set `API_TOKEN_GITHUB` to a GitHub access token, and export.
* Ensure `CI` is not set in your environment.
* Run `BUILD_BASE=/path/to/jetpack-build GITHUB_ACTOR=name GITHUB_REF=refs/heads/master projects/github-actions/push-to-mirrors/push-to-mirrors.sh`. It should complete successfully.

Test 2

* `DIR=$(mktemp -d
* `mkdir -p $DIR/Automattic/this-does-not-exist`
* `echo 'Automattic/this-does-not-exist' > $DIR/mirrors.txt`
* Set `API_TOKEN_GITHUB` to a GitHub access token.
* Run `BUILD_BASE=$DIR GITHUB_ACTOR=name GITHUB_REF=refs/heads/master projects/github-actions/push-to-mirrors/push-to-mirrors.sh`. It should complete successfully, with output including "Mirror repo for Automattic/this-does-not-exist does not exist. Skipping."

Test 3

* Merge this. Does it update the mirror at https://github.com/Automattic/action-push-to-mirrors correctly?