### PR TITLE
cli: Fix tests

### DIFF
--- a/tools/cli/tests/integration/commands/commands.test.js
+++ b/tools/cli/tests/integration/commands/commands.test.js
@@ -13,7 +13,7 @@ describe( 'verify commands are available', function () {
 		chai.expect( test ).to.contain( 'jetpack build [project]' );
 	} );
 	it( 'changelog command exists', () => {
-		chai.expect( test ).to.contain( 'jetpack changelog <cmd> [project]' );
+		chai.expect( test ).to.contain( 'jetpack changelog [cmd]' );
 	} );
 	it( 'cli command exists', () => {
 		chai.expect( test ).to.contain( 'jetpack cli <cmd>' );

--- a/tools/cli/tests/integration/helpers/github.test.js
+++ b/tools/cli/tests/integration/helpers/github.test.js
@@ -8,7 +8,8 @@ import chai from 'chai';
  */
 import { doesRepoExist } from '../../../helpers/github';
 
-describe( 'doesRepoExist Integration Tests', function () {
+/** @todo Fix these tests and un-skip them. */
+describe.skip( 'doesRepoExist Integration Tests', function () {
 	it( 'checks for an existing mirror repo', async function () {
 		this.timeout( 0 );
 		return doesRepoExist( 'jetpack' ).then( data => {

--- a/tools/cli/tests/unit/helpers/projectHelpers.test.js
+++ b/tools/cli/tests/unit/helpers/projectHelpers.test.js
@@ -23,7 +23,7 @@ describe( 'projectHelpers', function () {
 	} );
 	it( 'dirs should output number of subfolders for the given path', function () {
 		// The repo-root projects dir.
-		chai.expect( dirs( 'projects' ) ).to.have.lengthOf( 4 );
+		chai.expect( dirs( 'projects' ) ).to.have.lengthOf( 5 );
 	} );
 	it( 'dirs should output a subfolder of given path', function () {
 		chai.expect( dirs( 'projects/plugins' ) ).to.have.contains( 'jetpack' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The CLI has tests, but they haven't been running because one of the
tests tries to prompt for a GitHub access token. Mark that test as
skipped.

Then fix some other tests that are failing.

We could, in theory, fix the skipped test by providing the `GITHUB_TOKEN` or some other access token to the tests. But do we really want to provide a GH token to _all_ the tests? Is there a way to mock it or something instead?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #19443

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the "Tests / JS Tests" job, step "Run project tests", group "Running tests for monorepo". Are the CLI tests running?