### PR TITLE
CLI: Remove autotagger prompt when generating a new plugin

### DIFF
--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -344,7 +344,7 @@ async function createComposerJson( composerJson, answers ) {
 	try {
 		if ( answers.mirrorrepo ) {
 			// For testing, add a third arg here for the org.
-			await mirrorRepo( composerJson, name );
+			await mirrorRepo( composerJson, name, answers.type );
 		}
 	} catch ( e ) {
 		// This means we couldn't create the mirror repo or something else failed, GitHub API is down, etc.
@@ -372,9 +372,10 @@ async function createComposerJson( composerJson, answers ) {
  *
  * @param {object} composerJson - the composer.json object being developed by the generator.
  * @param {string} name - The name of the project.
+ * @param {string} type - The tyope of project that's being generated.
  * @param {string} org - The GitHub owner for the project.
  */
-async function mirrorRepo( composerJson, name, org = 'Automattic' ) {
+async function mirrorRepo( composerJson, name, type, org = 'Automattic' ) {
 	const repo = org + '/' + name;
 	const exists = await doesRepoExist( name, org );
 	const answers = await inquirer.prompt( [
@@ -408,6 +409,7 @@ async function mirrorRepo( composerJson, name, org = 'Automattic' ) {
 			name: 'autotagger',
 			default: true,
 			message: 'Configure mirror repo to create new tags automatically (based on CHANGELOG.md)?',
+			when: type !== 'plugin',
 		},
 	] );
 
@@ -425,7 +427,7 @@ async function mirrorRepo( composerJson, name, org = 'Automattic' ) {
 	if ( answers.useExisting ) {
 		await addMirrorRepo( composerJson, name, org, answers.autotagger );
 	} else if ( answers.newName ) {
-		await mirrorRepo( composerJson, answers.newName, org ); // Rerun this function so we can check if the new name exists or not, etc.
+		await mirrorRepo( composerJson, answers.newName, type, org ); // Rerun this function so we can check if the new name exists or not, etc.
 	} else {
 		await addMirrorRepo( composerJson, name, org, answers.autotagger );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When using `jetpack generate` to create a new plugin, we shouldn't ask if mirror repo should be tagged automatically. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1629842984089000-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack generate plugin` and go through the prompts, selecting Yes to adding a mirror repo
* You shouldn't be asked if you want to create new tags automatically.
* Run `jetpack generate package` and go through the prompts, selecting Yes to adding a mirror repo.
* You should see the autotagger prompt.