### PR TITLE
Backup: bring back the connection screen image

### DIFF
--- a/projects/plugins/backup/changelog/fix-backup-connect-image
+++ b/projects/plugins/backup/changelog/fix-backup-connect-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Bring back the disappeared connection screen image.

--- a/projects/plugins/backup/src/js/hooks/useConnection.js
+++ b/projects/plugins/backup/src/js/hooks/useConnection.js
@@ -21,6 +21,7 @@ export default function useConnection() {
 	const APINonce = useSelect( select => select( STORE_ID ).getAPINonce(), [] );
 	const APIRoot = useSelect( select => select( STORE_ID ).getAPIRoot(), [] );
 	const registrationNonce = useSelect( select => select( STORE_ID ).getRegistrationNonce(), [] );
+	const assetBuildUrl = useSelect( select => select( STORE_ID ).getAssetBuildUrl(), [] );
 
 	const connectionStatus = useSelect( select => select( STORE_ID ).getConnectionStatus(), [] );
 	const { setConnectionStatus } = useDispatch( STORE_ID );
@@ -46,6 +47,7 @@ export default function useConnection() {
 				redirectUri="admin.php?page=jetpack-backup"
 				statusCallback={ statusCallback }
 				images={ [ ConnectRight ] }
+				assetBaseUrl={ assetBuildUrl }
 			>
 				<p>
 					{ __(

--- a/projects/plugins/backup/src/js/reducers/assets.js
+++ b/projects/plugins/backup/src/js/reducers/assets.js
@@ -1,0 +1,5 @@
+const assets = ( state = {} ) => {
+	return state;
+};
+
+export default assets;

--- a/projects/plugins/backup/src/js/reducers/index.js
+++ b/projects/plugins/backup/src/js/reducers/index.js
@@ -9,11 +9,13 @@ import { combineReducers } from '@wordpress/data';
 import connectionStatus from './connection-status';
 import API from './api';
 import jetpackStatus from './jetpack-status';
+import assets from './assets';
 
 const reducer = combineReducers( {
 	connectionStatus,
 	API,
 	jetpackStatus,
+	assets,
 } );
 
 export default reducer;

--- a/projects/plugins/backup/src/js/selectors/index.js
+++ b/projects/plugins/backup/src/js/selectors/index.js
@@ -4,11 +4,13 @@
 import connectionSelectors from './connection-status';
 import APISelectors from './api';
 import jetpackStatusSelectors from './jetpack-status';
+import assetsSelectors from './assets';
 
 const selectors = {
 	...connectionSelectors,
 	...APISelectors,
 	...jetpackStatusSelectors,
+	...assetsSelectors,
 };
 
 export default selectors;

--- a/projects/plugins/backup/src/php/class-initial-state.php
+++ b/projects/plugins/backup/src/php/class-initial-state.php
@@ -28,6 +28,9 @@ class Initial_State {
 			'jetpackStatus' => array(
 				'calypsoSlug' => ( new Status() )->get_site_suffix(),
 			),
+			'assets'        => array(
+				'buildUrl' => plugins_url( 'build/', JETPACK_BACKUP_PLUGIN_ROOT_FILE ),
+			),
 		);
 	}
 


### PR DESCRIPTION
Updating Webpack (#20789) changed the asset loading behavior, and the connection screen image disappeared:
<img width="1097" alt="Screen Shot 2021-08-25 at 3 04 00 PM" src="https://user-images.githubusercontent.com/1341249/130850046-86981cb6-70d6-4323-92ea-df6ab3c1afb6.png">

This PR brings it back by reintroducing the asset base URL we previously didn't need.


#### Changes proposed in this Pull Request:
* Reintroduce the asset base URL.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Disconnect Jetpack.
2. Go to the Backup plugin, and confirm that there's an image on the connection screen:
<img width="1097" alt="Screen Shot 2021-08-25 at 3 13 13 PM" src="https://user-images.githubusercontent.com/1341249/130851054-b42eb81c-21c8-4497-ae6e-4895a336a3ec.png">
