### PR TITLE
Release forgotten projects

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/CHANGELOG.md
+++ b/projects/github-actions/pr-is-up-to-date/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2021-08-26
+### Changed
+- Avoid context expression substitution in GitHub Actions `run` steps.
+- Update package dependencies.
+
 ## 1.0.0 - 2021-04-05
 ### Added
 - Initial release.
+
+[1.0.1]: https://github.com/Automattic/action-pr-is-up-to-date/compare/v1.0.0...v1.0.1

--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-changelogger-in-subdir
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-changelogger-in-subdir
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-gh-actions-context-vars-in-run
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-gh-actions-context-vars-in-run
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Avoid context expression substitution in GitHub Actions `run` steps.

--- a/projects/github-actions/pr-is-up-to-date/changelog/remove-licensetxt
+++ b/projects/github-actions/pr-is-up-to-date/changelog/remove-licensetxt
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Removed license.txt from source. Still auto-added into the built version.
-
-

--- a/projects/github-actions/push-to-mirrors/CHANGELOG.md
+++ b/projects/github-actions/push-to-mirrors/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2021-08-26
+### Added
+- Add autotagger action to simplify releases.
+- Created a changelog from the git history with help from [auto-changelog](https://www.npmjs.com/package/auto-changelog). It could probably use cleanup!
+
+### Changed
+- Avoid context expression substitution in GitHub Actions `run` steps.
+- Avoid setting global state during the action.
+- Update package dependencies.
+
+### Fixed
+- Correctly supply git auth token.
+
 ## 1.0.0 - 2021-02-01
 
 - Initial release
+
+[1.0.1]: https://github.com/Automattic/action-push-to-mirrors/compare/v1.0.0...v1.0.1

--- a/projects/github-actions/push-to-mirrors/changelog/add-changelogs-for-everything
+++ b/projects/github-actions/push-to-mirrors/changelog/add-changelogs-for-everything
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Created a changelog from the git history with help from [auto-changelog](https://www.npmjs.com/package/auto-changelog). It could probably use cleanup!

--- a/projects/github-actions/push-to-mirrors/changelog/fix-changelogger-in-subdir
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-changelogger-in-subdir
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/push-to-mirrors/changelog/fix-gh-actions-context-vars-in-run
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-gh-actions-context-vars-in-run
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Avoid context expression substitution in GitHub Actions `run` steps.

--- a/projects/github-actions/push-to-mirrors/changelog/fix-gh-actions-git-auth
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-gh-actions-git-auth
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Correctly supply git auth token.

--- a/projects/github-actions/push-to-mirrors/changelog/update-actions-avoid-git-config-global
+++ b/projects/github-actions/push-to-mirrors/changelog/update-actions-avoid-git-config-global
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Avoid setting global state during the action.

--- a/projects/github-actions/push-to-mirrors/changelog/update-autotagger-for-actions
+++ b/projects/github-actions/push-to-mirrors/changelog/update-autotagger-for-actions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added autotagger action to simplify releases

--- a/projects/github-actions/push-to-mirrors/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/github-actions/push-to-mirrors/changelog/update-changelogger-allow-unreleased-date
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/github-actions/push-to-mirrors/changelog/update-push-to-mirrors-remote-auth
+++ b/projects/github-actions/push-to-mirrors/changelog/update-push-to-mirrors-remote-auth
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Make auth more reliable when checking whether the mirror repo exists.

--- a/projects/github-actions/repo-gardening/CHANGELOG.md
+++ b/projects/github-actions/repo-gardening/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2021-08-26
+### Added
+- Add E2E Tests label in gardening.
+- Include e2e test report url in PR bot comment.
+- New task: triage newly opened issues to add the proper product labels.
+
+### Changed
+- jslint formatting.
+- Labels: update label names to match new naming convention in use in the monorepo.
+- Labels task: update paths to support new location of the Boost plugin.
+- Update `@actions/github` with attendent code adjustments.
+- Update node version requirement to 14.16.1.
+
+### Fixed
+- Milestone detection: fallback to any milestone when we cannot find any with a due date.
+
 ## [1.3.0] - 2021-05-28
 ### Fixed
 - Slack notification tasks: both tasks now listen for `pull_request_target` events so they can be run on PRs opened from forks.
@@ -46,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[1.4.0]: https://github.com/Automattic/action-repo-gardening/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/Automattic/action-repo-gardening/compare/v1.2.2...v1.3.0
 [1.2.2]: https://github.com/Automattic/action-repo-gardening/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Automattic/action-repo-gardening/compare/v1.2.0...v1.2.1

--- a/projects/github-actions/repo-gardening/changelog/add-gardening-e2e-tests-label
+++ b/projects/github-actions/repo-gardening/changelog/add-gardening-e2e-tests-label
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add E2E Tests label in gardening

--- a/projects/github-actions/repo-gardening/changelog/add-issue-forms-and-triage
+++ b/projects/github-actions/repo-gardening/changelog/add-issue-forms-and-triage
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-New task: triage newly opened issues to add the proper product labels.

--- a/projects/github-actions/repo-gardening/changelog/e2e-gardening-add-e2e-report-url
+++ b/projects/github-actions/repo-gardening/changelog/e2e-gardening-add-e2e-report-url
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Included e2e test report url in PR bot comment

--- a/projects/github-actions/repo-gardening/changelog/feature-replace-yarn-1-with-pnpm
+++ b/projects/github-actions/repo-gardening/changelog/feature-replace-yarn-1-with-pnpm
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Switch to pnpm
-
-

--- a/projects/github-actions/repo-gardening/changelog/fix-gardening-milestone-no-due-date
+++ b/projects/github-actions/repo-gardening/changelog/fix-gardening-milestone-no-due-date
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Milestone detection: fallback to any milestone when we cannot find any with a due date.

--- a/projects/github-actions/repo-gardening/changelog/remove-licensetxt
+++ b/projects/github-actions/repo-gardening/changelog/remove-licensetxt
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Removed license.txt from source. Still auto-added into the built version.
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-eslint-jsdoc
+++ b/projects/github-actions/repo-gardening/changelog/update-eslint-jsdoc
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: JSDoc updates after eslint-plugin-jsdoc update
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-concurrency
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-concurrency
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated `@actions/github` with attendent code adjustments.

--- a/projects/github-actions/repo-gardening/changelog/update-idc-endpoint-migration
+++ b/projects/github-actions/repo-gardening/changelog/update-idc-endpoint-migration
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-jslint formatting.

--- a/projects/github-actions/repo-gardening/changelog/update-node-version-14161
+++ b/projects/github-actions/repo-gardening/changelog/update-node-version-14161
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update node version requirement to 14.16.1

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-boost
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-boost
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Labels task: update paths to support new location of the Boost plugin.

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-boost-labels
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-boost-labels
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Labels: update label names to match new naming convention in use in the monorepo.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "1.4.0-alpha",
+	"version": "1.4.0",
 	"description": "Manage PR and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/analyzer/CHANGELOG.md
+++ b/projects/packages/analyzer/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2021-08-26
+### Added
+- Composer alias for dev-master, to improve dependencies.
+- Created a changelog from the git history with help from [auto-changelog](https://www.npmjs.com/package/auto-changelog). It could probably use cleanup!
+
+### Changed
+- Update package dependencies.
+
 ## [1.6.0] - 2021-02-05
 
 - CI: Make tests more generic
@@ -52,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack code analyzer
 
+[1.6.1]: https://github.com/Automattic/jetpack-analyzer/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/Automattic/jetpack-analyzer/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/Automattic/jetpack-analyzer/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/Automattic/jetpack-analyzer/compare/v1.3.0...v1.4.0

--- a/projects/packages/analyzer/changelog/2021-03-30-16-43-23-939963
+++ b/projects/packages/analyzer/changelog/2021-03-30-16-43-23-939963
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Updated composer.json (and composer.lock) for all packages to enable auto-tagging
-
-

--- a/projects/packages/analyzer/changelog/add-changelogs-for-everything
+++ b/projects/packages/analyzer/changelog/add-changelogs-for-everything
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Created a changelog from the git history with help from [auto-changelog](https://www.npmjs.com/package/auto-changelog). It could probably use cleanup!

--- a/projects/packages/analyzer/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/analyzer/changelog/fix-changelogger-in-subdir
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/analyzer/changelog/update-branch-alias-all-packages
+++ b/projects/packages/analyzer/changelog/update-branch-alias-all-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Composer alias for dev-master, to improve dependencies

--- a/projects/packages/analyzer/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/analyzer/changelog/update-changelogger-allow-unreleased-date
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/analyzer/changelog/update-packages-changelogger-range-dep
+++ b/projects/packages/analyzer/changelog/update-packages-changelogger-range-dep
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Range dep for changelogger, to make releases easier
-
-

--- a/projects/packages/codesniffer/CHANGELOG.md
+++ b/projects/packages/codesniffer/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2021-08-26
+### Added
+- Composer alias for dev-master, to improve dependencies.
+- Created a changelog from the git history with help from [auto-changelog](https://www.npmjs.com/package/auto-changelog). It could probably use cleanup!
+
+### Changed
+- Run composer update on test-php command instead of phpunit.
+- Update package dependencies.
+
+### Fixed
+- Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.
+
 ## [2.2.0] - 2021-02-05
 
 - CI: Make tests more generic
@@ -43,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Codesniffer: Add a package to hold our coding standard
 
+[2.2.1]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.0.0...v2.1.0

--- a/projects/packages/codesniffer/changelog/2021-03-30-16-43-23-939963
+++ b/projects/packages/codesniffer/changelog/2021-03-30-16-43-23-939963
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Updated composer.json (and composer.lock) for all packages to enable auto-tagging
-
-

--- a/projects/packages/codesniffer/changelog/add-changelogs-for-everything
+++ b/projects/packages/codesniffer/changelog/add-changelogs-for-everything
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Created a changelog from the git history with help from [auto-changelog](https://www.npmjs.com/package/auto-changelog). It could probably use cleanup!

--- a/projects/packages/codesniffer/changelog/fix-changelogger-in-subdir
+++ b/projects/packages/codesniffer/changelog/fix-changelogger-in-subdir
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/codesniffer/changelog/fix-cli-composer-install-vs-update
+++ b/projects/packages/codesniffer/changelog/fix-cli-composer-install-vs-update
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.

--- a/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-36.x
+++ b/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-36.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-37.x
+++ b/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-37.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/packages/codesniffer/changelog/try-remove-composer-update-2
+++ b/projects/packages/codesniffer/changelog/try-remove-composer-update-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Run composer update on test-php command instead of phpunit

--- a/projects/packages/codesniffer/changelog/update-branch-alias-all-packages
+++ b/projects/packages/codesniffer/changelog/update-branch-alias-all-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Composer alias for dev-master, to improve dependencies

--- a/projects/packages/codesniffer/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/packages/codesniffer/changelog/update-changelogger-allow-unreleased-date
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/codesniffer/changelog/update-packages-changelogger-range-dep
+++ b/projects/packages/codesniffer/changelog/update-packages-changelogger-range-dep
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Range dep for changelogger, to make releases easier
-
-

--- a/projects/plugins/debug-helper/CHANGELOG.md
+++ b/projects/plugins/debug-helper/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2021-08-26
+### Added
+- Broken Token: Add clear current user token functionality.
+- Created a changelog from the git history with help from [auto-changelog](https://www.npmjs.com/package/auto-changelog). It could probably use cleanup!
+- Display the registration nonce to test the endpoint `connection/register`.
+
+### Changed
+- Remove composer dev-monorepo hack.
+- Update package dependencies.
+
 ## 1.0.1 - 2021-03-04
 
 - Initial version.
+
+[1.1.0]: https://github.com/Automattic/jetpack-debug-helper/compare/v1.0.1...v1.1.0

--- a/projects/plugins/debug-helper/changelog/2021-08-10-04-36-32-657116
+++ b/projects/plugins/debug-helper/changelog/2021-08-10-04-36-32-657116
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/add-broken-token-clear-current-user
+++ b/projects/plugins/debug-helper/changelog/add-broken-token-clear-current-user
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Broken Token: Add clear current user token functionality

--- a/projects/plugins/debug-helper/changelog/add-changelogs-for-everything
+++ b/projects/plugins/debug-helper/changelog/add-changelogs-for-everything
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Created a changelog from the git history with help from [auto-changelog](https://www.npmjs.com/package/auto-changelog). It could probably use cleanup!

--- a/projects/plugins/debug-helper/changelog/add-connection-register-endpoint
+++ b/projects/plugins/debug-helper/changelog/add-connection-register-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Displaying the registration nonce to test the endpoint `connection/register`.

--- a/projects/plugins/debug-helper/changelog/add-enable-package-autotagger-to-test
+++ b/projects/plugins/debug-helper/changelog/add-enable-package-autotagger-to-test
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/add-license-info
+++ b/projects/plugins/debug-helper/changelog/add-license-info
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Added license to build process
-
-

--- a/projects/plugins/debug-helper/changelog/add-project-structure-check
+++ b/projects/plugins/debug-helper/changelog/add-project-structure-check
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/fix-changelogger-in-subdir
+++ b/projects/plugins/debug-helper/changelog/fix-changelogger-in-subdir
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/fix-cli-composer-install-vs-update
+++ b/projects/plugins/debug-helper/changelog/fix-cli-composer-install-vs-update
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock
-
-

--- a/projects/plugins/debug-helper/changelog/try-remove-composer-update-2
+++ b/projects/plugins/debug-helper/changelog/try-remove-composer-update-2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/update-branch-alias-all-packages
+++ b/projects/plugins/debug-helper/changelog/update-branch-alias-all-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove composer dev-monorepo hack.

--- a/projects/plugins/debug-helper/changelog/update-changelogger-allow-unreleased-date
+++ b/projects/plugins/debug-helper/changelog/update-changelogger-allow-unreleased-date
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/debug-helper/changelog/update-sync-v4-endpoints
+++ b/projects/plugins/debug-helper/changelog/update-sync-v4-endpoints
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: lock file update
-
-

--- a/projects/plugins/debug-helper/plugin.php
+++ b/projects/plugins/debug-helper/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Debug Tools
  * Description: Give me a Jetpack connection, and I'll break it every way possible.
  * Author: Automattic - Jetpack Crew
- * Version: 1.1.0-alpha
+ * Version: 1.1.0
  * Text Domain: jetpack
  *
  * @package automattic/jetpack-debug-helper.
@@ -33,7 +33,7 @@ define( 'JETPACK_DEBUG_HELPER_BASE_PLUGIN_FILE', __FILE__ );
  * The plugin version.
  * Increase that if you do any edits to ensure refreshing the cached assets.
  */
-define( 'JETPACK_DEBUG_HELPER_VERSION', '1.1.0-alpha' );
+define( 'JETPACK_DEBUG_HELPER_VERSION', '1.1.0' );
 
 /**
  * Include file names from the modules directory here.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We regularly release Jetpack (and other plugins) and the things that
they depend on. But we seem to forget to release other monorepo
projects.

* github-actions/pr-is-up-to-date had change entries from 117 days ago
* github-actions/push-to-mirrors had change entries from 170 days ago
* github-actions/repo-gardening had change entries from 85 days ago
* packages/analyzer had change entries from 170 days ago
* packages/codesniffer had change entries from 170 days ago
* plugins/debug-helper had change entries from 170 days ago

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the changelogs.
* Merge, wait for the mirroring, then make sure the autotagger worked.
