### PR TITLE
Search: fix some interface strings are not being localized

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-translation
+++ b/projects/plugins/jetpack/changelog/fix-search-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fix instant search translations are not fully loaded

--- a/projects/plugins/jetpack/changelog/fix-search-translation
+++ b/projects/plugins/jetpack/changelog/fix-search-translation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Search: fix instant search translations are not fully loaded
+Search: fix some interface strings are not being localized

--- a/projects/plugins/jetpack/modules/search.php
+++ b/projects/plugins/jetpack/modules/search.php
@@ -14,8 +14,6 @@
  * @package automattic/jetpack
  */
 
-define( 'JETPACK__SEARCH_FALLBACK_TRANSLATION_MD5', '1a2821bfb803906d5e27' );
-
 // Include everything.
 require_once __DIR__ . '/search/class.jetpack-search.php';
 require_once __DIR__ . '/search/class-jetpack-search-customberg.php';

--- a/projects/plugins/jetpack/modules/search.php
+++ b/projects/plugins/jetpack/modules/search.php
@@ -14,6 +14,8 @@
  * @package automattic/jetpack
  */
 
+define( 'JETPACK__SEARCH_FALLBACK_TRANSLATION_MD5', '1a2821bfb803906d5e27' );
+
 // Include everything.
 require_once __DIR__ . '/search/class.jetpack-search.php';
 require_once __DIR__ . '/search/class-jetpack-search-customberg.php';

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -6,6 +6,10 @@
  * @package automattic/jetpack
  */
 
+/**
+ * This is the fallback payload md5 value, and will be used if there's no other translations available.
+ * TODO: Remembers recent translations files and use them as fallbacks.
+ */
 define( 'JETPACK__SEARCH_FALLBACK_TRANSLATION_MD5', '1a2821bfb803906d5e27' );
 
 /**

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -108,8 +108,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 		add_action( 'widgets_init', array( $this, 'register_jetpack_instant_sidebar' ) );
 		add_action( 'jetpack_deactivate_module_search', array( $this, 'move_search_widgets_to_inactive' ) );
-
-		add_filter( 'load_script_translation_file', array( $this, 'fix_language_file_path' ), 10, 3 );
 	}
 
 	/**
@@ -206,7 +204,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		// Then register it, which is required for the next steps.
 		wp_register_script( $handle, $payload_url, array(), JETPACK__VERSION, false );
 		// Set translation domain to `jetpack`.
-		wp_set_script_translations( $handle, 'jetpack' );
+		wp_set_script_translations( $handle, 'jetpack', WP_LANG_DIR . '/plugins/jetpack' );
 		// Inline the translations before `$before_handle` handle.
 		wp_add_inline_script( $before_handle, wp_scripts()->print_translations( $handle, false ), 'before' );
 		// Deregister the script as we don't really enqueue it from PHP side.
@@ -733,29 +731,5 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	public function add_body_class( $classes ) {
 		$classes[] = 'jps-theme-' . get_stylesheet();
 		return $classes;
-	}
-
-	/**
-	 * Fix language file path for WPCOM.
-	 *
-	 * @param string $file - Language file path.
-	 * @param string $handle - handle for the translations.
-	 * @param string $domain - translations domain.
-	 *
-	 * @return string - Alternative path for the language file.
-	 */
-	public function fix_language_file_path( $file, $handle, $domain ) {
-		if ( 'jetpack' !== $domain ) {
-			return $file;
-		}
-		if ( $file && is_readable( $file ) ) {
-			return $file;
-		}
-
-		if ( strpos( $file, 'languages/mu-plugins/jetpack' ) !== false ) {
-			return str_replace( 'languages/mu-plugins/jetpack', 'languages/plugins/jetpack', $file );
-		}
-
-		return $file;
 	}
 }

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -175,7 +175,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	protected function get_instant_search_payload_urls( $pattern = self::JETPACK_INSTANT_SEARCH_PAYLOAD_PATTERN ) {
 		$payload_file_key = 'payload-files-' . md5( $pattern );
 		$payload_files    = get_transient( $payload_file_key );
-		if ( ! $payload_files || $this->any_file_not_exists( $payload_files ) ) {
+		if ( ! $payload_files || $this->any_files_not_exists( $payload_files ) ) {
 			$payload_files = glob( JETPACK__PLUGIN_DIR . $pattern );
 			set_transient( $payload_file_key, $payload_files );
 		}
@@ -189,7 +189,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	}
 
 	/**
-	 * Add inline translation for `$payload_url` before `$before_handle`
+	 * Add inline translations for script `$payload_url` before loading `$before_handle` script.
 	 *
 	 * @param string $payload_url - The payload url for which we load the translations.
 	 * @param string $before_handle - Inline the translations before this handle.
@@ -217,13 +217,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	}
 
 	/**
-	 * Test if any of files don't exist
+	 * Test if any of the files don't exist.
 	 *
-	 * @param array $files - File to check.
+	 * @param array $files - Files to check.
 	 *
 	 * @return boolean - True if any of the files do not exist.
 	 */
-	protected function any_file_not_exists( $files ) {
+	protected function any_files_not_exists( $files ) {
 		foreach ( $files as $file ) {
 			if ( ! file_exists( $file ) ) {
 				return true;

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -158,7 +158,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * Inject translations of the lazy-loaded payload.
 	 */
 	protected function inject_payload_translations() {
-		$payload_urls = $this->get_instant_search_payloads();
+		$payload_urls = $this->get_instant_search_payload_urls();
 		foreach ( $payload_urls as $payload_url ) {
 			$this->inject_payload_translation_for( $payload_url );
 		}
@@ -172,7 +172,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 *
 	 * @return array - Array of matching payload URLs
 	 */
-	protected function get_instant_search_payloads( $pattern = self::JETPACK_INSTANT_SEARCH_PAYLOAD_PATTERN ) {
+	protected function get_instant_search_payload_urls( $pattern = self::JETPACK_INSTANT_SEARCH_PAYLOAD_PATTERN ) {
 		$payload_file_key = 'payload-files-' . md5( $pattern );
 		$payload_files    = get_transient( $payload_file_key );
 		if ( ! $payload_files || $this->any_file_not_exists( $payload_files ) ) {

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -6,6 +6,8 @@
  * @package automattic/jetpack
  */
 
+define( 'JETPACK__SEARCH_FALLBACK_TRANSLATION_MD5', '1a2821bfb803906d5e27' );
+
 /**
  * Class to load Instant Search experience on the site.
  *

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -209,8 +209,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$handle = 'jetpack-instant-search' . wp_unique_id();
 		// Then register it, which is required for the next steps.
 		wp_register_script( $handle, $payload_url, array(), JETPACK__VERSION, false );
-		// Set translation domain to `jetpack`.
-		wp_set_script_translations( $handle, 'jetpack', WP_LANG_DIR . '/plugins/jetpack' );
+		// Set translation domain to `jetpack`, and we need to explicitly set the `path` to load translations files for WPCOM.
+		// Otherwise WPCOM would try to load from `WP_LANG_DIR . '/mu-plugins'` and fails.
+		wp_set_script_translations( $handle, 'jetpack', WP_LANG_DIR . '/plugins' );
 		// Inline the translations before `$before_handle` handle.
 		wp_add_inline_script( $before_handle, wp_scripts()->print_translations( $handle, false ), 'before' );
 		// Deregister the script as we don't really enqueue it from PHP side.

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -10,7 +10,6 @@
  * This is the fallback payload md5 value, and will be used if there's no other translations available.
  * TODO: Remembers recent translations files and use them as fallbacks.
  */
-define( 'JETPACK__SEARCH_FALLBACK_TRANSLATION_MD5', '1a2821bfb803906d5e27' );
 
 /**
  * Class to load Instant Search experience on the site.
@@ -156,12 +155,17 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$this->load_and_initialize_tracks();
 		$this->inject_javascript_options();
 
-		// Load the translations for previous build as a fallback.
-		if ( defined( 'JETPACK__SEARCH_FALLBACK_TRANSLATION_MD5' ) ) {
-			$this->inject_payload_translation_for( plugin_dir_url( JETPACK__PLUGIN_FILE ) . str_replace( '*', JETPACK__SEARCH_FALLBACK_TRANSLATION_MD5, static::JETPACK_INSTANT_SEARCH_PAYLOAD_PATTERN ) );
-		}
-		// We detect and load translations for instant search lazy-loaded payload(s).
-		$this->inject_payload_translations();
+		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+			// For Jetpack site, we detect and load translations for instant search lazy-loaded payload(s).
+			$this->inject_payload_translations();
+		} elseif ( defined( 'JETPACK__SEARCH_MAIN_PAYLOAD_MD5' ) ) {
+			// Because WPCOM is deployed on-going, so the strings in the payload are not translated.
+			// The work-around is to load the translations from a Jetpack release.
+			$this->inject_payload_translation_for(
+				plugin_dir_url( JETPACK__PLUGIN_FILE )
+				. str_replace( '*', JETPACK__SEARCH_MAIN_PAYLOAD_MD5, static::JETPACK_INSTANT_SEARCH_PAYLOAD_PATTERN )
+			);
+		} //Otherwise we don't load anything.
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -150,6 +150,10 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$this->load_and_initialize_tracks();
 		$this->inject_javascript_options();
 
+		// Load the translations for previous build as a fallback.
+		if ( defined( 'JETPACK__SEARCH_FALLBACK_TRANSLATION_MD5' ) ) {
+			$this->inject_payload_translation_for( plugin_dir_url( JETPACK__PLUGIN_FILE ) . str_replace( '*', JETPACK__SEARCH_FALLBACK_TRANSLATION_MD5, static::JETPACK_INSTANT_SEARCH_PAYLOAD_PATTERN ) );
+		}
 		// We detect and load translations for instant search lazy-loaded payload(s).
 		$this->inject_payload_translations();
 	}

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -155,7 +155,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	}
 
 	/**
-	 * Inject translations of the lazy-loaded payload.
+	 * Inject translations of the lazy-loaded payload(s).
 	 */
 	protected function inject_payload_translations() {
 		$payload_urls = $this->get_instant_search_payload_urls();

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -175,7 +175,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	protected function get_instant_search_payload_urls( $pattern = self::JETPACK_INSTANT_SEARCH_PAYLOAD_PATTERN ) {
 		$payload_file_key = 'payload-files-' . md5( $pattern );
 		$payload_files    = get_transient( $payload_file_key );
-		if ( ! $payload_files || $this->any_files_not_exists( $payload_files ) ) {
+		if ( ! $payload_files || $this->any_files_not_exist( $payload_files ) ) {
 			$payload_files = glob( JETPACK__PLUGIN_DIR . $pattern );
 			set_transient( $payload_file_key, $payload_files );
 		}
@@ -223,7 +223,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 *
 	 * @return boolean - True if any of the files do not exist.
 	 */
-	protected function any_files_not_exists( $files ) {
+	protected function any_files_not_exist( $files ) {
 		foreach ( $files as $file ) {
 			if ( ! file_exists( $file ) ) {
 				return true;

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -108,6 +108,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 		add_action( 'widgets_init', array( $this, 'register_jetpack_instant_sidebar' ) );
 		add_action( 'jetpack_deactivate_module_search', array( $this, 'move_search_widgets_to_inactive' ) );
+
+		add_filter( 'load_script_translation_file', array( $this, 'fix_language_file_path' ), 10, 3 );
 	}
 
 	/**
@@ -731,5 +733,29 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	public function add_body_class( $classes ) {
 		$classes[] = 'jps-theme-' . get_stylesheet();
 		return $classes;
+	}
+
+	/**
+	 * Fix language file path for WPCOM.
+	 *
+	 * @param string $file - Language file path.
+	 * @param string $handle - handle for the translations.
+	 * @param string $domain - translations domain.
+	 *
+	 * @return string - Alternative path for the language file.
+	 */
+	public function fix_language_file_path( $file, $handle, $domain ) {
+		if ( 'jetpack' !== $domain ) {
+			return $file;
+		}
+		if ( $file && is_readable( $file ) ) {
+			return $file;
+		}
+
+		if ( strpos( $file, 'languages/mu-plugins/jetpack' ) !== false ) {
+			return str_replace( 'languages/mu-plugins/jetpack', 'languages/plugins/jetpack', $file );
+		}
+
+		return $file;
 	}
 }

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -155,7 +155,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$this->load_and_initialize_tracks();
 		$this->inject_javascript_options();
 
-		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+		if ( ! defined( 'JETPACK__SEARCH_MAIN_PAYLOAD_MD5' ) ) {
 			// For Jetpack site, we detect and load translations for instant search lazy-loaded payload(s).
 			$this->inject_payload_translations();
 		} elseif ( defined( 'JETPACK__SEARCH_MAIN_PAYLOAD_MD5' ) ) {


### PR DESCRIPTION
Fixes #20520 

#### Changes proposed in this Pull Request:
Inline translations before enqueuing the main payload to make sure translations for lazy-loaded payloads are available. 

**TODO: test on WPCOM**

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Open your local site with Jetpack Search subscription
* Caculate signature `php -r "echo md5('_inc/build/instant-search/jp-search.chunk-main-payload-a7fe2cd7399a1c7473a1.js');"`
    * You need to replace the file name with your local one
    * Please NOTE: no `min` should be in the file name even that is the case
 * Change the translation file name, e.g.  from `jetpack-fr_FR-MD5.json` to `jetpack-fr_FR-83c2622273c4d246d24c018dd16b3510.json`, `83c2622273c4d246d24c018dd16b3510` is the md5 you get from the previous step.
 * Ensure everything is translated, especially the marked ones.
 
![image](https://user-images.githubusercontent.com/1425433/131072161-9e29d951-a60f-4d63-b7cd-d362fed4a65b.png)
