### PR TITLE
Docker: Add a workaround to allow interactive wp shell in dev context

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -332,7 +332,11 @@ const buildExecCmd = argv => {
 		);
 	} else if ( cmd === 'wp' ) {
 		const wpArgs = argv._.slice( 2 );
-		opts.splice( 1, 0, '-T' );
+		// Ugly solution to allow interactive shell work in dev context
+		// TODO: Look for prettier alternatives.
+		if ( argv.type === 'e2e' ) {
+			opts.splice( 1, 0, '-T' );
+		}
 		opts.push( 'wp', '--allow-root', '--path=/var/www/html/', ...wpArgs );
 	} else if ( cmd === 'tail' ) {
 		opts.push( '/var/scripts/tail.sh' );


### PR DESCRIPTION
In the E2E to Jetpack Docker migration PR we introduced some changes to docker cli, that essentially disables interactive shells for some of the cli commands. While it was the requirement for E2Es, it did break some of the dev workflows. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out the branch locally
* Start Jetpack docker: `jetpack docker up`
* Run `jetpack docker wp shell` and make sure you can interact
* Make sure that E2Es are still passing
