### PR TITLE
Codesniffer: plan additional release

### DIFF
--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2021-08-27
+### Changed
+- Run composer update on test-php command instead of phpunit
+- Tests: update PHPUnit polyfills dependency (yoast/phpunit-polyfills).
+
 ## [1.2.0] - 2021-05-12
 ### Added
 - New option, `--filename-auto-suffix`, to ensure that a reused branch won't prevent entry creation in non-interactive mode.
@@ -36,6 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[1.2.1]: https://github.com/Automattic/jetpack-changelogger/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/Automattic/jetpack-changelogger/compare/1.1.2...1.2.0
 [1.1.2]: https://github.com/Automattic/jetpack-changelogger/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/Automattic/jetpack-changelogger/compare/1.1.0...1.1.1

--- a/projects/packages/changelogger/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/packages/changelogger/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Tests: update PHPUnit polyfills dependency (yoast/phpunit-polyfills).

--- a/projects/packages/changelogger/changelog/try-remove-composer-update-2
+++ b/projects/packages/changelogger/changelog/try-remove-composer-update-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Run composer update on test-php command instead of phpunit

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '1.2.1-alpha';
+	const VERSION = '1.2.1';
 
 	/**
 	 * Constructor.

--- a/projects/packages/codesniffer/CHANGELOG.md
+++ b/projects/packages/codesniffer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2021-08-27
+### Changed
+- Tests: update PHPUnit polyfills dependency (yoast/phpunit-polyfills).
+
 ## [2.2.1] - 2021-08-26
 ### Added
 - Composer alias for dev-master, to improve dependencies.
@@ -55,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Codesniffer: Add a package to hold our coding standard
 
+[2.2.2]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.1.0...v2.1.1

--- a/projects/packages/codesniffer/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/packages/codesniffer/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Tests: update PHPUnit polyfills dependency (yoast/phpunit-polyfills).


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

﻿This is a follow-up from yesterday's release in #20837.

This can be useful for folks who may want to update to the newest version of the Codesniffer, but who cannot do so yet because of they're running a newer version of the `yoast/phpunit-polyfills` package (that just got updated in the monorepo in #20840).

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Check for typos
* Is CI happy?
