### PR TITLE
Change BUILD_DIR -> BUILD_BASE in initial checks of build-all-projects.sh

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -8,11 +8,11 @@ if [[ -z "$BUILD_BASE" ]]; then
 	BUILD_BASE=$(mktemp -d "${TMPDIR:-/tmp}/jetpack-project-mirrors.XXXXXXXX")
 elif [[ ! -e "$BUILD_BASE" ]]; then
 	mkdir -p "$BUILD_BASE"
-elif [[ ! -d "$BUILD_DIR" ]]; then
-	echo "$BUILD_DIR already exists, and is not a directory." >&2
+elif [[ ! -d "$BUILD_BASE" ]]; then
+	echo "$BUILD_BASE already exists, and is not a directory." >&2
 	exit 1
-elif [[ "$(ls -A -- "$BUILD_DIR")" ]]; then
-	echo "Directory $BUILD_DIR already exists, and is not empty." >&2
+elif [[ "$(ls -A -- "$BUILD_BASE")" ]]; then
+	echo "Directory $BUILD_BASE already exists, and is not empty." >&2
 	exit 1
 fi
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix a typo at the top of build-all-projects.sh
  * It runs fine when it creates the BUILD_BASE directory itself, but if you create an empty directory beforehand, it stops running, because it mistakenly checks another variable. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In bash, run `rm -rf /tmp/build && export BUILD_BASE='/tmp/build' && mkdir $BUILD_BASE && .github/files/build-all-projects.sh`
  * Expect to see: Build starts
  * Actually see: ` already exists, and is not a directory.`
  * After fix, see: Build starts
