### PR TITLE
Bug Fix - ensure last object is included in checksum histogram.

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-checksum-dangling-object
+++ b/projects/packages/sync/changelog/fix-sync-checksum-dangling-object
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync Checksums - ensure last object is included in histogram

--- a/projects/packages/sync/src/class-replicastore.php
+++ b/projects/packages/sync/src/class-replicastore.php
@@ -1358,7 +1358,7 @@ class Replicastore implements Replicastore_Interface {
 
 			$previous_max_id = $ids_range['max_range'] + 1;
 			// If we've reached the max_range lets bail out.
-			if ( $previous_max_id >= $range_edges['max_range'] ) {
+			if ( $previous_max_id > $range_edges['max_range'] ) {
 				break;
 			}
 		} while ( true );


### PR DESCRIPTION
When performing a Sync checksum if there is only 1 object that didn't fit into the previous bucket it would be excluded from the calculated histogram. This patch ensures we retrieve the last object.


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Bug Fix for Sync Checksum/Fix process

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO

#### Testing instructions:

* Setup a Test site and create 5 posts that have sequential ids
* access the sites shell
* `$store = new Automattic\Jetpack\Sync\Replicastore();`
* `$store->checksum_histogram( "posts", 10 );`
* Verify the histogram includes the last post
* `$store->checksum_histogram( "posts" );
* Verify the sum of the histogram with buckets match the single bucket histogram
