### PR TITLE
E2E tests: Fix missing action for atomic workflow

### DIFF
--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -2,6 +2,12 @@ name: E2E Tests on Atomic sites
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+  push:
+    branches: [fix/e2e-atomic-workflow]
+    paths-ignore:
+      - '**.md'
   schedule:
     - cron:  '0 */4 * * *'
 

--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -1,13 +1,6 @@
 name: E2E Tests on Atomic sites
 
 on:
-  pull_request:
-    paths-ignore:
-      - '**.md'
-  push:
-    branches: [fix/e2e-atomic-workflow]
-    paths-ignore:
-      - '**.md'
   schedule:
     - cron:  '0 */4 * * *'
 

--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -76,34 +76,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Read tool versions
-        id: versions
-        uses: ./.github/actions/read-versions
-
-      - name: Setup Node
-        uses: actions/setup-node@v2
+      - name: Setup tools
+        uses: ./.github/actions/tool-setup
         with:
-          node-version: ${{ steps.versions.outputs.node-version }}
-
-      - name: Use pnpm cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ steps.versions.outputs.node-version }}-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-${{ steps.versions.outputs.node-version }}-
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: ${{ steps.versions.outputs.pnpm-version }}
-
-      - name: Tool versions
-        run: |
-          which node
-          node --version
-          which pnpm
-          pnpm --version
+          php: false
 
       - name: Send Slack notification
         working-directory: projects/plugins/jetpack/tests/e2e

--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/tool-setup
       with:
-        - php: false
+        php: false
 
     - name: Install
       working-directory: projects/plugins/jetpack/tests/e2e

--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -32,7 +32,7 @@ jobs:
       working-directory: projects/plugins/jetpack/tests/e2e
       env:
         TEST_SITE: atomic
-      run: pnpm run test-e2e -- --group=atomic
+      run: pnpm run test-e2e -- --group=atomic --testNamePattern='^(?!Paid blocks WordAds block).*$'
 
     - name: Upload test artifacts
       if: ${{ always() }}

--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -2,12 +2,6 @@ name: E2E Tests on Atomic sites
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-  push:
-    branches: [fix/e2e-atomic-workflow]
-    paths-ignore:
-      - '**.md'
   schedule:
     - cron:  '0 */4 * * *'
 
@@ -22,6 +16,8 @@ jobs:
 
     - name: Setup tools
       uses: ./.github/actions/tool-setup
+      with:
+        - php: false
 
     - name: Install
       working-directory: projects/plugins/jetpack/tests/e2e

--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -1,7 +1,13 @@
 name: E2E Tests on Atomic sites
 
 on:
-  pull-request:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  push:
+    branches: [fix/e2e-atomic-workflow]
+    paths-ignore:
+      - '**.md'
   schedule:
     - cron:  '0 */4 * * *'
 

--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -1,6 +1,7 @@
 name: E2E Tests on Atomic sites
 
 on:
+  pull-request:
   schedule:
     - cron:  '0 */4 * * *'
 
@@ -13,36 +14,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Read tool versions
-      id: versions
-      uses: ./.github/actions/read-versions
-
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ steps.versions.outputs.node-version }}
-
-    - name: Use pnpm cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.pnpm-store
-        key: ${{ runner.os }}-pnpm-${{ steps.versions.outputs.node-version }}-${{ hashFiles('**/package.json') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-${{ steps.versions.outputs.node-version }}-
-
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v2.0.1
-      with:
-        version: ${{ steps.versions.outputs.pnpm-version }}
-
-    - name: Tool versions
-      run: |
-        which node
-        node --version
-        which pnpm
-        pnpm --version
-        which jq
-        jq --version
+    - name: Setup tools
+      uses: ./.github/actions/tool-setup
 
     - name: Install
       working-directory: projects/plugins/jetpack/tests/e2e

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,13 @@
 name: E2E Tests
 
 on:
+  pull_request:
+    paths-ignore:
+    - '**.md'
+  push:
+    branches: [master]
+    paths-ignore:
+    - '**.md'
   schedule:
     - cron:  '0 */12 * * *'
 concurrency:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,13 +1,6 @@
 name: E2E Tests
 
 on:
-  pull_request:
-    paths-ignore:
-    - '**.md'
-  push:
-    branches: [master]
-    paths-ignore:
-    - '**.md'
   schedule:
     - cron:  '0 */12 * * *'
 concurrency:

--- a/projects/plugins/jetpack/changelog/fix-e2e-atomic-workflow
+++ b/projects/plugins/jetpack/changelog/fix-e2e-atomic-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: fix missing action for e2e on atomic workflow


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix broken e2e on atomic test site workflow caused by missing action. The workflow was probably added at the same time #20838 removed the action.

#### Jetpack product discussion
no

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* [E2E tests on Atomic sites workflow](https://github.com/Automattic/jetpack/actions/workflows/e2e-tests-atomic.yml?query=branch%3Afix%2Fe2e-atomic-workflow) should run successfully