### PR TITLE
Google Calendar: Allow iFrame popups

### DIFF
--- a/projects/plugins/jetpack/changelog/update-google-calendar-sandbox-popups
+++ b/projects/plugins/jetpack/changelog/update-google-calendar-sandbox-popups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add allow-popups permission to Google Calendar embed so that links internal to the iFrame will open.

--- a/projects/plugins/jetpack/extensions/blocks/google-calendar/google-calendar.php
+++ b/projects/plugins/jetpack/extensions/blocks/google-calendar/google-calendar.php
@@ -49,7 +49,7 @@ function load_assets( $attr ) {
 		return '';
 	}
 
-	$sandbox = 'allow-scripts allow-same-origin';
+	$sandbox = 'allow-scripts allow-same-origin allow-popups';
 	if ( Blocks::is_amp_request() ) {
 		$noscript_src = str_replace(
 			'//calendar.google.com/calendar/embed',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #17788

Over on a site I managed, I notice that on the details event modal, that none of the linked items worked. Specifically, more details and copy to my calendar didn't work. Further, in testing, the "+ Google Calendar" at the bottom right of the calendar view didn't work.

The error that I noticed was that an `allow-popups` permission wasn't being set on the iFrame.

This PR adds that.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Add `allow-popups` so that functionality within the Google Calendar iFrame works. Specifically, the add to calendar button in the bottom right.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To test:

- Checkout branch
- Connect Jetpack
- Create new post
- Add Google Calendar block
- Insert embed code
- Click the "More details", "Copy to calendar", "+ Google Calendar" items within the calendar
- Ensure that all work

