### PR TITLE
Notifications: Fix VR shortcode render

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-vr-shortcode-notification-render
+++ b/projects/plugins/jetpack/changelog/fix-vr-shortcode-notification-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix VR shortcode not rendered on notification content.

--- a/projects/plugins/jetpack/modules/shortcodes/vr.php
+++ b/projects/plugins/jetpack/modules/shortcodes/vr.php
@@ -86,6 +86,18 @@ function jetpack_vr_viewer_get_html( $url_params ) {
 	$maxwidth = ( isset( $content_width ) ) ? $content_width : 720;
 	$view     = ( isset( $url_params['view'] ) ) ? $url_params['view'] : 'cinema';
 
+	// If the shortcode is displayed in a WPCOM notification, display a simple link only.
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		require_once WP_CONTENT_DIR . '/lib/display-context.php';
+		$context = A8C\Display_Context\get_current_context();
+		if ( A8C\Display_Context\NOTIFICATIONS === $context ) {
+			return sprintf(
+				'<a href="%1$s" target="_blank" rel="noopener noreferrer">%1$s</a>',
+				esc_url( $iframe )
+			);
+		}
+	}
+
 	$rtn  = '<div style="position: relative; max-width: ' . $maxwidth . 'px; margin-left: auto; margin-right: auto; overflow: hidden; margin-bottom: 1em;">';
 	$rtn .= '<div style="padding-top: ' . jetpack_vr_viewer_iframe_padding( $view ) . ';"></div>';
 	$rtn .= '<iframe style="position: absolute; top: 0; right: 0; bottom: 0; left: 0; height: 100%" allowfullscreen="true" frameborder="0" width="100%" height="300" src="' . esc_url( $iframe ) . '">';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR addresses the issue where the VR shortcode isn't properly rendered in WPCOM notifications.

The proposed code checks whether it is running on WPCOM and then confirms the display context with the help of `/lib/display-context.php`.

(TODO: Add screenshots.)

#### Jetpack product discussion
To be added.

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Apply the generated patch to WPCOM sandbox as outlined in p7H4VZ-30i-p2.
2. Make sure there is a subscriber on your site that can receive notifications on newly published posts. Notification settings are located in the subscriber's account at `/following/manage` → (gear icon) "Settings" -> "Notify me of new posts" (toggle):
![Markup_on_2021-07-29_at_15_35_56](https://user-images.githubusercontent.com/25105483/131311466-807fc010-e301-45dd-9f6f-24529dc1edb8.png)
3. Log in to the account of the user that can publish posts on the site.
4. Create and publish a new post that has the `[vr]` shortcode in it. Example shortcode that can be used: `[vr guid=q739qW9b view=360]`.
5. Review the notification in the subscriber's account. The shortcode should be rendered as a link that opens in a new tab.