### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -19,7 +19,7 @@ body:
         - Beta
         - Debug Helper
         - VaultPress
-        - None
+        - Other
       multiple: true
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -15,7 +15,7 @@ body:
         - Beta
         - Debug Helper
         - VaultPress
-        - None
+        - Other
       multiple: true
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -15,7 +15,7 @@ body:
         - Beta
         - Debug Helper
         - VaultPress
-        - None
+        - Other
       multiple: true
     validations:
       required: true


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes issue `body[1]: options must not include the reserved word, 'None'.` introduced in https://github.com/Automattic/jetpack/pull/20821

More info at: https://gh-community.github.io/issue-template-feedback/structured/#body0-options-must-not-include-the-reserved-word-none

> This is fixed by removing "None" as an option. If you want a contributor to be able to indicate that they like none of those types of pies, you can additionally remove the required validation:

Instead, I've simply changed "None" to "Other" for now.

#### Jetpack product discussion

Internal: p1630349786015800-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Proofread, then merge & test issue templates are visible.