### PR TITLE
Carousel: add more specific selectors for the carousel cursor

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel_cursor_css
+++ b/projects/plugins/jetpack/changelog/update-carousel_cursor_css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: fix a bug that changes the cursor to a pointer over all nested blocks

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -22,7 +22,7 @@
 }
 /* end of temporary fix */
 
-[data-carousel-extra]:not( .jp-carousel-wrap ) {
+[data-carousel-extra]:not( .jp-carousel-wrap ) img, img + figcaption {
 	cursor: pointer;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The cursor should only change to a pointer when over an img or a figcaption that is the sibling of an img.

**I'm not sure if this change adequately covers all situations where images can be opened in the carousel.** If you know any other situations that should be tested (maybe galleries from other plugins?), please let me know.

I'm suggesting this as a possible temporary solution to the issue reported in #13428, until we have a better solution for gallery parsing.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
##### Reproduce the Bug
1. Install, activate, and connect the master branch of Jetpack.
2. In wp-admin, navigate to Jetpack -> Settings -> Writing. Enable the `Display images in a full-screen carousel gallery` setting. It's in the `Media` section, at the top.
3. Create a new post to test the Gallery block:
    a. Add a Gallery block with some images.
    b. Add a columns block with a couple of columns. Add some paragraph blocks in the columns.
4. Visit the post with the Gallery block. Mouse over the test in the columns and notice that the cursor changes to a pointer.
5. Create a new post to test the Tiled Gallery block:
    a. Add a Tiled Gallery block with some images.
    b. Add a columns block with a couple of columns. Add some paragraph blocks in the columns.
6. Visit the post with the Gallery block. Mouse over the test in the columns and notice that the cursor changes to a pointer.

#### Test this PR
7. Switch to this branch of Jetpack
8. Visit the post with the Gallery block. Mouse over the test in the columns and notice that the cursor does not change to a pointer.
6. Visit the post with the Tiled Gallery block. Mouse over the test in the columns and notice that the cursor does not change to a pointer.