### PR TITLE
E2E tests: improve error handling

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-dont-throw-cli
+++ b/projects/plugins/jetpack/changelog/e2e-dont-throw-cli
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: don't throw when get debug log from docker fails

--- a/projects/plugins/jetpack/tests/e2e/lib/env/playwright-environment.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/env/playwright-environment.js
@@ -157,11 +157,11 @@ class PlaywrightEnvironment extends AllureNodeEnvironment {
 		} );
 
 		page.on( 'pageerror', exception => {
-			logger.error( `Page error: "${ exception }"` );
+			logger.debug( `Page error: "${ exception }"` );
 		} );
 
 		page.on( 'requestfailed', request => {
-			logger.error( `Request failed: ${ request.url() }  ${ request.failure().errorText }` );
+			logger.debug( `Request failed: ${ request.url() }  ${ request.failure().errorText }` );
 		} );
 	}
 

--- a/projects/plugins/jetpack/tests/e2e/lib/utils-helper.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/utils-helper.js
@@ -126,10 +126,8 @@ async function logDebugLog() {
 			'pnpx jetpack docker --type e2e --name t1 exec-silent cat wp-content/debug.log'
 		);
 	} catch ( error ) {
-		if ( error.toString().includes( 'No such file or directory' ) ) {
-			return;
-		}
-		throw error;
+		logger.error( `Error caught when trying to save debug log! ${ error }` );
+		return;
 	}
 
 	const escapedDate = new Date().toISOString().split( '.' )[ 0 ].replace( /:/g, '-' );


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Don't throw if getting debug log from Docker container fails. 
* Changed log level to debug for page errors and requests fails to reduce noise in CI console.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI green