### PR TITLE
Only report tests with status failed in Slack failure notification

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-slack-notif-skipped-tests
+++ b/projects/plugins/jetpack/changelog/e2e-slack-notif-skipped-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: fix skipped tests being reported as failed in Slack notifications

--- a/projects/plugins/jetpack/tests/e2e/bin/slack.js
+++ b/projects/plugins/jetpack/tests/e2e/bin/slack.js
@@ -73,7 +73,7 @@ async function reportTestRunResults( suite = 'Jetpack e2e tests' ) {
 	// Go through all test results and extract failure details
 	for ( const tr of result.testResults ) {
 		for ( const ar of tr.assertionResults ) {
-			if ( ar.status !== 'passed' ) {
+			if ( ar.status === 'failed' ) {
 				detailLines.push( `- ${ ar.fullName }` );
 				for ( const failureMessage of ar.failureMessages ) {
 					failureDetails.push( {


### PR DESCRIPTION
Closing as already included in #20887 

#### Changes proposed in this Pull Request:

Only include tests with status `failed` in test failure Slack notifications. The previous condition also included skipped tests in the failures list.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI green