### PR TITLE
E2E Tests: Fix pre-connection test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-pre-connection-test
+++ b/projects/plugins/jetpack/changelog/fix-pre-connection-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Adapt the test to recent changes to connection banner

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/jetpack.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/jetpack.js
@@ -85,9 +85,9 @@ export default class JetpackPage extends WpPage {
 		const containerSelector = '.jp-connect-screen';
 		const buttonSelector = '.jp-connect-screen button.jp-connect-button--button';
 
-		const isCardVisible = await this.isElementVisible( containerSelector );
+		await this.waitForElementToBeVisible( containerSelector );
 		const isConnectButtonVisible = await this.isElementVisible( buttonSelector );
 
-		return isCardVisible && isConnectButtonVisible;
+		return isConnectButtonVisible;
 	}
 }

--- a/projects/plugins/jetpack/tests/e2e/specs/pro-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/pro-blocks.test.js
@@ -24,7 +24,6 @@ describe( 'Paid blocks', () => {
 			.withLoggedIn( true )
 			.withConnection( true )
 			.withPlan( Plans.Complete )
-			// .withActiveModules( [ 'publicize' ] )
 			.build();
 	} );
 


### PR DESCRIPTION
One of the pre-connection tests started to fail, presumably after a new connection banner was added. Apparently, new banner gets rendered async, but our tests were expecting the banner to be there already. I added a simple wait, and it does fixes the tests.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure CI is green
*
