### PR TITLE
Social Icons: fix being able to remove icons

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-removing-social-icons
+++ b/projects/plugins/jetpack/changelog/fix-removing-social-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social Icons: fix being able to remove icons from widget.

--- a/projects/plugins/jetpack/modules/widgets/social-icons/social-icons-admin.js
+++ b/projects/plugins/jetpack/modules/widgets/social-icons/social-icons-admin.js
@@ -56,12 +56,9 @@
 			event
 		) {
 			event.preventDefault();
-
-			var button = $( this ).parents( '.form' ).find( '.widget-control-save' );
-
-			$( this ).parents( '.jetpack-social-icons-widget-item' ).remove();
-
-			livePreviewUpdate( button );
+			var widgetItem = $( this ).parents( '.jetpack-social-icons-widget-item' );
+			widgetItem.find( 'input' ).change();
+			widgetItem.remove();
 		} );
 
 		// Event handler for widget open button.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Simulating a click on `.widget-control-save` doesn't seem to work as it
did previously, so we're triggering a change event in a different way
here.
* Fixes #20846

#### Jetpack product discussion

#20846 

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* With changes pulled down, in the Customizer add some social icons to the `Social Icons (Jetpack)` widget.
* Publish those changes.
* Make sure you can see social icons on the frontend.
* Then back in the Customizer, you should be able to edit the widget and `Remove` social icons. The Publish/Update buttons should become active without clicking any other widget options.
* These same steps should work in the block-based widget editor as well.
* There should be no JS errors generated.

![Markup on 2021-08-31 at 12:35:39](https://user-images.githubusercontent.com/15803018/131560281-4f526c6e-adba-4f22-bff3-9b56abcd4d99.png)