### PR TITLE
Backup: fix dashboard styling

### DIFF
--- a/projects/plugins/backup/changelog/fix-backup-dashboard-styling
+++ b/projects/plugins/backup/changelog/fix-backup-dashboard-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adjust dashboard styling.

--- a/projects/plugins/backup/src/js/components/Admin.js
+++ b/projects/plugins/backup/src/js/components/Admin.js
@@ -160,10 +160,6 @@ const Admin = () => {
 		}
 	};
 
-	const renderManageConnection = () => {
-		return renderConnectionStatusCard();
-	};
-
 	// Renders additional segments under the jp-hero area condition on having a backup plan
 	const renderBackupSegments = () => {
 		return (
@@ -211,6 +207,8 @@ const Admin = () => {
 							</a>
 						</p>
 					) }
+
+					{ renderConnectionStatusCard() }
 				</div>
 			</div>
 		);
@@ -221,18 +219,7 @@ const Admin = () => {
 			<div className="content">
 				<div className="jp-hero">{ renderLoadedState() }</div>
 				<div className="jp-section">
-					<div className="jp-wrap">
-						{ isFullyConnected() && renderBackupSegments() }
-						{ isFullyConnected() && (
-							<div className="jp-row">
-								<div class="lg-col-span-6 md-col-span-4 sm-col-span-4"></div>
-								<div class="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
-								<div class="lg-col-span-5 md-col-span-3 sm-col-span-4">
-									{ renderManageConnection() }
-								</div>
-							</div>
-						) }
-					</div>
+					<div className="jp-wrap">{ isFullyConnected() && renderBackupSegments() }</div>
 				</div>
 			</div>
 		);

--- a/projects/plugins/backup/src/js/components/Backups.js
+++ b/projects/plugins/backup/src/js/components/Backups.js
@@ -154,9 +154,9 @@ const Backups = () => {
 				</div>
 				<div class="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
 				<div class="backup__animation lg-col-span-6 md-col-span-2 sm-col-span-2">
-					<img className="backup__animation-el-1" src={ BackupAnim1 } alt="" />
-					<img className="backup__animation-el-2" src={ BackupAnim2 } alt="" />
-					<img className="backup__animation-el-3" src={ BackupAnim3 } alt="" />
+					<img className="backup__animation-el-1" src={ assetBuildUrl + BackupAnim1 } alt="" />
+					<img className="backup__animation-el-2" src={ assetBuildUrl + BackupAnim2 } alt="" />
+					<img className="backup__animation-el-3" src={ assetBuildUrl + BackupAnim3 } alt="" />
 				</div>
 			</div>
 		);
@@ -195,28 +195,28 @@ const Backups = () => {
 				<div className="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
 				<div className="lg-col-span-2 md-col-span-2 sm-col-span-2">
 					<StatBlock
-						icon={ PostsIcon }
+						icon={ assetBuildUrl + PostsIcon }
 						label={ __( 'Posts', 'jetpack-backup' ) }
 						value={ stats.posts }
 					/>
 				</div>
 				<div className="lg-col-span-2 md-col-span-2 sm-col-span-2">
 					<StatBlock
-						icon={ UploadsIcon }
+						icon={ assetBuildUrl + UploadsIcon }
 						label={ __( 'Uploads', 'jetpack-backup' ) }
 						value={ stats.uploads }
 					/>
 				</div>
 				<div className="lg-col-span-2 md-col-span-2 sm-col-span-2">
 					<StatBlock
-						icon={ PluginsIcon }
+						icon={ assetBuildUrl + PluginsIcon }
 						label={ __( 'Plugins', 'jetpack-backup' ) }
 						value={ stats.plugins }
 					/>
 				</div>
 				<div className="lg-col-span-2 md-col-span-2 sm-col-span-2">
 					<StatBlock
-						icon={ ThemesIcon }
+						icon={ assetBuildUrl + ThemesIcon }
 						label={ __( 'Themes', 'jetpack-backup' ) }
 						value={ stats.themes }
 					/>

--- a/projects/plugins/backup/src/js/components/Backups.js
+++ b/projects/plugins/backup/src/js/components/Backups.js
@@ -37,6 +37,8 @@ const Backups = () => {
 	} );
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
 
+	const assetBuildUrl = useSelect( select => select( STORE_ID ).getAssetBuildUrl(), [] );
+
 	const BACKUP_STATE = {
 		LOADING: 0,
 		IN_PROGRESS: 1,
@@ -177,7 +179,7 @@ const Backups = () => {
 			<div className="jp-row">
 				<div className="lg-col-span-3 md-col-span-4 sm-col-span-4">
 					<div className="backup__latest">
-						<img src={ CloudIcon } alt="" />
+						<img src={ assetBuildUrl + CloudIcon } alt="" />
 						<h2>{ __( 'Latest Backup', 'jetpack-backup' ) }</h2>
 					</div>
 					<h1>{ formatDateString( latestTime ) }</h1>

--- a/projects/plugins/backup/src/js/components/admin-style.scss
+++ b/projects/plugins/backup/src/js/components/admin-style.scss
@@ -37,6 +37,16 @@
 		font-weight: 500;
 	}
 
+	.jp-section {
+		h2, h3 {
+			margin-bottom: 14px;
+		}
+
+		p {
+			margin-top: 14px;
+		}
+	}
+
 	p, li {
 		font-size: 16px;
 		line-height: 1.5;
@@ -69,6 +79,7 @@
 		background: var( --jp-black );
 		text-decoration: none;
 		border-radius: var( --jp-border-radius );
+		border: 0;
 
 		&.is-full-width {
 			width: 100%;

--- a/projects/plugins/backup/src/js/components/rna-styles.scss
+++ b/projects/plugins/backup/src/js/components/rna-styles.scss
@@ -6,7 +6,7 @@
 	--font-title-small: 24px;
 	--font-body: 16px;
 	--font-label: 12px;
-	
+
 	--jp-black:           #000000;
 	--jp-black-80:        #2C3338;
 	--jp-white:           #FFFFFF;
@@ -64,12 +64,12 @@ body {
 	grid-template-columns: repeat(4, 1fr);
 	width: 100%;
 	margin: 0 16px;
-	
+
 	@include for-phone-up {
 		grid-template-columns: repeat(8, 1fr);
 		margin: 0 18px;
 	}
-	
+
 	@include for-tablet-up {
 		grid-template-columns: repeat(12, 1fr);
 		max-width: 1128px;
@@ -125,12 +125,12 @@ body {
 	grid-template-columns: repeat(4, 1fr);
 	width: 100%;
 	margin: 0 16px;
-	
+
 	@include for-phone-up {
 		grid-template-columns: repeat(8, 1fr);
 		margin: 0 18px;
 	}
-	
+
 	@include for-tablet-up {
 		grid-template-columns: repeat(12, 1fr);
 		max-width: 1128px;
@@ -141,11 +141,11 @@ body {
 .jp-cut {
 	position: relative;
 	display: block;
-	margin: 32px 0;
 	padding: 16px 64px 16px 24px;
 	border: 2px solid var( --jp-green-primary );
 	border-radius: var( --jp-border-radius );
 	text-decoration: none;
+	margin: 24px 0 32px;
 
 	span {
 		display: block;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* fix dashboard styling for the Backup plugin
* bring back the "Cloud" icon, the path changed after the Webpack update (#20789)

#### Jetpack product discussion
p1HpG7-cGL-p2#comment-48367

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Connect Jetpack Backup, purchase a Backup plan.
2. Confirm that the Dashboard renders well, and looks good.
<img width="1191" alt="Screen Shot 2021-09-01 at 8 54 45 AM" src="https://user-images.githubusercontent.com/1341249/131676231-edb60354-e687-470e-99b8-ba851830115e.png">