### PR TITLE
VideoPress Block: New Icon for Edit Button

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-block-edit-icon
+++ b/projects/plugins/jetpack/changelog/update-videopress-block-edit-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Updated the edit icon design in the VideoPress block toolbar.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -7,6 +7,7 @@ import {
 	BaseControl,
 	Button,
 	PanelBody,
+	Path,
 	SandBox,
 	SelectControl,
 	ToggleControl,
@@ -34,6 +35,7 @@ import { get, indexOf } from 'lodash';
 import Loading from './loading';
 import { getVideoPressUrl } from './url';
 import { getClassNames } from './utils';
+import renderMaterialIcon from '../../shared/render-material-icon';
 import SeekbarColorSettings from './seekbar-color-settings';
 
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -276,7 +278,14 @@ const VideoPressEdit = CoreVideoEdit =>
 								className="components-icon-button components-toolbar__control"
 								label={ __( 'Edit video', 'jetpack' ) }
 								onClick={ this.switchToEditing }
-								icon="edit"
+								icon={ renderMaterialIcon(
+									<Path
+										d="M20.1 5.1L16.9 2 6.2 12.7l-1.3 4.4 4.5-1.3L20.1 5.1zM4 20.8h8v-1.5H4v1.5z"
+										stroke="currentColor"
+									/>,
+									18,
+									18
+								) }
 							/>
 						</ToolbarGroup>
 					</BlockControls>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -7,7 +7,6 @@ import {
 	BaseControl,
 	Button,
 	PanelBody,
-	Path,
 	SandBox,
 	SelectControl,
 	ToggleControl,
@@ -26,6 +25,7 @@ import {
 } from '@wordpress/block-editor';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
+import { Icon, pencil } from '@wordpress/icons';
 import classnames from 'classnames';
 import { get, indexOf } from 'lodash';
 
@@ -35,7 +35,6 @@ import { get, indexOf } from 'lodash';
 import Loading from './loading';
 import { getVideoPressUrl } from './url';
 import { getClassNames } from './utils';
-import renderMaterialIcon from '../../shared/render-material-icon';
 import SeekbarColorSettings from './seekbar-color-settings';
 
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -278,14 +277,7 @@ const VideoPressEdit = CoreVideoEdit =>
 								className="components-icon-button components-toolbar__control"
 								label={ __( 'Edit video', 'jetpack' ) }
 								onClick={ this.switchToEditing }
-								icon={ renderMaterialIcon(
-									<Path
-										d="M20.1 5.1L16.9 2 6.2 12.7l-1.3 4.4 4.5-1.3L20.1 5.1zM4 20.8h8v-1.5H4v1.5z"
-										stroke="currentColor"
-									/>,
-									18,
-									18
-								) }
+								icon={ <Icon icon={ pencil } /> }
 							/>
 						</ToolbarGroup>
 					</BlockControls>


### PR DESCRIPTION
This PR updates the icon for the edit button in the toolbar for the VideoPress block.

**Before**
<img width="639" alt="Screen Shot 2021-09-01 at 9 30 29 AM" src="https://user-images.githubusercontent.com/789137/131702869-5352202b-e9da-4b05-88f9-160ec917420f.png">

**After**
<img width="625" alt="Screen Shot 2021-09-01 at 9 34 34 AM" src="https://user-images.githubusercontent.com/789137/131702915-1e0de79d-dfef-40b2-936b-f14d1687ae7b.png">

I made the icon a bit smaller so that it fits in with the other icons on the toolbar that are still "dashicons".

#### Changes proposed in this Pull Request:
* Updates edit icon to the svg available at: https://wordpress.github.io/gutenberg/?path=/story/icons-icon--library

#### Jetpack product discussion
pxWta-Zz-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Add or edit a VideoPress block, you should see the new icon and clicking it should take the block back to the upload/select video view.
* Hopefully the icon looks nice 😉 