### PR TITLE
Update renovate config

### DIFF
--- a/.github/files/renovate-helper.sh
+++ b/.github/files/renovate-helper.sh
@@ -121,7 +121,7 @@ fi
 
 # Update deps and lock files.
 echo "::group::Updating dependencies on changed packages"
-tools/check-intra-monorepo-deps.sh -uv
+tools/check-intra-monorepo-deps.sh -uav
 echo "::endgroup::"
 
 # Create and push the commit.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,6 @@
 	"schedule": [ "before 3am on the first day of the month" ],
 	"updateNotScheduled": false,
 	"gitIgnoredAuthors": [ "matticbot@users.noreply.github.com" ],
-	"ignoreDeps": [ "mockery/mockery", "php-mock/php-mock", "phpunit/phpunit" ],
 	"packageRules": [
 		{
 			"groupName": "Monorepo packages",
@@ -62,8 +61,10 @@
 			"matchDepTypes": [ "monorepo:wordpress", "monorepo:react" ]
 		},
 		{
-			"groupName": "Eslint and plugins",
-			"matchPackagePatterns": [ "^eslint$", "^eslint-plugin-", "^eslint-config-" ]
+			"extends": "packages:eslint"
+		},
+		{
+			"extends": "packages:jsUnitTest"
 		},
 		{
 			"matchPaths": [ "packages/codesniffer/composer.json" ],
@@ -85,6 +86,10 @@
 			"labels": [ "Search", "Instant Search" ]
 		}
 	],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": [ "before 3:00 am on Monday on the 7th through 13th day of the month" ]
+	},
 	"dependencyDashboard": true,
 	"dependencyDashboardTitle": "Renovate Dependency Updates",
 	"dependencyDashboardLabels": [ "Primary Issue", "[Type] Janitorial" ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Helper: Pass `-a` to check-intra-monorepo-deps.sh.
* Use renovate's built-in `packages:eslint` grouping.
* Group JS unit testing packages with `packages:jsUnitTest`.
* Try enabling lock file maintenance, scheduled for the Monday after the
  first Tuesday of the month.
* Remove obsolete `ignoreDeps` entries, nothing directly depends on any
  of these anymore.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge, then have renovate rebase #20905, see if the helper works now.
* Merge, then see how renovate reacts.
