### PR TITLE
Connection: remove invalid user token before reconnect

### DIFF
--- a/projects/packages/connection/changelog/fix-reconnect-button-missing
+++ b/projects/packages/connection/changelog/fix-reconnect-button-missing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove invalid user token before reconnect.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.3';
+	const PACKAGE_VERSION = '1.30.4-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
If user token exists, the connection screen doesn't show the "Connect" button.
Therefore, if reconnect process requires user to reconnect, we need to remove the existing invalid user token so they would be able to connect their WP.com account again.

This PR makes the reconnect process remove user token if it's invalid before initiating the user connection process.

#### Jetpack product discussion
p1630509554174800-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?


#### Testing instructions:
1. Connect Jetpack, then use the "Broken Token" plugin to set an invalid user token.
2. Go to the "Reconnect" modal page: `/wp-admin/admin.php?page=jetpack#/reconnect`, click "Reconnect".
3. Confirm that the "Connect" button shows up.
4. Complete the user connection process, make sure it goes well.
5. Go back to the "Broken Token" plugin and remove the user token entirely, but leave the primary user ID in place.
6. Open the "Reconnect" page: `/wp-admin/admin.php?page=jetpack#/reconnect`, click "Reconnect".
7. Finish the user connection process, confirm that it goes well.