### PR TITLE
Sync: Defensive coding against E_NOTICE

### DIFF
--- a/projects/packages/sync/changelog/fix-wporg-notices
+++ b/projects/packages/sync/changelog/fix-wporg-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP notices on queue_pull if all args are not set.

--- a/projects/packages/sync/src/class-rest-sender.php
+++ b/projects/packages/sync/src/class-rest-sender.php
@@ -44,7 +44,7 @@ class REST_Sender {
 		// try to give ourselves as much time as possible.
 		set_time_limit( 0 );
 
-		if ( $args['pop'] ) {
+		if ( ! empty( $args['pop'] ) ) {
 			$buffer = new Queue_Buffer( 'pop', $queue->pop( $number_of_items ) );
 		} else {
 			// let's delete the checkin state.
@@ -62,15 +62,17 @@ class REST_Sender {
 			return new WP_Error( 'buffer_non-object', 'Buffer is not an object', 400 );
 		}
 
+		$encode = isset( $args['encode'] ) ? $args['encode'] : null;
+
 		Settings::set_is_syncing( true );
-		list( $items_to_send, $skipped_items_ids ) = $sender->get_items_to_send( $buffer, $args['encode'] );
+		list( $items_to_send, $skipped_items_ids ) = $sender->get_items_to_send( $buffer, $encode );
 		Settings::set_is_syncing( false );
 
 		return array(
 			'buffer_id'      => $buffer->id,
 			'items'          => $items_to_send,
 			'skipped_items'  => $skipped_items_ids,
-			'codec'          => $args['encode'] ? $sender->get_codec()->name() : null,
+			'codec'          => $encode ? $sender->get_codec()->name() : null,
 			'sent_timestamp' => time(),
 		);
 	}

--- a/projects/packages/sync/src/class-rest-sender.php
+++ b/projects/packages/sync/src/class-rest-sender.php
@@ -62,7 +62,7 @@ class REST_Sender {
 			return new WP_Error( 'buffer_non-object', 'Buffer is not an object', 400 );
 		}
 
-		$encode = isset( $args['encode'] ) ? $args['encode'] : null;
+		$encode = isset( $args['encode'] ) ? $args['encode'] : true;
 
 		Settings::set_is_syncing( true );
 		list( $items_to_send, $skipped_items_ids ) = $sender->get_items_to_send( $buffer, $encode );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes a series of E_NOTICEs thrown when testing on w.org:

```
E_NOTICE: Undefined index: pop in /home//public_html/wp-content/plugins/jetpack/vendor/automattic/jetpack-sync/src/class-rest-sender.php:47
```

```
E_NOTICE: Undefined index: encode in /home//public_html/wp-content/plugins/jetpack/vendor/automattic/jetpack-sync/src/class-rest-sender.php:66
```

```
E_NOTICE: Undefined index: encode in /home//public_html/wp-content/plugins/jetpack/vendor/automattic/jetpack-sync/src/class-rest-sender.php:73
```

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds some checks.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unclear how to reproduce, going off of log review.
*
