### PR TITLE
Carousel: Fix cursor css selector

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel_css_fix
+++ b/projects/plugins/jetpack/changelog/update-carousel_css_fix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: No entry needed because this fixes and issue in a previous PR.
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -22,7 +22,7 @@
 }
 /* end of temporary fix */
 
-[data-carousel-extra]:not( .jp-carousel-wrap ) img, img + figcaption {
+[data-carousel-extra]:not( .jp-carousel-wrap ) img, [data-carousel-extra]:not( .jp-carousel-wrap ) img + figcaption {
 	cursor: pointer;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The CSS selector for the pointer cursor is incorrect. Fix it by specifying that the `img+figcaption` selector must have the `data-carousel-extra` attribute. This problem was introduced in PR #20882, which has been merged but not released.

#### Jetpack product discussion
* p8oabR-IS-p2#comment-5462

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
This PR fixes a problem that occurs when the Carousel feature is disabled.

##### Set up the site
1. Install, activate, and connect the release candidate of Jetpack version 10.1.
2. Create a post with a Gallery block. 
    a. Make sure to add multiple images and make sure that the images have captions.
    b. Add a Columns block. In each column, add something like a paragraph block with some text.
3. Create a post with a Tiled Gallery block.
    a. Make sure to add multiple images.
    b. Add a Columns block. In each column, add something like a paragraph block with some text.

##### Reproduce the problem
4. Verify that the Carousel feature is not enabled. In wp-admin, navigate to Jetpack -> Settings -> Writing. In the media section, the "Create full-screen carousel slideshows..." setting must be disabled.
5. On the front end of the site, open the post with the Gallery block. Mouse over the image captions and notice that the cursor turns into a pointer. This shouldn't happen.

##### Test the fix
6. Switch to this branch of Jetpack.
7. On the front end of the site, open the post with the Gallery block. Mouse over the image captions and notice that the cursor doesn't turn into a pointer.

##### Test with the Carousel feature enabled
8. Enable the Carousel feature. In wp-admin, navigate to Jetpack -> Settings -> Writing. In the media section, the "Create full-screen carousel slideshows..." setting must be enabled.
9. On the front end of the site, open the post with the Gallery block. Mouse over the images and image captions and notice that the cursor turns into a pointer. Click the images and verify the the carousel opens.
10. Mouse over the text in the columns block and verify that the cursor does not turn into a pointer.
11. Repeat steps 9 through 11 on the post with the Tiled Gallery block. 