### PR TITLE
Tiled gallery: fix transform again

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-transform-again
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-transform-again
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Fixes an issue with transform to tiled gallery block not working for galleries with more than 3 images
+
+

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.js
@@ -66,7 +66,11 @@ export const pickRelevantMediaFiles = image => {
 class TiledGalleryEdit extends Component {
 	state = {
 		selectedImage: null,
-		changed: 'undefined' === typeof this.props.attributes.columnWidths ? true : false,
+		changed:
+			'undefined' === typeof this.props.attributes.columnWidths ||
+			this.props.attributes.columnWidths?.length === 0
+				? true
+				: false,
 	};
 
 	static getDerivedStateFromProps( props, state ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/index.js
@@ -246,7 +246,6 @@ export const settings = {
 							alt,
 						} ) ),
 						ids: validImages.map( ( { id } ) => id ),
-						columnWidths: [ [ '100.00000' ] ],
 					} );
 				},
 			},
@@ -264,7 +263,6 @@ export const settings = {
 								alt,
 							} ) ),
 							ids: validImages.map( ( { id } ) => id ),
-							columnWidths: [ [ '100.00000' ] ],
 						} );
 					}
 					return createBlock( `jetpack/${ name }` );


### PR DESCRIPTION
Fixes #13254

#### Changes proposed in this Pull Request:

* Instead of setting a default columnWidths in transform, which only works with transforming a very small gallery, check for an empty columnWidths array on mount instead

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Check out PR to local dev env
* Add a core gallery block with 4 or more images
* Make sure transform works, then save post/page and make sure it still displays correctly in the editor and frontend
