### PR TITLE
Search: don't translate product name in wp-admin menu

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-search-dashboard-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-search-dashboard-page.php
@@ -44,7 +44,7 @@ class Jetpack_Search_Dashboard_Page extends Jetpack_Admin_Page {
 		return add_submenu_page(
 			'jetpack',
 			__( 'Search Settings', 'jetpack' ),
-			__( 'Search', 'jetpack' ),
+			'Search', // Not translated as it's a product name.
 			'manage_options',
 			'jetpack-search',
 			array( $this, 'render' ),

--- a/projects/plugins/jetpack/changelog/fix-menu-translation-search
+++ b/projects/plugins/jetpack/changelog/fix-menu-translation-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: don't translate product name in wp-admin menu


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fixes #20906.

Search was appearing as 'Recherche' in the wp-admin when the interface language is French.

Generally we do not translate the product name - see https://jetpack.com/upgrade/search/ for example.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On a site with Jetpack Search enabled, go to wp-admin.
* Make sure your interface language is set to a non-English language.
* Make sure the Jetpack menu contains an item 'Search'.

<img width="166" alt="Screen Shot 2021-09-02 at 16 21 59" src="https://user-images.githubusercontent.com/17325/131781345-41ae43ba-a017-4123-a99d-91e19a6d846f.png">
