### PR TITLE
Instant Search customization: use sentence case consistently

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-customberg-case
+++ b/projects/plugins/jetpack/changelog/fix-customberg-case
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Instant Search customization: use sentence case consistently
+
+

--- a/projects/plugins/jetpack/modules/search/customberg/components/sidebar/color-control.jsx
+++ b/projects/plugins/jetpack/modules/search/customberg/components/sidebar/color-control.jsx
@@ -39,7 +39,7 @@ export default function ColorControl( { disabled, value, onChange } ) {
 	return (
 		<div className="jp-search-configure-color-input components-base-control">
 			<ColorGradientControl
-				label={ __( 'Highlight for Search Terms', 'jetpack' ) }
+				label={ __( 'Highlight for search terms', 'jetpack' ) }
 				disabled={ disabled }
 				colorValue={ value }
 				colors={ colors }

--- a/projects/plugins/jetpack/modules/search/customberg/components/sidebar/excluded-post-types-control.jsx
+++ b/projects/plugins/jetpack/modules/search/customberg/components/sidebar/excluded-post-types-control.jsx
@@ -48,7 +48,7 @@ export default function ExcludedPostTypesControl( {
 	return (
 		<div className="jp-search-configure-excluded-post-types-control components-base-control">
 			<div className="jp-search-configure-excluded-post-types-control__label">
-				{ __( 'Excluded Post Types', 'jetpack' ) }
+				{ __( 'Excluded post types', 'jetpack' ) }
 			</div>
 			{ isLastUnchecked && (
 				<Notice isDismissible={ false } status="info">

--- a/projects/plugins/jetpack/modules/search/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/plugins/jetpack/modules/search/customberg/components/sidebar/sidebar-options.jsx
@@ -70,7 +70,7 @@ export default function SidebarOptions() {
 				<ThemeControl disabled={ isDisabled } onChange={ setTheme } value={ theme } />
 				<RadioControl
 					className="jp-search-configure-result-format-radios"
-					label={ __( 'Result Format', 'jetpack' ) }
+					label={ __( 'Result format', 'jetpack' ) }
 					selected={ resultFormat }
 					options={ [
 						{ label: __( 'Minimal', 'jetpack' ), value: 'minimal' },
@@ -82,10 +82,10 @@ export default function SidebarOptions() {
 				<ColorControl disabled={ isDisabled } onChange={ setColor } value={ color } />
 			</PanelBody>
 
-			<PanelBody title={ __( 'Search Options', 'jetpack' ) } initialOpen={ true }>
+			<PanelBody title={ __( 'Search options', 'jetpack' ) } initialOpen={ true }>
 				<SelectControl
 					disabled={ isDisabled }
-					label={ __( 'Default Sort', 'jetpack' ) }
+					label={ __( 'Default sort', 'jetpack' ) }
 					value={ sort }
 					options={ [
 						{ label: __( 'Relevance (recommended)', 'jetpack' ), value: 'relevance' },
@@ -96,7 +96,7 @@ export default function SidebarOptions() {
 				/>
 				<SelectControl
 					disabled={ isDisabled }
-					label={ __( 'Overlay Trigger', 'jetpack' ) }
+					label={ __( 'Overlay trigger', 'jetpack' ) }
 					value={ trigger }
 					options={ [
 						{ label: __( 'Open when the user starts typing', 'jetpack' ), value: 'immediate' },
@@ -112,7 +112,7 @@ export default function SidebarOptions() {
 				/>
 			</PanelBody>
 
-			<PanelBody title={ __( 'Additional Settings', 'jetpack' ) } initialOpen={ true }>
+			<PanelBody title={ __( 'Additional settings', 'jetpack' ) } initialOpen={ true }>
 				<ToggleControl
 					checked={ sortEnabled }
 					disabled={ isDisabled }
@@ -122,7 +122,7 @@ export default function SidebarOptions() {
 				<ToggleControl
 					checked={ infiniteScroll }
 					disabled={ isDisabled }
-					label={ __( 'Enable Infinite Scroll', 'jetpack' ) }
+					label={ __( 'Enable infinite scroll', 'jetpack' ) }
 					onChange={ setInfiniteScroll }
 				/>
 				<ToggleControl


### PR DESCRIPTION
Fixes #20909.

#### Changes proposed in this Pull Request:

This PR aims to ensure our whole Search wp-admin section uses consistent capitalization.

Gutenberg has made a big effort to use sentence case consistently:

WordPress/gutenberg#18758

Here's the developer guide documentation on it:

https://developer.wordpress.org/block-editor/contributors/documentation/copy-guide/#five-pay-attention-to-capitalization

It recommends title case for product names and main titles, and sentence case for everything else.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
On a site with Jetpack Instant Search enabled, visit `/wp-admin/admin.php?page=jetpack-search-configure`.

Check all the UI text and make sure sentence case (e.g. "Monkey badger panda") rather than title case (e.g. "Monkey Badger Panda") is used.