### PR TITLE
Blocks: fix HTML markup of buttons added to our blocks.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-button-block-markup
+++ b/projects/plugins/jetpack/changelog/fix-button-block-markup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blocks: fix HTML markup of buttons added to our blocks.

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -82,7 +82,7 @@ function render_block( $attributes, $content ) {
 		: '<' . $element . $button_attributes . '>' . $text . '</' . $element . '>';
 
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	return '<div "' . $wrapper_attributes . '">' . $button . '</div>';
+	return '<div' . $wrapper_attributes . '>' . $button . '</div>';
 }
 
 /**


### PR DESCRIPTION
Fixes #20924

#### Changes proposed in this Pull Request:

Since `$wrapper_attributes` is already fully formed, we do not need any extra quotes in the final output.

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a connected site.
* Go to Posts > Add New, and add a Revue block or a MailChimp block.
* Play with the button settings, add custom colors, ..
* Publish your post.
* Ensure the button markup is correct.
