### PR TITLE
Carousel: update prev/next nav button colors

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-nav-colors
+++ b/projects/plugins/jetpack/changelog/update-carousel-nav-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Carousel: change prev/next nav button color to match with selected color scheme.

--- a/projects/plugins/jetpack/changelog/update-carousel-nav-colors
+++ b/projects/plugins/jetpack/changelog/update-carousel-nav-colors
@@ -1,4 +1,5 @@
 Significance: patch
-Type: enhancement
+Type: other
+Comment: correct load order of Swiper/JP CSS.
 
-Carousel: change prev/next nav button color to match with selected color scheme.
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -60,8 +60,8 @@ class Jetpack {
 	 * When making changes to that list, you must also update concat_list in tools/builder/frontend-css.js.
 	 */
 	public $concatenated_style_handles = array(
-		'jetpack-carousel',
 		'jetpack-carousel-swiper-css',
+		'jetpack-carousel',
 		'grunion.css',
 		'the-neverending-homepage',
 		'jetpack_likes',

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -384,7 +384,7 @@ class Jetpack_Carousel {
 				itemscope
 				itemtype="https://schema.org/ImageGallery">
 				<div class="jp-carousel swiper-wrapper"></div>
-				<div class="jp-swiper-button-prev swiper-button-prev swiper-button-<?php echo ( $is_light ? 'black' : 'white' ); ?>">
+				<div class="jp-swiper-button-prev swiper-button-prev">
 					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<mask id="maskPrev" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="9" height="12">
 							<path d="M16.2072 16.59L11.6496 12L16.2072 7.41L14.8041 6L8.8335 12L14.8041 18L16.2072 16.59Z" fill="white"/>
@@ -394,7 +394,7 @@ class Jetpack_Carousel {
 						</g>
 					</svg>
 				</div>
-				<div class="jp-swiper-button-next swiper-button-next swiper-button-<?php echo ( $is_light ? 'black' : 'white' ); ?>">
+				<div class="jp-swiper-button-next swiper-button-next">
 					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<mask id="maskNext" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="8" height="12">
 							<path d="M8.59814 16.59L13.1557 12L8.59814 7.41L10.0012 6L15.9718 12L10.0012 18L8.59814 16.59Z" fill="white"/>

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -384,7 +384,7 @@ class Jetpack_Carousel {
 				itemscope
 				itemtype="https://schema.org/ImageGallery">
 				<div class="jp-carousel swiper-wrapper"></div>
-				<div class="jp-swiper-button-prev swiper-button-prev">
+				<div class="jp-swiper-button-prev swiper-button-prev swiper-button-<?php echo ( $is_light ? 'black' : 'white' ); ?>">
 					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<mask id="maskPrev" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="9" height="12">
 							<path d="M16.2072 16.59L11.6496 12L16.2072 7.41L14.8041 6L8.8335 12L14.8041 18L16.2072 16.59Z" fill="white"/>
@@ -394,7 +394,7 @@ class Jetpack_Carousel {
 						</g>
 					</svg>
 				</div>
-				<div class="jp-swiper-button-next swiper-button-next">
+				<div class="jp-swiper-button-next swiper-button-next swiper-button-<?php echo ( $is_light ? 'black' : 'white' ); ?>">
 					<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<mask id="maskNext" mask-type="alpha" maskUnits="userSpaceOnUse" x="8" y="6" width="8" height="12">
 							<path d="M8.59814 16.59L13.1557 12L8.59814 7.41L10.0012 6L15.9718 12L10.0012 18L8.59814 16.59Z" fill="white"/>

--- a/projects/plugins/jetpack/tools/builder/frontend-css.js
+++ b/projects/plugins/jetpack/tools/builder/frontend-css.js
@@ -23,8 +23,8 @@ import { transformRelativePath } from './transform-relative-paths';
  * When making changes to that list, you must also update $concatenated_style_handles in class.jetpack.php.
  */
 export const frontendCSSSeparateFilesList = [
-	'modules/carousel/jetpack-carousel.css',
 	'modules/carousel/swiper-bundle.css',
+	'modules/carousel/jetpack-carousel.css',
 	'modules/contact-form/css/grunion.css',
 	'modules/infinite-scroll/infinity.css',
 	'modules/likes/style.css',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Sometimes the carousel is showing blue prev/next nav buttons (regardless of black/white carousel color scheme):

<img width="600" alt="Screen Shot 2021-09-02 at 1 53 25 PM" src="https://user-images.githubusercontent.com/15803018/131907558-f33e25b4-c83d-4bbe-b873-505aa1573324.png">

Edit: Seems like the root issue has to do with CSS file load order, see: https://github.com/Automattic/jetpack/pull/20940#issuecomment-912148708

#### Jetpack product discussion

Internal, asked in testing: p8oabR-IS-p2#comment-5467

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* After applying changes, you should see the carousel nav buttons be based off the carousel color scheme rather than being blue all the time.