### PR TITLE
Search: Improve style specificity for result highlights in Customberg

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-customberg-result-highlight
+++ b/projects/plugins/jetpack/changelog/fix-customberg-result-highlight
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: Improve style specificity for result highlights in Customberg

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-results.jsx
@@ -117,7 +117,7 @@ class SearchResults extends Component {
 					dangerouslySetInnerHTML={ {
 						__html: `
 							.jetpack-instant-search *::selection,
-							.jetpack-instant-search .jetpack-instant-search__search-results .jetpack-instant-search__search-results-primary mark {
+							.jetpack-instant-search .jetpack-instant-search__search-results .jetpack-instant-search__search-results-primary .jetpack-instant-search__search-result mark {
 								color: ${ textColor };
 								background-color: ${ highlightColor };
 							}


### PR DESCRIPTION
Fixes a bug discovered in #20754 by @keoshi:

> - The highlight color takes into consideration the text color, but not when changing to the Dark theme. Note how it behaves with the “june bud” swatch. [text omitted]
> 
> Light theme | Dark theme
> --|--
> ![image](https://user-images.githubusercontent.com/390760/130478354-c5c930a0-71f9-427a-93a4-ec2ee1f01c41.png) | ![image](https://user-images.githubusercontent.com/390760/130478430-582c7bf6-3eaf-41f8-ad27-da43bbd8131d.png)
> ![image](https://user-images.githubusercontent.com/390760/130478398-e8d2274b-99b3-418e-a88a-db9b7d05ab28.png) | ![image](https://user-images.githubusercontent.com/390760/130478505-898a8b6e-e352-43fd-befd-847da80c0599.png)

#### Changes proposed in this Pull Request:
Increase specificity for dynamically generated `mark` styling to ensure it's not being overridden by the dark theme styling.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Navigate to Customberg (e.g. `/wp-admin/admin.php?page=jetpack-search-configure`) and try changing the theme as well as the result highlight color. Ensure that the text color within the highlight is unaffected by theme changes.
* Ensure that the same highlight & text colors appear on the actual Instant Search application (e.g. `/?s=`).