### PR TITLE
Change add "new plugin" menu item destination to calypso.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-use-calypso-for-add-new-plugin
+++ b/projects/plugins/jetpack/changelog/update-use-calypso-for-add-new-plugin
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add filter to add_plugins_menu to allow for submenu updates within WPCOMSH
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -346,9 +346,10 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * Adds Plugins menu.
 	 */
 	public function add_plugins_menu() {
-		// On any environment, users adding new plugins should go through the calypso (marketplace) screens.
-		$submenus_to_update['plugin-install.php'] = 'https://wordpress.com/plugins/' . $this->domain;
-		$this->update_submenus( 'plugins.php', $submenus_to_update );
+		$submenus_to_update = apply_filters( 'wpcom_plugins_submenu_update', array() );
+		if ( ! empty( $submenus_to_update ) ) {
+			$this->update_submenus( 'plugins.php', $submenus_to_update );
+		}
 
 		if ( self::CLASSIC_VIEW === $this->get_preferred_view( 'plugins.php' ) ) {
 			return;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -346,6 +346,10 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * Adds Plugins menu.
 	 */
 	public function add_plugins_menu() {
+		// On any environment, users adding new plugins should go through the calypso (marketplace) screens.
+		$submenus_to_update['plugin-install.php'] = 'https://wordpress.com/plugins/' . $this->domain;
+		$this->update_submenus( 'plugins.php', $submenus_to_update );
+
 		if ( self::CLASSIC_VIEW === $this->get_preferred_view( 'plugins.php' ) ) {
 			return;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/55893

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a filter in the function that returns the plugins menu so anyone can hook into it and alter it if needed. This is mainly needed by 741-gh-Automattic/wpcomsh

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**In an WoA developer blog**
* Apply the code changes this PR introduces in `wp-content/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php`
* Make sure that the Plugins menu still behave the same way
* Add the following code in wpcomsh `wp-content/mu-plugins/wpcomsh/feature-plugins/masterbar.php` 
```
function temporary_update_plugin_submenus() {
	return array(
		'plugin-install.php' => 'https://wordpress.com/plugins/' . ( new Automattic\Jetpack\Status() )->get_site_suffix(),
	);
}

function temporary_update_plugin_submenus_add_filter() {
	add_filter( 'wpcom_plugins_submenu_update', 'temporary_update_plugin_submenus' );
}
add_action( 'admin_menu', 'temporary_update_plugin_submenus_add_filter' );
``` 
* Go to **Plugins -> Add New** menu item
* You should be redirected to Calypso `https://wordpress.com/plugins/[DOMAIN]`
* While in Calypso, make sure that you get the same behavior

**In a Simple site**
* apply D66349-code
* make sure that there are no regressions - Simple Sites should only have a Plugins menu linking to `https://wordpress.com/plugins/[DOMAIN]`