### PR TITLE
action: Allow renovate helper workflow re-run

### DIFF
--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -13,7 +13,7 @@ jobs:
   cleanup:
     name: Amend Renovate PR
     runs-on: ubuntu-latest
-    if: github.actor == 'renovate[bot]'
+    if: github.event.pull_request.head.user.login == 'renovate[bot]'
     timeout-minutes: 5  # 2021-03-25: Guess.
 
     steps:

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -13,7 +13,7 @@ jobs:
   cleanup:
     name: Amend Renovate PR
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.user.login == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'renovate[bot]'
     timeout-minutes: 5  # 2021-03-25: Guess.
 
     steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Currently it looks at the "actor", which on a re-run is apparently the
user re-running the action rather than the user that triggered it in the
first place. Have it look at the user associated with the PR instead.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this, then trigger renovate to create a PR. The workflow should run.
* Merge this, then find a renovate PR where renovate[bot] is still the most recent user, and re-run the workflow. It should actually run instead of skipping.