### PR TITLE
tools: Fix check-intra-monorepo-deps.sh in CI mode

### DIFF
--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -218,7 +218,11 @@ done
 
 if $ANYJS; then
 	debug "Updating pnpm-lock.yaml"
-	pnpm install --silent
+	if [[ -n "$CI" ]]; then
+		pnpm install --no-frozen-lockfile
+	else
+		pnpm install --silent
+	fi
 fi
 
 if ! $UPDATE && [[ "$EXIT" != "0" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
`pnpm install` defaults to `--frozen-lockfile` when running in GH Actions,
which is specifically what we don't want when the renovate helper runs
`check-intra-monorepo-deps.sh -u`. So have it detect when it's running
in CI and pass `--no-frozen-lockfile` in that case (and also omit the
`--silent` that made this so hard to debug).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this, then trigger renovate to recreate #20905. Hopefully it works now.
