### PR TITLE
Search: fix search admin page wrapping issue for ultra wide screens

### DIFF
--- a/projects/plugins/jetpack/_inc/client/search/dashboard/rna-styles.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/rna-styles.scss
@@ -4,7 +4,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	flex-wrap: wrap;
+	flex-flow: column nowrap;
 	width: 100%;
 	margin: 0 auto;
 }

--- a/projects/plugins/jetpack/changelog/fix-fix-style-for-super-wide-screen
+++ b/projects/plugins/jetpack/changelog/fix-fix-style-for-super-wide-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fix wrapping issue on super wide screens


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fixed an layout issue when screen is ultra wide. Changed row wrap to flex layout to `column nowrap`.

#### Jetpack product discussion
no

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Go to  a site with Jetpack Search subscription `/wp-admin/admin.php?page=jetpack-search`
* Set Zoom to 40% (or change viewport wider than 2500px)
* Ensure items do not get wrapped in the same row

| NOT THIS | 
| ------------- | 
| ![image](https://user-images.githubusercontent.com/1425433/132157914-78414843-10f9-4fb5-8e12-69b8fec46a49.png) | 

| BUT THIS | 
| ------------- | 
| ![image](https://user-images.githubusercontent.com/1425433/132158055-7bc748c3-4cc4-48d2-bd30-895aad06330c.png)  | 


