### PR TITLE
Widget Visibility: fix undefined property ref

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-widget-vis-php-notice
+++ b/projects/plugins/jetpack/changelog/fix-widget-vis-php-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Widget Visibility: fix undefined property reference.

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -320,17 +320,17 @@ class Jetpack_Widget_Conditions {
 	}
 
 	/**
-	 * Retrieves a full list of all pages, containing just the IDs, post_parent, and post_title fields.
+	 * Retrieves a full list of all pages, containing just the IDs, post_parent, post_title, and post_status fields.
 	 *
 	 * Since the WordPress' `get_pages` function does not allow us to fetch only the fields mentioned
 	 * above, we need to introduce a custom method using a direct SQL query fetching those.
 	 *
-	 * By fetching only those 3 fields and not populating the object cache for all the pages, we can
+	 * By fetching only those four fields and not populating the object cache for all the pages, we can
 	 * improve the performance of the query on sites having a lot of pages.
 	 *
 	 * @see https://core.trac.wordpress.org/ticket/51469
 	 *
-	 * @return array List of all pages on the site (stdClass objects containing ID, post_title, and post_parent only).
+	 * @return array List of all pages on the site (stdClass objects containing ID, post_title, post_parent, and post_status only).
 	 */
 	public static function get_pages() {
 		global $wpdb;
@@ -369,7 +369,7 @@ class Jetpack_Widget_Conditions {
 		 *
 		 * @module widget-visibility
 		 *
-		 * @param stdClass[] $pages       Array of objects containing only the ID, post_parent, and post_title fields.
+		 * @param stdClass[] $pages       Array of objects containing only the ID, post_parent, post_title, and post_status fields.
 		 * @param array      $parsed_args Array of get_pages() arguments.
 		 */
 		return apply_filters( 'jetpack_widget_visibility_get_pages', $pages, $parsed_args );

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -339,7 +339,7 @@ class Jetpack_Widget_Conditions {
 		$cache_key    = "get_pages:$last_changed";
 		$pages        = wp_cache_get( $cache_key, 'widget_conditions' );
 		if ( false === $pages ) {
-			$pages = $wpdb->get_results( "SELECT {$wpdb->posts}.ID, {$wpdb->posts}.post_parent, {$wpdb->posts}.post_title FROM {$wpdb->posts} WHERE {$wpdb->posts}.post_type = 'page' AND {$wpdb->posts}.post_status = 'publish' ORDER BY {$wpdb->posts}.post_title ASC" );
+			$pages = $wpdb->get_results( "SELECT {$wpdb->posts}.ID, {$wpdb->posts}.post_parent, {$wpdb->posts}.post_title, {$wpdb->posts}.post_status FROM {$wpdb->posts} WHERE {$wpdb->posts}.post_type = 'page' AND {$wpdb->posts}.post_status = 'publish' ORDER BY {$wpdb->posts}.post_title ASC" );
 			wp_cache_set( $cache_key, $pages, 'widget_conditions' );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix the following PHP notice:

> PHP Notice:  Undefined property: stdClass::$post_status in /var/www/html/wp-admin/includes/misc.php on line 1433

Fixes #18616

#### Jetpack product discussion

#18616

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Before patching, on a site with Jetpack active make sure you have a couple pages published and that the Widget Visibility module is turned on.
* Visit `/wp-admin/widgets.php` and verify that you can see the mentioned PHP Notice.
* Patch with change and make sure that you are no longer seeing the notice when visiting `/wp-admin/widgets.php`.
