### PR TITLE
Fix git hooks when Jetpack is a git submodule of another repository 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ phpcs.xml
 
 # This file indicates we're in draft mode, which reduces checks
 .jetpack-draft
+.git-hook-data

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,3 @@ phpcs.xml
 
 # This file indicates we're in draft mode, which reduces checks
 .jetpack-draft
-.git-hook-data

--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,6 @@ phpcs.xml
 /tools/jt/
 /tools/docker/bin/jt/
 
-# This folder contains temporary files used by git hooks
-/.git-hook-data/
-
 # This file indicates we're in draft mode, which reduces checks
 .jetpack-draft
+.git-hook-data

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ phpcs.xml
 /tools/jt/
 /tools/docker/bin/jt/
 
+# This folder contains temporary files used by git hooks
+/.git-hook-data/
+
 # This file indicates we're in draft mode, which reduces checks
 .jetpack-draft
-.git-hook-data

--- a/tools/js-tools/git-hooks/pre-commit-hook.js
+++ b/tools/js-tools/git-hooks/pre-commit-hook.js
@@ -147,7 +147,7 @@ function checkFileAgainstDirtyList( file, filesList ) {
 function capturePreCommitTreeHash() {
 	if ( exitCode === 0 ) {
 		// .git folder location varies if this repo is used a submodule. Also, remove trailing new-line.
-		const gitFolderPath = execSync( 'git rev-parse --git-dir' ).toString().replace( /\n$/, '' );
+		const gitFolderPath = execSync( 'git rev-parse --git-dir' ).toString().trim();
 		fs.writeFileSync( `${ gitFolderPath }/last-commit-tree`, execSync( 'git write-tree' ) );
 	}
 }

--- a/tools/js-tools/git-hooks/pre-commit-hook.js
+++ b/tools/js-tools/git-hooks/pre-commit-hook.js
@@ -146,11 +146,7 @@ function checkFileAgainstDirtyList( file, filesList ) {
  */
 function capturePreCommitTreeHash() {
 	if ( exitCode === 0 ) {
-		const dataDir = '.git-hook-data';
-		if ( ! fs.existsSync( dataDir ) ) {
-			fs.mkdirSync( dataDir );
-		}
-		fs.writeFileSync( `${ dataDir }/last-commit-tree`, execSync( 'git write-tree' ) );
+		fs.writeFileSync( '.git/last-commit-tree', execSync( 'git write-tree' ) );
 	}
 }
 

--- a/tools/js-tools/git-hooks/pre-commit-hook.js
+++ b/tools/js-tools/git-hooks/pre-commit-hook.js
@@ -146,7 +146,11 @@ function checkFileAgainstDirtyList( file, filesList ) {
  */
 function capturePreCommitTreeHash() {
 	if ( exitCode === 0 ) {
-		fs.writeFileSync( '.git/last-commit-tree', execSync( 'git write-tree' ) );
+		const dataDir = '.git-hook-data';
+		if ( ! fs.existsSync( dataDir ) ) {
+			fs.mkdirSync( dataDir );
+		}
+		fs.writeFileSync( `${ dataDir }/last-commit-tree`, execSync( 'git write-tree' ) );
 	}
 }
 

--- a/tools/js-tools/git-hooks/pre-commit-hook.js
+++ b/tools/js-tools/git-hooks/pre-commit-hook.js
@@ -146,7 +146,9 @@ function checkFileAgainstDirtyList( file, filesList ) {
  */
 function capturePreCommitTreeHash() {
 	if ( exitCode === 0 ) {
-		fs.writeFileSync( '.git/last-commit-tree', execSync( 'git write-tree' ) );
+		// .git folder location varies if this repo is used a submodule. Also, remove trailing new-line.
+		const gitFolderPath = execSync( 'git rev-parse --git-dir' ).toString().replace( /\n$/, '' );
+		fs.writeFileSync( `${ gitFolderPath }/last-commit-tree`, execSync( 'git write-tree' ) );
 	}
 }
 

--- a/tools/js-tools/git-hooks/prepare-commit-msg.js
+++ b/tools/js-tools/git-hooks/prepare-commit-msg.js
@@ -3,9 +3,8 @@ const execSync = require( 'child_process' ).execSync;
 const fs = require( 'fs' );
 
 const notVerifiedPrefix = '[not verified] ';
-const dataDir = '.git-hook-data';
 
-fs.readFile( `${ dataDir }/last-commit-tree`, ( err, data ) => {
+fs.readFile( '.git/last-commit-tree', ( err, data ) => {
 	if ( err ) {
 		console.log( 'skipping prepare-commit-msg hook' );
 		return;
@@ -13,19 +12,14 @@ fs.readFile( `${ dataDir }/last-commit-tree`, ( err, data ) => {
 	const commitTree = data.toString();
 	const curTree = execSync( 'git write-tree' ).toString();
 
-	let commitMsg;
-	try {
-		commitMsg = fs.readFileSync( `${ dataDir }/COMMIT_EDITMSG` ).toString();
-	} catch ( e ) {
-		commitMsg = null;
-	}
+	const commitMsg = fs.readFileSync( '.git/COMMIT_EDITMSG' ).toString();
 	let newCommitMsg = null;
 	if ( commitTree !== curTree ) {
 		console.log( 'WARNING: git pre-commit hook was skipped!' );
-		if ( commitMsg && ! commitMsg.startsWith( notVerifiedPrefix ) ) {
+		if ( ! commitMsg.startsWith( notVerifiedPrefix ) ) {
 			newCommitMsg = notVerifiedPrefix + commitMsg;
 		}
-	} else if ( commitMsg && commitMsg.startsWith( notVerifiedPrefix ) ) {
+	} else if ( commitMsg.startsWith( notVerifiedPrefix ) ) {
 		// Ideally we'd remove the tag here, but to reliably do that we'd have to have
 		// pre-commit-hook.js check all files in --amend instead of only the ones being
 		// changed in the amendment. So for now, don't do it.
@@ -33,9 +27,6 @@ fs.readFile( `${ dataDir }/last-commit-tree`, ( err, data ) => {
 		// newCommitMsg = commitMsg.substring( notVerifiedPrefix.length );
 	}
 	if ( null !== newCommitMsg ) {
-		if ( ! fs.existsSync( dataDir ) ) {
-			fs.mkdirSync( dataDir );
-		}
-		fs.writeFileSync( `${ dataDir }/COMMIT_EDITMSG`, newCommitMsg );
+		fs.writeFileSync( '.git/COMMIT_EDITMSG', newCommitMsg );
 	}
 } );

--- a/tools/js-tools/git-hooks/prepare-commit-msg.js
+++ b/tools/js-tools/git-hooks/prepare-commit-msg.js
@@ -4,7 +4,10 @@ const fs = require( 'fs' );
 
 const notVerifiedPrefix = '[not verified] ';
 
-fs.readFile( '.git/last-commit-tree', ( err, data ) => {
+// .git folder location varies if this repo is used a submodule. Also, remove trailing new-line.
+const gitFolderPath = execSync( 'git rev-parse --git-dir' ).toString().replace( /\n$/, '' );
+
+fs.readFile( `${ gitFolderPath }/last-commit-tree`, ( err, data ) => {
 	if ( err ) {
 		console.log( 'skipping prepare-commit-msg hook' );
 		return;
@@ -12,7 +15,7 @@ fs.readFile( '.git/last-commit-tree', ( err, data ) => {
 	const commitTree = data.toString();
 	const curTree = execSync( 'git write-tree' ).toString();
 
-	const commitMsg = fs.readFileSync( '.git/COMMIT_EDITMSG' ).toString();
+	const commitMsg = fs.readFileSync( `${ gitFolderPath }/COMMIT_EDITMSG` ).toString();
 	let newCommitMsg = null;
 	if ( commitTree !== curTree ) {
 		console.log( 'WARNING: git pre-commit hook was skipped!' );
@@ -27,6 +30,6 @@ fs.readFile( '.git/last-commit-tree', ( err, data ) => {
 		// newCommitMsg = commitMsg.substring( notVerifiedPrefix.length );
 	}
 	if ( null !== newCommitMsg ) {
-		fs.writeFileSync( '.git/COMMIT_EDITMSG', newCommitMsg );
+		fs.writeFileSync( `${ gitFolderPath }/COMMIT_EDITMSG`, newCommitMsg );
 	}
 } );

--- a/tools/js-tools/git-hooks/prepare-commit-msg.js
+++ b/tools/js-tools/git-hooks/prepare-commit-msg.js
@@ -5,7 +5,7 @@ const fs = require( 'fs' );
 const notVerifiedPrefix = '[not verified] ';
 
 // .git folder location varies if this repo is used a submodule. Also, remove trailing new-line.
-const gitFolderPath = execSync( 'git rev-parse --git-dir' ).toString().replace( /\n$/, '' );
+const gitFolderPath = execSync( 'git rev-parse --git-dir' ).toString().trim();
 
 fs.readFile( `${ gitFolderPath }/last-commit-tree`, ( err, data ) => {
 	if ( err ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/20969

#### Changes proposed in this Pull Request:

The code was relying on `.git` being a folder, but this is not always the case. For example, when Jetpack is a submodule within another git repository, `.git` is a file that points to the parent repository's `.git/modules/jetpack` folder.
More information about how `.git` works in the context of a git submodule can be found here: https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.8.txt#L109-L114

* Move git hook data from `.git` to `.git-hook-data`
* Add `.git-hook-data` to the `.gitignore`

#### Jetpack product discussion

This change affects the development setup, related conversation is here: p1630958602197300-slack-C6UJ0KRKQ

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

1. Create a new folder and enter that folder e.g. `mkdir testme && cd testme`
2. Initialize a new git repository: `git init`
3. Add Jetpack as a submodule: `git submodule add https://github.com/Automattic/jetpack.git`
4. Enter the submodule: `cd jetpack` 
5. Follow the instructions to setup a developer environment: https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md
6. Checkout this branch: `git checkout fix/git-hooks-when-jetpack-is-submodule`
7. Make a commit e.g. `git commit --allow-empty -m "hi"`
8. Verify that the commit is made successfully