### PR TITLE
Fix Block Previews

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-calyps-build-hack
+++ b/projects/plugins/jetpack/changelog/fix-calyps-build-hack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes previews in block editor by working around incorrect Calypso build configuration

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -140,6 +140,23 @@ const componentsWebpackConfig = getBaseWebpackConfig(
 	}
 );
 
+/**
+ * Calyso Build sets publicPath to '/' instead of the default '__webpack_public_path__'
+ * This workaround removes the custom set publicPath from Calypso build until a long term solution is fixed.
+ *
+ * @param {object} obj - the configuration file we're checking and editing.
+ * @todo remove once we switch away from Calypso Build, or if this is addressed later.
+ */
+function hackBrokenCalypsoBuildFileConfig( obj ) {
+	obj.module.rules.forEach( v => {
+		if ( v.type === 'asset/resource' ) {
+			delete v.generator.publicPath;
+		}
+	} );
+}
+hackBrokenCalypsoBuildFileConfig( extensionsWebpackConfig );
+hackBrokenCalypsoBuildFileConfig( componentsWebpackConfig );
+
 // We export two configuration files: One for admin.js, and one for components.jsx.
 // The latter produces pre-rendered components HTML.
 module.exports = [

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -144,18 +144,18 @@ const componentsWebpackConfig = getBaseWebpackConfig(
  * Calyso Build sets publicPath to '/' instead of the default '__webpack_public_path__'
  * This workaround removes the custom set publicPath from Calypso build until a long term solution is fixed.
  *
- * @param {object} obj - the configuration file we're checking and editing.
+ * @param {object} config - the configuration file we're checking and editing.
  * @todo remove once we switch away from Calypso Build, or if this is addressed later.
  */
-function hackBrokenCalypsoBuildFileConfig( obj ) {
-	obj.module.rules.forEach( v => {
+function overrideCalypsoBuildFileConfig( config ) {
+	config.module.rules.forEach( v => {
 		if ( v.type === 'asset/resource' ) {
 			delete v.generator.publicPath;
 		}
 	} );
 }
-hackBrokenCalypsoBuildFileConfig( extensionsWebpackConfig );
-hackBrokenCalypsoBuildFileConfig( componentsWebpackConfig );
+overrideCalypsoBuildFileConfig( extensionsWebpackConfig );
+overrideCalypsoBuildFileConfig( componentsWebpackConfig );
 
 // We export two configuration files: One for admin.js, and one for components.jsx.
 // The latter produces pre-rendered components HTML.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #20898

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Calyspo build's process sets publicPath to '/' instead of the default __webpack_public_path__. This PR overrides the Calypso build config where necessary to prevent breaking image file paths such as those in the block previews.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1630700944248800-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to add a new post
* Check a few blocks, such as slideshow, tiled gallery, image compare, etc. 
* Before this patch, image preview doesn't show images and you'll see errors in the console. 
* Post patch, preview images should appear and console errors regarding GET requests should not be present.
* General regression testing

Fix may need to be applied elsewhere as well, but couldn't find anything else broken in testing so far.