### PR TITLE
Search: hide search sub menu on disconnection

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -181,6 +181,7 @@ class Main extends React.Component {
 			const $items = jQuery( '#toplevel_page_jetpack' ).find( 'ul.wp-submenu li' );
 			$items.find( 'a[href$="#/settings"]' ).hide();
 			$items.find( 'a[href$="admin.php?page=stats"]' ).hide();
+			$items.find( 'a[href$="admin.php?page=jetpack-search"]' ).hide();
 		}
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-hide-search-menu-on-disconnect
+++ b/projects/plugins/jetpack/changelog/fix-hide-search-menu-on-disconnect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: hide search sub menu on site disconnection


### PR DESCRIPTION
Fixes #20965

#### Changes proposed in this Pull Request:
Hide search sub menu on site disconnection.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with Jetpack Search subscription
* Navigate to `/wp-admin/admin.php?page=jetpack#/dashboard`
* Click `Manage site connection` in `Connections` section
* Then click `disconnect` button
* Ensure Search sub menu is hidden after disconnection.

![image](https://user-images.githubusercontent.com/1425433/132264221-f0bee137-4005-4a36-9066-da87ff913e37.png)

