### PR TITLE
Search: add translator context to menu item to ensure correct translation

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-search-dashboard-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-search-dashboard-page.php
@@ -44,7 +44,7 @@ class Jetpack_Search_Dashboard_Page extends Jetpack_Admin_Page {
 		return add_submenu_page(
 			'jetpack',
 			__( 'Search Settings', 'jetpack' ),
-			__( 'Search', 'jetpack' ),
+			_x( 'Search', 'product name shown in menu', 'jetpack' ),
 			'manage_options',
 			'jetpack-search',
 			array( $this, 'render' ),

--- a/projects/plugins/jetpack/changelog/add-search-menu-translator-context
+++ b/projects/plugins/jetpack/changelog/add-search-menu-translator-context
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Search: add translator context for menu item
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The menu item for 'Search' can end up being a verb in some languages because we're reusing the translation for "do a search". This PR adds a translator context so it's clear that this a product name shown in the menu.

See 'Disambiguation by context' section here:

https://codex.wordpress.org/I18n_for_WordPress_Developers

#### Jetpack product discussion
Discussed in pxLjZ-6Bs-p2.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
On a site with Jetpack Search enabled, go to wp-admin and check that 'Search' appears in the Jetpack submenu. (It will not appear translated because this translation has not been completed yet.)