### PR TITLE
actions: Display all PHP errors in CI

### DIFF
--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -45,6 +45,7 @@ runs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ steps.versions.outputs.php-version }}
+        ini-values: error_reporting=E_ALL, display_errors=On
         tools: composer:${{ steps.versions.outputs.composer-version }}
         extensions: mysql, imagick
         coverage: none

--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -45,7 +45,7 @@ runs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ steps.versions.outputs.php-version }}
-        ini-values: error_reporting=E_ALL, display_errors=On
+        ini-values: error_reporting=E_ALL, display_errors=On, zend.assertions=1
         tools: composer:${{ steps.versions.outputs.composer-version }}
         extensions: mysql, imagick
         coverage: none

--- a/.github/files/list-changed-projects.php
+++ b/.github/files/list-changed-projects.php
@@ -15,6 +15,7 @@ ob_end_clean();
 // Files that mean all tests should be run.
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 $infrastructure_files = array(
+	'.github/actions/tool-setup/action.yml',
 	'.github/files/list-changed-projects.php',
 	'.github/files/generate-ci-matrix.php',
 	'.github/files/process-coverage.sh',

--- a/tools/get-wp-version.php
+++ b/tools/get-wp-version.php
@@ -31,7 +31,7 @@ $versions = $versions->offers;
  * @return bool|int
  */
 function offer_version_sort( $first, $second ) {
-	return version_compare( $first->version, $second->version, '<' );
+	return version_compare( $second->version, $first->version );
 }
 
 uasort( $versions, 'offer_version_sort' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It seems that the default is to set `error_reporting` to
`E_ALL & ~E_DEPRECATED & ~E_STRICT`. Probably more useful to check for
deprecation warnings and such too.

This is probably going to matter once we start testing with PHP 8.1,
which adds return types to a bunch of interfaces and emits
deprecation warnings if you don't use them.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
