### PR TITLE
Google Calendar block: Fix links

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-google-calendar-block-links
+++ b/projects/plugins/jetpack/changelog/fix-google-calendar-block-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Google Calendar block: fix issue that prevented liink is in the calendar from opening

--- a/projects/plugins/jetpack/extensions/blocks/google-calendar/google-calendar.php
+++ b/projects/plugins/jetpack/extensions/blocks/google-calendar/google-calendar.php
@@ -49,7 +49,7 @@ function load_assets( $attr ) {
 		return '';
 	}
 
-	$sandbox = 'allow-scripts allow-same-origin';
+	$sandbox = 'allow-scripts allow-same-origin allow-popups';
 	if ( Blocks::is_amp_request() ) {
 		$noscript_src = str_replace(
 			'//calendar.google.com/calendar/embed',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR addresses the issue where the links in the Google Calendar that is embedded using the Google Calendar block are not working: https://github.com/Automattic/jetpack/issues/17788

The cause of the issue is that the Google Calendar iframe is missing the `allow-popups` sandbox attribute which the proposed code change is adding.

Example with a calendar event description link that goes to external link:

Before:
![Screen Capture on 2021-09-07 at 17-30-42](https://user-images.githubusercontent.com/25105483/132371904-2eba190a-6a19-4b15-83a7-cd0ddb03f78d.gif)

After:
![Screen Capture on 2021-09-07 at 17-27-04](https://user-images.githubusercontent.com/25105483/132371566-dcdb9c19-4f71-46a0-8ae0-e00f277608e8.gif)

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Create an event in your Google Calendar, and on the description, add a link or hyperlink.
2. Get the embed code by following the steps here: https://wordpress.com/support/google-calendar/#google-calendar-block
2. Go to your post/page editor
3. Add a Google Calendar block > paste the embed code
4. Publish the post/page
5. Try to click the link on the published post/page. The link should open in a new tab.
