### PR TITLE
Allow current node LTS 14.17.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"jetpack-js-tools": "workspace:*"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/github-actions/repo-gardening/changelog/try-allow-node-14
+++ b/projects/github-actions/repo-gardening/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -27,7 +27,7 @@
 		"build": "ncc build src/index.js -o dist --source-map --license licenses.txt"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/github-actions/required-review/changelog/try-allow-node-14
+++ b/projects/github-actions/required-review/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/github-actions/required-review/package.json
+++ b/projects/github-actions/required-review/package.json
@@ -19,7 +19,7 @@
 		"build": "ncc build src/main.js -o dist --source-map --license licenses.txt"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/api/changelog/try-allow-node-14
+++ b/projects/js-packages/api/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -21,7 +21,7 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./test/*.jsx'"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/base-styles/changelog/try-allow-node-14
+++ b/projects/js-packages/base-styles/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/base-styles": "3.6.0"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/components/changelog/try-allow-node-14
+++ b/projects/js-packages/components/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -35,7 +35,7 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./!(node_modules)/**/test/*.jsx'"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/connection/changelog/try-allow-node-14
+++ b/projects/js-packages/connection/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -39,7 +39,7 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./!(node_modules)/**/test/*.jsx'"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/eslint-changed/changelog/try-allow-node-14
+++ b/projects/js-packages/eslint-changed/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/js-packages/eslint-changed/package.json
+++ b/projects/js-packages/eslint-changed/package.json
@@ -33,7 +33,7 @@
 		"eslint": ">=1.1.0"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/storybook/changelog/try-allow-node-14
+++ b/projects/js-packages/storybook/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -64,7 +64,7 @@
 		"webpack": "5.51.1"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/connection-ui/changelog/try-allow-node-14
+++ b/projects/packages/connection-ui/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -36,7 +36,7 @@
 		"jest": "27.0.4"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/identity-crisis/changelog/try-allow-node-14
+++ b/projects/packages/identity-crisis/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.2.5",
+	"version": "0.2.6-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-identity-crisis",

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -38,7 +38,7 @@
 		"sass": "1.38.1"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -28,7 +28,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.2.5';
+	const PACKAGE_VERSION = '0.2.6-alpha';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/jitm/changelog/try-allow-node-14
+++ b/projects/packages/jitm/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/packages/jitm/package.json
+++ b/projects/packages/jitm/package.json
@@ -26,7 +26,7 @@
 		"webpack-cli": "4.8.0"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.0.0';
+	const PACKAGE_VERSION = '2.0.1-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/lazy-images/changelog/try-allow-node-14
+++ b/projects/packages/lazy-images/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/packages/lazy-images/package.json
+++ b/projects/packages/lazy-images/package.json
@@ -33,7 +33,7 @@
 		"webpack": "5.51.1"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/plugins/backup/changelog/try-allow-node-14
+++ b/projects/plugins/backup/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/plugins/backup/package.json
+++ b/projects/plugins/backup/package.json
@@ -53,7 +53,7 @@
 		"webpack": "5.51.1"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/plugins/boost/changelog/try-allow-node-14
+++ b/projects/plugins/boost/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -78,7 +78,7 @@
 	},
 	"homepage": "https://jetpack.com/boost/",
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/plugins/jetpack/changelog/try-allow-node-14
+++ b/projects/plugins/jetpack/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -206,7 +206,7 @@
 		"react-dom": "17.0.2"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -56,7 +56,7 @@
 		"yargs": "16.2.0"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/plugins/search/changelog/try-allow-node-14
+++ b/projects/plugins/search/changelog/try-allow-node-14
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/plugins/search/package.json
+++ b/projects/plugins/search/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -43,7 +43,7 @@
 		"yargs-parser": "20.2.4"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/tools/cli/skeletons/common/package.json
+++ b/tools/cli/skeletons/common/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/tools/js-test-runner/package.json
+++ b/tools/js-test-runner/package.json
@@ -26,7 +26,7 @@
 		"sinon-chai": "3.5.0"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -40,7 +40,7 @@
 		"yaml": "1.10.2"
 	},
 	"engines": {
-		"node": "^16.7.0",
+		"node": "^14.17.6 || ^16.7.0",
 		"pnpm": "^6.5.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- This change proposes allowing use of node ^14.17.6 (14.17.6 is the current node LTS version at time of writing) in addition to node 16.7.0 which is what the project currently specifies in its node engines attribute. `.nvmrc` will still point to 16.7.0, but the project can now be used in environments such as Gutenberg Mobile which are using node 14.17.6 LTS. This change is related to https://github.com/wordpress-mobile/gutenberg-mobile/pull/3928.

#### Jetpack product discussion

See p9dueE-3ls-p2#comment-6040

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

1. Verify all required PR checks pass (this verifies that node 16.7.0 support is still working)
2. To verify node 14.17.6 support:
  1. Checkout this branch locally
  2. Switch to node 14.17.6 e.g. `nvm use 14.17.6`
  3. Setup the environment (e.g. `npm install -g pnpm && pnpm install && pnpm cli-setup && jetpack install --root`) and verify it using `tools/check-development-environment.sh`
  4. Build all affected packages and verify there are no errors:

```
jetpack build github-actions/repo-gardening \
jetpack build github-actions/required-review \
jetpack build js-packages/api \
jetpack build js-packages/base-styles \
jetpack build js-packages/components \
jetpack build js-packages/connection \
jetpack build js-packages/eslint-changed \
jetpack build js-packages/storybook \
jetpack build packages/connection-ui \
jetpack build packages/identity-crisis \
jetpack build packages/jitm \
jetpack build packages/lazy-images \
jetpack build plugins/backup \
jetpack build plugins/boost \
jetpack build plugins/jetpack \
jetpack build plugins/search
```
