### PR TITLE
Update: allow for multiple steps in disconnection flow

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-termination-dialog/confirm.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-termination-dialog/confirm.jsx
@@ -1,0 +1,13 @@
+/**
+ * External Dependencies
+ */
+
+/**
+ * Internal Dependencies
+ */
+
+const JetpackTerminationDialogConfirmStep = () => {
+	return 'Disconnection confirm step';
+};
+
+export default JetpackTerminationDialogConfirmStep;

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-termination-dialog/thank-you.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-termination-dialog/thank-you.jsx
@@ -1,0 +1,13 @@
+/**
+ * External Dependencies
+ */
+
+/**
+ * Internal Dependencies
+ */
+
+const JetpackTerminationDialogThankYouStep = () => {
+	return 'Thank You Step';
+};
+
+export default JetpackTerminationDialogThankYouStep;

--- a/projects/plugins/jetpack/changelog/update-add-multiple-step-handling-to-disconnection-flow
+++ b/projects/plugins/jetpack/changelog/update-add-multiple-step-handling-to-disconnection-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow disconnection flow to have multiple steps, introduces survey after disconnect


### PR DESCRIPTION
This PR sets up the structure for the Jetpack disconnection flow to present multiple steps and to change between the steps based on user interaction. This branch is intended to serve as a base branch for other changes to the individual steps in the disconnection flow.

#### Changes proposed in this Pull Request:
* This PR modifies the `JetpackTerminationDialog` component to specify an expanded set of steps for the disconnection flow and manage the state for the current step in the flow. 

#### Does this pull request change what data or activity we track or use?
This PR does not introduce changes to data/ activity tracked at this time. Will update this message before the PR exits draft status if anything changes.

#### Testing instructions:
* Open the disconnection flow from the Jetpack Dashboard by clicking "Manage site Connection" 
* In the disconnection flow, temporary "next" and "previous" buttons can be used to move between different steps
* Confirm that you are able to navigate between and view the different steps in the modal by using the "next" and "previous" buttons
