### PR TITLE
Fix/20961 recolor score bars

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/score.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/score.scss
@@ -173,15 +173,15 @@ $label_z_index: 50;
 	}
 
 	.fill-good {
-		background-color: $jetpack-green;
+		background-color: $green_40;
 	}
 
 	.fill-mediocre {
-		background-color: darkorange;
+		background-color: $orange_20;
 	}
 
 	.fill-bad {
-		background-color: $color_warning;
+		background-color: $red_50;
 	}
 }
 

--- a/projects/plugins/boost/app/assets/src/css/components/score.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/score.scss
@@ -173,7 +173,7 @@ $label_z_index: 50;
 	}
 
 	.fill-good {
-		background-color: $green_40;
+		background-color: $jetpack_green_40;
 	}
 
 	.fill-mediocre {

--- a/projects/plugins/boost/app/assets/src/css/main/variables.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/variables.scss
@@ -37,7 +37,7 @@ $jetpack_green_90: #003010;
 $jetpack_green_100: #001c09;
 
 $red_50: #D63638;
-
+$orange_20: #FAA754;
 $jetpack_green: $jetpack_green_50;
 
 $padding: 48px;

--- a/projects/plugins/boost/app/assets/src/css/main/variables.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/variables.scss
@@ -38,6 +38,7 @@ $jetpack_green_100: #001c09;
 
 $red_50: #D63638;
 $orange_20: #FAA754;
+$green_40: #069e08;
 $jetpack_green: $jetpack_green_50;
 
 $padding: 48px;

--- a/projects/plugins/boost/app/assets/src/css/main/variables.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/variables.scss
@@ -38,7 +38,6 @@ $jetpack_green_100: #001c09;
 
 $red_50: #D63638;
 $orange_20: #FAA754;
-$green_40: #069e08;
 $jetpack_green: $jetpack_green_50;
 
 $padding: 48px;

--- a/projects/plugins/boost/changelog/fix-20961-recolor-score-bars
+++ b/projects/plugins/boost/changelog/fix-20961-recolor-score-bars
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed boost plugin score bar styling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #20961 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduced new colour variables as mentioned in the issue.
* Updated the `score.scss` file to support new styling.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use? NO
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out to PR branch
* Build boost plugin
* Open Admin area and navigate to Jetpack boost dashboard
* Observe the score bar colours.

I have tested it locally and attached screenshots for reference.

* `orange_20` 
![2021-09-09_00-44](https://user-images.githubusercontent.com/21127788/132576133-26312a38-4f03-4c1a-9b15-f98ad448dc93.png)

* `red_50` 
![2021-09-09_00-44_1](https://user-images.githubusercontent.com/21127788/132576217-3fe99374-60f8-4b06-9281-c4d176ed110b.png)

* `green_40`: for this I noticed one thing.. In `variable.scss` file. `$jetpack-green` was not styling as expected. Because in the file. It is defined multiple times as in 2 places with a difference of `_` and `-`.
I was able to reproduce this issue on some online platform.
![2021-09-09_00-57](https://user-images.githubusercontent.com/21127788/132576525-096356fe-cb78-46c8-a201-703067a27c79.png)

Before
It was showing a different color earlier (attached screenshot)
![2021-09-09_01-01](https://user-images.githubusercontent.com/21127788/132576653-783521cb-cb3c-49eb-99de-f344994b33e8.png)


After
I have fixed it as well.  
![2021-09-09_01-12](https://user-images.githubusercontent.com/21127788/132576769-296c11ad-f596-458e-aea2-d6d4d22fa300.png)

cc @thingalon 