### PR TITLE
CLI: add 'cli status'

### DIFF
--- a/tools/cli/commands/cli.js
+++ b/tools/cli/commands/cli.js
@@ -14,6 +14,15 @@ import PATH from 'path-name';
 import { chalkJetpackGreen } from '../helpers/styling';
 
 /**
+ * Show us the status of the cli, such as the currenet linked directory.
+ */
+function cliStatus() {
+	console.log(
+		chalkJetpackGreen( 'Jetpack CLI is currently linked to ' + path.join( __dirname, `../../../` ) )
+	);
+	console.log( 'To change the linked directory of the CLI, run `pnpm cli-setup` ' );
+}
+/**
  * CLI link.
  *
  * @param {object} options - The argv options.
@@ -109,6 +118,17 @@ export function cliDefine( yargs ) {
 				() => {},
 				argv => {
 					cliUnlink( argv );
+					if ( argv.v ) {
+						console.log( argv );
+					}
+				}
+			)
+			.command(
+				'status',
+				'Get the status of the CLI',
+				() => {},
+				argv => {
+					cliStatus( argv );
 					if ( argv.v ) {
 						console.log( argv );
 					}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a status command that returns what working directory the CLI is linked to. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Sometimes when working with different checked out versions of the repo, you need to switch which directory the cli is linked to. This lets you see what directory it's currently linked to before switching.
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check this branch out
* run `jetpack cli status`
* It should return the working directory you're on. 
* After merge, we can test and make sure it returns the correct path if there are multiple checked out repos. 
