### PR TITLE
Settings: show "Connect" button on Media card in site-only mode

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -122,7 +122,7 @@ export const SettingsCard = props => {
 
 		switch ( feature ) {
 			case FEATURE_VIDEO_HOSTING_JETPACK:
-				if ( hasPremiumOrBetter ) {
+				if ( props.hasConnectedOwner && hasPremiumOrBetter ) {
 					return '';
 				}
 

--- a/projects/plugins/jetpack/_inc/client/performance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/index.jsx
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getModule, getModuleOverride } from 'state/modules';
-import { isUnavailableInOfflineMode } from 'state/connection';
+import { isUnavailableInOfflineMode, hasConnectedOwner } from 'state/connection';
 import { isModuleFound } from 'state/search';
 import Card from 'components/card';
 import QuerySite from 'components/data/query-site';
@@ -27,6 +27,7 @@ class Performance extends Component {
 			isUnavailableInOfflineMode: this.props.isUnavailableInOfflineMode,
 			isModuleFound: this.props.isModuleFound,
 			getModuleOverride: this.props.getModuleOverride,
+			hasConnectedOwner: this.props.hasConnectedOwner,
 		};
 
 		const found = [ 'photon', 'videopress', 'lazy-images', 'photon-cdn', 'search' ].some(
@@ -69,5 +70,6 @@ export default connect( state => {
 		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		isModuleFound: module_name => isModuleFound( state, module_name ),
 		getModuleOverride: module_name => getModuleOverride( state, module_name ),
+		hasConnectedOwner: hasConnectedOwner( state ),
 	};
 } )( Performance );

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -31,45 +31,46 @@ class Media extends React.Component {
 		const videoPress = this.props.module( 'videopress' ),
 			planClass = getPlanClass( this.props.sitePlan.product_slug );
 
-		const videoPressSettings = includes(
-			[
-				'is-premium-plan',
-				'is-business-plan',
-				'is-daily-security-plan',
-				'is-realtime-security-plan',
-				'is-complete-plan',
-			],
-			planClass
-		) && (
-			<SettingsGroup
-				hasChild
-				disableInOfflineMode
-				module={ videoPress }
-				support={ {
-					link: getRedirectUrl( 'jetpack-support-videopress' ),
-				} }
-			>
-				<FormLegend className="jp-form-label-wide">{ __( 'Video', 'jetpack' ) }</FormLegend>
-				<p>
-					{ ' ' }
-					{ __(
-						'Make the content you publish more engaging with high-resolution video. With Jetpack Video you can customize your media player and deliver high-speed, ad-free, and unbranded videos to your visitors. Videos are hosted on our WordPress.com servers and do not subtract space from your hosting plan!',
-						'jetpack'
-					) }{ ' ' }
-				</p>
-				<ModuleToggle
-					slug="videopress"
-					disabled={ this.props.isUnavailableInOfflineMode( 'videopress' ) }
-					activated={ this.props.getOptionValue( 'videopress' ) }
-					toggling={ this.props.isSavingAnyOption( 'videopress' ) }
-					toggleModule={ this.props.toggleModuleNow }
+		const videoPressSettings = this.props.hasConnectedOwner &&
+			includes(
+				[
+					'is-premium-plan',
+					'is-business-plan',
+					'is-daily-security-plan',
+					'is-realtime-security-plan',
+					'is-complete-plan',
+				],
+				planClass
+			) && (
+				<SettingsGroup
+					hasChild
+					disableInOfflineMode
+					module={ videoPress }
+					support={ {
+						link: getRedirectUrl( 'jetpack-support-videopress' ),
+					} }
 				>
-					<span className="jp-form-toggle-explanation">
-						{ __( 'Enable high-speed, ad-free video player', 'jetpack' ) }
-					</span>
-				</ModuleToggle>
-			</SettingsGroup>
-		);
+					<FormLegend className="jp-form-label-wide">{ __( 'Video', 'jetpack' ) }</FormLegend>
+					<p>
+						{ ' ' }
+						{ __(
+							'Make the content you publish more engaging with high-resolution video. With Jetpack Video you can customize your media player and deliver high-speed, ad-free, and unbranded videos to your visitors. Videos are hosted on our WordPress.com servers and do not subtract space from your hosting plan!',
+							'jetpack'
+						) }{ ' ' }
+					</p>
+					<ModuleToggle
+						slug="videopress"
+						disabled={ this.props.isUnavailableInOfflineMode( 'videopress' ) }
+						activated={ this.props.getOptionValue( 'videopress' ) }
+						toggling={ this.props.isSavingAnyOption( 'videopress' ) }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						<span className="jp-form-toggle-explanation">
+							{ __( 'Enable high-speed, ad-free video player', 'jetpack' ) }
+						</span>
+					</ModuleToggle>
+				</SettingsGroup>
+			);
 
 		const videoPressForcedInactive = 'inactive' === this.props.getModuleOverride( 'videopress' );
 

--- a/projects/plugins/jetpack/changelog/fix-settings-media-site-only
+++ b/projects/plugins/jetpack/changelog/fix-settings-media-site-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Show the Connect button on the Media card in site-only mode.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The Media card gets displayed in the site-only mode if a plan that supports VideoPress has already been purchased.
In this PR we make it show the "Connect" button instead.

#### Jetpack product discussion
p8oabR-IS-p2#comment-5501

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Create new JN site (free plan), connect it in site-only mode.
2. Go to "Settings -> Performance -> Media", confirm that you see the "Connect" button and don't see the media settings.
3. Click "Connect", connect the user.
4. Go to "Settings -> Performance -> Media", confirm that you see the "Upgrade" button now. No media settings should show up.
5. Click "Upgrade", complete the purchase.
6. Go to "Settings -> Performance -> Media", confirm that you see the media settings. Try to switch the VideoPress setting on and off, confirm that the value persists upon page reloading.
7. Disconnect Jetpack, connect again in site-only mode.
8. Go to "Settings -> Performance -> Media", confirm that you see the "Connect" button and don't see the media settings.