### PR TITLE
Search: Improve filter label alignment for longer terms

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-filter-label-alignment
+++ b/projects/plugins/jetpack/changelog/fix-search-filter-label-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: improve filter label formatting for longer text entries

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
@@ -35,7 +35,7 @@
 
 	> div {
 		display: flex;
-		align-items: center;
+		align-items: baseline;
 		margin-top: 8px;
 	}
 

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
@@ -43,7 +43,7 @@
 	// Extra specific to override in some themes
 	.widget_search .jetpack-instant-search__search-filter-list-input {
 		cursor: pointer;
-		top: 1px; // Ensures align-items: center; works as expected.
+		top: 1px; // Ensures align-items: baseline; works as expected.
 
 		// Remove any custom checkbox styling
 		appearance: checkbox;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-filters.scss
@@ -43,7 +43,7 @@
 	// Extra specific to override in some themes
 	.widget_search .jetpack-instant-search__search-filter-list-input {
 		cursor: pointer;
-		top: 0; // Ensures align-items: center; works as expected.
+		top: 1px; // Ensures align-items: center; works as expected.
 
 		// Remove any custom checkbox styling
 		appearance: checkbox;


### PR DESCRIPTION
fixes #20977

**Changes proposed in this Pull Request:**

* This PR fixes the alignment of filter labels on longer terms, so that filter checkboxes align with first line of label instead of center.

**Does this pull request change what data or activity we track or use?**

* No.

**Testing instructions:**

* Go to a site with Jetpack Instant Search subscription.
* Search for a keyword which will result in a page with a longer, multi-line filter (category or tag)
* Check that the filter checkbox is aligned with the first line of the label text. 


| Before  | After |
| ------------- | ------------- |
| ![](https://user-images.githubusercontent.com/17325/132280988-4f1e0436-e337-4f05-9dbc-e2f7a3e5a249.png)  | ![image](https://user-images.githubusercontent.com/30754158/132605875-a6e36130-cf56-40cf-abfc-016ecfe6d29e.png)  |
