### PR TITLE
Block Editor: update path used to detect images on wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/update-photon-url-tiled-gallery
+++ b/projects/plugins/jetpack/changelog/update-photon-url-tiled-gallery
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Block Editor: update path that can be used to detect images on WordPress.com.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/utils/index.js
@@ -116,7 +116,7 @@ function isVIP() {
 }
 function isWpcomFilesUrl( url ) {
 	const { host } = parseUrl( url );
-	return /\.files\.wordpress\.com$/.test( host );
+	return /\.files\.wordpress\.com|s0\.wp\.com$/.test( host );
 }
 
 /**


### PR DESCRIPTION
Fixes #20898 

#### Changes proposed in this Pull Request:

On WordPress.com Simple, block previews' images are built thanks to `__webpack_public_path__`, which is set to use `s0.wp.com` in production there, vs. the path images use when they are uploaded via the media library.
We must support that use-case as well so tiled gallery block's previews work.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* This won't change much on Jetpack
* On WordPress.com simple (see D66586-code), check that the tiled gallery block works well in the editor (block and its preview) as well as on the frontend. Note that on your sandbox, the path will not use `s0.wp.com` since you're not in production, so that may be harder to test.
