### PR TITLE
Show like button if disabled in global settings but enabled in post-meta. Also show reblog button when like button is hidden on wpcom.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-show-reblog-button-without-like-button
+++ b/projects/plugins/jetpack/changelog/update-show-reblog-button-without-like-button
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: no user-visible change. simply porting wpcom code for compatibility.
+
+

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -276,7 +276,7 @@ class Jetpack_Likes {
 
 	/** Initialize action */
 	public function action_init() {
-		if ( is_admin() || ! $this->settings->is_likes_visible() ) {
+		if ( is_admin() || ! $this->settings->is_likes_module_enabled() ) {
 			return;
 		}
 
@@ -467,7 +467,7 @@ class Jetpack_Likes {
 	public function post_likes( $content ) {
 		$post_id = get_the_ID();
 
-		if ( ! is_numeric( $post_id ) || ! $this->settings->is_likes_visible() ) {
+		if ( ! is_numeric( $post_id ) || ! $this->settings->is_likes_module_enabled() ) {
 			return $content;
 		}
 


### PR DESCRIPTION
In wpcom a reblog button is available as well as a like button. But if the reblog button is enabled, and the like button is disabled, the reblog button will not be shown. Automattic/wp-calypso#44658

The issue was that the entire likes module was not being activated if the likes button was not shown.

The solution was to break the code responsible for enabling the likes module out from the code specific to the likes button. The likes button specific code is checked on page load via the API D66115-code.

This change has also fixed another bug: If the sitewide "Show like button" setting is disabled, but a post has the "Show Likes" meta set, the post should show a like button. See https://github.com/Automattic/jetpack/pull/11298#issuecomment-463786910 . But previously, the post meta was only being checked if the sitewide setting was enabled. With this change, the post setting will be checked even if the sitewide setting is false. ( as long as other module level checks return true ). More discussion in slack p1631219137431800-slack-CBG1CP4EN.

Since the reblog button is not available in non-wpcom sites, the reblog aspects of this change can only be tested on wpcom with  D66115-code.

Previous truth table

| Global reblog | Global Likes  | Meta Likes | Show Likes | Show Reblog |
| ------------- | ------------- | ------------- |------------- | ------------- |
| True | True  | Empty | True | True |
| True | True  | True  | True | True |
| True | True  | False  | False | *False* |
| True | False | Empty | False | *False* |
| True | False | True | ***False*** | *False* |
| True | False | False  | False | *False* |
| False | True | Empty | True | False |
| False | True | True  | True | False |
| False | True | False  | False | False |
| False | False | Empty | False | False |
| False | False | True | True | False |
| False | False | False  | False | False |

Updated truth table

| Global reblog | Global Likes  | Meta Likes | Show Likes | Show Reblog |
| ------------- | ------------- | ------------- |------------- | ------------- |
| True | True  | Empty | True | True |
| True | True  | True  | True | True |
| True | True  | False  | False | *True* |
| True | False | Empty | False | *True* |
| True | False | True | ***True*** | *True* |
| True | False | False  | False | *True* |
| False | True | Empty | True | False |
| False | True | True  | True | False |
| False | True | False  | False | False |
| False | False | Empty | False | False |
| False | False | True | True | False |
| False | False | False  | False | False |

Note that there is no equivalent post specific control of the reblog button. The reblog button ignores the switch_like_status flag.