### PR TITLE
Notifications: fix DailyMotion shortcode render in Calypso

### DIFF
--- a/projects/plugins/jetpack/changelog/2021-09-10-12-08-45-616768
+++ b/projects/plugins/jetpack/changelog/2021-09-10-12-08-45-616768
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WordPress.com Notifications: fix Dailymotion shortcode notification render

--- a/projects/plugins/jetpack/modules/shortcodes/dailymotion.php
+++ b/projects/plugins/jetpack/modules/shortcodes/dailymotion.php
@@ -239,6 +239,26 @@ function dailymotion_shortcode( $atts ) {
 		}
 	}
 
+	/**
+	 * Calypso Helper
+	 *
+	 * Makes shortcode output responsive to the location it is loaded:
+	 * Notifications, Reader, Email
+	 */
+
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		require_once WP_CONTENT_DIR . '/lib/display-context.php';
+		$context = A8C\Display_Context\get_current_context();
+
+		// Notifications
+		if ( A8C\Display_Context\NOTIFICATIONS === $context ) {
+			return sprintf(
+				'<a href="%1$s" target="_blank" rel="noopener noreferrer">%1$s</a>',
+				esc_url( 'https://www.dailymotion.com/video/' . $id )
+			);
+		}
+	}
+
 	return $output;
 }
 add_shortcode( 'dailymotion', 'dailymotion_shortcode' );


### PR DESCRIPTION
## The issue
DailyMotion shortcode does not render properly from Calypso notifications. Currently, it shows the video URL partially bold and not clickable.

<img width="402" alt="Markup 2021-09-10 at 14 36 33" src="https://user-images.githubusercontent.com/33258733/132854208-1daeb3cb-6273-4695-b141-5cd795bfa46e.png">


#### Testing instructions:
1. Create a new post.
2. Add the DailyMotion shortcode to your new post.
3. Be sure your WordPress.com notifications are enabled and that you are subscribed to the test site.
4. Publish the post
5. View your notifications

*Tested on Simple and Atomic sites*

## The solution
Added a check for WPCOM and where it is being rendered. Adjust the output to use video URL as a clickable link.

<img width="400" alt="Markup 2021-09-10 at 14 33 47" src="https://user-images.githubusercontent.com/33258733/132853958-7e337e2a-6d2c-44cb-9aa7-e8ae48e3c9e5.png">

#### Does this pull request change what data or activity we track or use?
No changes