### PR TITLE
CI: Process coverage on test failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,7 +138,7 @@ jobs:
           exit $EXIT
 
       - name: Process coverage results
-        if: matrix.script == 'test-coverage'
+        if: matrix.script == 'test-coverage' && always()
         run: .github/files/process-coverage.sh
 
       - name: Check for artifacts

--- a/projects/plugins/jetpack/changelog/update-process-coverage-on-failures
+++ b/projects/plugins/jetpack/changelog/update-process-coverage-on-failures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+allow coverage to be reported for failing tests

--- a/projects/plugins/jetpack/tests/action-test-coverage.sh
+++ b/projects/plugins/jetpack/tests/action-test-coverage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -o pipefail
 
 PLUGINDIR="$PWD"
 


### PR DESCRIPTION
Currently, Jetpack coverage would be reported only if the tests succeed. Generally, it's probably fine, since we block merges for PRs with failing tests. But I guess it still would be nice to report coverage for all runs.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Report coverage for both success and failed runs.
* Don't exit from Jetpack coverage script on failure.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not much to test here. Do the changes make sense? 
*
