### PR TITLE
Label Task: handle new block plugin type

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-block-plugins
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-block-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Label Task: handle new block plugin type

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -165,13 +165,17 @@ async function getLabelsToAdd( octokit, owner, repo, number ) {
 			keywords.add( 'Docs' );
 		}
 
-		// Existing blocks.
+		// Existing blocks and block plugins.
 		const blocks = file.match(
-			/^projects\/plugins\/jetpack\/extensions\/blocks\/(?<block>[^/]*)\//
+			/^projects\/plugins\/jetpack\/extensions\/(?<type>blocks|plugins)\/(?<block>[^/]*)\//
 		);
-		const blockName = blocks && blocks.groups.block;
-		if ( blockName ) {
-			keywords.add( `[Block] ${ cleanName( blockName ) }` );
+		if ( blocks !== null ) {
+			const { groups: { type: blockType, block: blockName } = {} } = blocks;
+			if ( blockType && blockName ) {
+				keywords.add(
+					`[${ 'plugins' === blockType ? 'Extension' : 'Block' }] ${ cleanName( blockName ) }`
+				);
+			}
 		}
 
 		// React Dashboard and Boost Admin.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿Since #20944, we now have block plugins in their own directory. Let's make sure our auto-labeling system supports that.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Branch off this branch
* Make a change to `projects/plugins/jetpack/extensions/plugins/sharing/editor.js`
* Commit your changes and open a new PR for it. Do not add any labels as you create the PR.
* The Gardening action should add the product label for you.
* See #21035 for an example.