### PR TITLE
Jetpack Sync: Fix broken Sync unit tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-sync-unit-tests-failing
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-sync-unit-tests-failing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix broken Jetpack Sync unit tests

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -279,15 +279,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 		);
 	}
 
-	public function test_add_whitelisted_option_on_init_89() {
-		add_action( 'init', array( $this, 'add_option_on_89' ), 89 );
-		do_action( 'init' );
-
-		$whitelist = $this->options_module->get_options_whitelist();
-
-		$this->assertTrue( in_array( 'foo_option_bar', $whitelist ) );
-	}
-
 	function assertOptionIsSynced( $option_name, $value ) {
 		$this->assertEqualsObject( $value, $this->server_replica_storage->get_option( $option_name ), 'Option ' . $option_name . ' did\'t have the extected value of ' . json_encode( $value ) );
 	}
@@ -295,12 +286,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 	public function add_jetpack_options_whitelist_filter( $options ) {
 		$options[] = 'foo_option_bar';
 		return $options;
-	}
-
-
-
-	function add_option_on_89() {
-		add_filter( 'jetpack_options_whitelist', array( $this, 'add_jetpack_options_whitelist_filter' ) );
 	}
 
 	/**
@@ -326,8 +311,10 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 	 * Verify that get_object_by_id returns settings logic for jetpack_sync_settings_* options.
 	 */
 	public function test_get_objects_by_id_sync_settings() {
-		$module      = Modules::get_module( 'options' );
-		$settings    = Settings::get_settings();
+		$module   = Modules::get_module( 'options' );
+		$settings = Settings::get_settings();
+		// Reload the proper allowlist of options, as `setUp` only lists `test_option`.
+		$this->options_module->update_options_whitelist();
 		$get_options = $module->get_objects_by_id( 'option', array( 'jetpack_sync_settings_post_meta_whitelist' ) );
 		$this->assertEquals( $settings['post_meta_whitelist'], $get_options['jetpack_sync_settings_post_meta_whitelist'] );
 	}

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1051,7 +1051,7 @@ That was a cool video.';
 
 		$oembeded =
 			'<p>Check out this cool video:</p>
-<p><span class="embed-youtube" style="text-align:center; display: block;"><iframe class="youtube-player" #DIMENSIONS# src="https://www.youtube.com/embed/dQw4w9WgXcQ?version=3&#038;rel=1&#038;showsearch=0&#038;showinfo=1&#038;iv_load_policy=1&#038;fs=1&#038;hl=en-US&#038;autohide=2&#038;wmode=transparent" allowfullscreen="true" style="border:0;" sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"></iframe></span></p>
+<p><iframe title="Rick Astley - Never Gonna Give You Up (Official Music Video)" #DIMENSIONS# src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></p>
 <p>That was a cool video.</p>'. "\n";
 
 		$filtered = '<p>Check out this cool video:</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fix broken Jetpack Sync unit tests

#### Jetpack product discussion
N/a

#### Does this pull request change what data or activity we track or use?
N/a
#### Testing instructions:
* Run `jetpack docker phpunit -- --filter WP_Test_Jetpack_Sync_`
* Make sure it finishes OK. There are a few tests that are incomplete, but that's not part of this effort.
