### PR TITLE
jetpack: Catch calls to `exit()` and `die()` in PHPUnit

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-tests-catch-exit
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-tests-catch-exit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+PHPUnit tests will now catch `exit` calls, instead of exiting PHPUnit.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -41,6 +41,7 @@
 		"nojimage/twitter-text-php": "3.1.2"
 	},
 	"require-dev": {
+		"antecedent/patchwork": "2.1.15",
 		"automattic/jetpack-changelogger": "1.2.x-dev"
 	},
 	"scripts": {

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2e82cd35aa9e736f17cadf7186179ea",
+    "content-hash": "610cbf74047fcb18dfd84ca4113a752e",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1608,6 +1608,54 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.1.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "0430ceaac7f447f1778c199ec19d7e4362a6f961"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/0430ceaac7f447f1778c199ec19d7e4362a6f961",
+                "reference": "0430ceaac7f447f1778c199ec19d7e4362a6f961",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "http://patchwork2.org/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.15"
+            },
+            "time": "2021-08-22T08:00:13+00:00"
+        },
         {
             "name": "automattic/jetpack-changelogger",
             "version": "dev-master",

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -7,6 +7,9 @@
  * @package wordpress-plugin-tests
  */
 
+// Catch `exit()` and `die()` so they won't make PHPUnit exit.
+require __DIR__ . '/redefine-exit.php';
+
 /**
  * For tests that should be skipped in Jetpack but run in WPCOM (or vice versa), test against this constant.
  *

--- a/projects/plugins/jetpack/tests/php/patchwork.json
+++ b/projects/plugins/jetpack/tests/php/patchwork.json
@@ -1,0 +1,3 @@
+{
+	"redefinable-internals": [ "exit", "die" ]
+}

--- a/projects/plugins/jetpack/tests/php/redefine-exit.php
+++ b/projects/plugins/jetpack/tests/php/redefine-exit.php
@@ -1,0 +1,35 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Use Patchwork to redefine `exit()` and `die()`.
+ *
+ * This should be loaded as early as possible, as it will only take effect
+ * for files loaded after this one.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Exception to represent the calling of `exit()` or `die()`.
+ */
+class ExitException extends Exception {
+}
+
+require_once __DIR__ . '/../../vendor/antecedent/patchwork/Patchwork.php';
+
+$exitfunc = function ( $arg = null ) {
+	if ( is_int( $arg ) ) {
+		throw new ExitException( "Exit called with code $arg", $arg );
+	} elseif ( is_string( $arg ) ) {
+		if ( '' === $arg ) {
+			throw new ExitException( 'Exit called with an empty string' );
+		}
+		throw new ExitException( "Exit called: $arg" );
+	} elseif ( null === $arg ) {
+		throw new ExitException( 'Exit called (with no argument)' );
+	}
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+	throw new ExitException( 'Exit called with argument ' . var_export( $arg, true ) );
+};
+\Patchwork\redefine( 'exit', $exitfunc );
+\Patchwork\redefine( 'die', $exitfunc );
+unset( $exitfunc );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It's too easy to wind up having WordPress just `exit()`, for example by
having something call `wp_die()` while `wp_doing_ajax()` returns true.

Let's use antecedent/patchwork (which we already use as part of
brain/monkey in a bunch of package tests) to redefine these functions to
throw an exception instead, which PHPUnit will catch.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-3sh-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This will probably prove itself by making CI fail, as `Test_Base_Admin_Menu::test_handle_preferred_view` is still exiting. In the failures you should see that failing with "ExitException: Exit called with an empty string" as the reason.
* Once that's fixed (and other failing tests masked by it too), a master merge will result in CI then passing.