### PR TITLE
Instagram Widget: Remove from legacy-widget block

### DIFF
--- a/projects/plugins/jetpack/changelog/instagram-widget-block
+++ b/projects/plugins/jetpack/changelog/instagram-widget-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Instagram Widget: removed from Legacy Widget block

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/index.js
@@ -45,8 +45,15 @@ export const settings = {
 					}
 					return idBase === 'wpcom_instagram_widget';
 				},
-				transform: () => {
-					return createBlock( 'jetpack/instagram-gallery' );
+				transform: ( { instance } ) => {
+					return [
+						createBlock( 'core/heading', { content: instance.raw.title } ),
+						createBlock( 'jetpack/instagram-gallery', {
+							columns: instance.raw.columns,
+							count: instance.raw.count,
+							accessToken: instance.raw.token_id,
+						} ),
+					];
 				},
 			},
 		],

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -31,6 +32,24 @@ export const settings = {
 	supports: {
 		align: true,
 		html: false,
+	},
+	// Transform from classic widget
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/legacy-widget' ],
+				isMatch: ( { idBase, instance } ) => {
+					if ( ! instance?.raw ) {
+						return false;
+					}
+					return idBase === 'wpcom_instagram_widget';
+				},
+				transform: () => {
+					return createBlock( 'jetpack/instagram-gallery' );
+				},
+			},
+		],
 	},
 	attributes,
 	edit,

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/index.js
@@ -46,14 +46,11 @@ export const settings = {
 					return idBase === 'wpcom_instagram_widget';
 				},
 				transform: ( { instance } ) => {
-					return [
-						createBlock( 'core/heading', { content: instance.raw.title } ),
-						createBlock( 'jetpack/instagram-gallery', {
-							columns: instance.raw.columns,
-							count: instance.raw.count,
-							accessToken: instance.raw.token_id,
-						} ),
-					];
+					return createBlock( 'jetpack/instagram-gallery', {
+						columns: instance.raw.columns,
+						count: instance.raw.count,
+						accessToken: instance.raw.token_id,
+					} );
 				},
 			},
 		],

--- a/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
@@ -42,7 +42,8 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', esc_html__( 'Instagram', 'jetpack' ) ),
 			array(
-				'description' => __( 'Display your latest Instagram photos.', 'jetpack' ),
+				'description'           => __( 'Display your latest Instagram photos.', 'jetpack' ),
+				'show_instance_in_rest' => true,
 			)
 		);
 
@@ -624,3 +625,15 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Remove Instagram widget from Legacy Widget block.
+ *
+ * @param array $widget_types Widget type data.
+ * This only applies to new blocks being added.
+ */
+function hide_from_legacy_block( $widget_types ) {
+	$widget_types[] = 'wpcom_instagram_widget';
+	return $widget_types;
+}
+add_filter( 'widget_types_to_hide_from_legacy_widget_block', 'hide_from_legacy_block' );

--- a/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
@@ -73,6 +73,19 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 			'columns'  => 2,
 			'count'    => 6,
 		);
+
+		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+	}
+
+	/**
+	 * Remove Instagram widget from Legacy Widget block.
+	 *
+	 * @param array $widget_types Widget type data.
+	 * This only applies to new blocks being added.
+	 */
+	public function hide_widget_in_block_editor( $widget_types ) {
+		$widget_types[] = self::ID_BASE;
+		return $widget_types;
 	}
 
 	/**
@@ -626,14 +639,3 @@ add_action(
 	}
 );
 
-/**
- * Remove Instagram widget from Legacy Widget block.
- *
- * @param array $widget_types Widget type data.
- * This only applies to new blocks being added.
- */
-function hide_from_legacy_block( $widget_types ) {
-	$widget_types[] = 'wpcom_instagram_widget';
-	return $widget_types;
-}
-add_filter( 'widget_types_to_hide_from_legacy_widget_block', 'hide_from_legacy_block' );


### PR DESCRIPTION
## Summary
With the new current widget block editor, the Instagram Widget does not configure properly. The current Instagram Gallery block already exists and offers the same functions. Rather than fixing the broken widget this PR removes it from the `core/legacy-widget` and adds the widget to the REST API to allow a block `transform:` to be created.

Fixes Automattic/wp-calypso#55344

#### Changes proposed in this Pull Request:
* Added filter to hide `wpcom_instagram_widget` from legacy-widget block
* Added widget_option to allow it to be displayed in the REST API. This will allow it to be "transformed" into the `jetpack/instagram-gallery` block

#### Jetpack product discussion
No discussions

#### Does this pull request change what data or activity we track or use?
No data changes

#### Testing instructions:
* Got to Appearance ⇢ Customize ⇢ Widgets
* Add a new block and select Legacy
* In the dropdown check to make sure the `Instagram (Jetpack)` option is gone
* Next search in the available blocks for "Instagram". You should no longer see a legacy block for Instagram.
