### PR TITLE
if other plugin use jetpack-autoloader ，Own will not be loaded hook-m…

### DIFF
--- a/projects/packages/autoloader/src/class-container.php
+++ b/projects/packages/autoloader/src/class-container.php
@@ -60,8 +60,8 @@ class Container {
 		}
 
 		$key = self::SHARED_DEPENDENCY_KEYS[ Hook_Manager::class ];
+		require_once __DIR__ . '/class-hook-manager.php';
 		if ( ! isset( $jetpack_autoloader_container_shared[ $key ] ) ) {
-			require_once __DIR__ . '/class-hook-manager.php';
 			$jetpack_autoloader_container_shared[ $key ] = new Hook_Manager();
 		}
 		$this->dependencies[ Hook_Manager::class ] = &$jetpack_autoloader_container_shared[ $key ];


### PR DESCRIPTION
Fixes #

fix not load `class-hook-manager.php` file bug。

bug steps #
1、a new wordpress install `WooCommerce` plugin。
2、Create a new plugin and install the Jetpack-Autoloader Composer package
3、in the new plugin `$hook = new Automattic\Jetpack\Autoloader\xxxx\Hook_Manager` ，will be error notice `class not found`
