### PR TITLE
Admin Menu: Fix skipped tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-screen-options-switcher-tests
+++ b/projects/plugins/jetpack/changelog/fix-screen-options-switcher-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add back skipped tests checking the Screen Options functionality of Nav Unification

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -78,7 +78,7 @@ abstract class Base_Admin_Menu {
 			add_action( 'admin_head', array( $this, 'set_site_icon_inline_styles' ) );
 			add_filter( 'screen_settings', array( $this, 'register_dashboard_switcher' ), 99999 );
 			add_action( 'admin_menu', array( $this, 'handle_preferred_view' ), 99997 );
-			add_action( 'wp_ajax_set_preferred_view', array( $this, 'handle_preferred_view' ) );
+			add_action( 'wp_ajax_set_preferred_view', array( $this, 'handle_preferred_view_ajax' ) );
 		}
 	}
 
@@ -647,11 +647,15 @@ abstract class Base_Admin_Menu {
 		 * @param string The preferred view the user selected.
 		 */
 		\do_action( 'jetpack_dashboard_switcher_changed_view', $current_screen, $preferred_view );
-
-		if ( wp_doing_ajax() ) {
-			wp_die();
-		}
 		// phpcs:enable WordPress.Security.NonceVerification
+	}
+
+	/**
+	 * Handles AJAX requests setting a preferred view for a given screen.
+	 */
+	public function handle_preferred_view_ajax() {
+		$this->handle_preferred_view();
+		wp_die();
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -563,7 +563,6 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 	 * Check if the dashboard switcher is registered correctly.
 	 */
 	public function test_register_dashboard_switcher() {
-		$this->markTestSkipped( 'Test causing PHPUnit process to silently exit' );
 		global $pagenow;
 		$pagenow = 'edit.php?post_type=feedback';
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-base-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-base-admin-menu.php
@@ -140,7 +140,6 @@ class Test_Base_Admin_Menu extends WP_UnitTestCase {
 	 * @covers ::handle_preferred_view
 	 */
 	public function test_handle_preferred_view() {
-		$this->markTestSkipped( 'Test causing PHPUnit process to silently exit' );
 		global $pagenow;
 		$pagenow                = 'test.php';
 		$_GET['preferred-view'] = 'classic';


### PR DESCRIPTION
Fixes #21042

#### Changes proposed in this Pull Request:

Adds back the `test_handle_preferred_view` and `test_register_dashboard_switcher` tests that were skipped in #21030. 

Seems that these tests were unintentionally terminating the `phpunit` process because some AJAX requests were executing the `handle_preferred_view` function hooked into the `admin_menu` action, as opposed to the one hooked into `wp_ajax_set_preferred_view` which is the only one that should kill the WordPress execution.

To fix that, we now have two separate functions which are hooked independently. 

#### Jetpack product discussion
p9dueE-3sh-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Make sure that Jetpack PHPUnit tests actually succeeds (or check [this direct link](https://github.com/Automattic/jetpack/pull/21055/checks?check_run_id=3586164579#step:9:202)).
- Additionally, check that the Nav Unification's screen switcher continues to work as expected:
  - Simple sites: Apply D66737-codee to your WP.com sandbox, and sandbox both the API and a Simple site.
  - Atomic sites: Install Jetpack Beta and activate the `fix/screen-options-switcher-tests` branch.
  - Go to https://wordpress.com.
  - Switch to your Simple or Atomic site.
  - Go to any of the following screens:
    - Posts > All posts
    - Posts > Categories
    - Posts > Tags
    - Media
    - Pages > All pages
    - Testimonials > All testimonials
    - Portfolio > All projects
    - Comments
    - Appearance > Themes
    - Users > All users
    - Tools > Import
    - Tools > Export
    - Settings > General
    - Settings > Writing
    - Settings > Discussion
  - Click on the "Screen Options" tab and then select "Classic view".
  - Make sure you're redirected to the equivalent WP Admin screen.
  - Make sure that the menu/submenu item of that screen now always links to the WP Admin screen from both Calypso and WP Admin.
  - On the WP Admin screen, click on the "Screen Options" tab and then select "Use WordPress.com view".
  - Make sure you're redirected to the equivalent Calypso screen.
  - Make sure that the menu/submenu item of that screen now always links to the Calypso screen from both Calypso and WP Admin.
