### PR TITLE
Extensions:  register plugins from a single index file

### DIFF
--- a/projects/plugins/jetpack/changelog/update-extensions-plugins-registering-order
+++ b/projects/plugins/jetpack/changelog/update-extensions-plugins-registering-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Register block-editor plugins from a single file.

--- a/projects/plugins/jetpack/extensions/README.md
+++ b/projects/plugins/jetpack/extensions/README.md
@@ -226,6 +226,12 @@ add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
 
 This will allow you to take advantage of those registered blocks. They will not be rendered to logged out visitors on the frontend of the site, but the block will be available in the block picker in the editor. When you add a paid block to a post, an `UpgradeNudge` component will display above the block in the editor and on the front end of the site to inform users that this is a paid block. If a paid block is nested within another paid block, only the parent block will display its upgrade nudge on the front end.
 
+
+## Registering plugins
+
+Plugins in Jetpack are registered via the `register Jetpack Plugin()` helper. Although they can be registered arbitrarily from any place, we encourage you to do it in the `./extensions/plugins/index.js` especially when the order matters.
+For instance, in the Jetpack settings sidebar, we'd like to show the Publicize plugin at the top of it. Therefore, it's registered before to other plugins that coexist in the same area.
+
 ### Upgrades for Jetpack sidebar extensions
 
 Unlike blocks, adding an extension for the Jetpack sidebar requires calling `registerJetpackPlugin` (a high level wrapper around Gutenberg's `registerPlugin`) to register the Plugin with Gutenberg.

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -14,6 +14,9 @@ import './shared/styles/external-link-fix.scss';
 // Register media source store to the centralized data registry.
 import './store/media-source';
 
+// Load Jetpack plugins.
+import './plugins';
+
 import analytics from '../_inc/client/lib/analytics';
 
 // @TODO Please make a shared analytics solution and remove this!

--- a/projects/plugins/jetpack/extensions/plugins/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/index.js
@@ -10,11 +10,16 @@ import { name as publicizePluginName, settings as publicizePluginSettings } from
 import { name as sharingPluginName, settings as sharingPluginSettings } from './sharing';
 
 /*
- * Register plugins.
+ * Jetpack plugins list.
  * Order matters. The plugins will be registered in the order they are listed here,
- * impacting the order in which they are rendered in the UI.
+ * probably impacting the order in which they are rendered in the UI.
  *
  * https://github.com/Automattic/jetpack/issues/21036
  */
-registerJetpackPlugin( publicizePluginName, publicizePluginSettings );
-registerJetpackPlugin( sharingPluginName, sharingPluginSettings );
+const jetpackPlugins = [
+	[ publicizePluginName, publicizePluginSettings ],
+	[ sharingPluginName, sharingPluginSettings ],
+];
+
+// Register plugins.
+jetpackPlugins.forEach( ( [ name, settings ] ) => registerJetpackPlugin( name, settings ) );

--- a/projects/plugins/jetpack/extensions/plugins/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/index.js
@@ -11,7 +11,10 @@ import { name as sharingPluginName, settings as sharingPluginSettings } from './
 
 /*
  * Register plugins.
- * Order matters: https://github.com/Automattic/jetpack/issues/21036
+ * Order matters. The plugins will be registered in the order they are listed here,
+ * impacting the order in which they are rendered in the UI.
+ *
+ * https://github.com/Automattic/jetpack/issues/21036
  */
 registerJetpackPlugin( publicizePluginName, publicizePluginSettings );
 registerJetpackPlugin( sharingPluginName, sharingPluginSettings );

--- a/projects/plugins/jetpack/extensions/plugins/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/index.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import registerJetpackPlugin from '../shared/register-jetpack-plugin';
+
+/*
+ * Jetpack core-editor plugins dependencies
+ */
+import { name as publicizePluginName, settings as publicizePluginSettings } from './publicize';
+import { name as sharingPluginName, settings as sharingPluginSettings } from './sharing';
+
+/*
+ * Register plugins.
+ * Order matters: https://github.com/Automattic/jetpack/issues/21036
+ */
+registerJetpackPlugin( publicizePluginName, publicizePluginSettings );
+registerJetpackPlugin( sharingPluginName, sharingPluginSettings );

--- a/projects/plugins/jetpack/extensions/plugins/publicize/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/editor.js
@@ -1,7 +1,0 @@
-/**
- * Internal dependencies
- */
-import { name, settings } from '.';
-import registerJetpackPlugin from '../../shared/register-jetpack-plugin';
-
-registerJetpackPlugin( name, settings );

--- a/projects/plugins/jetpack/extensions/plugins/sharing/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/sharing/editor.js
@@ -1,7 +1,0 @@
-/**
- * Internal dependencies
- */
-import { name, settings } from '.';
-import registerJetpackPlugin from '../../shared/register-jetpack-plugin';
-
-registerJetpackPlugin( name, settings );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Registering the plugins from a single order will help to set the importing order, and thus and depending on the plugin, it will be reflected in the UI.
For instance, we register the Publicize plugin in the first place of the list because we want to render it at the top of the sidebar.

Fixes #21036
Related with https://github.com/Automattic/jetpack/issues/16816

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Extensions:  register block-editor plugins from a single index file

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the changes
* Confirm the sidebar looks as expected.
* No visual changes should happen compared with prod.

<img src="https://user-images.githubusercontent.com/77539/133086420-b9fd4ed8-c782-4e06-967c-77c46168c3e9.png" width="300px" />


