### PR TITLE
Subscription Block: Pass form ID as `redirect_fragment` instead of enqueueing `jetpack-subscriptions-js`

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-widget-amp-compat
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-widget-amp-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Correct AMP validation errors.

--- a/projects/plugins/jetpack/modules/subscriptions/subscriptions.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscriptions.js
@@ -1,0 +1,8 @@
+( function () {
+	window.addEventListener( 'load', function () {
+		var notificationElement = document.querySelector( '.jetpack-sub-notification' );
+		if ( notificationElement ) {
+			notificationElement.scrollIntoView();
+		}
+	} );
+} )();

--- a/projects/plugins/jetpack/modules/subscriptions/subscriptions.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscriptions.js
@@ -1,8 +1,0 @@
-( function () {
-	window.addEventListener( 'load', function () {
-		var notificationElement = document.querySelector( '.jetpack-sub-notification' );
-		if ( notificationElement ) {
-			notificationElement.scrollIntoView();
-		}
-	} );
-} )();

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -425,8 +425,8 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 				if ( ! isset ( $_GET['subscribe'] ) || 'success' != $_GET['subscribe'] ) { ?>
                     <p id="subscribe-email">
                         <label id="jetpack-subscribe-label"
-                               class="screen-reader-text"
-                               for="<?php echo esc_attr( $subscribe_field_id . '-' . $widget_id ); ?>">
+							class="screen-reader-text"
+							for="<?php echo esc_attr( $subscribe_field_id . '-' . $widget_id ); ?>">
 							<?php echo ! empty( $subscribe_placeholder ) ? esc_html( $subscribe_placeholder ) : esc_html__( 'Email Address:', 'jetpack' ); ?>
                         </label>
                         <input type="email" name="email" required="required"
@@ -437,7 +437,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			                    style="<?php echo esc_attr( $email_field_styles ); ?>"
 		                    <?php }; ?>
                             value="<?php echo esc_attr( $subscribe_email ); ?>"
-                            id="<?php echo esc_attr( $subscribe_field_id . '-' . $widget_id ); ?>"
+							id="<?php echo esc_attr( $subscribe_field_id . '-' . $widget_id ); ?>"
                             placeholder="<?php echo esc_attr( $subscribe_placeholder ); ?>"
                         />
                     </p>

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -238,12 +238,22 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			}
 
 			$border_color = isset( $themecolors['border'] ) ? " #{$themecolors['border']}" : '';
+
+			$redirect_fragment = self::get_wpcom_redirect_fragment();
 			printf(
-				'<div class="jetpack-sub-notification" style="border: 1px solid%1$s; padding-left: 5px; padding-right: 5px; margin-bottom: 10px;">%2$s</div>',
+				'<div id="%1$s" class="jetpack-sub-notification" style="border: 1px solid%2$s; padding-left: 5px; padding-right: 5px; margin-bottom: 10px;">%3$s</div>',
+				esc_attr( $redirect_fragment ),
 				esc_attr( $border_color ),
 				wp_kses_post( $message )
 			);
 		}
+	}
+
+	/**
+	 * Generates the redirect fragment used after form submission.
+	 */
+	protected static function get_wpcom_redirect_fragment() {
+		return 'subscribe-blog' . ( self::$instance_count > 1 ? '-' . self::$instance_count : '' );
 	}
 
 	/**
@@ -275,10 +285,9 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			global $current_blog;
 
 			$url     = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '';
-			$form_id = 'subscribe-blog' . self::$instance_count > 1
-				? '-' . self::$instance_count
-				: '';
+			$form_id = self::get_wpcom_redirect_fragment();
 			?>
+
 			<form
 				action="<?php echo esc_url( $url ); ?>"
 				method="post"

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -92,14 +92,6 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			}
 		}
 
-		wp_enqueue_script(
-			'jetpack-subscriptions-js',
-			plugins_url( 'subscriptions.js', __FILE__ ),
-			array(),
-			JETPACK__VERSION,
-			true
-		);
-
 		$stats_action = self::is_jetpack() ? 'jetpack_subscriptions' : 'follow_blog';
 		/** This action is documented in modules/widgets/gravatar-profile.php */
 		do_action( 'jetpack_stats_extra', 'widget_view', $stats_action );
@@ -359,7 +351,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                     <input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
                     <input type="hidden" name="source" value="<?php echo esc_url( $referer ); ?>"/>
                     <input type="hidden" name="sub-type" value="<?php echo esc_attr( $source ); ?>"/>
-                    <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $widget_id ); ?>"/>
+                    <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
                     <button type="submit"
 	                    <?php if ( ! empty( $submit_button_classes ) ) { ?>
@@ -393,8 +385,10 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			 * @param int $widget_id Widget ID.
 			 */
 			$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field', $widget_id );
+
+			$form_id = "subscribe-blog-{$widget_id}";
 			?>
-            <form action="#" method="post" accept-charset="utf-8" id="subscribe-blog-<?php echo $widget_id; ?>">
+            <form action="#" method="post" accept-charset="utf-8" id="<?php echo esc_attr( $form_id ); ?>">
 				<?php
 				if ( $subscribe_text && ( ! isset ( $_GET['subscribe'] ) || 'success' != $_GET['subscribe'] ) ) {
 					?>
@@ -441,7 +435,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                         <input type="hidden" name="action" value="subscribe"/>
                         <input type="hidden" name="source" value="<?php echo esc_url( $referer ); ?>"/>
                         <input type="hidden" name="sub-type" value="<?php echo esc_attr( $source ); ?>"/>
-                        <input type="hidden" name="redirect_fragment" value="<?php echo $widget_id; ?>"/>
+                        <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 						<?php
 						if ( is_user_logged_in() ) {
 							wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -261,7 +261,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			false;
 		$referer                      = ( is_ssl() ? 'https' : 'http' ) . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 		$source                       = 'widget';
-		$widget_id                    = esc_attr( ! empty( $args['widget_id'] ) ? esc_attr( $args['widget_id'] ) : wp_rand( 450, 550 ) );
+		$widget_id                    = ! empty( $args['widget_id'] ) ? $args['widget_id'] : self::$instance_count;
 		$subscribe_button             = ! empty( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : $instance['subscribe_button'];
 		$subscribers_total            = self::fetch_subscriber_count();
 		$subscribe_placeholder        = isset( $instance['subscribe_placeholder'] ) ? stripslashes( $instance['subscribe_placeholder'] ) : '';
@@ -411,7 +411,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                     <p id="subscribe-email">
                         <label id="jetpack-subscribe-label"
                                class="screen-reader-text"
-                               for="<?php echo esc_attr( $subscribe_field_id ) . '-' . esc_attr( $widget_id ); ?>">
+                               for="<?php echo esc_attr( $subscribe_field_id . '-' . $widget_id ); ?>">
 							<?php echo ! empty( $subscribe_placeholder ) ? esc_html( $subscribe_placeholder ) : esc_html__( 'Email Address:', 'jetpack' ); ?>
                         </label>
                         <input type="email" name="email" required="required"
@@ -422,7 +422,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			                    style="<?php echo esc_attr( $email_field_styles ); ?>"
 		                    <?php }; ?>
                             value="<?php echo esc_attr( $subscribe_email ); ?>"
-                            id="<?php echo esc_attr( $subscribe_field_id ) . '-' . esc_attr( $widget_id ); ?>"
+                            id="<?php echo esc_attr( $subscribe_field_id . '-' . $widget_id ); ?>"
                             placeholder="<?php echo esc_attr( $subscribe_placeholder ); ?>"
                         />
                     </p>

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -401,7 +401,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			 */
 			$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field', $widget_id );
 
-			$form_id = self::get_redirect_fragment();
+			$form_id = self::get_redirect_fragment( $widget_id );
 			?>
 			<form action="#" method="post" accept-charset="utf-8" id="<?php echo esc_attr( $form_id ); ?>">
 				<?php

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -351,7 +351,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                     <input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
                     <input type="hidden" name="source" value="<?php echo esc_url( $referer ); ?>"/>
                     <input type="hidden" name="sub-type" value="<?php echo esc_attr( $source ); ?>"/>
-                    <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+					<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
                     <button type="submit"
 	                    <?php if ( ! empty( $submit_button_classes ) ) { ?>
@@ -388,7 +388,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 
 			$form_id = "subscribe-blog-{$widget_id}";
 			?>
-            <form action="#" method="post" accept-charset="utf-8" id="<?php echo esc_attr( $form_id ); ?>">
+			<form action="#" method="post" accept-charset="utf-8" id="<?php echo esc_attr( $form_id ); ?>">
 				<?php
 				if ( $subscribe_text && ( ! isset ( $_GET['subscribe'] ) || 'success' != $_GET['subscribe'] ) ) {
 					?>
@@ -435,7 +435,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
                         <input type="hidden" name="action" value="subscribe"/>
                         <input type="hidden" name="source" value="<?php echo esc_url( $referer ); ?>"/>
                         <input type="hidden" name="sub-type" value="<?php echo esc_attr( $source ); ?>"/>
-                        <input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 						<?php
 						if ( is_user_logged_in() ) {
 							wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -239,7 +239,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 
 			$border_color = isset( $themecolors['border'] ) ? " #{$themecolors['border']}" : '';
 
-			$redirect_fragment = self::get_wpcom_redirect_fragment();
+			$redirect_fragment = self::get_redirect_fragment();
 			printf(
 				'<div id="%1$s" class="jetpack-sub-notification" style="border: 1px solid%2$s; padding-left: 5px; padding-right: 5px; margin-bottom: 10px;">%3$s</div>',
 				esc_attr( $redirect_fragment ),
@@ -251,9 +251,15 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 
 	/**
 	 * Generates the redirect fragment used after form submission.
+	 *
+	 * @param string $id is the specific id that will appear in the redirect fragment. If none is provided self::$instance_count will be used.
 	 */
-	protected static function get_wpcom_redirect_fragment() {
-		return 'subscribe-blog' . ( self::$instance_count > 1 ? '-' . self::$instance_count : '' );
+	protected static function get_redirect_fragment( $id = null ) {
+		if ( is_null( $id ) ) {
+			return 'subscribe-blog' . ( self::$instance_count > 1 ? '-' . self::$instance_count : '' );
+		}
+
+		return 'subscribe-blog-' . $id;
 	}
 
 	/**
@@ -285,7 +291,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			global $current_blog;
 
 			$url     = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '';
-			$form_id = self::get_wpcom_redirect_fragment();
+			$form_id = self::get_redirect_fragment();
 			?>
 
 			<form
@@ -395,7 +401,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			 */
 			$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field', $widget_id );
 
-			$form_id = "subscribe-blog-{$widget_id}";
+			$form_id = self::get_redirect_fragment();
 			?>
 			<form action="#" method="post" accept-charset="utf-8" id="<?php echo esc_attr( $form_id ); ?>">
 				<?php


### PR DESCRIPTION
This is a follow-up on #18015.

I found that #20763 was causing AMP validation errors due to the enqueueing of a custom script on a page. The introduced script scrolls the subscriptions widget into view if a certain DOM element was on the page. Beyond not working in AMP due to the custom script, this is not ideal because adding a new external script for every page load negatively impacts frontend performance. It also doesn't work if JS is turned off.

I believe the the better fix for #18015 is merely to make sure that the ID for the `form` is passed as the `redirect_fragment` input value. Previously it was relying on the widget wrapper element to have an ID, but this appears to be no longer in place as of WordPress 5.8.

#### Changes proposed in this Pull Request:

* Revert #20763 to instead scroll to subscription form by passing the form ID as the `redirect_fragment`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a Subscription form to a page.
2. Submit the form (on an AMP page and a non-AMP page)
3. When the subsequent page loads, ensure you are scrolled back to the form you submitted.
