### PR TITLE
Boost: Fix module toggle console error

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
@@ -41,7 +41,7 @@ let hasGenerateRun = false;
  * runs if the module is enabled again.
  */
 modules.subscribe( modulesState => {
-	if ( ! modulesState[ 'critical-css' ].enabled ) {
+	if ( ! modulesState[ 'critical-css' ] || ! modulesState[ 'critical-css' ].enabled ) {
 		hasGenerateRun = false;
 	}
 } );

--- a/projects/plugins/boost/changelog/fix-module-toggle-console-error
+++ b/projects/plugins/boost/changelog/fix-module-toggle-console-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix console error on critical-css module subscription status


### PR DESCRIPTION
#### Issue
Fresh installation of Jetpack boost throws the following error.
```
Uncaught TypeError: Cannot read properties of undefined (reading 'enabled')
at jetpack-boost.js?ver=1.3.0-alpha:1
at Object.subscribe (jetpack-boost.js?ver=1.3.0-alpha:1)
at jetpack-boost.js?ver=1.3.0-alpha:1
at jetpack-boost.js?ver=1.3.0-alpha:1
```

#### Changes proposed in this Pull Request:
* Fix console error on fresh Boost install.
* Check for existence of `critical-css` property in `modulesState` before checking if the module is enabled.

#### Jetpack product discussion
Slack: C0232B8CUHG/p1631611381010500

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:


* Go to a site with Jetpack Boost Plugin freshly installed and activated.
* (If the plugin was already activated before, clear the Jetpack Boost related options from the wp_options table)
* Navigate to wp-admin/admin.php?page=jetpack-boost.
* Open the Browser Console and verify that there is no error.
