### PR TITLE
RNA Connect Button: Display error message on site registration failure

### DIFF
--- a/projects/js-packages/connection/changelog/update-rna-connect-button-error-handling
+++ b/projects/js-packages/connection/changelog/update-rna-connect-button-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Display an error message on site registration failure.

--- a/projects/js-packages/connection/components/connect-button/index.jsx
+++ b/projects/js-packages/connection/components/connect-button/index.jsx
@@ -33,6 +33,7 @@ import './style.scss';
 const ConnectButton = props => {
 	const [ isRegistering, setIsRegistering ] = useState( false );
 	const [ isUserConnecting, setIsUserConnecting ] = useState( false );
+	const [ registationError, setRegistrationError ] = useState( false );
 
 	const [ authorizationUrl, setAuthorizationUrl ] = useState( null );
 
@@ -64,6 +65,8 @@ const ConnectButton = props => {
 		e => {
 			e && e.preventDefault();
 
+			setRegistrationError( false );
+
 			if ( connectionStatus.isRegistered ) {
 				setIsUserConnecting( true );
 				return;
@@ -85,6 +88,7 @@ const ConnectButton = props => {
 				} )
 				.catch( error => {
 					setIsRegistering( false );
+					setRegistrationError( error );
 					throw error;
 				} );
 		},
@@ -123,6 +127,12 @@ const ConnectButton = props => {
 						{ isRegistering || isUserConnecting ? <Spinner /> : connectLabel }
 					</Button>
 				) }
+
+			{ registationError && (
+				<p className="jp-connect-button__error">
+					{ __( 'An error occurred. Please try again.', 'jetpack' ) }
+				</p>
+			) }
 
 			{ isUserConnecting && (
 				<ConnectUser connectUrl={ authorizationUrl } redirectUri={ redirectUri } from={ from } />

--- a/projects/js-packages/connection/components/connect-button/style.scss
+++ b/projects/js-packages/connection/components/connect-button/style.scss
@@ -1,5 +1,5 @@
 .jp-connect-button {
-	.jp-connect-button--button {
+	&--button {
 		background: #000;
 		border-radius: 4px;
 		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
@@ -11,5 +11,11 @@
 		width: 264px;
 		height: 40px;
 		display: block;
+	}
+	&__error{
+		color: var( --jp-red ) !important;
+		line-height: 25px !important;
+		padding-left: 25px;
+		background: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDIwQzE2LjQxODMgMjAgMjAgMTYuNDE4MyAyMCAxMkMyMCA3LjU4MTcyIDE2LjQxODMgNCAxMiA0QzcuNTgxNzIgNCA0IDcuNTgxNzIgNCAxMkM0IDE2LjQxODMgNy41ODE3MiAyMCAxMiAyMFoiIHN0cm9rZT0iI0Q2MzYzOSIgc3Ryb2tlLXdpZHRoPSIxLjUiLz4KPHBhdGggZD0iTTEzIDdIMTFWMTNIMTNWN1oiIGZpbGw9IiNENjM2MzkiLz4KPHBhdGggZD0iTTEzIDE1SDExVjE3SDEzVjE1WiIgZmlsbD0iI0Q2MzYzOSIvPgo8L3N2Zz4K") no-repeat 0 0;
 	}
 }


### PR DESCRIPTION
RNA Connect Button: Display error message on site registration failure

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the RNA Connect Button component to display an error message when the request to register the site fails.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1199658893173824-as-1200603127282609/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
If you're using a JN site, you need to install[ this plugin](https://gist.github.com/sergeymitr/bc005e1b893e778c03e4f43debb91c30) to activate the Connection Manager page.

- Start with a non-connected site
- Sabotage the response from `jetpack/v4/connection/register` by immediately returning a failed response
- Go to Tools->Connection Manager
- Click the "Set up Jetpack" button
- Verify that an error message shows up, as displayed in the following screenshot:

<img width="439" alt="Screenshot 2021-09-14 at 3 07 14 PM" src="https://user-images.githubusercontent.com/1758399/133254758-19da5a50-53f8-4520-91af-478f6aa5af06.png">

- By clicking "Set up Jetpack" once more, the error message should not be displayed any more.

**Extra bonus points** for testing this with Jetpack and Backup plugin as well.
