### PR TITLE
Related Posts: enable lazy loading for images.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-related-posts-img-lazy
+++ b/projects/plugins/jetpack/changelog/update-related-posts-img-lazy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Related Posts: enable lazy loading for images.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -5,7 +5,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Sync\Settings;
 
 class Jetpack_RelatedPosts {
-	const VERSION   = '20210604';
+	const VERSION   = '20210914';
 	const SHORTCODE = 'jetpack-related-posts';
 
 	private static $instance     = null;
@@ -303,7 +303,7 @@ EOT;
 
 		if ( ! empty( $block_attributes['show_thumbnails'] ) && ! empty( $related_post['img']['src'] ) ) {
 			$img_link = sprintf(
-				'<li class="jp-related-posts-i2__post-img-link"><a href="%1$s" %2$s><img src="%3$s" width="%4$s" height="%5$s" alt="%6$s" /></a></li>',
+				'<li class="jp-related-posts-i2__post-img-link"><a href="%1$s" %2$s><img src="%3$s" width="%4$s" height="%5$s" alt="%6$s" loading="lazy" /></a></li>',
 				esc_url( $related_post['url'] ),
 				( ! empty( $related_post['rel'] ) ? 'rel="' . esc_attr( $related_post['rel'] ) . '"' : '' ),
 				esc_url( $related_post['img']['src'] ),

--- a/projects/plugins/jetpack/modules/related-posts/related-posts.js
+++ b/projects/plugins/jetpack/modules/related-posts/related-posts.js
@@ -161,7 +161,7 @@
 				if ( post.img.src ) {
 					html +=
 						anchor[ 0 ] +
-						'<img class="jp-relatedposts-post-img" src="' +
+						'<img class="jp-relatedposts-post-img" loading="lazy" src="' +
 						post.img.src +
 						'" width="' +
 						post.img.width +


### PR DESCRIPTION
Fixes #13068

#### Changes proposed in this Pull Request:

Let's add the lazy attribute to all images generated for Related Posts (blocks and appended to post content).

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site that's connected to WordPress.com, with Related Posts active, and with enough posts to generate related posts.
* View one of the posts.
* Inspect the related post markup: you should see the `loading="lazy"` attribute.
