### PR TITLE
Adds support for trigerring an action after admin_menu gets registered.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-use-calypso-for-add-new-plugin
+++ b/projects/plugins/jetpack/changelog/update-use-calypso-for-add-new-plugin
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Add an action which fires after the admin_menu gets registered.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -45,6 +45,14 @@ class Admin_Menu extends Base_Admin_Menu {
 			remove_menu_page( 'link-manager.php' );
 		}
 
+		/**
+		 * Action fired after the Admin_Menu is registered,
+		 * which allows for further manipulation.
+		 *
+		 * @since-jetpack 10.2
+		 */
+		do_action( 'after_admin_menu_registered', $this );
+
 		ksort( $GLOBALS['menu'] );
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
@@ -26,7 +26,7 @@ class Domain_Only_Admin_Menu extends Base_Admin_Menu {
 		add_menu_page( esc_attr__( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 'dashicons-admin-settings' );
 
 		/**
-		 * Action fired after the Admin_Menu is registered,
+		 * Action fired after the Domain_Only_Admin_Menu is registered,
 		 * which allows for further manipulation.
 		 *
 		 * @since-jetpack 10.2

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
@@ -24,5 +24,13 @@ class Domain_Only_Admin_Menu extends Base_Admin_Menu {
 		$submenu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		add_menu_page( esc_attr__( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, 'dashicons-admin-settings' );
+
+		/**
+		 * Action fired after the Admin_Menu is registered,
+		 * which allows for further manipulation.
+		 *
+		 * @since-jetpack 10.2
+		 */
+		do_action( 'after_admin_menu_registered', $this );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
