### PR TITLE
Sharing: Icon position fix

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-icon-position-button
+++ b/projects/plugins/jetpack/changelog/fix-sharing-icon-position-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: fix the icon position in icon-only button style.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -562,8 +562,7 @@ body .sd-social-icon .sd-content li.share-custom a span {
 
 
 .sd-social-icon .sd-content ul li[class*='share-'] a.sd-button:before {
-	top: 1px;
-	top: 0px\9; /* IE8 and below */
+	top: 0;
 }
 
 .sd-social-icon .sd-content ul li[class*='share-'] a.sd-button.share-custom {


### PR DESCRIPTION
This fixes the sharing icons position in icon-only button style, which is currently off-center.

Closes https://github.com/Automattic/jetpack/issues/16301.