### PR TITLE
repo-gardening: Use `pull_request_target` for all tasks

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,16 +1,14 @@
 name: Gardening
 on:
-  pull_request_target:
-    types: [opened, labeled]
-  pull_request: # When a PR is opened, edited, updated, closed, or a label is added.
-    types: [opened, synchronize, labeled, edited, closed]
+  pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
+    types: [opened, reopened, synchronize, edited, labeled, closed]
   issues: # For auto-triage of issues.
     types: [opened, reopened]
   push:
     branches:
       - master # Every time a PR is merged to master.
 concurrency:
-  # For pull_request and pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
+  # For pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
   # Don't cancel any for pushes, accomplished by grouping on the unique run_id.
   group: gardening-${{ github.event_name }}-${{ github.event_name == 'push' && github.run_id || github.event.action }}-${{ github.ref }}
   cancel-in-progress: true
@@ -19,7 +17,7 @@ jobs:
   # review-crew-afk:
   #   name: "Review check"
   #   runs-on: ubuntu-latest
-  #   if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == '[Status] Needs Review'
+  #   if: github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == '[Status] Needs Review'
   #   timeout-minutes: 1  # 2021-01-18: Successful runs probably take a few seconds
   #   steps:
   #     - name: Comment
@@ -51,6 +49,15 @@ jobs:
         run: composer build-development
         working-directory: ./projects/github-actions/repo-gardening
 
+      - name: Checkout the PR
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # DO NOT run any code in this checkout. Not even an `npm install`.
+          path: ./pr-checkout
+
       - name: Wait for prior instances of the workflow to finish
         uses: softprops/turnstyle@v1
         env:
@@ -58,6 +65,8 @@ jobs:
 
       - name: "Run the action (assign, manage milestones, for issues and PRs)"
         uses: ./projects/github-actions/repo-gardening
+        env:
+          PR_WORKSPACE: ${{ github.workspace }}${{ github.event_name == 'pull_request_target' && '/pr-checkout' || '' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_token: ${{ secrets.SLACK_TOKEN }}

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-pr-target
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-pr-target
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+BREAKING: Use `pull_request_target` instead of `pull_request` for the following tasks: assignIssues, addLabels, cleanLabels, checkDescription.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "1.4.1-alpha",
+	"version": "2.0.0-alpha",
 	"description": "Manage PR and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/repo-gardening/src/get-affected-changelogger-projects.js
+++ b/projects/github-actions/repo-gardening/src/get-affected-changelogger-projects.js
@@ -1,6 +1,6 @@
 const glob = require( 'glob' );
 const fs = require( 'fs' );
-const getPrWorkspace = require( '../../get-pr-workspace' );
+const getPrWorkspace = require( './get-pr-workspace' );
 
 /**
  * Returns a list of Projects that use changelogger package

--- a/projects/github-actions/repo-gardening/src/get-affected-changelogger-projects.js
+++ b/projects/github-actions/repo-gardening/src/get-affected-changelogger-projects.js
@@ -1,5 +1,6 @@
 const glob = require( 'glob' );
 const fs = require( 'fs' );
+const getPrWorkspace = require( '../../get-pr-workspace' );
 
 /**
  * Returns a list of Projects that use changelogger package
@@ -8,7 +9,7 @@ const fs = require( 'fs' );
  */
 function getChangeloggerProjects() {
 	const projects = [];
-	const composerFiles = glob.sync( process.env.GITHUB_WORKSPACE + '/projects/*/*/composer.json' );
+	const composerFiles = glob.sync( getPrWorkspace() + '/projects/*/*/composer.json' );
 	composerFiles.forEach( file => {
 		const json = JSON.parse( fs.readFileSync( file ) );
 		if (

--- a/projects/github-actions/repo-gardening/src/get-pr-workspace.js
+++ b/projects/github-actions/repo-gardening/src/get-pr-workspace.js
@@ -1,0 +1,14 @@
+/**
+ * Get the path to the PR workspace.
+ *
+ * @returns {string} Path.
+ */
+function getPrWorkspace() {
+	if ( 'undefined' !== typeof process.env.PR_WORKSPACE ) {
+		return process.env.PR_WORKSPACE;
+	}
+
+	throw new Error( 'Environment variable PR_WORKSPACE is not defined.' );
+}
+
+module.exports = getPrWorkspace;

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -23,7 +23,7 @@ const ifNotClosed = require( './if-not-closed' );
 
 const automations = [
 	{
-		event: 'pull_request',
+		event: 'pull_request_target',
 		action: [ 'opened', 'synchronize', 'edited' ],
 		task: ifNotFork( assignIssues ),
 	},
@@ -32,19 +32,20 @@ const automations = [
 		task: addMilestone,
 	},
 	{
-		event: 'pull_request',
+		event: 'pull_request_target',
 		action: [ 'opened', 'reopened', 'synchronize', 'edited', 'labeled' ],
 		task: ifNotClosed( addLabels ),
 	},
 	{
-		event: 'pull_request',
+		event: 'pull_request_target',
 		action: [ 'closed' ],
 		task: cleanLabels,
 	},
 	{
-		event: 'pull_request',
+		event: 'pull_request_target',
 		action: [ 'opened', 'reopened', 'synchronize', 'edited', 'labeled' ],
 		task: ifNotClosed( checkDescription ),
+		// Note this task requires a PR checkout. See README.md for details.
 	},
 	{
 		event: 'pull_request_target',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This will let them run for PRs from forked repos. Also it'll reduce the
number of workflow runs, since we won't have runs for both
`pull_request` and `pull_request_target`.

The main drawback is some extra complication for the checkDescription
task, as that looks at the filesystem to determine whether changelogger
was properly used.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a PR targeting this one (or look at #21079). Check that
  * The Gardening workflow does not run on `pull_request`.
  * All the labels and comments are still applied as appropriate.