### PR TITLE
Admin Page: do not display JP version in UI on WoA sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
@@ -14,6 +14,7 @@ import analytics from 'lib/analytics';
 import { canDisplayDevCard, enableDevCard, resetOptions } from 'state/dev-version';
 import DevCard from 'components/dev-card';
 import {
+	isAtomicSite,
 	isDevVersion as _isDevVersion,
 	getCurrentVersion,
 	userCanManageOptions,
@@ -176,17 +177,9 @@ export class Footer extends React.Component {
 			}
 		};
 
-		const aboutPageUrl = this.props.siteConnectionStatus
-			? this.props.siteAdminUrl + 'admin.php?page=jetpack_about'
-			: getRedirectUrl( 'jetpack' );
-
-		const privacyUrl = this.props.siteConnectionStatus
-			? this.props.siteAdminUrl + 'admin.php?page=jetpack#/privacy'
-			: getRedirectUrl( 'a8c-privacy' );
-
-		return (
-			<div className={ classes }>
-				<ul className="jp-footer__links">
+		const maybeShowVersionNumber = () => {
+			if ( ! this.props.isAtomicSite ) {
+				return (
 					<li className="jp-footer__link-item">
 						<a
 							onClick={ this.trackVersionClick }
@@ -205,6 +198,22 @@ export class Footer extends React.Component {
 								: 'Jetpack' }
 						</a>
 					</li>
+				);
+			}
+		};
+
+		const aboutPageUrl = this.props.siteConnectionStatus
+			? this.props.siteAdminUrl + 'admin.php?page=jetpack_about'
+			: getRedirectUrl( 'jetpack' );
+
+		const privacyUrl = this.props.siteConnectionStatus
+			? this.props.siteAdminUrl + 'admin.php?page=jetpack#/privacy'
+			: getRedirectUrl( 'a8c-privacy' );
+
+		return (
+			<div className={ classes }>
+				<ul className="jp-footer__links">
+					{ maybeShowVersionNumber() }
 					<li className="jp-footer__link-item">
 						<a
 							onClick={ this.trackAboutClick }
@@ -257,6 +266,7 @@ export default connect(
 		return {
 			currentVersion: getCurrentVersion( state ),
 			displayDevCard: canDisplayDevCard( state ),
+			isAtomicSite: isAtomicSite( state ),
 			isDevVersion: _isDevVersion( state ),
 			isInIdentityCrisis: isInIdentityCrisis( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -14,7 +14,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 /**
  * Internal dependencies
  */
-import { getCurrentVersion, getSiteAdminUrl } from 'state/initial-state';
+import { getCurrentVersion, getSiteAdminUrl, isAtomicSite } from 'state/initial-state';
 import {
 	getJetpackStateNoticesErrorCode,
 	getJetpackStateNoticesMessageCode,
@@ -202,16 +202,18 @@ class JetpackStateNotices extends React.Component {
 		switch ( key ) {
 			// This is the message that is shown on first page load after a Jetpack plugin update.
 			case 'modules_activated':
-				message = createInterpolateElement(
-					sprintf(
-						/* translators: placeholder is a version number, like 8.8. */
-						__( 'Welcome to <s>Jetpack %s</s>!', 'jetpack' ),
-						this.props.currentVersion
-					),
-					{
-						s: <strong />,
-					}
-				);
+				if ( ! this.props.isAtomicSite ) {
+					message = createInterpolateElement(
+						sprintf(
+							/* translators: placeholder is a version number, like 8.8. */
+							__( 'Welcome to <s>Jetpack %s</s>!', 'jetpack' ),
+							this.props.currentVersion
+						),
+						{
+							s: <strong />,
+						}
+					);
+				}
 				break;
 			case 'already_authorized':
 				message = __( 'Your Jetpack is already connected.', 'jetpack' );
@@ -278,7 +280,7 @@ class JetpackStateNotices extends React.Component {
 		}
 
 		// Show custom message for updated Jetpack.
-		if ( messageContent && messageContent.release_post_content ) {
+		if ( messageContent && messageContent.release_post_content && ! this.props.isAtomicSite ) {
 			return (
 				<UpgradeNoticeContent
 					dismiss={ this.dismissJetpackStateNotice }
@@ -316,6 +318,7 @@ class JetpackStateNotices extends React.Component {
 export default connect( state => {
 	return {
 		currentVersion: getCurrentVersion( state ),
+		isAtomicSite: isAtomicSite( state ),
 		jetpackStateNoticesErrorCode: getJetpackStateNoticesErrorCode( state ),
 		jetpackStateNoticesMessageCode: getJetpackStateNoticesMessageCode( state ),
 		jetpackStateNoticesErrorDescription: getJetpackStateNoticesErrorDescription( state ),

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -299,6 +299,10 @@ class JetpackStateNotices extends React.Component {
 			action = messageData[ 2 ];
 		}
 
+		if ( '' === noticeText ) {
+			return;
+		}
+
 		return (
 			<SimpleNotice
 				status={ status }

--- a/projects/plugins/jetpack/changelog/update-version-jetpack-atomic
+++ b/projects/plugins/jetpack/changelog/update-version-jetpack-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: do not display Jetpack version on WoA sites.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿We do not need to display the Jetpack version on WoA sites, where that version is managed by the host.

Worth noting that the Jetpack version is still in use internally for things like tracking, but this should stop the display of the version in the Jetpack footer and in the notice that is displayed after updating to a new version of Jetpack.

This PR does not hide the version that's displayed in the Plugins menu. For this, see 745-gh-wpcomsh

![image](https://user-images.githubusercontent.com/426388/133306414-324a6bb7-6fd2-4bf0-9dc0-bc170decc647.png)


#### Jetpack product discussion

* p9dueE-3ca-p2#comment-6130

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from an Atomic site that's connected to WordPress.com, but does not use a custom version of Jetpack.
* Go to Jetpack > Dashboard
* In the footer, you should see the current version of Jetpack.
* Install and activate [the Jetpack Beta plugin](https://github.com/Automattic/jetpack-beta/releases/download/3.0.2/jetpack-beta.zip).
* Go to Jetpack > Beta and switch to this branch.
* Go to Jetpack > Dashboard; the version number in the footer should be gone.
* On a regular Jetpack site, the version number should still be there.
