### PR TITLE
Add external services proxy endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-services.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-services.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * REST API endpoint for External Services.
+ *
+ * @package automattic/jetpack
+ * @since
+ */
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * External Services proxy endpoint.
+ *
+ * @since
+ */
+class WPCOM_REST_API_V2_Endpoint_External_Services extends WP_REST_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'external-services';
+		$this->is_wpcom  = false;
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->is_wpcom = true;
+
+			if ( ! class_exists( 'WPCOM_External_Connections' ) ) {
+				\jetpack_require_lib( 'external-connections' );
+			}
+		}
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the route.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_external_services' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Get External Services.
+	 *
+	 * @return mixed
+	 */
+	public function get_external_services() {
+		if ( $this->is_wpcom ) {
+			return WPCOM_External_Connections::get_external_services_list();
+		}
+
+		$site_id = self::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$path     = sprintf( '/sites/%d/external-services', $site_id );
+		$response = Client::wpcom_json_api_request_as_user( $path );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( ! property_exists( $body, 'services' ) ) {
+			return new WP_Error(
+				'bad_request',
+				__( 'An error occurred. Please try again later.', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return $body;
+	}
+
+	/**
+	 * Get the WPCOM or self-hosted site ID.
+	 *
+	 * @return mixed
+	 */
+	private static function get_site_id() {
+		$is_wpcom = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
+		$site_id  = $is_wpcom ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return new WP_Error(
+				'unavailable_site_id',
+				__( 'Sorry, something is wrong with your Jetpack connection.', 'jetpack' ),
+				403
+			);
+		}
+		return (int) $site_id;
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_External_Services' );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-services.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-services.php
@@ -1,63 +1,85 @@
 <?php
 /**
  * REST API endpoint for External Services.
+ * This endpoint is used by the Publicize feature to avoid client-side CORS issues.
  *
  * @package automattic/jetpack
- * @since
+ * @since 10.1
  */
 
 use Automattic\Jetpack\Connection\Client;
 
 /**
- * External Services proxy endpoint.
+ * This class creates the Jetpack endpoint: http://{$site}/wp-json/wpcom/v2/external-services
+ * It is a proxy of the WPCOM endpoint: https://public-api.wordpress.com/wpcom/v2/sites/{$site}/external-services
+ * This give us the same data found in the WPCOM API, but returned on our customized domain.
+ * Below we simply register the Jetpack route, call the WPCOM endpoint, and return the response body.
  *
- * @since
+ * @since 10.1
  */
 class WPCOM_REST_API_V2_Endpoint_External_Services extends WP_REST_Controller {
 	/**
-	 * Constructor.
+	 * The constructor sets the route namespace and rest_base.
+	 * It also adds the action that registers our API endpoint route.
 	 */
 	public function __construct() {
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'external-services';
-		$this->is_wpcom  = false;
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$this->is_wpcom = true;
-
-			if ( ! class_exists( 'WPCOM_External_Connections' ) ) {
-				\jetpack_require_lib( 'external-connections' );
-			}
-		}
-
-		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		add_action( 'rest_api_init', array( $this, 'register_route' ) );
 	}
 
 	/**
-	 * Register the route.
+	 * This is the function we reference in the add_action callback in the constructor.
+	 * It registers the endpoint route: http://{$site}/wp-json/wpcom/v2/external-services
 	 */
-	public function register_routes() {
+	public function register_route() {
 		register_rest_route(
 			$this->namespace,
 			$this->rest_base,
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_external_services' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'permissions_check' ),
 			)
 		);
 	}
 
 	/**
-	 * Get External Services.
+	 * This is the function we reference in the register_rest_route permission_callback in the register_route function.
+	 * It returns true if the user has access to the Publicize feature or WP_Error if not.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function permissions_check() {
+		global $publicize;
+
+		if ( ! $publicize ) {
+			return new WP_Error(
+				'publicize_not_available',
+				__( 'Sorry, Publicize is not available on your site right now.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		if ( $publicize->current_user_can_access_publicize_data() ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'invalid_user_permission_publicize',
+			__( 'Sorry, you are not allowed to access Publicize data on this site.', 'jetpack' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * This method gets the current site ID, then calls a GET request to /wpcom/v2/sites/{$site}/external-services
+	 * as the user, and finally returns the response body.
 	 *
 	 * @return mixed
 	 */
 	public function get_external_services() {
-		if ( $this->is_wpcom ) {
-			return WPCOM_External_Connections::get_external_services_list();
-		}
-
 		$site_id = self::get_site_id();
 		if ( is_wp_error( $site_id ) ) {
 			return $site_id;
@@ -82,13 +104,12 @@ class WPCOM_REST_API_V2_Endpoint_External_Services extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get the WPCOM or self-hosted site ID.
+	 * Gets the Jetpack site_id and returns it as an int. If the site_id is not found it returns a WP_Error.
 	 *
-	 * @return mixed
+	 * @return int|WP_Error
 	 */
 	private static function get_site_id() {
-		$is_wpcom = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
-		$site_id  = $is_wpcom ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+		$site_id = Jetpack_Options::get_option( 'id' );
 		if ( ! $site_id ) {
 			return new WP_Error(
 				'unavailable_site_id',

--- a/projects/plugins/jetpack/changelog/add-external-services-endpoint
+++ b/projects/plugins/jetpack/changelog/add-external-services-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Publicize: add "external-services" proxy API endpoint for use in account linking.

--- a/projects/plugins/jetpack/extensions/plugins/publicize/authorize.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/authorize.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import requestExternalAccess from '@automattic/request-external-access';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+import { useState, useCallback } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+// Copied from projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-auth.js
+function Authorize() {
+	const [ isAuthing, setIsAuthing ] = useState( false );
+
+	const onAuthorize = useCallback( () => {
+		setIsAuthing( true );
+		// Get connection details
+		apiFetch( {
+			url: '/wp-json/wpcom/v2/external-services',
+		} )
+			.then( data => {
+				console.log( 'here' );
+				console.log( data );
+				if ( data.error ) {
+					throw data.message;
+				}
+				// Open authorize URL in a window and let it play out
+				requestExternalAccess( data.services.tumblr.connect_URL, () => {} );
+			} )
+			.catch( () => {
+				console.log( 'failed' );
+				setIsAuthing( false );
+			} );
+	} );
+
+	return (
+		<div className="jetpack-external-media-auth">
+			<Button isPrimary disabled={ isAuthing } onClick={ onAuthorize }>
+				{ __( 'Connect to Tumblr', 'jetpack' ) }
+			</Button>
+		</div>
+	);
+}
+
+export default Authorize;

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -24,6 +24,7 @@ import './store';
 import TwitterThreadListener from './components/twitter';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import PublicizePanel from './components/panel';
+import Authorize from './authorize';
 
 export const name = 'publicize';
 
@@ -33,6 +34,7 @@ export const settings = {
 			<TwitterThreadListener />
 			<JetpackPluginSidebar>
 				<PanelBody title={ __( 'Share this post', 'jetpack' ) }>
+					<Authorize />
 					<PublicizePanel />
 				</PanelBody>
 			</JetpackPluginSidebar>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

In this PR we add a new API endpoint in Jetpack that acts as a proxy to expose the "external-services" endpoint in WPCOM.

- Existing endpoint: `https://public-api.wordpress.com/wpcom/v2/sites/{$site}/external-services`
- New endpoint with this PR: `http://{$site}/wp-json/wpcom/v2/external-services`

This new endpoint gives us the ability to authenticate to 3rd party services from the Publicize panel in the post editor. It does this by giving us client-side access to the connect_URL variable found in the 'external-services' endpoint. Having this new endpoint in Jetpack puts the API call on our user's customized domain name, avoiding client-side CORS issues.

Please see the "Authorizing With External Services P2" pb5gDS-1oZ-p2 post for more information.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds new proxy endpoint that mirrors the "external-services" endpoint in WPCOM.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
