### PR TITLE
Fix check dev env script when Jetpack is submodule

### DIFF
--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -362,9 +362,8 @@ else
 	elif [[ -f .git && -d "$GIT_DIR" ]]; then
 		success 'yes (as a submodule)'
 		OK=true
-	elif [[ -f "$GIT_DIR" ]]; then
+	elif [[ -d "$GIT_DIR" ]]; then
 		failure 'unknown' 'clone-the-repository' "It seems to be in a git repo, but it's not clearly a Jetpack monorepo checkout."
-		OK=true
 	else
 		failure "no" 'clone-the-repository'
 	fi

--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -354,7 +354,7 @@ else
 	version_range 'Git' "$BIN" '' "$VER" "0" "$GITVER" "9999999"
 
 	checking 'If this is a git checkout'
-	if [[ ! -d .git ]]; then
+	if [[ ! -d $(git rev-parse --git-dir) ]]; then
 		failure "no" 'clone-the-repository'
 	else
 		success 'yes'

--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -354,11 +354,21 @@ else
 	version_range 'Git' "$BIN" '' "$VER" "0" "$GITVER" "9999999"
 
 	checking 'If this is a git checkout'
-	if [[ ! -d $(git rev-parse --git-dir) ]]; then
-		failure "no" 'clone-the-repository'
-	else
+	GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)"
+	OK=false
+	if [[ -d .git && "$GIT_DIR" == '.git' ]]; then
 		success 'yes'
-
+		OK=true
+	elif [[ -f .git && -d "$GIT_DIR" ]]; then
+		success 'yes (as a submodule)'
+		OK=true
+	elif [[ -f "$GIT_DIR" ]]; then
+		failure 'unknown' 'clone-the-repository' "It seems to be in a git repo, but it's not clearly a Jetpack monorepo checkout."
+		OK=true
+	else
+		failure "no" 'clone-the-repository'
+	fi
+	if $OK; then
 		checking 'If the repo is checked out using ssh'
 		URL="$(git remote get-url --push origin 2>/dev/null)"
 		if [[ -z "$URL" ]]; then


### PR DESCRIPTION
Similar to https://github.com/Automattic/jetpack/pull/20971, this PR fixes an issue that arises when Jetpack is a submodule of another repository.
Here, when Jetpack is a submodule, the `tools/check-development-environment.sh` script reports not being inside a git checkout and incorrectly prompts the user to clone the repository.

#### Changes proposed in this Pull Request:
* Switch from inspecting `.git` to inspecting the output of `git rev-parse --git-dir`. This lets the script work properly even when ran within a submodule git checkout of Jetpack.

#### Jetpack product discussion

None, this is just a tweak to the development tools.

#### Does this pull request change what data or activity we track or use?

No, nothing.

#### Testing instructions:

<details><summary>Verify this issue is present on <code>master</code>:</summary>
<p>

```
cd /tmp && mkdir clone1 && cd clone1
git init
git submodule add https://github.com/Automattic/jetpack.git
cd jetpack
npm install -g pnpm && pnpm install && pnpm cli-setup
tools/check-development-environment.sh
```

Notice the the "If this is a git checkout" step returns **no**, even though this is a (submodule) git checkout.
</p>
</details>

<details><summary>Now, verify this branch fixes the issue:</summary>
<p>

```
git fetch && git checkout fix/check-dev-env-script-when-jetpack-is-submodule
tools/check-development-environment.sh
```

Notice now that the same step returns **yes** as expected.
</p>
</details>

<details><summary>Check that script flags a broken git checkout</summary>
<p>

```
cd /tmp
git clone --single-branch --branch fix/check-dev-env-script-when-jetpack-is-submodule https://github.com/Automattic/jetpack.git clone2
cd clone2
npm install -g pnpm && pnpm install && pnpm cli-setup
mv .git .gitz
tools/check-development-environment.sh
```

Notice now that the same step returns **unknown**, followed by instructions and a link to the "clone the repo docs".
</p>
</details>

<details><summary>Verify the script works as expected in an ordinary clone</summary>
<p>

```
cd /tmp
git clone --single-branch --branch fix/check-dev-env-script-when-jetpack-is-submodule https://github.com/Automattic/jetpack.git clone3
cd clone3
npm install -g pnpm && pnpm install && pnpm cli-setup
tools/check-development-environment.sh
```

Notice now that the same step returns **yes** as expected.
</p>
</details>

<details><summary>Verify the ssh check script works as expected in an ordinary clone</summary>
<p>

```
cd /tmp
git clone --single-branch --branch fix/check-dev-env-script-when-jetpack-is-submodule git@github.com:Automattic/jetpack.git clone4
cd clone4
npm install -g pnpm && pnpm install && pnpm cli-setup
tools/check-development-environment.sh
```

Expect a result of **yes**.
</p>
</details>



