### PR TITLE
Implement SmartFrame embedding

### DIFF
--- a/projects/plugins/jetpack/changelog/add-smartframe-embed-support
+++ b/projects/plugins/jetpack/changelog/add-smartframe-embed-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+SmartFrame Embeds: add support SmartFrame embed using URLs, embed code, and shortcodes

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-embed/index.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-embed/index.js
@@ -4,3 +4,4 @@
 import './facebook';
 import './instagram';
 import './loom';
+import './smartframe';

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-embed/smartframe.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-embed/smartframe.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockVariation } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SmartFrameIcon } from '../../shared/icons';
+/*
+ * New `core/embed` block variation.
+ */
+
+const coreEmbedVariationGetty = {
+	name: 'smartframe',
+	title: 'SmartFrame',
+	icon: SmartFrameIcon,
+	keywords: [ __( 'smartframe', 'jetpack' ) ],
+	description: __( 'Embed a SmartFrame Image.', 'jetpack' ),
+	patterns: [ /^https?:\/\/(.*?).smartframe.(io|net)\/.*/i ],
+	attributes: { providerNameSlug: 'smartframe', responsive: true },
+};
+registerBlockVariation( 'core/embed', coreEmbedVariationGetty );

--- a/projects/plugins/jetpack/extensions/shared/icons.js
+++ b/projects/plugins/jetpack/extensions/shared/icons.js
@@ -157,6 +157,17 @@ export const LoomIcon = {
 	),
 };
 
+export const SmartFrameIcon = {
+	foreground: getIconColor(),
+	src: (
+		<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20.7 17" xmlSpace="preserve">
+			<Path
+				d="m20.7 12.9-.9-11c0-.5-.2-.9-.5-1.3-.3-.3-.8-.5-1.3-.5L1.9 0h-.1c-.2 0-.5 0-.7.1C.9.2.7.4.5.5.4.7.2.9.1 1.1c-.1.2-.1.5-.1.7v.1l.9 13.4c0 .5.2.9.5 1.3.3.2.8.4 1.3.4H3l16.1-2c.4 0 .9-.3 1.1-.6.3-.3.5-.8.5-1.2v-.3zm-3.1.8L4.2 15.3H4c-.4 0-.8-.1-1-.4-.3-.3-.4-.6-.5-1L1.7 3.2v-.1c0-.4.2-.8.5-1 .3-.3.7-.4 1-.4h.1l13.5.1c.4 0 .8.1 1 .4.3.3.4.6.5 1L19 12v.3c0 .4-.2.7-.4 1-.3.2-.6.4-1 .4z"
+			/>
+		</SVG>
+	),
+};
+
 export const DonationsIcon = {
 	foreground: getIconColor(),
 	src: (

--- a/projects/plugins/jetpack/modules/shortcodes/smartframe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/smartframe.php
@@ -4,7 +4,7 @@
  *
  * Example URL: https://mikael-korpela.smartframe.io/p/mantymetsa_1630927773870/7673dc41a775fb845cc26acf24f1fe4?t=rql1c6dbpv2
  * Example embed code: <script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>
- * 
+ *
  * @package automattic/jetpack
  */
 
@@ -14,68 +14,20 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 	jetpack_smartframe_enable_embeds();
 }
 
-
 /**
  * Register smartframe as oembed provider. Add filter to reverse iframes to shortcode. Register [smartframe] shortcode.
  *
  * @since 9.3.3
  */
 function jetpack_smartframe_enable_embeds() {
-    // Support their oEmbed Endpoint.
-    wp_oembed_add_provider( '#https?://(.*?).smartframe.(io|net)/.*#i', 'https://oembed.smartframe.io/', true );
+	// Support their oEmbed Endpoint.
+	wp_oembed_add_provider( '#https?://(.*?)\.smartframe\.(io|net)/.*#i', 'https://oembed.smartframe.io/', true );
 
-    // Allow script to be filtered to short code (so direct copy+paste can be done).
+	// Allow script to be filtered to short code (so direct copy+paste can be done).
 	add_filter( 'the_content', 'wpcom_shortcodereverse_smartframe' );
 
 	// Actually display the smartframe Embed.
 	add_shortcode( 'smartframe', 'jetpack_smartframe_shortcode' );
-}
-
-/**
- * Filters the oEmbed provider URL for smartframe URLs to include site URL host as
- * caller if available, falling back to "wordpress.com". Must be applied at
- * time of embed in case that `init` is too early (WP.com REST API).
- *
- * @module shortcodes
- *
- * @since 9.3.3
- *
- * @see WP_oEmbed::fetch
- *
- * @return string oEmbed provider URL
- */
-add_filter( 'oembed_fetch_url', 'smartframe_add_oembed_endpoint_caller' );
-
-/**
- * Filter the embeds to add a caller parameter.
- *
- * @param string $provider URL of the oEmbed provider.
- */
-function smartframe_add_oembed_endpoint_caller( $provider ) {
-
-	// By time filter is called, original provider URL has had url, maxwidth,
-	// maxheight query parameters added.
-	if ( 0 !== strpos( $provider, 'https://oembed.smartframe.io/' ) ) {
-		return $provider;
-	}
-
-	// Set the caller argument to pass to smartframe's oembed provider.
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-
-		// Only include caller for non-private sites.
-		if ( ! function_exists( 'is_private_blog' ) || ! is_private_blog() ) {
-			$host = wp_parse_url( get_bloginfo( 'url' ), PHP_URL_HOST );
-		}
-
-		// Fall back to WordPress.com.
-		if ( empty( $host ) ) {
-			$host = 'wordpress.com';
-		}
-	} else {
-		$host = wp_parse_url( get_home_url(), PHP_URL_HOST );
-	}
-
-	return add_query_arg( 'caller', $host, $provider );
 }
 
 /**
@@ -88,11 +40,12 @@ function smartframe_add_oembed_endpoint_caller( $provider ) {
  * @return mixed
  */
 function wpcom_shortcodereverse_smartframe( $content ) {
-	if ( ! is_string( $content ) || false === stripos( $content, 'embed.smartframe.io' ) ) {
+	if ( ! is_string( $content ) || false === stripos( $content, 'embed.smartframe' ) ) {
 		return $content;
 	}
 
-	$regexp     = '!<script\ssrc="https://embed.smartframe.io/(\w+).js"\sdata-image-id="(.*?)"(\sdata-width="(\d+(%|px))"\s)?(data-max-width="(\d+(%|px)))?"></script>!i';
+	// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	$regexp     = '!<script\ssrc="https://embed.smartframe.(io|net)/(\w+).js"\sdata-image-id="(.*?)"(\sdata-width="(\d+(%|px))"\s)?(data-max-width="(\d+(%|px)))?"></script>!i';
 	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 
 	foreach ( compact( 'regexp', 'regexp_ent' ) as $regexp ) {
@@ -100,28 +53,28 @@ function wpcom_shortcodereverse_smartframe( $content ) {
 			continue;
 		}
 
-		foreach ( $matches as $match ) {	
-            $script_id = $match[1];
+		foreach ( $matches as $match ) {
+			$script_id = $match[1];
 
-            if ( empty( $script_id ) ) {
+			if ( empty( $script_id ) ) {
 				continue;
 			}
 
-            $image_id = $match[2];
+			$image_id = $match[2];
 
-            if ( empty( $image_id ) ) {
+			if ( empty( $image_id ) ) {
 				continue;
 			}
 
-            if( isset( $match[4] ) ) {
-                $width = $match[4];
-            }
+			if ( isset( $match[4] ) ) {
+				$width = $match[4];
+			}
 
-            if( isset( $match[7] )) {
-                $max_width = $match[7];  
-            }		
+			if ( isset( $match[7] ) ) {
+				$max_width = $match[7];
+			}
 
-			$shortcode = '[smartframe script-id="'.$script_id.'" image-id="' . esc_attr( $image_id ) . '"';
+			$shortcode = '[smartframe script-id="' . $script_id . '" image-id="' . esc_attr( $image_id ) . '"';
 			if ( ! empty( $width ) ) {
 				$shortcode .= ' width="' . esc_attr( $width ) . '"';
 			}
@@ -144,8 +97,7 @@ function wpcom_shortcodereverse_smartframe( $content ) {
  *
  * @since 9.3.3
  *
- * @param array  $atts    Shortcode parameters.
- * @param string $content Content enclosed by shortcode tags.
+ * @param array $atts Shortcode parameters.
  *
  * @return string
  */
@@ -155,18 +107,18 @@ function jetpack_smartframe_shortcode( $atts ) {
 	} else {
 		return '<!-- Missing smartframe image-id -->';
 	}
-    if ( ! empty( $atts['script-id'] ) ) {
+	if ( ! empty( $atts['script-id'] ) ) {
 		$script_id = $atts['script-id'];
 	} else {
 		return '<!-- Missing smartframe script-id -->';
 	}
 
 	$params = array(
-        // ignore width for now, smartframe embed code has it "100%". % isn't allowed in oembed, making it 100px
-		// 'width'  => isset( $atts['width'] ) ? (int) $atts['width'] : null,
+		// ignore width for now, smartframe embed code has it "100%". % isn't allowed in oembed, making it 100px.
+		// 'width'  => isset( $atts['width'] ) ? (int) $atts['width'] : null,.
 		'max-width' => isset( $atts['max-width'] ) ? (int) $atts['max-width'] : null,
 	);
 
-    // wrap the embed with wp-block-embed__wrapper, otherwise it would be aligned to the very left of the viewport
-	return "<div class='wp-block-embed__wrapper'>" . wp_oembed_get( 'https://imagecards.smartframe.io/' . $script_id . '/' . $image_id, array_filter( $params ) ) . "</div>";
+	// wrap the embed with wp-block-embed__wrapper, otherwise it would be aligned to the very left of the viewport.
+	return "<div class='wp-block-embed__wrapper'>" . wp_oembed_get( 'https://imagecards.smartframe.io/' . $script_id . '/' . $image_id, array_filter( $params ) ) . '</div>';
 }

--- a/projects/plugins/jetpack/modules/shortcodes/smartframe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/smartframe.php
@@ -15,7 +15,7 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 }
 
 /**
- * Register smartframe as oembed provider. Add filter to reverse iframes to shortcode. Register [smartframe] shortcode.
+ * Register smartframe as oembed provider. Add filter to reverse iframes to shortcode. Register [jetpack_smartframe] shortcode.
  *
  * @since 10.2.0
  */
@@ -64,7 +64,7 @@ function jetpack_shortcodereverse_smartframe( $content ) {
 				esc_attr( $match[2] ),
 				! empty( $match[3] ) ? ' max-width="' . esc_attr( $match[3] ) . '"' : ''
 			);
-			$content = str_replace( $match[0], $shortcode, $content );
+			$content   = str_replace( $match[0], $shortcode, $content );
 		}
 	}
 	/** This action is documented in modules/widgets/social-media-icons.php */
@@ -110,5 +110,5 @@ function jetpack_smartframe_shortcode( $atts ) {
 	return sprintf(
 		'<div class="wp-block-embed__wrapper">%1$s</div>',
 		wp_oembed_get( $embed_url, array_filter( $params ) )
-	);	
+	);
 }

--- a/projects/plugins/jetpack/modules/shortcodes/smartframe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/smartframe.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Smartframe.io embed
+ *
+ * Example URL: https://mikael-korpela.smartframe.io/p/mantymetsa_1630927773870/7673dc41a775fb845cc26acf24f1fe4?t=rql1c6dbpv2
+ * Example embed code: <script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>
+ * 
+ * @package automattic/jetpack
+ */
+
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	add_action( 'init', 'jetpack_smartframe_enable_embeds' );
+} else {
+	jetpack_smartframe_enable_embeds();
+}
+
+
+/**
+ * Register smartframe as oembed provider. Add filter to reverse iframes to shortcode. Register [smartframe] shortcode.
+ *
+ * @since 9.3.3
+ */
+function jetpack_smartframe_enable_embeds() {
+    // Support their oEmbed Endpoint.
+    wp_oembed_add_provider( '#https?://(.*?).smartframe.(io|net)/.*#i', 'https://oembed.smartframe.io/', true );
+
+    // Allow script to be filtered to short code (so direct copy+paste can be done).
+	add_filter( 'the_content', 'wpcom_shortcodereverse_smartframe' );
+
+	// Actually display the smartframe Embed.
+	add_shortcode( 'smartframe', 'jetpack_smartframe_shortcode' );
+}
+
+/**
+ * Filters the oEmbed provider URL for smartframe URLs to include site URL host as
+ * caller if available, falling back to "wordpress.com". Must be applied at
+ * time of embed in case that `init` is too early (WP.com REST API).
+ *
+ * @module shortcodes
+ *
+ * @since 9.3.3
+ *
+ * @see WP_oEmbed::fetch
+ *
+ * @return string oEmbed provider URL
+ */
+add_filter( 'oembed_fetch_url', 'smartframe_add_oembed_endpoint_caller' );
+
+/**
+ * Filter the embeds to add a caller parameter.
+ *
+ * @param string $provider URL of the oEmbed provider.
+ */
+function smartframe_add_oembed_endpoint_caller( $provider ) {
+
+	// By time filter is called, original provider URL has had url, maxwidth,
+	// maxheight query parameters added.
+	if ( 0 !== strpos( $provider, 'https://oembed.smartframe.io/' ) ) {
+		return $provider;
+	}
+
+	// Set the caller argument to pass to smartframe's oembed provider.
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+
+		// Only include caller for non-private sites.
+		if ( ! function_exists( 'is_private_blog' ) || ! is_private_blog() ) {
+			$host = wp_parse_url( get_bloginfo( 'url' ), PHP_URL_HOST );
+		}
+
+		// Fall back to WordPress.com.
+		if ( empty( $host ) ) {
+			$host = 'wordpress.com';
+		}
+	} else {
+		$host = wp_parse_url( get_home_url(), PHP_URL_HOST );
+	}
+
+	return add_query_arg( 'caller', $host, $provider );
+}
+
+/**
+ * Compose shortcode based on smartframe iframes.
+ *
+ * @since 9.3.3
+ *
+ * @param string $content Post content.
+ *
+ * @return mixed
+ */
+function wpcom_shortcodereverse_smartframe( $content ) {
+	if ( ! is_string( $content ) || false === stripos( $content, 'embed.smartframe.io' ) ) {
+		return $content;
+	}
+
+	$regexp     = '!<script\ssrc="https://embed.smartframe.io/(\w+).js"\sdata-image-id="(.*?)"(\sdata-width="(\d+(%|px))"\s)?(data-max-width="(\d+(%|px)))?"></script>!i';
+	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
+
+	foreach ( compact( 'regexp', 'regexp_ent' ) as $reg => $regexp ) {
+		if ( ! preg_match_all( $regexp, $content, $matches, PREG_SET_ORDER ) ) {
+			continue;
+		}
+
+		foreach ( $matches as $match ) {	
+            $script_id = $match[1];
+
+            if ( empty( $script_id ) ) {
+				continue;
+			}
+
+            $image_id = $match[2];
+
+            if ( empty( $image_id ) ) {
+				continue;
+			}
+
+            if( isset( $match[4] ) ) {
+                $width = $match[4];
+            }
+
+            if( isset( $match[7] )) {
+                $max_width = $match[7];  
+            }		
+
+			$shortcode = '[smartframe script-id="'.$script_id.'" image-id="' . esc_attr( $image_id ) . '"';
+			if ( ! empty( $width ) ) {
+				$shortcode .= ' width="' . esc_attr( $width ) . '"';
+			}
+			if ( ! empty( $max_width ) ) {
+				$shortcode .= ' max-width="' . esc_attr( $max_width ) . '"';
+			}
+			$shortcode .= ']';
+
+			$content = str_replace( $match[0], $shortcode, $content );
+		}
+	}
+	/** This action is documented in modules/widgets/social-media-icons.php */
+	do_action( 'jetpack_bump_stats_extras', 'html_to_shortcode', 'smartframe' );
+
+	return $content;
+}
+
+/**
+ * Parse shortcode arguments and render its output.
+ *
+ * @since 9.3.3
+ *
+ * @param array  $atts    Shortcode parameters.
+ * @param string $content Content enclosed by shortcode tags.
+ *
+ * @return string
+ */
+function jetpack_smartframe_shortcode( $atts, $content = '' ) {
+	if ( ! empty( $atts['image-id'] ) ) {
+		$image_id = $atts['image-id'];
+	} else {
+		return '<!-- Missing smartframe image-id -->';
+	}
+    if ( ! empty( $atts['script-id'] ) ) {
+		$script_id = $atts['script-id'];
+	} else {
+		return '<!-- Missing smartframe script-id -->';
+	}
+
+	$params = array(
+        // ignore width for now, smartframe embed code has it "100%". % isn't allowed in oembed, making it 100px
+		// 'width'  => isset( $atts['width'] ) ? (int) $atts['width'] : null,
+		'max-width' => isset( $atts['max-width'] ) ? (int) $atts['max-width'] : null,
+	);
+
+    // wrap the embed with wp-block-embed__wrapper, otherwise it would be aligned to the very left of the viewport
+	return "<div class='wp-block-embed__wrapper'>" . wp_oembed_get( 'https://imagecards.smartframe.io/' . $script_id . '/' . $image_id, array_filter( $params ) ) . "</div>";
+}

--- a/projects/plugins/jetpack/modules/shortcodes/smartframe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/smartframe.php
@@ -24,7 +24,7 @@ function jetpack_smartframe_enable_embeds() {
 	wp_oembed_add_provider( '#https?://(.*?)\.smartframe\.(io|net)/.*#i', 'https://oembed.smartframe.io/', true );
 
 	// Allow script to be filtered to short code (so direct copy+paste can be done).
-	add_filter( 'the_content', 'jetpack_shortcodereverse_smartframe' );
+	add_filter( 'pre_kses', 'jetpack_shortcodereverse_smartframe' );
 
 	// Actually display the smartframe Embed.
 	add_shortcode( 'jetpack_smartframe', 'jetpack_smartframe_shortcode' );

--- a/projects/plugins/jetpack/modules/shortcodes/smartframe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/smartframe.php
@@ -15,7 +15,7 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 }
 
 /**
- * Register smartframe as oembed provider. Add filter to reverse iframes to shortcode. Register [jetpack_smartframe] shortcode.
+ * Register smartframe as oembed provider. Add filter to reverse iframes to shortcode. Register [smartframe] shortcode.
  *
  * @since 10.2.0
  */
@@ -27,7 +27,7 @@ function jetpack_smartframe_enable_embeds() {
 	add_filter( 'pre_kses', 'jetpack_shortcodereverse_smartframe' );
 
 	// Actually display the smartframe Embed.
-	add_shortcode( 'jetpack_smartframe', 'jetpack_smartframe_shortcode' );
+	add_shortcode( 'smartframe', 'jetpack_smartframe_shortcode' );
 }
 
 /**
@@ -59,7 +59,7 @@ function jetpack_shortcodereverse_smartframe( $content ) {
 				continue;
 			}
 			$shortcode = sprintf(
-				'[jetpack_smartframe script-id="%1$s" image-id="%2$s"%3$s]',
+				'[smartframe script-id="%1$s" image-id="%2$s"%3$s]',
 				esc_attr( $match[1] ),
 				esc_attr( $match[2] ),
 				! empty( $match[3] ) ? ' max-width="' . esc_attr( $match[3] ) . '"' : ''

--- a/projects/plugins/jetpack/modules/shortcodes/smartframe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/smartframe.php
@@ -45,7 +45,7 @@ function wpcom_shortcodereverse_smartframe( $content ) {
 	}
 
 	// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-	$regexp     = '!<script\ssrc="https://embed.smartframe.(io|net)/(\w+).js"\sdata-image-id="(.*?)"(\sdata-width="(\d+(%|px))"\s)?(data-max-width="(\d+(%|px)))?"></script>!i';
+	$regexp     = '!<script\ssrc="https://embed\.smartframe\.(io|net)/(\w+)\.js"\sdata-image-id="(.*?)"(\sdata-width="(\d+(%|px))"\s)?(data-max-width="(\d+(%|px)))?"></script>!i';
 	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 
 	foreach ( compact( 'regexp', 'regexp_ent' ) as $regexp ) {
@@ -54,24 +54,24 @@ function wpcom_shortcodereverse_smartframe( $content ) {
 		}
 
 		foreach ( $matches as $match ) {
-			$script_id = $match[1];
+			$script_id = $match[2];
 
 			if ( empty( $script_id ) ) {
 				continue;
 			}
 
-			$image_id = $match[2];
+			$image_id = $match[3];
 
 			if ( empty( $image_id ) ) {
 				continue;
 			}
 
-			if ( isset( $match[4] ) ) {
-				$width = $match[4];
+			if ( isset( $match[5] ) ) {
+				$width = $match[5];
 			}
 
-			if ( isset( $match[7] ) ) {
-				$max_width = $match[7];
+			if ( isset( $match[8] ) ) {
+				$max_width = $match[8];
 			}
 
 			$shortcode = '[smartframe script-id="' . $script_id . '" image-id="' . esc_attr( $image_id ) . '"';

--- a/projects/plugins/jetpack/modules/shortcodes/smartframe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/smartframe.php
@@ -95,7 +95,7 @@ function wpcom_shortcodereverse_smartframe( $content ) {
 	$regexp     = '!<script\ssrc="https://embed.smartframe.io/(\w+).js"\sdata-image-id="(.*?)"(\sdata-width="(\d+(%|px))"\s)?(data-max-width="(\d+(%|px)))?"></script>!i';
 	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 
-	foreach ( compact( 'regexp', 'regexp_ent' ) as $reg => $regexp ) {
+	foreach ( compact( 'regexp', 'regexp_ent' ) as $regexp ) {
 		if ( ! preg_match_all( $regexp, $content, $matches, PREG_SET_ORDER ) ) {
 			continue;
 		}
@@ -149,7 +149,7 @@ function wpcom_shortcodereverse_smartframe( $content ) {
  *
  * @return string
  */
-function jetpack_smartframe_shortcode( $atts, $content = '' ) {
+function jetpack_smartframe_shortcode( $atts ) {
 	if ( ! empty( $atts['image-id'] ) ) {
 		$image_id = $atts['image-id'];
 	} else {

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe-HttpRequestCache.json
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe-HttpRequestCache.json
@@ -1,0 +1,77 @@
+{
+	"https://oembed.smartframe.io/?maxwidth=500&maxheight=750&url=https%3A%2F%2Fimagecards.smartframe.io%2F6ae67829d1264ee0ea6071a788940eae%2Fmantymetsa_1630927773870&dnt=1&caller=example.org&format=json": [
+		{
+			"args": {
+				"body": null,
+				"method": "GET"
+			},
+			"response": {
+				"body": "{\"type\":\"rich\",\"version\":\"1.0\",\"html\":\"<script data-image-id='mantymetsa_1630927773870' src='https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js' data-width='500' data-height='354\"></script>\",\"width\":500,\"height\":354,\"thumbnail_url\":\"https://thumbs.smartframe.io/6ae67829d1264ee0ea6071a788940eae/d9cb5f3e6787557531b960586f59388d/mantymetsa.jpg\",\"thumbnail_width\":400,\"thumbnail_height\":283,\"author_name\":\"\"}",
+				"response": {
+					"code": 200,
+					"message": "OK"
+				}
+			}
+		}
+	],
+	"https://oembed.smartframe.io/?maxwidth=640&maxheight=960&url=https%3A%2F%2Fimagecards.smartframe.io%2F6ae67829d1264ee0ea6071a788940eae%2Fmantymetsa_1630927773870&dnt=1&caller=example.org": [
+		{
+			"args": {
+				"body": null,
+				"method": "GET"
+			},
+			"response": {
+				"body": "{\"type\":\"rich\",\"version\":\"1.0\",\"html\":\"<script data-image-id='mantymetsa_1630927773870' src='https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js' data-width='640' data-height='453'></script>\",\"width\":640,\"height\":453,\"thumbnail_url\":\"https://thumbs.smartframe.io/6ae67829d1264ee0ea6071a788940eae/d9cb5f3e6787557531b960586f59388d/mantymetsa.jpg\",\"thumbnail_width\":400,\"thumbnail_height\":283,\"author_name\":\"\"}",
+				"response": {
+					"code": 200,
+					"message": "OK"
+				}
+			}
+		}
+	],
+	"https://oembed.smartframe.io/?maxwidth=640&maxheight=960&url=https%3A%2F%2Fimagecards.smartframe.io%2F6ae67829d1264ee0ea6071a788940eae%2Fmantymetsa_1630927773870&dnt=1&caller=example.org&format=json": [
+		{
+			"args": {
+				"body": null,
+				"method": "GET"
+			},
+			"response": {
+				"body": "{\"type\":\"rich\",\"version\":\"1.0\",\"html\":\"<script data-image-id='mantymetsa_1630927773870' src='https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js' data-width='640' data-height='453'></script>\",\"width\":640,\"height\":453,\"thumbnail_url\":\"https://thumbs.smartframe.io/6ae67829d1264ee0ea6071a788940eae/d9cb5f3e6787557531b960586f59388d/mantymetsa.jpg\",\"thumbnail_width\":400,\"thumbnail_height\":283,\"author_name\":\"\"}",
+				"response": {
+					"code": 200,
+					"message": "OK"
+				}
+			}
+		}
+	],
+	"https://oembed.smartframe.io/?maxwidth=640&maxheight=960&url=https%3A%2F%2Fimagecards.smartframe.io%2F6ae67829d1264ee0ea6071a788940eae%2Fmantymetsa_1630927773870&dnt=1&format=json": [
+		{
+			"args": {
+				"body": null,
+				"method": "GET"
+			},
+			"response": {
+				"body": "{\"type\":\"rich\",\"version\":\"1.0\",\"html\":\"<script data-image-id='mantymetsa_1630927773870' src='https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js' data-width='640' data-height='453'></script>\",\"width\":640,\"height\":453,\"thumbnail_url\":\"https://thumbs.smartframe.io/6ae67829d1264ee0ea6071a788940eae/d9cb5f3e6787557531b960586f59388d/mantymetsa.jpg\",\"thumbnail_width\":400,\"thumbnail_height\":283,\"author_name\":\"\"}",
+				"response": {
+					"code": 200,
+					"message": "OK"
+				}
+			}
+		}
+	],
+	"https://oembed.smartframe.io/?maxwidth=640&maxheight=960&url=https%3A%2F%2Fimagecards.smartframe.io%2F6ae67829d1264ee0ea6071a788940eae%2Fmantymetsa_1630927773870&dnt=1F                                                                  2 / 2 (100%)omarhttps://oembed.smartframe.io/?maxwidth=640&maxheight=960&url=https%3A%2F%2Fimagecards.smartframe.io%2F6ae67829d1264ee0ea6071a788940eae%2Fmantymetsa_1630927773870&dnt=1": [
+		{
+			"args": {
+				"body": null,
+				"method": "GET"
+			},
+			"response": {
+				"body": "{\"type\":\"rich\",\"version\":\"1.0\",\"html\":\"<script data-image-id='mantymetsa_1630927773870' src='https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js' data-width='640' data-height='453'></script>\",\"width\":640,\"height\":453,\"thumbnail_url\":\"https://thumbs.smartframe.io/6ae67829d1264ee0ea6071a788940eae/d9cb5f3e6787557531b960586f59388d/mantymetsa.jpg\",\"thumbnail_width\":400,\"thumbnail_height\":283,\"author_name\":\"\"}",
+				"response": {
+					"code": 200,
+					"message": "OK"
+				}
+			}
+		}
+	]
+}

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
@@ -62,7 +62,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that [smartframe] exists.
+	 * Verify that [jetpack_smartframe] exists.
 	 *
 	 * @since 10.2.0
 	 */

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
@@ -94,12 +94,13 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_smartframe_image() {
 		$image_id          = self::SMARTFRAME_IDENTIFIER;
-		$content           = "[smartframe src='$image_id']";
+		$script_id         = self::SMARTFRAME_SCRIPT_ID;
+		$content           = "[smartframe script-id='$$script_id' src='$image_id']";
 		$shortcode_content = do_shortcode( $content );
-
+		
 		$this->assertContains( $image_id, $shortcode_content );
 	}
-
+	
 	/**
 	 * Uses a real HTTP request to SmartFrame's oEmbed endpoint to
 	 * verify that rendering the shortcode returns a SmartFrame image.
@@ -109,8 +110,9 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	 * @since 9.3.3
 	 */
 	public function test_shortcodes_smartframe_image_via_oembed_http_request() {
-		$image_id = self::SMARTFRAME_IDENTIFIER;
-		$content  = "[smartframe src='$image_id']";
+		$image_id  = self::SMARTFRAME_IDENTIFIER;
+		$script_id = self::SMARTFRAME_SCRIPT_ID;
+		$content   = "[smartframe script-id='$$script_id' src='$image_id']";
 
 		$shortcode_content = do_shortcode( $content );
 

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
@@ -23,7 +23,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	const SMARTFRAME_IDENTIFIER = 'mantymetsa_1630927773870';
 	const SMARTFRAME_SCRIPT_ID  = '6ae67829d1264ee0ea6071a788940eae';
 
-	const SMARTFRAME_SHORTCODE = '[smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" width="100%" max-width="1412px"]';
+	const SMARTFRAME_SHORTCODE = '[jetpack_smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" max-width="1412px"]';
 	// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	const SMARTFRAME_EMBED = '<script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>';
 
@@ -52,7 +52,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	 * @param string $html Post content.
 	 * @param string $url found URL.
 	 *
-	 * @since  9.3.3
+	 * @since 10.2.0
 	 */
 	public function smartframe_oembed_response( $html, $url ) {
 		if ( 0 !== strpos( $url, 'smartframe.io' ) ) {
@@ -64,10 +64,10 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	/**
 	 * Verify that [smartframe] exists.
 	 *
-	 * @since  9.3.3
+	 * @since 10.2.0
 	 */
 	public function test_shortcodes_smartframe_exists() {
-		$this->assertEquals( shortcode_exists( 'smartframe' ), true );
+		$this->assertEquals( shortcode_exists( 'jetpack_smartframe' ), true );
 	}
 
 	/**
@@ -75,7 +75,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	 *
 	 * @group external-http
 	 *
-	 * @since  9.3.3
+	 * @since 10.2.0
 	 */
 	public function test_smartframe_shortcode() {
 		$parsed = do_shortcode( self::SMARTFRAME_SHORTCODE );
@@ -93,10 +93,10 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	/**
 	 * Verify that embedding code is reversed into a valid shortcode
 	 *
-	 * @since 9.3.3
+	 * @since10.2.0
 	 */
 	public function test_smartframe_reverse_shortcode() {
-		$shortcode = wpcom_shortcodereverse_smartframe( self::SMARTFRAME_EMBED );
+		$shortcode = jetpack_shortcodereverse_smartframe( self::SMARTFRAME_EMBED );
 		$this->assertEquals( self::SMARTFRAME_SHORTCODE, $shortcode );
 	}
 
@@ -106,12 +106,12 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	 *
 	 * @group external-http
 	 *
-	 * @since 9.3.3
+	 * @since10.2.0
 	 */
 	public function test_shortcodes_smartframe_image_via_oembed_http_request() {
 		$image_id          = self::SMARTFRAME_IDENTIFIER;
 		$script_id         = self::SMARTFRAME_SCRIPT_ID;
-		$content           = "[smartframe script-id='$script_id' image-id='$image_id']";
+		$content           = "[jetpack_smartframe script-id='$script_id' image-id='$image_id']";
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertContains( $image_id, $shortcode_content );

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
@@ -1,0 +1,98 @@
+<?php
+
+require_once __DIR__ . '/trait.http-request-cache.php';
+
+class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
+	use Automattic\Jetpack\Tests\HttpRequestCacheTrait;
+
+	const SMARTFRAME_IDENTIFIER = 'mantymetsa_1630927773870';
+	const SMARTFRAME_SCRIPT_ID = '6ae67829d1264ee0ea6071a788940eae';
+
+	const SMARTFRAME_SHORTCODE = '[smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" width="100%" max-width="1412px"]';
+	const SMARTFRAME_EMBED = '<script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>';
+
+	static function strip_url_signature_args( $str ) {
+		return preg_replace( '/((id=\'[:alpha:\-]+)|[\?&]|&amp;|&#038;)(et=[\w-]+|sig=[\w-=]+)/', '', $str );
+	}
+
+	function setUp() {
+		parent::setUp();
+
+		if ( in_array( 'external-http', $this->getGroups(), true ) ) {
+			// Used by WordPress.com - does nothing in Jetpack.
+			add_filter( 'tests_allow_http_request', '__return_true' );
+		} else {
+			/*
+			 * We normally make an HTTP request to SmartFrame's oEmbed endpoint to generate
+			 * the shortcode output.
+			 * This filter bypasses that HTTP request for these tests
+			 */
+			add_filter( 'pre_oembed_result', array( $this, 'smartframe_oembed_response' ), 10, 3 );
+		}
+	}
+
+	function smartframe_oembed_response( $html, $url, $args ) {
+		if ( 0 !== strpos( $url, 'https://smartframe.io/' ) ) {
+			return $html;
+		}
+		return self::SMARTFRAME_EMBED;
+	}
+
+	/**
+	 * Verify that [smartframe] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_smartframe_exists() {
+		$this->assertEquals( shortcode_exists( 'smartframe' ), true );
+	}
+
+	function test_smartframe_shortcode() {
+		$parsed = do_shortcode( self::SMARTFRAME_SHORTCODE );
+
+		$doc = new DOMDocument();
+		$doc->loadHTML( $parsed );
+		$links = $doc->getElementsByTagName( 'script' );
+
+		foreach( $links as $link ) {
+			$this->assertTrue( $link->hasAttribute( 'data-image-id' ) );
+			$this->assertContains( self::SMARTFRAME_IDENTIFIER, $link->getAttribute( 'data-image-id' ) );
+		}
+	}
+
+	function test_smartframe_reverse_shortcode() {
+		$shortcode = wpcom_shortcodereverse_smartframe( self::SMARTFRAME_EMBED );
+		$this->assertEquals( self::SMARTFRAME_SHORTCODE, $shortcode );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a SmartFrame image.
+	 *
+	 * @since 9.3.3
+	 */
+	public function test_shortcodes_smartframe_image() {
+		$image_id = self::SMARTFRAME_IDENTIFIER;
+		$content = "[smartframe src='$image_id']";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( $image_id, $shortcode_content );
+	}
+
+	/**
+	 * Uses a real HTTP request to SmartFrame's oEmbed endpoint to
+	 * verify that rendering the shortcode returns a SmartFrame image.
+	 *
+	 * @group external-http
+	 *
+	 * @since 9.3.3
+	 */
+	public function test_shortcodes_smartframe_image_via_oembed_http_request() {
+		$image_id = self::SMARTFRAME_IDENTIFIER;
+		$content = "[smartframe src='$image_id']";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( $image_id, $shortcode_content );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
@@ -23,7 +23,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	const SMARTFRAME_IDENTIFIER = 'mantymetsa_1630927773870';
 	const SMARTFRAME_SCRIPT_ID  = '6ae67829d1264ee0ea6071a788940eae';
 
-	const SMARTFRAME_SHORTCODE = '[jetpack_smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" max-width="1412px"]';
+	const SMARTFRAME_SHORTCODE = '[smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" max-width="1412px"]';
 	// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	const SMARTFRAME_EMBED = '<script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>';
 
@@ -62,12 +62,12 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that [jetpack_smartframe] exists.
+	 * Verify that [smartframe] exists.
 	 *
 	 * @since 10.2.0
 	 */
 	public function test_shortcodes_smartframe_exists() {
-		$this->assertEquals( shortcode_exists( 'jetpack_smartframe' ), true );
+		$this->assertEquals( shortcode_exists( 'smartframe' ), true );
 	}
 
 	/**
@@ -111,7 +111,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	public function test_shortcodes_smartframe_image_via_oembed_http_request() {
 		$image_id          = self::SMARTFRAME_IDENTIFIER;
 		$script_id         = self::SMARTFRAME_SCRIPT_ID;
-		$content           = "[jetpack_smartframe script-id='$script_id' image-id='$image_id']";
+		$content           = "[smartframe script-id='$script_id' image-id='$image_id']";
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertContains( $image_id, $shortcode_content );

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
@@ -1,21 +1,28 @@
 <?php
+/**
+ * Unit tests for smartframe embedding
+ *
+ * @package automattic/jetpack
+ */
 
 require_once __DIR__ . '/trait.http-request-cache.php';
 
+/**
+ * @covers ::shortcode_smartframe
+ */
 class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	use Automattic\Jetpack\Tests\HttpRequestCacheTrait;
 
 	const SMARTFRAME_IDENTIFIER = 'mantymetsa_1630927773870';
-	const SMARTFRAME_SCRIPT_ID = '6ae67829d1264ee0ea6071a788940eae';
+	const SMARTFRAME_SCRIPT_ID  = '6ae67829d1264ee0ea6071a788940eae';
 
-	const SMARTFRAME_SHORTCODE = '[smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" width="100%" max-width="1412px"]';
-	const SMARTFRAME_EMBED = '<script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>';
+	const SMARTFRAME_SHORTCODE  = '[smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" width="100%" max-width="1412px"]';
+	const SMARTFRAME_EMBED      = '<script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>';
 
-	static function strip_url_signature_args( $str ) {
-		return preg_replace( '/((id=\'[:alpha:\-]+)|[\?&]|&amp;|&#038;)(et=[\w-]+|sig=[\w-=]+)/', '', $str );
-	}
-
-	function setUp() {
+	/**
+	 * Check for external HTTP requests and register filter
+	 */
+	public function setUp() {
 		parent::setUp();
 
 		if ( in_array( 'external-http', $this->getGroups(), true ) ) {
@@ -31,8 +38,13 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 		}
 	}
 
-	function smartframe_oembed_response( $html, $url, $args ) {
-		if ( 0 !== strpos( $url, 'https://smartframe.io/' ) ) {
+	/**
+	 * Mocks matching HTML for an embedded smartframe item
+	 * 
+	 * @since  9.3.3
+	 */
+	public function smartframe_oembed_response( $html, $url ) {
+		if ( 0 !== strpos( $url, 'smartframe.io' ) ) {
 			return $html;
 		}
 		return self::SMARTFRAME_EMBED;
@@ -41,13 +53,18 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	/**
 	 * Verify that [smartframe] exists.
 	 *
-	 * @since  4.5.0
+	 * @since  9.3.3
 	 */
 	public function test_shortcodes_smartframe_exists() {
 		$this->assertEquals( shortcode_exists( 'smartframe' ), true );
 	}
 
-	function test_smartframe_shortcode() {
+	/**
+	 * See if the shortcode is converted to valid embedding code
+	 * 
+	 * @since  9.3.3
+	 */
+	public function test_smartframe_shortcode() {
 		$parsed = do_shortcode( self::SMARTFRAME_SHORTCODE );
 
 		$doc = new DOMDocument();
@@ -60,7 +77,12 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 		}
 	}
 
-	function test_smartframe_reverse_shortcode() {
+	/**
+	 * Verify that embedding code is reversed into a valid shortcode
+	 *
+	 * @since 9.3.3
+	 */
+	public function test_smartframe_reverse_shortcode() {
 		$shortcode = wpcom_shortcodereverse_smartframe( self::SMARTFRAME_EMBED );
 		$this->assertEquals( self::SMARTFRAME_SHORTCODE, $shortcode );
 	}
@@ -71,9 +93,8 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	 * @since 9.3.3
 	 */
 	public function test_shortcodes_smartframe_image() {
-		$image_id = self::SMARTFRAME_IDENTIFIER;
-		$content = "[smartframe src='$image_id']";
-
+		$image_id          = self::SMARTFRAME_IDENTIFIER;
+		$content           = "[smartframe src='$image_id']";
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertContains( $image_id, $shortcode_content );
@@ -89,7 +110,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_smartframe_image_via_oembed_http_request() {
 		$image_id = self::SMARTFRAME_IDENTIFIER;
-		$content = "[smartframe src='$image_id']";
+		$content  = "[smartframe src='$image_id']";
 
 		$shortcode_content = do_shortcode( $content );
 

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
@@ -2,12 +2,19 @@
 /**
  * Unit tests for smartframe embedding
  *
+ * Tests smartframe shortcodes and embed code
+ *
  * @package automattic/jetpack
  */
 
+/**
+ * Shortcodes need external HTML requests to be converted to valid embed code (using smartframe's oembed endpoint)
+ */
 require_once __DIR__ . '/trait.http-request-cache.php';
 
 /**
+ * Implements unit tests for smartframe embedding
+ *
  * @covers ::shortcode_smartframe
  */
 class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
@@ -16,8 +23,9 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	const SMARTFRAME_IDENTIFIER = 'mantymetsa_1630927773870';
 	const SMARTFRAME_SCRIPT_ID  = '6ae67829d1264ee0ea6071a788940eae';
 
-	const SMARTFRAME_SHORTCODE  = '[smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" width="100%" max-width="1412px"]';
-	const SMARTFRAME_EMBED      = '<script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>';
+	const SMARTFRAME_SHORTCODE = '[smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" width="100%" max-width="1412px"]';
+	// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	const SMARTFRAME_EMBED = '<script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>';
 
 	/**
 	 * Check for external HTTP requests and register filter
@@ -40,7 +48,10 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 
 	/**
 	 * Mocks matching HTML for an embedded smartframe item
-	 * 
+	 *
+	 * @param string $html Post content.
+	 * @param string $url found URL.
+	 *
 	 * @since  9.3.3
 	 */
 	public function smartframe_oembed_response( $html, $url ) {
@@ -61,7 +72,9 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 
 	/**
 	 * See if the shortcode is converted to valid embedding code
-	 * 
+	 *
+	 * @group external-http
+	 *
 	 * @since  9.3.3
 	 */
 	public function test_smartframe_shortcode() {
@@ -71,7 +84,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 		$doc->loadHTML( $parsed );
 		$links = $doc->getElementsByTagName( 'script' );
 
-		foreach( $links as $link ) {
+		foreach ( $links as $link ) {
 			$this->assertTrue( $link->hasAttribute( 'data-image-id' ) );
 			$this->assertContains( self::SMARTFRAME_IDENTIFIER, $link->getAttribute( 'data-image-id' ) );
 		}
@@ -88,20 +101,6 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that rendering the shortcode returns a SmartFrame image.
-	 *
-	 * @since 9.3.3
-	 */
-	public function test_shortcodes_smartframe_image() {
-		$image_id          = self::SMARTFRAME_IDENTIFIER;
-		$script_id         = self::SMARTFRAME_SCRIPT_ID;
-		$content           = "[smartframe script-id='$$script_id' src='$image_id']";
-		$shortcode_content = do_shortcode( $content );
-		
-		$this->assertContains( $image_id, $shortcode_content );
-	}
-	
-	/**
 	 * Uses a real HTTP request to SmartFrame's oEmbed endpoint to
 	 * verify that rendering the shortcode returns a SmartFrame image.
 	 *
@@ -110,10 +109,9 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	 * @since 9.3.3
 	 */
 	public function test_shortcodes_smartframe_image_via_oembed_http_request() {
-		$image_id  = self::SMARTFRAME_IDENTIFIER;
-		$script_id = self::SMARTFRAME_SCRIPT_ID;
-		$content   = "[smartframe script-id='$$script_id' src='$image_id']";
-
+		$image_id          = self::SMARTFRAME_IDENTIFIER;
+		$script_id         = self::SMARTFRAME_SCRIPT_ID;
+		$content           = "[smartframe script-id='$script_id' image-id='$image_id']";
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertContains( $image_id, $shortcode_content );

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
@@ -93,7 +93,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	/**
 	 * Verify that embedding code is reversed into a valid shortcode
 	 *
-	 * @since10.2.0
+	 * @since 10.2.0
 	 */
 	public function test_smartframe_reverse_shortcode() {
 		$shortcode = jetpack_shortcodereverse_smartframe( self::SMARTFRAME_EMBED );
@@ -106,7 +106,7 @@ class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	 *
 	 * @group external-http
 	 *
-	 * @since10.2.0
+	 * @since 10.2.0
 	 */
 	public function test_shortcodes_smartframe_image_via_oembed_http_request() {
 		$image_id          = self::SMARTFRAME_IDENTIFIER;

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.soundcloud-HttpRequestCache.json
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.soundcloud-HttpRequestCache.json
@@ -13,5 +13,20 @@
 				}
 			}
 		}
+	],
+	"https://oembed.smartframe.io/?maxwidth=500&maxheight=750&url=https%3A%2F%2Fimagecards.smartframe.io%2F6ae67829d1264ee0ea6071a788940eae%2Fmantymetsa_1630927773870&dnt=1&caller=example.org&format=json": [
+		{
+			"args": {
+				"body": null,
+				"method": "GET"
+			},
+			"response": {
+				"body": "{\"type\":\"rich\",\"version\":\"1.0\",\"html\":\"\u003Cscript data-image-id=\u0022mantymetsa_1630927773870\u0022 src=\u0022https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js\u0022 data-width=\u0022500\u0022 data-height=\u0022354\u0022\u003E\u003C/script\u003E\",\"width\":500,\"height\":354,\"thumbnail_url\":\"https://thumbs.smartframe.io/6ae67829d1264ee0ea6071a788940eae/d9cb5f3e6787557531b960586f59388d/mantymetsa.jpg\",\"thumbnail_width\":400,\"thumbnail_height\":283,\"author_name\":\"\"}",
+				"response": {
+					"code": 200,
+					"message": "OK"
+				}
+			}
+		}
 	]
 }

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.soundcloud-HttpRequestCache.json
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.soundcloud-HttpRequestCache.json
@@ -13,20 +13,5 @@
 				}
 			}
 		}
-	],
-	"https://oembed.smartframe.io/?maxwidth=500&maxheight=750&url=https%3A%2F%2Fimagecards.smartframe.io%2F6ae67829d1264ee0ea6071a788940eae%2Fmantymetsa_1630927773870&dnt=1&caller=example.org&format=json": [
-		{
-			"args": {
-				"body": null,
-				"method": "GET"
-			},
-			"response": {
-				"body": "{\"type\":\"rich\",\"version\":\"1.0\",\"html\":\"\u003Cscript data-image-id=\u0022mantymetsa_1630927773870\u0022 src=\u0022https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js\u0022 data-width=\u0022500\u0022 data-height=\u0022354\u0022\u003E\u003C/script\u003E\",\"width\":500,\"height\":354,\"thumbnail_url\":\"https://thumbs.smartframe.io/6ae67829d1264ee0ea6071a788940eae/d9cb5f3e6787557531b960586f59388d/mantymetsa.jpg\",\"thumbnail_width\":400,\"thumbnail_height\":283,\"author_name\":\"\"}",
-				"response": {
-					"code": 200,
-					"message": "OK"
-				}
-			}
-		}
 	]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR adds support for SmartFrame embedding. It's heavily inspired by (more like shamelessly copies) gettyimages embedding logic. It adds support for:

1. It adds a SmartFrame embedding block, you can test it by adding a "SmartFrame" block and use [this URL](https://mikael-korpela.smartframe.io/p/mantymetsa_1630927773870/7673dc41a775fb845cc26acf24f1fe4f?source=aHR0cHM6Ly9wYW5lbC5zbWFydGZyYW1lLmlvL29uYm9hcmRpbmc=&t=2natn6iyg4) to test.
2. Smartframe [URLs](https://mikael-korpela.smartframe.io/p/mantymetsa_1630927773870/7673dc41a775fb845cc26acf24f1fe4f?source=aHR0cHM6Ly9wYW5lbC5zbWFydGZyYW1lLmlvL29uYm9hcmRpbmc=&t=2natn6iyg4) URLs using the embed block.
3. SmartFrame shortcodes like `[jetpack_smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" width="100%" max-width="1412px"]`.
4. SmartFrame embed code, it transforms it into a safe shortcode.
```html
<script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>
```

Fixes #21062

#### Jetpack product discussion
Context here: p58i-b8R-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Apply D66901-code diff on your sandbox.
2. Sandbox a site. Create a new post.
3. Using the SmartFrame component, embed https://mikael-korpela.smartframe.io/p/mantymetsa_1630927773870/7673dc41a775fb845cc26acf24f1fe4f (you can add random query params to verify the regex catches any valid URL).
3. Using the embed component, embed https://mikael-korpela.smartframe.io/p/mantymetsa_1630927773870/7673dc41a775fb845cc26acf24f1fe4f (you can add random query params to verify the regex catches any valid URL).
4. Using the shortcode component, please test `[jetpack_smartframe script-id="6ae67829d1264ee0ea6071a788940eae" image-id="mantymetsa_1630927773870" width="100%" max-width="1412px"]`. Only `script-id` and `image-id` are required, and the embed should work without the rest.
5. Using custom HTML block, use the embed code they provide `<script src="https://embed.smartframe.io/6ae67829d1264ee0ea6071a788940eae.js" data-image-id="mantymetsa_1630927773870" data-width="100%" data-max-width="1412px"></script>`