### PR TITLE
Update division in scss files for sass deprecation

### DIFF
--- a/projects/plugins/backup/changelog/fix-sass-division-deprecation
+++ b/projects/plugins/backup/changelog/fix-sass-division-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Updated scss files for sass division deprecation.

--- a/projects/plugins/backup/src/js/components/masthead/calypso-mixins.scss
+++ b/projects/plugins/backup/src/js/components/masthead/calypso-mixins.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $full-width:	960px;
 $one-col:		660px;
 $mobile:		480px;
@@ -229,7 +231,7 @@ $breakpoints: 480px, 660px, 960px, 1040px; // Think very carefully before adding
 		display: inline-block;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
-		font: normal $icon-size/1 'Noticons';
+		font: normal math.div($icon-size, 1) 'Noticons';
 		color: $white;
 		position: absolute;
 		top: 0;

--- a/projects/plugins/jetpack/_inc/client/scss/calypso-mixins.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/calypso-mixins.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $full-width:	960px;
 $one-col:		660px;
 $mobile:		480px;
@@ -229,7 +231,7 @@ $breakpoints: 480px, 660px, 960px, 1040px; // Think very carefully before adding
 		display: inline-block;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
-		font: normal $icon-size/1 'Noticons';
+		font: normal math.div($icon-size, 1) 'Noticons';
 		color: $white;
 		position: absolute;
 		top: 0;

--- a/projects/plugins/jetpack/_inc/client/scss/functions/rem.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/functions/rem.scss
@@ -7,8 +7,10 @@
 // Example: font-size: rem( 21px );
 // ======================================================================
 
+@use "sass:math";
+
 $root-font-size: 16px;
 
 @function rem( $pixels, $context: $root-font-size ) {
-	@return $pixels / $context * 1rem;
+	@return math.div($pixels, $context) * 1rem;
 }

--- a/projects/plugins/jetpack/changelog/fix-sass-division-deprecation
+++ b/projects/plugins/jetpack/changelog/fix-sass-division-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated scss files for sass division deprecation.

--- a/projects/plugins/jetpack/extensions/blocks/donations/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/view.scss
@@ -39,15 +39,15 @@
 		&::after {
 			content: '';
 			background-color: $white;
-			width:  math.div($spinner-size, 4.5) ;
-			height:  math.div($spinner-size, 4.5) ;
+			width: math.div($spinner-size, 4.5);
+			height: math.div($spinner-size, 4.5);
 			border-radius: 100%;
 			position: absolute;
 			top: 50%;
 			left: 50%;
 			margin-left: math.div(-$spinner-size, 3);
 			margin-top: math.div(-$spinner-size, 3);
-			transform-origin:  math.div($spinner-size, 3)   math.div($spinner-size, 3) ;
+			transform-origin: math.div($spinner-size, 3) math.div($spinner-size, 3);
 			animation: spinner 1s infinite linear;
 		}
 	}

--- a/projects/plugins/jetpack/extensions/blocks/donations/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/view.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import '../../shared/styles/gutenberg-base-styles.scss';
 @import './common';
 @import '../../shared/memberships';
@@ -37,15 +39,15 @@
 		&::after {
 			content: '';
 			background-color: $white;
-			width: ( $spinner-size / 4.5 );
-			height: ( $spinner-size / 4.5 );
+			width:  math.div($spinner-size, 4.5) ;
+			height:  math.div($spinner-size, 4.5) ;
 			border-radius: 100%;
 			position: absolute;
 			top: 50%;
 			left: 50%;
-			margin-left: -$spinner-size / 3;
-			margin-top: -$spinner-size / 3;
-			transform-origin: ( $spinner-size / 3 ) ( $spinner-size / 3 );
+			margin-left: math.div(-$spinner-size, 3);
+			margin-top: math.div(-$spinner-size, 3);
+			transform-origin:  math.div($spinner-size, 3)   math.div($spinner-size, 3) ;
 			animation: spinner 1s infinite linear;
 		}
 	}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/style.scss
@@ -222,7 +222,7 @@ $jetpack-podcast-player-error: $alert-red;
 			display: block;
 			width: $track-status-icon-size;
 			height: $track-status-icon-size;
-			margin-top: ( $editor-font-size * $editor-line-height - $track-status-icon-size ) / 2; // center vertically
+			margin-top: ( $editor-font-size * $editor-line-height - $track-status-icon-size ) * 0.5; // center vertically
 			fill: inherit;
 		}
 	}
@@ -244,7 +244,7 @@ $jetpack-podcast-player-error: $alert-red;
 	.jetpack-podcast-player__track-title-link {
 		display: inline-block;
 		height: $current-track-title-icon-size;
-		margin-left: $gutter-s / 2;
+		margin-left: $gutter-s * 0.5;
 		vertical-align: top;
 
 		&,

--- a/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import '../../../shared/styles/gutenberg-base-styles.scss';
 @import '../../../shared/styles/jetpack-variables.scss';
 @import './variables.scss';
@@ -20,12 +22,12 @@ $spinner-size: 18px;
 		content: "";
 		position: absolute;
 		background-color: $white;
-		top: ( $spinner-size - ( $spinner-size * ( 2 / 3 ) ) ) / 2;
-		left: ( $spinner-size - ( $spinner-size * ( 2 / 3 ) ) ) / 2;
-		width: ( $spinner-size / 4.5 );
-		height: ( $spinner-size / 4.5 );
+		top: ( $spinner-size - ( $spinner-size *  math.div(2, 3)  ) ) * 0.5;
+		left: ( $spinner-size - ( $spinner-size *  math.div(2, 3)  ) ) * 0.5;
+		width:  math.div($spinner-size, 4.5) ;
+		height:  math.div($spinner-size, 4.5) ;
 		border-radius: 100%;
-		transform-origin: ( $spinner-size / 3 ) ( $spinner-size / 3 );
+		transform-origin:  math.div($spinner-size, 3)   math.div($spinner-size, 3) ;
 		animation: components-spinner__animation 1s infinite linear;
 		/* rtl:end:ignore */
 	}

--- a/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
@@ -22,12 +22,12 @@ $spinner-size: 18px;
 		content: "";
 		position: absolute;
 		background-color: $white;
-		top: ( $spinner-size - ( $spinner-size *  math.div(2, 3)  ) ) * 0.5;
-		left: ( $spinner-size - ( $spinner-size *  math.div(2, 3)  ) ) * 0.5;
-		width:  math.div($spinner-size, 4.5) ;
-		height:  math.div($spinner-size, 4.5) ;
+		top: ( $spinner-size - ( $spinner-size *  math.div(2, 3) ) ) * 0.5;
+		left: ( $spinner-size - ( $spinner-size *  math.div(2, 3) ) ) * 0.5;
+		width: math.div($spinner-size, 4.5);
+		height: math.div($spinner-size, 4.5);
 		border-radius: 100%;
-		transform-origin:  math.div($spinner-size, 3)   math.div($spinner-size, 3) ;
+		transform-origin: math.div($spinner-size, 3) math.div($spinner-size, 3);
 		animation: components-spinner__animation 1s infinite linear;
 		/* rtl:end:ignore */
 	}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
@@ -146,7 +146,7 @@
 			// Use smaller buttons to fit when there are many columns.
 			.columns-7 &,
 			.columns-8 & {
-				padding: $grid-unit-05 / 2;
+				padding: $grid-unit-05 * 0.5;
 			}
 		}
 	}

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
@@ -84,7 +84,7 @@ $icon-background-color: #fff;
 // Banner height minus half the toolbar padding to center it.
 .block-editor-block-list__layout .jetpack-upgrade-plan-banner {
 	position: relative;
-	top: $banner-height - ( $grid-unit-15 / 2 );
+	top: $banner-height - ( $grid-unit-15 * 0.5 );
 	z-index: 10;
 }
 

--- a/projects/plugins/jetpack/scss/atoms/typography/_functions.scss
+++ b/projects/plugins/jetpack/scss/atoms/typography/_functions.scss
@@ -7,6 +7,8 @@
 // Examples:
 // 1. font-size: em(14px);
 // 2. font-size: em(30px/14px);
+@use "sass:math";
+
 @function em($value, $context: map-get($root-font, font-size)) {
-	@return ($value / $context * 1em);
+	@return (math.div($value, $context) * 1em);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This fixes the following warnings during sass processing:
```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
```

Sass's sass-migrator tool was used to make the fixes.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#20792

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that the built CSS files have not changed. Note the `.css.map` and `.asset.php` files may have, but they don't matter to display.
* Or just check if everything still looks the same.