### PR TITLE
Publicize: fix refreshing social media connections

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,6 +595,7 @@ importers:
       react: 17.0.2
       react-click-outside: 3.0.1
       react-dom: 17.0.2
+      react-page-visibility: 6.4.0
       react-pure-render: 1.0.2
       react-redux: 6.0.1
       react-router-dom: 5.2.0
@@ -691,6 +692,7 @@ importers:
       q-flat: 1.0.7
       qss: 2.0.3
       query-string: 7.0.0
+      react-page-visibility: 6.4.0_react@17.0.2
       react-pure-render: 1.0.2
       react-redux: 6.0.1_react@17.0.2+redux@4.0.5
       react-router-dom: 5.2.0_react@17.0.2
@@ -18339,6 +18341,16 @@ packages:
       prop-types: 15.7.2
       react: 17.0.2
     dev: true
+
+  /react-page-visibility/6.4.0_react@17.0.2:
+    resolution: {integrity: sha512-5vQ0zQU2DvKCQAxle9l5V6uxw2m180Lk7Jem+obmTeQ503fvMJLSUzFgWtTEgUVynhUx2pd+RzafnuMAG8uD6A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.13.1 || ^17.0.0
+    dependencies:
+      prop-types: 15.7.2
+      react: 17.0.2
+    dev: false
 
   /react-popper-tooltip/3.1.1_react@17.0.2:
     resolution: {integrity: sha512-EnERAnnKRptQBJyaee5GJScWNUKQPDD2ywvzZyUjst/wj5U64C8/CnSYLNEmP2hG0IJ3ZhtDxE8oDN+KOyavXQ==}

--- a/projects/plugins/jetpack/changelog/update-publicize-refresh-social-media-connections
+++ b/projects/plugins/jetpack/changelog/update-publicize-refresh-social-media-connections
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Publicize: fix/improve refreshing connections list

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/form/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/form/index.js
@@ -39,8 +39,6 @@ export default function PublicizeForm( { refreshCallback } ) {
 				) ) }
 			</ul>
 
-			<PublicizeSettingsButton refreshCallback={ refreshCallback } />
-
 			{ connections.some( connection => connection.enabled ) && (
 				<MessageBoxControl
 					disabled={ isDisabled() }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/form/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/form/index.js
@@ -15,7 +15,7 @@ import MessageBoxControl from '../message-box-control';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 
-export default function PublicizeForm( { refreshCallback } ) {
+export default function PublicizeForm() {
 	const { connections, toggleById } = useSocialMediaConnections();
 	const { message, updateMessage, maxLength } = useSocialMediaMessage();
 
@@ -38,6 +38,8 @@ export default function PublicizeForm( { refreshCallback } ) {
 					/>
 				) ) }
 			</ul>
+
+			<PublicizeSettingsButton />
 
 			{ connections.some( connection => connection.enabled ) && (
 				<MessageBoxControl

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
@@ -18,8 +18,24 @@ import { Fragment } from '@wordpress/element';
 import PublicizeConnectionVerify from '../connection-verify';
 import PublicizeForm from '../form';
 import PublicizeTwitterOptions from '../twitter/options';
+import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
+import usePostJustSave from '../../hooks/use-post-just-saved';
 
 const PublicizePanel = ( { prePublish } ) => {
+	const { refresh, hasEnabledConnections } = useSelectSocialMediaConnections();
+
+	// Refresh connections when the post is just saved.
+	usePostJustSave(
+		function () {
+			if ( ! hasEnabledConnections ) {
+				return;
+			}
+
+			refresh();
+		},
+		[ hasEnabledConnections, refresh ]
+	);
+
 	return (
 		<Fragment>
 			<PublicizeConnectionVerify />

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -12,7 +12,7 @@
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -39,8 +39,5 @@ const PublicizePanel = ( { connections, prePublish } ) => (
 export default compose( [
 	withSelect( select => ( {
 		connections: select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_connections' ),
-	} ) ),
-	withDispatch( dispatch => ( {
-		refreshConnections: dispatch( 'core/editor' ).refreshPost,
 	} ) ),
 ] )( PublicizePanel );

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -21,7 +21,7 @@ import PublicizeConnectionVerify from '../connection-verify';
 import PublicizeForm from '../form';
 import PublicizeTwitterOptions from '../twitter/options';
 
-const PublicizePanel = ( { connections, refreshConnections, prePublish } ) => (
+const PublicizePanel = ( { connections, prePublish } ) => (
 	<Fragment>
 		{ connections && connections.some( connection => connection.enabled ) && (
 			<PublicizeConnectionVerify />
@@ -29,9 +29,9 @@ const PublicizePanel = ( { connections, refreshConnections, prePublish } ) => (
 		<div>
 			{ __( "Connect and select the accounts where you'd like to share your post.", 'jetpack' ) }
 		</div>
-		{ connections && connections.length > 0 && (
-			<PublicizeForm refreshCallback={ refreshConnections } />
-		) }
+
+		<PublicizeForm />
+
 		<PublicizeTwitterOptions prePublish={ prePublish } />
 	</Fragment>
 );

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -10,9 +10,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -21,23 +19,20 @@ import PublicizeConnectionVerify from '../connection-verify';
 import PublicizeForm from '../form';
 import PublicizeTwitterOptions from '../twitter/options';
 
-const PublicizePanel = ( { connections, prePublish } ) => (
-	<Fragment>
-		{ connections && connections.some( connection => connection.enabled ) && (
+const PublicizePanel = ( { prePublish } ) => {
+	return (
+		<Fragment>
 			<PublicizeConnectionVerify />
-		) }
-		<div>
-			{ __( "Connect and select the accounts where you'd like to share your post.", 'jetpack' ) }
-		</div>
 
-		<PublicizeForm />
+			<div>
+				{ __( "Connect and select the accounts where you'd like to share your post.", 'jetpack' ) }
+			</div>
 
-		<PublicizeTwitterOptions prePublish={ prePublish } />
-	</Fragment>
-);
+			<PublicizeForm />
 
-export default compose( [
-	withSelect( select => ( {
-		connections: select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_connections' ),
-	} ) ),
-] )( PublicizePanel );
+			<PublicizeTwitterOptions prePublish={ prePublish } />
+		</Fragment>
+	);
+};
+
+export default PublicizePanel;

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -19,7 +19,6 @@ import { withDispatch, withSelect } from '@wordpress/data';
  */
 import PublicizeConnectionVerify from '../connection-verify';
 import PublicizeForm from '../form';
-import PublicizeSettingsButton from '../settings-button';
 import PublicizeTwitterOptions from '../twitter/options';
 
 const PublicizePanel = ( { connections, refreshConnections, prePublish } ) => (
@@ -34,7 +33,6 @@ const PublicizePanel = ( { connections, refreshConnections, prePublish } ) => (
 			<PublicizeForm refreshCallback={ refreshConnections } />
 		) }
 		<PublicizeTwitterOptions prePublish={ prePublish } />
-		<PublicizeSettingsButton />
 	</Fragment>
 );
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -34,12 +34,7 @@ const PublicizePanel = ( { connections, refreshConnections, prePublish } ) => (
 			<PublicizeForm refreshCallback={ refreshConnections } />
 		) }
 		<PublicizeTwitterOptions prePublish={ prePublish } />
-		{ connections && 0 === connections.length && (
-			<PublicizeSettingsButton
-				className="jetpack-publicize-add-connection-wrapper"
-				refreshCallback={ refreshConnections }
-			/>
-		) }
+		<PublicizeSettingsButton />
 	</Fragment>
 );
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -18,18 +18,19 @@ import { ExternalLink } from '@wordpress/components';
  */
 import getSiteFragment from '../../../../shared/get-site-fragment';
 
-export default function PublicizeSettingsButton( props ) {
-	function getButtonLink() {
-		const siteFragment = getSiteFragment();
+export default function PublicizeSettingsButton( { refreshCallback, className } ) {
+	const siteFragment = getSiteFragment();
 
-		// If running in WP.com wp-admin or in Calypso, we redirect to Calypso sharing settings.
-		if ( siteFragment ) {
-			return `https://wordpress.com/marketing/connections/${ siteFragment }`;
-		}
-
-		// If running in WordPress.org wp-admin we redirect to Sharing settings in wp-admin.
-		return 'options-general.php?page=sharing&publicize_popup=true';
-	}
+	/*
+	 * If running in WP.com wp-admin or in Calypso,
+	 * we redirect to Calypso sharing settings.
+	 *
+	 * If running in WordPress.org wp-admin,
+	 * we redirect to Sharing settings in wp-admin.
+	 */
+	const href = siteFragment
+		? `https://wordpress.com/marketing/connections/${ siteFragment }`
+		: 'options-general.php?page=sharing&publicize_popup=true';
 
 	/**
 	 * Opens up popup so user can view/modify connections
@@ -42,13 +43,11 @@ export default function PublicizeSettingsButton( props ) {
 			return;
 		}
 
-		const href = event.target.href;
-		const { refreshCallback } = props;
 		/**
 		 * Open a popup window, and
 		 * when it is closed, refresh connections
 		 */
-		const popupWin = window.open( href, '', '' );
+		const popupWin = window.open( event.target.href, '', '' );
 		const popupTimer = window.setInterval( () => {
 			if ( false !== popupWin.closed ) {
 				window.clearInterval( popupTimer );
@@ -57,11 +56,9 @@ export default function PublicizeSettingsButton( props ) {
 		}, 500 );
 	}
 
-	const className = classnames( 'jetpack-publicize-add-connection-container', props.className );
-
 	return (
-		<div className={ className }>
-			<ExternalLink href={ getButtonLink() } onClick={ settingsClick }>
+		<div className={ classnames( 'jetpack-publicize-add-connection-container', className ) }>
+			<ExternalLink href={ href } onClick={ settingsClick }>
 				{ __( 'Connect an account', 'jetpack' ) }
 			</ExternalLink>
 		</div>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -32,18 +32,18 @@ export default function PublicizeSettingsButton() {
 	const { refreshConnections } = useSocialMediaActions();
 	const { connections } = useSelectSocialMediaConnections();
 
+	if ( ! connections?.length ) {
+		return null;
+	}
+
+	const siteFragment = getSiteFragment();
+
 	const refresh = debounce( function ( isVisible ) {
 		if ( ! isVisible ) {
 			return;
 		}
 		refreshConnections();
 	}, refreshThreshold );
-
-	if ( ! connections?.length ) {
-		return null;
-	}
-
-	const siteFragment = getSiteFragment();
 
 	/*
 	 * If running in WP.com wp-admin or in Calypso,

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -7,10 +7,6 @@
  * then connections will be automatically refreshed.
  */
 import { debounce } from 'lodash';
-
-/**
- * External dependencies
- */
 import PageVisibility from 'react-page-visibility';
 
 /**
@@ -18,6 +14,7 @@ import PageVisibility from 'react-page-visibility';
  */
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,6 +27,11 @@ const refreshThreshold = 2000;
 export default function PublicizeSettingsButton() {
 	const { refresh } = useSelectSocialMediaConnections();
 	const siteFragment = getSiteFragment();
+
+	// Refresh connections when mounted.
+	useEffect( () => {
+		refresh();
+	}, [ refresh ] );
 
 	const debouncedRefresh = debounce( function ( isVisible ) {
 		if ( ! isVisible ) {

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -17,8 +17,10 @@ import { ExternalLink } from '@wordpress/components';
  * Internal dependencies
  */
 import getSiteFragment from '../../../../shared/get-site-fragment';
+import useSocialMediaConnection from '../../hooks/use-social-media-connections';
 
-export default function PublicizeSettingsButton( { refreshCallback, className } ) {
+export default function PublicizeSettingsButton( { className } ) {
+	const { refreshConnections } = useSocialMediaConnection();
 	const siteFragment = getSiteFragment();
 
 	/*
@@ -51,7 +53,7 @@ export default function PublicizeSettingsButton( { refreshCallback, className } 
 		const popupTimer = window.setInterval( () => {
 			if ( false !== popupWin.closed ) {
 				window.clearInterval( popupTimer );
-				refreshCallback();
+				refreshConnections();
 			}
 		}, 500 );
 	}

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -14,7 +14,6 @@ import PageVisibility from 'react-page-visibility';
  */
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -27,11 +26,6 @@ const refreshThreshold = 2000;
 export default function PublicizeSettingsButton() {
 	const { refresh } = useSelectSocialMediaConnections();
 	const siteFragment = getSiteFragment();
-
-	// Refresh connections when mounted.
-	useEffect( () => {
-		refresh();
-	}, [ refresh ] );
 
 	const debouncedRefresh = debounce( function ( isVisible ) {
 		if ( ! isVisible ) {

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -31,7 +31,7 @@ export default function PublicizeSettingsButton() {
 	const { refresh } = useSelectSocialMediaConnections();
 	const siteFragment = getSiteFragment();
 
-	const debRefresh = debounce( function ( isVisible ) {
+	const debouncedRefresh = debounce( function ( isVisible ) {
 		if ( ! isVisible ) {
 			return;
 		}
@@ -50,7 +50,7 @@ export default function PublicizeSettingsButton() {
 		: 'options-general.php?page=sharing&publicize_popup=true';
 
 	return (
-		<PageVisibility onChange={ debRefresh }>
+		<PageVisibility onChange={ debouncedRefresh }>
 			<div className="jetpack-publicize-add-connection-wrapper">
 				<ExternalLink href={ href } target="_blank">
 					{ __( 'Connect an account', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -2,25 +2,32 @@
  * Publicize settings button component.
  *
  * Component which allows user to click to open settings
- * in a new window/tab. If window/tab is closed, then
- * connections will be automatically refreshed.
+ * in a new window/tab.
+ * If window/tab is closed,
+ * then connections will be automatically refreshed.
  */
 
 /**
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import classnames from 'classnames';
 import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import getSiteFragment from '../../../../shared/get-site-fragment';
-import useSocialMediaConnection from '../../hooks/use-social-media-connections';
+import useSocialMediaActions from '../../hooks/use-social-media-actions';
+import { useSelectSocialMediaConnections } from '../../hooks/use-select-social-media';
 
-export default function PublicizeSettingsButton( { className } ) {
-	const { refreshConnections } = useSocialMediaConnection();
+export default function PublicizeSettingsButton() {
+	const { refreshConnections } = useSocialMediaActions();
+	const { connections } = useSelectSocialMediaConnections();
+
+	if ( ! connections?.length ) {
+		return null;
+	}
+
 	const siteFragment = getSiteFragment();
 
 	/*
@@ -59,7 +66,7 @@ export default function PublicizeSettingsButton( { className } ) {
 	}
 
 	return (
-		<div className={ classnames( 'jetpack-publicize-add-connection-container', className ) }>
+		<div className="jetpack-publicize-add-connection-wrapper">
 			<ExternalLink href={ href } onClick={ settingsClick }>
 				{ __( 'Connect an account', 'jetpack' ) }
 			</ExternalLink>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -37,9 +37,13 @@ export default function PublicizeSettingsButton( props ) {
 	 * @param {object} event - Event instance for onClick.
 	 */
 	function settingsClick( event ) {
-		const href = getButtonLink();
-		const { refreshCallback } = props;
 		event.preventDefault();
+		if ( ! event.target?.href ) {
+			return;
+		}
+
+		const href = event.target.href;
+		const { refreshCallback } = props;
 		/**
 		 * Open a popup window, and
 		 * when it is closed, refresh connections
@@ -57,7 +61,7 @@ export default function PublicizeSettingsButton( props ) {
 
 	return (
 		<div className={ className }>
-			<ExternalLink onClick={ settingsClick }>
+			<ExternalLink href={ getButtonLink() } onClick={ settingsClick }>
 				{ __( 'Connect an account', 'jetpack' ) }
 			</ExternalLink>
 		</div>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -23,6 +23,7 @@ import { ExternalLink } from '@wordpress/components';
  * Internal dependencies
  */
 import getSiteFragment from '../../../../shared/get-site-fragment';
+
 import useSocialMediaActions from '../../hooks/use-social-media-actions';
 import { useSelectSocialMediaConnections } from '../../hooks/use-select-social-media';
 
@@ -30,7 +31,7 @@ const refreshThreshold = 2000;
 
 export default function PublicizeSettingsButton() {
 	const { refreshConnections } = useSocialMediaActions();
-	const { connections } = useSelectSocialMediaConnections();
+	const connections = useSelectSocialMediaConnections();
 
 	if ( ! connections?.length ) {
 		return null;

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/settings-button/index.js
@@ -23,27 +23,19 @@ import { ExternalLink } from '@wordpress/components';
  * Internal dependencies
  */
 import getSiteFragment from '../../../../shared/get-site-fragment';
-
-import useSocialMediaActions from '../../hooks/use-social-media-actions';
-import { useSelectSocialMediaConnections } from '../../hooks/use-select-social-media';
+import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
 
 const refreshThreshold = 2000;
 
 export default function PublicizeSettingsButton() {
-	const { refreshConnections } = useSocialMediaActions();
-	const connections = useSelectSocialMediaConnections();
-
-	if ( ! connections?.length ) {
-		return null;
-	}
-
+	const { refresh } = useSelectSocialMediaConnections();
 	const siteFragment = getSiteFragment();
 
-	const refresh = debounce( function ( isVisible ) {
+	const debRefresh = debounce( function ( isVisible ) {
 		if ( ! isVisible ) {
 			return;
 		}
-		refreshConnections();
+		refresh();
 	}, refreshThreshold );
 
 	/*
@@ -58,7 +50,7 @@ export default function PublicizeSettingsButton() {
 		: 'options-general.php?page=sharing&publicize_popup=true';
 
 	return (
-		<PageVisibility onChange={ refresh }>
+		<PageVisibility onChange={ debRefresh }>
 			<div className="jetpack-publicize-add-connection-wrapper">
 				<ExternalLink href={ href } target="_blank">
 					{ __( 'Connect an account', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/editor.scss
@@ -54,10 +54,6 @@
 	margin: 15px 0;
 }
 
-.jetpack-publicize-add-connection-container {
-	margin-bottom: 8px;
-}
-
 .jetpack-publicize__connections-list {
 	.components-notice {
 		margin: 5px 0 10px;

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-post-just-saved/Readme.md
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-post-just-saved/Readme.md
@@ -1,0 +1,14 @@
+# usePostJustSaved() hook
+React hook to detect when the post is just saved.
+It will run the callback when the post is just saved.
+Also, it accepts a dependency array passed to useEffect hook.
+
+```es6
+import usePostJustSave from '../../hooks/use-post-just-saved';
+
+function SavingPostLabel() {
+	usePostJustSave( function() {
+		console.log( 'The post has been saved!' );
+	} );
+}
+```

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-post-just-saved/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-post-just-saved/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { usePrevious } from '@wordpress/compose';
+import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+/**
+ * React hook to detect when the post is just saved.
+ * It will run the callback when the post is just saved.
+ * Also, it accepts a dependency array passed to useEffect hook.
+ *
+ * @param {Function} fn - Callback function to run when the post is just saved.
+ * @param {Array} deps  - Depencency array.
+ */
+export default function usePostJustSaved( fn, deps ) {
+	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );
+	const wasSaving = usePrevious( isSaving );
+
+	useEffect( () => {
+		if ( ! ( wasSaving && ! isSaving ) ) {
+			return;
+		}
+
+		fn();
+	}, [ isSaving, wasSaving, fn, deps ] );
+}

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/Readme.md
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/Readme.md
@@ -25,7 +25,7 @@ function ToggleConnectionControl() {
 
 The connections list for the site.
 
-### refreshConnections()
+### refresh()
 
 This method will refresh and save the current post in order to propagate the metadata where the connections store.
 
@@ -34,12 +34,12 @@ import { Button } from '@wordpress/components';
 import useSocialMediaConnections from './hooks/use-social-media-connection';
 
 function SocialMediaTextarea() {
-	const { refreshConnections } = useSocialMediaConnection();
+	const { refresh } = useSocialMediaConnection();
 
 	return (
 		<Button
 			value={ message }
-			onClick={ refreshConnections }
+			onClick={ refresh }
 		>
 			Click on it to update the social media connections.
 		</Button>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/Readme.md
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/Readme.md
@@ -24,3 +24,25 @@ function ToggleConnectionControl() {
 ### connections
 
 The connections list for the site.
+
+### refreshConnections()
+
+This method will refresh and save the current post in order to propagate the metadata where the connections store.
+
+```es6
+import { Button } from '@wordpress/components';
+import useSocialMediaConnections from './hooks/use-social-media-connection';
+
+function SocialMediaTextarea() {
+	const { refreshConnections } = useSocialMediaConnection();
+
+	return (
+		<Button
+			value={ message }
+			onClick={ refreshConnections }
+		>
+			Click on it to update the social media connections.
+		</Button>
+	);
+}
+```

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
@@ -11,8 +11,8 @@ import { store as editorStore } from '@wordpress/editor';
  */
 
 export default function useSocialMediaConnections() {
-	const { editPost, savePost } = useDispatch( editorStore );
-	const { refreshConnectionTestResults } = useDispatch( 'jetpack/publicize' );
+	const { editPost } = useDispatch( editorStore );
+	const { refreshConnectionTestResults: refresh } = useDispatch( 'jetpack/publicize' );
 
 	const connections = useSelect( select => select( 'jetpack/publicize' ).getConnections(), [] );
 
@@ -29,12 +29,6 @@ export default function useSocialMediaConnections() {
 			} );
 		},
 
-		refreshConnectionTestResults,
-
-		// To refresh the connections, we need to save the post.
-		refresh: function () {
-			refreshConnectionTestResults(); // refresh the jetpack/publicize connections.
-			savePost(); // refresh the `jetpack_publicize_connections` metadata.
-		},
+		refresh,
 	};
 }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
@@ -14,10 +14,7 @@ export default function useSocialMediaConnections() {
 	const { editPost, savePost } = useDispatch( editorStore );
 	const { refreshConnectionTestResults } = useDispatch( 'jetpack/publicize' );
 
-	const connections = useSelect(
-		select => select( editorStore ).getEditedPostAttribute( 'jetpack_publicize_connections' ),
-		[]
-	);
+	const connections = useSelect( select => select( 'jetpack/publicize' ).getConnections(), [] );
 
 	return {
 		connections,
@@ -35,7 +32,7 @@ export default function useSocialMediaConnections() {
 		refreshConnectionTestResults,
 
 		// To refresh the connections, we need to save the post.
-		refreshConnections: function () {
+		refresh: function () {
 			refreshConnectionTestResults(); // refresh the jetpack/publicize connections.
 			savePost(); // refresh the `jetpack_publicize_connections` metadata.
 		},

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
@@ -31,9 +31,13 @@ export default function useSocialMediaConnections() {
 				jetpack_publicize_connections: filteredConnections,
 			} );
 		},
+
 		refreshConnectionTestResults,
 
 		// To refresh the connections, we need to save the post.
-		refreshConnections: savePost,
+		refreshConnections: function () {
+			refreshConnectionTestResults(); // refresh the jetpack/publicize connections.
+			savePost(); // refresh the `jetpack_publicize_connections` metadata.
+		},
 	};
 }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Hooks to deal with the social media connections.
@@ -11,9 +10,7 @@ import { store as editorStore } from '@wordpress/editor';
  */
 
 export default function useSocialMediaConnections() {
-	const { editPost } = useDispatch( editorStore );
 	const { refreshConnectionTestResults: refresh } = useDispatch( 'jetpack/publicize' );
-
 	const connections = useSelect( select => select( 'jetpack/publicize' ).getConnections(), [] );
 
 	return {
@@ -24,11 +21,7 @@ export default function useSocialMediaConnections() {
 				enabled: connection.id === id ? ! connection.enabled : connection.enabled,
 			} ) );
 
-			// Update post metadata.
-			editPost( { jetpack_publicize_connections } );
-
-			// Refresh jetpack/publicize store.
-			refresh();
+			refresh( jetpack_publicize_connections );
 		},
 
 		refresh,

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
@@ -9,8 +9,10 @@ import { store as editorStore } from '@wordpress/editor';
  *
  * @returns {Function} Social media connection handler.
  */
+
 export default function useSocialMediaConnections() {
-	const { editPost } = useDispatch( editorStore );
+	const { editPost, savePost } = useDispatch( editorStore );
+	const { refreshConnectionTestResults } = useDispatch( 'jetpack/publicize' );
 
 	const connections = useSelect(
 		select => select( editorStore ).getEditedPostAttribute( 'jetpack_publicize_connections' ),
@@ -29,5 +31,9 @@ export default function useSocialMediaConnections() {
 				jetpack_publicize_connections: filteredConnections,
 			} );
 		},
+		refreshConnectionTestResults,
+
+		// To refresh the connections, we need to save the post.
+		refreshConnections: savePost,
 	};
 }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
@@ -10,20 +10,13 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 
 export default function useSocialMediaConnections() {
-	const { refreshConnectionTestResults: refresh } = useDispatch( 'jetpack/publicize' );
-	const connections = useSelect( select => select( 'jetpack/publicize' ).getConnections(), [] );
+	const { refreshConnectionTestResults: refresh, toggleConnectionById } = useDispatch(
+		'jetpack/publicize'
+	);
 
 	return {
-		connections,
-		toggleById: function ( id ) {
-			const jetpack_publicize_connections = connections.map( connection => ( {
-				...connection,
-				enabled: connection.id === id ? ! connection.enabled : connection.enabled,
-			} ) );
-
-			refresh( jetpack_publicize_connections );
-		},
-
+		connections: useSelect( select => select( 'jetpack/publicize' ).getConnections(), [] ),
+		toggleById: toggleConnectionById,
 		refresh,
 	};
 }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
@@ -19,14 +19,16 @@ export default function useSocialMediaConnections() {
 	return {
 		connections,
 		toggleById: function ( id ) {
-			const filteredConnections = connections.map( connection => ( {
+			const jetpack_publicize_connections = connections.map( connection => ( {
 				...connection,
 				enabled: connection.id === id ? ! connection.enabled : connection.enabled,
 			} ) );
 
-			editPost( {
-				jetpack_publicize_connections: filteredConnections,
-			} );
+			// Update post metadata.
+			editPost( { jetpack_publicize_connections } );
+
+			// Refresh jetpack/publicize store.
+			refresh();
 		},
 
 		refresh,

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-social-media-connections/index.js
@@ -14,8 +14,11 @@ export default function useSocialMediaConnections() {
 		'jetpack/publicize'
 	);
 
+	const connections = useSelect( select => select( 'jetpack/publicize' ).getConnections(), [] );
+
 	return {
-		connections: useSelect( select => select( 'jetpack/publicize' ).getConnections(), [] ),
+		connections,
+		hasEnabledConnections: connections && connections.some( connection => connection.enabled ),
 		toggleById: toggleConnectionById,
 		refresh,
 	};

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/actions.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/actions.js
@@ -40,6 +40,13 @@ export function refreshConnectionTestResults( connections = null ) {
 	};
 }
 
+export function toggleConnectionById( connectionId ) {
+	return {
+		type: 'TOGGLE_CONNECTION_BY_ID',
+		connectionId,
+	};
+}
+
 /**
  * Returns an action object used in signalling that
  * we're initiating a fetch request to the REST API.

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/actions.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Returns an action object used in signalling that
@@ -20,12 +21,14 @@ export function setConnectionTestResults( results ) {
 /**
  * Returns an action object used in signalling that
  * we're refreshing the Publicize connection test results.
+ * It picks the connections from the post meta.
  *
  * @returns {object} Action object.
  */
 export function refreshConnectionTestResults() {
 	return {
 		type: 'REFRESH_CONNECTION_TEST_RESULTS',
+		results: select( editorStore ).getEditedPostAttribute( 'jetpack_publicize_connections' ) || [],
 	};
 }
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/actions.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/actions.js
@@ -8,27 +8,35 @@ import { store as editorStore } from '@wordpress/editor';
  * Returns an action object used in signalling that
  * we're setting the Publicize connection test results.
  *
- * @param {Array} results - Connection test results.
+ * @param {Array} connections - Processed connections list.
  * @returns {object} Action object.
  */
-export function setConnectionTestResults( results ) {
+export function setConnectionTestResults( connections ) {
 	return {
 		type: 'SET_CONNECTION_TEST_RESULTS',
-		results,
+		connections,
 	};
 }
 
 /**
  * Returns an action object used in signalling that
- * we're refreshing the Publicize connection test results.
- * It picks the connections from the post meta.
+ * we're refreshing the Publicize connection.
  *
+ * It accepts an optional `connections` parameter, which
+ * can be used to refresh the connections straight away.
+ * Otherwise, it will pick the connections from the post metadata.
+ *
+ * @param {Array} connections - Processed connections list.
  * @returns {object} Action object.
  */
-export function refreshConnectionTestResults() {
+export function refreshConnectionTestResults( connections = null ) {
+	connections = connections
+		? connections
+		: select( editorStore ).getEditedPostAttribute( 'jetpack_publicize_connections' ) || [];
+
 	return {
 		type: 'REFRESH_CONNECTION_TEST_RESULTS',
-		results: select( editorStore ).getEditedPostAttribute( 'jetpack_publicize_connections' ) || [],
+		connections,
 	};
 }
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
@@ -22,7 +22,7 @@ export async function refreshConnectionTestResults() {
 		const results = await apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } );
 
 		// Combine current connections with new connections.
-		const prevConnections = select( 'jetpack/publicize' ).getConnections( results );
+		const prevConnections = select( 'jetpack/publicize' ).getConnections();
 		const prevConnectionIds = prevConnections.map( connection => connection.id );
 		const freshConnections = results;
 		const connections = [];
@@ -72,6 +72,17 @@ export async function refreshConnectionTestResults() {
 	} catch ( error ) {
 		// Refreshing connections failed
 	}
+}
+
+/**
+ * Effect handler which will update the connections
+ * in the post metadata.
+ */
+export async function toggleConnectionById() {
+	const connections = select( 'jetpack/publicize' ).getConnections();
+
+	// Update post metadata.
+	dispatch( editorStore ).editPost( { jetpack_publicize_connections: connections } );
 }
 
 /**
@@ -164,6 +175,7 @@ export async function getTwitterCards( action ) {
 
 export default {
 	REFRESH_CONNECTION_TEST_RESULTS: refreshConnectionTestResults,
+	TOGGLE_CONNECTION_BY_ID: toggleConnectionById,
 	REFRESH_TWEETS: refreshTweets,
 	GET_TWITTER_CARDS: getTwitterCards,
 };

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
@@ -5,6 +5,7 @@ import { flatMap, throttle } from 'lodash';
 import apiFetch from '@wordpress/api-fetch';
 import { serialize } from '@wordpress/blocks';
 import { select, dispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -19,7 +20,55 @@ import { SUPPORTED_CONTAINER_BLOCKS } from '../components/twitter';
 export async function refreshConnectionTestResults() {
 	try {
 		const results = await apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } );
-		return dispatch( 'jetpack/publicize' ).setConnectionTestResults( results );
+
+		// Combine current connections with new connections.
+		const prevConnections = select( 'jetpack/publicize' ).getConnections( results );
+		const prevConnectionIds = prevConnections.map( connection => connection.id );
+		const freshConnections = results;
+		const connections = [];
+
+		/*
+		 * Iterate connection by connection,
+		 * in order to refresh or update current connections.
+		 */
+		for ( const freshConnection of freshConnections ) {
+			let connection;
+			if ( prevConnectionIds.includes( freshConnection.id ) ) {
+				/*
+				 * The connection is already defined.
+				 * Do not overwrite the existing connection.
+				 */
+				connection = prevConnections.filter(
+					prevConnection => prevConnection.id === freshConnection.id
+				)[ 0 ];
+			} else {
+				/*
+				 * Here the connection is new.
+				 * Let's map it.
+				 */
+				connection = {
+					display_name: freshConnection.display_name,
+					service_name: freshConnection.service_name,
+					id: freshConnection.id,
+					done: false,
+					enabled: true,
+					toggleable: true,
+				};
+			}
+
+			// Populate the connection with extra fresh data.
+			if ( freshConnection.profile_picture ) {
+				connection.profile_picture = freshConnection.profile_picture;
+			}
+
+			connections.push( connection );
+		}
+
+		// Update post metadata.
+		dispatch( editorStore ).editPost( { jetpack_publicize_connections: connections } );
+
+		// Update connections in the piblicize store.
+		return dispatch( 'jetpack/publicize' ).setConnectionTestResults( connections );
 	} catch ( error ) {
 		// Refreshing connections failed
 	}

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
@@ -29,6 +29,22 @@ export default function ( state = DEFAULT_STATE, action ) {
 			};
 		}
 
+		case 'TOGGLE_CONNECTION_BY_ID': {
+			/*
+			 * Map connections re-defining the enabled state of the connection,
+			 * based on the connection ID.
+			 */
+			const connections = state.connections.map( connection => ( {
+				...connection,
+				enabled: connection.id === action.connectionId ? ! connection.enabled : connection.enabled,
+			} ) );
+
+			return {
+				...state,
+				connections,
+			};
+		}
+
 		case 'SET_TWEETS':
 			return {
 				...state,

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
@@ -47,7 +47,7 @@ export default function ( state = DEFAULT_STATE, action ) {
 				}
 
 				// Populate the connection with extra fresh data.
-				if ( connection.profile_picture ) {
+				if ( freshConnection.profile_picture ) {
 					connection.profile_picture = freshConnection.profile_picture;
 				}
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
@@ -14,57 +14,21 @@ export const DEFAULT_STATE = {
 export default function ( state = DEFAULT_STATE, action ) {
 	switch ( action.type ) {
 		case 'SET_CONNECTION_TEST_RESULTS': {
-			// Combine current connections with new connections.
-			const { connections: prevConnections } = state;
-			const prevConnectionIds = prevConnections.map( connection => connection.id );
-
-			const { results: freshConnections } = action;
-
-			const connections = [];
-			for ( const freshConnection of freshConnections ) {
-				let connection;
-				if ( prevConnectionIds.includes( freshConnection.id ) ) {
-					/*
-					 * The connection is already defined.
-					 * Do not overwrite the existing connection.
-					 */
-					connection = prevConnections.filter(
-						prevConnection => prevConnection.id === freshConnection.id
-					)[ 0 ];
-				} else {
-					/*
-					 * Here the connection is new.
-					 * Let's map it.
-					 */
-					connection = {
-						display_name: freshConnection.display_name,
-						service_name: freshConnection.service_name,
-						id: freshConnection.id,
-						done: false,
-						enabled: true,
-						toggleable: true,
-					};
-				}
-
-				// Populate the connection with extra fresh data.
-				if ( freshConnection.profile_picture ) {
-					connection.profile_picture = freshConnection.profile_picture;
-				}
-
-				connections.push( connection );
-			}
-
+			const { connections } = action;
 			return {
 				...state,
 				connections,
 			};
 		}
 
-		case 'REFRESH_CONNECTION_TEST_RESULTS':
+		case 'REFRESH_CONNECTION_TEST_RESULTS': {
+			const { connections } = action;
 			return {
 				...state,
-				connections: action.results,
+				connections,
 			};
+		}
+
 		case 'SET_TWEETS':
 			return {
 				...state,

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
@@ -19,10 +19,12 @@ export default function ( state = DEFAULT_STATE, action ) {
 				connections: action.results,
 			};
 		case 'REFRESH_CONNECTION_TEST_RESULTS':
-			return {
-				...state,
-				connections: [],
-			};
+			/*
+			 * state will be updated by the `SET_CONNECTION_TEST_RESULTS` action.
+			 * triggered by the sync refreshConnectionTestResults method,
+			 * defined in the effects.js file.
+			 */
+			return state;
 		case 'SET_TWEETS':
 			return {
 				...state,

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/reducer.js
@@ -13,18 +13,58 @@ export const DEFAULT_STATE = {
  */
 export default function ( state = DEFAULT_STATE, action ) {
 	switch ( action.type ) {
-		case 'SET_CONNECTION_TEST_RESULTS':
+		case 'SET_CONNECTION_TEST_RESULTS': {
+			// Combine current connections with new connections.
+			const { connections: prevConnections } = state;
+			const prevConnectionIds = prevConnections.map( connection => connection.id );
+
+			const { results: freshConnections } = action;
+
+			const connections = [];
+			for ( const freshConnection of freshConnections ) {
+				let connection;
+				if ( prevConnectionIds.includes( freshConnection.id ) ) {
+					/*
+					 * The connection is already defined.
+					 * Do not overwrite the existing connection.
+					 */
+					connection = prevConnections.filter(
+						prevConnection => prevConnection.id === freshConnection.id
+					)[ 0 ];
+				} else {
+					/*
+					 * Here the connection is new.
+					 * Let's map it.
+					 */
+					connection = {
+						display_name: freshConnection.display_name,
+						service_name: freshConnection.service_name,
+						id: freshConnection.id,
+						done: false,
+						enabled: true,
+						toggleable: true,
+					};
+				}
+
+				// Populate the connection with extra fresh data.
+				if ( connection.profile_picture ) {
+					connection.profile_picture = freshConnection.profile_picture;
+				}
+
+				connections.push( connection );
+			}
+
+			return {
+				...state,
+				connections,
+			};
+		}
+
+		case 'REFRESH_CONNECTION_TEST_RESULTS':
 			return {
 				...state,
 				connections: action.results,
 			};
-		case 'REFRESH_CONNECTION_TEST_RESULTS':
-			/*
-			 * state will be updated by the `SET_CONNECTION_TEST_RESULTS` action.
-			 * triggered by the sync refreshConnectionTestResults method,
-			 * defined in the effects.js file.
-			 */
-			return state;
 		case 'SET_TWEETS':
 			return {
 				...state,

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/selectors.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/selectors.js
@@ -539,10 +539,6 @@ export function getConnections( state ) {
 
 	const { connections: jetpackPublicizeConnections } = state;
 
-	if ( ! jetpackPublicizeConnections?.length ) {
-		return cachedConnections;
-	}
-
 	// Collect fresh connections here.
 	const freshConnections = [];
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/selectors.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/selectors.js
@@ -5,7 +5,6 @@ import { get, isEqual } from 'lodash';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import createSelector from 'rememo';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -524,49 +523,11 @@ export function contentAttributesChanged( state, prevProps, props ) {
 }
 
 /**
- * Collect social media connections for the current post,
- * considering the collections stored in the post metadata,
- * but also checking the new connections stored in the jetpack/publicize store.
+ * Return social media connections.
  *
  * @param {state} state
  * @returns {Array} An array of fresh social media connections for the current post.
  */
 export function getConnections( state ) {
-	const cachedConnections = select( editorStore ).getEditedPostAttribute(
-		'jetpack_publicize_connections'
-	);
-	const cachedConnectionsIds = cachedConnections.map( connection => connection.id );
-
-	const { connections: jetpackPublicizeConnections } = state;
-
-	// Collect fresh connections here.
-	const freshConnections = [];
-
-	// jetpackPublicizeConnections rules the current connections for this post.
-	for ( const conn of jetpackPublicizeConnections ) {
-		let freshConnection;
-		if ( cachedConnectionsIds.includes( conn.id ) ) {
-			// The connection is already defined in the `jetpack_publicize_connections` metadata.
-			freshConnection = cachedConnections.filter( connection => connection.id === conn.id )[ 0 ];
-		} else {
-			// The connection is new. Add to fresh connection with initial state.
-			freshConnection = {
-				display_name: conn.display_name,
-				service_name: conn.service_name,
-				id: conn.id,
-				done: false,
-				enabled: true,
-				toggleable: true,
-			};
-		}
-
-		// Populate the connection with extra fresh data.
-		if ( conn.profile_picture ) {
-			freshConnection.profile_picture = conn.profile_picture;
-		}
-
-		freshConnections.push( freshConnection );
-	}
-
-	return freshConnections;
+	return state.connections;
 }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/selectors.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/selectors.js
@@ -539,6 +539,10 @@ export function getConnections( state ) {
 
 	const { connections: jetpackPublicizeConnections } = state;
 
+	if ( ! jetpackPublicizeConnections?.length ) {
+		return cachedConnections;
+	}
+
 	// Collect fresh connections here.
 	const freshConnections = [];
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/selectors.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/selectors.js
@@ -548,22 +548,28 @@ export function getConnections( state ) {
 
 	// jetpackPublicizeConnections rules the current connections for this post.
 	for ( const conn of jetpackPublicizeConnections ) {
+		let freshConnection;
 		if ( cachedConnectionsIds.includes( conn.id ) ) {
 			// The connection is already defined in the `jetpack_publicize_connections` metadata.
-			freshConnections.push(
-				cachedConnections.filter( connection => connection.id === conn.id )[ 0 ]
-			);
+			freshConnection = cachedConnections.filter( connection => connection.id === conn.id )[ 0 ];
 		} else {
 			// The connection is new. Add to fresh connection with initial state.
-			freshConnections.push( {
+			freshConnection = {
 				display_name: conn.display_name,
 				service_name: conn.service_name,
 				id: conn.id,
 				done: false,
 				enabled: true,
 				toggleable: true,
-			} );
+			};
 		}
+
+		// Populate the connection with extra fresh data.
+		if ( conn.profile_picture ) {
+			freshConnection.profile_picture = conn.profile_picture;
+		}
+
+		freshConnections.push( freshConnection );
 	}
 
 	return freshConnections;

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -124,6 +124,7 @@
 		"q-flat": "1.0.7",
 		"qss": "2.0.3",
 		"query-string": "7.0.0",
+		"react-page-visibility": "6.4.0",
 		"react-pure-render": "1.0.2",
 		"react-redux": "6.0.1",
 		"react-router-dom": "5.2.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

### Branched off from https://github.com/Automattic/jetpack/pull/21090

This PR fixes the issue when the user changes the social media connections from the dotcom admin page. The issue is described [here](https://github.com/Automattic/jetpack/issues/21093), but in short, it doesn't refresh the connections list once the user edits them.

Fixes https://github.com/Automattic/jetpack/issues/21093 

### About the approach

It consumes the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API), through the [react-page-visibility](https://github.com/pgilad/react-page-visibility) React lib. It's pretty light and simplifies the implementation.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Publicize: fix refreshing social media connections

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post / Edit a post.
* Open the Jetpack sidebar.
* Click on the `Connect an account` external link.
* Edit the social media connections.
* Confirm the connections list is automatically updated once you go back to the block editor (it performs a request to the API, hitting the `wpcom/v2/publicize/connection-test-results` endpoint).
* Close the sidebar
* Change again the connections
* Confirm the browser doesn't hit the API
* Open the sidebar again
* Confirm the client hits the API
* Confirm the connections list is updated

The video below shows all these testing steps:

https://user-images.githubusercontent.com/77539/133631969-3d77b329-83fb-4f90-a41c-46d2df9ab149.mov
