### PR TITLE
Jetpack Components: fix height prop for JetpackLogo

### DIFF
--- a/projects/js-packages/components/changelog/fix-warning-jetpack-logo
+++ b/projects/js-packages/components/changelog/fix-warning-jetpack-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Footer: provide number instead of string for JetpackLogo's height prop.

--- a/projects/js-packages/components/components/jetpack-footer/index.jsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.jsx
@@ -33,7 +33,7 @@ export default function JetpackFooter( {
 				<JetpackLogo
 					logoColor="#000"
 					showText={ false }
-					height="16"
+					height={ 16 }
 					className="jp-dashboard-footer__jetpack-symbol"
 					aria-label={ __( 'Jetpack logo', 'jetpack' ) }
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿JetpackLogo expects a number for its height prop, we were providing a string. This should avoid any warnings when building the component.

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Jetpack > Dashboard, and check that the footer is displayed properly.
* Locally, `cd projects/plugins/jetpack && pnpm build-client`. You should not see any warnings about JetpackLogo using the wrong prop.

