### PR TITLE
Docker: Fix a bug in $COMPOSE_PROJECT_NAME

### DIFF
--- a/tools/docker/bin/install.sh
+++ b/tools/docker/bin/install.sh
@@ -21,7 +21,7 @@ wp --allow-root core install \
 # Discourage search engines from indexing. Can be changed via UI in Settings->Reading.
 wp --allow-root option update blog_public 0
 
-if [ "$COMPOSE_PROJECT_NAME" == "dev" ] ; then
+if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	# Install Query Monitor plugin
 	# https://wordpress.org/plugins/query-monitor/
 	wp --allow-root plugin install query-monitor --activate

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -63,7 +63,7 @@ if [ ! -f /var/www/html/.htaccess ]; then
 	cp /tmp/htaccess /var/www/html/.htaccess
 fi
 
-if [ "$COMPOSE_PROJECT_NAME" == "dev" ] ; then
+if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	# If we don't have the wordpress test helpers, download them
 	if [ ! -d /tmp/wordpress-develop/tests ]; then
 		# Get latest WordPress unit-test helper files

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -47,3 +47,4 @@ services:
       - .env
     environment:
       - HOST_PORT=${PORT_WORDPRESS:-80}
+      - COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR fixes few issues in jetpack docker:
- passes through `$COMPOSE_PROJECT_NAME` env variable into docker context, which is used in `run.sh` and `install.sh` scripts.
- Updates expected project name from `dev` to `jetpack_dev` to match the value set by `docker.js`

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout the PR and build the image locally `jetpack docker build-image`. Probably containers need to be recreated with the new image (`jetpack docker clean` should do the trick)
* Nuke the containers and images OR remove `tools/docker/wordpress-develop` folder
* Start the containers, make sure it pulls from SVN as you do so
* run `jetpack docker phpunit`, and make sure it starts the tests.
*
