### PR TITLE
E2E tests: include commit SHA in Jetpack version

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-add-gh-sha-jetpack-version
+++ b/projects/plugins/jetpack/changelog/e2e-add-gh-sha-jetpack-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+E2E tests: include Github commit SHA in Jetpack version for local dev sites

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/pinterest.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/pinterest.js
@@ -27,7 +27,7 @@ export default class PinterestBlock extends PageActions {
 
 		await this.fill( inputSelector, this.embedUrl() );
 		await this.click( descriptionSelector );
-		await this.waitForElementToBeVisible( '.wp-block-jetpack-pinterest .components-sandbox' );
+		await this.waitForElementToBeVisible( '.wp-block-jetpack-pinterest .components-sandbox--' );
 	}
 
 	getSelector( selector ) {

--- a/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/pinterest.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/pages/wp-admin/blocks/pinterest.js
@@ -27,7 +27,7 @@ export default class PinterestBlock extends PageActions {
 
 		await this.fill( inputSelector, this.embedUrl() );
 		await this.click( descriptionSelector );
-		await this.waitForElementToBeVisible( '.wp-block-jetpack-pinterest .components-sandbox--' );
+		await this.waitForElementToBeVisible( '.wp-block-jetpack-pinterest .components-sandbox' );
 	}
 
 	getSelector( selector ) {

--- a/projects/plugins/jetpack/tests/e2e/lib/utils-helper.js
+++ b/projects/plugins/jetpack/tests/e2e/lib/utils-helper.js
@@ -318,10 +318,14 @@ async function getJetpackVersion() {
 		const env = JSON.parse( fileContent );
 
 		const jetpack = env.plugins.filter( function ( p ) {
-			return p.plugin === 'jetpack-dev/jetpack' && p.status === 'active';
+			return p.plugin.endsWith( '/jetpack' ) && p.status === 'active';
 		} );
 
 		version = jetpack[ 0 ].version;
+
+		if ( process.env.GITHUB_SHA && ! process.env.TEST_SITE ) {
+			version += `-${ process.env.GITHUB_SHA }`;
+		}
 	} catch ( error ) {
 		console.log( `ERROR: Failed to get Jetpack version. ${ error }` );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Include the commit SHA in Jetpack version when testing using local dev sites.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Check Slack notifications (p1631797526059200-slack-C1Y1F7ZM1) and [test reports](https://automattic.github.io/jetpack-e2e-reports/21114/report/#suites/de427aebb347850ede0b8a09dd39ece0/80baa395fdca625/)