### PR TITLE
Docker: Fix shebang printing from `wp`

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -54,8 +54,11 @@ RUN curl -o /usr/local/bin/wp -SL https://raw.githubusercontent.com/wp-cli/build
 	&& chmod +x /usr/local/bin/wp
 
 # Install PsySH to use in wp-cli shell
-RUN curl https://psysh.org/psysh -L -o /usr/local/bin/psysh \
-	&& chmod +x /usr/local/bin/psysh
+RUN mkdir /usr/local/src/psysh \
+	&& cd /usr/local/src/psysh \
+	&& composer require psy/psysh:@stable && composer clear-cache \
+	&& mkdir ~/.wp-cli \
+	&& echo "require: /usr/local/src/psysh/vendor/autoload.php" > ~/.wp-cli/config.yml
 
 # Install PHPUnit
 RUN curl https://phar.phpunit.de/phpunit-7.phar -L -o phpunit.phar \

--- a/tools/docker/bin/install.sh
+++ b/tools/docker/bin/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if $(wp --allow-root core is-installed); then
+if wp --allow-root core is-installed; then
 	echo
 	echo "WordPress has already been installed. Uninstall it first by running:"
 	echo

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -63,6 +63,16 @@ if [ ! -f /var/www/html/.htaccess ]; then
 	cp /tmp/htaccess /var/www/html/.htaccess
 fi
 
+# Clean up old method of including psysh (used from 2019 until 2021)
+if [[ -e /var/www/html/wp-cli.yml ]] && grep -q '^require: /usr/local/bin/psysh$' /var/www/html/wp-cli.yml; then
+	TMP="$(grep -v '^require: /usr/local/bin/psysh$' /var/www/html/wp-cli.yml || true)"
+	if [[ -z "$TMP" ]]; then
+		rm /var/www/html/wp-cli.yml
+	else
+		echo "$TMP" > /var/www/html/wp-cli.yml
+	fi
+fi
+
 if [ "$COMPOSE_PROJECT_NAME" == "dev" ] ; then
 	# If we don't have the wordpress test helpers, download them
 	if [ ! -d /tmp/wordpress-develop/tests ]; then
@@ -89,9 +99,6 @@ if [ "$COMPOSE_PROJECT_NAME" == "dev" ] ; then
 	if [ ! -L $WP_TESTS_JP_DIR ] || [ ! -e $WP_TESTS_JP_DIR ]; then
 		ln -s /var/www/html/wp-content/plugins/jetpack $WP_TESTS_JP_DIR
 	fi
-
-	# Add a PsySH dependency to wp-cli
-	echo 'require: /usr/local/bin/psysh' >> /var/www/html/wp-cli.yml
 fi
 
 for DIR in /usr/local/src/jetpack-monorepo/projects/plugins/*; do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The way `psysh` is being installed causes `wp` to print `#!/usr/bin/env
php` every time it is run.

Also install.sh prints a weird error (and probably fails to detect
whether WP is installed) because of this plus another bug.

Instead, let's install psysh as a library and require that in `wp`
instead. And may as well do so once globally, instead of blindly
appending the line every startup to /var/www/html/wp-cli.yml.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before you begin, if you have a docker env that has been around for a while, check how long your `tools/docker/wordpress/wp- cli.yml` is. 😉 Or do a few `jetpack docker stop && jetpack docker up` cycles while testing #21112, then look. 😉

* Build the image with `jetpack docker build-image`
* Recreate your containers, e.g. by doing `jetpack docker down` then `jetpack docker up`.
  * You can check if your container is using the new image in this case by doing `jetpack docker exec ls /usr/local/src/psysh`, if it works you're using the new image.
* Execute `jetpack docker wp shell`.
  * It should not print "#!/usr/bin/env php" before the banner.
  * It should print the Psy Shell banner.
* Execute `jetpack docker install` twice.
  * There should be no "/var/scripts/install.sh: line 3: #!/usr/bin/env: No such file or directory" message.
  * The second time should state "WordPress has already been installed". The first time may state this too, depending on whether you had already installed WordPress in the container.