### PR TITLE
docker: Use the same PHP and Composer versions as CI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -780,6 +780,7 @@ importers:
       chai: 4.3.4
       chalk: 4.1.1
       configstore: 5.0.1
+      envfile: 6.17.0
       esm: 3.2.25
       execa: 5.0.0
       inquirer: 7.3.3
@@ -799,6 +800,7 @@ importers:
       '@octokit/rest': 18.6.7
       chalk: 4.1.1
       configstore: 5.0.1
+      envfile: 6.17.0
       esm: 3.2.25
       execa: 5.0.0
       inquirer: 7.3.3
@@ -10780,6 +10782,12 @@ packages:
 
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+
+  /envfile/6.17.0:
+    resolution: {integrity: sha512-RnhtVw3auDZeeh5VtaNrbE7s6Kq8BoRtGIzcbMpMsJ+wIpRgs5jiDG4gQjW+vfws5QPlizE57/fUU0Tj6Nrs8A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: false
 
   /envinfo/7.8.1:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -3,6 +3,7 @@
  */
 import { spawnSync } from 'child_process';
 import chalk from 'chalk';
+import * as envfile from 'envfile';
 import fs from 'fs';
 import { dockerFolder, setConfig } from '../helpers/docker-config';
 
@@ -483,11 +484,18 @@ export function dockerDefine( yargs ) {
 					command: 'build-image',
 					description: 'Builds local docker image',
 					handler: argv => {
+						const versions = envfile.parse(
+							fs.readFileSync( `${ dockerFolder }/../../.github/versions.sh`, 'utf8' )
+						);
 						const res = executor( argv, () =>
 							shellExecutor( argv, 'docker', [
 								'build',
 								'-t',
 								'automattic/jetpack-wordpress-dev',
+								'--build-arg',
+								`PHP_VERSION=${ versions.PHP_VERSION }`,
+								'--build-arg',
+								`COMPOSER_VERSION=${ versions.COMPOSER_VERSION }`,
 								dockerFolder,
 							] )
 						);

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -24,6 +24,7 @@
 		"@octokit/rest": "18.6.7",
 		"chalk": "4.1.1",
 		"configstore": "5.0.1",
+		"envfile": "6.17.0",
 		"esm": "3.2.25",
 		"execa": "5.0.0",
 		"inquirer": "7.3.3",

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -2,93 +2,113 @@ FROM ubuntu:focal
 
 VOLUME ["/var/www/html"]
 
+ARG PHP_VERSION
+ARG COMPOSER_VERSION
+
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
-# Install required Ubuntu packages for having Apache PHP as a module
-# as well a bunch of other packages
+# Install basic packages, including Apache.
 RUN \
-	apt-get update \
+	export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get update \
 	&& apt-get install -y language-pack-en-base software-properties-common \
 	&& add-apt-repository ppa:ondrej/php \
 	&& apt-get update \
 	&& apt-get install -y \
 		apache2 \
-		composer \
 		curl \
+		git \
 		less \
-		libapache2-mod-php7.4 \
 		libsodium23 \
 		mysql-client \
 		nano \
-		php-apcu \
-		php7.4 \
-		php7.4-bcmath \
-		php7.4-cli \
-		php7.4-curl \
-		php7.4-gd \
-		php7.4-imagick \
-		php7.4-json \
-		php7.4-ldap \
-		php7.4-mbstring \
-		php7.4-mysql \
-		php7.4-opcache \
-		php7.4-pgsql \
-		php7.4-soap \
-		php7.4-sqlite3 \
-		php7.4-xdebug \
-		php7.4-xml \
-		php7.4-xsl \
-		php7.4-zip \
 		ssmtp \
 		subversion \
 		sudo \
+		unzip \
 		vim \
 	&& rm -rf /var/lib/apt/lists/*
 
-# Enable mod_rewrite in Apache
+# Enable mod_rewrite in Apache.
 RUN a2enmod rewrite
 
-# Install wp-cli
+# Install requested version of PHP.
+RUN \
+	: "${PHP_VERSION:?Build argument PHP_VERSION needs to be set and non-empty.}" \
+	&& export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get update \
+	&& apt-get install -y \
+		libapache2-mod-php${PHP_VERSION} \
+		php${PHP_VERSION} \
+		php${PHP_VERSION}-apcu \
+		php${PHP_VERSION}-bcmath \
+		php${PHP_VERSION}-cli \
+		php${PHP_VERSION}-curl \
+		php${PHP_VERSION}-gd \
+		php${PHP_VERSION}-imagick \
+		php${PHP_VERSION}-json \
+		php${PHP_VERSION}-ldap \
+		php${PHP_VERSION}-mbstring \
+		php${PHP_VERSION}-mysql \
+		php${PHP_VERSION}-opcache \
+		php${PHP_VERSION}-pgsql \
+		php${PHP_VERSION}-soap \
+		php${PHP_VERSION}-sqlite3 \
+		php${PHP_VERSION}-xdebug \
+		php${PHP_VERSION}-xml \
+		php${PHP_VERSION}-xsl \
+		php${PHP_VERSION}-zip \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Install requested version of Composer.
+RUN \
+	: "${COMPOSER_VERSION:?Build argument COMPOSER_VERSION needs to be set and non-empty.}" \
+	&& php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+	&& php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=$COMPOSER_VERSION \
+	&& php -r "unlink('composer-setup.php');"
+
+# Install wp-cli.
 RUN curl -o /usr/local/bin/wp -SL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \
 	&& chmod +x /usr/local/bin/wp
 
-# Install PsySH to use in wp-cli shell
+# Install PsySH to use in wp-cli shell.
 RUN mkdir /usr/local/src/psysh \
 	&& cd /usr/local/src/psysh \
-	&& composer require psy/psysh:@stable && composer clear-cache \
+	&& composer require psy/psysh:@stable \
 	&& mkdir ~/.wp-cli \
-	&& echo "require: /usr/local/src/psysh/vendor/autoload.php" > ~/.wp-cli/config.yml
+	&& echo "require: /usr/local/src/psysh/vendor/autoload.php" > ~/.wp-cli/config.yml \
+	&& rm -rf ~/.cache ~/.config ~/.local ~/.subversion
 
-# Install PHPUnit
+# Install old version of PHPUnit needed for WP unit tests.
 RUN curl https://phar.phpunit.de/phpunit-7.phar -L -o phpunit.phar \
 	&& chmod +x phpunit.phar \
 	&& mv phpunit.phar /usr/local/bin/phpunit
 
-# Copy a default config file for an apache host
+# Copy a default config file for an apache host.
 COPY ./config/apache_default /etc/apache2/sites-available/000-default.conf
 
-# Copy a default set of settings for PHP (php.ini)
-COPY ./config/php.ini /etc/php/7.4/apache2/conf.d/20-jetpack-wordpress.ini
-COPY ./config/php.ini /etc/php/7.4/cli/conf.d/20-jetpack-wordpress.ini
+# Copy a default set of settings for PHP (php.ini).
+COPY ./config/php.ini /etc/php/${PHP_VERSION}/apache2/conf.d/20-jetpack-wordpress.ini
+COPY ./config/php.ini /etc/php/${PHP_VERSION}/cli/conf.d/20-jetpack-wordpress.ini
 
-# Copy single site htaccess to tmp. run.sh will move it to the site's base dir if there's none present.
-COPY ./config/htaccess /tmp/htaccess
-COPY ./config/htaccess-multi /tmp/htaccess-multi
+# Copy single site htaccess to /var/lib/jetpack-config. run.sh will move it to the site's base dir if there's none present.
+COPY ./config/htaccess /var/lib/jetpack-config/htaccess
+COPY ./config/htaccess-multi /var/lib/jetpack-config/htaccess-multi
 
-# Copy wp-tests-config to tmp. run.sh will move it to the WordPress source code base dir if there's none present.
-COPY ./config/wp-tests-config.php /tmp/wp-tests-config.php
+# Copy wp-tests-config to /var/lib/jetpack-config. run.sh will move it to the WordPress source code base dir if there's none present.
+COPY ./config/wp-tests-config.php /var/lib/jetpack-config/wp-tests-config.php
 
 # Copy a default set of settings for SMTP.
 COPY ./config/ssmtp.conf /etc/ssmtp/ssmtp.conf
 
-# Copy our cmd bash script
+# Copy our cmd bash script.
 COPY ./bin/run.sh /usr/local/bin/run
 
-# Make our cmd script be executable
+# Make our cmd script be executable.
 RUN chmod +x /usr/local/bin/run
 
-# Set the working directory for the next commands
+# Set the working directory for the next commands.
 WORKDIR /var/www/html
 
 CMD ["/usr/local/bin/run"]

--- a/tools/docker/bin/multisite-convert.sh
+++ b/tools/docker/bin/multisite-convert.sh
@@ -16,7 +16,7 @@ wp --allow-root core multisite-convert
 wp --allow-root config set DOMAIN_CURRENT_SITE "${WP_DOMAIN}" --type=constant
 
 # Use multisite htaccess template
-cp -f /tmp/htaccess-multi /var/www/html/.htaccess
+cp -f /var/lib/jetpack-config/htaccess-multi /var/www/html/.htaccess
 
 # Update domain to DB
 wp --allow-root db query "UPDATE wp_blogs SET domain='${WP_DOMAIN}' WHERE blog_id=1;"

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -60,7 +60,7 @@ fi
 
 # Copy single site htaccess if none is present
 if [ ! -f /var/www/html/.htaccess ]; then
-	cp /tmp/htaccess /var/www/html/.htaccess
+	cp /var/lib/jetpack-config/htaccess /var/www/html/.htaccess
 fi
 
 # Clean up old method of including psysh (used from 2019 until 2021)
@@ -91,7 +91,7 @@ if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 
 	# Create a wp-tests-config.php if there's none currently
 	if [ ! -f /tmp/wordpress-develop/wp-tests-config.php ]; then
-		cp /tmp/wp-tests-config.php /tmp/wordpress-develop/wp-tests-config.php
+		cp /var/lib/jetpack-config/wp-tests-config.php /tmp/wordpress-develop/wp-tests-config.php
 	fi
 
 	# Symlink jetpack into wordpress-develop for WP >= 5.6-beta1

--- a/tools/docker/bin/uninstall.sh
+++ b/tools/docker/bin/uninstall.sh
@@ -5,7 +5,7 @@ wp --allow-root db reset --yes
 
 # Ensure we have single-site htaccess instead of multisite,
 # just like we would have in fresh container.
-cp -f /tmp/htaccess /var/www/html/.htaccess
+cp -f /var/lib/jetpack-config/htaccess /var/www/html/.htaccess
 
 # Remove "uploads" and "upgrade" folders
 rm -fr /var/www/html/wp-content/uploads /var/www/html/wp-content/upgrade


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We can have the Jetpack CLI read the `.github/versions.sh` file to
determine the needed versions, and install those instead of hard-coding
to PHP 7.4 and whichever old version of composer is in the version of
Ubuntu being used.

I also took the opportunity to rearrange a few other things in the
image, primarily moving the config files from /tmp to
/var/lib/jetpack-config where they're less likely to be accidentally
messed with.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build the image with `jetpack docker build-image`
* Recreate your containers, e.g. by doing `jetpack docker down` then `jetpack docker up`.
  * You can check if your container is using the new image in this case by doing `jetpack docker exec ls /var/lib/jetpack-config`, if it works you're using the new image.
* Do stuff, make sure it all still works.