### PR TITLE
Posts List: Don't display the category and tag columns by default.

### DIFF
--- a/projects/packages/post-list/changelog/update-posts-list-default-columns
+++ b/projects/packages/post-list/changelog/update-posts-list-default-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated the default columns displayed on the post and page list screens

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -41,6 +41,8 @@ class Post_List {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_action( 'in_admin_footer', array( $this, 'create_app_root_element' ) );
 
+			add_filter( 'default_hidden_columns', array( $this, 'adjust_default_columns' ), 10, 2 );
+
 			/**
 			 * Action called after initializing Post_List Admin resources.
 			 *
@@ -117,6 +119,28 @@ class Post_List {
 	 */
 	public function create_app_root_element() {
 		echo '<div id="wp-post-list-app" style="display: none;"></div>';
+	}
+
+	/**
+	 * Removes the tags and columns from the posts and pages
+	 * screens if the screen options haven't been changed from
+	 * the default.
+	 *
+	 * @param array     $cols The columns to hide.
+	 * @param WP_Screen $screen The current screen object.
+	 * @return array    The columns to hide by default.
+	 */
+	public function adjust_default_columns( $cols, $screen ) {
+		if ( ! ( 'edit' === $screen->base && in_array( $screen->post_type, array( 'post', 'page' ), true ) ) ) {
+			return $cols;
+		}
+
+		$cols[] = 'tags';
+		if ( 'post' === $screen->post_type ) {
+			$cols[] = 'categories';
+		}
+
+		return $cols;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change hides the category and tag columns from the posts list
screens by default. They can be enabled again in screen options, and
won't be changed if the columns to display has already been adjusted.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Related #21132

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Enable the post list package
* View the posts list screen and check the category and tag columns are not displayed by default
* If they are still displayed then you may need to reset the screen options with `delete_user_meta( <YOUR USER ID>, 'manageedit-postcolumnshidden' );`

