### PR TITLE
Ads: Fix Typo in Banner

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -168,7 +168,7 @@ export const SettingsCard = props => {
 				) : (
 					<JetpackBanner
 						title={ __(
-							'Connect your WordPress.com account to upgrade and generate income with high-quality adds.',
+							'Connect your WordPress.com account to upgrade and generate income with high-quality ads.',
 							'jetpack'
 						) }
 						callToAction={ connectLabel }

--- a/projects/plugins/jetpack/changelog/fix-typo-in-ad-banner
+++ b/projects/plugins/jetpack/changelog/fix-typo-in-ad-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix typo in Jetpack ad banner.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #21133

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes typo in Jetpack ad banner when not connected to wpcom.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site.
* Connect using a site-only connection (connect Jetpack, then hit back on the browser before approving user connection)
* Go to Jetpack -> Settings -> Traffic and view the banner that should now say "Connect your WordPress.com account to upgrade and generate income with high-quality ads." instead of "adds."
