### PR TITLE
Social Icons Widget: Remove from legacy-widget block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-social-icons-widget-block-compatibility
+++ b/projects/plugins/jetpack/changelog/update-social-icons-widget-block-compatibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Social Icons Widget: deprecate widget and transform to Social Links block

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -7,6 +7,7 @@ import './shared/plan-upgrade-notification';
 import './shared/stripe-connection-notification';
 import './shared/external-media';
 import './extended-blocks/core-embed';
+import './extended-blocks/core-social-links';
 import './extended-blocks/paid-blocks';
 import './shared/styles/slideshow-fix.scss';
 import './shared/styles/external-link-fix.scss';

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/index.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/index.js
@@ -38,7 +38,7 @@ const socialLinksTransform = {
 					} );
 
 					const innerBlock = createBlock( 'core/social-link', {
-						service: iconService ? iconService.name : 'default',
+						service: iconService ? iconService.name : 'chain',
 						url: icon.url,
 					} );
 					innerBlocks = [ ...innerBlocks, innerBlock ];

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/index.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/index.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { createBlock } from '@wordpress/blocks';
+
+const socialLinksTransform = {
+	from: [
+		{
+			type: 'block',
+			isMultiBlock: false,
+			blocks: [ 'core/legacy-widget' ],
+			isMatch: ( { idBase, instance } ) => {
+				if ( ! instance?.raw ) {
+					return false;
+				}
+				return idBase === 'jetpack_widget_social_icons';
+			},
+			transform: () => {
+				return createBlock( 'core/social-links' );
+			},
+		},
+	],
+};
+
+function addTransformToSocialLinksWidget( settings, name ) {
+	if ( name !== 'core/social-links' ) {
+		return settings;
+	}
+
+	settings.transforms = socialLinksTransform;
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'addTransformToSocialLinksWidget',
+	addTransformToSocialLinksWidget
+);

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/index.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/index.js
@@ -4,6 +4,17 @@
 import { addFilter } from '@wordpress/hooks';
 import { createBlock } from '@wordpress/blocks';
 
+/**
+ * The Social Icons widget and Social Links block determine the link source
+ * differently. The widget instance includes no data that can be easily used
+ * to transfer to the new block.
+ *
+ * This will return a blank 'core/social-links' block
+ *
+ * @param {object} instance - The widget instance returned from the API
+ * @param {string} idBase - The widget name
+ * @returns {object} The transforms settings
+ */
 const socialLinksTransform = {
 	from: [
 		{
@@ -23,12 +34,24 @@ const socialLinksTransform = {
 	],
 };
 
+/**
+ * With the upgrade to block editor in widgets, the Social Icons widget is redundant.
+ *
+ * Since this feature is built into the Gutenberg core and there is no relevant Jetpack
+ * block to place this in, we need to hook into the core block and apply the transform to
+ * handle this addition.
+ *
+ * @param {object} settings - Block settings object.
+ * @param {string} name - The block name
+ * @returns {object} The settings for the given block with the patched variations.
+ */
 function addTransformToSocialLinksWidget( settings, name ) {
 	if ( name !== 'core/social-links' ) {
 		return settings;
 	}
 
 	settings.transforms = socialLinksTransform;
+
 	return settings;
 }
 

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/services.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/services.js
@@ -1,0 +1,160 @@
+/**
+ * Services list to help with convert to block
+ */
+
+const services = [
+	{
+		name: 'wordpress',
+		url: [ 'wordpress.' ],
+	},
+	{
+		name: 'fivehundredpx',
+		url: [ '500px.com' ],
+	},
+	{
+		name: 'amazon',
+		url: [ 'amazon.' ],
+	},
+	{
+		name: 'bandcamp',
+		url: [ 'bandcamp.com' ],
+	},
+	{
+		name: 'behance',
+		url: [ 'behance.net' ],
+	},
+	{
+		name: 'codepen',
+		url: [ 'codepen.io' ],
+	},
+	{
+		name: 'deviantart',
+		url: [ 'deviantart.com' ],
+	},
+	{
+		name: 'dribbble',
+		url: [ 'dribbble.com' ],
+	},
+	{
+		name: 'dropbox',
+		url: [ 'dropbox.com' ],
+	},
+	{
+		name: 'etsy',
+		url: [ 'etsy.com' ],
+	},
+	{
+		name: 'facebook',
+		url: [ 'facebook.com' ],
+	},
+	{
+		name: 'flickr',
+		url: [ 'flickr.com' ],
+	},
+	{
+		name: 'foursquare',
+		url: [ 'foursquare.com' ],
+	},
+	{
+		name: 'goodreads',
+		url: [ 'goodreads.com' ],
+	},
+	{
+		name: 'google',
+		url: [ 'google.' ],
+	},
+	{
+		name: 'github',
+		url: [ 'github.com' ],
+	},
+	{
+		name: 'instagram',
+		url: [ 'instagram.com' ],
+	},
+	{
+		name: 'linkedin',
+		url: [ 'linkedin.com' ],
+	},
+	{
+		name: 'mail',
+		url: [ 'mailto:' ],
+	},
+	{
+		name: 'meetup',
+		url: [ 'meetup.com' ],
+	},
+	{
+		name: 'medium',
+		url: [ 'medium.com' ],
+	},
+	{
+		name: 'patreon',
+		url: [ 'patreon.com' ],
+	},
+	{
+		name: 'pinterest',
+		url: [ 'pinterest.' ],
+	},
+	{
+		name: 'pocket',
+		url: [ 'getpocket.com' ],
+	},
+	{
+		name: 'reddit',
+		url: [ 'reddit.com' ],
+	},
+	{
+		name: 'skype',
+		url: [ 'skype.com', 'skype:' ],
+	},
+	{
+		name: 'snapchat',
+		url: [ 'snapchat.com' ],
+	},
+	{
+		name: 'soundcloud',
+		url: [ 'soundcloud.com' ],
+	},
+	{
+		name: 'spotify',
+		url: [ 'spotify.com' ],
+	},
+	{
+		name: 'telegram',
+		url: [ 'telegram.me', 't.me' ],
+	},
+	{
+		name: 'tiktok',
+		url: [ 'tiktok.com' ],
+	},
+	{
+		name: 'tumblr',
+		url: [ 'tumblr.com' ],
+	},
+	{
+		name: 'twitch',
+		url: [ 'twitch.tv' ],
+	},
+	{
+		name: 'twitter',
+		url: [ 'twitter.com' ],
+	},
+	{
+		name: 'vimeo',
+		url: [ 'vimeo.com' ],
+	},
+	{
+		name: 'vk',
+		url: [ 'vk.com' ],
+	},
+	{
+		name: 'yelp',
+		url: [ 'yelp.com' ],
+	},
+	{
+		name: 'youtube',
+		url: [ 'youtube.com' ],
+	},
+];
+
+export default services;

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/services.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-social-links/services.js
@@ -1,5 +1,5 @@
 /**
- * Services list to help with convert to block
+ * Services list to help with transforming widget urls to social-link block
  */
 
 const services = [
@@ -72,12 +72,24 @@ const services = [
 		url: [ 'instagram.com' ],
 	},
 	{
+		name: 'lastfm',
+		url: [ 'last.fm' ],
+	},
+	{
 		name: 'linkedin',
 		url: [ 'linkedin.com' ],
 	},
 	{
 		name: 'mail',
 		url: [ 'mailto:' ],
+	},
+	{
+		name: 'linkedin',
+		url: [ 'linkedin.com' ],
+	},
+	{
+		name: 'mastodon',
+		url: [ 'mastodon.social' ],
 	},
 	{
 		name: 'meetup',

--- a/projects/plugins/jetpack/modules/widgets/social-icons.php
+++ b/projects/plugins/jetpack/modules/widgets/social-icons.php
@@ -57,7 +57,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 			add_action( 'wp_footer', array( $this, 'include_svg_icons' ), 9999 );
 		}
 
-		// add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/widgets/social-icons.php
+++ b/projects/plugins/jetpack/modules/widgets/social-icons.php
@@ -4,6 +4,9 @@
  * Social Icons Widget.
  */
 class Jetpack_Widget_Social_Icons extends WP_Widget {
+
+	const ID_BASE = 'jetpack_widget_social_icons';
+
 	/**
 	 * Default widget options.
 	 *
@@ -20,6 +23,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 		$widget_ops = array(
 			'classname'                   => 'jetpack_widget_social_icons',
 			'description'                 => __( 'Add social-media icons to your site.', 'jetpack' ),
+			'show_instance_in_rest'       => true,
 			'customize_selective_refresh' => true,
 		);
 
@@ -52,6 +56,19 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_icon_scripts' ) );
 			add_action( 'wp_footer', array( $this, 'include_svg_icons' ), 9999 );
 		}
+
+		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+	}
+
+	/**
+	 * Remove Social Icons widget from Legacy Widget block.
+	 *
+	 * @param array $widget_types Widget type data.
+	 * This only applies to new blocks being added.
+	 */
+	public function hide_widget_in_block_editor( $widget_types ) {
+		$widget_types[] = self::ID_BASE;
+		return $widget_types;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/widgets/social-icons.php
+++ b/projects/plugins/jetpack/modules/widgets/social-icons.php
@@ -57,7 +57,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 			add_action( 'wp_footer', array( $this, 'include_svg_icons' ), 9999 );
 		}
 
-		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+		// add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
With the new current widget block editor, the Social Icons Widget is redundant. The core block, [Social Links](https://wordpress.com/support/wordpress-editor/blocks/social-links-block/). This PR removes it from the `core/legacy-widget` and adds the widget to the REST API to allow a block `transforms: ` to be created.

Due to the difference in the way Social Links block compared to the Social Icons widget it may be a little complicated to transfer over the existing icons. In the long term we may be able to get a function that is capable of filtering this based on the URL, but in the interest of resolving this issue sooner rather than later it we may want to save that for a later update.

*Legacy Block*
<img width="464" alt="Markup 2021-09-21 at 22 57 31" src="https://user-images.githubusercontent.com/33258733/134250004-0a426d9b-36eb-4e88-9eb0-5be15a72ec8b.png">

*Transform*
<img width="610" alt="Markup 2021-09-21 at 22 57 52" src="https://user-images.githubusercontent.com/33258733/134250109-19ad0c8c-65d0-4989-8377-1f05c8267bf9.png">

*Finish*
<img width="629" alt="Markup 2021-09-21 at 22 58 05" src="https://user-images.githubusercontent.com/33258733/134250170-aabda6f8-7d71-4f2c-9d4b-75f7eebd594a.png">


#### Jetpack product discussion
Working on #21069 

#### Does this pull request change what data or activity we track or use?
Nope

#### Testing instructions:
* Before loading this PR, be sure to add the Social Icon widget (using the Legacy Block) to your testing site and save it.
* Load the changes and add the Legacy Block in the Widget Block editor.
* You should no longer have the option to select Social Links from the Legacy Block dropdown.
* Next, click the Social Icons widget you previously added.
* Select the transform option and choose `Social Icons`
* It should switch to a blank Social Links block.
