### PR TITLE
Connection: move IDC args from Sync to Connection

### DIFF
--- a/projects/packages/connection/changelog/update-remote_request_query_args
+++ b/projects/packages/connection/changelog/update-remote_request_query_args
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Client: add IDC query args to remote requests

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -7,6 +7,7 @@
 		"automattic/jetpack-a8c-mc-stats": "^1.4",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-heartbeat": "^1.3",
+		"automattic/jetpack-identity-crisis": "^0.2",
 		"automattic/jetpack-options": "^1.13",
 		"automattic/jetpack-roles": "^1.4",
 		"automattic/jetpack-status": "^1.8",

--- a/projects/packages/connection/tests/php/test_Client.php
+++ b/projects/packages/connection/tests/php/test_Client.php
@@ -1,0 +1,122 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * Client functionality testing.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Client functionality testing.
+ */
+class Client_Test extends BaseTestCase {
+
+	const TEST_URL = 'https://www.example.com';
+
+	/**
+	 * Tests that the idc query arguments are added to the request url in the remote_request() method.
+	 */
+	public function test_remote_request_adds_idc_args() {
+		$this->set_up_idc_query_arg_tests();
+
+		$result = Client::remote_request( array( 'url' => 'https://www.example.com/' ) );
+
+		$this->tear_down_idc_query_arg_tests();
+
+		$query_args = wp_parse_args( wp_parse_url( $result )['query'] );
+
+		$this->assertSame( self::TEST_URL, $query_args['siteurl'] );
+		$this->assertSame( self::TEST_URL, $query_args['home'] );
+		$this->assertSame( '1', $query_args['idc'] );
+		$this->assertFalse( isset( $query_args['migrate_for_idc'] ) );
+	}
+
+	/**
+	 * Tests that the idc query arguments are added to the request url in the remote_request() method when the
+	 * `migrate_for_idc` option is set to true.
+	 */
+	public function test_remote_request_adds_idc_args_with_migrate_for_idc() {
+		$this->set_up_idc_query_arg_tests();
+		\Jetpack_Options::update_option( 'migrate_for_idc', true );
+
+		$result = Client::remote_request( array( 'url' => 'https://www.example.com/' ) );
+
+		$this->tear_down_idc_query_arg_tests();
+
+		$query_args = wp_parse_args( wp_parse_url( $result )['query'] );
+
+		$this->assertSame( self::TEST_URL, $query_args['siteurl'] );
+		$this->assertSame( self::TEST_URL, $query_args['home'] );
+		$this->assertSame( '1', $query_args['idc'] );
+		$this->assertSame( '1', $query_args['migrate_for_idc'] );
+	}
+
+	/**
+	 * Tests that the idc query arguments are added to the request url in the remote_request() method when the
+	 * 'jetpack_sync_idc_optin' filter returns false.
+	 */
+	public function test_remote_request_adds_idc_args_without_idc() {
+		$this->set_up_idc_query_arg_tests();
+		add_filter( 'jetpack_sync_idc_optin', '__return_false' );
+
+		$result = Client::remote_request( array( 'url' => 'https://www.example.com/' ) );
+
+		$this->tear_down_idc_query_arg_tests();
+
+		$query_args = wp_parse_args( wp_parse_url( $result )['query'] );
+
+		$this->assertSame( self::TEST_URL, $query_args['siteurl'] );
+		$this->assertSame( self::TEST_URL, $query_args['home'] );
+		$this->assertFalse( isset( $query_args['idc'] ) );
+		$this->assertFalse( isset( $query_args['migrate_for_idc'] ) );
+	}
+
+	/**
+	 * Sets up the test environment for idc query argument tests.
+	 */
+	public function set_up_idc_query_arg_tests() {
+		// Short circuit the request.
+		add_filter( 'pre_http_request', array( $this, 'return_request_url' ), 10, 3 );
+
+		add_filter( 'jetpack_sync_site_url', array( $this, 'return_test_url' ) );
+		add_filter( 'jetpack_sync_home_url', array( $this, 'return_test_url' ) );
+
+		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+	}
+
+	/**
+	 * Tears down the test environment after idc query argument tests.
+	 */
+	public function tear_down_idc_query_arg_tests() {
+		remove_filter( 'pre_http_request', array( $this, 'return_request_url' ), 10, 3 );
+
+		remove_filter( 'jetpack_sync_site_url', array( $this, 'return_test_url' ) );
+		remove_filter( 'jetpack_sync_home_url', array( $this, 'return_test_url' ) );
+
+		remove_filter( 'jetpack_sync_idc_optin', '__return_false' );
+
+		\Jetpack_Options::delete_option( 'blog_token' );
+		\Jetpack_Options::delete_option( 'migrate_for_idc' );
+	}
+
+	/**
+	 * Returns the request url to the 'pre_http_request' filter hook.
+	 *
+	 * @param false|array|WP_Error $preempt     A preemptive return value of an HTTP request. Default false.
+	 * @param array                $parsed_args HTTP request arguments.
+	 * @param string               $url         The request URL.
+	 */
+	public function return_request_url( $preempt, $parsed_args, $url ) {
+		return $url;
+	}
+
+	/**
+	 * Returns the test url.
+	 */
+	public function return_test_url() {
+		return self::TEST_URL;
+	}
+}

--- a/projects/packages/sync/changelog/update-remote_request_query_args
+++ b/projects/packages/sync/changelog/update-remote_request_query_args
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Actions: remove the IDC query args from sync requests
+
+

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
-use Automattic\Jetpack\Connection\Urls;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Identity_Crisis;
 use Automattic\Jetpack\Status;
@@ -359,22 +358,11 @@ class Actions {
 			'codec'      => $codec_name,
 			'timestamp'  => $sent_timestamp,
 			'queue'      => $queue_id,
-			'home'       => Urls::home_url(),  // Send home url option to check for Identity Crisis server-side.
-			'siteurl'    => Urls::site_url(),  // Send siteurl option to check for Identity Crisis server-side.
 			'cd'         => sprintf( '%.4f', $checkout_duration ),
 			'pd'         => sprintf( '%.4f', $preprocess_duration ),
 			'queue_size' => $queue_size,
 			'buffer_id'  => $buffer_id,
 		);
-
-		// Has the site opted in to IDC mitigation?
-		if ( Identity_Crisis::sync_idc_optin() ) {
-			$query_args['idc'] = true;
-		}
-
-		if ( \Jetpack_Options::get_option( 'migrate_for_idc', false ) ) {
-			$query_args['migrate_for_idc'] = true;
-		}
 
 		$query_args['timeout'] = Settings::is_doing_cron() ? 30 : 15;
 		if ( 'immediate-send' === $queue_id ) {


### PR DESCRIPTION
**This PR needs to be updated to use the new filter and method names from PR #21104.**

#### Changes proposed in this Pull Request:
* Add the IDC query args (`siteurl`, `home`, `idc`, and `migrate_for_idc`) to the remote requests in the Connection package rather than in the Sync package.

#### Jetpack product discussion
* p9dueE-3oW-p2

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* tbd