### PR TITLE
[RNMobile] Embed block: Add native version to control the available variations

### DIFF
--- a/projects/plugins/jetpack/extensions/extended-blocks/core-embed/index.native.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-embed/index.native.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import './facebook';
+import './instagram';
+import './loom';
+import './smartframe';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- This PR only introduces the native version of the index file of the `core-embed` block, the goal for this change is to be able to control which embed block variations are enabled in the native version.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- The testing instructions are described in the Gutenberg Mobile PR:
https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008
