### PR TITLE
Color lib: avoid the use of extract()

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.color.php
+++ b/projects/plugins/jetpack/_inc/lib/class.color.php
@@ -689,7 +689,11 @@ class Jetpack_Color {
 
 	public function incrementLightness( $amount ) {
 		$hsl = $this->toHsl();
-		extract( $hsl );
+
+		$h = isset( $hsl['h'] ) ? $hsl['h'] : 0;
+		$s = isset( $hsl['s'] ) ? $hsl['s'] : 0;
+		$l = isset( $hsl['l'] ) ? $hsl['l'] : 0;
+
 		$l += $amount;
 		if ( $l < 0 ) $l = 0;
 		if ( $l > 100 ) $l = 100;
@@ -706,7 +710,11 @@ class Jetpack_Color {
 
 	public function incrementSaturation( $amount ) {
 		$hsl = $this->toHsl();
-		extract( $hsl );
+
+		$h = isset( $hsl['h'] ) ? $hsl['h'] : 0;
+		$s = isset( $hsl['s'] ) ? $hsl['s'] : 0;
+		$l = isset( $hsl['l'] ) ? $hsl['l'] : 0;
+
 		$s += $amount;
 		if ( $s < 0 ) $s = 0;
 		if ( $s > 100 ) $s = 100;
@@ -715,8 +723,11 @@ class Jetpack_Color {
 
 	public function toGrayscale() {
 		$hsl = $this->toHsl();
-		extract( $hsl );
+
+		$h = isset( $hsl['h'] ) ? $hsl['h'] : 0;
 		$s = 0;
+		$l = isset( $hsl['l'] ) ? $hsl['l'] : 0;
+
 		return $this->fromHsl( $h, $s, $l );
 	}
 
@@ -746,7 +757,11 @@ class Jetpack_Color {
 
 	public function incrementHue( $amount ) {
 		$hsl = $this->toHsl();
-		extract( $hsl );
+
+		$h = isset( $hsl['h'] ) ? $hsl['h'] : 0;
+		$s = isset( $hsl['s'] ) ? $hsl['s'] : 0;
+		$l = isset( $hsl['l'] ) ? $hsl['l'] : 0;
+
 		$h = ( $h + $amount ) % 360;
 		if ( $h < 0 ) $h = 360 - $h;
 		return $this->fromHsl( $h, $s, $l );

--- a/projects/plugins/jetpack/changelog/2021-09-23-18-49-09-569454
+++ b/projects/plugins/jetpack/changelog/2021-09-23-18-49-09-569454
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Refactor extract() usage.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Refactor `extract()` usage; no functionality changes.
* Internal: syncs changes from D67197-code

#### Jetpack product discussion

Internal: p3btAN-1xB-p2

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Code has already been tested on WPcom simple.
* This will require using a specific theme, like Ryu, on your site.
* Each image format post's background color should align with the image used in the post.