### PR TITLE
Widgets: remove use of extract in widgets

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-extract-usage-D67194
+++ b/projects/plugins/jetpack/changelog/fix-extract-usage-D67194
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Refactor extract() usage.

--- a/projects/plugins/jetpack/modules/widgets/facebook-likebox.php
+++ b/projects/plugins/jetpack/modules/widgets/facebook-likebox.php
@@ -57,10 +57,18 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		wp_style_add_data( 'jetpack_facebook_likebox', 'jetpack-inline', true );
 	}
 
-	function widget( $args, $instance ) {
-		extract( $args );
-
-		$like_args = $this->get_default_args();
+	/**
+	 * Display the widget.
+	 *
+	 * @param array $args Display arguments including before_title, after_title, before_widget, and after_widget.
+	 * @param array $instance The settings for the particular instance of the widget.
+	 */
+	public function widget( $args, $instance ) {
+		$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+		$before_title  = isset( $args['before_title'] ) ? $args['before_title'] : '';
+		$after_title   = isset( $args['after_title'] ) ? $args['after_title'] : '';
+		$after_widget  = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
+		$like_args     = $this->get_default_args();
 
 		if ( isset( $instance['like_args'] ) ) {
 			$like_args = $this->normalize_facebook_args( $instance['like_args'] );
@@ -68,9 +76,22 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 
 		if ( empty( $like_args['href'] ) || ! $this->is_valid_facebook_url( $like_args['href'] ) ) {
 			if ( current_user_can( 'edit_theme_options' ) ) {
-				echo $before_widget;
-				echo '<p>' . sprintf( __( 'It looks like your Facebook URL is incorrectly configured. Please check it in your <a href="%s">widget settings</a>.', 'jetpack' ), admin_url( 'widgets.php' ) ) . '</p>';
-				echo $after_widget;
+				echo $before_widget; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+				$error_link = wp_kses(
+					sprintf(
+						/* translators: %s: link to widgets administration screen. */
+						__( 'It looks like your Facebook URL is incorrectly configured. Please check it in your <a href="%1$s">widget settings</a>.', 'jetpack' ),
+						esc_url( admin_url( 'widgets.php' ) )
+					),
+					array( 'a' => array( 'href' => array() ) )
+				);
+				printf(
+					'<p>%s</p>',
+					$error_link // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				);
+
+				echo $after_widget; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 			echo '<!-- Invalid Facebook Page URL -->';
 			return;
@@ -96,13 +117,12 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		 */
 		$hide_cta = apply_filters( 'jetpack_facebook_likebox_hide_cta', false );
 
-		echo $before_widget;
+		echo $before_widget; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		if ( ! empty( $title ) ) :
-			echo $before_title;
+			echo $before_title; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			$likebox_widget_title = '<a href="' . esc_url( $page_url ) . '">' . esc_html( $title ) . '</a>';
-
 			/**
 			 * Filter Facebook Likebox's widget title.
 			 *
@@ -114,9 +134,14 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 			 * @param string $title Widget title as set in the widget settings.
 			 * @param string $page_url Facebook Page URL.
 			 */
-			echo apply_filters( 'jetpack_facebook_likebox_title', $likebox_widget_title, $title, $page_url );
+			$likebox_widget_title = apply_filters( 'jetpack_facebook_likebox_title', $likebox_widget_title, $title, $page_url );
 
-			echo $after_title;
+			echo wp_kses(
+				$likebox_widget_title,
+				array( 'a' => array( 'href' => array() ) )
+			);
+
+			echo $after_title; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		endif;
 
 		?>
@@ -126,7 +151,8 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		</div>
 		<?php
 		wp_enqueue_script( 'jetpack-facebook-embed' );
-		echo $after_widget;
+
+		echo $after_widget; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This action is documented in modules/widgets/gravatar-profile.php */
 		do_action( 'jetpack_stats_extra', 'widget_view', 'facebook-likebox' );

--- a/projects/plugins/jetpack/modules/widgets/gallery.php
+++ b/projects/plugins/jetpack/modules/widgets/gallery.php
@@ -52,6 +52,8 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Display the widget.
+	 *
 	 * @param array $args Display arguments including before_title, after_title, before_widget, and after_widget.
 	 * @param array $instance The settings for the particular instance of the widget.
 	 */
@@ -60,7 +62,10 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 
 		$this->enqueue_frontend_scripts();
 
-		extract( $args );
+		$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+		$before_title  = isset( $args['before_title'] ) ? $args['before_title'] : '';
+		$after_title   = isset( $args['after_title'] ) ? $args['after_title'] : '';
+		$after_widget  = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
 
 		$instance['attachments'] = $this->get_attachments( $instance );
 
@@ -68,11 +73,14 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 
 		$classes[] = 'widget-gallery-' . $instance['type'];
 
-		// Due to a bug in the carousel plugin, carousels will be triggered for all tiled galleries that exist on a page
-		// with other tiled galleries, regardless of whether or not the widget was set to Carousel mode. The onClick selector
-		// is simply too broad, since it was not written with widgets in mind. This special class prevents that behavior, via
-		// an override handler in gallery.js
-		if ( 'carousel' != $instance['link'] && 'slideshow' != $instance['type'] ) {
+		/*
+		 * Due to a bug in the carousel plugin,
+		 * carousels will be triggered for all tiled galleries that exist on a page with other tiled galleries,
+		 * regardless of whether or not the widget was set to Carousel mode.
+		 * The onClick selector is simply too broad, since it was not written with widgets in mind.
+		 * This special class prevents that behavior, via an override handler in gallery.js.
+		 */
+		if ( 'carousel' !== $instance['link'] && 'slideshow' !== $instance['type'] ) {
 			$classes[] = 'no-carousel';
 		} else {
 			$classes[] = 'carousel';
@@ -80,8 +88,8 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 
 		$classes = implode( ' ', $classes );
 
-		if ( 'carousel' == $instance['link'] ) {
-			require_once plugin_dir_path( realpath( dirname( __FILE__ ) . '/../carousel/jetpack-carousel.php' ) ) . 'jetpack-carousel.php';
+		if ( 'carousel' === $instance['link'] ) {
+			require_once plugin_dir_path( realpath( __DIR__ . '/../carousel/jetpack-carousel.php' ) ) . 'jetpack-carousel.php';
 
 			if ( class_exists( 'Jetpack_Carousel' ) ) {
 				// Create new carousel so we can use the enqueue_assets() method. Not ideal, but there is a decent amount
@@ -93,13 +101,13 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 			}
 		}
 
-		echo $before_widget . "\n";
+		echo $before_widget . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $instance['title'] );
 
 		if ( $title ) {
-			echo $before_title . esc_html( $title ) . $after_title . "\n";
+			echo $before_title . esc_html( $title ) . $after_title . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 		echo '<div class="' . esc_attr( $classes ) . '">' . "\n";
@@ -124,18 +132,18 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 		add_filter( 'tiled_gallery_content_width', array( $this, 'tiled_gallery_content_width' ) );
 
 		if ( method_exists( $this, $method ) ) {
-			echo $this->$method( $args, $instance );
+			echo $this->$method( $args, $instance ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		// Remove the stored $_instance_width, as it is no longer needed
+		// Remove the stored $_instance_width, as it is no longer needed.
 		$this->_instance_width = null;
 
-		// Remove the filter, so any Jetpack_Tiled_Gallery in a post is not affected
+		// Remove the filter, so any Jetpack_Tiled_Gallery in a post is not affected.
 		remove_filter( 'tiled_gallery_content_width', array( $this, 'tiled_gallery_content_width' ) );
 
 		echo "\n" . '</div>'; // .widget-gallery-$type
 
-		echo "\n" . $after_widget;
+		echo "\n" . $after_widget; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This action is documented in modules/widgets/gravatar-profile.php */
 		do_action( 'jetpack_stats_extra', 'widget_view', 'gallery' );

--- a/projects/plugins/jetpack/modules/widgets/rsslinks-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/rsslinks-widget.php
@@ -22,37 +22,46 @@ class Jetpack_RSS_Links_Widget extends WP_Widget {
 		);
 	}
 
-	function widget( $args, $instance ) {
+	/**
+	 * Display the widget.
+	 *
+	 * @param array $args Display arguments including before_title, after_title, before_widget, and after_widget.
+	 * @param array $instance The settings for the particular instance of the widget.
+	 */
+	public function widget( $args, $instance ) {
 		$instance = wp_parse_args( (array) $instance, $this->defaults() );
 
-		extract( $args );
+		$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+		$before_title  = isset( $args['before_title'] ) ? $args['before_title'] : '';
+		$after_title   = isset( $args['after_title'] ) ? $args['after_title'] : '';
+		$after_widget  = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
 
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $instance['title'] );
-		echo $before_widget;
+		echo $before_widget; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		if ( $title ) {
-			echo $before_title . stripslashes( $title ) . $after_title;
+			echo $before_title . esc_html( $title ) . $after_title; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		if ( 'text' == $instance['format'] ) {
+		if ( 'text' === $instance['format'] ) {
 			echo '<ul>';
 		}
 
-		if ( 'posts' == $instance['display'] ) {
+		if ( 'posts' === $instance['display'] ) {
 			$this->_rss_link( 'posts', $instance );
-		} elseif ( 'comments' == $instance['display'] ) {
+		} elseif ( 'comments' === $instance['display'] ) {
 			$this->_rss_link( 'comments', $instance );
-		} elseif ( 'posts-comments' == $instance['display'] ) {
+		} elseif ( 'posts-comments' === $instance['display'] ) {
 			$this->_rss_link( 'posts', $instance );
 			$this->_rss_link( 'comments', $instance );
 		}
 
-		if ( 'text' == $instance['format'] ) {
+		if ( 'text' === $instance['format'] ) {
 			echo '</ul>';
 		}
 
-		echo "\n" . $after_widget;
+		echo "\n" . $after_widget; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This action is documented in modules/widgets/gravatar-profile.php */
 		do_action( 'jetpack_stats_extra', 'widget_view', 'rss-links' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Refactor extract() usage; no functionality changes.
* Internal: syncs changes from D67194-code

#### Jetpack product discussion

Internal: p3btAN-1xB-p2

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Code has already been tested on WPcom simple.
* Add all 3 widgets to a new site.
* Ensure they can be saved, and are displayed properly.