### PR TITLE
Search: fix search dashboard buttons style

### DIFF
--- a/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
+++ b/projects/plugins/jetpack/_inc/client/search/dashboard/module-control.scss
@@ -64,7 +64,6 @@ p.jp-form-search-settings-group__toggle-explanation {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	height: 100%;
 	min-height: 2.5em;
 	padding: 0.5em 1.5em;
 	text-align: center;

--- a/projects/plugins/jetpack/changelog/fix-search-dashboard-buttons
+++ b/projects/plugins/jetpack/changelog/fix-search-dashboard-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fix dashboard buttons too big on Safari


### PR DESCRIPTION
Fixes #21177

#### Changes proposed in this Pull Request:
Fixed dashboard button too high on Safari.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* On a site with Jetpack Search enabled, go to /wp-admin/admin.php?page=jetpack-search.
* Ensure the buttons look okay on Firefox, Chrome and Safari

![image](https://user-images.githubusercontent.com/1425433/134601743-87e52ed4-5efd-4160-9ca5-ac4334e09801.png)



