### PR TITLE
Move the identity-crisis files from the identity-crisis package to the connection package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,51 @@ importers:
       style-loader: 2.0.0_webpack@5.51.1
       webpack: 5.51.1
 
+  projects/packages/connection:
+    specifiers:
+      '@automattic/calypso-build': 9.0.0
+      '@babel/core': 7.15.0
+      '@babel/helper-module-imports': 7.14.5
+      '@babel/preset-env': 7.15.0
+      '@babel/register': 7.15.3
+      '@wordpress/data': 6.1.0
+      '@wordpress/dependency-extraction-webpack-plugin': 3.2.1
+      babel-minify-webpack-plugin: 0.3.1
+      fancy-log: 1.3.3
+      gulp: 4.0.2
+      gulp-append-prepend: 1.0.9
+      gulp-autoprefixer: 7.0.1
+      gulp-clean-css: 4.3.0
+      gulp-rename: 2.0.0
+      gulp-rtlcss: 1.4.1
+      gulp-sass: 5.0.0
+      gulp-sourcemaps: 3.0.0
+      sass: 1.38.1
+      static-site-generator-webpack-plugin: 3.4.2
+      webpack: 5.51.1
+    dependencies:
+      '@automattic/calypso-build': 9.0.0_webpack@5.51.1
+      '@babel/core': 7.15.0
+      '@babel/helper-module-imports': 7.14.5
+      '@babel/preset-env': 7.15.0_@babel+core@7.15.0
+      '@babel/register': 7.15.3_@babel+core@7.15.0
+      '@wordpress/data': 6.1.0
+      fancy-log: 1.3.3
+      gulp: 4.0.2
+      static-site-generator-webpack-plugin: 3.4.2
+      webpack: 5.51.1
+    devDependencies:
+      '@wordpress/dependency-extraction-webpack-plugin': 3.2.1_webpack@5.51.1
+      babel-minify-webpack-plugin: 0.3.1_webpack@5.51.1
+      gulp-append-prepend: 1.0.9
+      gulp-autoprefixer: 7.0.1_gulp@4.0.2
+      gulp-clean-css: 4.3.0
+      gulp-rename: 2.0.0
+      gulp-rtlcss: 1.4.1
+      gulp-sass: 5.0.0
+      gulp-sourcemaps: 3.0.0
+      sass: 1.38.1
+
   projects/packages/connection-ui:
     specifiers:
       '@automattic/calypso-build': 9.0.0
@@ -947,23 +992,23 @@ packages:
       webpack: ^5.46.0
     dependencies:
       '@automattic/webpack-rtl-plugin': 5.0.0_webpack@5.51.1
-      '@babel/cli': 7.15.7_@babel+core@7.15.0
+      '@babel/cli': 7.15.7_@babel+core@7.15.5
       '@babel/compat-data': 7.15.0
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       '@babel/helpers': 7.15.4
-      '@babel/plugin-proposal-class-properties': 7.14.5_@babel+core@7.15.0
-      '@babel/plugin-transform-react-jsx': 7.14.9_@babel+core@7.15.0
-      '@babel/plugin-transform-runtime': 7.15.0_@babel+core@7.15.0
-      '@babel/preset-env': 7.15.0_@babel+core@7.15.0
-      '@babel/preset-react': 7.14.5_@babel+core@7.15.0
-      '@babel/preset-typescript': 7.15.0_@babel+core@7.15.0
+      '@babel/plugin-proposal-class-properties': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-react-jsx': 7.14.9_@babel+core@7.15.5
+      '@babel/plugin-transform-runtime': 7.15.0_@babel+core@7.15.5
+      '@babel/preset-env': 7.15.6_@babel+core@7.15.5
+      '@babel/preset-react': 7.14.5_@babel+core@7.15.5
+      '@babel/preset-typescript': 7.15.0_@babel+core@7.15.5
       '@types/webpack-env': 1.16.2
-      '@wordpress/babel-plugin-import-jsx-pragma': 3.1.0_@babel+core@7.15.0
+      '@wordpress/babel-plugin-import-jsx-pragma': 3.1.0_@babel+core@7.15.5
       '@wordpress/browserslist-config': 3.0.3
       '@wordpress/dependency-extraction-webpack-plugin': 3.2.1_webpack@5.51.1
       autoprefixer: 10.3.4
-      babel-jest: 27.2.1_@babel+core@7.15.0
-      babel-loader: 8.2.2_080b9887a086cbf3e61f158e7c92b566
+      babel-jest: 27.2.1_@babel+core@7.15.5
+      babel-loader: 8.2.2_80927b313c74087b681f254ee0e3e2fc
       browserslist: 4.17.0
       cache-loader: 4.1.0_webpack@5.51.1
       css-loader: 5.2.7_webpack@5.51.1
@@ -982,8 +1027,8 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       recursive-copy: 2.0.13
-      sass: 1.38.1
-      sass-loader: 11.1.1_sass@1.38.1+webpack@5.51.1
+      sass: 1.39.0
+      sass-loader: 11.1.1_sass@1.39.0+webpack@5.51.1
       semver: 7.3.5
       terser-webpack-plugin: 5.2.4_webpack@5.51.1
       thread-loader: 3.0.4_webpack@5.51.1
@@ -1019,23 +1064,23 @@ packages:
       webpack: ^5.46.0
     dependencies:
       '@automattic/webpack-rtl-plugin': 5.0.0_webpack@5.51.1
-      '@babel/cli': 7.15.7_@babel+core@7.15.0
+      '@babel/cli': 7.15.7_@babel+core@7.15.5
       '@babel/compat-data': 7.15.0
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       '@babel/helpers': 7.15.4
-      '@babel/plugin-proposal-class-properties': 7.14.5_@babel+core@7.15.0
-      '@babel/plugin-transform-react-jsx': 7.14.9_@babel+core@7.15.0
-      '@babel/plugin-transform-runtime': 7.15.0_@babel+core@7.15.0
-      '@babel/preset-env': 7.15.0_@babel+core@7.15.0
-      '@babel/preset-react': 7.14.5_@babel+core@7.15.0
-      '@babel/preset-typescript': 7.15.0_@babel+core@7.15.0
+      '@babel/plugin-proposal-class-properties': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-react-jsx': 7.14.9_@babel+core@7.15.5
+      '@babel/plugin-transform-runtime': 7.15.0_@babel+core@7.15.5
+      '@babel/preset-env': 7.15.6_@babel+core@7.15.5
+      '@babel/preset-react': 7.14.5_@babel+core@7.15.5
+      '@babel/preset-typescript': 7.15.0_@babel+core@7.15.5
       '@types/webpack-env': 1.16.2
-      '@wordpress/babel-plugin-import-jsx-pragma': 3.1.0_@babel+core@7.15.0
+      '@wordpress/babel-plugin-import-jsx-pragma': 3.1.0_@babel+core@7.15.5
       '@wordpress/browserslist-config': 3.0.3
       '@wordpress/dependency-extraction-webpack-plugin': 3.2.1_webpack@5.51.1
       autoprefixer: 10.3.4
-      babel-jest: 27.2.1_@babel+core@7.15.0
-      babel-loader: 8.2.2_080b9887a086cbf3e61f158e7c92b566
+      babel-jest: 27.2.1_@babel+core@7.15.5
+      babel-loader: 8.2.2_80927b313c74087b681f254ee0e3e2fc
       browserslist: 4.17.0
       cache-loader: 4.1.0_webpack@5.51.1
       css-loader: 5.2.7_webpack@5.51.1
@@ -1052,8 +1097,8 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       recursive-copy: 2.0.13
-      sass: 1.38.1
-      sass-loader: 11.1.1_sass@1.38.1+webpack@5.51.1
+      sass: 1.39.0
+      sass-loader: 11.1.1_sass@1.39.0+webpack@5.51.1
       semver: 7.3.5
       terser-webpack-plugin: 5.2.4_webpack@5.51.1
       thread-loader: 3.0.4_webpack@5.51.1
@@ -1089,23 +1134,23 @@ packages:
       webpack: ^5.46.0
     dependencies:
       '@automattic/webpack-rtl-plugin': 5.0.0_webpack@5.51.1
-      '@babel/cli': 7.15.7_@babel+core@7.15.0
+      '@babel/cli': 7.15.7_@babel+core@7.15.5
       '@babel/compat-data': 7.15.0
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       '@babel/helpers': 7.15.4
-      '@babel/plugin-proposal-class-properties': 7.14.5_@babel+core@7.15.0
-      '@babel/plugin-transform-react-jsx': 7.14.9_@babel+core@7.15.0
-      '@babel/plugin-transform-runtime': 7.15.0_@babel+core@7.15.0
-      '@babel/preset-env': 7.15.0_@babel+core@7.15.0
-      '@babel/preset-react': 7.14.5_@babel+core@7.15.0
-      '@babel/preset-typescript': 7.15.0_@babel+core@7.15.0
+      '@babel/plugin-proposal-class-properties': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-react-jsx': 7.14.9_@babel+core@7.15.5
+      '@babel/plugin-transform-runtime': 7.15.0_@babel+core@7.15.5
+      '@babel/preset-env': 7.15.6_@babel+core@7.15.5
+      '@babel/preset-react': 7.14.5_@babel+core@7.15.5
+      '@babel/preset-typescript': 7.15.0_@babel+core@7.15.5
       '@types/webpack-env': 1.16.2
-      '@wordpress/babel-plugin-import-jsx-pragma': 3.1.0_@babel+core@7.15.0
+      '@wordpress/babel-plugin-import-jsx-pragma': 3.1.0_@babel+core@7.15.5
       '@wordpress/browserslist-config': 3.0.3
       '@wordpress/dependency-extraction-webpack-plugin': 3.2.1_webpack@5.51.1
       autoprefixer: 10.3.4
-      babel-jest: 27.2.1_@babel+core@7.15.0
-      babel-loader: 8.2.2_080b9887a086cbf3e61f158e7c92b566
+      babel-jest: 27.2.1_@babel+core@7.15.5
+      babel-loader: 8.2.2_80927b313c74087b681f254ee0e3e2fc
       browserslist: 4.17.0
       cache-loader: 4.1.0_webpack@5.51.1
       css-loader: 5.2.7_webpack@5.51.1
@@ -1120,8 +1165,8 @@ packages:
       postcss-custom-properties: 11.0.0
       postcss-loader: 5.3.0_webpack@5.51.1
       recursive-copy: 2.0.13
-      sass: 1.38.1
-      sass-loader: 11.1.1_sass@1.38.1+webpack@5.51.1
+      sass: 1.39.0
+      sass-loader: 11.1.1_sass@1.39.0+webpack@5.51.1
       semver: 7.3.5
       terser-webpack-plugin: 5.2.4_webpack@5.51.1
       thread-loader: 3.0.4_webpack@5.51.1
@@ -1222,14 +1267,14 @@ packages:
       rtlcss: 3.3.0
       webpack: 5.51.1
 
-  /@babel/cli/7.15.7_@babel+core@7.15.0:
+  /@babel/cli/7.15.7_@babel+core@7.15.5:
     resolution: {integrity: sha512-YW5wOprO2LzMjoWZ5ZG6jfbY9JnkDxuHDwvnrThnuYtByorova/I0HNXJedrUfwuXFQfYOjcqDA4PU3qlZGZjg==}
     engines: {node: '>=6.9.0'}
     hasBin: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       commander: 4.1.1
       convert-source-map: 1.8.0
       fs-readdir-recursive: 1.1.0
@@ -1406,6 +1451,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helper-create-class-features-plugin/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-annotate-as-pure': 7.15.4
+      '@babel/helper-function-name': 7.15.4
+      '@babel/helper-member-expression-to-functions': 7.15.4
+      '@babel/helper-optimise-call-expression': 7.15.4
+      '@babel/helper-replace-supers': 7.15.4
+      '@babel/helper-split-export-declaration': 7.15.4
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/helper-create-regexp-features-plugin/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-TLawwqpOErY2HhWbGJ2nZT5wSkR192QpN+nBg1THfBfftrlvOh+WbhrxXCH4q4xJ9Gl16BGPR/48JA+Ryiho/A==}
     engines: {node: '>=6.9.0'}
@@ -1413,6 +1474,16 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-annotate-as-pure': 7.15.4
+      regexpu-core: 4.8.0
+
+  /@babel/helper-create-regexp-features-plugin/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-TLawwqpOErY2HhWbGJ2nZT5wSkR192QpN+nBg1THfBfftrlvOh+WbhrxXCH4q4xJ9Gl16BGPR/48JA+Ryiho/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-annotate-as-pure': 7.15.4
       regexpu-core: 4.8.0
 
@@ -1441,6 +1512,23 @@ packages:
     dependencies:
       '@babel/core': 7.15.0
       '@babel/helper-compilation-targets': 7.15.4_@babel+core@7.15.0
+      '@babel/helper-module-imports': 7.15.4
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/traverse': 7.15.4
+      debug: 4.3.2
+      lodash.debounce: 4.0.8
+      resolve: 1.20.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/helper-define-polyfill-provider/0.2.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==}
+    peerDependencies:
+      '@babel/core': ^7.4.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-compilation-targets': 7.15.4_@babel+core@7.15.5
       '@babel/helper-module-imports': 7.15.4
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/traverse': 7.15.4
@@ -1616,6 +1704,17 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.15.4
       '@babel/plugin-proposal-optional-chaining': 7.14.5_@babel+core@7.15.0
 
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-eBnpsl9tlhPhpI10kU06JHnrYXwg3+V6CaP2idsCXNef0aeslpqyITXQ74Vfk5uHgY7IG7XP0yIH8b42KSzHog==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.13.0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.15.4
+      '@babel/plugin-proposal-optional-chaining': 7.14.5_@babel+core@7.15.5
+
   /@babel/plugin-proposal-async-generator-functions/7.15.4_@babel+core@7.15.0:
     resolution: {integrity: sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==}
     engines: {node: '>=6.9.0'}
@@ -1626,6 +1725,19 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-remap-async-to-generator': 7.15.4
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.15.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/plugin-proposal-async-generator-functions/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-remap-async-to-generator': 7.15.4
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.15.5
     transitivePeerDependencies:
       - supports-color
 
@@ -1641,6 +1753,18 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-proposal-class-properties/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-create-class-features-plugin': 7.15.4_@babel+core@7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/plugin-proposal-class-static-block/7.15.4_@babel+core@7.15.0:
     resolution: {integrity: sha512-M682XWrrLNk3chXCjoPUQWOyYsB93B9z3mRyjtqqYJWDf2mfCdIYgDrA11cgNVhAQieaq6F2fn2f3wI0U4aTjA==}
     engines: {node: '>=6.9.0'}
@@ -1651,6 +1775,19 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.15.4_@babel+core@7.15.0
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.15.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/plugin-proposal-class-static-block/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-M682XWrrLNk3chXCjoPUQWOyYsB93B9z3mRyjtqqYJWDf2mfCdIYgDrA11cgNVhAQieaq6F2fn2f3wI0U4aTjA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-create-class-features-plugin': 7.15.4_@babel+core@7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.15.5
     transitivePeerDependencies:
       - supports-color
 
@@ -1678,6 +1815,16 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.15.0
 
+  /@babel/plugin-proposal-dynamic-import/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-ExjiNYc3HDN5PXJx+bwC50GIx/KKanX2HiggnIUAYedbARdImiCU4RhhHfdf0Kd7JNXGpsBBBCOm+bBVy3Gb0g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.15.5
+
   /@babel/plugin-proposal-export-default-from/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-T8KZ5abXvKMjF6JcoXjgac3ElmXf0AWzJwi2O/42Jk+HmCky3D9+i1B7NPP1FblyceqTevKeV/9szeikFoaMDg==}
     engines: {node: '>=6.9.0'}
@@ -1699,6 +1846,16 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.15.0
 
+  /@babel/plugin-proposal-export-namespace-from/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-g5POA32bXPMmSBu5Dx/iZGLGnKmKPc5AiY7qfZgurzrCYgIztDlHFbznSNCoQuv57YQLnQfaDi7dxCtLDIdXdA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.15.5
+
   /@babel/plugin-proposal-json-strings/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-NSq2fczJYKVRIsUJyNxrVUMhB27zb7N7pOFGQOhBKJrChbGcgEAqyZrmZswkPk18VMurEeJAaICbfm57vUeTbQ==}
     engines: {node: '>=6.9.0'}
@@ -1708,6 +1865,16 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.15.0
+
+  /@babel/plugin-proposal-json-strings/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-NSq2fczJYKVRIsUJyNxrVUMhB27zb7N7pOFGQOhBKJrChbGcgEAqyZrmZswkPk18VMurEeJAaICbfm57vUeTbQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.15.5
 
   /@babel/plugin-proposal-logical-assignment-operators/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-YGn2AvZAo9TwyhlLvCCWxD90Xq8xJ4aSgaX3G5D/8DW94L8aaT+dS5cSP+Z06+rCJERGSr9GxMBZ601xoc2taw==}
@@ -1719,6 +1886,16 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.15.0
 
+  /@babel/plugin-proposal-logical-assignment-operators/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-YGn2AvZAo9TwyhlLvCCWxD90Xq8xJ4aSgaX3G5D/8DW94L8aaT+dS5cSP+Z06+rCJERGSr9GxMBZ601xoc2taw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.15.5
+
   /@babel/plugin-proposal-nullish-coalescing-operator/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==}
     engines: {node: '>=6.9.0'}
@@ -1729,6 +1906,16 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.15.0
 
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.15.5
+
   /@babel/plugin-proposal-numeric-separator/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-yiclALKe0vyZRZE0pS6RXgjUOt87GWv6FYa5zqj15PvhOGFO69R5DusPlgK/1K5dVnCtegTiWu9UaBSrLLJJBg==}
     engines: {node: '>=6.9.0'}
@@ -1738,6 +1925,16 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.15.0
+
+  /@babel/plugin-proposal-numeric-separator/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-yiclALKe0vyZRZE0pS6RXgjUOt87GWv6FYa5zqj15PvhOGFO69R5DusPlgK/1K5dVnCtegTiWu9UaBSrLLJJBg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.15.5
 
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.9:
     resolution: {integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==}
@@ -1763,6 +1960,19 @@ packages:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.15.0
       '@babel/plugin-transform-parameters': 7.15.4_@babel+core@7.15.0
 
+  /@babel/plugin-proposal-object-rest-spread/7.15.6_@babel+core@7.15.5:
+    resolution: {integrity: sha512-qtOHo7A1Vt+O23qEAX+GdBpqaIuD3i9VRrWgCJeq7WO6H2d14EK3q11urj5Te2MAeK97nMiIdRpwd/ST4JFbNg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.15.0
+      '@babel/core': 7.15.5
+      '@babel/helper-compilation-targets': 7.15.4_@babel+core@7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-transform-parameters': 7.15.4_@babel+core@7.15.5
+
   /@babel/plugin-proposal-optional-catch-binding/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-3Oyiixm0ur7bzO5ybNcZFlmVsygSIQgdOa7cTfOYCMY+wEPAYhZAJxi3mixKFCTCKUhQXuCTtQ1MzrpL3WT8ZQ==}
     engines: {node: '>=6.9.0'}
@@ -1772,6 +1982,16 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.15.0
+
+  /@babel/plugin-proposal-optional-catch-binding/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-3Oyiixm0ur7bzO5ybNcZFlmVsygSIQgdOa7cTfOYCMY+wEPAYhZAJxi3mixKFCTCKUhQXuCTtQ1MzrpL3WT8ZQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.15.5
 
   /@babel/plugin-proposal-optional-chaining/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==}
@@ -1784,6 +2004,17 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.15.4
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.15.0
 
+  /@babel/plugin-proposal-optional-chaining/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.15.4
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.15.5
+
   /@babel/plugin-proposal-private-methods/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-838DkdUA1u+QTCplatfq4B7+1lnDa/+QMI89x5WZHBcnNv+47N8QEj2k9I2MUU9xIv8XJ4XvPCviM/Dj7Uwt9g==}
     engines: {node: '>=6.9.0'}
@@ -1792,6 +2023,18 @@ packages:
     dependencies:
       '@babel/core': 7.15.0
       '@babel/helper-create-class-features-plugin': 7.15.4_@babel+core@7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/plugin-proposal-private-methods/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-838DkdUA1u+QTCplatfq4B7+1lnDa/+QMI89x5WZHBcnNv+47N8QEj2k9I2MUU9xIv8XJ4XvPCviM/Dj7Uwt9g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-create-class-features-plugin': 7.15.4_@babel+core@7.15.5
       '@babel/helper-plugin-utils': 7.14.5
     transitivePeerDependencies:
       - supports-color
@@ -1810,6 +2053,20 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-proposal-private-property-in-object/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-X0UTixkLf0PCCffxgu5/1RQyGGbgZuKoI+vXP4iSbJSYwPb7hu06omsFGBvQ9lJEvwgrxHdS8B5nbfcd8GyUNA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-annotate-as-pure': 7.15.4
+      '@babel/helper-create-class-features-plugin': 7.15.4_@babel+core@7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.15.5
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/plugin-proposal-unicode-property-regex/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-6axIeOU5LnY471KenAB9vI8I5j7NQ2d652hIYwVyRfgaZT5UpiqFKCuVXCDMSrU+3VFafnu2c5m3lrWIlr6A5Q==}
     engines: {node: '>=4'}
@@ -1820,6 +2077,16 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.14.5_@babel+core@7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-proposal-unicode-property-regex/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-6axIeOU5LnY471KenAB9vI8I5j7NQ2d652hIYwVyRfgaZT5UpiqFKCuVXCDMSrU+3VFafnu2c5m3lrWIlr6A5Q==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-create-regexp-features-plugin': 7.14.5_@babel+core@7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.15.0:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
@@ -1828,12 +2095,29 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+    dev: true
+
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.15.0:
@@ -1844,6 +2128,14 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.15.5:
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
@@ -1851,6 +2143,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-decorators/7.14.5_@babel+core@7.15.0:
@@ -1871,6 +2172,14 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-export-default-from/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-snWDxjuaPEobRBnhpqEfZ8RMxDbHt8+87fiEioGuE+Uc0xAKgSD8QiuL3lF93hPVQfZFAcYwrrf+H5qUhike3Q==}
     engines: {node: '>=6.9.0'}
@@ -1887,6 +2196,14 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-flow/7.14.5_@babel+core@7.15.0:
@@ -1906,6 +2223,15 @@ packages:
     dependencies:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
+    dev: true
+
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
@@ -1913,6 +2239,14 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.9:
@@ -1942,12 +2276,29 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-syntax-jsx/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.15.0:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.15.0:
@@ -1958,12 +2309,28 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.15.0:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.9:
@@ -1983,6 +2350,14 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
@@ -1991,12 +2366,28 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.15.0:
@@ -2008,6 +2399,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
@@ -2015,6 +2415,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-typescript/7.14.5_@babel+core@7.15.0:
@@ -2025,6 +2434,16 @@ packages:
     dependencies:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
+    dev: true
+
+  /@babel/plugin-syntax-typescript/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-arrow-functions/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==}
@@ -2033,6 +2452,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-arrow-functions/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-async-to-generator/7.14.5_@babel+core@7.15.0:
@@ -2048,6 +2476,19 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-async-to-generator/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-szkbzQ0mNk0rpu76fzDdqSyPu0MuvpXgC+6rz5rpMb5OIRxdmHfQxrktL8CYolL2d8luMCZTR0DpIMIdL27IjA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-module-imports': 7.15.4
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-remap-async-to-generator': 7.15.4
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/plugin-transform-block-scoped-functions/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-dtqWqdWZ5NqBX3KzsVCWfQI3A53Ft5pWFCT2eCVUftWZgjc5DpDponbIF1+c+7cSGk2wN0YK7HGL/ezfRbpKBQ==}
     engines: {node: '>=6.9.0'}
@@ -2057,6 +2498,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-block-scoped-functions/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-dtqWqdWZ5NqBX3KzsVCWfQI3A53Ft5pWFCT2eCVUftWZgjc5DpDponbIF1+c+7cSGk2wN0YK7HGL/ezfRbpKBQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-block-scoping/7.15.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-nBAzfZwZb4DkaGtOes1Up1nOAp9TDRRFw4XBzBBSG9QK7KVFmYzgj9o9sbPv7TX5ofL4Auq4wZnxCoPnI/lz2Q==}
     engines: {node: '>=6.9.0'}
@@ -2064,6 +2514,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-block-scoping/7.15.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-nBAzfZwZb4DkaGtOes1Up1nOAp9TDRRFw4XBzBBSG9QK7KVFmYzgj9o9sbPv7TX5ofL4Auq4wZnxCoPnI/lz2Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-classes/7.15.4_@babel+core@7.15.0:
@@ -2083,6 +2542,23 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-classes/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-Yjvhex8GzBmmPQUvpXRPWQ9WnxXgAFuZSrqOK/eJlOGIXwvv8H3UEdUigl1gb/bnjTrln+e8bkZUYCBt/xYlBg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-annotate-as-pure': 7.15.4
+      '@babel/helper-function-name': 7.15.4
+      '@babel/helper-optimise-call-expression': 7.15.4
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-replace-supers': 7.15.4
+      '@babel/helper-split-export-declaration': 7.15.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/plugin-transform-computed-properties/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==}
     engines: {node: '>=6.9.0'}
@@ -2092,6 +2568,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-computed-properties/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-destructuring/7.14.7_@babel+core@7.15.0:
     resolution: {integrity: sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==}
     engines: {node: '>=6.9.0'}
@@ -2099,6 +2584,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-destructuring/7.14.7_@babel+core@7.15.5:
+    resolution: {integrity: sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-dotall-regex/7.14.5_@babel+core@7.15.0:
@@ -2111,6 +2605,16 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.14.5_@babel+core@7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-dotall-regex/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-loGlnBdj02MDsFaHhAIJzh7euK89lBrGIdM9EAtHFo6xKygCUGuuWe07o1oZVk287amtW1n0808sQM99aZt3gw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-create-regexp-features-plugin': 7.14.5_@babel+core@7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-duplicate-keys/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-iJjbI53huKbPDAsJ8EmVmvCKeeq21bAze4fu9GBQtSLqfvzj2oRuHVx4ZkDwEhg1htQ+5OBZh/Ab0XDf5iBZ7A==}
     engines: {node: '>=6.9.0'}
@@ -2120,6 +2624,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-duplicate-keys/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-iJjbI53huKbPDAsJ8EmVmvCKeeq21bAze4fu9GBQtSLqfvzj2oRuHVx4ZkDwEhg1htQ+5OBZh/Ab0XDf5iBZ7A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-exponentiation-operator/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-jFazJhMBc9D27o9jDnIE5ZErI0R0m7PbKXVq77FFvqFbzvTMuv8jaAwLZ5PviOLSFttqKIW0/wxNSDbjLk0tYA==}
     engines: {node: '>=6.9.0'}
@@ -2127,6 +2640,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.15.4
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-exponentiation-operator/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-jFazJhMBc9D27o9jDnIE5ZErI0R0m7PbKXVq77FFvqFbzvTMuv8jaAwLZ5PviOLSFttqKIW0/wxNSDbjLk0tYA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.15.4
       '@babel/helper-plugin-utils': 7.14.5
 
@@ -2150,6 +2673,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-for-of/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-DRTY9fA751AFBDh2oxydvVm4SYevs5ILTWLs6xKXps4Re/KG5nfUkr+TdHCrRWB8C69TlzVgA9b3RmGWmgN9LA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-function-name/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-vbO6kv0fIzZ1GpmGQuvbwwm+O4Cbm2NrPzwlup9+/3fdkuzo1YqOZcXw26+YUJB84Ja7j9yURWposEHLYwxUfQ==}
     engines: {node: '>=6.9.0'}
@@ -2157,6 +2689,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-function-name': 7.15.4
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-function-name/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-vbO6kv0fIzZ1GpmGQuvbwwm+O4Cbm2NrPzwlup9+/3fdkuzo1YqOZcXw26+YUJB84Ja7j9yURWposEHLYwxUfQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-function-name': 7.15.4
       '@babel/helper-plugin-utils': 7.14.5
 
@@ -2169,6 +2711,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-literals/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-member-expression-literals/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-WkNXxH1VXVTKarWFqmso83xl+2V3Eo28YY5utIkbsmXoItO8Q3aZxN4BTS2k0hz9dGUloHK26mJMyQEYfkn/+Q==}
     engines: {node: '>=6.9.0'}
@@ -2176,6 +2727,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-member-expression-literals/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-WkNXxH1VXVTKarWFqmso83xl+2V3Eo28YY5utIkbsmXoItO8Q3aZxN4BTS2k0hz9dGUloHK26mJMyQEYfkn/+Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-modules-amd/7.14.5_@babel+core@7.15.0:
@@ -2191,6 +2751,19 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-modules-amd/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-3lpOU8Vxmp3roC4vzFpSdEpGUWSMsHFreTWOMMLzel2gNGfHE5UWIh/LN6ghHs2xurUp4jRFYMUIZhuFbody1g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-module-transforms': 7.15.7
+      '@babel/helper-plugin-utils': 7.14.5
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/plugin-transform-modules-commonjs/7.15.4_@babel+core@7.15.0:
     resolution: {integrity: sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==}
     engines: {node: '>=6.9.0'}
@@ -2198,6 +2771,20 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-module-transforms': 7.15.7
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-simple-access': 7.15.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/plugin-transform-modules-commonjs/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-module-transforms': 7.15.7
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-simple-access': 7.15.4
@@ -2220,6 +2807,21 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-modules-systemjs/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-fJUnlQrl/mezMneR72CKCgtOoahqGJNVKpompKwzv3BrEXdlPspTcyxrZ1XmDTIr9PpULrgEQo3qNKp6dW7ssw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-hoist-variables': 7.15.4
+      '@babel/helper-module-transforms': 7.15.7
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-validator-identifier': 7.15.7
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/plugin-transform-modules-umd/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-RfPGoagSngC06LsGUYyM9QWSXZ8MysEjDJTAea1lqRjNECE3y0qIJF/qbvJxc4oA4s99HumIMdXOrd+TdKaAAA==}
     engines: {node: '>=6.9.0'}
@@ -2227,6 +2829,18 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-module-transforms': 7.15.7
+      '@babel/helper-plugin-utils': 7.14.5
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/plugin-transform-modules-umd/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-RfPGoagSngC06LsGUYyM9QWSXZ8MysEjDJTAea1lqRjNECE3y0qIJF/qbvJxc4oA4s99HumIMdXOrd+TdKaAAA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-module-transforms': 7.15.7
       '@babel/helper-plugin-utils': 7.14.5
     transitivePeerDependencies:
@@ -2241,6 +2855,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-create-regexp-features-plugin': 7.14.5_@babel+core@7.15.0
 
+  /@babel/plugin-transform-named-capturing-groups-regex/7.14.9_@babel+core@7.15.5:
+    resolution: {integrity: sha512-l666wCVYO75mlAtGFfyFwnWmIXQm3kSH0C3IRnJqWcZbWkoihyAdDhFm2ZWaxWTqvBvhVFfJjMRQ0ez4oN1yYA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-create-regexp-features-plugin': 7.14.5_@babel+core@7.15.5
+
   /@babel/plugin-transform-new-target/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-Nx054zovz6IIRWEB49RDRuXGI4Gy0GMgqG0cII9L3MxqgXz/+rgII+RU58qpo4g7tNEx1jG7rRVH4ihZoP4esQ==}
     engines: {node: '>=6.9.0'}
@@ -2250,6 +2873,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-new-target/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-Nx054zovz6IIRWEB49RDRuXGI4Gy0GMgqG0cII9L3MxqgXz/+rgII+RU58qpo4g7tNEx1jG7rRVH4ihZoP4esQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-object-super/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-MKfOBWzK0pZIrav9z/hkRqIk/2bTv9qvxHzPQc12RcVkMOzpIKnFCNYJip00ssKWYkd8Sf5g0Wr7pqJ+cmtuFg==}
     engines: {node: '>=6.9.0'}
@@ -2257,6 +2889,18 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-replace-supers': 7.15.4
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/plugin-transform-object-super/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-MKfOBWzK0pZIrav9z/hkRqIk/2bTv9qvxHzPQc12RcVkMOzpIKnFCNYJip00ssKWYkd8Sf5g0Wr7pqJ+cmtuFg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-replace-supers': 7.15.4
     transitivePeerDependencies:
@@ -2281,6 +2925,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-parameters/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-9WB/GUTO6lvJU3XQsSr6J/WKvBC2hcs4Pew8YxZagi6GkTdniyqp8On5kqdK8MN0LMeu0mGbhPN+O049NV/9FQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-property-literals/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==}
     engines: {node: '>=6.9.0'}
@@ -2288,6 +2941,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-property-literals/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-react-display-name/7.15.1_@babel+core@7.15.0:
@@ -2299,6 +2961,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-react-display-name/7.15.1_@babel+core@7.15.5:
+    resolution: {integrity: sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-react-jsx-development/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-rdwG/9jC6QybWxVe2UVOa7q6cnTpw8JRRHOxntG/h6g/guAOe6AhtQHJuJh5FwmnXIT1bdm5vC2/5huV8ZOorQ==}
     engines: {node: '>=6.9.0'}
@@ -2307,6 +2978,15 @@ packages:
     dependencies:
       '@babel/core': 7.15.0
       '@babel/plugin-transform-react-jsx': 7.14.9_@babel+core@7.15.0
+
+  /@babel/plugin-transform-react-jsx-development/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-rdwG/9jC6QybWxVe2UVOa7q6cnTpw8JRRHOxntG/h6g/guAOe6AhtQHJuJh5FwmnXIT1bdm5vC2/5huV8ZOorQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/plugin-transform-react-jsx': 7.14.9_@babel+core@7.15.5
 
   /@babel/plugin-transform-react-jsx/7.14.9_@babel+core@7.15.0:
     resolution: {integrity: sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==}
@@ -2321,6 +3001,19 @@ packages:
       '@babel/plugin-syntax-jsx': 7.14.5_@babel+core@7.15.0
       '@babel/types': 7.15.6
 
+  /@babel/plugin-transform-react-jsx/7.14.9_@babel+core@7.15.5:
+    resolution: {integrity: sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-annotate-as-pure': 7.15.4
+      '@babel/helper-module-imports': 7.15.4
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-jsx': 7.14.5_@babel+core@7.15.5
+      '@babel/types': 7.15.6
+
   /@babel/plugin-transform-react-pure-annotations/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-3X4HpBJimNxW4rhUy/SONPyNQHp5YRr0HhJdT2OH1BRp0of7u3Dkirc7x9FRJMKMqTBI079VZ1hzv7Ouuz///g==}
     engines: {node: '>=6.9.0'}
@@ -2328,6 +3021,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-annotate-as-pure': 7.15.4
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-react-pure-annotations/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-3X4HpBJimNxW4rhUy/SONPyNQHp5YRr0HhJdT2OH1BRp0of7u3Dkirc7x9FRJMKMqTBI079VZ1hzv7Ouuz///g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-annotate-as-pure': 7.15.4
       '@babel/helper-plugin-utils': 7.14.5
 
@@ -2340,6 +3043,15 @@ packages:
       '@babel/core': 7.15.0
       regenerator-transform: 0.14.5
 
+  /@babel/plugin-transform-regenerator/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-NVIY1W3ITDP5xQl50NgTKlZ0GrotKtLna08/uGY6ErQt6VEQZXla86x/CTddm5gZdcr+5GSsvMeTmWA5Ii6pkg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      regenerator-transform: 0.14.5
+
   /@babel/plugin-transform-reserved-words/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-cv4F2rv1nD4qdexOGsRQXJrOcyb5CrgjUH9PKrrtyhSDBNWGxd0UIitjyJiWagS+EbUGjG++22mGH1Pub8D6Vg==}
     engines: {node: '>=6.9.0'}
@@ -2347,6 +3059,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-reserved-words/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-cv4F2rv1nD4qdexOGsRQXJrOcyb5CrgjUH9PKrrtyhSDBNWGxd0UIitjyJiWagS+EbUGjG++22mGH1Pub8D6Vg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-runtime/7.15.0_@babel+core@7.15.0:
@@ -2365,6 +3086,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-runtime/7.15.0_@babel+core@7.15.5:
+    resolution: {integrity: sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-module-imports': 7.15.4
+      '@babel/helper-plugin-utils': 7.14.5
+      babel-plugin-polyfill-corejs2: 0.2.2_@babel+core@7.15.5
+      babel-plugin-polyfill-corejs3: 0.2.4_@babel+core@7.15.5
+      babel-plugin-polyfill-regenerator: 0.2.2_@babel+core@7.15.5
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/plugin-transform-shorthand-properties/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==}
     engines: {node: '>=6.9.0'}
@@ -2372,6 +3109,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-shorthand-properties/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-spread/7.14.6_@babel+core@7.15.0:
@@ -2384,6 +3130,16 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.15.4
 
+  /@babel/plugin-transform-spread/7.14.6_@babel+core@7.15.5:
+    resolution: {integrity: sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.15.4
+
   /@babel/plugin-transform-sticky-regex/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-Z7F7GyvEMzIIbwnziAZmnSNpdijdr4dWt+FJNBnBLz5mwDFkqIXU9wmBcWWad3QeJF5hMTkRe4dAq2sUZiG+8A==}
     engines: {node: '>=6.9.0'}
@@ -2391,6 +3147,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-sticky-regex/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-Z7F7GyvEMzIIbwnziAZmnSNpdijdr4dWt+FJNBnBLz5mwDFkqIXU9wmBcWWad3QeJF5hMTkRe4dAq2sUZiG+8A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-template-literals/7.14.5_@babel+core@7.15.0:
@@ -2402,6 +3167,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-template-literals/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-22btZeURqiepOfuy/VkFr+zStqlujWaarpMErvay7goJS6BWwdd6BY9zQyDLDa4x2S3VugxFb162IZ4m/S/+Gg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-typeof-symbol/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-lXzLD30ffCWseTbMQzrvDWqljvZlHkXU+CnseMhkMNqU1sASnCsz3tSzAaH3vCUXb9PHeUb90ZT1BdFTm1xxJw==}
     engines: {node: '>=6.9.0'}
@@ -2409,6 +3183,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-typeof-symbol/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-lXzLD30ffCWseTbMQzrvDWqljvZlHkXU+CnseMhkMNqU1sASnCsz3tSzAaH3vCUXb9PHeUb90ZT1BdFTm1xxJw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-transform-typescript/7.15.4_@babel+core@7.15.0:
@@ -2423,6 +3206,20 @@ packages:
       '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.15.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/plugin-transform-typescript/7.15.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-sM1/FEjwYjXvMwu1PJStH11kJ154zd/lpY56NQJ5qH2D0mabMv1CAy/kdvS9RP4Xgfj9fBBA3JiSLdDHgXdzOA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-create-class-features-plugin': 7.15.4_@babel+core@7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.15.5
+    transitivePeerDependencies:
+      - supports-color
 
   /@babel/plugin-transform-unicode-escapes/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-crTo4jATEOjxj7bt9lbYXcBAM3LZaUrbP2uUdxb6WIorLmjNKSpHfIybgY4B8SRpbf8tEVIWH3Vtm7ayCrKocA==}
@@ -2433,6 +3230,15 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-transform-unicode-escapes/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-crTo4jATEOjxj7bt9lbYXcBAM3LZaUrbP2uUdxb6WIorLmjNKSpHfIybgY4B8SRpbf8tEVIWH3Vtm7ayCrKocA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-transform-unicode-regex/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-UygduJpC5kHeCiRw/xDVzC+wj8VaYSoKl5JNVmbP7MadpNinAm3SvZCxZ42H37KZBKztz46YC73i9yV34d0Tzw==}
     engines: {node: '>=6.9.0'}
@@ -2441,6 +3247,16 @@ packages:
     dependencies:
       '@babel/core': 7.15.0
       '@babel/helper-create-regexp-features-plugin': 7.14.5_@babel+core@7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-transform-unicode-regex/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-UygduJpC5kHeCiRw/xDVzC+wj8VaYSoKl5JNVmbP7MadpNinAm3SvZCxZ42H37KZBKztz46YC73i9yV34d0Tzw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-create-regexp-features-plugin': 7.14.5_@babel+core@7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/preset-env/7.15.0_@babel+core@7.15.0:
@@ -2610,6 +3426,89 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/preset-env/7.15.6_@babel+core@7.15.5:
+    resolution: {integrity: sha512-L+6jcGn7EWu7zqaO2uoTDjjMBW+88FXzV8KvrBl2z6MtRNxlsmUNRlZPaNNPUTgqhyC5DHNFk/2Jmra+ublZWw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.15.0
+      '@babel/core': 7.15.5
+      '@babel/helper-compilation-targets': 7.15.4_@babel+core@7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-validator-option': 7.14.5
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.15.4_@babel+core@7.15.5
+      '@babel/plugin-proposal-async-generator-functions': 7.15.4_@babel+core@7.15.5
+      '@babel/plugin-proposal-class-properties': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-class-static-block': 7.15.4_@babel+core@7.15.5
+      '@babel/plugin-proposal-dynamic-import': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-export-namespace-from': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-json-strings': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-logical-assignment-operators': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-numeric-separator': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-object-rest-spread': 7.15.6_@babel+core@7.15.5
+      '@babel/plugin-proposal-optional-catch-binding': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-optional-chaining': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-private-methods': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-proposal-private-property-in-object': 7.15.4_@babel+core@7.15.5
+      '@babel/plugin-proposal-unicode-property-regex': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.15.5
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-arrow-functions': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-async-to-generator': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-block-scoped-functions': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-block-scoping': 7.15.3_@babel+core@7.15.5
+      '@babel/plugin-transform-classes': 7.15.4_@babel+core@7.15.5
+      '@babel/plugin-transform-computed-properties': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-destructuring': 7.14.7_@babel+core@7.15.5
+      '@babel/plugin-transform-dotall-regex': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-duplicate-keys': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-exponentiation-operator': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-for-of': 7.15.4_@babel+core@7.15.5
+      '@babel/plugin-transform-function-name': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-literals': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-member-expression-literals': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-modules-amd': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-modules-commonjs': 7.15.4_@babel+core@7.15.5
+      '@babel/plugin-transform-modules-systemjs': 7.15.4_@babel+core@7.15.5
+      '@babel/plugin-transform-modules-umd': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.14.9_@babel+core@7.15.5
+      '@babel/plugin-transform-new-target': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-object-super': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-parameters': 7.15.4_@babel+core@7.15.5
+      '@babel/plugin-transform-property-literals': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-regenerator': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-reserved-words': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-shorthand-properties': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-spread': 7.14.6_@babel+core@7.15.5
+      '@babel/plugin-transform-sticky-regex': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-template-literals': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-typeof-symbol': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-unicode-escapes': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-unicode-regex': 7.14.5_@babel+core@7.15.5
+      '@babel/preset-modules': 0.1.4_@babel+core@7.15.5
+      '@babel/types': 7.15.6
+      babel-plugin-polyfill-corejs2: 0.2.2_@babel+core@7.15.5
+      babel-plugin-polyfill-corejs3: 0.2.4_@babel+core@7.15.5
+      babel-plugin-polyfill-regenerator: 0.2.2_@babel+core@7.15.5
+      core-js-compat: 3.18.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/preset-flow/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==}
     engines: {node: '>=6.9.0'}
@@ -2634,6 +3533,18 @@ packages:
       '@babel/types': 7.15.6
       esutils: 2.0.3
 
+  /@babel/preset-modules/0.1.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-proposal-unicode-property-regex': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-dotall-regex': 7.14.5_@babel+core@7.15.5
+      '@babel/types': 7.15.6
+      esutils: 2.0.3
+
   /@babel/preset-react/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-XFxBkjyObLvBaAvkx1Ie95Iaq4S/GUEIrejyrntQ/VCMKUYvKLoyKxOBzJ2kjA3b6rC9/KL6KXfDC2GqvLiNqQ==}
     engines: {node: '>=6.9.0'}
@@ -2648,6 +3559,20 @@ packages:
       '@babel/plugin-transform-react-jsx-development': 7.14.5_@babel+core@7.15.0
       '@babel/plugin-transform-react-pure-annotations': 7.14.5_@babel+core@7.15.0
 
+  /@babel/preset-react/7.14.5_@babel+core@7.15.5:
+    resolution: {integrity: sha512-XFxBkjyObLvBaAvkx1Ie95Iaq4S/GUEIrejyrntQ/VCMKUYvKLoyKxOBzJ2kjA3b6rC9/KL6KXfDC2GqvLiNqQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-validator-option': 7.14.5
+      '@babel/plugin-transform-react-display-name': 7.15.1_@babel+core@7.15.5
+      '@babel/plugin-transform-react-jsx': 7.14.9_@babel+core@7.15.5
+      '@babel/plugin-transform-react-jsx-development': 7.14.5_@babel+core@7.15.5
+      '@babel/plugin-transform-react-pure-annotations': 7.14.5_@babel+core@7.15.5
+
   /@babel/preset-typescript/7.15.0_@babel+core@7.15.0:
     resolution: {integrity: sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==}
     engines: {node: '>=6.9.0'}
@@ -2658,6 +3583,20 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-validator-option': 7.14.5
       '@babel/plugin-transform-typescript': 7.15.4_@babel+core@7.15.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/preset-typescript/7.15.0_@babel+core@7.15.5:
+    resolution: {integrity: sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-validator-option': 7.14.5
+      '@babel/plugin-transform-typescript': 7.15.4_@babel+core@7.15.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3465,7 +4404,7 @@ packages:
     resolution: {integrity: sha512-xmB5vh81KK8DiiCMtI5vI59mP+GggNmc9BiN+fg4mKdQHV369+WuZc1Lq2xWFCOCsRPHt24D9h7Idp4YaMB1Ww==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       '@jest/types': 27.1.1
       babel-plugin-istanbul: 6.0.0
       chalk: 4.1.2
@@ -5805,6 +6744,15 @@ packages:
       '@babel/core': ^7.12.9
     dependencies:
       '@babel/core': 7.15.0
+    dev: true
+
+  /@wordpress/babel-plugin-import-jsx-pragma/3.1.0_@babel+core@7.15.5:
+    resolution: {integrity: sha512-518mL3goaSeXtJCQcPK9OYHUUiA0sjXuoGWHBwRalkyTIQZZy5ZZzlwrlSc9ESZcOw9BZ+Uo8CJRjV2OWnx+Zw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@babel/core': ^7.12.9
+    dependencies:
+      '@babel/core': 7.15.5
 
   /@wordpress/babel-preset-default/6.3.2:
     resolution: {integrity: sha512-RKKO5rhUlEtYYd2kHRkuSY97irq+MTxPYy/IJzM5D8Z17irasNRWs1GwOlbelewHUXA9BIHkX465R5ec7D7OHw==}
@@ -8148,18 +9096,18 @@ packages:
       - supports-color
     dev: true
 
-  /babel-jest/27.2.1_@babel+core@7.15.0:
+  /babel-jest/27.2.1_@babel+core@7.15.5:
     resolution: {integrity: sha512-kkaekSJHew1zfDW3cA2QiSBPg4uiLpiW0OwJKqFv0r2/mFgym/IBn7hxPntL6FvS66G/ROh+lz4pRiCJAH1/UQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       '@jest/transform': 27.2.1
       '@jest/types': 27.1.1
       '@types/babel__core': 7.1.16
       babel-plugin-istanbul: 6.0.0
-      babel-preset-jest: 27.2.0_@babel+core@7.15.0
+      babel-preset-jest: 27.2.0_@babel+core@7.15.5
       chalk: 4.1.2
       graceful-fs: 4.2.8
       slash: 3.0.0
@@ -8174,6 +9122,21 @@ packages:
       webpack: '>=2'
     dependencies:
       '@babel/core': 7.15.0
+      find-cache-dir: 3.3.2
+      loader-utils: 1.4.0
+      make-dir: 3.1.0
+      schema-utils: 2.7.1
+      webpack: 5.51.1
+    dev: true
+
+  /babel-loader/8.2.2_80927b313c74087b681f254ee0e3e2fc:
+    resolution: {integrity: sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==}
+    engines: {node: '>= 8.9'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    dependencies:
+      '@babel/core': 7.15.5
       find-cache-dir: 3.3.2
       loader-utils: 1.4.0
       make-dir: 3.1.0
@@ -8365,6 +9328,18 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /babel-plugin-polyfill-corejs2/0.2.2_@babel+core@7.15.5:
+    resolution: {integrity: sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.15.0
+      '@babel/core': 7.15.5
+      '@babel/helper-define-polyfill-provider': 0.2.3_@babel+core@7.15.5
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   /babel-plugin-polyfill-corejs3/0.1.7_@babel+core@7.15.0:
     resolution: {integrity: sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==}
     peerDependencies:
@@ -8388,6 +9363,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /babel-plugin-polyfill-corejs3/0.2.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-define-polyfill-provider': 0.2.3_@babel+core@7.15.5
+      core-js-compat: 3.18.0
+    transitivePeerDependencies:
+      - supports-color
+
   /babel-plugin-polyfill-regenerator/0.2.2_@babel+core@7.15.0:
     resolution: {integrity: sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==}
     peerDependencies:
@@ -8395,6 +9381,16 @@ packages:
     dependencies:
       '@babel/core': 7.15.0
       '@babel/helper-define-polyfill-provider': 0.2.3_@babel+core@7.15.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /babel-plugin-polyfill-regenerator/0.2.2_@babel+core@7.15.5:
+    resolution: {integrity: sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-define-polyfill-provider': 0.2.3_@babel+core@7.15.5
     transitivePeerDependencies:
       - supports-color
 
@@ -8477,6 +9473,26 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.15.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.15.0
       '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.15.0
+    dev: true
+
+  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.15.5:
+    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.15.5
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.15.5
 
   /babel-preset-jest/27.2.0_@babel+core@7.15.0:
     resolution: {integrity: sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==}
@@ -8487,6 +9503,17 @@ packages:
       '@babel/core': 7.15.0
       babel-plugin-jest-hoist: 27.2.0
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.15.0
+    dev: true
+
+  /babel-preset-jest/27.2.0_@babel+core@7.15.5:
+    resolution: {integrity: sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.15.5
+      babel-plugin-jest-hoist: 27.2.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.15.5
 
   /babel-preset-minify/0.3.0:
     resolution: {integrity: sha512-+VV2GWEyak3eDOmzT1DDMuqHrw3VbE9nBNkx2LLVs4pH/Me32ND8DRpVDd8IRvk1xX5p75nygyRPtkMh6GIAbQ==}
@@ -14266,10 +15293,10 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       '@jest/test-sequencer': 27.2.1
       '@jest/types': 27.1.1
-      babel-jest: 27.2.1_@babel+core@7.15.0
+      babel-jest: 27.2.1_@babel+core@7.15.5
       chalk: 4.1.2
       deepmerge: 4.2.2
       glob: 7.1.7
@@ -14770,17 +15797,17 @@ packages:
     resolution: {integrity: sha512-8CTg2YrgZuQbPHW7G0YvLTj4yTRXLmSeEO+ka3eC5lbu5dsTRyoDNS1L7x7EFUTyYQhFH9HQG1/TNlbUgR9Lug==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       '@babel/generator': 7.15.4
       '@babel/parser': 7.15.7
-      '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.15.0
+      '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.15.5
       '@babel/traverse': 7.15.4
       '@babel/types': 7.15.6
       '@jest/transform': 27.2.1
       '@jest/types': 27.1.1
       '@types/babel__traverse': 7.14.2
       '@types/prettier': 2.3.2
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.15.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.15.5
       chalk: 4.1.2
       expect: 27.2.1
       graceful-fs: 4.2.8
@@ -14814,7 +15841,7 @@ packages:
     dependencies:
       '@jest/types': 27.1.1
       '@types/node': 16.9.4
-      chalk: 4.1.1
+      chalk: 4.1.2
       graceful-fs: 4.2.8
       is-ci: 3.0.0
       picomatch: 2.3.0
@@ -19750,7 +20777,7 @@ packages:
       webpack: 5.51.1
     dev: true
 
-  /sass-loader/11.1.1_sass@1.38.1+webpack@5.51.1:
+  /sass-loader/11.1.1_sass@1.39.0+webpack@5.51.1:
     resolution: {integrity: sha512-fOCp/zLmj1V1WHDZbUbPgrZhA7HKXHEqkslzB+05U5K9SbSbcmH91C7QLW31AsXikxUMaxXRhhcqWZAxUMLDyA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -19768,7 +20795,7 @@ packages:
     dependencies:
       klona: 2.0.4
       neo-async: 2.6.2
-      sass: 1.38.1
+      sass: 1.39.0
       webpack: 5.51.1
 
   /sass-loader/12.1.0_sass@1.39.0:
@@ -19805,7 +20832,6 @@ packages:
     hasBin: true
     dependencies:
       chokidar: 3.5.2
-    dev: true
 
   /sax/1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}

--- a/projects/packages/connection/.babelrc
+++ b/projects/packages/connection/.babelrc
@@ -1,0 +1,9 @@
+{
+	"presets": [
+		["@babel/preset-env", {
+			"targets": {
+				"node": "current"
+			}
+		}]
+	]
+}

--- a/projects/packages/connection/.gitattributes
+++ b/projects/packages/connection/.gitattributes
@@ -5,6 +5,16 @@
 docs/            export-ignore
 phpunit.xml.dist export-ignore
 tests/           export-ignore
+ackage.json      export-ignore
+webpack.config.js export-ignore
+gulpfile.babel.js export-ignore
+.babelrc          export-ignore
 
 # Files not needed in the production build.
-/changelog/**    production-exclude
+.gitignore        production-exclude
+_inc/**           production-exclude
+changelog/**      production-exclude
+
+
+# Files to include in the mirror repo
+/build/**           production-include

--- a/projects/packages/connection/.gitignore
+++ b/projects/packages/connection/.gitignore
@@ -1,1 +1,4 @@
 wordpress
+/build
+/node_modules
+/.cache

--- a/projects/packages/connection/changelog/update-move_idc_to_connection
+++ b/projects/packages/connection/changelog/update-move_idc_to_connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Move the IDC files from the identity-crisis package to the connection package to resolve a circular dependency

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -27,6 +27,14 @@
 		]
 	},
 	"scripts": {
+		"build-development": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run build"
+		],
+		"build-production": [
+			"Composer\\Config::disableProcessTimeout",
+			"NODE_ENV='production' pnpm run build"
+		],
 		"phpunit": [
 			"./vendor/phpunit/phpunit/phpunit --colors=always"
 		],

--- a/projects/packages/connection/gulpfile.babel.js
+++ b/projects/packages/connection/gulpfile.babel.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import gulp from 'gulp';
+import webpack from 'webpack';
+import log from 'fancy-log';
+import gulpSass from 'gulp-sass';
+import dartSass from 'sass';
+import prepend from 'gulp-append-prepend';
+import autoprefixer from 'gulp-autoprefixer';
+import sourcemaps from 'gulp-sourcemaps';
+import rename from 'gulp-rename';
+import cleanCSS from 'gulp-clean-css';
+import rtlcss from 'gulp-rtlcss';
+
+const sass = gulpSass( dartSass );
+
+/**
+ * Get the Webpack config.
+ *
+ * @returns {Array} - The Webpack config.
+ */
+function getWebpackConfig() {
+	return require( './webpack.config.js' );
+}
+
+gulp.task( 'scss', function () {
+	return (
+		gulp
+			.src( './src/idc/scss/*.scss', { base: './src/idc/scss/' } )
+			.pipe( sass( { outputStyle: 'expanded' } ) )
+			.pipe(
+				prepend.prependText(
+					'/*!\n' + '* Do not modify this file directly.  It is compiled SASS code.\n' + '*/\n'
+				)
+			)
+			.pipe( autoprefixer() )
+			// Build *.css
+			.pipe( sourcemaps.init() )
+			.pipe( sourcemaps.write() )
+			.pipe( gulp.dest( './build/css' ) )
+			// Build *.min.css
+			.pipe( cleanCSS() )
+			.pipe( rename( { suffix: '.min' } ) )
+			.pipe( gulp.dest( './build/css' ) )
+			// Finished
+			.on( 'end', function () {
+				log( 'SCSS now compiled' );
+			} )
+	);
+} );
+
+gulp.task(
+	'scss:rtl',
+	gulp.series( 'scss', function () {
+		return (
+			gulp
+				.src( './src/idc/scss/*.scss', { base: './src/idc/scss/' } )
+				.pipe( sass( { outputStyle: 'expanded' } ) )
+				.pipe(
+					prepend.prependText(
+						'/*!\n' +
+							'* Do not modify this file directly.  It is automatically generated.\n' +
+							'*/\n'
+					)
+				)
+				.pipe( autoprefixer() )
+				// Build *-rtl.css
+				.pipe( rtlcss() )
+				.pipe( rename( { suffix: '-rtl' } ) )
+				.pipe( gulp.dest( './build/css' ) )
+				// Build *-rtl.min.css
+				.pipe( cleanCSS() )
+				.pipe( rename( { suffix: '.min' } ) )
+				.pipe( gulp.dest( './build/css' ) )
+				// Finished
+				.on( 'end', function () {
+					log( 'SCSS now available in RTL.' );
+				} )
+		);
+	} )
+);
+
+gulp.task( 'scss:watch', function () {
+	return gulp.watch( './src/idc/scss/**/*.scss', gulp.parallel( 'scss:rtl' ) );
+} );
+
+gulp.task(
+	'build',
+	gulp.series( 'scss:rtl', done => webpack( getWebpackConfig() ).run( done ) )
+); //function ( done ) {
+//webpack( getWebpackConfig() ).run( done );
+/*gulp.series( 'scss:rtl' );
+	done();
+} );*/
+
+gulp.task( 'watch', function () {
+	gulp.parallel( () => {
+		return webpack( getWebpackConfig() ).watch( { aggregateTimeout: 100 }, error => {
+			if ( error ) {
+				log( error );
+			}
+		} );
+	}, 'scss:watch' );
+} );
+
+gulp.task( 'default', gulp.series( 'build' ) );

--- a/projects/packages/connection/package.json
+++ b/projects/packages/connection/package.json
@@ -1,0 +1,45 @@
+{
+	"name": "jetpack-identity-crisis",
+	"version": "0.2.6-alpha",
+	"description": "Jetpack Identity Crisis",
+	"main": "_inc/admin.jsx",
+	"repository": "https://github.com/Automattic/jetpack-identity-crisis",
+	"author": "Automattic",
+	"license": "GPL-2.0-or-later",
+	"scripts": {
+		"build": "pnpm run install-if-deps-outdated && pnpm clean && pnpm build-client",
+		"build-client": "gulp",
+		"clean": "rm -rf build/",
+		"install-if-deps-outdated": "pnpm install --no-prod --frozen-lockfile",
+		"watch": "pnpm run build && pnpx gulp watch"
+	},
+	"dependencies": {
+		"@automattic/calypso-build": "9.0.0",
+		"@babel/core": "7.15.0",
+		"@babel/helper-module-imports": "7.14.5",
+		"@babel/preset-env": "7.15.0",
+		"@babel/register": "7.15.3",
+		"@wordpress/data": "6.1.0",
+		"fancy-log": "1.3.3",
+		"gulp": "4.0.2",
+		"static-site-generator-webpack-plugin": "3.4.2",
+		"webpack": "5.51.1"
+	},
+	"devDependencies": {
+		"@wordpress/dependency-extraction-webpack-plugin": "3.2.1",
+		"babel-minify-webpack-plugin": "0.3.1",
+		"gulp-append-prepend": "1.0.9",
+		"gulp-autoprefixer": "7.0.1",
+		"gulp-clean-css": "4.3.0",
+		"gulp-rename": "2.0.0",
+		"gulp-rtlcss": "1.4.1",
+		"gulp-sass": "5.0.0",
+		"gulp-sourcemaps": "3.0.0",
+		"sass": "1.38.1"
+	},
+	"engines": {
+		"node": "^14.17.6 || ^16.7.0",
+		"pnpm": "^6.5.0",
+		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	}
+}

--- a/projects/packages/connection/src/idc/_inc/admin.css
+++ b/projects/packages/connection/src/idc/_inc/admin.css
@@ -1,0 +1,4409 @@
+.jp-iframe-wrap {
+  text-align: center; }
+
+.fade-in {
+  animation: fadeIn ease 1.5s;
+  -webkit-animation: fadeIn ease 1.5s;
+  -moz-animation: fadeIn ease 1.5s;
+  -o-animation: fadeIn ease 1.5s;
+  -ms-animation: fadeIn ease 1.5s; }
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
+
+.dops-button {
+  background: #f6f7f7;
+  border-color: #2271b1;
+  border-style: solid;
+  border-width: 1px;
+  color: #2271b1;
+  cursor: pointer;
+  display: inline-block;
+  margin: 0;
+  outline: 0;
+  overflow: hidden;
+  font-size: 0.875rem;
+  text-overflow: ellipsis;
+  text-decoration: none;
+  vertical-align: top;
+  box-sizing: border-box;
+  border-radius: 3px;
+  padding: 7px 14px 9px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+       appearance: none; }
+  .dops-button:hover {
+    background: #f0f0f1;
+    border-color: #0a4b78;
+    color: #0a4b78; }
+  .dops-button[disabled], .dops-button:disabled {
+    color: #eeeeee;
+    background: white;
+    border-color: #eeeeee;
+    cursor: default; }
+  .dops-button:focus {
+    background: white;
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1; }
+  .dops-button.is-compact {
+    padding: 0 10px;
+    line-height: 2; }
+    .dops-button.is-compact:disabled {
+      color: #eeeeee; }
+    .dops-button.is-compact .gridicon {
+      top: 4px;
+      margin-top: -8px; }
+    .dops-button.is-compact .gridicons-plus-small {
+      margin-left: -4px; }
+    .dops-button.is-compact .gridicons-plus-small:last-of-type {
+      margin-left: 0; }
+    .dops-button.is-compact .gridicons-plus-small + .gridicon {
+      margin-left: -4px; }
+  .dops-button.hidden {
+    display: none; }
+  .dops-button .gridicon {
+    position: relative;
+    top: 4px;
+    margin-top: -2px;
+    width: 18px;
+    height: 18px; }
+
+.dops-button.is-primary {
+  background: #3582c4;
+  border-color: #3582c4;
+  color: white; }
+  .dops-button.is-primary:hover, .dops-button.is-primary:focus {
+    border-color: #2271b1;
+    background: #2271b1;
+    color: white; }
+  .dops-button.is-primary:focus {
+    box-shadow: 0 0 0 1px white, 0 0 0 3px #2271b1; }
+  .dops-button.is-primary[disabled], .dops-button.is-primary:disabled {
+    color: #66c6e4 !important;
+    background-color: #008ec2 !important;
+    border-color: #008ec2 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    cursor: default; }
+  .dops-button.is-primary.is-compact {
+    color: white;
+    white-space: nowrap; }
+
+.dops-button.is-scary {
+  color: #d94f4f; }
+  .dops-button.is-scary:hover, .dops-button.is-scary:focus {
+    border-color: #d94f4f; }
+  .dops-button.is-scary:focus {
+    box-shadow: 0 0 0 2px #eba3a3; }
+  .dops-button.is-scary[disabled], .dops-button.is-scary:disabled {
+    color: #f4cdcd;
+    border-color: #eeeeee; }
+
+.dops-button.is-primary.is-scary {
+  background: #d94f4f;
+  border-color: #a02222;
+  color: white; }
+  .dops-button.is-primary.is-scary:hover, .dops-button.is-primary.is-scary:focus {
+    border-color: #4c1010; }
+  .dops-button.is-primary.is-scary[disabled], .dops-button.is-primary.is-scary:disabled {
+    background: #eba3a3;
+    border-color: #e48484; }
+
+.dops-button.is-borderless {
+  border: none;
+  color: #888888;
+  padding-left: 0;
+  padding-right: 0; }
+  .dops-button.is-borderless:hover {
+    color: #414141; }
+  .dops-button.is-borderless:focus {
+    box-shadow: none; }
+  .dops-accessible-focus .dops-button.is-borderless:focus {
+    outline: thin dotted; }
+  .dops-button.is-borderless .gridicon {
+    width: 24px;
+    height: 24px;
+    top: 6px; }
+  .dops-button.is-borderless[disabled], .dops-button.is-borderless:disabled {
+    color: #eeeeee;
+    background: white;
+    cursor: default; }
+    .dops-button.is-borderless[disabled]:active, .dops-button.is-borderless:disabled:active {
+      border-width: 0; }
+  .dops-button.is-borderless.is-scary {
+    color: #d94f4f; }
+    .dops-button.is-borderless.is-scary:hover, .dops-button.is-borderless.is-scary:focus {
+      color: #a02222; }
+    .dops-button.is-borderless.is-scary[disabled] {
+      color: #f4cdcd; }
+  .dops-button.is-borderless.is-compact {
+    background: transparent;
+    border-radius: 0; }
+    .dops-button.is-borderless.is-compact .gridicon {
+      width: 18px;
+      height: 18px;
+      top: 5px; }
+
+.dops-button-group .dops-button {
+  border-left-width: 0;
+  border-radius: 0; }
+  .dops-button-group .dops-button:focus {
+    position: relative;
+    z-index: z-index("button-group-parent", ".button-group .button:focus"); }
+  .dops-button-group .dops-button.is-primary:focus {
+    box-shadow: 0 0 0 1px white, 0 0 0 3px #2271b1; }
+  .dops-button-group .dops-button.is-scary:focus {
+    box-shadow: inset 1px 0 0 #d94f4f, 0 0 0 2px #eba3a3; }
+  .dops-button-group .dops-button.is-primary.is-scary:focus {
+    box-shadow: inset 1px 0 0 #761919, 0 0 0 2px #eba3a3; }
+  .dops-button-group .dops-button.is-scary:first-child:focus {
+    box-shadow: 0 0 0 2px #eba3a3; }
+
+.dops-button-group .dops-button:first-child {
+  border-left-width: 1px;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px; }
+
+.dops-button-group .dops-button:last-child {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px; }
+
+.dops-section-header .dops-button-group .dops-button {
+  margin-right: 0; }
+
+.dops-count {
+  display: inline-block;
+  padding: 0.0625rem 0.375rem;
+  border: solid 1px #a2a2a2;
+  border-radius: 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 0.875rem;
+  color: #a2a2a2;
+  text-align: center; }
+
+/**
+ * Select Dropdown
+ */
+.dops-select-dropdown {
+  height: 43px; }
+  .dops-select-dropdown.is-compact {
+    height: 28px; }
+  .dops-select-dropdown.is-disabled .dops-select-dropdown__header {
+    background: #f6f6f6;
+    border-color: #eeeeee;
+    color: #bbbbbb;
+    -webkit-text-fill-color: #bbbbbb; }
+
+.dops-select-dropdown__container {
+  position: relative;
+  overflow: hidden;
+  display: inline-block;
+  width: auto;
+  max-width: 100%; }
+  .dops-select-dropdown.is-open .dops-select-dropdown__container {
+    z-index: 170; }
+  .dops-accessible-focus .dops-select-dropdown__container:focus,
+  .dops-accessible-focus .dops-select-dropdown.is-open .dops-select-dropdown__container {
+    z-index: 170;
+    box-shadow: 0 0 0 2px #78dcfa; }
+    .dops-accessible-focus .dops-select-dropdown__container:focus .select-dropdown__header,
+    .dops-accessible-focus .dops-select-dropdown.is-open .dops-select-dropdown__container .select-dropdown__header {
+      border-color: #0087be; }
+  .dops-accessible-focus .dops-select-dropdown__container:focus {
+    border-color: #00aadc;
+    box-shadow: 0 0 0 2px #78dcfa;
+    outline: 0;
+    border-radius: 4px; }
+
+.dops-select-dropdown__header {
+  padding: 11px 44px 11px 16px;
+  border-style: solid;
+  border-color: #d5d5d5;
+  border-width: 1px 1px 2px;
+  border-radius: 4px;
+  background-color: white;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 18px;
+  height: 18px;
+  color: #414141;
+  transition: background-color 0.2s ease;
+  cursor: pointer; }
+  .dops-select-dropdown__header::after {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    display: inline-block;
+    vertical-align: middle;
+    font: normal 16px/1 'Dashicons';
+    content: '\f347';
+    position: absolute;
+    right: 13px;
+    top: 12px;
+    display: block;
+    line-height: 18px;
+    color: rgba(162, 162, 162, 0.5); }
+    .is-compact .dops-select-dropdown__header::after {
+      right: 4px;
+      top: 4px; }
+  .is-compact .dops-select-dropdown__header {
+    padding: 7px;
+    color: #888888;
+    font-size: 11px;
+    line-height: 1;
+    text-transform: uppercase; }
+    .is-compact .dops-select-dropdown__header .dops-count {
+      border-width: 0;
+      margin-left: 0;
+      line-height: 1; }
+  .dops-select-dropdown.is-open .dops-select-dropdown__header {
+    border-radius: 4px 4px 0 0;
+    box-shadow: none;
+    background-color: #f6f6f6; }
+    .dops-select-dropdown.is-open .dops-select-dropdown__header::after {
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      display: inline-block;
+      vertical-align: middle;
+      font: normal 16px/1 'Dashicons';
+      content: '\f343'; }
+  .dops-select-dropdown__header .dops-count {
+    margin-left: 8px; }
+
+.dops-select-dropdown__header-text {
+  display: block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden; }
+
+.dops-select-dropdown__options {
+  visibility: hidden;
+  height: 0;
+  box-sizing: border-box;
+  padding: 0;
+  list-style: none;
+  margin: -2px 0 0 0;
+  background-color: white;
+  border: 1px solid #d5d5d5;
+  border-radius: 0 0 4px 4px; }
+  .dops-accessible-focus .dops-select-dropdown__options {
+    border: solid 1px #0087be;
+    border-top-color: #d5d5d5; }
+  .dops-select-dropdown.is-open .dops-select-dropdown__options {
+    visibility: visible;
+    height: auto; }
+
+.dops-select-dropdown__option:last-child .dops-select-dropdown__item {
+  border-radius: 0 0 4px 4px; }
+
+.dops-select-dropdown__item,
+.dops-select-dropdown__item-text {
+  padding: 11px 44px 11px 16px; }
+
+.dops-select-dropdown__item {
+  display: block;
+  position: relative;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+  color: #414141;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  cursor: pointer; }
+  .dops-select-dropdown__item::before {
+    content: attr(data-bold-text);
+    font-weight: 700;
+    opacity: 0; }
+  .dops-select-dropdown__item:visited {
+    color: #414141; }
+  .dops-select-dropdown__item.is-selected {
+    background-color: #3582c4;
+    color: white; }
+  .dops-select-dropdown__item.is-disabled {
+    background-color: white;
+    color: #a2a2a2;
+    cursor: default;
+    opacity: .5; }
+  .notouch .dops-select-dropdown__item:hover {
+    color: #3582c4; }
+  .notouch .dops-select-dropdown__item.is-selected:hover {
+    color: white; }
+
+.dops-select-dropdown__item-text {
+  padding-right: 16px;
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: inherit;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between; }
+  .dops-select-dropdown__item-text .dops-count {
+    color: inherit;
+    border-color: inherit; }
+
+.dops-select-dropdown__separator {
+  border-top: 1px solid #d5d5d5;
+  display: block;
+  margin: 8px 0; }
+
+.dops-select-dropdown__label {
+  display: block;
+  color: #bbbbbb;
+  margin-top: 5px;
+  line-height: 20px; }
+  .dops-select-dropdown__label label {
+    font-size: 12px;
+    text-transform: uppercase;
+    padding: 0px 16px 0px 16px; }
+
+.gridicon {
+  fill: currentColor; }
+  .gridicon.needs-offset g {
+    transform: translate(1px, 1px);
+    /* translates to .5px because it's in a child element */ }
+  .gridicon.needs-offset-x g {
+    transform: translate(1px, 0);
+    /* only nudges horizontally */ }
+  .gridicon.needs-offset-y g {
+    transform: translate(0, 1px);
+    /* only nudges vertically */ }
+
+/**
+ * @component Search
+ */
+.dops-search {
+  display: flex;
+  flex: 1 1 auto;
+  margin-bottom: 24px;
+  width: 60px;
+  height: 51px;
+  position: relative;
+  align-items: center;
+  z-index: 22;
+  transition: all 0.15s ease-in-out; }
+  .dops-search .dops-search__icon-navigation {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    background-color: white;
+    border-radius: inherit;
+    height: 100%; }
+  .dops-search .dops-search__open-icon,
+  .dops-search .dops-search__close-icon {
+    flex: 0 0 auto;
+    width: 50px;
+    z-index: 20;
+    color: #0087be;
+    cursor: pointer; }
+    .accessible-focus .dops-search .dops-search__open-icon:focus, .accessible-focus
+    .dops-search .dops-search__close-icon:focus {
+      outline: dotted 1px #0087be; }
+  .dops-search .dops-search__open-icon:hover {
+    color: #555555; }
+  .dops-search .dops-search__close-icon {
+    color: #555555;
+    opacity: 0;
+    transition: opacity .2s ease-in; }
+  .accessible-focus .dops-search.has-focus {
+    box-shadow: 0 0 0 1px #0087be, 0 0 0 4px #78dcfa; }
+
+.dops-search.is-expanded-to-container {
+  margin-bottom: 0;
+  position: absolute;
+  display: flex;
+  height: 100%;
+  width: 50px;
+  top: 0;
+  right: 0;
+  overflow: hidden; }
+  .dops-search.is-expanded-to-container .dops-search__input-fade {
+    position: relative;
+    flex: 1 1 auto;
+    display: flex; }
+  .dops-search.is-expanded-to-container .dops-search__input[type="search"] {
+    flex: 1 1 auto;
+    display: flex;
+    margin: 0;
+    box-shadow: none; }
+
+.dops-search__input[type="search"] {
+  flex: 1 1 auto;
+  display: none;
+  z-index: 10;
+  top: 0;
+  border: none;
+  border-radius: inherit;
+  height: 100%;
+  background: white;
+  -moz-appearance: none;
+       appearance: none;
+  box-sizing: border-box;
+  padding: 0px;
+  -webkit-appearance: none; }
+  .dops-search__input[type="search"]::-webkit-search-cancel-button {
+    -webkit-appearance: none; }
+  .dops-search__input[type="search"]:focus {
+    box-shadow: none;
+    border: none; }
+
+.dops-search.is-open {
+  width: 100%; }
+  .dops-search.is-open .dops-search__open-icon {
+    color: #555555; }
+  .dops-search.is-open .dops-search__close-icon {
+    display: inline-block; }
+  .dops-search.is-open .dops-search__input,
+  .dops-search.is-open .dops-search__close-icon {
+    opacity: 1; }
+  .dops-search.is-open .dops-search__input {
+    display: block; }
+  .dops-search.is-open .dops-search__input-fade {
+    flex: 1 1 auto;
+    height: 100%;
+    position: relative;
+    font-size: 16px;
+    border-radius: inherit; }
+    .dops-search.is-open .dops-search__input-fade::before {
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      pointer-events: none;
+      z-index: 12;
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), white 90%);
+      top: 0px;
+      bottom: 0px;
+      right: 0px;
+      left: auto;
+      width: 32px;
+      height: auto;
+      border-radius: inherit; }
+    .dops-search.is-open .dops-search__input-fade.ltr {
+      /*rtl:ignore*/ }
+      .dops-search.is-open .dops-search__input-fade.ltr::before {
+        content: '';
+        display: block;
+        position: absolute;
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        pointer-events: none;
+        z-index: 12;
+        background: linear-gradient(to right, rgba(255, 255, 255, 0), white 90%);
+        top: 0px;
+        bottom: 0px;
+        right: 0px;
+        left: auto;
+        width: 32px;
+        height: auto;
+        border-radius: inherit; }
+
+.dops-search__input-fade .dops-search__text-overlay {
+  color: transparent;
+  position: absolute;
+  pointer-events: none;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  overflow: hidden;
+  font: inherit;
+  width: 100%;
+  height: 100%;
+  top: 0px;
+  left: 0px;
+  z-index: 11; }
+
+.dops-search.is-searching .dops-search__open-icon {
+  display: none; }
+
+.animating.dops-search-opening .dops-search input {
+  opacity: 1; }
+
+/**
+ * Section Nav
+ */
+.dops-section-nav {
+  position: relative;
+  width: 100%;
+  padding: 0;
+  margin: 0 0 17px 0;
+  background: white;
+  box-sizing: border-box;
+  box-shadow: 0 0 0 1px #c3c4c7, 0 1px 1px 1px rgba(0, 0, 0, 0.04); }
+  .dops-section-nav.is-empty .dops-section-nav__panel {
+    visibility: hidden; }
+  @media (max-width: 480px) {
+    .dops-section-nav.is-open {
+      box-shadow: 0 0 0 1px #a2a2a2, 0 2px 4px #d5d5d5; } }
+  @media (min-width: 481px) {
+    .dops-section-nav.has-pinned-items {
+      padding-right: 60px; } }
+  @media (min-width: 481px) and (max-width: 660px) {
+    .dops-section-nav.has-pinned-items {
+      padding-right: 50px; } }
+  @media (max-width: 660px) {
+    .dops-section-nav {
+      margin-bottom: 9px; } }
+
+.dops-section-nav__mobile-header {
+  display: flex;
+  padding: 15px;
+  font-size: 14px;
+  line-height: 16px;
+  color: #414141;
+  font-weight: 600;
+  cursor: pointer; }
+  .dops-section-nav__mobile-header:after {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    display: inline-block;
+    vertical-align: middle;
+    font: normal 16px/1 'Dashicons';
+    content: '\f347';
+    line-height: 16px;
+    color: rgba(162, 162, 162, 0.5); }
+  .dops-section-nav.is-open .dops-section-nav__mobile-header:after {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    display: inline-block;
+    vertical-align: middle;
+    font: normal 16px/1 'Dashicons';
+    content: '\f343'; }
+  .dops-section-nav.has-pinned-items .dops-section-nav__mobile-header {
+    padding-right: 50px; }
+    .dops-section-nav.has-pinned-items .dops-section-nav__mobile-header:after {
+      margin-left: 8px; }
+  @media (min-width: 481px) {
+    .dops-section-nav__mobile-header {
+      display: none; } }
+
+.dops-section-nav__mobile-header-text {
+  width: 0;
+  flex: 1 0 auto;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis; }
+  .dops-section-nav__mobile-header-text small {
+    margin-left: 5px;
+    font-size: 11px;
+    color: #a2a2a2;
+    font-weight: 600;
+    text-transform: uppercase; }
+  .dops-section-nav.has-pinned-items .dops-section-nav__mobile-header-text {
+    width: auto;
+    flex: 0 1 auto; }
+
+.dops-section-nav__panel {
+  box-sizing: border-box;
+  width: 100%; }
+  @media (max-width: 480px) {
+    .dops-section-nav.is-open .dops-section-nav__panel {
+      padding-bottom: 15px;
+      border-top: solid 1px #d5d5d5;
+      background: linear-gradient(to bottom, #f6f6f6 0%, white 4px); } }
+  @media (min-width: 481px) {
+    .dops-section-nav__panel {
+      display: flex;
+      align-items: center; }
+      .dops-section-nav__panel:first-child {
+        width: 0;
+        flex: 1 0 auto; } }
+
+.dops-section-nav-group {
+  position: relative;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: solid 1px #d5d5d5; }
+  .dops-section-nav-group:first-child {
+    padding-top: 0;
+    border-top: none; }
+  @media (max-width: 480px) {
+    .dops-section-nav-group {
+      display: none; }
+      .dops-section-nav.is-open .dops-section-nav-group {
+        display: block; } }
+  @media (min-width: 481px) {
+    .dops-section-nav-group {
+      margin-top: 0;
+      padding-top: 0;
+      border-top: none; }
+      .dops-section-nav-group:first-child {
+        display: flex;
+        width: 0;
+        flex: 1 0 auto; } }
+
+.dops-section-nav__button {
+  width: 100%;
+  margin-top: 24px; }
+
+.dops-section-nav__hr {
+  background: #eeeeee; }
+
+.dops-section-nav-group__label {
+  display: none;
+  margin-bottom: 8px;
+  padding: 0 15px;
+  font-size: 11px;
+  color: #a2a2a2;
+  font-weight: 600;
+  text-transform: uppercase;
+  line-height: 12px; }
+  @media (max-width: 480px) {
+    .has-siblings .dops-section-nav-group__label {
+      display: block; } }
+
+.dops-section-nav-group__label-text {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden; }
+
+.dops-section-nav-tab .count {
+  margin-left: 8px; }
+
+@media (min-width: 481px) {
+  .dops-section-nav-tabs {
+    width: 0;
+    flex: 1 0 auto; }
+    .dops-section-nav-tabs.is-dropdown {
+      position: relative;
+      width: auto;
+      flex: 0 1 auto;
+      margin: 8px; } }
+
+.dops-section-nav-tabs__list {
+  margin: 0;
+  list-style: none; }
+  @media (min-width: 481px) {
+    .dops-section-nav-tabs__list {
+      display: flex;
+      width: 100%;
+      overflow: hidden; }
+      .is-dropdown .dops-section-nav-tabs__list {
+        display: none; } }
+
+.dops-section-nav-tab {
+  margin-bottom: 0; }
+  @media (min-width: 481px) {
+    .dops-section-nav-tab {
+      width: auto;
+      flex: none;
+      border-bottom: 2px solid transparent;
+      border-top: none;
+      text-align: center; }
+      .dops-section-nav-tab.is-selected {
+        border-bottom-color: #414141; } }
+
+.dops-section-nav-tab__link,
+.dops-section-nav-tab__text {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis; }
+
+.dops-section-nav-tab__link {
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  padding: 15px;
+  width: 100%;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 18px;
+  color: #414141;
+  cursor: pointer; }
+  .dops-section-nav-tab__link:visited {
+    color: #414141; }
+  .dops-section-nav-tab__link[disabled],
+  .notouch .dops-section-nav-tab__link[disabled]:hover {
+    color: #eeeeee;
+    cursor: default; }
+  .is-selected .dops-section-nav-tab__link {
+    color: white;
+    background-color: #2271b1; }
+  .dops-section-nav-tab__link:focus {
+    outline: none;
+    box-shadow: none; }
+    .dops-accessible-focus .dops-section-nav-tab__link:focus {
+      outline: solid #a2a2a2 1px; }
+  .is-external .dops-section-nav-tab__link:after {
+    font-size: 18px;
+    padding-left: 2px; }
+  .dops-section-nav-tab__link:hover {
+    color: #0a4b78; }
+  .notouch .dops-section-nav-tab__link:hover {
+    color: #2271b1; }
+  .notouch .is-selected .dops-section-nav-tab__link:hover {
+    color: white; }
+  @media (min-width: 481px) {
+    .dops-section-nav-tab__link {
+      display: block;
+      width: auto;
+      padding: 16px 16px 14px 16px;
+      color: #2271b1;
+      font-weight: 400; }
+      .dops-section-nav-tab__link:visited {
+        color: #2271b1; }
+      .is-selected .dops-section-nav-tab__link {
+        color: #414141;
+        background-color: transparent; }
+        .is-selected .dops-section-nav-tab__link:after {
+          display: none; }
+      .notouch .is-selected .dops-section-nav-tab__link:hover {
+        color: #414141; } }
+
+.dops-section-nav-tab__text {
+  display: block;
+  flex: 1 0 auto;
+  width: 0;
+  color: inherit; }
+  @media (min-width: 481px) {
+    .dops-section-nav-tab__text {
+      display: inline;
+      flex: none;
+      width: auto; } }
+
+.dops-section-nav-tabs__dropdown {
+  position: relative;
+  z-index: 3;
+  width: 100%; }
+  .dops-section-nav-tabs__dropdown.is-open {
+    z-index: 4; }
+  .dops-section-nav-tabs__dropdown .dops-select-dropdown__container {
+    position: static; }
+
+.dops-section-nav__segmented .dops-segmented-control {
+  margin: 0 15px; }
+
+.dops-section-nav__segmented .dops-segmented-control__link {
+  padding: 3px 16px 5px; }
+
+@media (max-width: 480px) {
+  .dops-section-nav .dops-search.is-pinned {
+    height: 46px; } }
+
+#jp-plugin-container {
+  min-height: 100vh; }
+
+/* Card */
+.dops-card {
+  display: block;
+  position: relative;
+  margin: 0 auto 10px auto;
+  padding: 16px;
+  box-sizing: border-box;
+  background: white;
+  box-shadow: 0 0 0 1px #c3c4c7, 0 1px 1px 1px rgba(0, 0, 0, 0.04); }
+  .dops-card:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden; }
+  @media (min-width: 481px) {
+    .dops-card {
+      margin-bottom: 16px;
+      padding: 24px; } }
+  .dops-card.is-compact {
+    margin-bottom: 1px; }
+    @media (min-width: 481px) {
+      .dops-card.is-compact {
+        margin-bottom: 1px;
+        padding: 16px 24px; } }
+  .dops-card.is-card-link {
+    padding-right: 48px; }
+
+h2.dops-card-title {
+  font-size: rem(20px); }
+
+.dops-card__link-indicator {
+  color: #d5d5d5;
+  display: block;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 16px; }
+
+a.dops-card:hover .dops-card__link-indicator {
+  color: #bbbbbb; }
+
+a.dops-card:focus {
+  outline: 0; }
+  a.dops-card:focus .dops-card__link-indicator {
+    color: tint(#3582c4, 20%); }
+
+/**
+ * "popover" theme for `component/tip`.
+ */
+.dops-popover {
+  font-size: 11px;
+  z-index: 1000;
+  position: absolute;
+  top: 0;
+  left: 0 /*rtl:ignore*/;
+  right: auto /*rtl:ignore*/; }
+  .dops-popover .dops-popover__inner {
+    background-color: white;
+    border: 1px solid #d5d5d5;
+    border-radius: 4px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1), 0 0 56px rgba(0, 0, 0, 0.075);
+    text-align: center;
+    position: relative; }
+  .dops-popover .dops-popover__arrow {
+    border: 10px dashed #d5d5d5;
+    height: 0;
+    line-height: 0;
+    position: absolute;
+    width: 0;
+    z-index: 1; }
+  .dops-popover.fade {
+    transition: opacity 100ms; }
+  .dops-popover.is-top .dops-popover__arrow,
+  .dops-popover.is-top-left .dops-popover__arrow,
+  .dops-popover.is-top-right .dops-popover__arrow {
+    bottom: 0 /*rtl:ignore*/;
+    left: 50% /*rtl:ignore*/;
+    margin-left: -10px/*rtl:ignore*/;
+    border-top-style: solid/*rtl:ignore*/;
+    border-bottom: none/*rtl:ignore*/;
+    border-left-color: transparent/*rtl:ignore*/;
+    border-right-color: transparent/*rtl:ignore*/; }
+    .dops-popover.is-top .dops-popover__arrow::before,
+    .dops-popover.is-top-left .dops-popover__arrow::before,
+    .dops-popover.is-top-right .dops-popover__arrow::before {
+      bottom: 2px /*rtl:ignore*/;
+      border: 10px solid white;
+      content: " ";
+      position: absolute;
+      left: 50% /*rtl:ignore*/;
+      margin-left: -10px/*rtl:ignore*/;
+      border-top-style: solid/*rtl:ignore*/;
+      border-bottom: none/*rtl:ignore*/;
+      border-left-color: transparent/*rtl:ignore*/;
+      border-right-color: transparent/*rtl:ignore*/; }
+  .dops-popover.is-bottom .dops-popover__arrow,
+  .dops-popover.is-bottom-left .dops-popover__arrow,
+  .dops-popover.is-bottom-right .dops-popover__arrow {
+    top: 0 /*rtl:ignore*/;
+    left: 50% /*rtl:ignore*/;
+    margin-left: -10px/*rtl:ignore*/;
+    border-bottom-style: solid/*rtl:ignore*/;
+    border-top: none/*rtl:ignore*/;
+    border-left-color: transparent/*rtl:ignore*/;
+    border-right-color: transparent/*rtl:ignore*/; }
+    .dops-popover.is-bottom .dops-popover__arrow::before,
+    .dops-popover.is-bottom-left .dops-popover__arrow::before,
+    .dops-popover.is-bottom-right .dops-popover__arrow::before {
+      top: 2px /*rtl:ignore*/;
+      border: 10px solid white;
+      content: " ";
+      position: absolute;
+      left: 50% /*rtl:ignore*/;
+      margin-left: -10px/*rtl:ignore*/;
+      border-bottom-style: solid/*rtl:ignore*/;
+      border-top: none/*rtl:ignore*/;
+      border-left-color: transparent/*rtl:ignore*/;
+      border-right-color: transparent/*rtl:ignore*/; }
+  .dops-popover.is-left .dops-popover__arrow,
+  .dops-popover.is-left-top .dops-popover__arrow,
+  .dops-popover.is-left-bottom .dops-popover__arrow {
+    right: 0 /*rtl:ignore*/;
+    top: 50% /*rtl:ignore*/;
+    margin-top: -10px/*rtl:ignore*/;
+    border-left-style: solid/*rtl:ignore*/;
+    border-right: none/*rtl:ignore*/;
+    border-top-color: transparent/*rtl:ignore*/;
+    border-bottom-color: transparent/*rtl:ignore*/; }
+    .dops-popover.is-left .dops-popover__arrow::before,
+    .dops-popover.is-left-top .dops-popover__arrow::before,
+    .dops-popover.is-left-bottom .dops-popover__arrow::before {
+      right: 2px /*rtl:ignore*/;
+      border: 10px solid white;
+      content: " ";
+      position: absolute;
+      top: 50% /*rtl:ignore*/;
+      margin-top: -10px/*rtl:ignore*/;
+      border-left-style: solid/*rtl:ignore*/;
+      border-right: none/*rtl:ignore*/;
+      border-top-color: transparent/*rtl:ignore*/;
+      border-bottom-color: transparent/*rtl:ignore*/; }
+  .dops-popover.is-right .dops-popover__arrow,
+  .dops-popover.is-right-top .dops-popover__arrow,
+  .dops-popover.is-right-bottom .dops-popover__arrow {
+    left: 0 /*rtl:ignore*/;
+    top: 50% /*rtl:ignore*/;
+    margin-top: -10px/*rtl:ignore*/;
+    border-right-style: solid/*rtl:ignore*/;
+    border-left: none/*rtl:ignore*/;
+    border-top-color: transparent/*rtl:ignore*/;
+    border-bottom-color: transparent/*rtl:ignore*/; }
+    .dops-popover.is-right .dops-popover__arrow::before,
+    .dops-popover.is-right-top .dops-popover__arrow::before,
+    .dops-popover.is-right-bottom .dops-popover__arrow::before {
+      left: 2px /*rtl:ignore*/;
+      border: 10px solid white;
+      content: " ";
+      position: absolute;
+      top: 50% /*rtl:ignore*/;
+      margin-top: -10px/*rtl:ignore*/;
+      border-right-style: solid/*rtl:ignore*/;
+      border-left: none/*rtl:ignore*/;
+      border-top-color: transparent/*rtl:ignore*/;
+      border-bottom-color: transparent/*rtl:ignore*/; }
+  .dops-popover.is-top-left, .dops-popover.is-bottom-left, .dops-popover.is-top-right, .dops-popover.is-bottom-right {
+    padding-right: 0;
+    padding-left: 0; }
+  .dops-popover.is-top-left .dops-popover__arrow,
+  .dops-popover.is-bottom-left .dops-popover__arrow {
+    left: auto /*rtl:ignore*/;
+    right: 5px /*rtl:ignore*/; }
+  .dops-popover.is-top-right .dops-popover__arrow,
+  .dops-popover.is-bottom-right .dops-popover__arrow {
+    left: 15px /*rtl:ignore*/; }
+  .dops-popover.is-top .dops-popover__inner,
+  .dops-popover.is-top-left .dops-popover__inner,
+  .dops-popover.is-top-right .dops-popover__inner {
+    top: -10px /*rtl:ignore*/; }
+  .dops-popover.is-left .dops-popover__inner,
+  .dops-popover.is-top-right .dops-popover__inner,
+  .dops-popover.is-bottom-right .dops-popover__inner {
+    left: -10px /*rtl:ignore*/; }
+  .dops-popover.is-bottom .dops-popover__inner,
+  .dops-popover.is-bottom-left .dops-popover__inner,
+  .dops-popover.is-bottom-right .dops-popover__inner {
+    top: 10px /*rtl:ignore*/; }
+  .dops-popover.is-right .dops-popover__inner,
+  .dops-popover.is-top-left .dops-popover__inner,
+  .dops-popover.is-bottom-left .dops-popover__inner {
+    left: 10px /*rtl:ignore*/; }
+  .dops-popover.is-dialog-visible {
+    z-index: 100300;
+    /* Above .dialog */ }
+
+.dops-popover__menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 200px; }
+
+.dops-popover__menu-item {
+  position: relative;
+  background: inherit;
+  border: none;
+  border-radius: 0;
+  color: #414141;
+  cursor: pointer;
+  display: block;
+  font-size: 14px;
+  font-weight: 400;
+  margin: 0;
+  padding: 8px 16px;
+  text-align: left;
+  transition: all 0.05s ease-in-out; }
+  .dops-popover__menu-item:first-child {
+    margin-top: 5px; }
+  .dops-popover__menu-item:hover, .dops-popover__menu-item:focus {
+    background-color: #3582c4;
+    border: 0;
+    box-shadow: none;
+    color: white; }
+    .dops-popover__menu-item:hover .gridicon, .dops-popover__menu-item:focus .gridicon {
+      color: white; }
+  .dops-popover__menu-item[disabled]:hover, .dops-popover__menu-item[disabled]:focus {
+    background: transparent;
+    cursor: default; }
+  .dops-popover__menu-item:last-child {
+    margin-bottom: 5px; }
+  .dops-popover__menu-item::-moz-focus-inner {
+    border: 0; }
+  .dops-popover__menu-item.has-icon {
+    padding-left: 42px; }
+  .dops-popover__menu-item .gridicon {
+    color: #bbbbbb;
+    vertical-align: bottom;
+    margin-right: 8px; }
+
+.dops-popover__hr {
+  margin: 8px 0;
+  background: #eeeeee; }
+
+.form-toggle[type="checkbox"] {
+  display: none; }
+
+.form-toggle__switch {
+  flex: none;
+  position: relative;
+  display: inline-block;
+  border-radius: 12px;
+  box-sizing: border-box;
+  padding: 2px;
+  width: 40px;
+  height: 24px;
+  vertical-align: middle;
+  outline: 0;
+  cursor: pointer;
+  transition: all .4s ease, box-shadow 0s; }
+  .form-toggle__switch:before, .form-toggle__switch:after {
+    position: relative;
+    display: block;
+    content: "";
+    width: 20px;
+    height: 20px; }
+  .form-toggle__switch:after {
+    left: 0;
+    border-radius: 50%;
+    background: white;
+    transition: all .2s ease; }
+  .form-toggle__switch:before {
+    display: none; }
+  .dops-accessible-focus .form-toggle__switch:focus {
+    box-shadow: 0 0 0 2px #3582c4; }
+
+.form-toggle__label {
+  display: flex;
+  cursor: pointer; }
+  .is-disabled .form-toggle__label {
+    cursor: default; }
+  .form-toggle__label .form-toggle__label-content {
+    flex: 0 1 100%;
+    margin-left: 12px; }
+
+.dops-accessible-focus .form-toggle:focus + .form-toggle__label .form-toggle__switch {
+  box-shadow: 0 0 0 2px #3582c4; }
+
+.dops-accessible-focus .form-toggle:focus:checked + .form-toggle__label .form-toggle__switch {
+  box-shadow: 0 0 0 2px #78dcfa; }
+
+.form-toggle + .form-toggle__label .form-toggle__switch {
+  background: #bbbbbb; }
+
+.form-toggle:not(:disabled) + .form-toggle__label:hover .form-toggle__switch {
+  background: #d5d5d5; }
+
+.form-toggle:checked + .form-toggle__label .form-toggle__switch {
+  background: #3582c4; }
+  .form-toggle:checked + .form-toggle__label .form-toggle__switch:after {
+    left: 16px; }
+
+.form-toggle:checked:not(:disabled) + .form-toggle__label:hover .form-toggle__switch {
+  background: #78dcfa; }
+
+.form-toggle:disabled + label.form-toggle__label span.form-toggle__switch {
+  opacity: 0.25;
+  cursor: default; }
+
+.form-toggle.is-toggling + .form-toggle__label .form-toggle__switch {
+  background: #3582c4; }
+
+.form-toggle.is-toggling:checked + .form-toggle__label .form-toggle__switch {
+  background: #d5d5d5; }
+
+.form-toggle.is-compact + .form-toggle__label .form-toggle__switch {
+  border-radius: 8px;
+  width: 24px;
+  height: 16px; }
+  .form-toggle.is-compact + .form-toggle__label .form-toggle__switch:before, .form-toggle.is-compact + .form-toggle__label .form-toggle__switch:after {
+    width: 12px;
+    height: 12px; }
+
+.form-toggle.is-compact:checked + .form-toggle__label .form-toggle__switch:after {
+  left: 8px; }
+
+.dops-section-header.dops-card {
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 100%;
+  padding-top: 0.6875rem;
+  padding-bottom: 0.6875rem;
+  position: relative; }
+  .dops-section-header.dops-card:after {
+    content: ''; }
+
+.dops-section-header__label {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  min-width: 0;
+  line-height: 1.75rem;
+  position: relative;
+  color: #414141;
+  font-size: 0.875rem; }
+  .dops-section-header__label .dops-count {
+    margin-left: 0.5rem; }
+
+.dops-section-header__label-text {
+  position: relative;
+  margin-right: 0.5rem;
+  white-space: nowrap;
+  overflow: hidden;
+  width: 100%;
+  padding-right: 0.5rem;
+  min-width: 0; }
+  .dops-section-header__label-text:before {
+    content: '';
+    display: block;
+    position: absolute;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    pointer-events: none;
+    background: linear-gradient(to right, rgba(255, 255, 255, 0), white 90%);
+    top: 0px;
+    bottom: 0px;
+    right: 0px;
+    left: auto;
+    width: 8px;
+    height: auto; }
+  .has-card-badge .dops-section-header__label-text {
+    width: auto; }
+
+.dops-section-header__actions {
+  flex-grow: 0;
+  position: relative; }
+  .dops-section-header__actions:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden; }
+
+.section-header__actions .button {
+  float: left;
+  margin-right: 0.5rem; }
+  .section-header__actions .button:last-child {
+    margin-right: 0; }
+
+#jp-plugin-container {
+  min-height: 100vh; }
+
+@keyframes appear {
+  0% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
+
+.dops-notice {
+  display: flex;
+  position: relative;
+  width: 100%;
+  margin-bottom: 24px;
+  box-sizing: border-box;
+  animation: appear .3s ease-in-out;
+  background: #414141;
+  color: white;
+  border-radius: 3px;
+  line-height: 1.5; }
+  .dops-notice.is-success .dops-notice__icon-wrapper {
+    background: #4ab866; }
+  .dops-notice.is-warning .dops-notice__icon-wrapper {
+    background: #f0b849; }
+  .dops-notice.is-error .dops-notice__icon-wrapper {
+    background: #d94f4f; }
+  .dops-notice.is-info .dops-notice__icon-wrapper {
+    background: #3582c4; }
+  .dops-notice .dops-notice__dismiss {
+    overflow: hidden; }
+  .dops-notice.is-success .dops-notice__dismiss, .dops-notice.is-error .dops-notice__dismiss, .dops-notice.is-warning .dops-notice__dismiss, .dops-notice.is-info .dops-notice__dismiss {
+    overflow: hidden; }
+
+.dops-notice__icon-wrapper {
+  background: #747474;
+  color: white;
+  display: flex;
+  align-items: baseline;
+  width: 47px;
+  justify-content: center;
+  border-radius: 3px 0 0 3px;
+  flex-shrink: 0;
+  align-self: stretch; }
+  .dops-notice__icon-wrapper .gridicon {
+    margin-top: 10px; }
+    @media (min-width: 481px) {
+      .dops-notice__icon-wrapper .gridicon {
+        margin-top: 12px; } }
+
+.dops-notice__content.dops-notice__content {
+  padding: 13px;
+  font-size: 12px;
+  flex-grow: 1; }
+  @media (min-width: 481px) {
+    .dops-notice__content.dops-notice__content {
+      font-size: 14px; } }
+  .dops-notice__content.dops-notice__content a {
+    text-decoration: underline;
+    color: white; }
+  .dops-notice__content.dops-notice__content a:hover {
+    text-decoration: none; }
+
+.dops-notice__text a.dops-notice__text-no-underline {
+  text-decoration: none; }
+
+.dops-notice__text a,
+.dops-notice__text a:visited {
+  text-decoration: underline;
+  color: white; }
+  .dops-notice__text a:hover,
+  .dops-notice__text a:visited:hover {
+    color: white;
+    text-decoration: none; }
+
+.dops-notice__text ul {
+  margin-bottom: 0;
+  margin-left: 0; }
+
+.dops-notice__text li {
+  margin-left: 2em;
+  margin-top: 0.5em; }
+
+.dops-notice__text p {
+  margin-bottom: 0;
+  margin-top: 0.5em; }
+  .dops-notice__text p:first-child {
+    margin-top: 0; }
+
+.dops-notice__button {
+  cursor: pointer;
+  margin-left: 0.428em; }
+
+.dops-notice__dismiss {
+  flex-shrink: 0;
+  padding: 12px;
+  cursor: pointer;
+  padding-bottom: 0; }
+  .dops-notice__dismiss .gridicon {
+    width: 18px;
+    height: 18px; }
+  @media (min-width: 481px) {
+    .dops-notice__dismiss {
+      padding: 11px;
+      padding-bottom: 0; }
+      .dops-notice__dismiss .gridicon {
+        width: 24px;
+        height: 24px; } }
+  .dops-notice .dops-notice__dismiss {
+    color: #bbbbbb; }
+    .dops-notice .dops-notice__dismiss:hover, .dops-notice .dops-notice__dismiss:focus {
+      color: white; }
+
+a.dops-notice__action {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 400;
+  text-decoration: none;
+  white-space: nowrap;
+  color: #bbbbbb;
+  padding: 13px;
+  display: flex;
+  align-items: center; }
+  @media (min-width: 481px) {
+    a.dops-notice__action {
+      flex-shrink: 1;
+      flex-grow: 0;
+      align-items: center;
+      border-radius: 0;
+      font-size: 14px;
+      margin: 0 0 0 auto;
+      padding: 13px 16px; }
+      a.dops-notice__action .gridicon {
+        width: 24px;
+        height: 24px; } }
+  a.dops-notice__action:visited {
+    color: #bbbbbb; }
+  a.dops-notice__action:hover {
+    color: white; }
+  a.dops-notice__action .gridicon {
+    margin-left: 8px;
+    opacity: 0.7;
+    width: 18px;
+    height: 18px; }
+
+.dops-notice.is-compact {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  width: auto;
+  border-radius: 3px;
+  min-height: 20px;
+  margin: 0;
+  padding: 0;
+  text-decoration: none;
+  text-transform: none;
+  vertical-align: middle;
+  line-height: 1.5; }
+  .dops-notice.is-compact .dops-notice__content {
+    font-size: 12px;
+    padding: 6px 10px; }
+  .dops-notice.is-compact .dops-notice__icon-wrapper {
+    width: 28px; }
+    .dops-notice.is-compact .dops-notice__icon-wrapper .dops-notice__icon {
+      width: 18px;
+      height: 18px;
+      margin: 0; }
+    .dops-notice.is-compact .dops-notice__icon-wrapper .gridicon {
+      margin-top: 6px; }
+  .dops-notice.is-compact .dops-notice__dismiss {
+    position: relative;
+    align-self: center;
+    flex: none;
+    margin: 0 8px 0 0;
+    padding: 0; }
+    .dops-notice.is-compact .dops-notice__dismiss .gridicon {
+      width: 18px;
+      height: 18px; }
+  .dops-notice.is-compact a.dops-notice__action {
+    background: transparent;
+    display: inline-block;
+    margin: 0;
+    font-size: 12px;
+    align-self: center;
+    margin-left: 16px;
+    padding: 0 10px; }
+    .dops-notice.is-compact a.dops-notice__action:hover, .dops-notice.is-compact a.dops-notice__action:active, .dops-notice.is-compact a.dops-notice__action:focus {
+      background: transparent; }
+    .dops-notice.is-compact a.dops-notice__action .gridicon {
+      margin-left: 8px;
+      width: 14px;
+      height: 14px;
+      vertical-align: sub;
+      opacity: 1; }
+
+.dops-plan-icon {
+  width: inherit;
+  height: inherit;
+  background-repeat: no-repeat; }
+
+.dops-plan-icon__free .dops-plan-icon__free-0 {
+  fill: #78dcfa; }
+
+.dops-plan-icon__free .dops-plan-icon__free-1 {
+  fill: white; }
+
+.dops-plan-icon__free .dops-plan-icon__free-2 {
+  fill: #006a95; }
+
+.dops-plan-icon__free .dops-plan-icon__free-3 {
+  fill: #0087be; }
+
+.dops-plan-icon__free .dops-plan-icon__free-4 {
+  fill: #00a4e7; }
+
+.dops-plan-icon__personal .dops-plan-icon__personal-0 {
+  fill: #f0b849; }
+
+.dops-plan-icon__personal .dops-plan-icon__personal-1 {
+  fill: #a2a2a2; }
+
+.dops-plan-icon__personal .dops-plan-icon__personal-2 {
+  fill: #d5d5d5; }
+
+.dops-plan-icon__personal .dops-plan-icon__personal-3 {
+  fill: white; }
+
+.dops-plan-icon__personal .dops-plan-icon__personal-4 {
+  fill: #888888; }
+
+.dops-plan-icon__personal .dops-plan-icon__personal-5 {
+  fill: #6f6f6f; }
+
+.dops-plan-icon__premium .dops-plan-icon__premium-0 {
+  fill: #4ab866; }
+
+.dops-plan-icon__premium .dops-plan-icon__premium-1 {
+  fill: #a2a2a2; }
+
+.dops-plan-icon__premium .dops-plan-icon__premium-2 {
+  fill: #6f6f6f; }
+
+.dops-plan-icon__premium .dops-plan-icon__premium-3 {
+  fill: white; }
+
+.dops-plan-icon__premium .dops-plan-icon__premium-4 {
+  fill: #d5d5d5; }
+
+.dops-plan-icon__premium .dops-plan-icon__premium-5 {
+  fill: #6f6f6f; }
+
+.dops-plan-icon__premium .dops-plan-icon__premium-6 {
+  fill: #555555; }
+
+.dops-plan-icon__business .dops-plan-icon__business-0 {
+  fill: #855DA6; }
+
+.dops-plan-icon__business .dops-plan-icon__business-1 {
+  fill: white; }
+
+.dops-plan-icon__business .dops-plan-icon__business-2 {
+  fill: #eeeeee; }
+
+.dops-plan-icon__business .dops-plan-icon__business-3 {
+  fill: #0087be; }
+
+.dops-plan-icon__business .dops-plan-icon__business-4 {
+  fill: #005082; }
+
+@charset "UTF-8";
+#jp-plugin-container {
+  min-height: 100vh; }
+
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+.dops-banner.dops-card {
+  border-left: 3px solid;
+  display: flex;
+  padding: 12px 6px 12px 12px;
+  position: relative;
+  z-index: 2;
+  border-left-color: #0087be; }
+  .dops-banner.dops-card.is-card-link {
+    padding: 12px 48px 12px 16px; }
+  .dops-banner.dops-card.is-dismissible {
+    padding-right: 48px; }
+  .dops-banner.dops-card .dops-banner__icon {
+    color: #0087be; }
+  .dops-banner.dops-card .dops-banner__icon-circle {
+    background-color: #0087be; }
+  .dops-banner.dops-card.is-jetpack-info {
+    border-left-color: #00be28; }
+    .dops-banner.dops-card.is-jetpack-info .dops-banner__icon {
+      color: #00be28; }
+    .dops-banner.dops-card.is-jetpack-info .dops-banner__icon-circle {
+      background-color: #00be28; }
+  .dops-banner.dops-card.is-product {
+    border-left-color: #3895ba; }
+    .dops-banner.dops-card.is-product .dops-banner__icon {
+      color: #3895ba; }
+    .dops-banner.dops-card.is-product .dops-banner__icon-circle {
+      background-color: #3895ba; }
+  .dops-banner.dops-card.is-plan {
+    border-left-color: #069e08; }
+    .dops-banner.dops-card.is-plan .dops-banner__icon {
+      color: #069e08; }
+    .dops-banner.dops-card.is-plan .dops-banner__icon-circle {
+      background-color: #069e08; }
+    .dops-banner.dops-card.is-plan.is-upgrade-personal {
+      border-left-color: #f0b849; }
+      .dops-banner.dops-card.is-plan.is-upgrade-personal .dops-banner__icon {
+        color: #f0b849; }
+      .dops-banner.dops-card.is-plan.is-upgrade-personal .dops-banner__icon-circle {
+        background-color: #f0b849; }
+    .dops-banner.dops-card.is-plan.is-upgrade-premium {
+      border-left-color: #4ab866; }
+      .dops-banner.dops-card.is-plan.is-upgrade-premium .dops-banner__icon {
+        color: #4ab866; }
+      .dops-banner.dops-card.is-plan.is-upgrade-premium .dops-banner__icon-circle {
+        background-color: #4ab866; }
+    .dops-banner.dops-card.is-plan.is-upgrade-business {
+      border-left-color: #855da6; }
+      .dops-banner.dops-card.is-plan.is-upgrade-business .dops-banner__icon {
+        color: #855da6; }
+      .dops-banner.dops-card.is-plan.is-upgrade-business .dops-banner__icon-circle {
+        background-color: #855da6; }
+    .dops-banner.dops-card.is-plan.is-bundle {
+      border-left-color: #984a9c; }
+      .dops-banner.dops-card.is-plan.is-bundle .dops-banner__icon {
+        color: #984a9c; }
+      .dops-banner.dops-card.is-plan.is-bundle .dops-banner__icon-circle {
+        background-color: #984a9c; }
+  .dops-banner.dops-card .dops-card__link-indicator {
+    align-items: center;
+    color: #0087be;
+    display: flex; }
+  .dops-banner.dops-card:hover {
+    transition: all 100ms ease-in-out; }
+    .dops-banner.dops-card:hover.is-card-link {
+      box-shadow: 0 0 0 1px #a2a2a2, 0 2px 4px #d5d5d5; }
+    .dops-banner.dops-card:hover .dops-card__link-indicator {
+      color: #005082; }
+  @media (min-width: 481px) {
+    .dops-banner.dops-card {
+      padding: 12px 16px; }
+      .dops-banner.dops-card.is-dismissible {
+        padding-right: 16px; } }
+
+.dops-banner__icons {
+  display: flex; }
+  .dops-banner__icons .dops-banner__icon,
+  .dops-banner__icons .dops-banner__icon-circle {
+    border-radius: 50%;
+    flex-shrink: 0;
+    height: 24px;
+    margin-right: 16px;
+    margin-top: -2px;
+    text-align: center;
+    top: 4px;
+    width: 24px; }
+  .dops-banner__icons .dops-banner__icon {
+    align-self: center;
+    color: white;
+    display: block; }
+  .dops-banner__icons .dops-banner__icon-circle {
+    color: white;
+    display: none;
+    padding: 3px 4px 4px 3px; }
+    .dops-banner__icons .dops-banner__icon-circle .gridicon {
+      margin-bottom: -7px; }
+  @media (min-width: 481px) {
+    .dops-banner__icons {
+      align-items: center; }
+      .dops-banner__icons .dops-banner__icon {
+        display: none; }
+      .dops-banner__icons .dops-banner__icon-circle {
+        display: block; } }
+
+.dops-banner__icon-plan {
+  display: flex;
+  margin-right: 16px; }
+  .dops-banner__icon-plan .dops-plan-icon {
+    height: 32px;
+    width: 32px; }
+  @media (min-width: 481px) {
+    .dops-banner__icon-plan {
+      align-items: center; } }
+
+.dops-banner__content {
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: wrap; }
+  @media (min-width: 481px) {
+    .dops-banner__content {
+      flex-wrap: nowrap; } }
+
+.dops-banner__info {
+  flex-grow: 1;
+  line-height: 1.4;
+  width: 100%; }
+  .dops-banner__info .dops-banner__title,
+  .dops-banner__info .dops-banner__description,
+  .dops-banner__info .dops-banner__list {
+    color: #414141; }
+  .dops-banner__info .dops-banner__title {
+    font-size: 0.875rem;
+    font-weight: 500; }
+  .dops-banner__info .dops-banner__description {
+    font-size: 0.75rem;
+    margin-top: 3px; }
+  .dops-banner__info .dops-banner__list {
+    font-size: 0.75rem;
+    list-style: none;
+    margin: 0; }
+    .dops-banner__info .dops-banner__list li {
+      margin: 6px 0; }
+      .dops-banner__info .dops-banner__list li .gridicon {
+        color: #a2a2a2;
+        display: none; }
+  @media (min-width: 481px) {
+    .dops-banner__info {
+      width: auto; }
+      .dops-banner__info .dops-banner__list li .gridicon {
+        display: inline;
+        margin-right: 12px;
+        vertical-align: bottom; } }
+
+.dops-banner__action {
+  align-self: center;
+  font-size: 0.75rem;
+  margin: 8px 0 0 0;
+  text-align: left;
+  width: 100%; }
+  .dops-banner__action .dops-banner__prices {
+    display: flex;
+    justify-content: flex-start; }
+    .dops-banner__action .dops-banner__prices .dops-plan-price {
+      margin-bottom: 0; }
+    .dops-banner__action .dops-banner__prices .dops-plan-price.is-discounted,
+    .dops-banner__action .dops-banner__prices .dops-plan-price.is-discounted .dops-plan-price__currency-symbol {
+      color: #414141; }
+    .has-call-to-action .dops-banner__action .dops-banner__prices .dops-plan-price {
+      margin-bottom: 8px; }
+  @media (min-width: 481px) {
+    .dops-banner__action {
+      margin: 0 4px 0 8px;
+      text-align: center;
+      width: auto; }
+      .is-dismissible .dops-banner__action {
+        margin-top: 40px; }
+      .dops-banner__action .dops-banner__prices {
+        justify-content: flex-end;
+        text-align: right; } }
+
+.module-overridden-banner.dops-banner.is-compact {
+  margin-bottom: 0; }
+
+.module-overridden-banner.dops-banner .dops-banner__description a {
+  text-decoration: underline; }
+
+.dops-info-popover-button {
+  background: transparent;
+  border: none;
+  color: #888888;
+  padding: 0; }
+  .dops-info-popover-button:hover {
+    color: #414141; }
+  .dops-info-popover-button:focus {
+    box-shadow: none; }
+  .dops-accessible-focus .dops-info-popover-button:focus {
+    outline: thin dotted; }
+
+.dops-info-popover .gridicon {
+  cursor: pointer;
+  color: #c8c8c8; }
+  .dops-info-popover .gridicon:hover {
+    color: #414141; }
+
+.dops-info-popover.is_active .gridicon {
+  color: #414141; }
+
+.dops-popover.dops-info-popover__tooltip .dops-popover__inner {
+  color: #6f6f6f;
+  font-size: 13px;
+  max-width: 220px;
+  padding: 16px;
+  text-align: left; }
+
+.dops-external-link .gridicons-external {
+  color: currentColor;
+  margin-left: 0.5rem;
+  top: 0.125rem;
+  position: relative; }
+
+#jp-plugin-container {
+  min-height: 100vh; }
+
+.jp-support-info {
+  position: absolute;
+  top: 1.6875rem;
+  right: 1.5625rem;
+  z-index: 1; }
+  @media (max-width: 480px) {
+    .jp-support-info {
+      top: 1.25rem;
+      right: 1rem; } }
+  .jp-form-fieldset .jp-support-info {
+    top: 4px; }
+  .jp-support-info .dops-info-popover {
+    white-space: nowrap; }
+
+.dops-popover .jp-support-info__privacy {
+  display: block;
+  margin-top: 0.875rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(162, 162, 162, 0.5); }
+
+.dops-text-input.dops-text-input {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 7px 14px;
+  width: 100%;
+  color: #414141;
+  font-size: 16px;
+  line-height: 1.5;
+  border: 1px solid #d5d5d5;
+  background-color: white;
+  transition: all .15s ease-in-out;
+  box-shadow: none; }
+  .dops-text-input.dops-text-input:-ms-input-placeholder {
+    color: #a2a2a2; }
+  .dops-text-input.dops-text-input::placeholder {
+    color: #a2a2a2; }
+  .dops-text-input.dops-text-input:hover {
+    border-color: #bbbbbb; }
+  .dops-text-input.dops-text-input:focus {
+    border-color: #0087be;
+    outline: none;
+    box-shadow: 0 0 0 2px #78dcfa; }
+    .dops-text-input.dops-text-input:focus::-ms-clear {
+      display: none; }
+  .dops-text-input.dops-text-input:disabled {
+    background: #f6f6f6;
+    border-color: #eeeeee;
+    color: #bbbbbb;
+    -webkit-text-fill-color: #bbbbbb; }
+    .dops-text-input.dops-text-input:disabled:hover {
+      cursor: default; }
+    .dops-text-input.dops-text-input:disabled:-ms-input-placeholder {
+      color: #bbbbbb; }
+    .dops-text-input.dops-text-input:disabled::placeholder {
+      color: #bbbbbb; }
+
+.dops-text-input.dops-text-input {
+  -webkit-appearance: none; }
+  .dops-text-input.dops-text-input.is-valid {
+    border-color: #4ab866; }
+    .dops-text-input.dops-text-input.is-valid:hover {
+      border-color: #3a9551; }
+  .dops-text-input.dops-text-input.is-error {
+    border-color: #d94f4f; }
+    .dops-text-input.dops-text-input.is-error:hover {
+      border-color: #c92c2c; }
+  .dops-text-input.dops-text-input:focus.is-valid {
+    box-shadow: 0 0 0 2px #caead2; }
+    .dops-text-input.dops-text-input:focus.is-valid:hover {
+      box-shadow: 0 0 0 2px #a6dcb3; }
+  .dops-text-input.dops-text-input:focus.is-error {
+    box-shadow: 0 0 0 2px #f9e2e2; }
+    .dops-text-input.dops-text-input:focus.is-error:hover {
+      box-shadow: 0 0 0 2px #f0b8b8; }
+
+#jp-plugin-container {
+  min-height: 100vh; }
+
+.jp-form-settings-group .jp-toggle-set {
+  position: relative; }
+  .jp-form-settings-group .jp-toggle-set .jp-support-info {
+    right: -1.25rem;
+    top: 0.3125rem; }
+    @media (max-width: 480px) {
+      .jp-form-settings-group .jp-toggle-set .jp-support-info {
+        right: -2rem;
+        top: 0.3125rem; } }
+
+@charset "UTF-8";
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+.jetpack-termination-dialog .dops-card {
+  margin: 0; }
+
+.jetpack-termination-dialog__spinner {
+  display: flex;
+  justify-content: center;
+  padding: 25px; }
+
+.jetpack-termination-dialog__header {
+  display: flex;
+  flex-direction: row;
+  align-content: center;
+  justify-content: space-between; }
+  .jetpack-termination-dialog__header h2 {
+    margin: 0;
+    font-size: 28px;
+    line-height: 24px; }
+
+.jetpack-termination-dialog__info {
+  font-size: 16px;
+  line-height: 24px;
+  margin-top: 0; }
+
+.jetpack-termination-dialog__generic-info ul {
+  list-style: inside;
+  font-size: 16px;
+  line-height: 24px; }
+
+.jetpack-termination-dialog__features-list {
+  position: relative;
+  left: calc( -1em);
+  display: flex;
+  flex-wrap: wrap;
+  width: calc( 100% + 2em); }
+  .jetpack-termination-dialog__features-list .jetpack-termination-dialog__feature {
+    width: calc( 100% - 2em); }
+    @media (min-width: 661px) {
+      .jetpack-termination-dialog__features-list .jetpack-termination-dialog__feature {
+        width: calc( 50% - 2em); } }
+
+.jetpack-termination-dialog__features-list-single-column {
+  position: relative;
+  left: calc( -1em);
+  display: flex;
+  flex-wrap: wrap;
+  width: calc( 100% + 2em); }
+  .jetpack-termination-dialog__features-list-single-column .jetpack-termination-dialog__feature {
+    width: calc( 100% - 2em); }
+
+.jetpack-termination-dialog__feature {
+  background: white;
+  border: 1px solid rgba(213, 213, 213, 0.5);
+  box-sizing: border-box;
+  box-shadow: 0px 1px 2px #f6f6f6;
+  margin: 1em; }
+
+.jetpack-termination-dialog__feature-header {
+  text-transform: uppercase;
+  font-size: 12px;
+  line-height: 12px;
+  background: #f6f6f6;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 13px 0 13px; }
+  .jetpack-termination-dialog__feature-header .gridicon {
+    color: #00be28; }
+
+.jetpack-termination-dialog__feature-body {
+  padding: 0 13px 0 13px; }
+  .jetpack-termination-dialog__feature-body .jetpack-termination-dialog__feature-body-amount {
+    font-weight: bold;
+    font-size: 24px;
+    line-height: 26px;
+    margin-top: 12px;
+    margin-bottom: 12px; }
+
+.jetpack-termination-dialog__get-help {
+  font-size: 16px;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 24px;
+  margin-top: 29px;
+  margin-bottom: 120px; }
+  @media (min-width: 481px) {
+    .jetpack-termination-dialog__get-help {
+      margin-top: 37px; } }
+  @media (min-width: 661px) {
+    .jetpack-termination-dialog__get-help {
+      margin-bottom: 0; } }
+
+@media only screen and (min-width: 600px) {
+  .admin-bar .dops-modal-wrapper {
+    top: 46px; } }
+
+@media only screen and (min-width: 782px) {
+  .admin-bar .dops-modal-wrapper {
+    top: 32px; } }
+
+.jetpack-termination-dialog__button-row {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: fixed;
+  background: white;
+  bottom: 0;
+  margin-left: -16px;
+  width: 100%;
+  padding: 10px 16px;
+  border-top: 1px solid #a2a2a2;
+  box-sizing: border-box; }
+  .jetpack-termination-dialog__button-row p {
+    text-align: center;
+    margin-top: 0; }
+  @media (min-width: 481px) {
+    .jetpack-termination-dialog__button-row {
+      margin-left: -24px;
+      padding: 10px 24px; } }
+  @media (min-width: 661px) {
+    .jetpack-termination-dialog__button-row {
+      flex-direction: row;
+      position: relative;
+      margin-left: 0;
+      padding: 0;
+      border-top: none; }
+      .jetpack-termination-dialog__button-row p {
+        text-align: auto;
+        margin-top: auto; } }
+
+.jetpack-termination-dialog__button-row-buttons {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between; }
+  .jetpack-termination-dialog__button-row-buttons .dops-button {
+    margin-bottom: 18px;
+    margin-left: 0px;
+    width: 100%; }
+  @media (min-width: 661px) {
+    .jetpack-termination-dialog__button-row-buttons {
+      flex-direction: row; }
+      .jetpack-termination-dialog__button-row-buttons .dops-button {
+        margin-bottom: 0px;
+        margin-left: 18px;
+        width: auto; } }
+
+.jetpack-termination-dialog__close-icon {
+  color: #a2a2a2;
+  cursor: pointer; }
+
+a.jetpack-termination-dialog__link {
+  font-style: normal !important;
+  text-decoration: underline !important; }
+
+ul.jetpack-termination-dialog__active-plugins-list {
+  list-style-type: none; }
+  ul.jetpack-termination-dialog__active-plugins-list li svg {
+    color: red;
+    margin-right: 10px;
+    vertical-align: sub; }
+
+@charset "UTF-8";
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+.multiple-choice-question__subheader {
+  font-weight: normal; }
+
+.multiple-choice-question__answer-item-content {
+  margin: 4px 0 0 24px;
+  width: calc( 100% - 24px); }
+
+.multiple-choice-question__answer-item-text-input {
+  width: 100%; }
+
+#jp-plugin-container {
+  min-height: 100vh; }
+
+/* This hack is used to prevent the body from scrolling when the modal is showing */
+body.dops-modal-showing {
+  overflow: hidden; }
+
+.dops-modal-wrapper {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1050;
+  display: block;
+  overflow-x: hidden;
+  overflow-y: auto;
+  text-align: center;
+  -webkit-overflow-scrolling: touch;
+  outline: 0;
+  transition: opacity .15s linear;
+  background-color: rgba(0, 0, 0, 0.5);
+  cursor: pointer; }
+  .dops-modal-wrapper:before {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle; }
+  .dops-modal-wrapper .dops-modal {
+    position: relative;
+    display: inline-block;
+    margin: 0 0;
+    width: 100%;
+    max-width: 550px;
+    vertical-align: middle;
+    text-align: left;
+    background-color: #fff;
+    transition: all 0.5s;
+    z-index: 100;
+    clear: both;
+    cursor: default; }
+    @media (min-width: 481px) {
+      .dops-modal-wrapper .dops-modal {
+        margin: 0 auto;
+        height: auto;
+        border-radius: 5px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2); } }
+
+@charset "UTF-8";
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+
+.jp-connect-user-frame {
+  display: flex;
+  justify-content: space-evenly;
+  margin: 50px 80px; }
+  .jp-connect-user-frame .jp-connect-user-frame__left {
+    margin-right: 45px; }
+  .jp-connect-user-frame h2 {
+    font-weight: bold;
+    font-size: 32px;
+    line-height: 36px; }
+  .jp-connect-user-frame ul {
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 28px;
+    list-style: none; }
+    .jp-connect-user-frame ul .gridicon {
+      color: #069E08;
+      height: 18px;
+      vertical-align: text-bottom; }
+  .jp-connect-user-frame .jp-connect-user-frame__features-link {
+    font-size: 13px;
+    line-height: 16px;
+    color: #2271B1; }
+    .jp-connect-user-frame .jp-connect-user-frame__features-link .gridicon {
+      vertical-align: text-bottom;
+      margin-left: 5px; }
+  .jp-connect-user-frame .jp-iframe-wrap {
+    border: 2px solid #C1D0E8;
+    border-radius: 6px; }
+
+.jp-connect-user-bar__card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #F3F5F6;
+  padding: 8px 24px;
+  border-top: 1px solid #ccd0d4; }
+  .jp-connect-user-bar__card .jp-connect-user-bar__text {
+    font-weight: 500;
+    font-size: 13px;
+    line-height: 16px;
+    color: #414141;
+    height: 16px; }
+  .jp-connect-user-bar__card .jp-connect-user-bar__button {
+    order: 3; }
+    .jp-connect-user-bar__card .jp-connect-user-bar__button .jp-jetpack-connect__button {
+      background: #F3F5F6;
+      border: 1px solid #0071A1;
+      box-sizing: border-box;
+      border-radius: 3px;
+      float: right;
+      font-weight: 600;
+      font-size: 13px;
+      line-height: 16px;
+      color: #0071A1;
+      text-align: center; }
+
+@keyframes appear {
+  0% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
+
+.dops-foldable-card.dops-card {
+  position: relative;
+  transition: margin .15s linear;
+  padding: 0; }
+  .dops-foldable-card.dops-card:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden; }
+  .dops-foldable-card.dops-card.is-expanded {
+    margin-bottom: 8px; }
+  .dops-foldable-card.dops-card .is-clickable {
+    cursor: pointer; }
+
+.dops-foldable-card__header {
+  min-height: 64px;
+  width: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative; }
+  .dops-foldable-card__header.has-border .dops-foldable-card__summary,
+  .dops-foldable-card__header.has-border .dops-foldable-card__summary_expanded {
+    margin-right: 48px; }
+  .dops-foldable-card__header.has-border .dops-foldable-card__expand {
+    border-left: 1px #f6f6f6 solid; }
+  .dops-foldable-card.is-compact .dops-foldable-card__header {
+    padding: 8px 16px;
+    min-height: 40px; }
+  .dops-foldable-card.is-expanded .dops-foldable-card__header {
+    margin-bottom: 0px;
+    height: inherit;
+    min-height: 64px; }
+  .dops-foldable-card.is-expanded.is-compact .dops-foldable-card__header {
+    min-height: 40px; }
+  .dops-foldable-card.is-disabled .dops-foldable-card__header {
+    opacity: 0.2; }
+
+.dops-foldable-card__action {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  background: none;
+  border: 0; }
+  .dops-foldable-card.is-expanded .dops-foldable-card__action {
+    height: 100%; }
+  .dops-foldable-card.is-disabled .dops-foldable-card__action {
+    cursor: default; }
+  .dops-accessible-focus .dops-foldable-card__action:focus {
+    outline: thin dotted; }
+
+button.dops-foldable-card__action {
+  cursor: pointer;
+  outline: 0; }
+
+.dops-foldable-card__main {
+  max-width: calc( 100% - 36px);
+  display: block;
+  align-items: center;
+  width: 100%;
+  margin-right: 5px; }
+  @media (max-width: 480px) {
+    .dops-foldable-card__main {
+      flex: 1 1; } }
+
+.dops-foldable-card__secondary {
+  display: flex;
+  align-items: center;
+  flex: 1 1;
+  justify-content: flex-end; }
+
+.dops-foldable-card__expand {
+  width: 48px; }
+  .dops-foldable-card__expand .gridicon {
+    fill: #a2a2a2;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    vertical-align: middle;
+    transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in; }
+    .dops-foldable-card.is-expanded .dops-foldable-card__expand .gridicon {
+      transform: rotate(180deg); }
+  .dops-foldable-card__expand .gridicon:hover {
+    fill: #a2a2a2; }
+  .dops-foldable-card__expand:focus .gridicon, .dops-foldable-card__expand:hover .gridicon {
+    fill: #3582c4; }
+
+.dops-foldable-card__header-text {
+  font-size: 1.125rem;
+  width: 100%; }
+
+.dops-foldable-card__subheader {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+  font-size: 0.875rem;
+  color: #6f6f6f; }
+
+.dops-foldable-card__content {
+  display: none; }
+  .dops-foldable-card.is-expanded .dops-foldable-card__content {
+    display: block;
+    padding: 16px;
+    border-top: 1px solid #f6f6f6; }
+    .dops-foldable-card.is-compact .dops-foldable-card.is-expanded .dops-foldable-card__content {
+      padding: 8px; }
+    .dops-foldable-card.is-expanded .dops-foldable-card__content p:first-child {
+      margin-top: 0; }
+    .dops-foldable-card.is-expanded .dops-foldable-card__content p:last-child {
+      margin-bottom: 0; }
+
+.dops-foldable-card__summary,
+.dops-foldable-card__summary_expanded {
+  margin-right: 40px;
+  color: #a2a2a2;
+  font-size: 12px;
+  transition: opacity 0.2s linear;
+  display: inline-block; }
+  .dops-foldable-card.has-expanded-summary .dops-foldable-card__summary, .dops-foldable-card.has-expanded-summary
+  .dops-foldable-card__summary_expanded {
+    transition: none;
+    flex: 2;
+    text-align: right; }
+  @media (max-width: 480px) {
+    .dops-foldable-card__summary,
+    .dops-foldable-card__summary_expanded {
+      display: none; } }
+
+.dops-foldable-card__summary {
+  opacity: 1;
+  display: inline-block; }
+  .dops-foldable-card.is-expanded .dops-foldable-card__summary {
+    display: none; }
+    .has-expanded-summary .dops-foldable-card.is-expanded .dops-foldable-card__summary {
+      display: none; }
+
+.dops-foldable-card__summary_expanded {
+  display: none; }
+  .dops-foldable-card.is-expanded .dops-foldable-card__summary_expanded {
+    display: inline-block; }
+
+#jp-plugin-container {
+  min-height: 100vh; }
+
+.form-input-validation {
+  color: #4ab866;
+  position: relative;
+  padding: 6px 24px 11px 34px;
+  border-radius: 1px;
+  box-sizing: border-box;
+  font-size: 14px;
+  animation: appear .3s ease-in-out; }
+  .form-input-validation.is-error {
+    color: #d94f4f; }
+  .form-input-validation.is-warning {
+    color: #f0b849; }
+  .form-input-validation .gridicon {
+    float: left;
+    margin-left: -34px; }
+
+.dops-textarea {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0.4375rem 0.875rem;
+  min-height: 5.75rem;
+  width: 100%;
+  color: #414141;
+  font-size: 1rem;
+  line-height: 1.5;
+  border: 1px solid #d5d5d5;
+  background-color: white;
+  transition: all .15s ease-in-out;
+  box-shadow: none; }
+  .dops-textarea:-ms-input-placeholder {
+    color: #a2a2a2; }
+  .dops-textarea::placeholder {
+    color: #a2a2a2; }
+  .dops-textarea:hover {
+    border-color: #bbbbbb; }
+  .dops-textarea:focus {
+    border-color: #0087be;
+    outline: none;
+    box-shadow: 0 0 0 2px #78dcfa; }
+    .dops-textarea:focus::-ms-clear {
+      display: none; }
+  .dops-textarea:disabled {
+    background: #f6f6f6;
+    border-color: #eeeeee;
+    color: #bbbbbb;
+    -webkit-text-fill-color: #bbbbbb; }
+    .dops-textarea:disabled:hover {
+      cursor: default; }
+    .dops-textarea:disabled:-ms-input-placeholder {
+      color: #bbbbbb; }
+    .dops-textarea:disabled::placeholder {
+      color: #bbbbbb; }
+
+/*
+ * CSS values in this file are specific and
+ * designed to match the CSS on external sites,
+ * such as Google and Facebook. Therefore there
+ * will be exceptions to our CSS guidelines here
+ * but please do not "update" this file to
+ * conform.
+ *
+ * @blame: dmsnell
+*/
+/* stylelint-disable scales/font-size */
+.facebook-preview {
+  border: none;
+  display: flex;
+  overflow-x: auto;
+  max-width: 527px;
+  margin: 20px;
+  -webkit-overflow-scrolling: touch; }
+
+.facebook-preview__content {
+  display: flex;
+  max-width: 100%;
+  background-color: #f2f3f5; }
+
+.facebook-preview__body {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 12px;
+  border: 1px solid #dadde1;
+  overflow: hidden;
+  font-family: Helvetica, Arial, sans-serif; }
+
+.facebook-preview__title {
+  color: #1d2129;
+  font-size: 16px;
+  /* stylelint-disable-next-line scales/font-weight */
+  font-weight: 600;
+  line-height: 20px;
+  max-height: 100px;
+  transition: color 0.1s ease-in-out; }
+
+.facebook-preview__description {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  overflow-y: hidden; }
+
+.facebook-preview__url {
+  color: #606770;
+  font-size: 12px;
+  line-height: 11px;
+  text-transform: uppercase;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden; }
+
+.facebook-preview__article .facebook-preview__content {
+  flex-direction: column;
+  min-width: 100%; }
+
+.facebook-preview__article .facebook-preview__image {
+  max-height: 250px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow-y: hidden; }
+  .facebook-preview__article .facebook-preview__image img {
+    height: auto;
+    width: 100%;
+    max-width: 527px; }
+
+.facebook-preview__article .facebook-preview__body {
+  height: auto;
+  max-height: 100px; }
+
+.facebook-preview__article .facebook-preview__title {
+  margin-bottom: 1px; }
+
+.facebook-preview__article .facebook-preview__description {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical; }
+
+.facebook-preview__article .facebook-preview__url {
+  margin-bottom: 5px; }
+
+.facebook-preview__website {
+  max-height: 158px;
+  overflow: hidden; }
+  .facebook-preview__website .facebook-preview__image {
+    flex-shrink: 0;
+    height: 158px;
+    width: 158px;
+    box-sizing: border-box;
+    border: 1px solid #dadde1;
+    border-right: 0; }
+    .facebook-preview__website .facebook-preview__image img {
+      display: block;
+      font-size: 14px;
+      height: auto;
+      width: 100%; }
+    .facebook-preview__website .facebook-preview__image::after {
+      content: '';
+      display: block;
+      height: 100%;
+      width: 100%;
+      background: #ffffff; }
+  .facebook-preview__website .facebook-preview__body {
+    width: 100%;
+    height: 136px;
+    justify-content: center; }
+  .facebook-preview__website .facebook-preview__title {
+    margin-bottom: 5px;
+    max-height: 110px;
+    overflow-wrap: break-word; }
+  .facebook-preview__website .facebook-preview__url {
+    margin-bottom: 5px; }
+  .facebook-preview__website .facebook-preview__description {
+    max-height: 80px; }
+
+/*
+ * CSS values in this file are specific and
+ * designed to match the CSS on Twitter. Therefore there
+ * will be exceptions to our CSS guidelines here
+ * but please do not "update" this file to conform.
+ *
+ * @blame: pento
+ */
+/* stylelint-disable scales/font-size */
+.twitter-preview {
+  background-color: #fff;
+  padding: 20px;
+  width: 635px; }
+
+.twitter-preview__container {
+  display: grid;
+  grid-template-columns: 65px auto;
+  margin-bottom: 5px;
+  margin-right: 24px; }
+  .twitter-preview__container .twitter-preview__sidebar {
+    display: grid;
+    grid-template-rows: 35px auto;
+    justify-items: center; }
+    .twitter-preview__container .twitter-preview__sidebar .twitter-preview__profile-image img {
+      height: 30px;
+      width: 30px;
+      border-radius: 15px;
+      object-fit: cover; }
+    .twitter-preview__container .twitter-preview__sidebar .twitter-preview__connector {
+      width: 2px;
+      background-color: #8c8f94; }
+  .twitter-preview__container .twitter-preview__name {
+    font-weight: bold;
+    font-size: 16px;
+    line-height: 19px; }
+  .twitter-preview__container .twitter-preview__screen-name,
+  .twitter-preview__container .twitter-preview__date {
+    color: #667886;
+    font-size: 16px;
+    line-height: 18px;
+    letter-spacing: -0.3px;
+    margin-left: 15px; }
+  .twitter-preview__container .twitter-preview__content {
+    margin: 7px 0; }
+    .twitter-preview__container .twitter-preview__content .twitter-preview__text {
+      font-size: 14px;
+      line-height: 18px;
+      letter-spacing: -0.3px;
+      color: #787c82;
+      white-space: pre-wrap; }
+    .twitter-preview__container .twitter-preview__content .twitter-preview__media {
+      border-radius: 15px;
+      overflow: hidden;
+      display: grid;
+      grid-gap: 2px;
+      grid-template-areas: 'a';
+      height: 300px;
+      margin-top: 10px; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__media img,
+      .twitter-preview__container .twitter-preview__content .twitter-preview__media video {
+        width: 100%;
+        height: 100%;
+        object-fit: cover; }
+        .twitter-preview__container .twitter-preview__content .twitter-preview__media img:nth-child(1),
+        .twitter-preview__container .twitter-preview__content .twitter-preview__media video:nth-child(1) {
+          grid-area: a; }
+        .twitter-preview__container .twitter-preview__content .twitter-preview__media img:nth-child(2),
+        .twitter-preview__container .twitter-preview__content .twitter-preview__media video:nth-child(2) {
+          grid-area: b; }
+        .twitter-preview__container .twitter-preview__content .twitter-preview__media img:nth-child(3),
+        .twitter-preview__container .twitter-preview__content .twitter-preview__media video:nth-child(3) {
+          grid-area: c; }
+        .twitter-preview__container .twitter-preview__content .twitter-preview__media img:nth-child(4),
+        .twitter-preview__container .twitter-preview__content .twitter-preview__media video:nth-child(4) {
+          grid-area: d; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__media.twitter-preview__media-children-2 {
+        grid-template-areas: 'a b'; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__media.twitter-preview__media-children-3 {
+        grid-template-areas: 'a b' 'a c'; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__media.twitter-preview__media-children-4 {
+        grid-template-areas: 'a b' 'c d'; }
+    .twitter-preview__container .twitter-preview__content .twitter-preview__quote-tweet {
+      margin-top: 10px;
+      min-height: 200px; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__quote-tweet .twitter-preview__quote-tweet-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        opacity: 0; }
+    .twitter-preview__container .twitter-preview__content .twitter-preview__card {
+      margin-top: 10px;
+      overflow: hidden;
+      border: 1px solid #e1e8ed;
+      border-radius: 12px; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-summary.twitter-preview__card-has-image {
+        height: 125px;
+        display: grid;
+        grid-template-columns: 125px auto; }
+        .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-summary.twitter-preview__card-has-image .twitter-preview__card-body {
+          border-left: 1px solid #e1e8ed;
+          height: 100%; }
+        .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-summary.twitter-preview__card-has-image .twitter-preview__card-description {
+          -webkit-line-clamp: 3; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-summary_large_image {
+        display: grid;
+        grid-template-rows: 254px auto; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-image {
+        width: 100%;
+        height: 100%;
+        object-fit: cover; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-body {
+        padding: 0.75em;
+        text-decoration: none;
+        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        color: black;
+        text-align: left;
+        line-height: 1.3em;
+        overflow: hidden; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-title {
+        max-height: 1.3em;
+        white-space: nowrap;
+        font-weight: bold;
+        font-size: 1em;
+        margin: 0 0 0.15em;
+        overflow: hidden;
+        text-overflow: ellipsis; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-description {
+        margin-top: 0.32333em;
+        max-height: 3.9em;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden; }
+      .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-url {
+        text-transform: lowercase;
+        color: #8899a6;
+        max-height: 1.3em;
+        white-space: nowrap;
+        overflow-inline: hidden;
+        text-overflow: ellipsis;
+        margin-top: 0.32333em; }
+        .twitter-preview__container .twitter-preview__content .twitter-preview__card .twitter-preview__card-url svg {
+          fill: #8899a6;
+          height: 15px;
+          width: 15px;
+          margin: 0 2px -4px 0; }
+  .twitter-preview__container .twitter-preview__footer {
+    display: grid;
+    grid-template-columns: repeat(4, auto); }
+    .twitter-preview__container .twitter-preview__footer svg {
+      fill: #787c82;
+      height: 16px;
+      width: 16px; }
+
+/*
+ * CSS values in this file are specific and
+ * designed to match the CSS on external sites,
+ * such as Google and Facebook. Therefore there
+ * will be exceptions to our CSS guidelines here
+ * but please do not "update" this file to
+ * conform.
+ *
+ * @blame: dmsnell
+*/
+/* stylelint-disable scales/font-size */
+.search-preview__display {
+  border: 1px solid #f6f7f7;
+  font-family: arial, sans-serif;
+  padding: 10px 20px;
+  word-wrap: break-word; }
+
+.search-preview__title {
+  color: #1a0dab;
+  font-size: 20px;
+  line-height: 26px;
+  max-width: 616px;
+  margin-bottom: 7px; }
+  .search-preview__title:hover {
+    cursor: pointer;
+    text-decoration: underline; }
+
+.search-preview__url {
+  color: #3c4043;
+  font-size: 14px;
+  line-height: 18.2px;
+  max-width: 616px;
+  margin-bottom: 8px; }
+
+.search-preview__description {
+  color: #3c4043;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22.12px;
+  max-width: 616px; }
+
+.dops-clipboard-button-input {
+  position: relative;
+  display: block; }
+  .dops-clipboard-button-input .dops-clipboard-button {
+    position: absolute;
+    top: 50%;
+    right: 4px;
+    transform: translateY(-50%);
+    overflow: visible; }
+    .dops-clipboard-button-input .dops-clipboard-button:not(:disabled)::before {
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      pointer-events: none;
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), #fff 90%);
+      top: 0px;
+      bottom: 0px;
+      right: 0px;
+      left: auto;
+      width: 16px;
+      height: auto;
+      right: calc( 100% + 1px); }
+    .dops-clipboard-button-input .dops-clipboard-button:focus::before {
+      right: calc( 100% + 3px); }
+
+.button {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+  background: transparent;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  margin: 0;
+  outline: 0;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  text-decoration: none;
+  vertical-align: top;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 22px;
+  border-radius: 2px;
+  padding: 8px 14px;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  background-color: #fff;
+  color: #3c434a;
+  border-color: #c3c4c7; }
+  .rtl .button {
+    font-family: Tahoma, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif; }
+  .button.hidden {
+    display: none; }
+  .button .gridicon {
+    position: relative;
+    top: 4px;
+    margin-top: -2px;
+    width: 18px;
+    height: 18px; }
+    .button .gridicon:not(:last-child) {
+      margin-right: 4px; }
+  .button:active, .button.is-active {
+    border-width: 1px; }
+  .button:hover {
+    border-color: #a7aaad;
+    color: #3c434a; }
+  .button:visited {
+    color: #3c434a; }
+  .button[disabled], .button:disabled, .button.disabled {
+    color: #a7aaad;
+    background-color: #fff;
+    border-color: #dcdcde;
+    cursor: default; }
+    .button[disabled]:active, .button[disabled].is-active, .button:disabled:active, .button:disabled.is-active, .button.disabled:active, .button.disabled.is-active {
+      border-width: 1px; }
+  .accessible-focus .button:focus {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 2px #5198d9; }
+  .button.is-compact {
+    padding: 7px;
+    color: #646970;
+    font-size: 12px;
+    line-height: 1; }
+    .button.is-compact:disabled {
+      color: #a7aaad; }
+    .button.is-compact .gridicon {
+      top: 5px;
+      margin-top: -8px; }
+    .button.is-compact .gridicons-plus-small {
+      margin-left: -4px; }
+    .button.is-compact .gridicons-plus-small:last-of-type {
+      margin-left: 0; }
+    .button.is-compact .gridicons-plus-small + .gridicon {
+      margin-left: -4px; }
+  .button.is-busy {
+    animation: button__busy-animation 3000ms infinite linear;
+    background-size: 120px 100%;
+    background-image: linear-gradient(-45deg, #f6f7f7 28%, #fff 28%, #fff 72%, #f6f7f7 72%); }
+
+.button.is-primary {
+  background-color: #c9356e;
+  border-color: #c9356e;
+  color: #fff; }
+  .button.is-primary:hover, .button.is-primary:focus {
+    background-color: #ab235a;
+    border-color: #ab235a;
+    color: #fff; }
+  .accessible-focus .button.is-primary:focus {
+    box-shadow: 0 0 0 2px #eb6594; }
+  .button.is-primary.is-compact {
+    color: #fff; }
+  .button.is-primary[disabled], .button.is-primary:disabled, .button.is-primary.disabled {
+    color: #a7aaad;
+    background-color: #fff;
+    border-color: #dcdcde; }
+  .button.is-primary.is-busy {
+    background-image: linear-gradient(-45deg, #c9356e 28%, #ab235a 28%, #ab235a 72%, #c9356e 72%); }
+
+.button.is-scary {
+  color: #d63638; }
+  .button.is-scary:hover, .button.is-scary:focus {
+    border-color: #d63638; }
+  .accessible-focus .button.is-scary:focus {
+    box-shadow: 0 0 0 2px #f86368; }
+  .button.is-scary[disabled], .button.is-scary:disabled {
+    color: #a7aaad;
+    background-color: #fff;
+    border-color: #fff; }
+
+.button.is-primary.is-scary {
+  background-color: #d63638;
+  border-color: #d63638;
+  color: #fff; }
+  .button.is-primary.is-scary:hover, .button.is-primary.is-scary:focus {
+    background-color: #b32d2e;
+    border-color: #b32d2e; }
+  .button.is-primary.is-scary[disabled], .button.is-primary.is-scary:disabled {
+    color: #a7aaad;
+    background-color: #fff;
+    border-color: #fff; }
+  .button.is-primary.is-scary.is-busy {
+    background-image: linear-gradient(-45deg, #d63638 28%, #b32d2e 28%, #b32d2e 72%, #d63638 72%); }
+
+.button.is-borderless {
+  border: none;
+  background: none;
+  color: #646970;
+  padding-left: 0;
+  padding-right: 0; }
+  .button.is-borderless:hover, .button.is-borderless:focus {
+    background: none;
+    color: #3c434a; }
+  .button.is-borderless .gridicon {
+    width: 24px;
+    height: 24px;
+    top: 6px; }
+  .button.is-borderless[disabled], .button.is-borderless:disabled {
+    color: #a7aaad;
+    cursor: default; }
+    .button.is-borderless[disabled]:active, .button.is-borderless[disabled].is-active, .button.is-borderless:disabled:active, .button.is-borderless:disabled.is-active {
+      border-width: 0; }
+  .button.is-borderless.is-scary {
+    color: #d63638; }
+    .button.is-borderless.is-scary:hover, .button.is-borderless.is-scary:focus {
+      color: #b32d2e; }
+    .button.is-borderless.is-scary[disabled] {
+      color: #ff8085; }
+  .button.is-borderless.is-primary {
+    color: #c9356e; }
+    .button.is-borderless.is-primary:focus, .button.is-borderless.is-primary:hover, .button.is-borderless.is-primary:active, .button.is-borderless.is-primary.is-active {
+      color: #8c1749; }
+    .button.is-borderless.is-primary:focus {
+      box-shadow: 0 0 0 2px #eb6594; }
+    .button.is-borderless.is-primary[disabled] {
+      color: #a7aaad; }
+  .button.is-borderless.is-compact .gridicon {
+    width: 18px;
+    height: 18px;
+    top: 5px; }
+  .button.is-borderless.is-compact .gridicons-arrow-left {
+    top: 4px;
+    margin-right: 4px; }
+  .button.is-borderless.is-compact .gridicons-arrow-right {
+    top: 4px;
+    margin-left: 4px; }
+
+.button-plain {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  background: transparent;
+  color: inherit;
+  border: none;
+  font-size: inherit;
+  font-weight: inherit;
+  outline: 0;
+  padding: 0;
+  vertical-align: baseline; }
+
+.button.is-link {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  color: #2271b1;
+  font-weight: 400;
+  font-size: inherit;
+  line-height: 1.65; }
+  .button.is-link:hover, .button.is-link:focus, .button.is-link:active, .button.is-link.is-active {
+    color: #0a4b78;
+    box-shadow: none; }
+
+@keyframes button__busy-animation {
+  0% {
+    background-position: 240px 0; } }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+
+.card {
+  display: block;
+  position: relative;
+  margin: 0 auto 10px;
+  padding: 16px;
+  box-sizing: border-box;
+  background: #fff;
+  box-shadow: 0 0 0 1px #dcdcde; }
+  .card::after {
+    content: '.';
+    display: block;
+    height: 0;
+    width: 0;
+    clear: both;
+    visibility: hidden;
+    overflow: hidden; }
+  @media (min-width: 480px) {
+    .card {
+      margin-bottom: 16px;
+      padding: 24px; } }
+  .card.is-compact {
+    margin-bottom: 1px; }
+    @media (min-width: 480px) {
+      .card.is-compact {
+        margin-bottom: 1px;
+        padding: 16px 24px; } }
+  .card.is-card-link {
+    padding-right: 48px; }
+    .card.is-card-link:not(a) {
+      color: #2271b1;
+      font-size: 100%;
+      line-height: 1.5;
+      text-align: left;
+      width: 100%; }
+      .card.is-card-link:not(a):active, .card.is-card-link:not(a):focus, .card.is-card-link:not(a):hover {
+        color: #0a4b78; }
+  .card.is-clickable {
+    cursor: pointer; }
+  .card.is-highlight {
+    padding-left: 21px; }
+  .card.is-error {
+    border-left: 3px solid #ff8085; }
+  .card.is-info {
+    border-left: 3px solid #72aee6; }
+  .card.is-success {
+    border-left: 3px solid #1ed15a; }
+  .card.is-warning {
+    border-left: 3px solid #f0c930; }
+
+.card__link-indicator {
+  color: #646970;
+  display: block;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 16px; }
+  html[dir='rtl'] .card__link-indicator.gridicons-chevron-right {
+    transform: scaleX(-1); }
+
+a.card:hover .card__link-indicator,
+.is-card-link.card:hover .card__link-indicator {
+  color: #2c3338; }
+
+a.card:focus .card__link-indicator,
+.is-card-link.card:focus .card__link-indicator {
+  color: #0a4b78; }
+
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+
+.dialog__backdrop,
+.dialog__backdrop.card {
+  background-color: rgba(246, 247, 247, 0.8);
+  align-items: center;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  position: fixed;
+  right: 0;
+  top: var(--masterbar-height);
+  transition: background-color 0.2s ease-in;
+  z-index: z-index("root", ".dialog__backdrop"); }
+  .dialog__backdrop.is-full-screen,
+  .dialog__backdrop.card.is-full-screen {
+    top: 0; }
+
+.dialog__backdrop.is-hidden {
+  background-color: transparent; }
+
+.dialog.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  max-width: 90%;
+  max-height: 90%;
+  margin: auto 0;
+  padding: 0;
+  opacity: 1;
+  transition: opacity 0.2s ease-in; }
+
+.dialog__content {
+  padding: 16px;
+  overflow-y: auto; }
+  @media (min-width: 480px) {
+    .dialog__content {
+      padding: 24px; } }
+  .dialog__content:last-child {
+    bottom: 0; }
+  .dialog__content h1 {
+    color: #3c434a;
+    /* stylelint-disable-next-line scales/font-size */
+    font-size: 1.375em;
+    font-weight: 600;
+    margin-bottom: 0.5em; }
+  .dialog__content p:last-child {
+    margin-bottom: 0; }
+
+.dialog__action-buttons {
+  position: relative;
+  border-top: 1px solid #f6f7f7;
+  padding: 16px;
+  margin: 0;
+  text-align: right;
+  flex-shrink: 0;
+  background-color: white; }
+  @media (min-width: 480px) {
+    .dialog__action-buttons {
+      padding-left: 24px;
+      padding-right: 24px; } }
+  @media (max-width: 480px) {
+    .dialog__action-buttons {
+      display: flex;
+      flex-direction: column-reverse; } }
+  .dialog__action-buttons::before {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: 100%;
+    left: 16px;
+    right: 16px;
+    height: 24px;
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, white 100%);
+    margin-bottom: 1px; }
+
+.dialog__action-buttons .button {
+  margin-left: 10px;
+  min-width: 80px;
+  text-align: center; }
+  .dialog__action-buttons .button .is-left-aligned {
+    margin-left: 0;
+    margin-right: 10px; }
+  @media (max-width: 480px) {
+    .dialog__action-buttons .button {
+      margin: 2px 0; } }
+
+.dialog__action-buttons .is-left-aligned {
+  float: left; }
+
+.ReactModal__Body--open {
+  overflow: hidden; }
+
+.ReactModal__Html--open {
+  overflow: visible; }
+
+.product-icon {
+  width: inherit;
+  height: inherit; }
+
+.screen-reader-text {
+  clip: rect(1px, 1px, 1px, 1px);
+  position: absolute !important; }
+  .screen-reader-text:hover, .screen-reader-text:active, .screen-reader-text:focus {
+    background-color: #f1f1f1;
+    border-radius: 3px;
+    box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+    clip: auto !important;
+    color: #21759b;
+    display: block;
+    font-size: 14px;
+    font-weight: bold;
+    height: auto;
+    left: 5px;
+    line-height: normal;
+    padding: 15px 23px 14px;
+    text-decoration: none;
+    top: 5px;
+    width: auto;
+    z-index: z-index("screen-reader-text-parent", ".screen-reader-text:focus"); }
+
+.progress-bar {
+  width: 100%;
+  display: inline-block;
+  position: relative;
+  height: 9px;
+  background-color: #c3c4c7;
+  border-radius: 4.5px; }
+  .progress-bar.is-compact {
+    height: 4px; }
+
+.progress-bar__progress {
+  display: inline-block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background-color: #2271b1;
+  border-radius: 4.5px;
+  transition: width 200ms; }
+  @media (prefers-reduced-motion: reduce) {
+    .progress-bar__progress {
+      transition: none; } }
+
+.progress-bar.is-pulsing .progress-bar__progress {
+  animation: progress-bar-animation 3300ms infinite linear;
+  background-size: 50px 100%;
+  background-image: linear-gradient(-45deg, #2271b1 28%, #5198d9 28%, #5198d9 72%, #2271b1 72%); }
+  @media (prefers-reduced-motion: reduce) {
+    .progress-bar.is-pulsing .progress-bar__progress {
+      animation: none; } }
+
+@keyframes progress-bar-animation {
+  0% {
+    background-position: 100px 0; } }
+
+/* Percentage bar */
+.percentage-bar {
+  border-radius: 0;
+  height: 8px;
+  width: 150px; }
+  .percentage-bar .progress-bar__progress {
+    border-radius: 0; }
+
+.ribbon {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+  position: absolute;
+  right: -5px;
+  top: -5px;
+  z-index: z-index("root", ".ribbon");
+  overflow: hidden;
+  width: 75px;
+  height: 75px;
+  text-align: right; }
+
+.ribbon .ribbon__title {
+  font-size: 10px;
+  font-weight: normal;
+  color: #fff;
+  text-align: center;
+  line-height: 20px;
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+  width: 100px;
+  display: block;
+  background: #c9356e;
+  position: absolute;
+  top: 19px;
+  right: -21px;
+  text-transform: uppercase; }
+
+.ribbon .ribbon__title::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 100%;
+  z-index: z-index(".ribbon", ".ribbon__title::before");
+  border-left: 3px solid #8c1749;
+  border-right: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  border-top: 3px solid #8c1749; }
+
+.ribbon .ribbon__title::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: z-index(".ribbon", ".ribbon__title::after");
+  border-left: 3px solid transparent;
+  border-right: 3px solid #8c1749;
+  border-bottom: 3px solid transparent;
+  border-top: 3px solid #8c1749; }
+
+.ribbon.is-green .ribbon__title {
+  background-color: #008a20; }
+
+.ribbon.is-green .ribbon__title::before {
+  border-left-color: #005c12;
+  border-top-color: #005c12; }
+
+.ribbon.is-green .ribbon__title::after {
+  border-right-color: #005c12;
+  border-top-color: #005c12; }
+
+.suggestions {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  z-index: 10; }
+
+.suggestions__item {
+  padding: 12px 16px;
+  background: #fff;
+  border: 1px solid #dcdcde;
+  border-top: 0;
+  font-size: 15px;
+  white-space: pre-wrap;
+  cursor: pointer;
+  text-align: left;
+  margin: 0; }
+  .suggestions__item.has-highlight {
+    background-color: #f6f7f7;
+    color: #2c3338; }
+
+.suggestions__label.is-emphasized {
+  font-weight: 600; }
+
+.suggestions__category-heading {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 12px 24px 8px 42px;
+  color: var(--color-neutral-400);
+  border-bottom: 1px solid #dcdcde; }
+
+.suggestions__title {
+  font-size: 10px;
+  color: #787c82;
+  background-color: #fff;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  text-transform: uppercase;
+  font-weight: 600;
+  padding: 16px 8px; }
+
+.jp-recommendations-question__content {
+  display: flex;
+  flex-direction: column; }
+  @media (min-width: 661px) {
+    .jp-recommendations-question__content {
+      padding-right: 48px; } }
+
+.jp-recommendations-question__progress-bar {
+  margin: 32px 32px 0 32px; }
+  .jp-recommendations-question__progress-bar .progress-bar {
+    width: 70px; }
+  @media (max-width: 480px) {
+    .jp-recommendations-question__progress-bar {
+      margin: 16px 16px 32px 16px; } }
+
+.jp-recommendations-question__question {
+  font-size: 1.5rem;
+  margin: 32px 32px 0 32px; }
+  @media (max-width: 480px) {
+    .jp-recommendations-question__question {
+      margin: 0 16px 32px 16px; } }
+
+.jp-recommendations-question__description {
+  font-size: 16px;
+  margin: 32px 0 24px 32px; }
+  @media (max-width: 660px) {
+    .jp-recommendations-question__description {
+      margin: 32px 32px 24px 32px; } }
+  @media (max-width: 480px) {
+    .jp-recommendations-question__description {
+      margin: 0 16px 16px 16px; } }
+  .jp-recommendations-question__description .gridicons-external {
+    margin-left: 0.25rem; }
+  .jp-recommendations-question__description a {
+    white-space: nowrap; }
+
+.jp-recommendations-question__answer {
+  height: 100%;
+  display: flex;
+  flex-direction: column; }
+
+.jp-recommendations-question__illustration-container {
+  width: 100%;
+  position: relative; }
+  .jp-recommendations-question__illustration-container img {
+    position: absolute;
+    bottom: 0;
+    right: 0; }
+  @media (max-width: 660px) {
+    .jp-recommendations-question__illustration-container {
+      display: none; } }
+
+.jp-recommendations-question__illustration-background {
+  width: 100%; }
+
+.jp-recommendations-question__illustration-foreground {
+  width: 75%;
+  margin: 10%; }
+
+.jp-recommendations-question__install-section {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end; }
+  .jp-recommendations-question__install-section button {
+    margin-top: auto;
+    margin-bottom: 16px;
+    min-width: 172px; }
+  .jp-recommendations-question__install-section a {
+    margin-bottom: 32px; }
+    .jp-recommendations-question__install-section a.dops-button {
+      margin-bottom: 16px;
+      text-align: center; }
+      @media (max-width: 480px) {
+        .jp-recommendations-question__install-section a.dops-button {
+          width: 100%; } }
+  @media (max-width: 480px) {
+    .jp-recommendations-question__install-section {
+      padding: 64px 16px 0 16px; } }
+
+.jp-checkbox-answer__container {
+  display: flex;
+  background: white;
+  box-sizing: border-box;
+  border: 1px solid #d5d5d5;
+  border-radius: 4px;
+  cursor: pointer; }
+  .jp-checkbox-answer__container.checked {
+    background: #f8fbff;
+    border: 1px solid #3582c4; }
+  @media (max-width: 480px) {
+    .jp-checkbox-answer__container {
+      margin-bottom: 8px; } }
+
+.jp-checkbox-answer__title {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 15px 0; }
+
+.jp-checkbox-answer__checkbox {
+  margin: 18px 8px 14px 16px; }
+
+.jp-checkbox-answer__info {
+  padding: 16px 16px 16px 0; }
+
+.jp-recommendations-question__site-type-checkboxes {
+  margin-bottom: 16px;
+  text-align: left; }
+  @media (min-width: 481px) {
+    .jp-recommendations-question__site-type-checkboxes {
+      display: grid;
+      gap: 16px;
+      grid-template-rows: auto auto;
+      grid-template-columns: auto auto; } }
+  @media (max-width: 480px) {
+    .jp-recommendations-question__site-type-checkboxes {
+      display: flex;
+      flex-direction: column; } }
+
+.jp-recommendations-question__site-type-answer-container {
+  text-align: center;
+  margin: 0 0 32px 32px; }
+  @media (max-width: 660px) {
+    .jp-recommendations-question__site-type-answer-container {
+      margin: 0 32px 32px 32px; } }
+  @media (max-width: 480px) {
+    .jp-recommendations-question__site-type-answer-container {
+      margin: 0 16px 16px 16px; } }
+  @media (max-width: 480px) {
+    .jp-recommendations-question__site-type-answer-container .dops-button {
+      width: 100%; } }
+
+.jp-recommendations-site-type-question__continue-description {
+  color: #646970;
+  margin: 24px auto 0 auto;
+  max-width: 300px; }
+  @media (max-width: 480px) {
+    .jp-recommendations-site-type-question__continue-description {
+      display: none; } }
+
+.jp-recommendations-site-type__illustration {
+  height: 200px;
+  padding: 65px; }
+
+.jp-install-button__spinner-container {
+  display: flex;
+  justify-content: center; }
+
+@charset "UTF-8";
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+.jp-recommendations-feature-summary {
+  display: grid;
+  grid-template-columns: auto 120px;
+  min-width: 275px;
+  border-bottom: 1px solid #e1e1e1; }
+  .jp-recommendations-feature-summary.is-feature-enabled {
+    grid-template-columns: 30px auto 120px; }
+  .jp-recommendations-feature-summary .gridicons-checkmark-circle {
+    fill: #00be28; }
+  .jp-recommendations-feature-summary:last-child {
+    border-bottom: none; }
+
+.jp-recommendations-feature-summary__checkmark {
+  display: flex;
+  align-items: center;
+  align-content: center; }
+
+.jp-recommendations-feature-summary__display-name {
+  display: flex;
+  align-items: center;
+  padding-left: 12px; }
+
+.jp-recommendations-feature-summary__cta button {
+  width: 100%; }
+
+.jp-recommendations-feature-summary__cta a {
+  width: 100%;
+  text-align: center; }
+
+.jp-recommendations-feature-summary__actions {
+  padding: 8px; }
+
+.jp-recommendations-loading-card {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center; }
+
+@charset "UTF-8";
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+.jp-recommendations-sidebar-card {
+  width: 100%;
+  background: linear-gradient(to bottom, #c5d9ed 115px, white 115px);
+  border-radius: 8px; }
+  .jp-recommendations-sidebar-card .dops-button {
+    width: 100%;
+    background: #069e08;
+    border-color: #069e08;
+    text-align: center; }
+
+.jp-recommendations-sidebar-card__illustration-container {
+  text-align: center; }
+
+.jp-recommendations-sidebar-card__illustration {
+  display: inline-flex;
+  justify-content: center;
+  width: 220px;
+  height: 115px;
+  margin-top: 24px;
+  padding: 8px;
+  background: white;
+  border-radius: 3px;
+  box-shadow: 0px 0px 24px rgba(0, 0, 0, 0.16); }
+
+.jp-recommendations-sidebar-card__content {
+  padding: 0 24px 24px 24px; }
+
+.jp-recommendations-sidebar-card__features {
+  margin: 32px 0 8px 0; }
+  .jp-recommendations-sidebar-card__features li {
+    display: flex;
+    align-items: center; }
+  .jp-recommendations-sidebar-card__features .gridicons-checkmark-circle {
+    fill: #00be28;
+    margin-right: 8px; }
+
+.jp-recommendations-one-click-restores h2 {
+  margin-top: 32px; }
+
+.jp-recommendations-one-click-restores p {
+  margin: 16px 0; }
+
+.jp-recommendations-one-click-restores .jp-recommendations-one-click-restores__cta {
+  margin-top: 32px;
+  text-align: center; }
+
+.jp-recommendations__app-badge {
+  display: flex;
+  max-width: 135px;
+  max-height: 40px;
+  overflow: hidden;
+  margin: 0; }
+  .jp-recommendations__app-badge:first-child {
+    margin-right: 8px; }
+  .jp-recommendations__app-badge img {
+    max-width: 100%; }
+  .jp-recommendations__app-badge.android-app-badge img {
+    transform: scale(1.13) translate(-7px, -5.1px);
+    transform-origin: left; }
+
+.jp-recommendations-sidebar-card__apps-badge {
+  display: flex;
+  margin-top: 32px; }
+  .jp-recommendations-sidebar-card__apps-badge .jp-recommendations__app-badge {
+    width: 50%; }
+
+@charset "UTF-8";
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+.jp-recommendations-product-card-upsell-no-price {
+  background: white;
+  border-radius: 8px; }
+  .jp-recommendations-product-card-upsell-no-price img {
+    margin-right: 8px; }
+  .jp-recommendations-product-card-upsell-no-price h2 {
+    margin: 0 0 24px 0; }
+  .jp-recommendations-product-card-upsell-no-price ul {
+    margin: 16px 0; }
+  .jp-recommendations-product-card-upsell-no-price li {
+    display: flex;
+    align-items: center; }
+  .jp-recommendations-product-card-upsell-no-price p {
+    margin: 0; }
+  .jp-recommendations-product-card-upsell-no-price .gridicons-checkmark-circle {
+    fill: #00be28;
+    margin-right: 8px; }
+  .jp-recommendations-product-card-upsell-no-price .dops-button {
+    margin: 32px 0 0 0;
+    width: 100%;
+    background: #069e08;
+    border-color: #069e08;
+    text-align: center; }
+
+.jp-recommendations-product-card-upsell-no-price__padding {
+  padding: 24px; }
+
+.jp-recommendations-product-card-upsell-no-price__header-chrome {
+  background: #3582c4;
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+  padding: 8px;
+  color: white; }
+
+@charset "UTF-8";
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+.jp-recommendations-product-card-upsell {
+  background: white;
+  border-radius: 8px; }
+  .jp-recommendations-product-card-upsell img {
+    margin-right: 8px; }
+  .jp-recommendations-product-card-upsell h1 {
+    margin-top: 0;
+    margin-bottom: 16px; }
+  .jp-recommendations-product-card-upsell p {
+    margin-top: 16px;
+    margin-bottom: 32px; }
+  .jp-recommendations-product-card-upsell .dops-button {
+    margin: 32px 0 0 0;
+    width: 100%;
+    background: #069e08;
+    border-color: #069e08;
+    text-align: center; }
+    .jp-recommendations-product-card-upsell .dops-button:hover {
+      background: #007117;
+      border-color: #007117; }
+
+.jp-recommendations-product-card-upsell__padding {
+  padding: 24px; }
+
+.jp-recommendations-product-card-upsell__header-chrome {
+  display: flex;
+  background: #3582c4;
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+  padding: 8px;
+  color: white; }
+
+.jp-recommendations-product-card-upsell__price {
+  display: flex;
+  align-items: center; }
+
+.jp-recommendations-product-card-upsell__raw-price h2 {
+  display: flex;
+  margin: 0; }
+
+.jp-recommendations-product-card-upsell__currency-symbol {
+  font-size: 1.5rem;
+  margin-top: -0.25rem; }
+
+.jp-recommendations-product-card-upsell__price-integer {
+  font-size: 3.375rem;
+  font-weight: 700;
+  line-height: 0.7; }
+
+.jp-recommendations-product-card-upsell__price-fraction {
+  font-size: 0.75rem;
+  margin-top: -0.25rem; }
+
+.jp-recommendations-product-card-upsell__billing-time-frame {
+  margin-left: 12px; }
+
+.jp-recommendations-product-card-upsell__cta-button .gridicons-external {
+  margin-left: 0.25rem; }
+
+.jp-recommendations-summary {
+  display: grid;
+  grid-template-columns: 57% 43%;
+  background: #e9eff5;
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.03), 0px 1px 2px rgba(0, 0, 0, 0.03);
+  border: 1px solid #d5d5d5; }
+  @media (max-width: 660px) {
+    .jp-recommendations-summary {
+      display: flex;
+      flex-direction: column; } }
+
+.jp-recommendations-summary__content {
+  background: white; }
+  .jp-recommendations-summary__content.isLoading {
+    min-height: 730px;
+    display: flex;
+    align-items: center;
+    justify-content: center; }
+
+.jp-recommendations-summary__configuration {
+  margin: 48px 48px 32px 48px; }
+  @media (max-width: 480px) {
+    .jp-recommendations-summary__configuration {
+      margin: 16px 16px 0 16px; } }
+  .jp-recommendations-summary__configuration h2 {
+    margin: 32px 0 16px 0; }
+
+.jp-recommendations-summary__sidebar {
+  border-left: 1px solid #d5d5d5;
+  padding: 24px; }
+  @media (max-width: 660px) {
+    .jp-recommendations-summary__sidebar {
+      padding: 0; } }
+  .jp-recommendations-summary__sidebar.isLoading {
+    min-height: 430px;
+    display: flex;
+    align-items: center;
+    justify-content: center; }
+
+.jp-recommendations-summary__more-features {
+  display: flex;
+  align-items: center;
+  border-top: 1px solid #dcdcde;
+  padding: 32px 48px; }
+  @media (max-width: 480px) {
+    .jp-recommendations-summary__more-features {
+      padding: 32px 16px; } }
+  .jp-recommendations-summary__more-features .gridicons-info-outline {
+    fill: #787c82;
+    margin-right: 18px; }
+  .jp-recommendations-summary__more-features .gridicons-external {
+    margin-left: 0.25rem; }
+
+.dops-tooltip.dops-popover .dops-popover__arrow {
+  border-width: 6px; }
+
+.dops-tooltip.dops-popover.is-bottom-right .dops-popover__arrow, .dops-tooltip.dops-popover.is-bottom-left .dops-popover__arrow, .dops-tooltip.dops-popover.is-bottom .dops-popover__arrow {
+  border-bottom-color: #555555;
+  top: 4px;
+  right: 10px; }
+  .dops-tooltip.dops-popover.is-bottom-right .dops-popover__arrow::before, .dops-tooltip.dops-popover.is-bottom-left .dops-popover__arrow::before, .dops-tooltip.dops-popover.is-bottom .dops-popover__arrow::before {
+    display: none; }
+
+.dops-tooltip.dops-popover.is-bottom-right.is-error .dops-popover__arrow, .dops-tooltip.dops-popover.is-bottom-left.is-error .dops-popover__arrow, .dops-tooltip.dops-popover.is-bottom.is-error .dops-popover__arrow {
+  border-bottom-color: #d94f4f; }
+
+.dops-tooltip.dops-popover.is-bottom-right.is-warning .dops-popover__arrow, .dops-tooltip.dops-popover.is-bottom-left.is-warning .dops-popover__arrow, .dops-tooltip.dops-popover.is-bottom.is-warning .dops-popover__arrow {
+  border-bottom-color: #f0b849; }
+
+.dops-tooltip.dops-popover.is-bottom-right.is-success .dops-popover__arrow, .dops-tooltip.dops-popover.is-bottom-left.is-success .dops-popover__arrow, .dops-tooltip.dops-popover.is-bottom.is-success .dops-popover__arrow {
+  border-bottom-color: #4ab866; }
+
+.dops-tooltip.dops-popover.is-top .dops-popover__arrow, .dops-tooltip.dops-popover.is-top-left .dops-popover__arrow, .dops-tooltip.dops-popover.is-top-right .dops-popover__arrow {
+  border-top-color: #555555;
+  bottom: 4px;
+  right: 10px; }
+  .dops-tooltip.dops-popover.is-top .dops-popover__arrow::before, .dops-tooltip.dops-popover.is-top-left .dops-popover__arrow::before, .dops-tooltip.dops-popover.is-top-right .dops-popover__arrow::before {
+    display: none; }
+
+.dops-tooltip.dops-popover.is-top.is-error .dops-popover__arrow, .dops-tooltip.dops-popover.is-top-left.is-error .dops-popover__arrow, .dops-tooltip.dops-popover.is-top-right.is-error .dops-popover__arrow {
+  border-top-color: #d94f4f; }
+
+.dops-tooltip.dops-popover.is-top.is-warning .dops-popover__arrow, .dops-tooltip.dops-popover.is-top-left.is-warning .dops-popover__arrow, .dops-tooltip.dops-popover.is-top-right.is-warning .dops-popover__arrow {
+  border-top-color: #f0b849; }
+
+.dops-tooltip.dops-popover.is-top.is-success .dops-popover__arrow, .dops-tooltip.dops-popover.is-top-left.is-success .dops-popover__arrow, .dops-tooltip.dops-popover.is-top-right.is-success .dops-popover__arrow {
+  border-top-color: #4ab866; }
+
+.dops-tooltip.dops-popover.is-top .dops-popover__arrow, .dops-tooltip.dops-popover.is-bottom .dops-popover__arrow {
+  margin-left: -6px; }
+
+.dops-tooltip.dops-popover.is-left, .dops-tooltip.dops-popover.is-right {
+  padding-top: 0; }
+  .dops-tooltip.dops-popover.is-left .dops-popover__arrow, .dops-tooltip.dops-popover.is-right .dops-popover__arrow {
+    margin-top: -6px; }
+    .dops-tooltip.dops-popover.is-left .dops-popover__arrow::before, .dops-tooltip.dops-popover.is-right .dops-popover__arrow::before {
+      display: none; }
+  .dops-tooltip.dops-popover.is-left.is-error .dops-popover__arrow, .dops-tooltip.dops-popover.is-right.is-error .dops-popover__arrow {
+    border-right-color: #d94f4f; }
+  .dops-tooltip.dops-popover.is-left.is-warning .dops-popover__arrow, .dops-tooltip.dops-popover.is-right.is-warning .dops-popover__arrow {
+    border-right-color: #f0b849; }
+  .dops-tooltip.dops-popover.is-left.is-success .dops-popover__arrow, .dops-tooltip.dops-popover.is-right.is-success .dops-popover__arrow {
+    border-right-color: #4ab866; }
+
+.dops-tooltip.dops-popover.is-left .dops-popover__arrow {
+  margin-right: 4px;
+  border-left-color: #555555; }
+
+.dops-tooltip.dops-popover.is-right .dops-popover__arrow {
+  margin-left: 4px;
+  border-right-color: #555555; }
+
+.dops-tooltip.dops-popover .dops-popover__inner {
+  border: 0px;
+  box-shadow: none;
+  border-radius: 2px;
+  color: white;
+  background: #555555;
+  font-size: 12px;
+  padding: 6px 10px;
+  text-align: left; }
+
+.dops-tooltip.dops-popover.is-error .dops-popover__inner {
+  background: #d94f4f; }
+
+.dops-tooltip.dops-popover.is-warning .dops-popover__inner {
+  background: #f0b849; }
+
+.dops-tooltip.dops-popover.is-success .dops-popover__inner {
+  background: #4ab866; }
+
+.dops-tooltip.dops-popover ul {
+  list-style: none;
+  margin: 0;
+  padding: 0; }
+  .dops-tooltip.dops-popover ul li {
+    font-size: 11px;
+    font-weight: 100;
+    border: 0; }
+
+.dops-tooltip__hr {
+  margin: 8px 0;
+  background: #a2a2a2; }
+
+#jp-plugin-container {
+  min-height: 100vh; }
+
+.dops-chart {
+  position: relative;
+  box-sizing: border-box;
+  background-color: white;
+  padding: 8px 0 8px 20px; }
+
+.dops-chart .dops-chart__y-axis-markers {
+  position: absolute;
+  top: 8px;
+  left: 0;
+  right: 0;
+  height: 200px; }
+
+.dops-chart .dops-chart__y-axis-marker {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 1px;
+  border-top: 1px solid #eeeeee; }
+
+.dops-chart__bar-marker {
+  z-index: 1;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 1px;
+  border-top: 1px solid rgba(238, 238, 238, 0.1); }
+
+.dops-chart__bar-marker.is-fifty,
+.dops-chart__y-axis-label.is-fifty,
+.dops-chart .dops-chart__y-axis-marker.is-fifty {
+  top: 50%; }
+
+.dops-chart__bar-marker.is-zero,
+.dops-chart__y-axis-label.is-zero,
+.dops-chart .dops-chart__y-axis-marker.is-zero {
+  top: 100%; }
+
+.dops-chart__y-axis {
+  position: relative;
+  float: right;
+  height: 200px;
+  padding: 0 20px 0 10px;
+  font-size: 11px;
+  color: #888888;
+  margin-bottom: 30px; }
+
+.dops-chart__y-axis-label {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  text-align: right; }
+
+.dops-chart__y-axis-width-fix {
+  color: rgba(255, 255, 255, 0); }
+
+.dops-chart__x-axis {
+  position: relative;
+  font-size: 0;
+  padding: 5px 0;
+  min-height: 18px;
+  color: #555555; }
+
+.dops-chart__x-axis-label {
+  position: absolute;
+  display: inline-block;
+  vertical-align: top;
+  font-size: 11px;
+  text-align: center; }
+
+.dops-chart__x-axis-label::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: -4px;
+  left: 50%;
+  margin-left: -.5px;
+  width: 1px;
+  height: 5px;
+  background: #f6f6f6;
+  background-image: linear-gradient(to bottom, #f6f6f6 0%, #d5d5d5 100%); }
+
+.dops-chart__bars {
+  position: relative;
+  font-size: 0;
+  height: 200px;
+  text-align: center;
+  overflow: hidden;
+  display: -ms-flex;
+  display: flex; }
+
+.dops-chart__bar {
+  text-align: center;
+  display: inline-block;
+  position: relative;
+  height: 200px;
+  -ms-flex-grow: 1;
+  flex-grow: 1;
+  -ms-flex-shrink: 1;
+  flex-shrink: 1; }
+  .dops-chart__bar.is-weekend {
+    background-color: rgba(238, 238, 238, 0.5); }
+  .dops-chart__bar:focus {
+    background-color: rgba(240, 130, 30, 0.1); }
+  .dops-chart__bar:hover {
+    cursor: pointer;
+    background-color: rgba(238, 238, 238, 0.3); }
+  .dops-chart__bar.is-selected {
+    cursor: default;
+    background-color: rgba(240, 130, 30, 0.1); }
+
+.dops-chart__bar-section {
+  display: inline-block;
+  background-color: #0087be;
+  position: absolute;
+  top: 0;
+  right: 16%;
+  bottom: 0;
+  left: 16%;
+  z-index: 2; }
+  .dops-chart__bar:hover .dops-chart__bar-section.is-bar {
+    background-color: #3582c4; }
+  .dops-chart__bar.is-selected .dops-chart__bar-section.is-bar {
+    background-color: #f0821e; }
+  .dops-chart__bar-section.is-spacer {
+    z-index: 0;
+    background-color: rgba(255, 255, 255, 0); }
+  .dops-chart__bar-section.is-ghost::after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 160px;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    width: 100%;
+    height: 40px;
+    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(238, 238, 238, 0.5)); }
+    .dops-chart__bar:hover .dops-chart__bar-section.is-ghost::after {
+      display: none; }
+
+.dops-chart__bar-section-inner {
+  background: #004069;
+  position: absolute;
+  right: 23.33%;
+  bottom: 0;
+  left: 23.33%; }
+  .dops-chart__bar.is-selected .dops-chart__bar-section-inner {
+    background-color: #d63638; }
+
+.dops-chart__legend {
+  margin-bottom: -8px; }
+  .dops-chart__legend:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden; }
+
+.dops-chart__legend .dops-chart__legend-options {
+  float: right;
+  color: #747474;
+  list-style-type: none;
+  margin: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em; }
+  @media (max-width: 480px) {
+    .dops-chart__legend .dops-chart__legend-options {
+      width: 100%; } }
+
+.dops-chart__legend-option {
+  display: inline;
+  text-align: left; }
+  @media (max-width: 480px) {
+    .dops-chart__legend-option {
+      width: 50%;
+      display: inline-block; } }
+
+.dops-chart__legend-label {
+  display: inline-block;
+  padding: 12px 19px 10px 20px; }
+  .dops-chart__legend-label.is-selectable {
+    cursor: pointer; }
+    .dops-chart__legend-label.is-selectable:focus, .dops-chart__legend-label.is-selectable:hover {
+      color: tint(#3582c4, 20%); }
+  @media (max-width: 480px) {
+    .dops-chart__legend-label {
+      display: block; } }
+
+.dops-chart__legend-option .dops-chart__legend-color {
+  width: 10px;
+  height: 10px;
+  background: #0087be;
+  display: inline-block;
+  border-radius: 1px;
+  vertical-align: top;
+  margin: 3px 5px 3px 8px; }
+
+@media (max-width: 480px) {
+  .dops-chart__legend-option:first-child .dops-chart__legend-color {
+    margin-left: 2px; } }
+
+.dops-chart__legend-color.is-dark-blue {
+  background: #004069; }
+
+.dops-chart__legend-option .dops-chart__legend-checkbox {
+  margin: 0;
+  float: none;
+  vertical-align: top; }
+
+.dops-chart__empty {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  text-align: center;
+  font-size: 14px;
+  line-height: 24px;
+  clear: both;
+  z-index: 1; }
+
+.dops-chart__empty_notice {
+  position: relative;
+  top: 97px;
+  padding: 11px 24px;
+  margin-bottom: 24px;
+  border-radius: 1px;
+  background: #fff;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1.4285;
+  animation: appear .3s ease-in-out;
+  box-shadow: 0 0 0 1px rgba(213, 213, 213, 0.5), 0 1px 2px #eeeeee; }
+  @media (min-width: 661px) {
+    .dops-chart__empty_notice {
+      padding: 13px 48px;
+      font-size: inherit; }
+      .dops-chart__empty_notice::before {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        display: inline-block;
+        vertical-align: middle;
+        font: normal 16px/1 'Noticons';
+        content: '\f456';
+        position: absolute;
+        top: 23px;
+        left: 20px;
+        margin: -12px 0px 0 -8px;
+        font-size: 24px;
+        line-height: 1; } }
+
+.dops-chart__tooltip .dops-popover__inner {
+  width: 230px;
+  text-align: left; }
+  .dops-chart__tooltip .dops-popover__inner ul {
+    list-style: none;
+    margin: 0;
+    padding: 0; }
+    .dops-chart__tooltip .dops-popover__inner ul:after {
+      content: ".";
+      display: block;
+      height: 0;
+      clear: both;
+      visibility: hidden; }
+    .dops-chart__tooltip .dops-popover__inner ul li {
+      font-size: 11px;
+      text-transform: uppercase;
+      font-weight: 100;
+      height: 24px;
+      letter-spacing: 0.1em;
+      border: 0;
+      margin-bottom: 0; }
+      .dops-chart__tooltip .dops-popover__inner ul li .dops-wrapper {
+        display: block;
+        line-height: inherit;
+        line-height: 24px;
+        clear: both; }
+      .dops-chart__tooltip .dops-popover__inner ul li .value {
+        text-align: right;
+        float: right;
+        min-width: 22px;
+        color: #d5d5d5; }
+      .dops-chart__tooltip .dops-popover__inner ul li .label {
+        display: block;
+        overflow: hidden;
+        word-break: break-all;
+        vertical-align: baseline; }
+      .dops-chart__tooltip .dops-popover__inner ul li .gridicon {
+        vertical-align: middle;
+        margin-right: 6px;
+        margin-top: -3px; }
+
+.dops-chart__tooltip.is-streak {
+  margin-top: -5px;
+  height: 35px; }
+  .dops-chart__tooltip.is-streak .dops-popover__arrow::before {
+    left: 85px;
+    top: 30px; }
+  .dops-chart__tooltip.is-streak .dops-popover__inner {
+    width: 160px;
+    position: relative;
+    top: -10px; }
+    .dops-chart__tooltip.is-streak .dops-popover__inner li {
+      height: 14px; }
+      .dops-chart__tooltip.is-streak .dops-popover__inner li .label {
+        width: 100%;
+        float: left;
+        text-align: center; }
+        .rtl .dops-chart__tooltip.is-streak .dops-popover__inner li .label {
+          font-size: 11px; }
+        .dops-chart__tooltip.is-streak .dops-popover__inner li .label .post-count {
+          font-weight: bold; }
+      .dops-chart__tooltip.is-streak .dops-popover__inner li .value {
+        float: none; }
+
+.dops-chart__tooltip .dops-module-content-list-item.is-date-label {
+  font-size: 11px;
+  margin-bottom: 2px;
+  text-transform: uppercase;
+  font-weight: bold;
+  border-bottom: 1px solid #5d5d5d;
+  padding-bottom: 2px; }
+
+.dops-chart__tooltip .dops-module-content-list-item.is-published-item {
+  height: 19px; }
+  .dops-chart__tooltip .dops-module-content-list-item.is-published-item .label {
+    text-transform: none;
+    color: #d5d5d5;
+    overflow: hidden;
+    letter-spacing: 0;
+    height: 19px; }
+  .dops-chart__tooltip .dops-module-content-list-item.is-published-item .value {
+    width: 0;
+    min-width: 0; }
+    .dops-chart__tooltip .dops-module-content-list-item.is-published-item .value::before {
+      content: '';
+      position: relative;
+      background-image: linear-gradient(to right, rgba(61, 89, 109, 0) 0%, rgba(61, 89, 109, 0.5), #3d596d);
+      left: -30px;
+      width: 30px;
+      height: 24px;
+      display: block; }
+
+@media (min-width: 961px) {
+  .my-plan-card {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between; } }
+
+.my-plan-card__primary {
+  display: flex;
+  flex-flow: row nowrap;
+  flex-grow: 1; }
+
+.my-plan-card__header {
+  flex: 1; }
+
+.my-plan-card__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 30px;
+  margin: 6px 0;
+  color: #414141; }
+
+.my-plan-card__tag-line {
+  font-weight: 400;
+  line-height: 18px;
+  margin: 0 0 24px; }
+  @media (min-width: 961px) {
+    .my-plan-card__tag-line {
+      margin-bottom: 8px; } }
+
+.my-plan-card__icon {
+  flex: 0 0 auto;
+  width: 64px;
+  height: 64px;
+  margin: 8px 20px 16px 0; }
+  @media (max-width: 660px) {
+    .my-plan-card__icon {
+      display: none; } }
+  .my-plan-card__icon img {
+    width: 100%;
+    height: 100%; }
+
+.my-plan-card__secondary {
+  position: relative;
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0 0; }
+  @media (min-width: 961px) {
+    .my-plan-card__secondary {
+      flex-flow: column nowrap;
+      justify-content: center;
+      align-items: flex-end;
+      padding: 0 0 0 24px; } }
+  .my-plan-card__secondary::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -16px;
+    right: -16px;
+    border-top: 1px solid #c3c4c7; }
+    @media (min-width: 481px) {
+      .my-plan-card__secondary::before {
+        left: -24px;
+        right: -24px; } }
+    @media (min-width: 961px) {
+      .my-plan-card__secondary::before {
+        content: none; } }
+  .has-action-only .my-plan-card__secondary {
+    padding-top: 0;
+    justify-content: center; }
+    .has-action-only .my-plan-card__secondary::before {
+      content: none; }
+
+.my-plan-card__details {
+  padding-top: 8px;
+  white-space: nowrap;
+  color: #888888; }
+  @media (min-width: 961px) {
+    .my-plan-card__details {
+      padding-top: 0; } }
+  .my-plan-card__details.is-error {
+    color: #d94f4f; }
+
+.my-plan-card__action {
+  padding-top: 8px;
+  white-space: nowrap; }
+  .has-action-only .my-plan-card__action {
+    padding-top: 0; }
+
+.notices-list {
+  overflow: hidden; }
+  .notices-list.is-pinned {
+    width: calc( 100% - 272px - 32px - 32px);
+    z-index: z-index("root", ".notices-list.is-pinned");
+    position: fixed;
+    top: 79px; }
+    .notices-list.is-pinned .notice {
+      z-index: z-index("root", ".notices-list.is-pinned .notice"); }
+
+.notices-list__whitespace {
+  height: 71px;
+  width: 100%;
+  display: block; }
+
+@keyframes appear {
+  0% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
+
+.global-notices {
+  text-align: right;
+  pointer-events: none;
+  z-index: 179;
+  position: fixed;
+  top: auto;
+  right: 0;
+  bottom: 0;
+  left: 0; }
+  @media (min-width: 661px) {
+    .global-notices {
+      top: 63px;
+      right: 16px;
+      bottom: auto;
+      left: auto;
+      /* `36px` being the width of the collapsed WP-admin sidebar */
+      max-width: calc( 100% - 32px - 36px); } }
+  @media (min-width: 961px) {
+    .global-notices {
+      top: 71px;
+      right: 24px;
+      /* `160px` being the width of the WP-admin sidebar */
+      max-width: calc( 100% - 48px - 160px); } }
+  @media (min-width: 1041px) {
+    .global-notices {
+      right: 32px;
+      /* `160px` being the width of the WP-admin sidebar */
+      max-width: calc( 100% - 64px - 160px); } }
+
+.global-notices .dops-notice {
+  flex-wrap: nowrap;
+  margin-bottom: 0;
+  text-align: left;
+  pointer-events: auto;
+  border-radius: 0;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2), 0 0 56px rgba(0, 0, 0, 0.15); }
+  .global-notices .dops-notice .dops-notice__icon-wrapper {
+    border-radius: 0; }
+  @media (min-width: 661px) {
+    .global-notices .dops-notice {
+      display: flex;
+      overflow: hidden;
+      margin-bottom: 24px;
+      border-radius: 3px; }
+      .global-notices .dops-notice .dops-notice__icon-wrapper {
+        border-radius: 3px 0 0 3px; } }
+
+@media (min-width: 661px) {
+  .global-notices .dops-notice a.dops-notice__action {
+    font-size: 14px;
+    padding: 13px 16px; } }
+
+.global-notices .dops-notice__dismiss {
+  flex-shrink: 0; }
+  @media (min-width: 661px) {
+    .global-notices .dops-notice__dismiss {
+      padding: 13px 16px 0; } }
+
+@charset "UTF-8";
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+.reconnect__modal__body {
+  margin: 0;
+  padding: rem(24px) rem(32px);
+  font-size: rem(14px);
+  color: #2e4453;
+  text-align: center; }
+  .reconnect__modal__body h2 {
+    margin: rem(32px) 0 rem(24px);
+    font-size: rem(32px);
+    font-weight: 300;
+    color: #2e4453; }
+  .reconnect__modal__body h4 {
+    margin: rem(16px) rem(24px) 0;
+    font-size: rem(16px);
+    font-weight: 400;
+    line-height: 1.5em;
+    color: #668eaa; }
+
+.reconnect__modal-actions {
+  margin: 2rem 0; }
+  .reconnect__modal-actions .reconnect__modal-cancel {
+    margin-right: 1em; }
+
+
+/*# sourceMappingURL=admin.css.map*/

--- a/projects/packages/connection/src/idc/_inc/idc-notice.js
+++ b/projects/packages/connection/src/idc/_inc/idc-notice.js
@@ -1,0 +1,262 @@
+/* global idcL10n, analytics, wpCookies */
+
+( function ( $ ) {
+	const restNonce = idcL10n.nonce,
+		currentUrl = idcL10n.currentUrl,
+		restRoot = idcL10n.apiRoot,
+		notice = $( '.jp-idc-notice' ),
+		idcButtons = $( '.jp-idc-notice .dops-button' ),
+		tracksUser = idcL10n.tracksUserData,
+		tracksEvent = idcL10n.tracksEventData,
+		adminBarMenu = $( '#wp-admin-bar-jetpack-idc' ),
+		confirmSafeModeButton = $( '#jp-idc-confirm-safe-mode-action' ),
+		fixConnectionButton = $( '#jp-idc-fix-connection-action' ),
+		migrateButton = $( '#jp-idc-migrate-action' ),
+		reconnectButton = $( '#jp-idc-reconnect-site-action' ),
+		errorNotice = $( '.jp-idc-error__notice' );
+
+	let erroredAction = false;
+
+	// Initialize Tracks and bump stats.
+	if ( 'undefined' !== typeof analytics ) {
+		analytics.initialize( tracksUser.userid, tracksUser.username );
+	}
+
+	if ( tracksEvent.isAdmin ) {
+		trackAndBumpMCStats( 'notice_view' );
+	} else {
+		trackAndBumpMCStats( 'non_admin_notice_view', { page: tracksEvent.currentScreen } );
+	}
+	clearConfirmationArgsFromUrl();
+
+	// If the user dismisses the notice, set a cookie for one week so we don't display it for that time.
+	notice.on( 'click', '.notice-dismiss', function () {
+		const secure = 'https:' === window.location.protocol;
+		wpCookies.set( 'jetpack_idc_dismiss_notice', '1', 7 * 24 * 60 * 60, false, false, secure );
+		trackAndBumpMCStats( 'non_admin_notice_dismiss', { page: tracksEvent.currentScreen } );
+	} );
+
+	notice.on( 'click', '#jp-idc-error__action', function () {
+		errorNotice.hide();
+		switch ( erroredAction ) {
+			case 'confirm':
+				confirmSafeMode();
+				break;
+			case 'start-fresh':
+				startFreshConnection();
+				break;
+			case 'migrate':
+				migrateStatsAndSubscribers();
+				break;
+			default:
+				return;
+		}
+	} );
+
+	// Confirm Safe Mode
+	confirmSafeModeButton.on( 'click', confirmSafeMode );
+
+	// Fix connection
+	fixConnectionButton.on( 'click', fixJetpackConnection );
+
+	// Start fresh connection
+	reconnectButton.on( 'click', startFreshConnection );
+
+	// Starts migration process.
+	migrateButton.on( 'click', migrateStatsAndSubscribers );
+
+	/**
+	 * Disable Dops Buttons.
+	 */
+	function disableDopsButtons() {
+		idcButtons.prop( 'disabled', true );
+	}
+
+	/**
+	 * Eanble Dops Buttons.
+	 */
+	function enableDopsButtons() {
+		idcButtons.prop( 'disabled', false );
+	}
+
+	/**
+	 * Cleare confirmation arguments from url.
+	 *
+	 * @param {boolean} allowReload - Should we allow reload.
+	 */
+	function clearConfirmationArgsFromUrl( allowReload ) {
+		allowReload = 'undefined' === typeof allowReload ? false : allowReload;
+
+		// If the jetpack_idc_clear_confirmation query arg is present, let's try to clear it.
+		//
+		// Otherwise, there's a weird flow where if the user dismisses the notice, then shows the notice, then clicks
+		// the confirm safe mode button again, and then reloads the page, then the notice never disappears.
+		if (
+			window.location.search &&
+			-1 !== window.location.search.indexOf( 'jetpack_idc_clear_confirmation' )
+		) {
+			trackAndBumpMCStats( 'clear_confirmation_clicked' );
+
+			// If push state is available, let's use that to minimize reloading the page.
+			// Otherwise, we can clear the args by reloading the page.
+			if ( history && history.pushState ) {
+				history.pushState( {}, '', currentUrl );
+			} else if ( allowReload ) {
+				window.location.href = currentUrl;
+			}
+		}
+	}
+
+	/**
+	 * Confirm Safe Mode.
+	 */
+	function confirmSafeMode() {
+		errorNotice.hide();
+		trackAndBumpMCStats( 'confirm_safe_mode' );
+
+		const route = restRoot + 'jetpack/v4/identity-crisis/confirm-safe-mode';
+		disableDopsButtons();
+		$.ajax( {
+			method: 'POST',
+			beforeSend: function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', restNonce );
+			},
+			url: route,
+			data: {},
+			success: function () {
+				notice.hide();
+				adminBarMenu.removeClass( 'hide' );
+
+				// We must refresh the Jetpack admin UI page in order for the React UI to render.
+				if ( window.location.search && 1 === window.location.search.indexOf( 'page=jetpack' ) ) {
+					window.location.reload();
+				}
+			},
+			error: function ( error ) {
+				erroredAction = 'confirm';
+				displayErrorNotice( error );
+				enableDopsButtons();
+			},
+		} );
+	}
+
+	/**
+	 * Migrate Stats and Subscribers.
+	 */
+	function migrateStatsAndSubscribers() {
+		errorNotice.hide();
+		trackAndBumpMCStats( 'migrate' );
+
+		const route = restRoot + 'jetpack/v4/identity-crisis/migrate';
+		disableDopsButtons();
+		$.ajax( {
+			method: 'POST',
+			beforeSend: function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', restNonce );
+			},
+			url: route,
+			data: {},
+			success: function () {
+				notice.hide();
+				if ( $( 'body' ).hasClass( 'toplevel_page_jetpack' ) ) {
+					// On the main Jetpack page, sites in IDC will not see Jetpack's interface.
+					// Once IDC is resolved, we need to refresh the page to regain access to the UI.
+					window.location.reload( true );
+				}
+			},
+			error: function ( error ) {
+				erroredAction = 'migrate';
+				displayErrorNotice( error );
+				enableDopsButtons();
+			},
+		} );
+	}
+
+	/**
+	 * Fix Jetpack Connection.
+	 */
+	function fixJetpackConnection() {
+		errorNotice.hide();
+		trackAndBumpMCStats( 'fix_connection' );
+		notice.addClass( 'jp-idc-show-second-step' );
+	}
+
+	/**
+	 * On successful request of the endpoint, we will redirect to the
+	 * connection auth flow after appending a specific 'from=' param for tracking.
+	 */
+	function startFreshConnection() {
+		errorNotice.hide();
+		trackAndBumpMCStats( 'start_fresh' );
+
+		const route = restRoot + 'jetpack/v4/identity-crisis/start-fresh';
+		disableDopsButtons();
+		$.ajax( {
+			method: 'POST',
+			beforeSend: function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', restNonce );
+			},
+			url: route,
+			data: {},
+			success: function ( connectUrl ) {
+				// Add a from param and take them to connect.
+				window.location = connectUrl + '&from=idc-notice';
+			},
+			error: function ( error ) {
+				erroredAction = 'start-fresh';
+				displayErrorNotice( error );
+				enableDopsButtons();
+			},
+		} );
+	}
+
+	/**
+	 * Displays an error message from the REST endpoints we're hitting.
+	 *
+	 * @param {object} error - Object containing the errored response from the API
+	 */
+	function displayErrorNotice( error ) {
+		const errorDescription = $( '.jp-idc-error__desc' );
+		if ( error && error.responseJSON && error.responseJSON.message ) {
+			errorDescription.html( error.responseJSON.message );
+		} else {
+			errorDescription.html( '' );
+		}
+		errorNotice.css( 'display', 'flex' );
+	}
+
+	/**
+	 * This function will fire both a Tracks and MC stat.
+	 * It will make sure to format the event name properly for the given stat home.
+	 *
+	 * Tracks Will be prefixed by 'jetpack_idc_' and use underscores.
+	 * MC Will not be prefixed, and will use dashes.
+	 *
+	 * @param {string} eventName - name.
+	 * @param {object} extraProps - extra props.
+	 */
+	function trackAndBumpMCStats( eventName, extraProps ) {
+		if ( 'undefined' === typeof extraProps || 'object' !== typeof extraProps ) {
+			extraProps = {};
+		}
+
+		if (
+			eventName &&
+			eventName.length &&
+			'undefined' !== typeof analytics &&
+			analytics.tracks &&
+			analytics.mc
+		) {
+			// Format for Tracks
+			eventName = eventName.replace( /-/g, '_' );
+			eventName =
+				eventName.indexOf( 'jetpack_idc_' ) !== 0 ? 'jetpack_idc_' + eventName : eventName;
+			analytics.tracks.recordEvent( eventName, extraProps );
+
+			// Now format for MC stats
+			eventName = eventName.replace( 'jetpack_idc_', '' );
+			eventName = eventName.replace( /_/g, '-' );
+			analytics.mc.bumpStat( 'jetpack-idc', eventName );
+		}
+	}
+} )( jQuery );

--- a/projects/packages/connection/src/idc/class-identity-crisis.php
+++ b/projects/packages/connection/src/idc/class-identity-crisis.php
@@ -1,0 +1,1120 @@
+<?php
+/**
+ * Identity_Crisis package.
+ *
+ * @package  automattic/jetpack-identity-crisis
+ */
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Urls;
+use Automattic\Jetpack\Constants as Constants;
+use Automattic\Jetpack\Status as Status;
+use Automattic\Jetpack\Tracking as Tracking;
+use Jetpack_Options;
+use Jetpack_Tracks_Client;
+use WP_Error;
+
+/**
+ * This class will handle everything involved with fixing an Identity Crisis.
+ *
+ * @since 0.2.0
+ * @since-jetpack 4.4.0
+ */
+class Identity_Crisis {
+
+	/**
+	 * Package Version
+	 */
+	const PACKAGE_VERSION = '0.2.6-alpha';
+
+	/**
+	 * Instance of the object.
+	 *
+	 * @var Identity_Crisis
+	 **/
+	private static $instance = null;
+
+	/**
+	 * The wpcom value of the home URL.
+	 *
+	 * @var string
+	 */
+	public static $wpcom_home_url;
+
+	/**
+	 * Has safe mode been confirmed?
+	 *
+	 * @var bool
+	 */
+	public static $is_safe_mode_confirmed;
+
+	/**
+	 * The current screen, which is set if the current user is a non-admin and this is an admin page.
+	 *
+	 * @var WP_Screen
+	 */
+	public static $current_screen;
+
+	/**
+	 * Initializer.
+	 *
+	 * @return object
+	 */
+	public static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new Identity_Crisis();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Class constructor.
+	 *
+	 * @return void
+	 */
+	private function __construct() {
+		add_action( 'jetpack_sync_processed_actions', array( $this, 'maybe_clear_migrate_option' ) );
+		add_action( 'rest_api_init', array( 'Automattic\\Jetpack\\IdentityCrisis\\REST_Endpoints', 'initialize_rest_api' ) );
+		add_action( 'jetpack_idc_disconnect', array( __CLASS__, 'do_jetpack_idc_disconnect' ) );
+
+		add_filter( 'jetpack_connection_disconnect_site_wpcom', array( __CLASS__, 'jetpack_connection_disconnect_site_wpcom_filter' ) );
+
+		$urls_in_crisis = self::check_identity_crisis();
+		if ( false === $urls_in_crisis ) {
+			return;
+		}
+
+		self::$wpcom_home_url = $urls_in_crisis['wpcom_home'];
+		add_action( 'init', array( $this, 'wordpress_init' ) );
+	}
+
+	/**
+	 * Disconnect current connection and clear IDC options.
+	 */
+	public static function do_jetpack_idc_disconnect() {
+		$connection = new Connection_Manager();
+
+		// If the site is in an IDC because sync is not allowed,
+		// let's make sure to not disconnect the production site.
+		if ( ! self::validate_sync_error_idc_option() ) {
+			$connection->disconnect_site( true );
+		} else {
+			$connection->disconnect_site( false );
+		}
+
+		// Clear IDC options.
+		self::clear_all_idc_options();
+	}
+
+	/**
+	 * Filter to prevent site from disconnecting from WPCOM if it's in an IDC.
+	 *
+	 * @see jetpack_connection_disconnect_site_wpcom filter.
+	 *
+	 * @return bool False if the site is in IDC, true otherwise.
+	 */
+	public static function jetpack_connection_disconnect_site_wpcom_filter() {
+		return ! self::validate_sync_error_idc_option();
+	}
+
+	/**
+	 * Gets the link to the support document used to explain Safe Mode to users.
+	 *
+	 * @return string
+	 */
+	public static function get_safe_mod_doc_url() {
+		return Redirect::get_url( 'jetpack-support-safe-mode' );
+	}
+
+	/**
+	 * This method loops through the array of processed items from sync and checks if one of the items was the
+	 * home_url or site_url callable. If so, then we delete the jetpack_migrate_for_idc option.
+	 *
+	 * @param array $processed_items Array of processed items that were synced to WordPress.com.
+	 */
+	public function maybe_clear_migrate_option( $processed_items ) {
+		foreach ( (array) $processed_items as $item ) {
+
+			// First, is this item a jetpack_sync_callable action? If so, then proceed.
+			$callable_args = ( is_array( $item ) && isset( $item[0], $item[1] ) && 'jetpack_sync_callable' === $item[0] )
+				? $item[1]
+				: null;
+
+			// Second, if $callable_args is set, check if the callable was home_url or site_url. If so,
+			// clear the migrate option.
+			if (
+				isset( $callable_args, $callable_args[0] )
+				&& ( 'home_url' === $callable_args[0] || 'site_url' === $callable_args[1] )
+			) {
+				Jetpack_Options::delete_option( 'migrate_for_idc' );
+				break;
+			}
+		}
+	}
+
+	/**
+	 * WordPress init.
+	 *
+	 * @return void
+	 */
+	public function wordpress_init() {
+		if ( ! current_user_can( 'jetpack_disconnect' ) && is_admin() ) {
+			add_action( 'admin_notices', array( $this, 'display_non_admin_idc_notice' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_idc_notice_files' ) );
+			add_action( 'current_screen', array( $this, 'non_admins_current_screen_check' ) );
+
+			return;
+		}
+
+		if (
+			isset( $_GET['jetpack_idc_clear_confirmation'], $_GET['_wpnonce'] ) &&
+			wp_verify_nonce( $_GET['_wpnonce'], 'jetpack_idc_clear_confirmation' )
+		) {
+			Jetpack_Options::delete_option( 'safe_mode_confirmed' );
+			self::$is_safe_mode_confirmed = false;
+		} else {
+			self::$is_safe_mode_confirmed = (bool) Jetpack_Options::get_option( 'safe_mode_confirmed' );
+		}
+
+		// 121 Priority so that it's the most inner Jetpack item in the admin bar.
+		add_action( 'admin_bar_menu', array( $this, 'display_admin_bar_button' ), 121 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_bar_css' ) );
+
+		if ( is_admin() && ! self::$is_safe_mode_confirmed ) {
+			add_action( 'admin_notices', array( $this, 'display_idc_notice' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_idc_notice_files' ) );
+		}
+	}
+
+	/**
+	 * Non-admins current screen check.
+	 *
+	 * @param object $current_screen Current screen.
+	 *
+	 * @return null
+	 */
+	public function non_admins_current_screen_check( $current_screen ) {
+		self::$current_screen = $current_screen;
+		if ( isset( $current_screen->id ) && 'toplevel_page_jetpack' === $current_screen->id ) {
+			return null;
+		}
+
+		// If the user has dismissed the notice, and we're not currently on a Jetpack page,
+		// then do not show the non-admin notice.
+		if ( isset( $_COOKIE, $_COOKIE['jetpack_idc_dismiss_notice'] ) ) {
+			remove_action( 'admin_notices', array( $this, 'display_non_admin_idc_notice' ) );
+			remove_action( 'admin_enqueue_scripts', array( $this, 'enqueue_idc_notice_files' ) );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Renders the admin bar button.
+	 *
+	 * @return void
+	 */
+	public function display_admin_bar_button() {
+		global $wp_admin_bar;
+
+		$href = is_admin()
+			? add_query_arg( 'jetpack_idc_clear_confirmation', '1' )
+			: add_query_arg( 'jetpack_idc_clear_confirmation', '1', admin_url() );
+
+		$href = wp_nonce_url( $href, 'jetpack_idc_clear_confirmation' );
+
+		$title = sprintf(
+			'<span class="jp-idc-admin-bar">%s %s</span>',
+			'<span class="dashicons dashicons-warning"></span>',
+			esc_html__( 'Jetpack Safe Mode', 'jetpack' )
+		);
+
+		$menu = array(
+			'id'     => 'jetpack-idc',
+			'title'  => $title,
+			'href'   => esc_url( $href ),
+			'parent' => 'top-secondary',
+		);
+
+		if ( ! self::$is_safe_mode_confirmed ) {
+			$menu['meta'] = array(
+				'class' => 'hide',
+			);
+		}
+
+		$wp_admin_bar->add_node( $menu );
+	}
+
+	/**
+	 * Checks if the site is currently in an identity crisis.
+	 *
+	 * @return array|bool Array of options that are in a crisis, or false if everything is OK.
+	 */
+	public static function check_identity_crisis() {
+		$connection = new Connection_Manager( 'jetpack' );
+
+		if ( ! $connection->is_connected() || ( new Status() )->is_offline_mode() || ! self::validate_sync_error_idc_option() ) {
+			return false;
+		}
+
+		return Jetpack_Options::get_option( 'sync_error_idc' );
+	}
+
+	/**
+	 * Prepare URL for display.
+	 *
+	 * @param string $url URL to display.
+	 *
+	 * @return string
+	 */
+	public static function prepare_url_for_display( $url ) {
+		return untrailingslashit( self::normalize_url_protocol_agnostic( $url ) );
+	}
+
+	/**
+	 * Clears all IDC specific options. This method is used on disconnect and reconnect.
+	 *
+	 * @return void
+	 */
+	public static function clear_all_idc_options() {
+		// If the site is currently in IDC, let's also clear the VaultPress connection options.
+		// We have to check if the site is in IDC, otherwise we'd be clearing the VaultPress
+		// connection any time the Jetpack connection is cycled.
+		if ( self::validate_sync_error_idc_option() ) {
+			delete_option( 'vaultpress' );
+			delete_option( 'vaultpress_auto_register' );
+		}
+
+		Jetpack_Options::delete_option(
+			array(
+				'sync_error_idc',
+				'safe_mode_confirmed',
+				'migrate_for_idc',
+			)
+		);
+	}
+
+	/**
+	 * Checks whether the sync_error_idc option is valid or not, and if not, will do cleanup.
+	 *
+	 * @return bool
+	 * @since-jetpack 5.4.0 Do not call get_sync_error_idc_option() unless site is in IDC
+	 *
+	 * @since 0.2.0
+	 * @since-jetpack 4.4.0
+	 */
+	public static function validate_sync_error_idc_option() {
+		$is_valid = false;
+
+		// Is the site opted in and does the stored sync_error_idc option match what we now generate?
+		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
+		if ( $sync_error && self::should_handle_idc() ) {
+			$local_options = self::get_sync_error_idc_option();
+			// Ensure all values are set.
+			if ( isset( $sync_error['home'] ) && isset( $local_options['home'] ) && isset( $sync_error['siteurl'] ) && isset( $local_options['siteurl'] ) ) {
+				// If the WP.com expected home and siteurl match local home and siteurl it is not valid IDC.
+				if (
+					isset( $sync_error['wpcom_home'] ) &&
+					isset( $sync_error['wpcom_siteurl'] ) &&
+					$sync_error['wpcom_home'] === $local_options['home'] &&
+					$sync_error['wpcom_siteurl'] === $local_options['siteurl']
+				) {
+					$is_valid = false;
+					// Enable migrate_for_idc so that sync actions are accepted.
+					Jetpack_Options::update_option( 'migrate_for_idc', true );
+				} elseif ( $sync_error['home'] === $local_options['home'] && $sync_error['siteurl'] === $local_options['siteurl'] ) {
+					$is_valid = true;
+				}
+			}
+		}
+
+		/**
+		 * Filters whether the sync_error_idc option is valid.
+		 *
+		 * @param bool $is_valid If the sync_error_idc is valid or not.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		$is_valid = (bool) apply_filters( 'jetpack_sync_error_idc_validation', $is_valid );
+
+		if ( ! $is_valid && $sync_error ) {
+			// Since the option exists, and did not validate, delete it.
+			Jetpack_Options::delete_option( 'sync_error_idc' );
+		}
+
+		return $is_valid;
+	}
+
+	/**
+	 * Normalizes a url by doing three things:
+	 *  - Strips protocol
+	 *  - Strips www
+	 *  - Adds a trailing slash
+	 *
+	 * @param string $url URL to parse.
+	 *
+	 * @return WP_Error|string
+	 * @since 0.2.0
+	 * @since-jetpack 4.4.0
+	 */
+	public static function normalize_url_protocol_agnostic( $url ) {
+		$parsed_url = wp_parse_url( trailingslashit( esc_url_raw( $url ) ) );
+		if ( ! $parsed_url || empty( $parsed_url['host'] ) || empty( $parsed_url['path'] ) ) {
+			return new WP_Error(
+				'cannot_parse_url',
+				sprintf(
+				/* translators: %s: URL to parse. */
+					esc_html__( 'Cannot parse URL %s', 'jetpack' ),
+					$url
+				)
+			);
+		}
+
+		// Strip www and protocols.
+		$url = preg_replace( '/^www\./i', '', $parsed_url['host'] . $parsed_url['path'] );
+
+		return $url;
+	}
+
+	/**
+	 * Gets the value that is to be saved in the jetpack_sync_error_idc option.
+	 *
+	 * @param array $response HTTP response.
+	 *
+	 * @return array Array of the local urls, wpcom urls, and error code.
+	 * @since 0.2.0
+	 * @since-jetpack 4.4.0
+	 * @since-jetpack 5.4.0 Add transient since home/siteurl retrieved directly from DB.
+	 */
+	public static function get_sync_error_idc_option( $response = array() ) {
+		// Since the local options will hit the database directly, store the values
+		// in a transient to allow for autoloading and caching on subsequent views.
+		$local_options = get_transient( 'jetpack_idc_local' );
+		if ( false === $local_options ) {
+			$local_options = array(
+				'home'    => Urls::home_url(),
+				'siteurl' => Urls::site_url(),
+			);
+			set_transient( 'jetpack_idc_local', $local_options, MINUTE_IN_SECONDS );
+		}
+
+		$options = array_merge( $local_options, $response );
+
+		$returned_values = array();
+		foreach ( $options as $key => $option ) {
+			if ( 'error_code' === $key ) {
+				$returned_values[ $key ] = $option;
+				continue;
+			}
+
+			$normalized_url = self::normalize_url_protocol_agnostic( $option );
+			if ( is_wp_error( $normalized_url ) ) {
+				continue;
+			}
+
+			$returned_values[ $key ] = $normalized_url;
+		}
+
+		set_transient( 'jetpack_idc_option', $returned_values, MINUTE_IN_SECONDS );
+
+		return $returned_values;
+	}
+
+	/**
+	 * Returns the value of the jetpack_sync_idc_optin filter, or constant.
+	 * If set to true, the site will be put into staging mode.
+	 *
+	 * @return bool
+	 * @since 0.2.0
+	 * @since-jetpack 4.3.2
+	 * @deprecated $$next-version$$ Use should_handle_idc()
+	 * @see Automattic\Jetpack\Identity_Crisis::should_handle_idc
+	 */
+	public static function sync_idc_optin() {
+		_deprecated_function( __METHOD__, '0.2.6', 'Automattic\\Jetpack\\Identity_Crisis::should_handle_idc' );
+		return self::should_handle_idc();
+	}
+
+	/**
+	 * Returns the value of the jetpack_should_handle_idc filter or constant.
+	 * If set to true, the site will be put into staging mode.
+	 *
+	 * This method uses both the current jetpack_should_handle_idc filter and constant and the
+	 * legacy jetpack_sync_idc_optin filter and constant to determine whether an IDC should be
+	 * handled.
+	 *
+	 * @return bool
+	 * @since $$next-version$$
+	 */
+	public static function should_handle_idc() {
+		if ( Constants::is_defined( 'JETPACK_SHOULD_HANDLE_IDC' ) ) {
+			$default = Constants::get_constant( 'JETPACK_SHOULD_HANDLE_IDC' );
+		} elseif ( Constants::is_defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) {
+			// Check the legacy constant. This constant should be considered deprecated as of version 0.2.6.
+			$default = Constants::get_constant( 'JETPACK_SYNC_IDC_OPTIN' );
+		} else {
+			$default = ! Constants::is_defined( 'SUNRISE' ) && ! is_multisite();
+		}
+
+		// Add a callback which uses the legacy filter 'jetpack_sync_idc_optin'.
+		add_filter( 'jetpack_should_handle_idc', array( __CLASS__, 'legacy_jetpack_sync_idc_optin_filter' ) );
+
+		/**
+		 * Allows sites to opt in for IDC mitigation which blocks the site from syncing to WordPress.com when the home
+		 * URL or site URL do not match what WordPress.com expects. The default value is either true, or the value of
+		 * JETPACK_SHOULD_HANDLE_IDC constant if set.
+		 *
+		 * @param bool $default Whether the site is opted in to IDC mitigation.
+		 *
+		 * @since $$next-version$$
+		 */
+		return (bool) apply_filters( 'jetpack_should_handle_idc', $default );
+	}
+
+	/**
+	 * Returns the value for the deprecated filter, 'jetpack_sync_idc_optin'. That filter has been replaced with the
+	 * 'jetpack_should_handle_idc' filter.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $default Whether the site is opted in to IDC mitigation.
+	 */
+	public static function legacy_jetpack_sync_idc_optin_filter( $default ) {
+		/**
+		 * Allows sites to opt in for IDC mitigation which blocks the site from syncing to WordPress.com when the home
+		 * URL or site URL do not match what WordPress.com expects. The default value is either true, or the value of
+		 * JETPACK_SYNC_IDC_OPTIN constant if set.
+		 *
+		 * @param bool $default Whether the site is opted in to IDC mitigation.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.3.2
+		 * @deprecated $$next-version$$ Use jetpack_should_handle_idc
+		 */
+		return (bool) apply_filters_deprecated( 'jetpack_sync_idc_optin', array( $default ), '0.2.6', 'jetpack_should_handle_idc' );
+	}
+
+	/**
+	 * Does the current admin page have help tabs?
+	 *
+	 * @return bool
+	 */
+	public function admin_page_has_help_tabs() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		$current_screen = get_current_screen();
+		$tabs           = $current_screen->get_help_tabs();
+
+		return ! empty( $tabs );
+	}
+
+	/**
+	 * Renders the non-admin IDC notice.
+	 *
+	 * @return void
+	 */
+	public function display_non_admin_idc_notice() {
+		$classes = 'jp-idc-notice inline is-non-admin notice notice-warning';
+		if ( isset( self::$current_screen ) && 'toplevel_page_jetpack' !== self::$current_screen->id ) {
+			$classes .= ' is-dismissible';
+		}
+
+		if ( $this->admin_page_has_help_tabs() ) {
+			$classes .= ' has-help-tabs';
+		}
+		?>
+
+		<div class="<?php echo esc_attr( $classes ); ?>">
+			<?php $this->render_notice_header(); ?>
+			<div class="jp-idc-notice__content-header">
+				<h3 class="jp-idc-notice__content-header__lead">
+					<?php echo $this->get_non_admin_notice_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</h3>
+
+				<p class="jp-idc-notice__content-header__explanation">
+					<?php echo $this->get_non_admin_contact_admin_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</p>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * First "step" of the IDC mitigation. Will provide some messaging and two options/buttons.
+	 * "Confirm Staging" - Dismiss the notice and continue on with our lives in staging mode.
+	 * "Fix Jetpack Connection" - Will disconnect the site and start the mitigation...
+	 *
+	 * @return void
+	 */
+	public function display_idc_notice() {
+		$classes = 'jp-idc-notice inline notice notice-warning';
+		if ( $this->admin_page_has_help_tabs() ) {
+			$classes .= ' has-help-tabs';
+		}
+		?>
+		<div class="<?php echo esc_attr( $classes ); ?>">
+			<?php $this->render_notice_header(); ?>
+			<?php $this->render_notice_first_step(); ?>
+			<?php $this->render_notice_second_step(); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Enqueue CSS for the admin bar.
+	 *
+	 * @return void
+	 */
+	public function enqueue_admin_bar_css() {
+
+		$build_assets = require __DIR__ . '/../../build/index.asset.php';
+
+		wp_enqueue_style(
+			'jetpack-idc-admin-bar-css',
+			plugin_dir_url( __DIR__ ) . '../build/css/jetpack-idc-admin-bar.css',
+			array( 'dashicons' ),
+			$build_assets['version']
+		);
+	}
+
+	/**
+	 * Enqueue scripts for the notice.
+	 *
+	 * @return void
+	 */
+	public function enqueue_idc_notice_files() {
+		$build_assets                   = require __DIR__ . '/../../build/index.asset.php';
+		$build_assets['dependencies'][] = 'jquery';
+
+		wp_enqueue_script(
+			'jetpack-idc-js',
+			plugin_dir_url( __DIR__ ) . '../build/index.js',
+			$build_assets['dependencies'],
+			$build_assets['version'],
+			true
+		);
+
+		wp_localize_script(
+			'jetpack-idc-js',
+			'idcL10n',
+			array(
+				'apiRoot'         => esc_url_raw( rest_url() ),
+				'nonce'           => wp_create_nonce( 'wp_rest' ),
+				'tracksUserData'  => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
+				'currentUrl'      => remove_query_arg( '_wpnonce', remove_query_arg( 'jetpack_idc_clear_confirmation' ) ),
+				'tracksEventData' => array(
+					'isAdmin'       => current_user_can( 'jetpack_disconnect' ),
+					'currentScreen' => self::$current_screen ? self::$current_screen->id : false,
+				),
+			)
+		);
+
+		if ( ! wp_style_is( 'jetpack-dops-style', 'registered' ) ) {
+			wp_register_style(
+				'jetpack-dops-style',
+				plugin_dir_url( __DIR__ ) . '../src/idc/_inc/admin.css', // TODO Detangle style depenedencies instead of copying whole css file.
+				array(),
+				self::PACKAGE_VERSION
+			);
+		}
+
+		wp_enqueue_style(
+			'jetpack-idc-admin-bar-css',
+			plugin_dir_url( __DIR__ ) . '../../build/css/jetpack-idc-admin-bar.css',
+			array( 'jetpack-dops-style' ),
+			self::PACKAGE_VERSION
+		);
+		wp_enqueue_style(
+			'jetpack-idc-css',
+			plugin_dir_url( __DIR__ ) . '../build/css/jetpack-idc.css',
+			array( 'jetpack-dops-style' ),
+			self::PACKAGE_VERSION
+		);
+
+		// Register and Enqueue jp-tracks-functions.
+		Tracking::register_tracks_functions_scripts( true );
+	}
+
+	/**
+	 * Renders the notice header.
+	 *
+	 * @return void
+	 */
+	public function render_notice_header() {
+		?>
+		<div class="jp-idc-notice__header">
+			<div class="jp-idc-notice__header__emblem">
+				<?php
+				$jetpack_logo = new Jetpack_Logo();
+				echo $jetpack_logo->get_jp_emblem(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				?>
+			</div>
+			<p class="jp-idc-notice__header__text">
+				<?php esc_html_e( 'Jetpack Safe Mode', 'jetpack' ); ?>
+			</p>
+		</div>
+
+		<div class="jp-idc-notice__separator"></div>
+		<?php
+	}
+
+	/**
+	 * Is a container for the error notices.
+	 * Will be shown/controlled by jQuery in idc-notice.js.
+	 *
+	 * @return void
+	 */
+	public function render_error_notice() {
+		?>
+		<div class="jp-idc-error__notice dops-notice is-error">
+			<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" viewBox="0 0 24 24">
+				<g>
+					<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"></path>
+				</g>
+			</svg>
+			<div class="dops-notice__content">
+				<span class="dops-notice__text">
+					<?php esc_html_e( 'Something went wrong:', 'jetpack' ); ?>
+					<span class="jp-idc-error__desc"></span>
+				</span>
+				<a class="dops-notice__action" href="javascript:void(0);">
+					<span id="jp-idc-error__action">
+						<?php esc_html_e( 'Try Again', 'jetpack' ); ?>
+					</span>
+				</a>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Renders the first step notice.
+	 *
+	 * @return void
+	 */
+	public function render_notice_first_step() {
+		?>
+		<div class="jp-idc-notice__first-step">
+			<div class="jp-idc-notice__content-header">
+				<h3 class="jp-idc-notice__content-header__lead">
+					<?php echo $this->get_first_step_header_lead(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</h3>
+
+				<p class="jp-idc-notice__content-header__explanation">
+					<?php echo $this->get_first_step_header_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</p>
+			</div>
+
+			<?php $this->render_error_notice(); ?>
+
+			<div class="jp-idc-notice__actions">
+				<div class="jp-idc-notice__action">
+					<p class="jp-idc-notice__action__explanation">
+						<?php echo $this->get_confirm_safe_mode_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</p>
+					<button id="jp-idc-confirm-safe-mode-action" class="dops-button">
+						<?php echo $this->get_confirm_safe_mode_button_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</button>
+				</div>
+
+				<div class="jp-idc-notice__action">
+					<p class="jp-idc-notice__action__explanation">
+						<?php echo $this->get_first_step_fix_connection_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</p>
+					<button id="jp-idc-fix-connection-action" class="dops-button">
+						<?php echo $this->get_first_step_fix_connection_button_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</button>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Renders the second step notice.
+	 *
+	 * @return void
+	 */
+	public function render_notice_second_step() {
+		?>
+		<div class="jp-idc-notice__second-step">
+			<div class="jp-idc-notice__content-header">
+				<h3 class="jp-idc-notice__content-header__lead">
+					<?php echo $this->get_second_step_header_lead(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</h3>
+			</div>
+
+			<?php $this->render_error_notice(); ?>
+
+			<div class="jp-idc-notice__actions">
+				<div class="jp-idc-notice__action">
+					<p class="jp-idc-notice__action__explanation">
+						<?php echo $this->get_migrate_site_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</p>
+					<button id="jp-idc-migrate-action" class="dops-button">
+						<?php echo $this->get_migrate_site_button_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</button>
+				</div>
+
+				<div class="jp-idc-notice__action">
+					<p class="jp-idc-notice__action__explanation">
+						<?php echo $this->get_start_fresh_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</p>
+					<button id="jp-idc-reconnect-site-action" class="dops-button">
+						<?php echo $this->get_start_fresh_button_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</button>
+				</div>
+
+			</div>
+
+			<p class="jp-idc-notice__unsure-prompt">
+				<?php echo $this->get_unsure_prompt(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Returns the first step header lead.
+	 *
+	 * @return string
+	 */
+	public function get_first_step_header_lead() {
+		$html = wp_kses(
+			sprintf(
+			/* translators: %s: Safe mode docs URL and site URL. */
+				__( 'Jetpack has been placed into <a href="%1$s">Safe mode</a> because we noticed this is an exact copy of <a href="%2$s">%3$s</a>.', 'jetpack' ),
+				esc_url( self::get_safe_mod_doc_url() ),
+				esc_url( self::$wpcom_home_url ),
+				self::prepare_url_for_display( esc_url_raw( self::$wpcom_home_url ) )
+			),
+			array( 'a' => array( 'href' => array() ) )
+		);
+
+		/**
+		 * Allows overriding of the default header text in the first step of the Safe Mode notice.
+		 *
+		 * @param string $html The HTML to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_first_step_header_lead', $html );
+	}
+
+	/**
+	 * Returns the first step header explanation.
+	 *
+	 * @return string
+	 */
+	public function get_first_step_header_explanation() {
+		$html = wp_kses(
+			sprintf(
+			/* translators: %s: Safe mode docs URL. */
+				__( 'Please confirm Safe Mode or fix the Jetpack connection. Select one of the options below or <a href="%1$s">learn more about Safe Mode</a>.', 'jetpack' ),
+				esc_url( self::get_safe_mod_doc_url() )
+			),
+			array( 'a' => array( 'href' => array() ) )
+		);
+
+		/**
+		 * Allows overriding of the default header explanation text in the first step of the Safe Mode notice.
+		 *
+		 * @param string $html The HTML to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_first_step_header_explanation', $html );
+	}
+
+	/**
+	 * Returns the confirm safe mode explanation.
+	 *
+	 * @return string
+	 */
+	public function get_confirm_safe_mode_action_explanation() {
+		$html = wp_kses(
+			sprintf(
+			/* translators: %s: Site URL. */
+				__( 'Is this website a temporary duplicate of <a href="%1$s">%2$s</a> for the purposes of testing, staging or development? If so, we recommend keeping it in Safe Mode.', 'jetpack' ),
+				esc_url( untrailingslashit( self::$wpcom_home_url ) ),
+				self::prepare_url_for_display( esc_url( self::$wpcom_home_url ) )
+			),
+			array( 'a' => array( 'href' => array() ) )
+		);
+
+		/**
+		 * Allows overriding of the default text used to explain the confirm safe mode action.
+		 *
+		 * @param string $html The HTML to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_confirm_safe_mode_explanation', $html );
+	}
+
+	/**
+	 * Returns the confirm safe mode button text.
+	 *
+	 * @return string
+	 */
+	public function get_confirm_safe_mode_button_text() {
+		$string = esc_html__( 'Confirm Safe Mode', 'jetpack' );
+
+		/**
+		 * Allows overriding of the default text used for the confirm safe mode action button.
+		 *
+		 * @param string $string The string to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_confirm_safe_mode_button_text', $string );
+	}
+
+	/**
+	 * Returns the first step fix connection action explanation.
+	 *
+	 * @return string
+	 */
+	public function get_first_step_fix_connection_action_explanation() {
+		$html = wp_kses(
+			sprintf(
+			/* translators: %s: Site URL. */
+				__( 'If this is a separate and new website, or the new home of <a href="%1$s">%2$s</a>, we recommend turning Safe Mode off, and re-establishing your connection to WordPress.com.', 'jetpack' ),
+				esc_url( untrailingslashit( self::$wpcom_home_url ) ),
+				self::prepare_url_for_display( esc_url( self::$wpcom_home_url ) )
+			),
+			array( 'a' => array( 'href' => array() ) )
+		);
+
+		/**
+		 * Allows overriding of the default text used to explain the fix Jetpack connection action.
+		 *
+		 * @param string $html The HTML to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_first_fix_connection_explanation', $html );
+	}
+
+	/**
+	 * Returns the first step fix connection button text.
+	 *
+	 * @return string
+	 */
+	public function get_first_step_fix_connection_button_text() {
+		$string = esc_html__( "Fix Jetpack's Connection", 'jetpack' );
+
+		/**
+		 * Allows overriding of the default text used for the fix Jetpack connection action button.
+		 *
+		 * @param string $string The string to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_first_step_fix_connection_button_text', $string );
+	}
+
+	/**
+	 * Returns the second step header lead.
+	 *
+	 * @return string
+	 */
+	public function get_second_step_header_lead() {
+		$string = sprintf(
+		/* translators: %s: Site URL. */
+			esc_html__( 'Is %1$s the new home of %2$s?', 'jetpack' ),
+			untrailingslashit( self::normalize_url_protocol_agnostic( get_home_url() ) ),
+			untrailingslashit( self::normalize_url_protocol_agnostic( esc_url_raw( self::$wpcom_home_url ) ) )
+		);
+
+		/**
+		 * Allows overriding of the default header text in the second step of the Safe Mode notice.
+		 *
+		 * @param string $html The HTML to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_second_step_header_lead', $string );
+	}
+
+	/**
+	 * Returns the site action explanation.
+	 *
+	 * @return string
+	 */
+	public function get_migrate_site_action_explanation() {
+		$html = wp_kses(
+			sprintf(
+			/* translators: %s: Site URL. */
+				__( 'Yes. <a href="%1$s">%2$s</a> is replacing <a href="%3$s">%4$s</a>. I would like to migrate my stats and subscribers from <a href="%3$s">%4$s</a> to <a href="%1$s">%2$s</a>.', 'jetpack' ),
+				esc_url( get_home_url() ),
+				self::prepare_url_for_display( get_home_url() ),
+				esc_url( self::$wpcom_home_url ),
+				untrailingslashit( self::normalize_url_protocol_agnostic( esc_url_raw( self::$wpcom_home_url ) ) )
+			),
+			array( 'a' => array( 'href' => array() ) )
+		);
+
+		/**
+		 * Allows overriding of the default text for explaining the migrate site action.
+		 *
+		 * @param string $html The HTML to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_migrate_site_explanation', $html );
+	}
+
+	/**
+	 * Returns the migrate site button text.
+	 *
+	 * @return string
+	 */
+	public function get_migrate_site_button_text() {
+		$string = esc_html__( 'Migrate Stats &amp; Subscribers', 'jetpack' );
+
+		/**
+		 * Allows overriding of the default text used for the migrate site action button.
+		 *
+		 * @param string $string The string to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_migrate_site_button_text', $string );
+	}
+
+	/**
+	 * Returns the start fresh explanation.
+	 *
+	 * @return string
+	 */
+	public function get_start_fresh_action_explanation() {
+		$html = wp_kses(
+			sprintf(
+			/* translators: %s: Site URL. */
+				__( 'No. <a href="%1$s">%2$s</a> is a new and different website that\'s separate from <a href="%3$s">%4$s</a>. It requires  a new connection to WordPress.com for new stats and subscribers.', 'jetpack' ),
+				esc_url( get_home_url() ),
+				self::prepare_url_for_display( get_home_url() ),
+				esc_url( self::$wpcom_home_url ),
+				untrailingslashit( self::normalize_url_protocol_agnostic( esc_url_raw( self::$wpcom_home_url ) ) )
+			),
+			array( 'a' => array( 'href' => array() ) )
+		);
+
+		/**
+		 * Allows overriding of the default text for explaining the start fresh action.
+		 *
+		 * @param string $html The HTML to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_start_fresh_explanation', $html );
+	}
+
+	/**
+	 * Returns the start fresh button text.
+	 *
+	 * @return string
+	 */
+	public function get_start_fresh_button_text() {
+		$string = esc_html__( 'Start Fresh &amp; Create New Connection', 'jetpack' );
+
+		/**
+		 * Allows overriding of the default text used for the start fresh action button.
+		 *
+		 * @param string $string The string to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_start_fresh_button_text', $string );
+	}
+
+	/**
+	 * Returns the unsure prompt text.
+	 *
+	 * @return string
+	 */
+	public function get_unsure_prompt() {
+		$html = wp_kses(
+			sprintf(
+			/* translators: %s: Safe mode docs URL. */
+				__( 'Unsure what to do? <a href="%1$s">Read more about Jetpack Safe Mode</a>', 'jetpack' ),
+				esc_url( self::get_safe_mod_doc_url() )
+			),
+			array( 'a' => array( 'href' => array() ) )
+		);
+
+		/**
+		 * Allows overriding of the default text using in the "Unsure what to do?" prompt.
+		 *
+		 * @param string $html The HTML to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_unsure_prompt', $html );
+	}
+
+	/**
+	 * Returns the non-admin notice text.
+	 *
+	 * @return string
+	 */
+	public function get_non_admin_notice_text() {
+		$html = wp_kses(
+			sprintf(
+			/* translators: %s: Safe mode docs URL. */
+				__( 'Jetpack has been placed into Safe Mode. Learn more about <a href="%1$s">Safe Mode</a>.', 'jetpack' ),
+				esc_url( self::get_safe_mod_doc_url() )
+			),
+			array( 'a' => array( 'href' => array() ) )
+		);
+
+		/**
+		 * Allows overriding of the default text that is displayed to non-admin on the Jetpack admin page.
+		 *
+		 * @param string $html The HTML to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_non_admin_notice_text', $html );
+	}
+
+	/**
+	 * Returns the non-admin contact admin text.
+	 *
+	 * @return string
+	 */
+	public function get_non_admin_contact_admin_text() {
+		$string = esc_html__( 'An administrator of this site can take Jetpack out of Safe Mode.', 'jetpack' );
+
+		/**
+		 * Allows overriding of the default text that is displayed to non-admins prompting them to contact an admin.
+		 *
+		 * @param string $string The string to be displayed.
+		 *
+		 * @since 0.2.0
+		 * @since-jetpack 4.4.0
+		 */
+		return apply_filters( 'jetpack_idc_non_admin_contact_admin_text', $string );
+	}
+}

--- a/projects/packages/connection/src/idc/class-rest-endpoints.php
+++ b/projects/packages/connection/src/idc/class-rest-endpoints.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Identity_Crisis package.
+ *
+ * @package  automattic/jetpack-identity-crisis
+ */
+
+namespace Automattic\Jetpack\IdentityCrisis;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Jetpack_Options;
+use WP_Error;
+use WP_REST_Server;
+
+/**
+ * This class will handle Identity Crisis Endpoints
+ *
+ * @since 0.2.0
+ */
+class REST_Endpoints {
+
+	/**
+	 * Initialize REST routes.
+	 */
+	public static function initialize_rest_api() {
+
+		// Confirm that a site in identity crisis should be in staging mode.
+		register_rest_route(
+			'jetpack/v4',
+			'/identity-crisis/confirm-safe-mode',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::confirm_safe_mode',
+				'permission_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
+			)
+		);
+
+		// Handles the request to migrate stats and subscribers during an identity crisis.
+		register_rest_route(
+			'jetpack/v4',
+			'identity-crisis/migrate',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::migrate_stats_and_subscribers',
+				'permission_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
+			)
+		);
+
+		// IDC resolve: create an entirely new shadow site for this URL.
+		register_rest_route(
+			'jetpack/v4',
+			'/identity-crisis/start-fresh',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::start_fresh_connection',
+				'permission_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
+			)
+		);
+
+	}
+
+	/**
+	 * Handles identity crisis mitigation, confirming safe mode for this site.
+	 *
+	 * @since 0.2.0
+	 * @since-jetpack 4.4.0
+	 *
+	 * @return bool | WP_Error True if option is properly set.
+	 */
+	public static function confirm_safe_mode() {
+		$updated = Jetpack_Options::update_option( 'safe_mode_confirmed', true );
+		if ( $updated ) {
+			return rest_ensure_response(
+				array(
+					'code' => 'success',
+				)
+			);
+		}
+
+		return new WP_Error(
+			'error_setting_jetpack_safe_mode',
+			esc_html__( 'Could not confirm safe mode.', 'jetpack' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	/**
+	 * Handles identity crisis mitigation, migrating stats and subscribers from old url to this, new url.
+	 *
+	 * @since 0.2.0
+	 * @since-jetpack 4.4.0
+	 *
+	 * @return bool | WP_Error True if option is properly set.
+	 */
+	public static function migrate_stats_and_subscribers() {
+		if ( Jetpack_Options::get_option( 'sync_error_idc' ) && ! Jetpack_Options::delete_option( 'sync_error_idc' ) ) {
+			return new WP_Error(
+				'error_deleting_sync_error_idc',
+				esc_html__( 'Could not delete sync error option.', 'jetpack' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		if ( Jetpack_Options::get_option( 'migrate_for_idc' ) || Jetpack_Options::update_option( 'migrate_for_idc', true ) ) {
+			return rest_ensure_response(
+				array(
+					'code' => 'success',
+				)
+			);
+		}
+		return new WP_Error(
+			'error_setting_jetpack_migrate',
+			esc_html__( 'Could not confirm migration.', 'jetpack' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	/**
+	 * This IDC resolution will disconnect the site and re-connect to a completely new
+	 * and separate shadow site than the original.
+	 *
+	 * It will first will disconnect the site without phoning home as to not disturb the production site.
+	 * It then builds a fresh connection URL and sends it back along with the response.
+	 *
+	 * @since 0.2.0
+	 * @since-jetpack 4.4.0
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public static function start_fresh_connection() {
+		/**
+		 * Fires when Users have requested through Identity Crisis for the connection to be reset.
+		 * Should be used to disconnect any connections and reset options.
+		 *
+		 * @since 0.2.0
+		 */
+		do_action( 'jetpack_idc_disconnect' );
+
+		$connection = new Connection_Manager();
+		$result     = $connection->try_registration( true );
+
+		// early return if site registration fails.
+		if ( ! $result || is_wp_error( $result ) ) {
+			return rest_ensure_response( $result );
+		}
+		/**
+		 * Filters the connection url that users should be redirected to for re-establishing their connection.
+		 *
+		 * @since 0.2.0
+		 *
+		 * @param WP_REST_Response|WP_Error    $connection_url Connection URL user should be redirected to.
+		 */
+		return apply_filters( 'jetpack_idc_authorization_url', rest_ensure_response( $connection->get_authorization_url( null, null ) ) );
+	}
+
+	/**
+	 * Verify that user can mitigate an identity crisis.
+	 *
+	 * @since 0.2.0
+	 * @since-jetpack 4.4.0
+	 *
+	 * @return bool Whether user has capability 'jetpack_disconnect'.
+	 */
+	public static function identity_crisis_mitigation_permission_check() {
+		if ( current_user_can( 'jetpack_disconnect' ) ) {
+			return true;
+		}
+		$error_msg = esc_html__(
+			'You do not have the correct user permissions to perform this action.
+			Please contact your site admin if you think this is a mistake.',
+			'jetpack'
+		);
+
+		return new WP_Error( 'invalid_user_permission_identity_crisis', $error_msg, array( 'status' => rest_authorization_required_code() ) );
+	}
+
+}

--- a/projects/packages/connection/src/idc/scss/functions/colors.scss
+++ b/projects/packages/connection/src/idc/scss/functions/colors.scss
@@ -1,0 +1,32 @@
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+
+// Add percentage of white to a color
+// Copyright © 2011–2015 thoughtbot. See CREDITS.md#L3
+@function tint($color, $percent){
+	@return mix(white, $color, $percent);
+}
+
+// Add percentage of black to a color
+// Copyright © 2011–2015 thoughtbot. See CREDITS.md#L3
+@function shade($color, $percent){
+	@return mix(black, $color, $percent);
+}

--- a/projects/packages/connection/src/idc/scss/jetpack-idc-admin-bar.scss
+++ b/projects/packages/connection/src/idc/scss/jetpack-idc-admin-bar.scss
@@ -1,0 +1,28 @@
+#wp-admin-bar-jetpack-idc.hide {
+  display: none;
+}
+
+#wp-admin-bar-jetpack-idc .jp-idc-admin-bar {
+  background: #fff;
+  border-radius: 2px;
+  color: #1d2327;
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+#wpadminbar #wp-admin-bar-jetpack-idc .dashicons {
+  color: #1d2327;
+  font-family: 'dashicons';
+}
+
+#wpadminbar #wp-admin-bar-jetpack-idc .dashicons:before {
+  font-size: 16px;
+}
+
+#wpadminbar #wp-admin-bar-jetpack-idc:hover .ab-item {
+  background: inherit;
+}
+
+#wpadminbar #wp-admin-bar-jetpack-idc:hover .jp-idc-admin-bar {
+  background: #f0f0f1;
+}

--- a/projects/packages/connection/src/idc/scss/jetpack-idc.scss
+++ b/projects/packages/connection/src/idc/scss/jetpack-idc.scss
@@ -1,0 +1,206 @@
+@import './variables/_colors.scss';
+
+.jp-idc-notice,
+.jp-idc-notice * {
+	box-sizing: border-box;
+}
+
+.jp-idc-notice {
+	margin-left: 0;
+	margin-right: 10px;
+	margin-top: 10px;
+	overflow: hidden;
+	padding-bottom: 16px;
+	padding-top: 0;
+
+	&.is-non-admin {
+		padding-bottom: 0;
+	}
+}
+
+@media all and ( min-width: 783px ) {
+	.jp-idc-notice {
+		margin-right: 20px;
+		margin-top: 20px;
+
+		&.has-help-tabs {
+			margin-top: 48px;
+		}
+	}
+}
+
+.jp-idc-notice p {
+	margin: 0;
+	padding: 0;
+}
+
+.jp-idc-notice {
+	h3, p {
+		color: $gray-dark;
+	}
+}
+
+.jp-idc-notice a:not( .dops-notice__action ) {
+	color: $blue-wordpress;
+	text-decoration: none;
+
+	&:visited {
+		color: $blue-wordpress;
+	}
+
+	&:hover,
+	&:focus,
+	&:active {
+		color: $link-highlight;
+	}
+}
+
+.jp-idc-notice .dops-button {
+	align-self: flex-start;
+	margin-top: auto;
+}
+
+.jp-idc-notice > div {
+	padding: 0 8px;
+}
+
+.jp-idc-notice__first-step {
+	display: inline-block;
+}
+
+.jp-idc-notice__second-step {
+	display: none;
+}
+
+.jp-idc-notice.jp-idc-show-second-step {
+	.jp-idc-notice__first-step {
+		display: none;
+	}
+
+	.jp-idc-notice__second-step {
+		display: inline-block;
+	}
+}
+
+.jp-idc-notice .jp-idc-notice__header {
+	padding-top: 8px;
+	padding-bottom: 8px;
+}
+
+.jp-idc-notice__header__emblem {
+	fill: $green-primary;
+	width: 25px;
+	height: 25px;
+	margin: 0 1em 0 auto;
+	float: left;
+}
+
+.jp-idc-notice__header__text {
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 25px;
+	margin: 0;
+}
+
+.jp-idc-notice__content-header {
+	margin: 16px 0;
+}
+
+.jp-idc-notice__content-header__lead {
+	font-size: 16px;
+	font-weight: 600;
+	line-height: 21px;
+	margin: 0;
+}
+
+.jp-idc-notice__content-header .jp-idc-notice__content-header__explanation {
+	font-size: 14px;
+	font-weight: 400;
+	margin: 8px 0 0;
+}
+
+@media only screen and ( min-width: 960px ) {
+	.jp-idc-notice__content-header .jp-idc-notice__content-header__explanation {
+		margin: 4px 0 0;
+	}
+}
+
+.jp-idc-notice__action {
+	border: 1px solid lighten( $gray, 30% );
+	border-radius: 4px;
+	display: flex;
+	padding: 16px;
+	flex-direction: column;
+	margin-top: auto;
+}
+
+.jp-idc-notice__action:last-child {
+	margin: 16px 0 0;
+}
+
+@media only screen and ( min-width: 960px ) {
+	.jp-idc-notice__actions {
+		display: flex;
+	}
+
+	.jp-idc-notice__action {
+		flex: 1;
+		margin: 0 8px 0 0;
+	}
+
+	.jp-idc-notice__action:last-child {
+		margin: 0 0 0 8px;
+	}
+
+	.jp-idc-notice__action:first-child {
+		padding-right: 24px;
+	}
+
+	.jp-idc-notice__action:last-child {
+		padding-left: 24px;
+	}
+}
+
+.jp-idc-notice .jp-idc-notice__action__explanation {
+	margin: 0 0 16px 0;
+}
+
+
+.jp-idc-notice__separator {
+	background-color: lighten( $gray, 30% );
+	margin: 0 -10px 0 -10px;
+	height: 1px;
+}
+
+.jp-idc-notice.is-dismissible .jp-idc-notice__separator {
+	margin-right: -46px;
+}
+
+@media only screen and ( min-width: 782px ) {
+	.jp-idc-notice__separator {
+		margin: 0 -12px 0 -12px;
+	}
+
+	.jp-idc-notice.is-dismissible .jp-idc-notice__separator {
+		margin-right: -38px;
+	}
+}
+
+.jp-idc-notice .jp-idc-notice__unsure-prompt {
+	margin: 16px 0 0;
+}
+
+.jp-idc-notice .jp-idc-error__notice {
+	display: none;
+
+	.dops-notice__icon {
+		height: auto;
+		width: auto;
+	}
+}
+
+@media only screen and ( min-width: 683px ) {
+	.jp-idc-notice .jp-idc-error__notice .dops-notice__text {
+		line-height: 24px;
+	}
+}

--- a/projects/packages/connection/src/idc/scss/variables/_colors.scss
+++ b/projects/packages/connection/src/idc/scss/variables/_colors.scss
@@ -1,0 +1,112 @@
+@import '../functions/colors.scss';
+
+// ==========================================================================
+// WordPress.com Colors
+// ==========================================================================
+
+// Primary Accent (Blues)
+$blue-wordpress: #0087be;
+$blue-light: #78dcfa;
+$blue-medium: #3582c4;
+$blue-dark: #005082;
+
+// Grays
+$gray-original: #87a6bc;
+$gray: desaturate( $gray-original, 100% ); // Intermediary transform to match dotcom's colors
+
+$gray-light: lighten( $gray, 33% ); //#f6f6f6
+$gray-dark: darken( $gray, 38% ); //#404040
+
+// Text blues
+$blue-heading: #668eaa;
+$blue-text: #537994;
+$blue-dark-text: #2e4453;
+
+// $gray-text: ideal for standard, non placeholder text
+// $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
+$gray-text: $gray-dark;
+$gray-text-min: darken( $gray, 18% ); //#537994
+
+// $gray color functions:
+// lighten( $gray, 10% )
+// lighten( $gray, 20% )
+// lighten( $gray, 30% )
+// darken( $gray, 10% )
+// darken( $gray, 20% )
+// darken( $gray, 30% )
+//
+// See wordpress.com/design-handbook/colors/ for more info.
+
+// Product types
+$color-product: #3895ba; // $studio-wordpress-blue-30
+$color-bundle: #984a9c; // $studio-purple-50
+$color-plan: #069e08; // $studio-jetpack-green-40
+$color-plan-dark: #007117; // $studio-jetpack-green-60
+
+// Secondary Accent (Oranges)
+$orange-jazzy: #f0821e;
+$orange-fire: #d63638;
+
+// Alerts
+$alert-yellow: #f0b849;
+$alert-red: #d94f4f;
+$alert-green: #4ab866;
+$alert-purple: #855da6;
+$alert-hot-red: #eb0001; // 2019
+
+// Link hovers
+$link-highlight: tint( $blue-medium, 20% );
+
+// Essentials
+$black: #000000;
+$white: rgba( 255, 255, 255, 1 );
+$transparent: rgba( 255, 255, 255, 0 );
+
+// Uncommon
+$border-ultra-light-gray: #e8f0f5;
+
+// Layout
+$masterbar-color: $blue-wordpress;
+$sidebar-bg-color: lighten( $gray, 30% );
+$sidebar-text-color: $gray-dark;
+$sidebar-selected-color: $gray;
+
+// Dashboard
+$dashboard-number-border: #cbd7e1;
+
+//Social media colors
+$color-facebook: #1877f2;
+$color-twitter: #55acee;
+$color-gplus: #df4a32;
+$color-tumblr: #35465c;
+$color-linkedin: #0976b4;
+$color-path: #df3b2f;
+$color-instagram: #e12f67;
+$color-eventbrite: #ff8000;
+$color-stumbleupon: #eb4924;
+$color-reddit: #5f99cf;
+$color-pinterest: #cc2127;
+$color-pocket: #ee4256;
+$color-email: #f8f8f8;
+$color-print: #f8f8f8;
+$color-skype: #00aff0;
+$color-telegram: #0088cc;
+$color-whatsapp: #43d854;
+$color-google: #4285f4;
+
+// ==========================================================================
+// Jetpack Specific Colors
+// ==========================================================================
+
+$green-primary: #00be28;
+$green-secondary: #00a523;
+$green-dark: #008b1d;
+
+// ==========================================================================
+// WP-ADMIN Specific Colors
+// full color list here: http://codepen.io/hugobaeta/full/RNOzoV/
+// ==========================================================================
+
+$wpui-gray-light: #f6f7f7;
+$wpui-dark-medium-gray: #50575e;
+$wpui-header-dark: #1d2327;

--- a/projects/packages/connection/tests/php/idc/test-identity-crisis.php
+++ b/projects/packages/connection/tests/php/idc/test-identity-crisis.php
@@ -1,0 +1,356 @@
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+/**
+ * Tests the Identity_Crisis package.
+ *
+ * @package automattic/jetpack-identity-crisis
+ */
+
+namespace Automattic\Jetpack;
+
+use Jetpack_Options;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test Identity_Crisis class
+ */
+class Test_Identity_Crisis extends BaseTestCase {
+	/**
+	 * Set up tests.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		Constants::set_constant( 'JETPACK_DISABLE_RAW_OPTIONS', true );
+	}
+
+	/**
+	 * Tear down tests.
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+		Constants::clear_constants();
+
+		// Reset IDC singleton.
+		$idc        = Identity_Crisis::init();
+		$reflection = new \ReflectionClass( $idc );
+		$instance   = $reflection->getProperty( 'instance' );
+
+		$instance->setAccessible( true );
+		$instance->setValue( null, null );
+		$instance->setAccessible( false );
+	}
+
+	/**
+	 * Test that clear_all_idc_options resets Options.
+	 */
+	public function test_clear_all_idc_options_clears_expected() {
+		$options = array(
+			'sync_error_idc',
+			'safe_mode_confirmed',
+			'migrate_for_idc',
+		);
+
+		foreach ( $options as $option ) {
+			Jetpack_Options::update_option( $option, true );
+		}
+
+		Identity_Crisis::clear_all_idc_options();
+
+		foreach ( $options as $option ) {
+			$this->assertFalse( Jetpack_Options::get_option( $option ) );
+		}
+	}
+
+	/**
+	 * Test jetpack_connection_disconnect_site_wpcom_filter.
+	 */
+	public function test_jetpack_connection_disconnect_site_wpcom_filter() {
+		Identity_Crisis::init();
+
+		// No IDC.
+		$this->assertTrue(
+			apply_filters( 'jetpack_connection_disconnect_site_wpcom', false ),
+			'IDC should not block the site from disconnecting on WPCOM.'
+		);
+
+		// Mock IDC.
+		add_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
+
+		$this->assertFalse(
+			apply_filters( 'jetpack_connection_disconnect_site_wpcom', true ),
+			'IDC should block the site from disconnecting on WPCOM.'
+		);
+
+		// Clean up.
+		remove_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
+	}
+
+	/**
+	 * Test the should_handle_idc default value.
+	 */
+	public function test_should_handle_idc_default() {
+		if ( is_multisite() ) {
+			$this->assertFalse( Identity_Crisis::should_handle_idc() );
+		} else {
+			$this->assertTrue( Identity_Crisis::should_handle_idc() );
+		}
+	}
+
+	/**
+	 * Test that the jetpack_should_handle_idc filter casts values to a bool.
+	 */
+	public function test_jetpack_should_handle_idc_casts_to_bool() {
+		add_filter( 'jetpack_should_handle_idc', array( $this, 'return_string_1' ) );
+		$result = Identity_Crisis::should_handle_idc();
+		remove_filter( 'jetpack_should_handle_idc', array( $this, 'return_string_1' ) );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that should_handle_idc returns true when the JETPACK_SHOULD_HANDLE_IDC constant is true.
+	 */
+	public function test_should_handle_idc_true_when_constant_true() {
+		Constants::set_constant( 'JETPACK_SHOULD_HANDLE_IDC', true );
+		$this->assertTrue( Identity_Crisis::should_handle_idc() );
+	}
+
+	/**
+	 * Test that should_handle_idc returns false when the JETPACK_SHOULD_HANDLE_IDC constant is false.
+	 */
+	public function test_should_handle_idc_false_when_constant_false() {
+		Constants::set_constant( 'JETPACK_SHOULD_HANDLE_IDC', false );
+		$this->assertFalse( Identity_Crisis::should_handle_idc() );
+	}
+
+	/**
+	 * Test that the jetpack_should_handle_idc filter overrides the JETPACK_SHOULD_HANDLE_IDC constant.
+	 */
+	public function test_jetpack_should_handle_idc_filter_overrides_constant() {
+		Constants::set_constant( 'JETPACK_SHOULD_HANDLE_IDC', true );
+		add_filter( 'jetpack_should_handle_idc', '__return_false' );
+		$result = Identity_Crisis::should_handle_idc();
+		remove_filter( 'jetpack_should_handle_idc', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that should_handle_idc returns true when the legacy JETPACK_SYNC_IDC_OPTIN constant is true.
+	 */
+	public function test_should_handle_idc_true_when_legacy_constant_true() {
+		Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', true );
+		$this->assertTrue( Identity_Crisis::should_handle_idc() );
+	}
+
+	/**
+	 * Test that should_handle_idc returns false when the legacy JETPACK_SYNC_IDC_OPTIN constant is false.
+	 */
+	public function test_should_handle_idc_false_when_legacy_constant_false() {
+		Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', false );
+		$this->assertFalse( Identity_Crisis::should_handle_idc() );
+	}
+
+	/**
+	 * Test that the legacy jetpack_sync_idc_optin filter is used by should_handle_idc.
+	 */
+	public function test_should_handle_idc_uses_legacy_filter() {
+		add_filter( 'jetpack_sync_idc_optin', '__return_false' );
+		$result = Identity_Crisis::should_handle_idc();
+		remove_filter( 'jetpack_sync_idc_optin', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that current JETPACK_SHOULD_HANDLE_IDC constant overrides the legacy JETPACK_SYNC_IDC_OPTIN constant.
+	 */
+	public function test_should_handle_idc_current_constant_overrides_legacy_constant() {
+		Constants::set_constant( 'JETPACK_SHOULD_HANDLE_IDC', true );
+		Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', false );
+		$this->assertTrue( Identity_Crisis::should_handle_idc() );
+	}
+
+	/**
+	 * Test that validate_sync_error_idc_option returns false if the sync_error_idc error doesn't exist.
+	 */
+	public function test_sync_error_idc_validation_returns_false_if_no_option() {
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+		$this->assertFalse( Identity_Crisis::validate_sync_error_idc_option() );
+	}
+
+	/**
+	 * Test that validate_sync_error_idc_option returns true when the value of sync_error_idc option
+	 * matches the expected value.
+	 */
+	public function test_sync_error_idc_validation_returns_true_when_option_matches_expected() {
+		add_filter( 'jetpack_should_handle_idc', '__return_true' );
+		Jetpack_Options::update_option( 'sync_error_idc', Identity_Crisis::get_sync_error_idc_option() );
+
+		$result = Identity_Crisis::validate_sync_error_idc_option();
+
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+		remove_filter( 'jetpack_should_handle_idc', '__return_true' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Verify that validate_sync_error returns false if wpcom_ is set and matches expected.
+	 */
+	public function test_sync_error_idc_validation_returns_false_when_wpcom_option_matches_expected() {
+		add_filter( 'jetpack_should_handle_idc', '__return_true' );
+
+		$option                  = Identity_Crisis::get_sync_error_idc_option();
+		$option['wpcom_home']    = $option['home'];
+		$option['wpcom_siteurl'] = $option['siteurl'];
+		Jetpack_Options::update_option( 'sync_error_idc', $option );
+
+		$validation_result = Identity_Crisis::validate_sync_error_idc_option();
+
+		// Verify the migrate_for_idc is set.
+		$option_result = Jetpack_Options::get_option( 'migrate_for_idc' );
+
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+		Jetpack_Options::delete_option( 'migrate_for_idc' );
+		remove_filter( 'jetpack_should_handle_idc', '__return_true' );
+
+		$this->assertFalse( $validation_result );
+		$this->assertTrue( $option_result );
+	}
+
+	/**
+	 * Verify that validate_sync_error returns true if wpcom_ is set and does not match.
+	 */
+	public function test_sync_error_idc_validation_returns_true_when_wpcom_option_does_not_match_expected() {
+		add_filter( 'jetpack_should_handle_idc', '__return_true' );
+
+		$option                  = Identity_Crisis::get_sync_error_idc_option();
+		$option['wpcom_home']    = $option['home'];
+		$option['wpcom_siteurl'] = 'coolrunnings.test';
+		Jetpack_Options::update_option( 'sync_error_idc', $option );
+
+		$validation_result = Identity_Crisis::validate_sync_error_idc_option();
+
+		// Verify the migrate_for_idc is not set.
+		$option_result = Jetpack_Options::get_option( 'migrate_for_idc' );
+
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+		Jetpack_Options::delete_option( 'migrate_for_idc' );
+		remove_filter( 'jetpack_should_handle_idc', '__return_true' );
+
+		$this->assertTrue( $validation_result );
+		$this->assertNotTrue( $option_result );
+	}
+
+	/**
+	 * Test that the sync_error_idc option is cleaned up when validation fails.
+	 */
+	public function test_sync_error_idc_validation_cleans_up_when_validation_fails() {
+		Jetpack_Options::update_option(
+			'sync_error_idc',
+			array(
+				'home'    => 'coolsite.com/',
+				'siteurl' => 'coolsite.com/wp/',
+			)
+		);
+
+		$this->assertFalse( Identity_Crisis::validate_sync_error_idc_option() );
+		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
+	}
+
+	/**
+	 * Test that the sync_error_idc option is cleaned up when part of the validation fails.
+	 */
+	public function test_sync_error_idc_validation_cleans_up_when_part_of_validation_fails() {
+		$test            = Identity_Crisis::get_sync_error_idc_option();
+		$test['siteurl'] = 'coolsite.com/wp/';
+		Jetpack_Options::update_option( 'sync_error_idc', $test );
+
+		$this->assertFalse( Identity_Crisis::validate_sync_error_idc_option() );
+		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
+	}
+
+	/**
+	 * Test the validate_sync_error_idc_option returns false and the sync_error_idc option is cleaned up
+	 * when the JETPACK_SHOULD_HANDLE_IDC constant is false.
+	 */
+	public function test_sync_error_idc_validation_returns_false_and_cleans_up_when_opted_out() {
+		Jetpack_Options::update_option( 'sync_error_idc', Identity_Crisis::get_sync_error_idc_option() );
+		Constants::set_constant( 'JETPACK_SHOULD_HANDLE_IDC', false );
+
+		$this->assertFalse( Identity_Crisis::validate_sync_error_idc_option() );
+		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
+	}
+
+	/**
+	 * Test that Status::is_staging_site returns true when sync_error_idc is valid.
+	 */
+	public function test_is_staging_site_true_when_sync_error_idc_is_valid() {
+		add_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
+		$result = ( new Status() )->is_staging_site();
+		remove_filter( 'jetpack_sync_error_idc_validation', '__return_false' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that get_sync_error_idc_option sanitizes out www and the protocol.
+	 */
+	public function test_get_sync_idc_option_sanitizes_out_www_and_protocol() {
+		$original_home    = get_option( 'home' );
+		$original_siteurl = get_option( 'siteurl' );
+
+		update_option( 'home', 'http://www.coolsite.com' );
+		update_option( 'siteurl', 'http://www.coolsite.com/wp' );
+
+		$expected = array(
+			'home'    => 'coolsite.com/',
+			'siteurl' => 'coolsite.com/wp/',
+		);
+
+		$result = Identity_Crisis::get_sync_error_idc_option();
+
+		// Cleanup.
+		update_option( 'home', $original_home );
+		update_option( 'siteurl', $original_siteurl );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test that get_sync_error_idc_option santizes out the protocol when there is an ip address
+	 * in the option.
+	 */
+	public function test_get_sync_idc_option_with_ip_address_in_option() {
+		$original_home    = get_option( 'home' );
+		$original_siteurl = get_option( 'siteurl' );
+
+		update_option( 'home', 'http://72.182.131.109/~wordpress' );
+		update_option( 'siteurl', 'http://72.182.131.109/~wordpress/wp' );
+
+		$expected = array(
+			'home'    => '72.182.131.109/~wordpress/',
+			'siteurl' => '72.182.131.109/~wordpress/wp/',
+		);
+
+		$result = Identity_Crisis::get_sync_error_idc_option();
+
+		// Cleanup.
+		update_option( 'home', $original_home );
+		update_option( 'siteurl', $original_siteurl );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Return string '1'.
+	 *
+	 * @return string
+	 */
+	public function return_string_1() {
+		return '1';
+	}
+}

--- a/projects/packages/connection/tests/php/idc/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/idc/test-rest-endpoints.php
@@ -1,0 +1,173 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\IdentityCrisis;
+
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Connection\REST_Connector;
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Identity_Crisis;
+use Jetpack_Options;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Unit tests for the REST API endpoints.
+ *
+ * @package automattic/jetpack-identity-crisis
+ */
+class Test_REST_Endpoints extends TestCase {
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * The original hostname to restore after tests are finished.
+	 *
+	 * @var string
+	 */
+	private $api_host_original;
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		Identity_Crisis::init();
+
+		do_action( 'rest_api_init' );
+		new REST_Connector( new Manager() );
+
+		$this->api_host_original = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
+
+		set_transient( 'jetpack_assumed_site_creation_date', '2020-02-28 01:13:27' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = $this->api_host_original;
+
+		delete_transient( 'jetpack_assumed_site_creation_date' );
+
+		WorDBless_Options::init()->clear_options();
+	}
+
+	/**
+	 * Testing the `/jetpack/v4/identity-crisis/confirm-safe-mode` endpoint.
+	 */
+	public function test_confirm_safe_mode() {
+
+		Jetpack_Options::update_option( 'safe_mode_confirmed', false );
+
+		$user = wp_get_current_user();
+		$user->add_cap( 'jetpack_disconnect' );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/identity-crisis/confirm-safe-mode' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$user->remove_cap( 'jetpack_disconnect' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $data['code'] );
+		$this->assertTrue( Jetpack_Options::get_option( 'safe_mode_confirmed' ) );
+	}
+
+	/**
+	 * Testing the `/jetpack/v4/identity-crisis/confirm-safe-mode` endpoint returns an error when user does not have permissions.
+	 */
+	public function test_confirm_safe_mode_no_access() {
+
+		Jetpack_Options::update_option( 'safe_mode_confirmed', false );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/identity-crisis/confirm-safe-mode' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+		$this->assertFalse( Jetpack_Options::get_option( 'safe_mode_confirmed' ) );
+	}
+
+	/**
+	 * Testing the `/jetpack/v4/identity-crisis/migrate` endpoint.
+	 */
+	public function test_migrate_stats_and_subscribers() {
+
+		Jetpack_Options::update_option( 'sync_error_idc', true );
+		Jetpack_Options::update_option( 'migrate_for_idc', false );
+
+		$user = wp_get_current_user();
+		$user->add_cap( 'jetpack_disconnect' );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/identity-crisis/migrate' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$user->remove_cap( 'jetpack_disconnect' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $data['code'] );
+		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
+		$this->assertTrue( Jetpack_Options::get_option( 'migrate_for_idc' ) );
+	}
+
+	/**
+	 * Testing the `/jetpack/v4/identity-crisis/migrate` endpoint returns an error when user does not have permissions.
+	 */
+	public function test_migrate_stats_and_subscribers_no_access() {
+
+		Jetpack_Options::update_option( 'sync_error_idc', true );
+		Jetpack_Options::update_option( 'migrate_for_idc', false );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/identity-crisis/migrate' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+		$this->assertFalse( Jetpack_Options::get_option( 'safe_mode_confirmed' ) );
+		$this->assertTrue( Jetpack_Options::get_option( 'sync_error_idc' ) );
+		$this->assertFalse( Jetpack_Options::get_option( 'migrate_for_idc' ) );
+	}
+
+	/**
+	 * Testing the `/jetpack/v4/identity-crisis/start-fresh` endpoint returns an error when user does not have permissions.
+	 */
+	public function test_start_fresh_no_access() {
+
+		$user = wp_get_current_user();
+		$user->remove_cap( 'jetpack_disconnect' );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/identity-crisis/start-fresh' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+}

--- a/projects/packages/connection/webpack.config.js
+++ b/projects/packages/connection/webpack.config.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const MinifyPlugin = require( 'babel-minify-webpack-plugin' );
+const path = require( 'path' );
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+const baseConfig = getBaseWebpackConfig(
+	{ WP: false },
+	{
+		entry: {}, // We'll override later
+		'output-filename': '[name].js',
+		'output-path': path.join( __dirname, './build' ),
+	}
+);
+
+const plugins = [ ...baseConfig.plugins, new DependencyExtractionWebpackPlugin() ];
+
+if ( ! isDevelopment ) {
+	plugins.push( new MinifyPlugin() );
+}
+
+module.exports = {
+	...baseConfig,
+	resolve: {
+		...baseConfig.resolve,
+		modules: [ 'node_modules' ],
+	},
+	devtool: isDevelopment ? 'source-map' : false,
+	entry: { index: path.join( __dirname, 'src/idc/_inc/idc-notice.js' ) },
+	plugins,
+};

--- a/projects/packages/sync/changelog/update-move_idc_to_connection
+++ b/projects/packages/sync/changelog/update-move_idc_to_connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove dependency on the identity-crisis package
+
+

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -7,7 +7,6 @@
 		"automattic/jetpack-connection": "^1.30",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-heartbeat": "^1.3",
-		"automattic/jetpack-identity-crisis": "^0.2",
 		"automattic/jetpack-options": "^1.13",
 		"automattic/jetpack-password-checker": "^0.1",
 		"automattic/jetpack-roles": "^1.4",

--- a/projects/plugins/jetpack/changelog/update-move_idc_to_connection
+++ b/projects/plugins/jetpack/changelog/update-move_idc_to_connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove dependency on the identity-crisis package
+
+

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -25,7 +25,6 @@
 		"automattic/jetpack-device-detection": "1.4.x-dev",
 		"automattic/jetpack-error": "1.3.x-dev",
 		"automattic/jetpack-heartbeat": "1.3.x-dev",
-		"automattic/jetpack-identity-crisis": "0.2.x-dev",
 		"automattic/jetpack-jitm": "2.0.x-dev",
 		"automattic/jetpack-lazy-images": "2.0.x-dev",
 		"automattic/jetpack-licensing": "1.4.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "686e541d06f84054ab4e80e74673da17",
+    "content-hash": "1d07edc5ff893de9a70369684481d0d8",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -426,7 +426,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b28190e75539efef4052e8935683791b45864a8f"
+                "reference": "7cc70c52ad7705351004c8537c7359067a116699"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -466,6 +466,14 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "NODE_ENV='production' pnpm run build"
+                ],
                 "phpunit": [
                     "./vendor/phpunit/phpunit/phpunit --colors=always"
                 ],
@@ -727,79 +735,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
-            "transport-options": {
-                "monorepo": true,
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-identity-crisis",
-            "version": "dev-master",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/identity-crisis",
-                "reference": "2ea95cf9598165da3f58d25a2790618a0a10a5e9"
-            },
-            "require": {
-                "automattic/jetpack-connection": "^1.30",
-                "automattic/jetpack-constants": "^1.6",
-                "automattic/jetpack-logo": "^1.5",
-                "automattic/jetpack-options": "^1.13",
-                "automattic/jetpack-status": "^1.8",
-                "automattic/jetpack-tracking": "^1.13"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^1.2",
-                "automattic/wordbless": "@dev",
-                "yoast/phpunit-polyfills": "1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-identity-crisis",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-identity-crisis.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-master": "0.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "Composer\\Config::disableProcessTimeout",
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "Composer\\Config::disableProcessTimeout",
-                    "NODE_ENV='production' pnpm run build"
-                ],
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "@composer install",
-                    "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
-                ],
-                "test-php": [
-                    "@composer install",
-                    "@composer phpunit"
-                ],
-                "post-update-cmd": [
-                    "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Identity Crisis.",
             "transport-options": {
                 "monorepo": true,
                 "relative": true
@@ -1360,13 +1295,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "f5a1b3b14df781457d93e2d208bbda0d25bb9ecc"
+                "reference": "fdb11f03c833effa5170c545f2ebdd48aa40e5f8"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.30",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-heartbeat": "^1.3",
-                "automattic/jetpack-identity-crisis": "^0.2",
                 "automattic/jetpack-options": "^1.13",
                 "automattic/jetpack-password-checker": "^0.1",
                 "automattic/jetpack-roles": "^1.4",
@@ -4799,7 +4733,6 @@
         "automattic/jetpack-device-detection": 20,
         "automattic/jetpack-error": 20,
         "automattic/jetpack-heartbeat": 20,
-        "automattic/jetpack-identity-crisis": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-lazy-images": 20,
         "automattic/jetpack-licensing": 20,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* There is circular dependency between the identity-crisis and connection packages. Since all connections
should be able to detect an identity crisis, and an identity crisis depends on having a connection, move
the identity crisis files to the connection package.

Also remove the identity-crisis dependencies from the sync package and the Jetpack plugin.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. tbd
