### PR TITLE
IDC: remove the unit test of the legacy jetpack_sync_idc_optin filter

### DIFF
--- a/projects/packages/identity-crisis/changelog/update-remove_deprecated_filter_test_idc
+++ b/projects/packages/identity-crisis/changelog/update-remove_deprecated_filter_test_idc
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove the legacy filter test to resolve a test error
+
+

--- a/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
+++ b/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
@@ -154,17 +154,6 @@ class Test_Identity_Crisis extends BaseTestCase {
 	}
 
 	/**
-	 * Test that the legacy jetpack_sync_idc_optin filter is used by should_handle_idc.
-	 */
-	public function test_should_handle_idc_uses_legacy_filter() {
-		add_filter( 'jetpack_sync_idc_optin', '__return_false' );
-		$result = Identity_Crisis::should_handle_idc();
-		remove_filter( 'jetpack_sync_idc_optin', '__return_false' );
-
-		$this->assertFalse( $result );
-	}
-
-	/**
 	 * Test that current JETPACK_SHOULD_HANDLE_IDC constant overrides the legacy JETPACK_SYNC_IDC_OPTIN constant.
 	 */
 	public function test_should_handle_idc_current_constant_overrides_legacy_constant() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* A depcreated notice is generated when the legacy `jetpack_sync_idc_optin` filter is used. This is expected, but it's causing a test error. This isn't a very important test, so remove it.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Check that all unit tests are passing and no errors are generated.
