### PR TITLE
PHP 7.4 Compatibility: Remove deprecated function

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-jeherve-r225393-wpcom-1632466003
+++ b/projects/plugins/jetpack/changelog/fusion-sync-jeherve-r225393-wpcom-1632466003
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Masterbar: replace deprecated get_called_class() function
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -88,7 +88,7 @@ abstract class Base_Admin_Menu {
 	 * @return Admin_Menu
 	 */
 	public static function get_instance() {
-		$class = get_called_class();
+		$class = static::class;
 
 		if ( empty( static::$instances[ $class ] ) ) {
 			static::$instances[ $class ] = new $class();


### PR DESCRIPTION

Differential Revision: D61013-code

This commit syncs r225393-wpcom.

#### Changes proposed in this Pull Request:

Use `static::class` instead which is available since PHP 5.6.

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Is CI happy?
