### PR TITLE
Repo Gardening: avoid errors when there are too many labels to add

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-too-many-labels
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-too-many-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid errors when there are too many labels to add to a PR.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -245,6 +245,11 @@ async function addLabels( payload, octokit ) {
 		return;
 	}
 
+	if ( 100 <= labels.length ) {
+		debug( 'add-labels: Too many labels to add to that PR. We will only keep 100.' );
+		labels.length = 100;
+	}
+
 	debug( `add-labels: Adding labels to PR #${ number }` );
 
 	await octokit.rest.issues.addLabels( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
﻿
GitHub does not allow you to add more than 100 labels via its API. When you attempt to do so, like it happened in PRs like #21143, you get an error from the API:

HttpError: Validation Failed. Issues cannot have more than 100 labels

To avoid this error, let's only keep the first 100 labels when there are more than 100 to add.

I considered failing the task and **not adding any labels** instead, but adding at least 100 seemed like a better experience. I am happy to be convinced otherwise though.

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Maybe merge this, and then update #21143 to see if the error disappears? That may be the easiest way to test.
