### PR TITLE
Jetpack Plugin: Product suggestion introductory price indicator

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/index.jsx
@@ -86,6 +86,9 @@ const ProductSuggestionsComponent = props => {
 					<ProductSuggestion key={ key } product={ item } />
 				) ) }
 			</div>
+			<div className="jp-recommendations-product-suggestion__introductory-pricing">
+				{ __( 'Special introductory pricing, all renewals are at full price.', 'jetpack' ) }
+			</div>
 			<div className="jp-recommendations-product-suggestion__money-back-guarantee">
 				<MoneyBackGuarantee text={ __( '14-day money-back guarantee', 'jetpack' ) } />
 			</div>

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/style.scss
@@ -1,3 +1,4 @@
+@import '_inc/client/scss/variables/_colors.scss';
 @import '../../../scss/mixin_breakpoint.scss';
 @import '../../../scss/functions/rem';
 
@@ -38,6 +39,15 @@
 			margin-bottom: 0;
 		}
 	}
+}
+
+.jp-recommendations-product-suggestion__introductory-pricing {
+	color: $wpui-header-dark;
+	font-size: rem( 14px );
+	line-height: 1.5;
+	letter-spacing: 0.1px;
+
+	margin-bottom: 10px;
 }
 
 .jp-recommendations-product-suggestion__money-back-guarantee {

--- a/projects/plugins/jetpack/changelog/update-product-suggestions-introductory-price
+++ b/projects/plugins/jetpack/changelog/update-product-suggestions-introductory-price
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add a description to the product suggestion steps to inform that discounts are only for the first purchase. Personally, this seems irrelevant for plugin users and just adds to changelog bloat of actual features.
+
+


### PR DESCRIPTION
### Introduction
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Marketing has agreed with Design that we should show a "Introductory price" text to communicate that the price we promote is only for the first purchase.

This PR currently assumes that #21189 will be approved so we do not clash with design.

---

### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add Introductory Pricing indicator/text 

---

### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* p1HpG7-cY7-p2#comment-48894

---

### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Nope!

---

### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up the Jetpack plugin with this branch
* Create a Jetpack Free connection
* Go to `/wp-admin/admin.php?page=jetpack#/recommendations/product-suggestions`
* Verify that the component looks like the screenshot below.

---

### Screenshots

**Before #21189**

![Screenshot 2021-09-24 at 17 13 59](https://user-images.githubusercontent.com/3846700/134701525-fdeab415-0b61-4fed-b0a2-a71539ac2ef9.png)

**After #21189**

_It's the wrong money back guarantee icon being used in this mock but I wanted to illustrate the similarity in text styles._

![Screenshot 2021-09-24 at 17 14 09](https://user-images.githubusercontent.com/3846700/134701541-49edaf31-d866-471c-8641-457b758adc98.png)
