### PR TITLE
Instant Search: ensure Safari input clear button is hidden

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-safari-cancel-button
+++ b/projects/plugins/jetpack/changelog/fix-safari-cancel-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instant Search: ensure Safari input clear button is hidden

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-box.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-box.scss
@@ -97,11 +97,8 @@ input.jetpack-instant-search__box-input.search-field {
 
 	&::-webkit-search-results-button,
 	&::-webkit-search-results-decoration {
+		appearance: none;
 		display: initial;
-	}
-
-	&::-webkit-search-decoration,
-	&::-webkit-search-cancel-button {
 		-webkit-appearance: none;
 	}
 

--- a/projects/plugins/jetpack/modules/search/instant-search/components/search-box.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/search-box.scss
@@ -80,7 +80,6 @@ input.jetpack-instant-search__box-input.search-field {
 	}
 }
 
-/* apply to all the inputs to try and pick up any theme styling */
 .jetpack-instant-search__box input[type='search'].jetpack-instant-search__box-input {
 	width: 100%;
 	height: 52px;
@@ -99,12 +98,15 @@ input.jetpack-instant-search__box-input.search-field {
 	&::-webkit-search-results-button,
 	&::-webkit-search-results-decoration {
 		display: initial;
-		-webkit-appearance: searchfield;
 	}
 
 	&::-webkit-search-decoration,
 	&::-webkit-search-cancel-button {
 		-webkit-appearance: none;
+	}
+
+	&::-webkit-search-cancel-button {
+		display: none;
 	}
 
 	&::-ms-clear,


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/21178.

Would be great to have this in for Jetpack 10.2 as it affects a WP Special Projects site.

#### Changes proposed in this Pull Request:
On an `input type="search"`, Safari renders its own cancel button by default. We currently override this by setting `-webkit-appearance: none` on the input.

It turns out that this isn't enough when the theme author has specified a background or border on `input[type="search"]::-webkit-search-cancel-button`. This PR ensures that the cancel button is completely hidden in this situation too.

#### Jetpack product discussion
p4Kr4c-53b-p2#comment-19918

https://www.printmag.com specifies a `background-image` on `-webkit-search-cancel-button` in their stylesheet, which appears despite the `-webkit-appearance: none`.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. On a test site with Instant Search enabled, go to the Customizer and edit your Custom CSS (`/wp-admin/customize.php?autofocus[section]=custom_css`):

```
input[type="search"]::-webkit-search-cancel-button {
	-webkit-appearance: searchfield;
	background-color: blue;
	cursor: pointer;
	display: block;
	border: 1px solid red;
}
```

2. Navigate to the front end of your site and perform a search. Ensure that you can't see the cancel button in the search input after you start typing.

Before
<img width="1144" alt="Screen Shot 2021-09-27 at 15 37 21" src="https://user-images.githubusercontent.com/17325/134838538-e91db8d9-0a5b-4b04-9d25-5bc3082669fb.png">

After
<img width="1140" alt="Screen Shot 2021-09-27 at 15 39 33" src="https://user-images.githubusercontent.com/17325/134838553-ef292cd0-e838-469d-9f80-6be459fd53df.png">


