### PR TITLE
Jetpack Plugin: Move <LoadingCard> to be generally accessible

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-loading-icon/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-loading-icon/index.jsx
@@ -13,10 +13,10 @@ import { imagePath } from 'constants/urls';
  */
 import './style.scss';
 
-export const LoadingCard = () => {
+export const JetpackLoadingIcon = () => {
 	return (
-		<div className="jp-recommendations-loading-card">
-			<img src={ imagePath + '/jetpack-logomark-blue.svg' } alt="Loading recommendations" />
+		<div className="jp-loading-icon">
+			<img src={ imagePath + '/jetpack-logomark-blue.svg' } alt="Loading..." />
 		</div>
 	);
 };

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-loading-icon/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-loading-icon/style.scss
@@ -1,4 +1,4 @@
-.jp-recommendations-loading-card {
+.jp-loading-icon {
 	width: 100%;
 	height: 100%;
 	display: flex;

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -20,7 +20,7 @@ import QueryRewindStatus from 'components/data/query-rewind-status';
 import QuerySite from 'components/data/query-site';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import { getStep, isRecommendationsDataLoaded } from 'state/recommendations';
-import { LoadingCard } from './sidebar/loading-card';
+import { JetpackLoadingIcon } from 'components/jetpack-loading-icon';
 import { RECOMMENDATION_WIZARD_STEP } from './constants';
 
 const RecommendationsComponent = props => {
@@ -70,7 +70,7 @@ const RecommendationsComponent = props => {
 			<QuerySitePlugins />
 			{ isLoading ? (
 				<div className="jp-recommendations__loading">
-					<LoadingCard />
+					<JetpackLoadingIcon />
 				</div>
 			) : (
 				<Switch>

--- a/projects/plugins/jetpack/_inc/client/recommendations/product-purchased/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/product-purchased/index.jsx
@@ -11,7 +11,7 @@ import { ProgressBar } from '@automattic/components';
  * Internal dependencies
  */
 import { PromptLayout } from '../prompts/prompt-layout';
-import { LoadingCard } from '../sidebar/loading-card';
+import { JetpackLoadingIcon } from 'components/jetpack-loading-icon';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import analytics from 'lib/analytics';
@@ -82,7 +82,7 @@ const ProductPurchasedComponent = props => {
 	}, [ suggestion ] );
 
 	if ( ! suggestion ) {
-		return <LoadingCard />;
+		return <JetpackLoadingIcon />;
 	}
 
 	const answerSection = (

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/index.jsx
@@ -10,7 +10,7 @@ import { ProgressBar } from '@automattic/components';
 /**
  * Internal dependencies
  */
-import { LoadingCard } from '../../sidebar/loading-card';
+import { JetpackLoadingIcon } from 'components/jetpack-loading-icon';
 import { PromptLayout } from '../prompt-layout';
 import { ProductSuggestion } from '../product-suggestion';
 import { MoneyBackGuarantee } from 'components/money-back-guarantee';
@@ -54,7 +54,7 @@ const ProductSuggestionsComponent = props => {
 	// This should only happen if the "step" is accessed directly and not
 	// as part of the initial flow where the user selects the site type.
 	if ( isFetchingSuggestions ) {
-		return <LoadingCard />;
+		return <JetpackLoadingIcon />;
 	}
 
 	// Redirect the user to the next step if they are not eligible for the product

--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/index.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { FeatureSummary } from '../feature-summary';
-import { LoadingCard } from '../sidebar/loading-card';
+import { JetpackLoadingIcon } from 'components/jetpack-loading-icon';
 import { OneClickRestores } from '../sidebar/one-click-restores';
 import { Security } from '../sidebar/security';
 import { MobileApp } from '../sidebar/mobile-app';
@@ -58,7 +58,7 @@ const SummaryComponent = props => {
 	}, [ updateRecommendationsStep ] );
 
 	const mainContent = isFetchingMainData ? (
-		<LoadingCard />
+		<JetpackLoadingIcon />
 	) : (
 		<>
 			<div className="jp-recommendations-summary__configuration">
@@ -130,11 +130,11 @@ const SummaryComponent = props => {
 
 	let sidebarCard;
 	if ( isFetchingSidebarData ) {
-		sidebarCard = <LoadingCard />;
+		sidebarCard = <JetpackLoadingIcon />;
 	} else {
 		switch ( sidebarCardSlug ) {
 			case 'loading':
-				sidebarCard = <LoadingCard />;
+				sidebarCard = <JetpackLoadingIcon />;
 				break;
 			case 'upsell':
 				sidebarCard = upsell.hide_upsell ? (

--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/test/component.js
@@ -33,7 +33,7 @@ describe( 'Recommendations – Summary', () => {
 				initialState: buildInitialState( { productSlug: undefined } ),
 			} );
 
-			expect( screen.getAllByAltText( 'Loading recommendations' ) ).to.be.not.null;
+			expect( screen.getAllByAltText( 'Loading...' ) ).to.be.not.null;
 		} );
 
 		it( "shows loading card when site's Rewind state is being fetched", () => {
@@ -41,7 +41,7 @@ describe( 'Recommendations – Summary', () => {
 				initialState: buildInitialState( { productSlug: 'jetpack_free', rewindStatus: {} } ),
 			} );
 
-			expect( screen.getAllByAltText( 'Loading recommendations' ) ).to.be.not.null;
+			expect( screen.getAllByAltText( 'Loading...' ) ).to.be.not.null;
 		} );
 	} );
 

--- a/projects/plugins/jetpack/changelog/generalise-assistant-loading-card
+++ b/projects/plugins/jetpack/changelog/generalise-assistant-loading-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Slight refactor so the component can be used by other dashboard components (it is just a name change).
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
### Introduction

This PR aims to make the simple `<LoadingCard>` component easier accessible by other components in the Jetpack Dashboard.


* Prerequisite for #21196

### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Move `<LoadingCard>` to the `/components/` directory.
* Rename it to `<JetpackLoadingIcon>` so it doesn't clash with other instances in the code where there is "local versions" with the same name.

### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

There is no direct discussion but it's part of splitting up #21196 which is part of a marketing effort that can be found here: p1HpG7-cY7-p2 

### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Nope!

### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a version of this branch.
* Go to `/wp-admin/admin.php?page=jetpack#/recommendations/summary`.
* Validate that you see a blue Jetpack logo (see screenshot below).
* Go to `/wp-admin/admin.php?page=jetpack#/recommendations/product-suggestions`.
* Validate that you see a blue Jetpack logo (see screenshot below).

### Screenshots

`/wp-admin/admin.php?page=jetpack#/recommendations/summary`:

![Screenshot 2021-09-27 at 18 14 59](https://user-images.githubusercontent.com/3846700/134946702-b145f0cb-4996-44e8-a07a-d4803e85298c.png)

`/wp-admin/admin.php?page=jetpack#/recommendations/product-suggestions`:

![Screenshot 2021-09-27 at 18 15 50](https://user-images.githubusercontent.com/3846700/134946805-543ebad4-d9af-4215-888e-5bf4b8a27dd4.png)
