### PR TITLE
CI: Run tests with PHP 8.1, experimentally

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -61,6 +61,15 @@ foreach ( array( '5.6', '7.0', '7.2', '7.3', '7.4', '8.0' ) as $php ) {
 		'timeout' => 15, // 2021-01-18: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 master run, ~5.5-6 for 7.x and 8.0.
 	);
 }
+// Merge this into the above once we decide PHP 8.1 is stable and WP latest works with 8.1.
+$matrix[] = array(
+	'name'         => 'PHP tests: PHP 8.1 WP master',
+	'script'       => 'test-php',
+	'php'          => '8.1',
+	'wp'           => 'master',
+	'timeout'      => 15,
+	'experimental' => true,
+);
 foreach ( array( 'previous', 'master' ) as $wp ) {
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP {$versions['PHP_VERSION']} WP $wp",

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '5.6', '7.0', '7.4', '8.0' ]
+        php-versions: [ '5.6', '7.0', '7.4', '8.0', '8.1' ]
         experimental: [ false ]
 
     steps:

--- a/projects/packages/a8c-mc-stats/changelog/add-test-with-php-8.1
+++ b/projects/packages/a8c-mc-stats/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/a8c-mc-stats/phpunit.xml.dist
+++ b/projects/packages/a8c-mc-stats/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/abtest/changelog/add-test-with-php-8.1
+++ b/projects/packages/abtest/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/abtest/phpunit.xml.dist
+++ b/projects/packages/abtest/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/assets/changelog/add-test-with-php-8.1
+++ b/projects/packages/assets/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/assets/phpunit.xml.dist
+++ b/projects/packages/assets/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="general">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/autoloader/changelog/add-test-with-php-8.1
+++ b/projects/packages/autoloader/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/autoloader/phpunit.xml.dist
+++ b/projects/packages/autoloader/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="true" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="true" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="unit">
 			<directory suffix="Test.php">tests/php/tests/unit</directory>

--- a/projects/packages/backup/changelog/add-test-with-php-8.1
+++ b/projects/packages/backup/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/backup/phpunit.xml.dist
+++ b/projects/packages/backup/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/blocks/changelog/add-test-with-php-8.1
+++ b/projects/packages/blocks/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/blocks/phpunit.xml.dist
+++ b/projects/packages/blocks/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/changelogger/changelog/add-test-with-php-8.1
+++ b/projects/packages/changelogger/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/changelogger/phpunit.xml.dist
+++ b/projects/packages/changelogger/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="true" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="true" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory suffix=".php">tests/php/tests</directory>

--- a/projects/packages/codesniffer/changelog/add-test-with-php-8.1
+++ b/projects/packages/codesniffer/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/codesniffer/phpunit.xml.dist
+++ b/projects/packages/codesniffer/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="true" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="true" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php/tests</directory>

--- a/projects/packages/connection/changelog/add-test-with-php-8.1
+++ b/projects/packages/connection/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/connection/phpunit.xml.dist
+++ b/projects/packages/connection/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="general">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/constants/changelog/add-test-with-php-8.1
+++ b/projects/packages/constants/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/constants/phpunit.xml.dist
+++ b/projects/packages/constants/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/device-detection/changelog/add-test-with-php-8.1
+++ b/projects/packages/device-detection/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/device-detection/phpunit.xml.dist
+++ b/projects/packages/device-detection/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/error/changelog/add-test-with-php-8.1
+++ b/projects/packages/error/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/error/phpunit.xml.dist
+++ b/projects/packages/error/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/identity-crisis/changelog/add-test-with-php-8.1
+++ b/projects/packages/identity-crisis/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/identity-crisis/phpunit.xml.dist
+++ b/projects/packages/identity-crisis/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/jitm/changelog/add-test-with-php-8.1
+++ b/projects/packages/jitm/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/jitm/phpunit.xml.dist
+++ b/projects/packages/jitm/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/lazy-images/changelog/add-test-with-php-8.1
+++ b/projects/packages/lazy-images/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/lazy-images/phpunit.xml.dist
+++ b/projects/packages/lazy-images/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/licensing/changelog/add-test-with-php-8.1
+++ b/projects/packages/licensing/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/licensing/phpunit.xml.dist
+++ b/projects/packages/licensing/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="general">
 			<directory prefix="class-test" suffix=".php">tests/php</directory>

--- a/projects/packages/logo/changelog/add-test-with-php-8.1
+++ b/projects/packages/logo/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/logo/phpunit.xml.dist
+++ b/projects/packages/logo/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/partner/changelog/add-test-with-php-8.1
+++ b/projects/packages/partner/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/partner/phpunit.xml.dist
+++ b/projects/packages/partner/phpunit.xml.dist
@@ -2,6 +2,7 @@
 		bootstrap="tests/php/bootstrap.php"
 		backupGlobals="false"
 		colors="true"
+		convertDeprecationsToExceptions="true"
 >
 	<testsuites>
 		<testsuite name="general">

--- a/projects/packages/password-checker/changelog/add-test-with-php-8.1
+++ b/projects/packages/password-checker/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/password-checker/phpunit.xml.dist
+++ b/projects/packages/password-checker/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/post-list/changelog/add-test-with-php-8.1
+++ b/projects/packages/post-list/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/post-list/phpunit.xml.dist
+++ b/projects/packages/post-list/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/redirect/changelog/add-test-with-php-8.1
+++ b/projects/packages/redirect/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/redirect/phpunit.xml.dist
+++ b/projects/packages/redirect/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="general">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/roles/changelog/add-test-with-php-8.1
+++ b/projects/packages/roles/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/roles/phpunit.xml.dist
+++ b/projects/packages/roles/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/status/changelog/add-test-with-php-8.1
+++ b/projects/packages/status/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/status/phpunit.xml.dist
+++ b/projects/packages/status/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/sync/changelog/add-test-with-php-8.1
+++ b/projects/packages/sync/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/sync/phpunit.xml.dist
+++ b/projects/packages/sync/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/terms-of-service/changelog/add-test-with-php-8.1
+++ b/projects/packages/terms-of-service/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/terms-of-service/phpunit.xml.dist
+++ b/projects/packages/terms-of-service/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="general">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/packages/tracking/changelog/add-test-with-php-8.1
+++ b/projects/packages/tracking/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/packages/tracking/phpunit.xml.dist
+++ b/projects/packages/tracking/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/plugins/backup/changelog/add-test-with-php-8.1
+++ b/projects/plugins/backup/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/plugins/backup/phpunit.xml.dist
+++ b/projects/plugins/backup/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/plugins/boost/changelog/add-test-with-php-8.1
+++ b/projects/plugins/boost/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/plugins/boost/phpunit.xml.dist
+++ b/projects/plugins/boost/phpunit.xml.dist
@@ -5,6 +5,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="true"
 	>
 
 	<testsuites>

--- a/projects/plugins/jetpack/changelog/add-test-with-php-8.1
+++ b/projects/plugins/jetpack/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/plugins/jetpack/phpunit.xml.dist
+++ b/projects/plugins/jetpack/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true"  convertDeprecationsToExceptions="true">
 	<php>
 		<const name="PHPUNIT_JETPACK_TESTSUITE" value="true"/>
 	</php>

--- a/projects/plugins/search/changelog/add-test-with-php-8.1
+++ b/projects/plugins/search/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/plugins/search/phpunit.xml.dist
+++ b/projects/plugins/search/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/projects/plugins/vaultpress/changelog/add-test-with-php-8.1
+++ b/projects/plugins/vaultpress/changelog/add-test-with-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/plugins/vaultpress/phpunit.xml.dist
+++ b/projects/plugins/vaultpress/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/tools/cli/skeletons/packages/phpunit.xml.dist
+++ b/tools/cli/skeletons/packages/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>

--- a/tools/cli/skeletons/plugins/phpunit.xml.dist
+++ b/tools/cli/skeletons/plugins/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
 			<directory prefix="test" suffix=".php">tests/php</directory>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
PHP 8.1 is getting close to release. Let's run tests with it so we can start
cleaning stuff up.
    
This is certainly going to fail a lot of stuff for the moment, as WordPress
itself is [still working on this][1]. But we may as well get a head start on
it.

Also set `convertDeprecationsToExceptions` true in PHPUnit configs. PHPUnit is
defaulting this to false starting in 8.5.21 and 9.5.10, and recommending
everyone change their configs to set it back to true. And PHP 8.1 is bringing a
lot of deprecations.

[1]: https://core.trac.wordpress.org/ticket/53635


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is a "PHP tests: PHP 8.1 WP master" job running? It won't be passing, of course.
* Did the "Tests" workflow report as passing even though the above job failed?
