### PR TITLE
Jetpack: add a fallback for is_connected in the is_connection_ready method

### DIFF
--- a/projects/plugins/jetpack/changelog/update-connection_ready_fallback
+++ b/projects/plugins/jetpack/changelog/update-connection_ready_fallback
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add a fallback for the Manager::is_connected method in the Jetpack::is_connected_ready method
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1735,6 +1735,14 @@ class Jetpack {
 	 * @return bool is the site connection ready to be used?
 	 */
 	public static function is_connection_ready() {
+		$is_connected = false;
+
+		if ( method_exists( self::connection(), 'is_connected' ) ) {
+			$is_connected = self::connection()->is_connected();
+		} elseif ( method_exists( self::connection(), 'is_registered' ) ) {
+			$is_connected = self::connection()->is_registered();
+		}
+
 		/**
 		 * Allows filtering whether the connection is ready to be used. If true, this will enable the Jetpack UI and modules
 		 *
@@ -1745,7 +1753,7 @@ class Jetpack {
 		 * @param bool                                  $is_connection_ready Is the connection ready?
 		 * @param Automattic\Jetpack\Connection\Manager $connection_manager Instance of the Manager class, can be used to check the connection status.
 		 */
-		return apply_filters( 'jetpack_is_connection_ready', self::connection()->is_connected(), self::connection() );
+		return apply_filters( 'jetpack_is_connection_ready', $is_connected, self::connection() );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
If an older version of the Connection package without the `Manager::is_connected` method is loaded and Jetpack is loaded in a way that can't be detected ahead of time (for example via CLI), a fatal error can occur during Jetpack activation.

To fix this, add a fallback to the `Manager::is_registered` method which is available in older versions of the Connection package.

#### Jetpack product discussion
* p91TBi-66k-p2#comment-6467

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
##### Cause the fatal error
1. Install and activate the WooCommerce and WooCommerce Payments plugins.
2. Install the latest stable version of Jetpack but don't activate it.
3. Activate Jetpack via cli: `wp plugin activate jetpack`.
4. Activation should fail with a fatal error: `PHP Fatal error:  Uncaught Error: Call to undefined method Automattic\Jetpack\Connection\Manager::is_connected() in .../wp-content/plugins/jetpack/class.jetpack.php:1745`

##### Test the fix
1. Clear the autoloader plugins transient to make sure that Jetpack isn't in the transient: `wp transient delete jetpack_autoloader_plugin_paths`.
2. Intall this branch of Jetpack but don't activate it.
3. Activate Jetpack via cli: `wp plugin activate jetpack`.
4. Activation should be successful and no error should be generated.