### PR TITLE
Fix PHP Notice when manipulating allowed_mime_types

### DIFF
--- a/projects/packages/sync/changelog/fix-user-meta-checksums
+++ b/projects/packages/sync/changelog/fix-user-meta-checksums
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Resolve indirect modification notice.

--- a/projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Sync\Replicastore;
 
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Sync;
 use Automattic\Jetpack\Sync\Modules;
 use WP_Error;
@@ -73,15 +74,47 @@ class Table_Checksum_Usermeta extends Table_Checksum {
 				if ( ! empty( $user_object->roles ) ) {
 					$checksum_entry = crc32( implode( '#', array( $this->salt, 'roles', maybe_serialize( $user_object->roles ) ) ) );
 				}
-				if ( ! empty( $user_object->allcaps ) ) {
-					$checksum_entry += crc32( implode( '#', array( $this->salt, 'capabilities', maybe_serialize( $user_object->allcaps ) ) ) );
+
+				// Meta only persisted if user is connected to WP.com.
+				if ( ( new Manager( 'jetpack' ) )->is_user_connected( $user_object->ID ) ) {
+					if ( ! empty( $user_object->allcaps ) ) {
+						$checksum_entry += crc32(
+							implode(
+								'#',
+								array(
+									$this->salt,
+									'capabilities',
+									maybe_serialize( $user_object->allcaps ),
+								)
+							)
+						);
+					}
+					if ( ! empty( $user_object->locale ) ) {
+						$checksum_entry += crc32(
+							implode(
+								'#',
+								array(
+									$this->salt,
+									'locale',
+									maybe_serialize( $user_object->locale ),
+								)
+							)
+						);
+					}
+					if ( ! empty( $user_object->allowed_mime_types ) ) {
+						$checksum_entry += crc32(
+							implode(
+								'#',
+								array(
+									$this->salt,
+									'allowed_mime_types',
+									maybe_serialize( $user_object->allowed_mime_types ),
+								)
+							)
+						);
+					}
 				}
-				if ( ! empty( $user_object->locale ) ) {
-					$checksum_entry += crc32( implode( '#', array( $this->salt, 'locale', maybe_serialize( $user_object->locale ) ) ) );
-				}
-				if ( ! empty( $user_object->allowed_mime_types ) ) {
-					$checksum_entry += crc32( implode( '#', array( $this->salt, 'allowed_mime_types', maybe_serialize( $user_object->allowed_mime_types ) ) ) );
-				}
+
 				$checksum_entries[ $user_object->ID ] = $checksum_entry;
 			}
 		}

--- a/projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php
@@ -115,7 +115,7 @@ class Table_Checksum_Usermeta extends Table_Checksum {
 					}
 				}
 
-				$checksum_entries[ $user_object->ID ] = $checksum_entry;
+				$checksum_entries[ $user_object->ID ] = '' . $checksum_entry;
 			}
 		}
 
@@ -123,16 +123,16 @@ class Table_Checksum_Usermeta extends Table_Checksum {
 		if ( ! $granular_result ) {
 			$checksum_sum = 0;
 			foreach ( $checksum_entries as $entry ) {
-				$checksum_sum += $entry;
+				$checksum_sum += intval( $entry );
 			}
 
 			if ( $simple_return_value ) {
-				return $checksum_sum;
+				return '' . $checksum_sum;
 			}
 
 			return array(
 				'range'    => $range_from . '-' . $range_to,
-				'checksum' => $checksum_sum,
+				'checksum' => '' . $checksum_sum,
 			);
 
 		}

--- a/projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php
@@ -141,11 +141,13 @@ class Table_Checksum_Usermeta extends Table_Checksum {
 		}
 
 		// Sanitize allowed_mime_types.
-		foreach ( $user_object->allowed_mime_types as $allowed_mime_type_short => $allowed_mime_type_long ) {
-			$allowed_mime_type_short                                     = wp_strip_all_tags( (string) $allowed_mime_type_short, true );
-			$allowed_mime_type_long                                      = wp_strip_all_tags( (string) $allowed_mime_type_long, true );
-			$user_object->allowed_mime_types[ $allowed_mime_type_short ] = $allowed_mime_type_long;
+		$allowed_mime_types = $user_object->allowed_mime_types;
+		foreach ( $allowed_mime_types as $allowed_mime_type_short => $allowed_mime_type_long ) {
+			$allowed_mime_type_short                        = wp_strip_all_tags( (string) $allowed_mime_type_short, true );
+			$allowed_mime_type_long                         = wp_strip_all_tags( (string) $allowed_mime_type_long, true );
+			$allowed_mime_types[ $allowed_mime_type_short ] = $allowed_mime_type_long;
 		}
+		$user_object->allowed_mime_types = $allowed_mime_types;
 
 		// Sanitize roles.
 		if ( is_array( $user_object->roles ) ) {


### PR DESCRIPTION
Resolve PHP Notice :: Indirect modification of overloaded property WP_User::$allowed_mime_types has no effect

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Resolve Indirect modification notice when performing user meta checksum

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See D67470
