### PR TITLE
ci: Fix composer monorepo repo entry in copied plugin

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -78,6 +78,11 @@ for PLUGIN in projects/plugins/*/composer.json; do
 	cp -r "$DIR" "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$NAME"
 	# Plugin dir for tests in WP >= 5.6-beta1
 	ln -s "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$NAME" "/tmp/wordpress-$WP_BRANCH/tests/phpunit/data/plugins/$NAME"
+
+	# Update monorepo repo entry in composer.json to point back here, and to mirror per COMPOSER_MIRROR_PATH_REPOS.
+	JSON="$(jq --tab --arg dir "$BASE/$DIR" '( .repositories // empty | .[] | select( .options.monorepo ) ) |= ( .url |= "\($dir)/\(.)" | .options.symlink |= false )' "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$NAME/composer.json")"
+	echo "$JSON" > "/tmp/wordpress-$WP_BRANCH/src/wp-content/plugins/$NAME/composer.json"
+
 	echo "::endgroup::"
 done
 

--- a/projects/plugins/jetpack/changelog/fix-ci-repo-locating
+++ b/projects/plugins/jetpack/changelog/fix-ci-repo-locating
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix maybe-downgrade-phpunit script.
+
+

--- a/projects/plugins/jetpack/tests/maybe-downgrade-phpunit.sh
+++ b/projects/plugins/jetpack/tests/maybe-downgrade-phpunit.sh
@@ -12,9 +12,6 @@ then
 
 	TMP1="$(<composer.json)"
 	TMP2="$(<composer.lock)"
-	if [[ ! -d ../../packages/ ]]; then
-		jq '.repositories |= empty' <<<"$TMP1" > composer.json
-	fi
 	composer require --with-all-dependencies --ignore-platform-reqs phpunit/phpunit=^7.5
 	echo "$TMP1" > composer.json
 	echo "$TMP2" > composer.lock


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The maybe-downgrade-phpunit logic added in #21157 was just deleting the
monorepo repo entry, which was causing it to re-download all the
monorepo deps from packagist. That's wrong, it should continue to use
the monorepo packages that were checked out.

To avoid that, when the setup-wordpress-env script copies the plugin
into place it needs to update that repo entry in composer.json to point
to the correct path (and set options.symlink = false to match the logic
used originally).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1632786514389700-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Combine this with #21038 and see if the CI jobs stop erroring out.