### PR TITLE
Avoid calypso-build's babel-plugin-optimize-i18n plugin

### DIFF
--- a/projects/packages/connection-ui/babel.config.js
+++ b/projects/packages/connection-ui/babel.config.js
@@ -1,10 +1,13 @@
 /**
- * A babel preset wrapper to set @babel/plugin-transform-runtime's absoluteRuntime to true.
+ * Mangle calypso-build's babel preset to work around some problems.
+ *
+ * - Set `absoluteRuntime` true for `@babel/plugin-transform-runtime`.
+ * - Remove the broken `babel-plugin-optimize-i18n`.
  *
  * @param {string|Function} preset - The preset being wrapped.
  * @returns {Function} The wrapped preset-function.
  */
-function presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime( preset ) {
+function overrideCalypsoBuildPreset( preset ) {
 	if ( 'string' === typeof preset ) {
 		preset = require( preset );
 	}
@@ -17,16 +20,15 @@ function presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime( preset ) {
 				p[ 1 ].absoluteRuntime = true;
 			}
 		} );
+		ret.plugins = ret.plugins.filter(
+			p => ! ( typeof p === 'string' && p.endsWith( '/babel-plugin-optimize-i18n.js' ) )
+		);
 		return ret;
 	};
 }
 
 const config = {
-	presets: [
-		presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime(
-			'@automattic/calypso-build/babel/default'
-		),
-	],
+	presets: [ overrideCalypsoBuildPreset( '@automattic/calypso-build/babel/default' ) ],
 };
 
 module.exports = config;

--- a/projects/packages/connection-ui/changelog/fix-avoid-calypso-build-i18n-plugin
+++ b/projects/packages/connection-ui/changelog/fix-avoid-calypso-build-i18n-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update babel config to avoid calypso-build's "babel-plugin-optimize-i18n" plugin.

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "1.4.1-alpha",
+	"version": "1.4.2-alpha",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-connection-ui",

--- a/projects/plugins/backup/babel.config.js
+++ b/projects/plugins/backup/babel.config.js
@@ -1,10 +1,13 @@
 /**
- * A babel preset wrapper to set @babel/plugin-transform-runtime's absoluteRuntime to true.
+ * Mangle calypso-build's babel preset to work around some problems.
+ *
+ * - Set `absoluteRuntime` true for `@babel/plugin-transform-runtime`.
+ * - Remove the broken `babel-plugin-optimize-i18n`.
  *
  * @param {string|Function} preset - The preset being wrapped.
  * @returns {Function} The wrapped preset-function.
  */
-function presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime( preset ) {
+function overrideCalypsoBuildPreset( preset ) {
 	if ( 'string' === typeof preset ) {
 		preset = require( preset );
 	}
@@ -17,16 +20,15 @@ function presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime( preset ) {
 				p[ 1 ].absoluteRuntime = true;
 			}
 		} );
+		ret.plugins = ret.plugins.filter(
+			p => ! ( typeof p === 'string' && p.endsWith( '/babel-plugin-optimize-i18n.js' ) )
+		);
 		return ret;
 	};
 }
 
 const config = {
-	presets: [
-		presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime(
-			'@automattic/calypso-build/babel/default'
-		),
-	],
+	presets: [ overrideCalypsoBuildPreset( '@automattic/calypso-build/babel/default' ) ],
 };
 
 module.exports = config;

--- a/projects/plugins/backup/changelog/fix-avoid-calypso-build-i18n-plugin
+++ b/projects/plugins/backup/changelog/fix-avoid-calypso-build-i18n-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update babel config to avoid calypso-build's "babel-plugin-optimize-i18n" plugin.

--- a/projects/plugins/jetpack/babel.config.js
+++ b/projects/plugins/jetpack/babel.config.js
@@ -1,10 +1,13 @@
 /**
- * A babel preset wrapper to set @babel/plugin-transform-runtime's absoluteRuntime to true.
+ * Mangle calypso-build's babel preset to work around some problems.
+ *
+ * - Set `absoluteRuntime` true for `@babel/plugin-transform-runtime`.
+ * - Remove the broken `babel-plugin-optimize-i18n`.
  *
  * @param {string|Function} preset - The preset being wrapped.
  * @returns {Function} The wrapped preset-function.
  */
-function presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime( preset ) {
+function overrideCalypsoBuildPreset( preset ) {
 	if ( 'string' === typeof preset ) {
 		preset = require( preset );
 	}
@@ -17,16 +20,15 @@ function presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime( preset ) {
 				p[ 1 ].absoluteRuntime = true;
 			}
 		} );
+		ret.plugins = ret.plugins.filter(
+			p => ! ( typeof p === 'string' && p.endsWith( '/babel-plugin-optimize-i18n.js' ) )
+		);
 		return ret;
 	};
 }
 
 const config = {
-	presets: [
-		presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime(
-			'@automattic/calypso-build/babel/default'
-		),
-	],
+	presets: [ overrideCalypsoBuildPreset( '@automattic/calypso-build/babel/default' ) ],
 	plugins: [ '@babel/plugin-proposal-nullish-coalescing-operator' ],
 	overrides: [
 		{
@@ -38,28 +40,18 @@ const config = {
 			test: [ './gulpfile.babel.js', './tools/webpack.config.js', './tools/builder/' ],
 			presets: [
 				[
-					presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime(
-						'@automattic/calypso-build/babel/default'
-					),
+					overrideCalypsoBuildPreset( '@automattic/calypso-build/babel/default' ),
 					{ modules: 'commonjs' },
 				],
 			],
 		},
 		{
 			test: './modules/search/instant-search',
-			presets: [
-				presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime(
-					'./modules/search/instant-search/babel.config.js'
-				),
-			],
+			presets: [ overrideCalypsoBuildPreset( './modules/search/instant-search/babel.config.js' ) ],
 		},
 		{
 			test: './modules/search/customberg',
-			presets: [
-				presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime(
-					'./modules/search/customberg/babel.config.js'
-				),
-			],
+			presets: [ overrideCalypsoBuildPreset( './modules/search/customberg/babel.config.js' ) ],
 		},
 	],
 	env: {

--- a/projects/plugins/jetpack/changelog/fix-avoid-calypso-build-i18n-plugin
+++ b/projects/plugins/jetpack/changelog/fix-avoid-calypso-build-i18n-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update babel config to avoid calypso-build's "babel-plugin-optimize-i18n" plugin.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -100,7 +100,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ10_2_alpha"
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ10_3_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-production",

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 10.2-alpha
+ * Version: 10.3-alpha
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '5.7' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '10.2-alpha' );
+define( 'JETPACK__VERSION', '10.3-alpha' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "10.2.0-alpha",
+	"version": "10.3.0-alpha",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It's not clear what exactly it's intended to do, but in the context of
Jetpack is seems to brokenly result in calls to WordPress's i18n
functions (`__` and so on) to be minified away.

Excluding it brings us back to the situation before the upgrade to
calypso-build 9.0.0, which should fix #21204.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#21204

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I guess run `wp i18n make-pot` on the output and see if it finds the right strings.