### PR TITLE
Contact Info & Map widget: Add legacy widget → block transform

### DIFF
--- a/projects/plugins/jetpack/changelog/update-contact-info-and-map-widget-block-compatibility
+++ b/projects/plugins/jetpack/changelog/update-contact-info-and-map-widget-block-compatibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Contact info & Map Widget: removed from Legacy Widget block

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/index.js
@@ -65,9 +65,31 @@ export const settings = {
 					return idBase === 'widget_contact_info';
 				},
 				transform: ( { instance } ) => {
-					return createBlock( 'jetpack/contact-info', {
-						name: instance.raw.name,
+					let innerBlocks = [];
+
+					const headingBlock = createBlock( 'core/heading', {
+						content: instance.raw.title,
 					} );
+
+					const emailBlock = createBlock( 'jetpack/email', {
+						email: instance.raw.email,
+					} );
+
+					const phoneBlock = createBlock( 'jetpack/phone', {
+						phone: instance.raw.phone,
+					} );
+
+					const addressBlock = createBlock( 'jetpack/address', {
+						address: instance.raw.address,
+					} );
+
+					const hoursBlock = createBlock( 'core/paragraph', {
+						content: instance.raw.hours,
+					} );
+
+					innerBlocks = [ headingBlock, emailBlock, phoneBlock, addressBlock, hoursBlock ];
+
+					return createBlock( 'jetpack/contact-info', {}, innerBlocks );
 				},
 			},
 		],

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/index.js
@@ -4,6 +4,7 @@
 import { __, _x } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { Path } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -50,6 +51,26 @@ export const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
+	},
+	// Transform from classic widget
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/legacy-widget' ],
+				isMatch: ( { idBase, instance } ) => {
+					if ( ! instance?.raw ) {
+						return false;
+					}
+					return idBase === 'widget_contact_info';
+				},
+				transform: ( { instance } ) => {
+					return createBlock( 'jetpack/contact-info', {
+						name: instance.raw.name,
+					} );
+				},
+			},
+		],
 	},
 	attributes,
 	edit,

--- a/projects/plugins/jetpack/modules/widgets/contact-info.php
+++ b/projects/plugins/jetpack/modules/widgets/contact-info.php
@@ -31,6 +31,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				'classname'                   => 'widget_contact_info',
 				'description'                 => __( 'Display a map with your location, hours, and contact information.', 'jetpack' ),
 				'customize_selective_refresh' => true,
+				'show_instance_in_rest'       => true,
 			);
 			parent::__construct(
 				'widget_contact_info',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR adds transform for the legacy / classic "Contact Info & Map" widget.

![Markup on 2021-09-29 at 14:34:20](https://user-images.githubusercontent.com/25105483/135269247-89749dce-80e1-4270-84d4-e20eeb4f2cb5.png)

The proposed change can help users move the content of their existing widget into the "Contact Info" block, plus several additional blocks:

- Heading (H2) block storing the `Title` of the widget
- Paragraph block storing the `Hours` field of the widget

At the moment, the `Address` field of the widget is transformed into the `Street Address` field of the block, leaving other block fields (e.g. Country, Postal/Zip Code, State) empty. We may consider parsing the `Address` field of the widget into separate block fields in the future iteration.

#### Jetpack product discussion
https://github.com/Automattic/jetpack/issues/21069

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Add the "Contact Info & Map" widget (using the Legacy Block) to your testing site and save it.
2. Select the transform option and choose "Contact Info" block (as can be seen in the screenshot above).
3. The widget information should be correctly transformed.