### PR TITLE
Publicize: set connection `done` state optimistically.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-publicize-update-done-connection-state
+++ b/projects/plugins/jetpack/changelog/update-publicize-update-done-connection-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Publicize: use post meta as the main source for data storing

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -19,21 +19,30 @@ import PublicizeConnectionVerify from '../connection-verify';
 import PublicizeForm from '../form';
 import PublicizeTwitterOptions from '../twitter/options';
 import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
-import { usePostJustPublished } from '../../hooks/use-saving-post';
+import { usePostJustBeforeToPublish } from '../../hooks/use-saving-post';
 
 const PublicizePanel = ( { prePublish } ) => {
-	const { refresh, hasEnabledConnections } = useSelectSocialMediaConnections();
+	const { refresh, connections } = useSelectSocialMediaConnections();
 
 	// Refresh connections when the post is just published.
-	usePostJustPublished(
+	usePostJustBeforeToPublish(
 		function () {
-			if ( ! hasEnabledConnections ) {
-				return;
-			}
+			/*
+			 * Being optimistic, it sets the connections
+			 * that are going to be used
+			 * to share the post as `done`.
+			 * The sharing process is handled by an async action,
+			 * in the server-side.
+			 */
+			const updatedConnections = connections.map( connection => ( {
+				...connection,
+				done: connection.enabled,
+				toggleable: ! connection.enabled,
+			} ) );
 
-			refresh();
+			refresh( updatedConnections );
 		},
-		[ hasEnabledConnections, refresh ]
+		[ refresh ]
 	);
 
 	return (

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -19,13 +19,13 @@ import PublicizeConnectionVerify from '../connection-verify';
 import PublicizeForm from '../form';
 import PublicizeTwitterOptions from '../twitter/options';
 import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
-import { usePostJustBeforeToPublish } from '../../hooks/use-saving-post';
+import { usePostJustBeforePublish } from '../../hooks/use-saving-post';
 
 const PublicizePanel = ( { prePublish } ) => {
 	const { refresh, connections } = useSelectSocialMediaConnections();
 
 	// Refresh connections when the post is just published.
-	usePostJustBeforeToPublish(
+	usePostJustBeforePublish(
 		function () {
 			/*
 			 * Being optimistic, it sets the connections

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-saving-post/Readme.md
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-saving-post/Readme.md
@@ -1,6 +1,5 @@
 # usePostJustSaved() hook
 React hook to detect when the post is just saved.
-Also, it accepts a dependency array passed to useEffect hook.
 
 ```es6
 import { usePostJustSaved } from '../../hooks/use-saving-post';
@@ -14,7 +13,6 @@ function SavingPostLabel() {
 
 # usePostJustPublished() hook
 React hook to detect when the post is just publihsed.
-Also, it accepts a dependency array passed to useEffect hook.
 
 ```es6
 import { usePostJustPublished } from '../../hooks/use-saving-post';

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-saving-post/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-saving-post/index.js
@@ -7,9 +7,8 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
- * React hook to detect when the post is just saved,
- * running the callback when it happens.
- * Additionally, it accepts a dependency array which is passed to useEffect hook.
+ * React hook to detect when the post is just saved.
+ * It accepts a dependency array which is passed to useEffect hook.
  *
  * @param {Function} fn - Callback function to run when the post is just saved.
  * @param {Array} deps  - Depencency array.
@@ -29,8 +28,7 @@ export function usePostJustSaved( fn, deps ) {
 
 /**
  * React hook to detect when the post is just published,
- * running the callback when it happens.
- * Additionally, it accepts a dependency array which is passed to useEffect hook.
+ * It accepts a dependency array which is passed to useEffect hook.
  *
  * @param {Function} fn - Callback function to run when the post is just published.
  * @param {Array} deps  - Depencency array.
@@ -41,6 +39,26 @@ export function usePostJustPublished( fn, deps ) {
 
 	useEffect( () => {
 		if ( ! ( wasPublishing && ! isPublishing ) ) {
+			return;
+		}
+
+		fn();
+	}, [ isPublishing, wasPublishing, fn, deps ] );
+}
+
+/**
+ * React hook to detect when the post is going to be published,
+ * It accepts a dependency array which is passed to useEffect hook.
+ *
+ * @param {Function} fn - Callback function to run when the post going to be published.
+ * @param {Array} deps  - Depencency array.
+ */
+export function usePostJustBeforeToPublish( fn, deps ) {
+	const isPublishing = useSelect( select => select( editorStore ).isPublishingPost(), [] );
+	const wasPublishing = usePrevious( isPublishing );
+
+	useEffect( () => {
+		if ( ! ( ! wasPublishing && isPublishing ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-saving-post/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-saving-post/index.js
@@ -7,61 +7,69 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
- * React hook to detect when the post is just saved.
- * It accepts a dependency array which is passed to useEffect hook.
+ * Hook action to run a function before the post is saved.
  *
- * @param {Function} fn - Callback function to run when the post is just saved.
- * @param {Array} deps  - Depencency array.
+ * @param {Object}        params  - hook parameters.
+ * @param {boolean} params.after  - whether to check the process after the post is saved. Default: True.
+ * @param {string} params.process - process to check. Default: 'save'.
+ * @param {Function}           fn - callback function.
+ * @param {Array}            deps - Hook dependencies.
+ */
+function useProcessingPost( params, fn, deps = [] ) {
+	const { after = true, process = 'save' } = params;
+	const selector = 'save' === process ? 'isSavingPost' : 'isPublishingPost';
+	const isProcessing = useSelect( select => select( editorStore )[ selector ](), [] );
+	const wasProcessing = usePrevious( isProcessing );
+
+	useEffect( () => after === wasProcessing && after !== isProcessing && fn(), [
+		isProcessing,
+		wasProcessing,
+		after,
+		fn,
+		deps,
+	] );
+}
+
+/**
+ * Hook action to run a function after the post is just saved.
+ *
+ * @param {Function} fn - callback function.
+ * @param {Array}  deps - Hook dependencies.
+ * @returns {Function} The hook function.
  */
 export function usePostJustSaved( fn, deps ) {
-	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );
-	const wasSaving = usePrevious( isSaving );
-
-	useEffect( () => {
-		if ( ! ( wasSaving && ! isSaving ) ) {
-			return;
-		}
-
-		fn();
-	}, [ isSaving, wasSaving, fn, deps ] );
+	return useProcessingPost( { after: true, process: 'save' }, fn, deps );
 }
 
 /**
- * React hook to detect when the post is just published,
- * It accepts a dependency array which is passed to useEffect hook.
+ * Hook action to run a function before the post is saved.
  *
- * @param {Function} fn - Callback function to run when the post is just published.
- * @param {Array} deps  - Depencency array.
+ * @param {Function} fn - callback function.
+ * @param {Array}  deps - Hook dependencies.
+ * @returns {Function} The hook function.
+ */
+export function usePostJustBeforeSave( fn, deps ) {
+	return useProcessingPost( { after: false, process: 'save' }, fn, deps );
+}
+
+/**
+ * Hook action to run a function after the post is just published.
+ *
+ * @param {Function} fn - callback function.
+ * @param {Array}  deps - Hook dependencies.
+ * @returns {Function} The hook function.
  */
 export function usePostJustPublished( fn, deps ) {
-	const isPublishing = useSelect( select => select( editorStore ).isPublishingPost(), [] );
-	const wasPublishing = usePrevious( isPublishing );
-
-	useEffect( () => {
-		if ( ! ( wasPublishing && ! isPublishing ) ) {
-			return;
-		}
-
-		fn();
-	}, [ isPublishing, wasPublishing, fn, deps ] );
+	return useProcessingPost( { after: true, process: 'publish' }, fn, deps );
 }
 
 /**
- * React hook to detect when the post is going to be published,
- * It accepts a dependency array which is passed to useEffect hook.
+ * Hook action to run a function before the post is published.
  *
- * @param {Function} fn - Callback function to run when the post going to be published.
- * @param {Array} deps  - Depencency array.
+ * @param {Function} fn - callback function.
+ * @param {Array}  deps - Hook dependencies.
+ * @returns {Function} The hook function.
  */
-export function usePostJustBeforeToPublish( fn, deps ) {
-	const isPublishing = useSelect( select => select( editorStore ).isPublishingPost(), [] );
-	const wasPublishing = usePrevious( isPublishing );
-
-	useEffect( () => {
-		if ( ! ( ! wasPublishing && isPublishing ) ) {
-			return;
-		}
-
-		fn();
-	}, [ isPublishing, wasPublishing, fn, deps ] );
+export function usePostJustBeforePublish( fn, deps ) {
+	return useProcessingPost( { after: false, process: 'publish' }, fn, deps );
 }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-saving-post/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-saving-post/index.js
@@ -21,13 +21,11 @@ function useProcessingPost( params, fn, deps = [] ) {
 	const isProcessing = useSelect( select => select( editorStore )[ selector ](), [] );
 	const wasProcessing = usePrevious( isProcessing );
 
-	useEffect( () => after === wasProcessing && after !== isProcessing && fn(), [
-		isProcessing,
-		wasProcessing,
-		after,
-		fn,
-		deps,
-	] );
+	useEffect( () => {
+		if ( after === wasProcessing && after !== isProcessing ) {
+			fn();
+		}
+	}, [ isProcessing, wasProcessing, after, fn, deps ] );
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/actions.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/actions.js
@@ -7,11 +7,13 @@ import { select } from '@wordpress/data';
  * Returns an action object used in signalling that
  * we're refreshing the Publicize connection.
  *
+ * @param {Array} connections  - Connections list (optional).
  * @returns {object} Action object.
  */
-export function refreshConnectionTestResults() {
+export function refreshConnectionTestResults( connections = [] ) {
 	return {
 		type: 'REFRESH_CONNECTION_TEST_RESULTS',
+		connections,
 	};
 }
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
@@ -15,14 +15,19 @@ import { SUPPORTED_CONTAINER_BLOCKS } from '../components/twitter';
 /**
  * Effect handler which will refresh the connection test results.
  *
- * @returns {object} Refresh connection test results action.
+ * @param {object} action              - Action which had initiated the effect handler.
+ * @param {Array} action.connections  - Current connections list.
+ * @returns {object} Refresh connection test results action in the post metadata.
  */
-export async function refreshConnectionTestResults() {
+export async function refreshConnectionTestResults( { connections: prevConnections } ) {
 	try {
 		const results = await apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } );
 
-		// Combine current connections with new connections.
-		const prevConnections = select( 'jetpack/publicize' ).getConnections();
+		// Define initial conncetions list.
+		prevConnections = prevConnections?.length
+			? prevConnections
+			: select( 'jetpack/publicize' ).getConnections();
+
 		const prevConnectionIds = prevConnections.map( connection => connection.id );
 		const freshConnections = results;
 		const connections = [];
@@ -36,7 +41,7 @@ export async function refreshConnectionTestResults() {
 			if ( prevConnectionIds.includes( freshConnection.id ) ) {
 				/*
 				 * The connection is already defined.
-				 * Do not overwrite the existing connection.
+				 * Do not overwrite.
 				 */
 				connection = prevConnections.filter(
 					prevConnection => prevConnection.id === freshConnection.id

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
@@ -23,7 +23,7 @@ export async function refreshConnectionTestResults( { connections: prevConnectio
 	try {
 		const results = await apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } );
 
-		// Define initial conncetions list.
+		// Define initial connections list.
 		prevConnections = prevConnections?.length
 			? prevConnections
 			: select( 'jetpack/publicize' ).getConnections();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

### Branched off from ~#21208~ and #21231

This PR populates updates the post metadata to mark those connections used to share the post as done once the post is published, without waiting for the final result of the async process. This is an optimistic approach to the final result of the post-sharing action. Take a look at the [issue](https://github.com/Automattic/jetpack/issues/21233) description to get the idea :-D

Fixes https://github.com/Automattic/jetpack/issues/21233


https://user-images.githubusercontent.com/77539/136374335-ac548222-7b20-4aa3-83a7-63bbee58bc6a.mov

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Publicize: set connection `done` state optimistically.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post
* Add some connections
* Add content to the post
* Publish
* Confirm the `done` state is updated once the post publishes 
* Confirm that it shows the same state after a hard refresh
* 
<img src="https://user-images.githubusercontent.com/77539/135283729-51ca00f6-a50d-4594-9212-b074298a0044.png" width="300px" />

* Take a look at the store to see how the `done` and `toggleable` properties are set as true in the post meta.

https://user-images.githubusercontent.com/77539/135283248-7c2b2342-8250-44a3-be3e-99d46c48d3db.mov


