### PR TITLE
jetpack: Disable webpack's concatenateModules optimization

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-disable-webpack-concatenateModules-optimization
+++ b/projects/plugins/jetpack/changelog/fix-disable-webpack-concatenateModules-optimization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Disable webpack's concatenateModules optimization, it can break WordPress's translation extraction.

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -167,6 +167,11 @@ overrideCalypsoBuildFileConfig( componentsWebpackConfig );
 module.exports = [
 	{
 		...extensionsWebpackConfig,
+		optimization: {
+			...extensionsWebpackConfig.optimization,
+			// This optimization sometimes causes webpack to drop `__()` and such.
+			concatenateModules: false,
+		},
 		resolve: {
 			...extensionsWebpackConfig.resolve,
 			// We want the compiled version, not the "calypso:src" sources.
@@ -189,6 +194,11 @@ module.exports = [
 	},
 	{
 		...componentsWebpackConfig,
+		optimization: {
+			...extensionsWebpackConfig.optimization,
+			// This optimization sometimes causes webpack to drop `__()` and such.
+			concatenateModules: false,
+		},
 		resolve: {
 			...componentsWebpackConfig.resolve,
 			// We want the compiled version, not the "calypso:src" sources.

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -23,6 +23,11 @@ const baseWebpackConfig = getBaseWebpackConfig(
 
 const sharedWebpackConfig = {
 	...baseWebpackConfig,
+	optimization: {
+		...baseWebpackConfig.optimization,
+		// This optimization sometimes causes webpack to drop `__()` and such.
+		concatenateModules: false,
+	},
 	resolve: {
 		...baseWebpackConfig.resolve,
 		modules: [ path.resolve( path.dirname( __dirname ), '_inc/client' ), 'node_modules' ],

--- a/projects/plugins/jetpack/tools/webpack.config.search-configure.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search-configure.js
@@ -28,6 +28,11 @@ const baseWebpackConfig = getBaseWebpackConfig(
 
 module.exports = {
 	...baseWebpackConfig,
+	optimization: {
+		...baseWebpackConfig.optimization,
+		// This optimization sometimes causes webpack to drop `__()` and such.
+		concatenateModules: false,
+	},
 	resolve: {
 		...baseWebpackConfig.resolve,
 		modules: [

--- a/projects/plugins/jetpack/tools/webpack.config.search.js
+++ b/projects/plugins/jetpack/tools/webpack.config.search.js
@@ -90,10 +90,13 @@ module.exports = {
 		definePaletteColorsAsStaticVariables(),
 	],
 	optimization: {
+		...baseWebpackConfig.optimization,
 		splitChunks: {
 			cacheGroups: {
 				vendors: false,
 			},
 		},
+		// This optimization sometimes causes webpack to drop `__()` and such.
+		concatenateModules: false,
 	},
 };

--- a/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
+++ b/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
@@ -34,6 +34,11 @@ const baseWebpackConfig = getBaseWebpackConfig(
 
 module.exports = {
 	...baseWebpackConfig,
+	optimization: {
+		...baseWebpackConfig.optimization,
+		// This optimization sometimes causes webpack to drop `__()` and such.
+		concatenateModules: false,
+	},
 	resolve: {
 		...baseWebpackConfig.resolve,
 		modules: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In the current setup, we rely on WordPress's translation infrastructure
scanning the webpacked JavaScript files to find calls to the i18n
functions. The concatenateModules optimization can sometimes
discard (or inline?) such calls, breaking things. A change in
calypso-build 9.0.0 makes this far more likely.

Fixes #21204.

Note the situation with respect to translations still isn't perfect.
- The "translator" comments are lost, unless it happens to pick them up
  scanning the unwebpacked sources.
- The `wp i18n make-pot` tool ignores all `*.min.js` files, which we
  have to use to avoid a broken minifier that wpcom applies to all `.js`
  files that aren't `.min.js`. If the WP translation infrastructure uses
  that or uses the same logic...

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#21204

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I guess run wp i18n make-pot on the output and see if it finds the right strings.