### PR TITLE
Jetpack: Exclude `vendor/` from coverage

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-coverage-slow
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-coverage-slow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Exclude `vendor/` from code coverage.

--- a/projects/plugins/jetpack/phpunit.xml.dist
+++ b/projects/plugins/jetpack/phpunit.xml.dist
@@ -144,6 +144,7 @@
 				<directory suffix=".php">views</directory>
 				<directory suffix=".php">tools</directory>
 				<directory suffix=".php">node_modules</directory>
+				<directory suffix=".php">vendor</directory>
 			</exclude>
 		</whitelist>
 	</filter>

--- a/projects/plugins/jetpack/tests/php.multisite.xml
+++ b/projects/plugins/jetpack/tests/php.multisite.xml
@@ -83,6 +83,7 @@
 				<directory suffix=".php">../views</directory>
 				<directory suffix=".php">../tools</directory>
 				<directory suffix=".php">../node_modules</directory>
+				<directory suffix=".php">../vendor</directory>
 			</exclude>
 		</whitelist>
 	</filter>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Something in #21218 seems to have changed the structure of the `vendor/` in
a way that makes PHPUnit take a very long time to generate the code coverage
report. Since there's no point in it including coverage for `vendor/` (as
nothing in there is part of Jetpack itself; even our monorepo modules should
have their own tests covering them), let's exclude it.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is the "Tests / Code coverage" job completing, in the expected ~20 minutes?
