### PR TITLE
Boost: Use admin_ui to register the admin menu

### DIFF
--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\Jetpack_Boost\Admin;
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack_Boost\Jetpack_Boost;
 use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
@@ -54,49 +55,28 @@ class Admin {
 		$this->speed_score   = new Speed_Score();
 		Environment_Change_Detector::init();
 
-		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_filter( 'plugin_action_links_' . JETPACK_BOOST_PLUGIN_BASE, array( $this, 'plugin_page_settings_link' ) );
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 		add_action( 'admin_notices', array( $this, 'show_notices' ) );
 
 		$this->handle_get_parameters();
-	}
 
-	/**
-	 * Runs the function that generates the admin menu for the plugin.
-	 */
-	public function admin_menu() {
-		add_menu_page(
-			__( 'Jetpack Boost', 'jetpack-boost' ),
-			__( 'Jetpack Boost', 'jetpack-boost' ),
-			'manage_options',
-			JETPACK_BOOST_SLUG,
-			array( $this, 'render_settings' ),
-			'dashicons-chart-line',
-			77 // Between Tools & Settings.
-		);
-
-		add_submenu_page(
-			'jetpack-boost',
+		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Boost - Settings', 'jetpack-boost' ),
-			__( 'Settings', 'jetpack-boost' ),
+			'Boost',
 			'manage_options',
 			JETPACK_BOOST_SLUG,
 			array( $this, 'render_settings' )
 		);
+		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
 	}
 
 	/**
-	 * Returns true if on Jetpack Boost admin page.
-	 *
-	 * @return bool
+	 * Enqueue scripts and styles for the admin page.
 	 */
-	public function on_boost_admin_page() {
-		$screen = get_current_screen();
-
-		return 'toplevel_page_jetpack-boost' === $screen->id;
+	public function admin_init() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
 
 	/**
@@ -105,9 +85,6 @@ class Admin {
 	 * @since    1.0.0
 	 */
 	public function enqueue_styles() {
-		if ( ! $this->on_boost_admin_page() ) {
-			return;
-		}
 
 		$internal_path = apply_filters( 'jetpack_boost_asset_internal_path', 'app/assets/dist/' );
 
@@ -125,9 +102,6 @@ class Admin {
 	 * @since    1.0.0
 	 */
 	public function enqueue_scripts() {
-		if ( ! $this->on_boost_admin_page() ) {
-			return;
-		}
 
 		$internal_path = apply_filters( 'jetpack_boost_asset_internal_path', 'app/assets/dist/' );
 

--- a/projects/plugins/boost/changelog/update-boost-menu-registration
+++ b/projects/plugins/boost/changelog/update-boost-menu-registration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use the Admin UI package and register the menu under the Jetpack top level menu

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -14,6 +14,7 @@
 	"prefer-stable": true,
 	"require": {
 		"ext-json": "*",
+		"automattic/jetpack-admin-ui": "0.1.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
 		"automattic/jetpack-config": "1.5.x-dev",
 		"automattic/jetpack-connection": "1.30.x-dev",

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fb68a85088aa383e8f1803f75e8fcd5",
+    "content-hash": "b4267c20d89e3fd7637d8e7715a8e6ff",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -51,6 +51,58 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
+            "transport-options": {
+                "monorepo": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-admin-ui",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/admin-ui",
+                "reference": "67323a173ff969bb0e424d1b1c6d691339b53626"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^1.1",
+                "automattic/wordbless": "dev-master",
+                "yoast/phpunit-polyfills": "1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-admin-menu.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "@composer install",
+                    "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer install",
+                    "@composer phpunit"
+                ],
+                "post-update-cmd": [
+                    "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Generic Jetpack wp-admin UI elements",
             "transport-options": {
                 "monorepo": true,
                 "relative": true
@@ -2044,16 +2096,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.9",
+            "version": "9.5.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b"
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
-                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
                 "shasum": ""
             },
             "require": {
@@ -2069,7 +2121,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-code-coverage": "^9.2.7",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -2131,7 +2183,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.9"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
             },
             "funding": [
                 {
@@ -2143,7 +2195,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-08-31T06:47:40+00:00"
+            "time": "2021-09-25T07:38:51+00:00"
         },
         {
             "name": "psr/container",
@@ -4389,6 +4441,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-admin-ui": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-connection": 20,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

IN PROGRESS. To be discussed with Boost team

This PR makes use of the Admin UI package (unmerged) to register the Boost menu under the Jetpack toplevel menu 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use admin_ui package to add admin menu

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbuNQi-1w3-p2#comment-2639

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Boost
* Check that the menu item is under the Jetpack top level menu
* Try it alongside Jetpack and without Jetpack. And also alongside the Backup plugin