### PR TITLE
Boost: Fix offline score refresh

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -34,9 +34,7 @@
 	let showRatingCard = false;
 	let improvementPercentage = 0;
 
-	if ( siteIsOnline ) {
-		refreshScore( false );
-	}
+	refreshScore( false );
 
 	/**
 	 * Derived datastore which makes it easy to check if module states are currently in sync with server.
@@ -71,6 +69,11 @@
 	async function refreshScore( force = false ) {
 		isLoading = true;
 		loadError = undefined;
+
+
+		if ( ! siteIsOnline ) {
+			return;
+		}
 
 		try {
 			scores = await requestSpeedScores( force );

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -67,13 +67,12 @@
 	let currentScoreConfigString = $scoreConfigString;
 
 	async function refreshScore( force = false ) {
-		isLoading = true;
-		loadError = undefined;
-
-
 		if ( ! siteIsOnline ) {
 			return;
 		}
+		
+		isLoading = true;
+		loadError = undefined;
 
 		try {
 			scores = await requestSpeedScores( force );

--- a/projects/plugins/boost/changelog/fix-offline-score-refresh
+++ b/projects/plugins/boost/changelog/fix-offline-score-refresh
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: It is a fix for issue introduced in current release
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #21229

#### Changes proposed in this Pull Request:
The auto refresh of score during module toggle was triggering a refresh even when Jetpack is offline. This is a fix for the issue. Now, refresh will not happen if jetpack is offline.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Access boost dashboard while [Jetpack is offline](https://jetpack.com/support/development-mode/). 
* Try to reproduce the issue as in: https://d.pr/v/71e6ur. See if requests dispatch if modules are toggled.
* Try to see if refresh works when Jetpack is not offline.