### PR TITLE
Consider Eventbrite URLs without event ids incorrect

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-eventbrite-urls
+++ b/projects/plugins/jetpack/changelog/fix-eventbrite-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Consider eventbrite URLs without event IDs incorrect

--- a/projects/plugins/jetpack/changelog/fix-eventbrite-urls
+++ b/projects/plugins/jetpack/changelog/fix-eventbrite-urls
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Consider eventbrite URLs without event IDs incorrect
+Eventbrite Block: consider event URLs without event IDs invalid.

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
@@ -49,29 +49,31 @@ export class EventbriteEdit extends Component {
 			return;
 		}
 
-		const newAttributes = {
-			eventId: eventIdFromUrl( url ),
-			url,
-		};
+		const eventId = eventIdFromUrl( url );
 
-		testEmbedUrl( newAttributes.url, this.setIsResolvingUrl )
-			.then( resolvedUrl => {
-				const newValidatedAttributes = getValidatedAttributes( attributeDetails, {
-					...newAttributes,
-					url: resolvedUrl,
-				} );
-				if ( newValidatedAttributes.eventId ) {
+		if ( ! eventId ) {
+			this.setErrorNotice();
+		} else {
+			const newAttributes = {
+				eventId,
+				url,
+			};
+
+			testEmbedUrl( newAttributes.url, this.setIsResolvingUrl )
+				.then( resolvedUrl => {
+					const newValidatedAttributes = getValidatedAttributes( attributeDetails, {
+						...newAttributes,
+						url: resolvedUrl,
+					} );
 					setAttributes( newValidatedAttributes );
 					this.setState( { editedUrl: resolvedUrl } );
 					noticeOperations.removeAllNotices();
-				} else {
+				} )
+				.catch( () => {
+					setAttributes( { eventId: undefined, url: undefined } );
 					this.setErrorNotice();
-				}
-			} )
-			.catch( () => {
-				setAttributes( { eventId: undefined, url: undefined } );
-				this.setErrorNotice();
-			} );
+				} );
+		}
 	};
 
 	setIsResolvingUrl = isResolvingUrl => this.setState( { isResolvingUrl } );

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
@@ -60,9 +60,13 @@ export class EventbriteEdit extends Component {
 					...newAttributes,
 					url: resolvedUrl,
 				} );
-				setAttributes( newValidatedAttributes );
-				this.setState( { editedUrl: resolvedUrl } );
-				noticeOperations.removeAllNotices();
+				if ( newValidatedAttributes.eventId ) {
+					setAttributes( newValidatedAttributes );
+					this.setState( { editedUrl: resolvedUrl } );
+					noticeOperations.removeAllNotices();
+				} else {
+					this.setErrorNotice();
+				}
 			} )
 			.catch( () => {
 				setAttributes( { eventId: undefined, url: undefined } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

As awesomely explained [here](https://github.com/Automattic/jetpack/issues/14507#issuecomment-915264550) by @ivan-ottinger, `testEmbedUrl` helper only checks for status 200. Any URL (like Google.com) can return 200, even though it's a bad embed URL.

This PR marks 200 responses without event IDs incorrect. Hence, rendering an error and allowing the user to convert the embed to a link.

#### Does this pull request change what data or activity we track or use?
No

Fixes https://github.com/Automattic/jetpack/issues/14507

#### Testing instructions:
1. Make sure https://github.com/Automattic/jetpack/issues/14507 isn't reproducible.
2. Make sure you can embed Eventbrite URLs eg: https://www.eventbrite.com/e/lady-gaga-swietuje-love-for-sale-tickets-166928917887?aff=ebdssbcitybrowse&keep_tld=1
