### PR TITLE
E2E tests: fix gutenberg setup

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: create-matrix
         run: |
-          MATRIX='[{"group":"pre-connection"},{"group":"connection"},{"group":"post-connection"},{"group":"gutenberg"}]'
+          MATRIX='[{"group":"pre-connection"},{"group":"connection"},{"group":"post-connection"}]'
           if [ "$GITHUB_EVENT_NAME" == schedule ]; then
             MATRIX=$(echo $MATRIX | jq '. + [{"group": "gutenberg"}]' | jq -c .)
           fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: create-matrix
         run: |
-          MATRIX='[{"group":"pre-connection"},{"group":"connection"},{"group":"post-connection"}]'
+          MATRIX='[{"group":"pre-connection"},{"group":"connection"},{"group":"post-connection"},{"group":"gutenberg"}]'
           if [ "$GITHUB_EVENT_NAME" == schedule ]; then
             MATRIX=$(echo $MATRIX | jq '. + [{"group": "gutenberg"}]' | jq -c .)
           fi
@@ -71,7 +71,7 @@ jobs:
     - name: Set up Gutenberg
       if: matrix.group == 'gutenberg'
       working-directory: projects/plugins/jetpack/tests/e2e
-      run: ./bin/e2e-env.sh gb-setup
+      run: pnpx e2e-env gb-setup
 
     - name: Run ${{ matrix.group }} tests
       working-directory: projects/plugins/jetpack/tests/e2e


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix the Gutenberg setup in the e2e test workflow. It was missed by #21115 

#### Jetpack product discussion
p1633004075206100-slack-C1Y1F7ZM1

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Tested with run https://github.com/Automattic/jetpack/pull/21248/checks?check_run_id=3755955141