### PR TITLE
Avoid errors on related posts when the main DIV is not in the DOM

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-avoid-errors-related-posts
+++ b/projects/plugins/jetpack/changelog/fix-avoid-errors-related-posts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Avoid console errors if Related Posts main div is not in the DOM

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -5,7 +5,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Sync\Settings;
 
 class Jetpack_RelatedPosts {
-	const VERSION   = '20210914';
+	const VERSION   = '20210930';
 	const SHORTCODE = 'jetpack-related-posts';
 
 	private static $instance     = null;

--- a/projects/plugins/jetpack/modules/related-posts/related-posts.js
+++ b/projects/plugins/jetpack/modules/related-posts/related-posts.js
@@ -40,6 +40,10 @@
 			var args = 'relatedposts=1';
 			var relatedPosts = document.querySelector( '#jp-relatedposts' );
 
+			if ( ! relatedPosts ) {
+				return false;
+			}
+
 			if ( relatedPosts.hasAttribute( 'data-exclude' ) ) {
 				args += '&relatedposts_exclude=' + relatedPosts.getAttribute( 'data-exclude' );
 			}
@@ -291,6 +295,10 @@
 
 		var endpointURL = jprp.getEndpointURL();
 		var relatedPosts = document.querySelector( '#jp-relatedposts' );
+
+		if ( ! endpointURL ) {
+			return;
+		}
 
 		if ( document.querySelectorAll( '#jp-relatedposts .jp-relatedposts-post' ).length ) {
 			afterPostsHaveLoaded();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

In our [support documentation for Related Posts](https://jetpack.com/support/related-posts/customize-related-posts/#delete), we recommend a code snippet to remove the Related Posts section from the post content. This snippet completely removes the main Related Posts DIV causing JS to trigger an error.

See 6959-gh-jpop-issues

The snippet is:

```PHP
function jetpackme_remove_rp() {
    if ( class_exists( 'Jetpack_RelatedPosts' ) ) {
        $jprp = Jetpack_RelatedPosts::init();
        $callback = array( $jprp, 'filter_add_target_to_dom' );
 
        remove_filter( 'the_content', $callback, 40 );
    }
}
add_action( 'wp', 'jetpackme_remove_rp', 20 );
```

This PR avoids JS to trigger error in the case the Related Posts DIV is not present in the DOM.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Avoid errors on related posts when the main DIV is not in the DOM

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
6959-gh-jpop-issues

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Ping me if you want a JN site ready for testing

* First confirm the bug (master branch):
* On a new site with some content and Related Posts enabled
* Visit a single post and make sure Related Posts is working normally
* Add the code snippet above to your theme's `functions.php`
* Reload the page and confirm you see an error in the console from related posts `Uncaught Type Error: ...`
* Checkout this branch, rebuild the branch, and make sure there are no errors in the console
* Remove the Code snippet and make sure Related Posts is working normally again