### PR TITLE
Backport packages/tracking v1.13.11 from 10.2 branch

### DIFF
--- a/projects/packages/tracking/CHANGELOG.md
+++ b/projects/packages/tracking/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.11] - 2021-09-30
+### Added
+- Set up the ajax hook in the Tracking class.
+
 ## [1.13.10] - 2021-09-28
 ### Changed
 - Updated package dependencies.
@@ -163,6 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create package for Jetpack Tracking
 
+[1.13.11]: https://github.com/Automattic/jetpack-tracking/compare/v1.13.10...v1.13.11
 [1.13.10]: https://github.com/Automattic/jetpack-tracking/compare/v1.13.9...v1.13.10
 [1.13.9]: https://github.com/Automattic/jetpack-tracking/compare/v1.13.8...v1.13.9
 [1.13.8]: https://github.com/Automattic/jetpack-tracking/compare/v1.13.7...v1.13.8

--- a/projects/packages/tracking/changelog/update-tracking_ajax_hook_and_prefix
+++ b/projects/packages/tracking/changelog/update-tracking_ajax_hook_and_prefix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Set up the ajax hook in the Tracking class

--- a/projects/packages/tracking/src/class-tracking.php
+++ b/projects/packages/tracking/src/class-tracking.php
@@ -56,7 +56,7 @@ class Tracking {
 			 * wp_ajax_jetpack_tracks action. This action is used to ensure that
 			 * the callback is hooked only once.
 			 *
-			 * @since $$next-version$$
+			 * @since 1.13.11
 			 */
 			do_action( 'jetpack_set_tracks_ajax_hook' );
 		}

--- a/projects/plugins/jetpack/changelog/jetpack-branch-10.2
+++ b/projects/plugins/jetpack/changelog/jetpack-branch-10.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a0c6736e3208430227976e963fc47da",
+    "content-hash": "3822a7ac4e53bf739b8f0826886cc93e",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1480,9 +1480,10 @@
             "name": "automattic/jetpack-tracking",
             "version": "dev-master",
             "dist": {
-                "type": "path",
-                "url": "../../packages/tracking",
-                "reference": "7d6238640b64fb8fe2860a83c1f2aa50e528b04c"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/ab152bf58aafa2dd0bdf925055dae44ef6d16aee",
+                "reference": "ab152bf58aafa2dd0bdf925055dae44ef6d16aee",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
@@ -1492,7 +1493,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^2.0",
-                "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3822a7ac4e53bf739b8f0826886cc93e",
+    "content-hash": "8a0c6736e3208430227976e963fc47da",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1480,10 +1480,9 @@
             "name": "automattic/jetpack-tracking",
             "version": "dev-master",
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/ab152bf58aafa2dd0bdf925055dae44ef6d16aee",
-                "reference": "ab152bf58aafa2dd0bdf925055dae44ef6d16aee",
-                "shasum": ""
+                "type": "path",
+                "url": "../../packages/tracking",
+                "reference": "7d6238640b64fb8fe2860a83c1f2aa50e528b04c"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.11",
@@ -1493,6 +1492,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^2.0",
+                "brain/monkey": "2.6.0",
                 "yoast/phpunit-polyfills": "1.0.1"
             },
             "type": "library",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Backports packages/tracking v1.13.11 release from the JP 10.2 release branch: https://github.com/Automattic/jetpack/commit/33eeba2b257a4bb40a3462ca01c8a42398577180

#### Does this pull request change what data or activity we track or use?

N/A

#### Testing instructions:

* Proofread changes.
