### PR TITLE
Backport packages/connection v1.30.6 from 10.2 branch

### DIFF
--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.30.6] - 2021-09-30
+### Changed
+- Moved the Package Tracker execution to the shutdown hook for performance improvement.
+
 ## [1.30.5] - 2021-09-28
 ### Changed
 - Package Version Tracker: send package versions to wpcom on the init hook instead of plugins_loaded
@@ -420,6 +424,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[1.30.6]: https://github.com/Automattic/jetpack-connection/compare/v1.30.5...v1.30.6
 [1.30.5]: https://github.com/Automattic/jetpack-connection/compare/v1.30.4...v1.30.5
 [1.30.4]: https://github.com/Automattic/jetpack-connection/compare/v1.30.3...v1.30.4
 [1.30.3]: https://github.com/Automattic/jetpack-connection/compare/v1.30.2...v1.30.3

--- a/projects/packages/connection/changelog/update-hook-for-package-tracker
+++ b/projects/packages/connection/changelog/update-hook-for-package-tracker
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Moved the Package Tracker execution to the shutdown hook for performance improvement

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.6-alpha';
+	const PACKAGE_VERSION = '1.30.6';
 
 	const PACKAGE_SLUG = 'connection';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Backports packages/connection v1.30.6 from the JP 10.2 release branch: https://github.com/Automattic/jetpack/commit/87e249cf1342754deb4c614a43cbaf3c0cc1ec09

#### Does this pull request change what data or activity we track or use?

N/A

#### Testing instructions:

* Proofread changes.