### PR TITLE
Jetpack: Fix a Tracking constructor call in the Jetpack class.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix_tracking_constructor_call
+++ b/projects/plugins/jetpack/changelog/update-fix_tracking_constructor_call
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Fix the Tracking constructor call
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -895,7 +895,7 @@ class Jetpack {
 			add_action( 'init', array( 'Jetpack_Keyring_Service_Helper', 'init' ), 9, 0 );
 		}
 
-		if ( ( new Tracking( $this->connection_manager ) )->should_enable_tracking( new Terms_Of_Service(), new Status() ) ) {
+		if ( ( new Tracking( 'jetpack', $this->connection_manager ) )->should_enable_tracking( new Terms_Of_Service(), new Status() ) ) {
 			add_action( 'init', array( new Plugin_Tracking(), 'init' ) );
 		} else {
 			/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The first parameter in the `Tracking` [constructor](https://github.com/Automattic/jetpack/blob/master/projects/packages/tracking/src/class-tracking.php#L43) is the product name. Fix the `Tracker` constructor call by adding the product name, `jetpack`.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
I'm not aware of any errors caused by this, so I don't think there's anything specific to test.
1. Install and activate this branch of Jetpack. Connect to WPCOM.
2. Confirm that no errors were generated.
