### PR TITLE
SSO: add filter to customize explanation text next to SSO button.

### DIFF
--- a/projects/plugins/jetpack/changelog/2021-09-30-21-44-26-570128
+++ b/projects/plugins/jetpack/changelog/2021-09-30-21-44-26-570128
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Secure Sign On: add new filter allowing one to customize the explanation displayed next to the SSO button.

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -498,12 +498,24 @@ class Jetpack_SSO {
 				<?php else : ?>
 					<p>
 						<?php
-							echo esc_html(
+							/**
+							 * Filter the messeage displayed below the SSO button.
+							 *
+							 * @module sso
+							 *
+							 * @since 10.3.0
+							 *
+							 * @param string $sso_explanation Message displayed below the SSO button.
+							 */
+							$sso_explanation = apply_filters(
+								'jetpack_sso_login_form_explanation_text',
 								sprintf(
+									/* Translators: %s is the name of the site. */
 									__( 'You can now save time spent logging in by connecting your WordPress.com account to %s.', 'jetpack' ),
 									esc_html( $site_name )
 								)
 							);
+							echo esc_html( $sso_explanation );
 						?>
 					</p>
 				<?php endif; ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This does not change the default behaviour of the SSO feature. It only allows third-parties to customize the form a bit more.

#### Jetpack product discussion

* Internal reference: pd81WV-6q-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a site that's connected to wpcom and where you've activated the SSO feature, log out.
* The login form should look the same as before.
* Now, in a functionality plugin, add the following:
```php
add_filter(
	'jetpack_sso_login_form_explanation_text',
	function () {
		return 'That is my new explanation text';
	}
);
```
* Notice that the explanation text changes.
