### PR TITLE
Identity Crisis: Move the check for an idc to the identity-crisis package

### DIFF
--- a/projects/packages/connection/changelog/update-check_idc_response
+++ b/projects/packages/connection/changelog/update-check_idc_response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a new action to the Client::remote_request method, jetpack_received_remote_request_response

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -27,7 +27,19 @@ class Client {
 		if ( ! $result || is_wp_error( $result ) ) {
 			return $result;
 		}
-		return self::_wp_remote_request( $result['url'], $result['request'] );
+
+		$response = self::_wp_remote_request( $result['url'], $result['request'] );
+
+		/**
+		 * Fired when the remote request response has been received.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array|WP_Error The HTTP response.
+		 */
+		do_action( 'jetpack_received_remote_request_response', $response );
+
+		return $response;
 	}
 
 	/**

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.6';
+	const PACKAGE_VERSION = '1.30.7-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.7';
+	const PACKAGE_VERSION = '1.30.8-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/identity-crisis/changelog/update-check_idc_response
+++ b/projects/packages/identity-crisis/changelog/update-check_idc_response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the new check_response_for_idc method to the Identity_Crisis class

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.2.6",
+	"version": "0.2.7-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-identity-crisis",

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -28,7 +28,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.2.6';
+	const PACKAGE_VERSION = '0.2.7-alpha';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -80,6 +80,7 @@ class Identity_Crisis {
 		add_action( 'jetpack_sync_processed_actions', array( $this, 'maybe_clear_migrate_option' ) );
 		add_action( 'rest_api_init', array( 'Automattic\\Jetpack\\IdentityCrisis\\REST_Endpoints', 'initialize_rest_api' ) );
 		add_action( 'jetpack_idc_disconnect', array( __CLASS__, 'do_jetpack_idc_disconnect' ) );
+		add_action( 'jetpack_received_remote_request_response', array( $this, 'check_http_response_for_idc_detected' ) );
 
 		add_filter( 'jetpack_connection_disconnect_site_wpcom', array( __CLASS__, 'jetpack_connection_disconnect_site_wpcom_filter' ) );
 
@@ -265,6 +266,27 @@ class Identity_Crisis {
 	}
 
 	/**
+	 * Checks the HTTP response body for the 'idc_detected' key. If the key exists,
+	 * checks the idc_detected value for a valid idc error.
+	 *
+	 * @param array|WP_Error $http_response The HTTP response.
+	 *
+	 * @return bool Whether the site is in an identity crisis.
+	 */
+	public function check_http_response_for_idc_detected( $http_response ) {
+		if ( ! is_array( $http_response ) ) {
+			return false;
+		}
+		$response_body = json_decode( wp_remote_retrieve_body( $http_response ), true );
+
+		if ( isset( $response_body['idc_detected'] ) ) {
+			return $this->check_response_for_idc( $response_body['idc_detected'] );
+		}
+
+		return false;
+	}
+
+	/**
 	 * Checks the WPCOM response to determine if the site is in an identity crisis. Updates the
 	 * sync_error_idc option if it is.
 	 *
@@ -348,6 +370,7 @@ class Identity_Crisis {
 		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
 		if ( $sync_error && self::should_handle_idc() ) {
 			$local_options = self::get_sync_error_idc_option();
+
 			// Ensure all values are set.
 			if ( isset( $sync_error['home'] ) && isset( $local_options['home'] ) && isset( $sync_error['siteurl'] ) && isset( $local_options['siteurl'] ) ) {
 				// If the WP.com expected home and siteurl match local home and siteurl it is not valid IDC.

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -265,6 +265,40 @@ class Identity_Crisis {
 	}
 
 	/**
+	 * Checks the WPCOM response to determine if the site is in an identity crisis. Updates the
+	 * sync_error_idc option if it is.
+	 *
+	 * @param array $response The response data.
+	 *
+	 * @return bool Whether the site is in an identity crisis.
+	 */
+	public function check_response_for_idc( $response ) {
+		if ( ! is_array( $response ) ) {
+			return false;
+		}
+
+		if ( is_array( $response ) && isset( $response['error_code'] ) ) {
+			$error_code              = $response['error_code'];
+			$allowed_idc_error_codes = array(
+				'jetpack_url_mismatch',
+				'jetpack_home_url_mismatch',
+				'jetpack_site_url_mismatch',
+			);
+
+			if ( in_array( $error_code, $allowed_idc_error_codes, true ) ) {
+				\Jetpack_Options::update_option(
+					'sync_error_idc',
+					self::get_sync_error_idc_option( $response )
+				);
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Prepare URL for display.
 	 *
 	 * @param string $url URL to display.

--- a/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
+++ b/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
@@ -426,7 +426,7 @@ class Test_Identity_Crisis extends BaseTestCase {
 	 */
 	public function data_provider_test_check_response_for_idc_with_error_code() {
 		return array(
-			'input is non-matching error code'      => array(
+			'input has non-matching error code'     => array(
 				'input'          => array(
 					'error_code'      => 'not an idc error code',
 					'request_siteurl' => 'example.org/',
@@ -451,7 +451,7 @@ class Test_Identity_Crisis extends BaseTestCase {
 					'error_code'      => 'jetpack_home_url_mismatch',
 					'request_siteurl' => 'example.org/',
 					'request_home'    => 'example.org/',
-					'wpcom_siteurl'   => 'example.com/',
+					'wpcom_siteurl'   => 'example.org/',
 					'wpcom_home'      => 'example.com/',
 				),
 				'option_updated' => true,
@@ -462,9 +462,109 @@ class Test_Identity_Crisis extends BaseTestCase {
 					'request_siteurl' => 'example.org/',
 					'request_home'    => 'example.org/',
 					'wpcom_siteurl'   => 'example.com/',
-					'wpcom_home'      => 'example.com/',
+					'wpcom_home'      => 'example.org/',
 				),
 				'option_updated' => true,
+			),
+		);
+	}
+
+	/**
+	 * Test the check_http_response_for_idc_detected method with invalid inputs. These inputs should
+	 * cause the method to return false.
+	 *
+	 * @param mixed $input The input value.
+	 *
+	 * @dataProvider data_provider_test_check_http_response_for_idc_detected_invalid_input
+	 */
+	public function test_check_http_response_for_idc_detected_invalid_input( $input ) {
+		$this->assertFalse( Identity_Crisis::init()->check_http_response_for_idc_detected( $input ) );
+	}
+
+	/**
+	 * Data provider for test_check_http_response_for_idc_detected_invalid_input
+	 *
+	 * @return array The test data.
+	 */
+	public function data_provider_test_check_http_response_for_idc_detected_invalid_input() {
+		$no_idc_detected_body = wp_json_encode(
+			array(
+				'test1' => 'test 1',
+				'test2' => 'test 2',
+			)
+		);
+
+		return array(
+			'input is null'                       => array(
+				null,
+			),
+			'input is string'                     => array(
+				'test',
+			),
+			'input is array, no idc_detected key' => array(
+				array(
+					'body' => $no_idc_detected_body,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Test the check_http_response_for_idc_detected method with an inputs that contains the idc_detected key.
+	 *
+	 * @param mixed $input         The input to the check_response_for_idc method.
+	 *
+	 * @dataProvider data_provider_test_check_http_response_for_idc_detected_idc_detected
+	 */
+	public function test_check_http_response_for_idc_detected_idc_detected( $input ) {
+		$this->assertTrue( Identity_Crisis::init()->check_http_response_for_idc_detected( $input ) );
+	}
+
+	/**
+	 * Data provider for test_check_http_response_for_idc_detected_idc_detected
+	 *
+	 * @return The test data with the structure:
+	 *    'input'           => The input for the check_response_for_idc method.
+	 *     'option_updated' => Whether the check_response_for_idc method should update
+	 *                         the sync_error_idc option.
+	 */
+	public function data_provider_test_check_http_response_for_idc_detected_idc_detected() {
+		$nonmatching_error_code_body = wp_json_encode(
+			array(
+				'idc_detected' => array(
+					'error_code'      => 'not an idc error code',
+					'request_siteurl' => 'example.org/',
+					'request_home'    => 'example.org/',
+					'wpcom_siteurl'   => 'example.com/',
+					'wpcom_home'      => 'example.com/',
+				),
+				'test'         => 'test value',
+			)
+		);
+
+		$matching_error_code_body = wp_json_encode(
+			array(
+				'idc_detected' => array(
+					'error_code'      => 'jetpack_url_mismatch',
+					'request_siteurl' => 'example.org/',
+					'request_home'    => 'example.org/',
+					'wpcom_siteurl'   => 'example.com/',
+					'wpcom_home'      => 'example.com/',
+				),
+				'test'         => 'test value',
+			)
+		);
+
+		return array(
+			'input has non-matching error code' => array(
+				array(
+					'body' => $nonmatching_error_code_body,
+				),
+			),
+			'input has url mismatch error code' => array(
+				array(
+					'body' => $matching_error_code_body,
+				),
 			),
 		);
 	}

--- a/projects/packages/sync/changelog/update-check_idc_response
+++ b/projects/packages/sync/changelog/update-check_idc_response
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use the new Identity_Crisis::check_response_for_idc method to check the response for an idc
+
+

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -436,21 +436,7 @@ class Actions {
 		$response = $rpc->getResponse();
 
 		// Check if WordPress.com IDC mitigation blocked the sync request.
-		if ( is_array( $response ) && isset( $response['error_code'] ) ) {
-			$error_code              = $response['error_code'];
-			$allowed_idc_error_codes = array(
-				'jetpack_url_mismatch',
-				'jetpack_home_url_mismatch',
-				'jetpack_site_url_mismatch',
-			);
-
-			if ( in_array( $error_code, $allowed_idc_error_codes, true ) ) {
-				\Jetpack_Options::update_option(
-					'sync_error_idc',
-					Identity_Crisis::get_sync_error_idc_option( $response )
-				);
-			}
-
+		if ( Identity_Crisis::init()->check_response_for_idc( $response ) ) {
 			return new WP_Error(
 				'sync_error_idc',
 				esc_html__( 'Sync has been blocked from WordPress.com because it would cause an identity crisis', 'jetpack' )

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.26.2';
+	const PACKAGE_VERSION = '1.26.3-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add a new method, `Identity_Crisis::check_response_for_idc`, which will check whether the response contains an IDC error code.
* Use this method in Sync to determine if the Sync request returned an error code.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions

Testing will consist of verifying that an IDC that's detected by a Sync request works as expected.
The 'idc_detected" key in the request body is not yet being sent by WPCOM.

1. Install this branch of Jetpack. Activate and connect to WPCOM.
2. Activate the Jetpack Debug plugin.
3. Enable the IDC simulator module in the Jetpack Debug menu.
4. Enable the IDC simulation in the UI.
5. Create a draft post,
6. Observe your site in IDC safe mode.
7. Check the site's debug.log file and verify that no errors were generated.
