### PR TITLE
tools: check-intra-monorepo-deps should check non-project deps too

### DIFF
--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -75,9 +75,11 @@ elif [[ -n "$CI" ]]; then
 fi
 
 function get_packages {
-	PACKAGES1=$(jq -nc 'reduce inputs as $in ({}; .[$in.name] |= if $in.extra["branch-alias"]["dev-master"] then [ $in.extra["branch-alias"]["dev-master"], ( $in.extra["branch-alias"]["dev-master"] | sub( "^(?<v>\\d+\\.\\d+)\\.x-dev$"; "^\(.v)" ) ) ] else [ "@dev" ] end )' "$BASE"/projects/packages/*/composer.json)
-	PACKAGES2=$(jq -c '( .[][0] | select( . != "@dev" ) ) |= empty' <<<"$PACKAGES1")
-	JSPACKAGES=$(jq -nc 'reduce inputs as $in ({}; if $in.name then .[$in.name] |= [ "workspace:^\($in.version)", "workspace:\($in.version)" ] else . end )' "$BASE"/projects/js-packages/*/package.json)
+	PACKAGES_DEV=$(jq -nc 'reduce inputs as $in ({}; .[$in.name] |= if $in.extra["branch-alias"]["dev-master"] then [ $in.extra["branch-alias"]["dev-master"], ( $in.extra["branch-alias"]["dev-master"] | sub( "^(?<v>\\d+\\.\\d+)\\.x-dev$"; "^\(.v)" ) ) ] else [ "@dev" ] end )' "$BASE"/projects/packages/*/composer.json)
+	PACKAGES_NODEV=$(jq -c '( .[][0] | select( . != "@dev" ) ) |= empty' <<<"$PACKAGES_DEV")
+	PACKAGES_STAR=$(jq -c '.[] |= [ "@dev" ]' <<<"$PACKAGES_DEV")
+	JSPACKAGES_PROJ=$(jq -nc 'reduce inputs as $in ({}; if $in.name then .[$in.name] |= [ "workspace:^\($in.version)", "workspace:\($in.version)" ] else . end )' "$BASE"/projects/js-packages/*/package.json)
+	JSPACKAGES_STAR=$(jq -c '.[] |= [ "workspace:*" ]' <<<"$JSPACKAGES_PROJ")
 }
 
 get_packages
@@ -86,8 +88,10 @@ SLUGS=()
 if [[ $# -le 0 ]]; then
 	# Use a temp variable so pipefail works
 	TMP="$(tools/get-build-order.php 2>/dev/null)"
-	TMP=monorepo$'\n'"$TMP"
 	mapfile -t SLUGS <<<"$TMP"
+	SLUGS+=( 'monorepo' )
+	TMP="$(git ls-files '**/composer.json' '**/package.json' | sed -ne '\!^projects/[^/]*/[^/]*/\(composer\|package\).json$! d' -e 's!/\(composer\|package\).json$!!' -e 's/^/nonproject:/p' | sort -u)"
+	mapfile -t -O ${#SLUGS[@]} SLUGS <<<"$TMP"
 else
 	SLUGS=( "$@" )
 fi
@@ -139,32 +143,46 @@ EXIT=0
 ANYJS=false
 for SLUG in "${SLUGS[@]}"; do
 	debug "Checking dependencies of $SLUG"
-	if [[ "$SLUG" == packages/* ]]; then
-		PACKAGES="$PACKAGES2"
-	else
-		PACKAGES="$PACKAGES1"
-	fi
 	if [[ "$SLUG" == monorepo ]]; then
+		PACKAGES="$PACKAGES_DEV"
+		JSPACKAGES="$JSPACKAGES_PROJ"
 		DOCL=false
 		DIR=.
-		PHPFILE=composer.json
-		JSFILE=package.json
+	elif [[ "$SLUG" == nonproject:* ]]; then
+		PACKAGES="$PACKAGES_STAR"
+		JSPACKAGES="$JSPACKAGES_STAR"
+		if [[ "$SLUG" == nonproject:tools/cli/skeletons/* ]]; then
+			PACKAGES="$PACKAGES_DEV"
+			JSPACKAGES="$JSPACKAGES_PROJ"
+			if [[ "$SLUG" == "nonproject:tools/cli/skeletons/packages" ]]; then
+				PACKAGES="$PACKAGES_NODEV"
+			fi
+		fi
+		DOCL=false
+		DIR="${SLUG#nonproject:}"
 	else
+		PACKAGES="$PACKAGES_DEV"
+		JSPACKAGES="$JSPACKAGES_PROJ"
+		if [[ "$SLUG" == packages/* ]]; then
+			PACKAGES="$PACKAGES_NODEV"
+		fi
 		DOCL=$DOCL_EVER
 		DIR="projects/$SLUG"
-		PHPFILE="projects/$SLUG/composer.json"
-		JSFILE="projects/$SLUG/package.json"
 	fi
+	PHPFILE="$DIR/composer.json"
+	JSFILE="$DIR/package.json"
 	if $UPDATE; then
-		JSON=$(jq --tab --argjson packages "$PACKAGES" -r 'def ver(e): if $packages[e.key] then if e.value[0:1] == "^" then $packages[e.key][1] else null end // $packages[e.key][0] else e.value end; if .require then .require |= with_entries( .value = ver(.) ) else . end | if .["require-dev"] then .["require-dev"] |= with_entries( .value = ver(.) ) else . end' "$PHPFILE")
-		if [[ "$JSON" != "$(<"$PHPFILE")" ]]; then
-			info "PHP dependencies of $SLUG changed!"
-			echo "$JSON" > "$PHPFILE"
+		if [[ -e "$PHPFILE" ]]; then
+			JSON=$(jq --tab --argjson packages "$PACKAGES" -r 'def ver(e): if $packages[e.key] then if e.value[0:1] == "^" then $packages[e.key][1] else null end // $packages[e.key][0] else e.value end; if .require then .require |= with_entries( .value = ver(.) ) else . end | if .["require-dev"] then .["require-dev"] |= with_entries( .value = ver(.) ) else . end' "$PHPFILE")
+			if [[ "$JSON" != "$(<"$PHPFILE")" ]]; then
+				info "PHP dependencies of $SLUG changed!"
+				echo "$JSON" > "$PHPFILE"
 
-			if $DOCL; then
-				info "Creating changelog entry for $SLUG"
-				changelogger "$SLUG" 'Updated package dependencies.'
-				DOCL=false
+				if $DOCL; then
+					info "Creating changelog entry for $SLUG"
+					changelogger "$SLUG" 'Updated package dependencies.'
+					DOCL=false
+				fi
 			fi
 		fi
 		if [[ -e "$JSFILE" ]]; then
@@ -208,7 +226,9 @@ for SLUG in "${SLUGS[@]}"; do
 				error "$M: Must depend on monorepo package $PKG version $VER"
 			fi
 		done < <(
-			jq --argjson packages "$PACKAGES" -r '.require // {}, .["require-dev"] // {} | to_entries[] | select( $packages[.key] as $vals | $vals and ( [ .value ] | inside( $vals ) | not ) ) | [ input_filename, .key, ( $packages[.key] | join( " or " ) ) ] | @tsv' "$PHPFILE"
+			if [[ -e "$PHPFILE" ]]; then
+				jq --argjson packages "$PACKAGES" -r '.require // {}, .["require-dev"] // {} | to_entries[] | select( $packages[.key] as $vals | $vals and ( [ .value ] | inside( $vals ) | not ) ) | [ input_filename, .key, ( $packages[.key] | join( " or " ) ) ] | @tsv' "$PHPFILE"
+			fi
 			if [[ -e "$JSFILE" ]]; then
 				jq --argjson packages "$JSPACKAGES" -r '.dependencies // {}, .devDependencies // {}, .peerDependencies // {}, .optionalDependencies // {} | to_entries[] | select( $packages[.key] as $vals | $vals and ( [ .value ] | inside( $vals ) | not ) ) | [ input_filename, .key, ( $packages[.key] | join( " or " ) ) ] | @tsv' "$JSFILE"
 			fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
That way we won't forget to update the skeleton files.

But most of the non-project deps should be versionless (i.e. `@dev` for
composer or `workspace:*` for JS), so enforce that too.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#21255

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try changing some deps in `tools/cli`, `tools/cli/skeletons/*`, or the like. Then run `tools/check-intra-monorepo-deps.sh`, possibly with `-u`, and make sure it does the right thing.
