### PR TITLE
Add admin notice to media-new.php regarding videopress uploads not being supported

### DIFF
--- a/projects/plugins/jetpack/changelog/add-videopress-warning-media-new
+++ b/projects/plugins/jetpack/changelog/add-videopress-warning-media-new
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Added an admin notice to media-new.php notifying the user that videos uploaded here will not be sent to VideoPress.

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -74,7 +74,6 @@ class Jetpack_VideoPress {
 		global $pagenow;
 
 		if ( 'media-new.php' === $pagenow ) {
-
 			echo wp_kses(
 				'<div class="notice notice-warning is-dismissible">' .
 					'<p>' .

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -74,18 +74,23 @@ class Jetpack_VideoPress {
 		global $pagenow;
 
 		if ( 'media-new.php' === $pagenow ) {
-			echo wp_kses(
-				'<div class="notice notice-warning is-dismissible">' .
+			echo '<div class="notice notice-warning is-dismissible">' .
 					'<p>' .
-						__( 'Videos added here will be uploaded directly to your server.', 'jetpack' ) .
+					wp_kses(
+						__( 'Videos added here will be uploaded directly to your server.', 'jetpack' ),
+						array()
+					) .
 					'</p>' .
 					'<p>' .
+					wp_kses(
 						/* translators: %s is the url to the Media Library */
-						sprintf( __( 'If you want to upload for VideoPress, please add your videos from the <a href="%s">Media Library</a>', 'jetpack' ), '/wp-admin/upload.php' ) .
+						sprintf( __( 'If you want to upload for VideoPress, please add your videos from the <a href="%s">Media Library</a>', 'jetpack' ), '/wp-admin/upload.php' ),
+						array(
+							'a' => array( 'href' => array() ),
+						)
+					) .
 					'</p>' .
-				'</div>',
-				array( 'a' => array( 'href' => array() ) )
-			);
+				'</div>';
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -79,7 +79,7 @@ class Jetpack_VideoPress {
 					wp_kses(
 						sprintf(
 							/* translators: %s is the url to the Media Library */
-							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a>', 'jetpack' ),
+							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a>.', 'jetpack' ),
 							'/wp-admin/upload.php'
 						),
 						array(

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -77,14 +77,11 @@ class Jetpack_VideoPress {
 			echo '<div class="notice notice-warning is-dismissible">' .
 					'<p>' .
 					wp_kses(
-						__( 'Videos added here will be uploaded directly to your server.', 'jetpack' ),
-						array()
-					) .
-					'</p>' .
-					'<p>' .
-					wp_kses(
-						/* translators: %s is the url to the Media Library */
-						sprintf( __( 'If you want to upload for VideoPress, please add your videos from the <a href="%s">Media Library</a>', 'jetpack' ), '/wp-admin/upload.php' ),
+						sprintf(
+							/* translators: %s is the url to the Media Library */
+							__( 'Videos added here will be uploaded directly to your server. If you want to upload for VideoPress, please add your videos from the <a href="%s">Media Library</a>', 'jetpack' ),
+							'/wp-admin/upload.php'
+						),
 						array(
 							'a' => array( 'href' => array() ),
 						)

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -79,7 +79,7 @@ class Jetpack_VideoPress {
 					wp_kses(
 						sprintf(
 							/* translators: %s is the url to the Media Library */
-							__( 'Videos added here will be uploaded directly to your server. If you want to upload for VideoPress, please add your videos from the <a href="%s">Media Library</a>', 'jetpack' ),
+							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a>', 'jetpack' ),
 							'/wp-admin/upload.php'
 						),
 						array(

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -328,6 +328,11 @@ class Jetpack_VideoPress {
 		return $this->is_videopress_enabled();
 	}
 
+	/**
+	 * Detects if VideoPress is enabled.
+	 *
+	 * @return bool
+	 */
 	protected function is_videopress_enabled() {
 		$options = VideoPress_Options::get_options();
 

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -60,24 +60,33 @@ class Jetpack_VideoPress {
 		VideoPress_XMLRPC::init();
 
 		if ( $this->is_videopress_enabled() ) {
-			add_action('admin_notices', array( $this, 'media_new_page_admin_notice' ) );
+			add_action( 'admin_notices', array( $this, 'media_new_page_admin_notice' ) );
 		}
 	}
 
 	/**
-	 * media-new.php isn't supported for uploading to VideoPress.
+	 * The media-new.php page isn't supported for uploading to VideoPress.
 	 *
 	 * There is either a technical reason for this (bulk uploader isn't overridable),
 	 * or it is an intentional way to give site owners an option for uploading videos that bypass VideoPress.
 	 */
-	public function media_new_page_admin_notice(){
+	public function media_new_page_admin_notice() {
 		global $pagenow;
 
-		if ( $pagenow == 'media-new.php' ) {
-			 echo '<div class="notice notice-warning is-dismissible">
-				 <p>' . __( 'Videos added here will be uploaded directly to your server.') . '</p>
-				 <p>' . sprintf( __( 'If you want to upload for VideoPress, please add your videos from the <a href="%s">Media Library</a>' ), '/wp-admin/upload.php' )  . '</p>
-			 </div>';
+		if ( 'media-new.php' === $pagenow ) {
+
+			echo wp_kses(
+				'<div class="notice notice-warning is-dismissible">' .
+					'<p>' .
+						__( 'Videos added here will be uploaded directly to your server.', 'jetpack' ) .
+					'</p>' .
+					'<p>' .
+						/* translators: %s is the url to the Media Library */
+						sprintf( __( 'If you want to upload for VideoPress, please add your videos from the <a href="%s">Media Library</a>', 'jetpack' ), '/wp-admin/upload.php' ) .
+					'</p>' .
+				'</div>',
+				array( 'a' => array( 'href' => array() ) )
+			);
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -79,7 +79,7 @@ class Jetpack_VideoPress {
 					wp_kses(
 						sprintf(
 							/* translators: %s is the url to the Media Library */
-							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a>.', 'jetpack' ),
+							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a> or the block editor using the /video block.', 'jetpack' ),
 							esc_url( admin_url( 'upload.php' ) )
 						),
 						array(

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -79,12 +79,11 @@ class Jetpack_VideoPress {
 					wp_kses(
 						sprintf(
 							/* translators: %s is the url to the Media Library */
-							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a> or the block editor using the <code>/video</code> block.', 'jetpack' ),
+							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a> or the block editor using the Video block.', 'jetpack' ),
 							esc_url( admin_url( 'upload.php' ) )
 						),
 						array(
-							'a'    => array( 'href' => array() ),
-							'code' => array(),
+							'a' => array( 'href' => array() ),
 						)
 					) .
 					'</p>' .

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -58,6 +58,27 @@ class Jetpack_VideoPress {
 
 		VideoPress_Scheduler::init();
 		VideoPress_XMLRPC::init();
+
+		if ( $this->is_videopress_enabled() ) {
+			add_action('admin_notices', array( $this, 'media_new_page_admin_notice' ) );
+		}
+	}
+
+	/**
+	 * media-new.php isn't supported for uploading to VideoPress.
+	 *
+	 * There is either a technical reason for this (bulk uploader isn't overridable),
+	 * or it is an intentional way to give site owners an option for uploading videos that bypass VideoPress.
+	 */
+	public function media_new_page_admin_notice(){
+		global $pagenow;
+
+		if ( $pagenow == 'media-new.php' ) {
+			 echo '<div class="notice notice-warning is-dismissible">
+				 <p>' . __( 'Videos added here will be uploaded directly to your server.') . '</p>
+				 <p>' . sprintf( __( 'If you want to upload for VideoPress, please add your videos from the <a href="%s">Media Library</a>' ), '/wp-admin/upload.php' )  . '</p>
+			 </div>';
+		}
 	}
 
 	/**
@@ -294,6 +315,10 @@ class Jetpack_VideoPress {
 			return false;
 		}
 
+		return $this->is_videopress_enabled();
+	}
+
+	protected function is_videopress_enabled() {
 		$options = VideoPress_Options::get_options();
 
 		return $options['shadow_blog_id'] > 0;

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -79,11 +79,12 @@ class Jetpack_VideoPress {
 					wp_kses(
 						sprintf(
 							/* translators: %s is the url to the Media Library */
-							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a> or the block editor using the /video block.', 'jetpack' ),
+							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a> or the block editor using the <code>/video</code> block.', 'jetpack' ),
 							esc_url( admin_url( 'upload.php' ) )
 						),
 						array(
-							'a' => array( 'href' => array() ),
+							'a'    => array( 'href' => array() ),
+							'code' => array(),
 						)
 					) .
 					'</p>' .

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -80,7 +80,7 @@ class Jetpack_VideoPress {
 						sprintf(
 							/* translators: %s is the url to the Media Library */
 							__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a>.', 'jetpack' ),
-							'/wp-admin/upload.php'
+							esc_url( admin_url( 'upload.php' ) )
 						),
 						array(
 							'a' => array( 'href' => array() ),


### PR DESCRIPTION
Anecdotal: There used to be a warning at the top of `media-new.php` warning users that uploading from this page would bypass VideoPress and upload directly to their server. This message is now gone and has caused confusion for us and others as we test Jetpack + VideoPress.

This PR re-introduces this message, only when VideoPress is enabled.

<img width="751" alt="Screen Shot 2021-10-01 at 4 51 48 PM" src="https://user-images.githubusercontent.com/4081020/135684826-976ba6c3-77d8-46b7-84b2-a11454ea852e.png">


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added an admin notice to the top of `media-new.php` warning the user that VideoPress uploading is not supported here, only when VideoPress is enabled

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope!

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On any Jetpack site, disable VideoPress (Jetpack -> Settings -> Performance)
* Visit Media -> Add New (not Library -> Add New)
* You should not see any admin notices.
* Enable VideoPress, then return to Media -> Add New
* You should now see the admin notice!