### PR TITLE
renovate: Don't pin johnkary/phpunit-speedtrap

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -74,6 +74,10 @@
 			"rangeStrategy": "replace"
 		},
 		{
+			"matchPackageNames": [ "johnkary/phpunit-speedtrap" ],
+			"rangeStrategy": "widen"
+		},
+		{
 			"groupName": "Instant Search Dependency Updates",
 			"matchPackageNames": [
 				"cache",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We need multiple versions to support multiple versions of PHP.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None, but see #21262.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this, then regenerate #21262 and see that it doesn't pin that dep anymore.
