### PR TITLE
Search: reduce browser history noise

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-browser-history-noise
+++ b/projects/plugins/jetpack/changelog/fix-search-browser-history-noise
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: reduce browser history noise by debounce setQuery requests

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/constants.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/constants.js
@@ -14,6 +14,7 @@ export const RESULT_FORMAT_MINIMAL = 'minimal';
 export const RESULT_FORMAT_PRODUCT = 'product';
 export const MINUTE_IN_MILLISECONDS = 60 * 1000;
 export const RELEVANCE_SORT_KEY = 'relevance';
+export const DEBOUNCED_TIME_TO_SET_QUERY_MILLISECONDS = 1000;
 // @todo extract this to a function that uses SORT_OPTIONS and PRODUCT_SORT_OPTIONS to avoid duplication
 export const VALID_SORT_KEYS = [
 	'newest',

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -36,7 +36,7 @@ function setQuery( queryObject ) {
 }
 
 // Create debounced function.
-// Debounce for 1s to really change the query string.
+// Uses a longer delay to ensure we're not filling up the user's browser history with part-typed queries.
 const setQueryDebounced = debounce( setQuery, DEBOUNCED_TIME_TO_SET_QUERY_MILLISECONDS );
 
 // Export debounced function with original function name.

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -16,8 +16,6 @@ import {
 import { getFilterKeys, getStaticFilterKeys } from './filters';
 import { decode } from '../external/query-string-decode';
 
-let mostRecentQueryObject = null;
-
 /**
  * Parses the address bar's query string into an object.
  *
@@ -30,21 +28,18 @@ export function getQuery( search = window.location.search ) {
 
 /**
  * Debounce for 1s to really change the query string.
- */
-const debouncedSetQuery = debounce(
-	() => pushQueryString( encode( mostRecentQueryObject ) ),
-	DEBOUNCED_TIME_TO_SET_QUERY_MILLISECONDS
-);
-
-/**
- * Updates the browser's query string via a query object.
  *
- * @param {object} queryObject - a query object.
+ * @param {*} queryObject - a query object.
  */
-export function setQuery( queryObject ) {
-	mostRecentQueryObject = queryObject;
-	debouncedSetQuery();
+function setQuery( queryObject ) {
+	pushQueryString( encode( queryObject ) );
 }
+
+// Create debounced function.
+const setQueryDebounced = debounce( setQuery, DEBOUNCED_TIME_TO_SET_QUERY_MILLISECONDS );
+
+// Export debounced function with original function name.
+export { setQueryDebounced as setQuery };
 
 /**
  * Updates the browser's query string via an encoded query string.

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -16,7 +16,7 @@ import {
 import { getFilterKeys, getStaticFilterKeys } from './filters';
 import { decode } from '../external/query-string-decode';
 
-let mostRecentQueryObject = {};
+let mostRecentQueryObject = null;
 
 /**
  * Parses the address bar's query string into an object.

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -29,7 +29,7 @@ export function getQuery( search = window.location.search ) {
 /**
  * Change the query string.
  *
- * @param {object} queryObject - a query object.
+ * @param {object|null} queryObject - a query object.
  */
 function setQuery( queryObject ) {
 	pushQueryString( encode( queryObject ) );

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -27,7 +27,7 @@ export function getQuery( search = window.location.search ) {
 }
 
 /**
- * Debounce for 1s to really change the query string.
+ * Change the query string.
  *
  * @param {*} queryObject - a query object.
  */
@@ -36,6 +36,7 @@ function setQuery( queryObject ) {
 }
 
 // Create debounced function.
+// Debounce for 1s to really change the query string.
 const setQueryDebounced = debounce( setQuery, DEBOUNCED_TIME_TO_SET_QUERY_MILLISECONDS );
 
 // Export debounced function with original function name.

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -2,13 +2,21 @@
  * External dependencies
  */
 import { encode } from 'qss';
+/*eslint lodash/import-scope: [2, "method"]*/
+import debounce from 'lodash/debounce';
 
 /**
  * Internal dependencies
  */
-import { SERVER_OBJECT_NAME, VALID_RESULT_FORMAT_KEYS } from './constants';
+import {
+	SERVER_OBJECT_NAME,
+	VALID_RESULT_FORMAT_KEYS,
+	DEBOUNCED_TIME_TO_SET_QUERY_MILLISECONDS,
+} from './constants';
 import { getFilterKeys, getStaticFilterKeys } from './filters';
 import { decode } from '../external/query-string-decode';
+
+let mostRecentQueryObject = {};
 
 /**
  * Parses the address bar's query string into an object.
@@ -21,12 +29,21 @@ export function getQuery( search = window.location.search ) {
 }
 
 /**
+ * Debounce for 1s to really change the query string.
+ */
+const debouncedSetQuery = debounce(
+	() => pushQueryString( encode( mostRecentQueryObject ) ),
+	DEBOUNCED_TIME_TO_SET_QUERY_MILLISECONDS
+);
+
+/**
  * Updates the browser's query string via a query object.
  *
  * @param {object} queryObject - a query object.
  */
 export function setQuery( queryObject ) {
-	pushQueryString( encode( queryObject ) );
+	mostRecentQueryObject = queryObject;
+	debouncedSetQuery();
 }
 
 /**

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/query-string.js
@@ -29,7 +29,7 @@ export function getQuery( search = window.location.search ) {
 /**
  * Change the query string.
  *
- * @param {*} queryObject - a query object.
+ * @param {object} queryObject - a query object.
  */
 function setQuery( queryObject ) {
 	pushQueryString( encode( queryObject ) );


### PR DESCRIPTION
Partially fixes #20607

#### Changes proposed in this Pull Request:
Changed `setQuery` to a debounced call, with wait time set to 1 second. This is to reduce the URLs pushed to browser history to reduce noise. 

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a website with Jetpack Search subscription
* Perform a search
* Ensure the URL changes only  1 second after of user input continuous typing.



