### PR TITLE
Boost: Restart stale pending requests for score

### DIFF
--- a/projects/plugins/boost/app/lib/class-speed-score-request.php
+++ b/projects/plugins/boost/app/lib/class-speed-score-request.php
@@ -189,6 +189,13 @@ class Speed_Score_Request extends Cacheable {
 
 		switch ( $response->status ) {
 			case 'pending':
+				// The initial job probalby failed, dispatch again if so.
+				if ( $this->created <= strtotime( '-15 mins' ) ) {
+					$this->execute();
+					$this->created = time();
+					$this->store();
+				}
+
 				break;
 
 			case 'error':

--- a/projects/plugins/boost/changelog/fix-restart-stale-pending-requests
+++ b/projects/plugins/boost/changelog/fix-restart-stale-pending-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Retry if a score request job is stuck for more than 15 minutes


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
It is possible that the job for the score request on WP.com somehow did not process or failed. In that case, the score request will stay in pending status. The plugin would not know this and keep trying to receive from the old request.

This PR would change this and a new request will be started if the job is stuck for more than 15 minutes.

#### Jetpack product discussion
none

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Using wpcom sandbox, keep a request in pending status intentionally.
- Load the Boost dashboard so that the scores are fetched.
- Make sure the fetch produces results by sending a new request to wp.com api.