### PR TITLE
Widget Visibility: Add click tracking

### DIFF
--- a/projects/plugins/jetpack/changelog/add-widget-visibility-click-tracking
+++ b/projects/plugins/jetpack/changelog/add-widget-visibility-click-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add click tracking for Widget Visibility

--- a/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
+++ b/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
@@ -250,9 +250,8 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 					...maybeAddDefaultConditions( conditions ),
 					match_all: conditions.match_all === '0' ? '1' : '0',
 				},
-			} ),
-				[ setAttributes, conditions ];
-		} );
+			} );
+		}, [ setAttributes, conditions ] );
 
 		const setAction = useCallback(
 			value =>

--- a/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
+++ b/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
@@ -7,6 +7,7 @@ import { __, _x } from '@wordpress/i18n';
 import { InspectorAdvancedControls } from '@wordpress/block-editor'; // eslint-disable-line import/no-unresolved
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
+import analytics from '../../../_inc/client/lib/analytics';
 
 /* global widget_conditions_data, wpcom */
 /* eslint-disable react/react-in-jsx-scope */
@@ -242,16 +243,16 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 			[ clientId ]
 		);
 
-		const toggleMatchAll = useCallback(
-			() =>
-				setAttributes( {
-					conditions: {
-						...maybeAddDefaultConditions( conditions ),
-						match_all: conditions.match_all === '0' ? '1' : '0',
-					},
-				} ),
-			[ setAttributes, conditions ]
-		);
+		const toggleMatchAll = useCallback( () => {
+			analytics.tracks.recordEvent( 'jetpack_widget_visibility_toggle_match_all_click' );
+			setAttributes( {
+				conditions: {
+					...maybeAddDefaultConditions( conditions ),
+					match_all: conditions.match_all === '0' ? '1' : '0',
+				},
+			} ),
+				[ setAttributes, conditions ];
+		} );
 
 		const setAction = useCallback(
 			value =>
@@ -265,6 +266,7 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 		);
 		const addNewRule = useCallback( () => {
 			const newRules = [ ...rules, { major: '', minor: '' } ];
+			analytics.tracks.recordEvent( 'jetpack_widget_visibility_add_new_rule_click' );
 			setAttributes( {
 				conditions: {
 					...maybeAddDefaultConditions( conditions ),
@@ -276,6 +278,7 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 		const deleteRule = useCallback(
 			i => {
 				const newRules = [ ...rules.slice( 0, i ), ...rules.slice( i + 1 ) ];
+				analytics.tracks.recordEvent( 'jetpack_widget_visibility_delete_rule_click' );
 				setAttributes( {
 					conditions: {
 						...maybeAddDefaultConditions( conditions ),
@@ -288,6 +291,7 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 
 		const setMajor = useCallback(
 			( i, majorValue ) => {
+				analytics.tracks.recordEvent( 'jetpack_widget_visibility_set_major_rule_click' );
 				// When changing majors, also change the minor to the first available option
 				let minorValue = '';
 				if (
@@ -315,6 +319,7 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 
 		const setMinor = useCallback(
 			( i, value ) => {
+				analytics.tracks.recordEvent( 'jetpack_widget_visibility_set_minor_rule_click' );
 				// Don't allow section headings to be set
 				if ( value && value.includes( '__HEADER__' ) ) {
 					return;


### PR DESCRIPTION
Fixes Automattic/wp-calypso#56582

#### Changes proposed in this Pull Request:

* Adds Tracks events for Add new rule, Remove rule, Set major and minor rules fields

<img width="479" alt="Screen Shot 2021-10-04 at 1 25 28 PM" src="https://user-images.githubusercontent.com/2124984/135897563-e0faae3c-c7b4-4c73-a5d9-865f02bc36dd.png">

#### Does this pull request change what data or activity we track or use?

This adds tracking on click events, so maybe?

#### Testing instructions:

* Switch to this PR, go to the Customizer on a site that supports block widgets
* In your browser's console, set local storage to track analytics changes: `localStorage.setItem('debug', 'dops:analytics');`; hit Enter and reload your browser
* Add a new block widget; click the three-dots menu to access the widget settings
* Click Advanced and scroll down to the Visibility section
* Add a new rule; check the browser console to confirm the tracks event fired as expected
* Set the rule's primary parameter - it should fire another event
* Set the rules minor parameter - it should also fire an event
* Remove the rule - it should fire an event

#### WPCOM

D67837-code
