### PR TITLE
Identity Crisis: move initialization to the Config package

### DIFF
--- a/projects/packages/config/changelog/update-move_idc_init_config
+++ b/projects/packages/config/changelog/update-move_idc_init_config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add support for the identity-crisis package

--- a/projects/packages/config/src/class-config.php
+++ b/projects/packages/config/src/class-config.php
@@ -34,10 +34,11 @@ class Config {
 	 * @var Array
 	 */
 	protected $config = array(
-		'jitm'       => false,
-		'connection' => false,
-		'sync'       => false,
-		'post_list'  => false,
+		'jitm'            => false,
+		'connection'      => false,
+		'sync'            => false,
+		'post_list'       => false,
+		'identity_crisis' => false,
 	);
 
 	/**
@@ -99,6 +100,11 @@ class Config {
 		if ( $this->config['post_list'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\Post_List\Post_List' )
 				&& $this->ensure_feature( 'post_list' );
+		}
+
+		if ( $this->config['identity_crisis'] ) {
+			$this->ensure_class( 'Automattic\Jetpack\Identity_Crisis' )
+				&& $this->ensure_feature( 'identity_crisis' );
 		}
 	}
 
@@ -204,6 +210,13 @@ class Config {
 		Manager::configure();
 
 		return true;
+	}
+
+	/**
+	 * Enables the identity-crisis feature.
+	 */
+	protected function enable_identity_crisis() {
+		Identity_Crisis::init();
 	}
 
 	/**

--- a/projects/packages/sync/changelog/update-move_idc_init_config
+++ b/projects/packages/sync/changelog/update-move_idc_init_config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove initialization of the identity-crisis package. That will be handled by the Config package.

--- a/projects/packages/sync/src/class-main.php
+++ b/projects/packages/sync/src/class-main.php
@@ -34,9 +34,6 @@ class Main {
 		// Any hooks below are special cases that need to be declared even if Sync is not allowed.
 		add_action( 'jetpack_site_registered', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );
 
-		// Initialize Identity Crisis.
-		add_action( 'plugins_loaded', array( 'Automattic\\Jetpack\\Identity_Crisis', 'init' ) );
-
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
 	}

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.26.2';
+	const PACKAGE_VERSION = '1.26.3-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/changelog/update-move_idc_init_config
+++ b/projects/plugins/jetpack/changelog/update-move_idc_init_config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Init the identity-crisis package using the Config package

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -830,6 +830,7 @@ class Jetpack {
 			array(
 				'sync',
 				'jitm',
+				'identity_crisis',
 			)
 			as $feature
 		) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
 * Add support for the identity-crisis package to the Config package.
 * Initialize the identity-crisis package in the Jetpack class.
 * Remove initialization of the identity-crisis package from the sync package.

#### Jetpack product discussion
* p9dueE-3oW-p2

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
Testing will consist of verifying that an IDC that's detected by a Sync request works as expected.

1. Install this branch of Jetpack. Activate and connect to WPCOM.
2. Activate the Jetpack Debug plugin.
3. Enable the IDC simulator module in the Jetpack Debug menu.
4. Enable the IDC simulation in the UI.
5. Create a draft post,
6. Observe your site in IDC safe mode.
7. Check the site's debug.log file and verify that no errors were generated.