### PR TITLE
Post List: Only display the thumbnail for types that support it

### DIFF
--- a/projects/packages/post-list/changelog/update-post-list-thumbnail-logic
+++ b/projects/packages/post-list/changelog/update-post-list-thumbnail-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Only add the thumbnail column for post types that support it

--- a/projects/packages/post-list/changelog/update-post-list-thumbnail-logic
+++ b/projects/packages/post-list/changelog/update-post-list-thumbnail-logic
@@ -1,4 +1,4 @@
 Significance: patch
-Type: enhancement
+Type: changed
 
 Only add the thumbnail column for post types that support it

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -79,7 +79,7 @@ class Post_List {
 	public function add_thumbnail_filters_and_actions( $current_screen ) {
 		if ( 'edit' === $current_screen->base ) {
 			// Add the thumbnail column to the "Posts" admin table.
-			add_filter( 'manage_posts_columns', array( $this, 'add_thumbnail_column' ) );
+			add_filter( 'manage_posts_columns', array( $this, 'add_thumbnail_column' ), 10, 2 );
 			add_action( 'manage_posts_custom_column', array( $this, 'populate_thumbnail_rows' ), 10, 2 );
 
 			// Add the thumbnail column to the "Pages" admin table.
@@ -91,10 +91,15 @@ class Post_List {
 	/**
 	 * Adds a new column header for displaying the thumbnail of a post.
 	 *
-	 * @param array $columns An array of column names.
+	 * @param array  $columns An array of column names.
+	 * @param string $post_type The post type being displayed in the post list. Defaults to 'page'.
 	 * @return array An array of column names.
 	 */
-	public function add_thumbnail_column( $columns ) {
+	public function add_thumbnail_column( $columns, $post_type = 'page' ) {
+		if ( ! post_type_supports( $post_type, 'thumbnail' ) ) {
+			return $columns;
+		}
+
 		$new_column = array( 'thumbnail' => '<span>' . __( 'Thumbnail', 'jetpack' ) . '</span>' );
 		$keys       = array_keys( $columns );
 		$position   = array_search( 'title', $keys, true );


### PR DESCRIPTION
We currently add the post thumbnail column to all post list displays.
This change checks that the post type supports `thumbnail`, before
adding the column.

Fixes #21274

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. On your Jetpack development site, register test post type with a code snippet like:

```php
function test_post_types() {
	$labels = array(
		'name'          => _x( 'Thumbnail items', 'post type general name' ),
		'singular_name' => _x( 'Thumbnail item', 'post type singular name' ),
		'menu_name'     => 'Thumbnail',
	);
	$args   = array(
		'labels'      => $labels,
		'description' => 'A test post type that supports thumbnails',
		'public'      => true,
		'supports'    => array( 'title', 'editor', 'thumbnail' ),
		'has_archive' => true,
	);
	register_post_type( 'thumbnail_item', $args );

	$labels = array(
		'name'          => _x( 'No Thumbnail items', 'post type general name' ),
		'singular_name' => _x( 'No Thumbnail item', 'post type singular name' ),
		'menu_name'     => 'No Thumbnail'
	);
	$args   = array(
		'labels'      => $labels,
		'description' => 'A test post type that doesn\'t support thumbnails',
		'public'      => true,
		'supports'    => array( 'title', 'editor' ),
		'has_archive' => true,
	);
	register_post_type( 'no_thumbnail_item', $args );
}
add_action( 'init', 'test_post_types' );
```
It can be added to a plugin file in `mu-plugins`. This registers two types, one that supports thumbnails and one that doesn't.

2. Add a post for each type
3. Require the post list in Jetpack with `composer require automattic/jetpack-post-list`
4. You may need to reinstall the packages with `jetpack install -r && jetpack install --all`
5. Head to https://yourdevsite.jurassic.tube/wp-admin/edit.php?post_type=no_thumbnail_item
6. Without this change, you'll see the thumbnail column added
7. With it, it shouldn't be displayed, but you should still see it on the other post type.


