### PR TITLE
Search: Fix infinite scroll in Customberg

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-customberg-infinite-scroll
+++ b/projects/plugins/jetpack/changelog/fix-customberg-infinite-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: Fix infinite scroll in Customberg

--- a/projects/plugins/jetpack/modules/search/customberg/components/app-wrapper/index.jsx
+++ b/projects/plugins/jetpack/modules/search/customberg/components/app-wrapper/index.jsx
@@ -74,7 +74,14 @@ export default function AppWrapper() {
 	const { isLoading } = useSiteLoadingState();
 
 	return (
-		<div className="jp-search-configure-app-wrapper">
+		<div
+			/* translators: accessibility text for the widgets screen content landmark region. */
+			aria-label={ __( 'Jetpack Search customization preview', 'jetpack' ) }
+			className="jp-search-configure-app-wrapper"
+			// className="interface-interface-skeleton__content"
+			role="region"
+			tabIndex="-1"
+		>
 			{ isLoading ? (
 				<img
 					className="jp-search-configure-loading-spinner"

--- a/projects/plugins/jetpack/modules/search/customberg/components/app-wrapper/index.jsx
+++ b/projects/plugins/jetpack/modules/search/customberg/components/app-wrapper/index.jsx
@@ -78,7 +78,6 @@ export default function AppWrapper() {
 			/* translators: accessibility text for the widgets screen content landmark region. */
 			aria-label={ __( 'Jetpack Search customization preview', 'jetpack' ) }
 			className="jp-search-configure-app-wrapper"
-			// className="interface-interface-skeleton__content"
 			role="region"
 			tabIndex="-1"
 		>

--- a/projects/plugins/jetpack/modules/search/customberg/components/app-wrapper/styles.scss
+++ b/projects/plugins/jetpack/modules/search/customberg/components/app-wrapper/styles.scss
@@ -1,15 +1,8 @@
 @import '../../lib/base-styles';
 @import '../../../instant-search/lib/styles/helper';
 
-.interface-interface-skeleton__content {
-	background: $gray-100;
-	height: 100%;
-}
-
-.interface-interface-skeleton__content > .jp-search-configure-app-wrapper {
-	background: $gray-100;
-	height: 100%;
-	position: relative;
+.jp-search-configure-app-wrapper {
+	flex-grow: 1;
 
 	.jp-search-configure-loading-spinner {
 		position: absolute;
@@ -19,12 +12,9 @@
 	}
 
 	.jetpack-instant-search {
-		max-width: 90%;
-		margin: 1em auto auto auto;
-
-		position: static;
-		padding: 0;
-		background: none;
+		background: $gray-100;
+		position: absolute;
+		padding-top: 2em;
 
 		.jetpack-instant-search__search-results {
 			max-width: initial;

--- a/projects/plugins/jetpack/modules/search/customberg/components/layout/interface.jsx
+++ b/projects/plugins/jetpack/modules/search/customberg/components/layout/interface.jsx
@@ -32,7 +32,7 @@ export default function Interface( props ) {
 				>
 					<Header enableSidebar={ enableSidebar } />
 				</div>
-				<div className="interface-interface-skeleton__body">
+				<div className="jp-search-configure-layout__body">
 					<AppWrapper />
 					{ /* Ensure sidebar is enabled before rendering. */ }
 					{ !! enabledSidebarName && (

--- a/projects/plugins/jetpack/modules/search/customberg/components/layout/interface.jsx
+++ b/projects/plugins/jetpack/modules/search/customberg/components/layout/interface.jsx
@@ -33,15 +33,7 @@ export default function Interface( props ) {
 					<Header enableSidebar={ enableSidebar } />
 				</div>
 				<div className="interface-interface-skeleton__body">
-					<div
-						/* translators: accessibility text for the widgets screen content landmark region. */
-						aria-label={ __( 'Jetpack Search customization preview', 'jetpack' ) }
-						className="interface-interface-skeleton__content"
-						role="region"
-						tabIndex="-1"
-					>
-						<AppWrapper />
-					</div>
+					<AppWrapper />
 					{ /* Ensure sidebar is enabled before rendering. */ }
 					{ !! enabledSidebarName && (
 						<div

--- a/projects/plugins/jetpack/modules/search/customberg/components/layout/styles.scss
+++ b/projects/plugins/jetpack/modules/search/customberg/components/layout/styles.scss
@@ -20,3 +20,9 @@
 		background-color: $white;
 	}
 }
+
+.jp-search-configure-layout__body {
+	display: flex;
+	flex-grow: 1;
+	overflow: auto;
+}

--- a/projects/plugins/jetpack/modules/search/customberg/lib/_base-styles.scss
+++ b/projects/plugins/jetpack/modules/search/customberg/lib/_base-styles.scss
@@ -8,7 +8,6 @@ $z-layers: map-merge(
 		'.interface-complementary-area .components-panel': 0,
 		'.interface-complementary-area .components-panel__header': 1,
 		'.interface-interface-skeleton__header': 30,
-		'.interface-interface-skeleton__content': 20,
 		'.interface-interface-skeleton__sidebar': 100000,
 		'.interface-interface-skeleton__sidebar {greater than small}': 90,
 		'.interface-interface-skeleton__footer': 90,

--- a/projects/plugins/jetpack/modules/search/customberg/lib/wordpress-interface.scss
+++ b/projects/plugins/jetpack/modules/search/customberg/lib/wordpress-interface.scss
@@ -195,25 +195,6 @@ html.interface-interface-skeleton__html-container {
 	}
 }
 
-.interface-interface-skeleton__content {
-	flex-grow: 1;
-
-	// Treat as flex container to allow children to grow to occupy full
-	// available height of the content area.
-	display: flex;
-	flex-direction: column;
-
-	// On Mobile the header is fixed to keep HTML as scrollable.
-	// Beyond the medium breakpoint, we allow the sidebar.
-	// The sidebar should scroll independently, so enable scroll here also.
-	overflow: auto;
-
-	// On Safari iOS on smaller viewports lack of a z-index causes the background
-	// to "bleed" through the header.
-	// See https://github.com/WordPress/gutenberg/issues/32631
-	z-index: z-index( '.interface-interface-skeleton__content' );
-}
-
 .interface-interface-skeleton__secondary-sidebar,
 .interface-interface-skeleton__sidebar {
 	display: block;

--- a/projects/plugins/jetpack/modules/search/customberg/lib/wordpress-interface.scss
+++ b/projects/plugins/jetpack/modules/search/customberg/lib/wordpress-interface.scss
@@ -166,35 +166,6 @@ html.interface-interface-skeleton__html-container {
 
 @include editor-left( '.interface-interface-skeleton' );
 
-.interface-interface-skeleton__body {
-	flex-grow: 1;
-	display: flex;
-
-	// Even on Mobile, we choose to scroll this element on its own.
-	// This helps enable a fixed-to-top toolbar that makes the editing experience
-	// on Mobile Safari usable.
-	// Unfortunately an issue still exists where if you swipe the top toolbar
-	// or beyond the bottom of the page when the soft keyboard is showing, you scroll
-	// the body element and can scroll the toolbar out of view.
-	// This is still preferable, though, as it allows the editor to function at all.
-	overflow: auto;
-
-	// In future versions of Mobile Safari, hopefully overscroll-behavior will be supported.
-	// This allows us to disallow the scroll-chaining and rubber-banding that is currently
-	// is the cause of the issue outlined above.
-	// In other words, the following behavior doesn't yet work in Safari, but if/when
-	// it is added, it should take care of the issue.
-	// See also: https://drafts.csswg.org/css-overscroll/
-	overscroll-behavior-y: none;
-
-	// Footer overlap prevention
-	.has-footer & {
-		@include break-medium() {
-			padding-bottom: $button-size-small + $border-width;
-		}
-	}
-}
-
 .interface-interface-skeleton__secondary-sidebar,
 .interface-interface-skeleton__sidebar {
 	display: block;

--- a/projects/plugins/jetpack/modules/search/instant-search/components/scroll-button.jsx
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/scroll-button.jsx
@@ -26,7 +26,7 @@ class ScrollButton extends Component {
 	checkScroll = debounce( () => {
 		if (
 			this.props.enableLoadOnScroll &&
-			window.innerHeight + this.overlayElement.scrollTop === this.overlayElement.scrollHeight
+			window.innerHeight + this.overlayElement.scrollTop >= this.overlayElement.scrollHeight
 		) {
 			this.props.onLoadNextPage();
 		}

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/styles/_mixins.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/styles/_mixins.scss
@@ -66,7 +66,7 @@
 	}
 }
 
-$customberg-container-selector: '.interface-interface-skeleton__content > .jp-search-configure-app-wrapper' !default;
+$customberg-container-selector: '.jp-search-configure-app-wrapper' !default;
 
 // NOTE: Only works if first breakpoint is more restrictive than the customberg breakpoint.
 //       E.g. multiple-breaks-for-customberg( '<l', '<xl' );


### PR DESCRIPTION
Fixes #20970.

#### Changes proposed in this Pull Request:
* Changes nesting of elements to enable infinite scrolling within Customberg.
* Begins deprecating styles copied over from the `@wordpress/interface` package.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription.
* Navigate to Customberg (`/wp-admin/admin.php?page=jetpack-search-configure`) and try interacting with the infinite scroll functionality in the preview.
* Ensure that the infinite scroll functionality works as expected in Customberg.
* Ensure that the mobile-friendly breakpoints work as expected in the Instant Search preview within Customberg.
* Ensure that the infinite scroll functionality continues to work as expected for the site (`?s=some search`).
