### PR TITLE
VideoPress: support "cover" option

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-blackbars-on-resize
+++ b/projects/plugins/jetpack/changelog/fix-videopress-blackbars-on-resize
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Add a "cover" option to the VideoPress iframe and shortcode to handle video resizing to its container

--- a/projects/plugins/jetpack/extensions/blocks/videopress/url.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/url.js
@@ -32,6 +32,7 @@ export const getVideoPressUrl = (
 	// - Preload: None by default.
 	const options = {
 		resizeToParent: true,
+		cover: true,
 		...( autoplay && { autoPlay: true } ),
 		...( ! controls && { controls: false } ),
 		...( loop && { loop: true } ),

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -622,6 +622,10 @@ class VideoPress_Player {
 			$this->options['hd'] = (bool) get_option( 'video_player_high_quality', false );
 		}
 
+		if ( ! array_key_exists( 'cover', $this->options ) ) {
+			$this->options['cover'] = true;
+		}
+
 		$videopress_options = array(
 			'width'  => absint( $this->video->calculated_width ),
 			'height' => absint( $this->video->calculated_height ),
@@ -638,6 +642,7 @@ class VideoPress_Player {
 				case 'hd':
 				case 'loop':
 				case 'permalink':
+				case 'cover':
 					if ( in_array( $value, array( 1, 'true' ) ) ) {
 						$videopress_options[ $option ] = true;
 					} elseif ( in_array( $value, array( 0, 'false' ) ) ) {

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -80,6 +80,7 @@ class VideoPress_Shortcode {
 			'permalink'       => true,  // Whether to display the permalink to the video
 			'flashonly'       => false, // Whether to support the Flash player exclusively
 			'defaultlangcode' => false, // Default language code
+			'cover'           => true,  // Whether to scale the video to its container.
 		);
 
 		$attr = shortcode_atts( $defaults, $attr, 'videopress' );
@@ -90,6 +91,7 @@ class VideoPress_Shortcode {
 		$attr['width']   = absint( $attr['w'] );
 		$attr['hd']      = (bool) $attr['hd'];
 		$attr['freedom'] = (bool) $attr['freedom'];
+		$attr['cover']   = (bool) $attr['cover'];
 
 		/**
 		 * If the provided width is less than the minimum allowed
@@ -129,6 +131,7 @@ class VideoPress_Shortcode {
 			array(
 				'at'              => (int) $attr['at'],
 				'hd'              => $attr['hd'],
+				'cover'           => $attr['cover'],
 				'loop'            => $attr['loop'],
 				'freedom'         => $attr['freedom'],
 				'autoplay'        => $attr['autoplay'],


### PR DESCRIPTION
This PR fixes Automattic/greenhouse#973

#### Changes proposed in this Pull Request:

Support the "cover" option in shortcode and iframe to resize the video to its container.

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* You need a sandbox environment with a Jetpack connection.
* Sandbox the API requests to your sandbox in Jetpack: define( 'JETPACK__SANDBOX_DOMAIN', '{your-sandbox}' ); in tools/docker/mu-plugins/debug.php
* Enable VideoPress features by toggling the VideoPress option at the bottom of /wp-admin/admin.php?page=jetpack#/dashboard on your Jetpack site's wp-admin.
* Edit a post : 
  * Add a video block and upload or select an existing VideoPress video.
  * Save, and view your post
  * ✅ No single pixel black bar should be seen at any scale
  * ✅ You should also see a class "videopress-cover" in the parent's video div :

![](https://user-images.githubusercontent.com/1420594/135040135-58480f59-871a-43b5-9b87-42b25533ebe3.png)

* Go back to your post edit :
  * Grab your video guid
  * Add a shortcode block
  * Edit it like so : [wpvideo ] (replace "" with your video guid)
  * Save and view your post
  * ✅ Result should be similar to "Edit a post" (no black bars and "videopress-cover")
