### PR TITLE
E2E checks: Move search helpers into plugin e2e checks project

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-move-search-helpers
+++ b/projects/plugins/jetpack/changelog/e2e-move-search-helpers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+E2E tests: move search helpers from e2e-commons to plugin e2e checks project

--- a/projects/plugins/jetpack/tests/e2e/specs/search.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/search.test.js
@@ -7,7 +7,8 @@ import {
 	disableInstantSearch,
 	getBlockWidgets,
 	setupBlockWidgets,
-} from 'jetpack-e2e-commons/helpers/search-helper';
+	searchAPIRoute,
+} from '../helpers/search-helper';
 import { testStep } from 'jetpack-e2e-commons/reporters/reporter';
 import { prerequisitesBuilder } from 'jetpack-e2e-commons/env/prerequisites';
 import { Plans } from 'jetpack-e2e-commons/env/types';
@@ -46,7 +47,7 @@ describe( 'Search', () => {
 
 	beforeEach( async () => {
 		homepage = await Homepage.visit( page );
-		await homepage.searchAPIRoute();
+		await searchAPIRoute( homepage.page );
 		await homepage.waitForNetworkIdle();
 	} );
 

--- a/tools/e2e-commons/pages/search-homepage.js
+++ b/tools/e2e-commons/pages/search-homepage.js
@@ -1,83 +1,9 @@
 import WpPage from './wp-page';
-import logger from '../logger';
-import { searchResultForTest1, searchResultForTest2 } from '../helpers/search-helper';
 
 export default class SearchHomepage extends WpPage {
-	static SEARCH_API_PATTERN = /^https:\/\/public-api\.wordpress.com\/rest\/v1.3\/sites\/\d+\/search.*/;
-
 	constructor( page ) {
 		const url = `${ siteUrl }/?result_format=expanded`;
 		super( page, { expectedSelectors: [ '.site-title' ], url } );
-	}
-
-	/**
-	 * The function intercepts requests made to WPCOM Search API and returns mocked
-	 * results to the frontend. It also simulates sorting and filtering.
-	 *
-	 * The route returns `searchResultForTest1` for query `test1`.
-	 * And returns `searchResultForTest2` for any other queries.
-	 *
-	 * NOTE: The route sometimes is not persisted after page reloads so would need to
-	 * call the function again to make sure.
-	 *
-	 * @see https://playwright.dev/docs/api/class-page#pagerouteurl-handler
-	 */
-	async searchAPIRoute() {
-		this.page.route( SearchHomepage.SEARCH_API_PATTERN, ( route, request ) => {
-			logger.info( `intercepted search API call: ${ request.url() }` );
-			const url = new URL( request.url() );
-			const params = url.searchParams;
-
-			// loads response for queries
-			let body;
-			switch ( params.get( 'query' ) ) {
-				case 'test1':
-					body = { ...searchResultForTest1 };
-					break;
-				case 'test2':
-				default:
-					body = { ...searchResultForTest2 };
-					break;
-			}
-
-			// deal with sorting
-			switch ( params.get( 'sort' ) ) {
-				case 'date_asc':
-					// put record 2 first
-					const tmpResult1 = body.results[ 0 ];
-					body.results[ 0 ] = body.results[ 1 ];
-					body.results[ 1 ] = tmpResult1;
-					break;
-				case 'date_desc':
-					// put record 3 first
-					const tmpResult2 = body.results[ 0 ];
-					body.results[ 0 ] = body.results[ 2 ];
-					body.results[ 2 ] = tmpResult2;
-					break;
-				case 'score_default':
-				default:
-					// the original sorting
-					break;
-			}
-
-			// deal with filtering: only works with one category and one tag by filtering the results array
-			const category = params.get( 'filter[bool][must][0][term][category.slug]' );
-			const tag = params.get( 'filter[bool][must][0][term][tag.slug]' );
-
-			if ( category ) {
-				body.results = body.results.filter( v => v?.categories?.includes( category ) );
-			}
-
-			if ( tag ) {
-				body.results = body.results.filter( v => v?.tags?.includes( tag ) );
-			}
-
-			route.fulfill( {
-				content: 'application/json',
-				headers: { 'Access-Control-Allow-Origin': '*' },
-				body: JSON.stringify( body ),
-			} );
-		} );
 	}
 
 	async focusSearchInput() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Move search helpers from e2e-commons into Jetpack plugin e2e checks project. The helper is specific to the plugin specs and belongs there.

#### Jetpack product discussion
1156386383419466-as-1201116468870453

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Tests pass