### PR TITLE
Jetpack Sync :: Reduce overflow to Sync Queue

### DIFF
--- a/projects/packages/sync/changelog/fix-minimize-queue-overflow
+++ b/projects/packages/sync/changelog/fix-minimize-queue-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reduce transient expiration for how often we check the state of the queue.

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Roles;
  */
 class Listener {
 	const QUEUE_STATE_CHECK_TRANSIENT = 'jetpack_sync_last_checked_queue_state';
-	const QUEUE_STATE_CHECK_TIMEOUT   = 300; // 5 minutes.
+	const QUEUE_STATE_CHECK_TIMEOUT   = 30; // 30 seconds.
 
 	/**
 	 * Sync queue.


### PR DESCRIPTION
The Sync Queue resides in the wp_options table and as such we minimize the number of operations we perform on it. One of the optimizations is to save the state of the queue (size) into a transient that has an expiration of 5 minutes. During import or bulk operations it is possible for 10,000 -> 50,000+ actions to occur that greatly overflow the queue and leads to delays and issues with ongoing changes.

This update reduces the expiration to 30 seconds which should reduce the amount of overflow that gets saved in the queue. More Data loss events will trigger but sites will recover faster.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Reduction of transient expiration to reduce queue size.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Regression Testing. Verify that data flows via Sync into the WP.com Cache
