### PR TITLE
Post List: Add the Share post action to Posts and Pages

### DIFF
--- a/projects/packages/post-list/changelog/add-share-post-action
+++ b/projects/packages/post-list/changelog/add-share-post-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a 'Share' post action

--- a/projects/packages/post-list/composer.json
+++ b/projects/packages/post-list/composer.json
@@ -51,7 +51,7 @@
 			"link-template": "https://github.com/automattic/jetpack-post-list/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "0.1.x-dev"
+			"dev-master": "0.2.x-dev"
 		}
 	}
 }

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -89,6 +89,15 @@ class Post_List {
 
 		if (
 			in_array( $current_screen->post_type, array( 'post', 'page' ), true ) &&
+			/**
+			 * Determine whether we should show the share action for this post type.
+			 * The default is false.
+			 *
+			 * @since $$next_version$$
+			 *
+			 * @param boolean Whether we should show the share action for this post type.
+			 * @param string  The current post type.
+			 */
 			apply_filters( 'jetpack_can_share_post', false, $current_screen->post_type )
 		) {
 			// Add Share post action.

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -87,7 +87,10 @@ class Post_List {
 		add_filter( 'manage_pages_columns', array( $this, 'add_thumbnail_column' ) );
 		add_action( 'manage_pages_custom_column', array( $this, 'populate_thumbnail_rows' ), 10, 2 );
 
-		if ( in_array( $current_screen->post_type, array( 'post', 'page' ), true ) && apply_filters( 'jetpack_can_share_post', false, $current_screen->post_type ) ) {
+		if (
+			in_array( $current_screen->post_type, array( 'post', 'page' ), true ) &&
+			apply_filters( 'jetpack_can_share_post', false, $current_screen->post_type )
+		) {
 			// Add Share post action.
 			add_filter( 'post_row_actions', array( $this, 'add_share_action' ), 20, 2 );
 			add_filter( 'page_row_actions', array( $this, 'add_share_action' ), 20, 2 );

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -98,7 +98,7 @@ class Post_List {
 			 * @param boolean Whether we should show the share action for this post type.
 			 * @param string  The current post type.
 			 */
-			apply_filters( 'jetpack_can_share_post', false, $current_screen->post_type )
+			apply_filters( 'jetpack_post_list_display_share_action', false, $current_screen->post_type )
 		) {
 			// Add Share post action.
 			add_filter( 'post_row_actions', array( $this, 'add_share_action' ), 20, 2 );

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Post_List;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.1.1-alpha';
+	const PACKAGE_VERSION = '0.2.0-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/post-list/tests/php/test-post-list.php
+++ b/projects/packages/post-list/tests/php/test-post-list.php
@@ -79,7 +79,10 @@ class Test_Post_List extends BaseTestCase {
 		$this->assertFalse( has_filter( 'manage_pages_columns' ) );
 		$this->assertFalse( has_action( 'manage_pages_custom_column' ) );
 
-		$current_screen = (object) array( 'base' => 'edit' );
+		$current_screen = (object) array(
+			'base'      => 'edit',
+			'post_type' => 'post',
+		);
 		$post_list->add_filters_and_actions( $current_screen );
 
 		// Assert that our style, filter, and action has been added.
@@ -94,7 +97,10 @@ class Test_Post_List extends BaseTestCase {
 	 */
 	public function test_add_filters_and_actions_wrong_screen() {
 		$post_list      = Post_List::get_instance();
-		$current_screen = (object) array( 'base' => 'edit-tags' );
+		$current_screen = (object) array(
+			'base'      => 'edit-tags',
+			'post_type' => 'post',
+		);
 		$post_list->add_filters_and_actions( $current_screen );
 
 		// Confirm that our style, filter, and action have not been added before the enqueue_scripts() method call.

--- a/projects/packages/post-list/tests/php/test-post-list.php
+++ b/projects/packages/post-list/tests/php/test-post-list.php
@@ -38,14 +38,14 @@ class Test_Post_List extends BaseTestCase {
 
 		// Assert our action has not been added yet.
 		$this->assertFalse( has_action( 'admin_enqueue_scripts', array( $post_list, 'enqueue_scripts' ) ) );
-		$this->assertFalse( has_action( 'current_screen', array( $post_list, 'add_thumbnail_filters_and_actions' ) ) );
+		$this->assertFalse( has_action( 'current_screen', array( $post_list, 'add_filters_and_actions' ) ) );
 
 		// Set up our action callbacks using the register() method.
 		$post_list->register();
 
 		// Assert the action was added.
 		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', array( $post_list, 'enqueue_scripts' ) ) );
-		$this->assertNotFalse( has_action( 'current_screen', array( $post_list, 'add_thumbnail_filters_and_actions' ) ) );
+		$this->assertNotFalse( has_action( 'current_screen', array( $post_list, 'add_filters_and_actions' ) ) );
 
 		// Confirm it was only fired once even though we call it twice.
 		$post_list->register();
@@ -68,9 +68,9 @@ class Test_Post_List extends BaseTestCase {
 	}
 
 	/**
-	 * Test the add_thumbnail_filters_and_actions() method.
+	 * Test the add_filters_and_actions() method.
 	 */
-	public function test_add_thumbnail_filters_and_actions() {
+	public function test_add_filters_and_actions() {
 		$post_list = Post_List::get_instance();
 
 		// Confirm that our style, filter, and action have not been added before the enqueue_scripts() method call.
@@ -80,7 +80,7 @@ class Test_Post_List extends BaseTestCase {
 		$this->assertFalse( has_action( 'manage_pages_custom_column' ) );
 
 		$current_screen = (object) array( 'base' => 'edit' );
-		$post_list->add_thumbnail_filters_and_actions( $current_screen );
+		$post_list->add_filters_and_actions( $current_screen );
 
 		// Assert that our style, filter, and action has been added.
 		$this->assertTrue( has_filter( 'manage_posts_columns' ) );
@@ -90,12 +90,12 @@ class Test_Post_List extends BaseTestCase {
 	}
 
 	/**
-	 * Test the add_thumbnail_filters_and_actions() method doesn't add if screen not 'edit' base.
+	 * Test the add_filters_and_actions() method doesn't add if screen not 'edit' base.
 	 */
-	public function test_add_thumbnail_filters_and_actions_wrong_screen() {
+	public function test_add_filters_and_actions_wrong_screen() {
 		$post_list      = Post_List::get_instance();
 		$current_screen = (object) array( 'base' => 'edit-tags' );
-		$post_list->add_thumbnail_filters_and_actions( $current_screen );
+		$post_list->add_filters_and_actions( $current_screen );
 
 		// Confirm that our style, filter, and action have not been added before the enqueue_scripts() method call.
 		$this->assertFalse( has_filter( 'manage_posts_columns' ) );


### PR DESCRIPTION
This adds the share action to the post list for the 'post' and 'page'
post types. It uses the query parameter to ensure the Jetpack sidebar is
open when the editor loads.

Determining exactly when it's appropriate to have the Share action
available is tricky and based on context. For now we are using a filter,
so the exact logic can be applied as the Post List package is configured
for each environment.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #21299

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Require the post list package and configure it in the same way as in #21274
* Add a filter to force the display of the action `add_filter( 'jetpack_post_list_display_share_action', '__return_true' );`
* Check that you can see a 'Share' post action on the Posts and Pages screens, and that it links to the editor with the `jetpackSidebarIsOpen` set to true.

<img width="911" alt="image" src="https://user-images.githubusercontent.com/96462/136104435-c13b9ff4-4753-4fe0-b9dc-a129a2ae6c06.png">

