### PR TITLE
Milestone widget: Fix styles of the widget fields

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-milestone-widget-styles
+++ b/projects/plugins/jetpack/changelog/fix-milestone-widget-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Milestone widget: Fix styles of w widget fields

--- a/projects/plugins/jetpack/modules/widgets/milestone/style-admin.css
+++ b/projects/plugins/jetpack/modules/widgets/milestone/style-admin.css
@@ -48,3 +48,23 @@
 		width: 4em;
 	}
 }
+
+/* Fix styles of the Milestone block when it is dispayed as a part of the Legacy Widget block */
+.wp-block-legacy-widget__edit-form .widget-inside .widget-content .jp-ms-data-time .month {
+    display: inline-block;
+    width: 5.4em;
+}
+
+.wp-block-legacy-widget__edit-form .widget-inside .widget-content .jp-ms-data-time input[type="text"] {
+    display: inline-block;
+    width: 3.2em;
+}
+
+.wp-block-legacy-widget__edit-form .widget-inside .widget-content .jp-ms-data-time .year[type="text"] {
+    width: 4.5em;
+}
+
+.editor-styles-wrapper ul.milestone-type {
+    list-style-type: none;
+	padding-left: 0;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The Milestone widget CSS is [overridden](https://build.trac.wordpress.org/browser/trunk/wp-includes/css/dist/widgets/style.css#L119) by the Legacy Widget block CSS in core. This fact is causing the Milestone widget styles to break - as can be seen in the screenshot below.

The proposed change adds extra CSS to the Milestone widget to fix the issue.

**Before:**
![Markup on 2021-10-06 at 14:10:43](https://user-images.githubusercontent.com/25105483/136199752-d8e27811-6afa-4d1f-bdef-7c1b4291c5be.png)

**After:**
![Markup on 2021-10-06 at 14:12:04](https://user-images.githubusercontent.com/25105483/136199757-5287b5ba-9c9d-46ad-8b1a-9caa9d739e60.png)

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Open Customizer and add the Milestone widget.
2. Review the widget fields. They should be formatted correctly.
