### PR TITLE
Sync Checksums :: Explicitly ignore locale if same as site setting

### DIFF
--- a/projects/packages/sync/changelog/fix-user-checksum-locale
+++ b/projects/packages/sync/changelog/fix-user-checksum-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync Checksums - exclude locale from checksum if same as site setting

--- a/projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php
@@ -89,7 +89,8 @@ class Table_Checksum_Usermeta extends Table_Checksum {
 							)
 						);
 					}
-					if ( ! empty( $user_object->locale ) ) {
+					// Explicitly check that locale is not same as site locale.
+					if ( ! empty( $user_object->locale ) && get_locale() !== $user_object->locale ) {
 						$checksum_entry += crc32(
 							implode(
 								'#',


### PR DESCRIPTION
During production testing of the Sync Checksums we noticed that user meta checksums were leading to consistent discrepancies. Upon review it was determined that the locale was being included in the remote checksum although the Cache locale is not persisted as it has the same value as the site's value.

This patch explicitly checks the users locale against the site value so that it only adds checksum to the calculation if they are different.

Note this is not a break that requires a hotfix as we have not enabled the usermeta checksums at this time, however this is blocking me from rolling out the functionality so if we do a hotfix I would like to see this included if possible.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*Sync Checksums :: Explicitly ignore locale if same as site setting

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The easiest way to test this change is to apply pb 2a622 to your site and then append ?a8c-test=XSDF to the sites url. This will output Sync data and will exclude locale.
