### PR TITLE
Allow an empty message string in the publicize share endpoint.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
@@ -54,7 +54,7 @@ class WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post extends WP_REST_Controller
 						'type'              => 'string',
 						'required'          => true,
 						'validate_callback' => function ( $param ) {
-							return is_string( $param ) && '' !== $param;
+							return is_string( $param );
 						},
 						'sanitize_callback' => 'sanitize_textarea_field',
 					),

--- a/projects/plugins/jetpack/changelog/update-publicize-share-post-endpoint
+++ b/projects/plugins/jetpack/changelog/update-publicize-share-post-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Allow empty string in message parameter.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
@@ -189,12 +189,6 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post extends WP_Test_Je
 					'skipped_connections' => array(),
 				),
 			),
-			'message can not be an empty string.'      => array(
-				array(
-					'message'             => '',
-					'skipped_connections' => array(),
-				),
-			),
 			'message can not be an array.'             => array(
 				array(
 					'message'             => array(),


### PR DESCRIPTION
For backwards compatibility, the publicize share endpoint should allow an empty `message` string. An empty `message` string sets the response message to the title of the current post.

## Endpoint

**Jetpack**
`[POST]` `/wpcom/v2/posts/{$postId}/publicize`

**WPCom**
`[POST]` `/wpcom/v2/sites/{$siteId}/posts/{$postId}/publicize`

Posts a message immediately to all of the user's external sites connected to the Publicize feature (Twitter, Facebook, Tumblr, LinkedIn). The `message` is set as a required parameter (an empty string is allowed) and is associated with a post using the {$postId} in the route.

### Required Input Parameters
 * **message** [string] - This is the message to be posted to the external accounts. An empty string defaults the message to the title of the post.

### Optional Input Parameters
 * **skipped_connections** [array] - This is an array of external site connection IDs to skip (aka not send to).

#### Changes proposed in this Pull Request:
* Updates share endpoint schema to allow an empty message string.

#### Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Create and Publish a blog post on a Premium or better Simple site. Note the site name and post id for use later.
![sitename-post-id](https://user-images.githubusercontent.com/140841/135688919-2fcb6a97-7841-48e0-ab56-b56601931243.png)
* Make sure Publicize is enabled in "[Marketing Connections](https://wordpress.com/marketing/connections/)" and you have 1-4 external accounts linked.
* Checkout this PR's mirror patch D67984-code and Sandbox the API.
* Goto the developer API console: https://developer.wordpress.com/docs/api/console/
* In the console path select WP REST API, wpcom/v2, POST, and use the path `/sites/<your site name or ID>/posts/<your published post id>/publicize`
* Open up your Network Connections in your web browser's web developer tools.
* Submit your API call using the web form and right click the network item and select "Edit and Resend." -- I'm not sure if "Edit and Resend" in available in Chrome. You may need to use Firefox.
* Update the Request Body with `{"message":""}` and Send.
* Verify that your post was shared **_with the title of your post as the message_** to your external accounts. 👍 

### Unit Tests
To run this PR's unit tests:
 * git checkout update/add-publicize-share-post-endpoint
 * jetpack docker up
 * jetpack docker phpunit -- --filter=WP_Test_WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post