### PR TITLE
Sync Unit Test updates

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sync-test-settings
+++ b/projects/plugins/jetpack/changelog/fix-sync-test-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Update Sync Unit Tests to reset settings modified during tests.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -79,6 +79,11 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		do_action( 'my_action' );
 		$this->assertEquals( 3, $this->listener->get_sync_queue()->size() );
 
+		// reset queue settings.
+		Settings::update_settings( array( 'max_queue_size' => Defaults::$default_max_queue_size ) );
+		Settings::update_settings( array( 'max_queue_lag' => Defaults::$default_max_queue_lag ) );
+		$this->listener->set_defaults(); // should reset queue size limit.
+
 		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -52,39 +52,43 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 
 		$this->listener->set_defaults(); // should pick up new queue size limit
 
-		$this->assertEquals( 2, $this->listener->get_queue_size_limit() );
-		$this->assertEquals( 3, $this->listener->get_queue_lag_limit() );
-		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
+		try {
 
-		// now let's try exceeding the new limit
-		add_action( 'my_action', array( $this->listener, 'action_handler' ) );
+			$this->assertEquals( 2, $this->listener->get_queue_size_limit() );
+			$this->assertEquals( 3, $this->listener->get_queue_lag_limit() );
+			$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
 
-		$this->listener->force_recheck_queue_limit();
-		do_action( 'my_action' );
-		$this->assertEquals( 1, $this->listener->get_sync_queue()->size() );
+			// now let's try exceeding the new limit.
+			add_action( 'my_action', array( $this->listener, 'action_handler' ) );
 
-		$this->listener->force_recheck_queue_limit();
-		do_action( 'my_action' );
-		$this->assertEquals( 2, $this->listener->get_sync_queue()->size() );
+			$this->listener->force_recheck_queue_limit();
+			do_action( 'my_action' );
+			$this->assertEquals( 1, $this->listener->get_sync_queue()->size() );
 
-		$this->listener->force_recheck_queue_limit();
-		do_action( 'my_action' );
-		$this->assertEquals( 3, $this->listener->get_sync_queue()->size() );
+			$this->listener->force_recheck_queue_limit();
+			do_action( 'my_action' );
+			$this->assertEquals( 2, $this->listener->get_sync_queue()->size() );
 
-		// sleep for 3 seconds, so the oldest item in the queue is at least 3 seconds old -
-		// now our queue limit should kick in
-		sleep( 3 );
+			$this->listener->force_recheck_queue_limit();
+			do_action( 'my_action' );
+			$this->assertEquals( 3, $this->listener->get_sync_queue()->size() );
 
-		$this->listener->force_recheck_queue_limit();
-		do_action( 'my_action' );
-		$this->assertEquals( 3, $this->listener->get_sync_queue()->size() );
+			// sleep for 3 seconds, so the oldest item in the queue is at least 3 seconds old.
+			// now our queue limit should kick in.
+			sleep( 3 );
 
-		// reset queue settings.
-		Settings::update_settings( array( 'max_queue_size' => Defaults::$default_max_queue_size ) );
-		Settings::update_settings( array( 'max_queue_lag' => Defaults::$default_max_queue_lag ) );
-		$this->listener->set_defaults(); // should reset queue size limit.
+			$this->listener->force_recheck_queue_limit();
+			do_action( 'my_action' );
+			$this->assertEquals( 3, $this->listener->get_sync_queue()->size() );
 
-		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
+		} finally {
+			// reset queue settings.
+			Settings::update_settings( array( 'max_queue_size' => Defaults::$default_max_queue_size ) );
+			Settings::update_settings( array( 'max_queue_lag' => Defaults::$default_max_queue_lag ) );
+			$this->listener->set_defaults(); // should reset queue size limit.
+
+			remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
+		}
 	}
 
 	function test_does_listener_add_actor_to_queue() {

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -28,7 +28,7 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		$updated_settings = Settings::get_settings();
 
 		// reset original value.
-		$settings['$dequeue_max_bytes'] = $dequeue_max_bytes;
+		$settings['dequeue_max_bytes'] = $dequeue_max_bytes;
 		Settings::update_settings( $settings );
 
 		$this->assertSame( 50, $updated_settings['dequeue_max_bytes'] );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -5,7 +5,8 @@ use Automattic\Jetpack\Sync\Settings;
 class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 	function test_can_write_settings() {
 		$settings = Settings::get_settings();
-
+		// store original value.
+		$dequeue_max_bytes = $settings['dequeue_max_bytes'];
 		foreach (
 			array(
 				'dequeue_max_bytes',
@@ -25,6 +26,10 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		Settings::update_settings( $settings );
 
 		$updated_settings = Settings::get_settings();
+
+		// reset original value.
+		$settings['$dequeue_max_bytes'] = $dequeue_max_bytes;
+		Settings::update_settings( $settings );
 
 		$this->assertSame( 50, $updated_settings['dequeue_max_bytes'] );
 	}


### PR DESCRIPTION
In #21296 we reduced the default settings for max_queue_size. After merger it was identified that existing tests were failing as the transient would expire and lead to can_add_to_queue returning false unexpectedly.  This resets the settings in tests that were reducing the queue size and lag so that tests can move forward with expected default behaviors.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Unit Test updates


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify Unit Tests all complete without issue.
