### PR TITLE
Use distinct query for Term Relationships

### DIFF
--- a/projects/packages/sync/changelog/fix-checksum-count-term-relationships
+++ b/projects/packages/sync/changelog/fix-checksum-count-term-relationships
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync Checksums - use distinct query when calculating count of Term Relationships

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -665,7 +665,7 @@ class Table_Checksum {
 
 		// Only make the distinct count when we know there can be multiple entries for the range column.
 		$distinct_count = '';
-		if ( count( $this->key_fields ) > 1 || 'terms' === $this->table ) {
+		if ( count( $this->key_fields ) > 1 || 'terms' === $this->table || 'term_relationships' === $this->table ) {
 			$distinct_count = 'DISTINCT';
 		}
 


### PR DESCRIPTION
Continued testing of the Checksum/Fix routine has revealed that the item_count for term relationships table are inconsistent. This is due to object_id belonging to multiple terms and having duplicate entries in the table. This patch ensures that distinct is used for the item_count query allowing us to have an accurate value for reporting of Accuracy.

Same fix as applied to Terms :: https://github.com/Automattic/jetpack/pull/21100

#### Changes proposed in this Pull Request:

Add distinct clause for term relationships table item counts

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Go to 'wp shell' on the jetpack site
$store = new Automattic\Jetpack\Sync\Replicastore();
$store->checksum_histogram( 'term_relationships', 1, null, null, null, true, '', false, true, false );
verify that the item_count returned matches the number of entries in the histogram.