### PR TITLE
Fix menu visibility in Admin UI package

### DIFF
--- a/projects/packages/admin-ui/changelog/fix-admin-ui-register-menu
+++ b/projects/packages/admin-ui/changelog/fix-admin-ui-register-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixing menu visibility issues

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -61,11 +61,10 @@ class Admin_Menu {
 	 * @return void
 	 */
 	public static function admin_menu_hook_callback() {
-		global $submenu;
+		$can_see_toplevel_menu  = true;
+		$jetpack_plugin_present = class_exists( 'Jetpack_React_Page' );
 
-		$can_see_toplevel_menu = true;
-
-		if ( ! isset( $submenu['jetpack'] ) ) {
+		if ( ! $jetpack_plugin_present ) {
 			add_action( 'admin_print_scripts', array( __CLASS__, 'enqueue_style' ) );
 			add_menu_page(
 				'Jetpack',
@@ -76,6 +75,7 @@ class Admin_Menu {
 				'div',
 				3
 			);
+
 			// If Jetpack plugin is not present, user will only be able to see this menu if they have enough capability to at least one of the sub menus being added.
 			$can_see_toplevel_menu = false;
 		}
@@ -98,7 +98,9 @@ class Admin_Menu {
 			);
 		}
 
-		remove_submenu_page( 'jetpack', 'jetpack' );
+		if ( ! $jetpack_plugin_present ) {
+			remove_submenu_page( 'jetpack', 'jetpack' );
+		}
 
 		if ( ! $can_see_toplevel_menu ) {
 			remove_menu_page( 'jetpack' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

We just merged the Admin UI package with the menu registration feature and identified some situations where

* we would not have access to the Jetpack menu when Jetpack was disconnected
* we would see two menu entries for Jetpack

This PR fixes it

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes menu registration

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1633693179283900-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test all the combination possible of Jetpack and Backup plugins
* Test Jetpack being connected and not connected
* Only Jetpack plugin
* Jetpack and Backup
* only Backup plugin
* Make sure the menu looks good in all combinations
*