### PR TITLE
Change the menu label to only Backup

### DIFF
--- a/projects/plugins/backup/changelog/update-rename-backup-menu
+++ b/projects/plugins/backup/changelog/update-rename-backup-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Changed menu label

--- a/projects/plugins/backup/src/php/class-jetpack-backup.php
+++ b/projects/plugins/backup/src/php/class-jetpack-backup.php
@@ -28,7 +28,7 @@ class Jetpack_Backup {
 
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Backup', 'jetpack-backup' ),
-			__( 'Jetpack Backup', 'jetpack-backup' ),
+			_x( 'Backup', 'The Jetpack Backup product name, without the Jetpack prefix', 'jetpack-backup' ),
 			'manage_options',
 			'jetpack-backup',
 			array( $this, 'plugin_settings_page' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

The menu entry below Jetpack top level menu should be only "Backup" and not "Jetpack Backup".

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes the menu label removing the Jetpack prefix

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/21345#pullrequestreview-775186897

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Backup plugin
* Check that the menu entry is only "Backup"
* Check that the page title is still "Jetpack Backup"
* Check if the `_x` context is good

