### PR TITLE
JS Package: Add ExPlat A/B Testing component

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,7 @@
 				"@automattic/jetpack-base-styles",
 				"@automattic/jetpack-components",
 				"@automattic/jetpack-connection",
+				"@automattic/jetpack-explat",
 				"@automattic/jetpack-idc",
 				"@automattic/jetpack-storybook",
 				"automattic/jetpack-a8c-mc-stats",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,23 @@ importers:
       jetpack-js-test-runner: link:../../../tools/js-test-runner
       nyc: 15.1.0
 
+  projects/js-packages/explat:
+    specifiers:
+      '@automattic/explat-client': 0.0.2
+      '@automattic/explat-client-react-helpers': 0.0.2
+      '@types/cookie': 0.4.1
+      cookie: ^0.4.1
+      jetpack-js-test-runner: workspace:*
+      qs: 6.9.6
+    dependencies:
+      '@automattic/explat-client': 0.0.2
+      '@automattic/explat-client-react-helpers': 0.0.2
+      cookie: 0.4.1
+      jetpack-js-test-runner: link:../../../tools/js-test-runner
+      qs: 6.9.6
+    devDependencies:
+      '@types/cookie': 0.4.1
+
   projects/js-packages/idc:
     specifiers:
       '@automattic/jetpack-api': workspace:^0.3.0-alpha
@@ -544,6 +561,7 @@ importers:
       '@automattic/jetpack-api': workspace:^0.3.0-alpha
       '@automattic/jetpack-components': workspace:^0.3.1
       '@automattic/jetpack-connection': workspace:^0.7.0-alpha
+      '@automattic/jetpack-explat': workspace:^0.1.0-alpha
       '@automattic/popup-monitor': 1.0.0
       '@automattic/request-external-access': 1.0.0
       '@automattic/social-previews': 1.1.1
@@ -683,6 +701,7 @@ importers:
       '@automattic/jetpack-api': link:../../js-packages/api
       '@automattic/jetpack-components': link:../../js-packages/components
       '@automattic/jetpack-connection': link:../../js-packages/connection
+      '@automattic/jetpack-explat': link:../../js-packages/explat
       '@automattic/popup-monitor': 1.0.0
       '@automattic/request-external-access': 1.0.0
       '@automattic/social-previews': 1.1.1_e3caced6dfd46fdc5acad859788fe6d3
@@ -1215,6 +1234,18 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-modal: 3.14.3_react-dom@17.0.2+react@17.0.2
+    dev: false
+
+  /@automattic/explat-client-react-helpers/0.0.2:
+    resolution: {integrity: sha512-0B4Z8u54sCrbPmD+Vy25JKEz6CpdFYJUSnrWuD3s90Gz+s3RsewDwW2LTm9w1BggXNslz0PzeK/x7JlsYWD3XQ==}
+    dependencies:
+      '@automattic/explat-client': 0.0.2
+      react: 16.14.0
+      tslib: 2.3.1
+    dev: false
+
+  /@automattic/explat-client/0.0.2:
+    resolution: {integrity: sha512-HOuudV8eRkDmEFCNO8aXiJfirPYBKglIXCNXfNqDzTrEP9rPfomry3DS2bmV17ZcVauQbNHaXjXpxHtEskeYZg==}
     dev: false
 
   /@automattic/format-currency/1.0.0-alpha.0:
@@ -6158,6 +6189,10 @@ packages:
 
   /@types/color-name/1.1.1:
     resolution: {integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==}
+    dev: true
+
+  /@types/cookie/0.4.1:
+    resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: true
 
   /@types/eslint-scope/3.7.1:
@@ -19109,6 +19144,11 @@ packages:
     resolution: {integrity: sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==}
     engines: {node: '>=0.6'}
     dev: true
+
+  /qs/6.9.6:
+    resolution: {integrity: sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==}
+    engines: {node: '>=0.6'}
+    dev: false
 
   /qss/2.0.3:
     resolution: {integrity: sha512-j48ZBT5IZbSqJiSU8EX4XrN8nXiflHvmMvv2XpFc31gh7n6EpSs75bNr6+oj3FOLWyT8m09pTmqLNl34L7/uPQ==}

--- a/projects/js-packages/explat/.gitattributes
+++ b/projects/js-packages/explat/.gitattributes
@@ -1,0 +1,7 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+node_modules      export-ignore
+
+# Files to exclude from the mirror repo
+/changelog/**     production-exclude
+/.eslintrc.cjs    production-exclude

--- a/projects/js-packages/explat/.gitignore
+++ b/projects/js-packages/explat/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/js-packages/explat/.nycrc
+++ b/projects/js-packages/explat/.nycrc
@@ -1,0 +1,5 @@
+{
+	"extensions": [".js", ".jsx"],
+	"exclude": "**/test/*.jsx",
+	"reporter": "clover"
+}

--- a/projects/js-packages/explat/CHANGELOG.md
+++ b/projects/js-packages/explat/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/projects/js-packages/explat/README.md
+++ b/projects/js-packages/explat/README.md
@@ -1,0 +1,41 @@
+# ExPlat
+
+Jetpack RNA component and utils for A/B testing.
+
+## How to install ExPlat
+
+### Installation From Git Repo
+
+This package assumes that your code will run in an ES2015+ environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using core-js or @babel/polyfill will add support for these methods. Learn more about it in Babel docs.
+
+## Usage
+
+```js
+import { Experiment } from '@automattic/jetpack-explat';
+
+const DefaultExperience = <div>Hello World!</div>;
+
+const TreatmentExperience = <div>Hello Jetpack!</div>;
+
+const LoadingExperience = <div>⏰</div>;
+
+<Experiment
+	name="jetpack_example_experiment"
+	defaultExperience={ DefaultExperience }
+	treatmentExperience={ TreatmentExperience }
+	loadingExperience={ LoadingExperience }
+/>;
+```
+
+## Contribute
+
+## Get Help
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+ExPlat is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/js-packages/explat/changelog/add-explat-package
+++ b/projects/js-packages/explat/changelog/add-explat-package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added A/B testing package

--- a/projects/js-packages/explat/composer.json
+++ b/projects/js-packages/explat/composer.json
@@ -1,0 +1,42 @@
+{
+	"name": "automattic/jetpack-explat",
+	"description": "Jetpack ExPlat RNA component and utils for A/B testing.",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "1.0.2",
+		"automattic/jetpack-changelogger": "^2.0"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"test-js": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm install",
+			"pnpm run test"
+		],
+		"test-coverage": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm install",
+			"pnpx nyc --report-dir=\"$COVERAGE_DIR\" pnpm run test"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"require-dev ": {
+		"automattic/jetpack-changelogger": "^2.0"
+	}
+}

--- a/projects/js-packages/explat/index.ts
+++ b/projects/js-packages/explat/index.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { createExPlatClient } from '@automattic/explat-client';
+import createExPlatClientReactHelpers from '@automattic/explat-client-react-helpers';
+
+/**
+ * Internal dependencies
+ */
+import { isDevelopmentMode } from './src/utils';
+import { logError } from './src/error';
+import { fetchExperimentAssignment } from './src/assignment';
+import { getAnonId, initializeAnonId } from './src/anon';
+
+declare global {
+	interface Window {
+		jetpackTracks: {
+			isEnabled: boolean;
+		};
+	}
+}
+
+/* @todo Jetpack: can Jetpack users disable event tracking? */
+/* @todo Jetpack: Remove this after we clarify if we have an equivalent of "Enable/Disable tracks". */
+window.jetpackTracks = {
+	isEnabled: true,
+};
+
+export const initializeExPlat = (): void => {
+	if ( window.jetpackTracks?.isEnabled ) {
+		initializeAnonId().catch( e => logError( { message: e.message } ) );
+	}
+};
+
+initializeExPlat();
+
+const exPlatClient = createExPlatClient( {
+	fetchExperimentAssignment,
+	getAnonId,
+	logError,
+	isDevelopmentMode,
+} );
+
+export const { loadExperimentAssignment, dangerouslyGetExperimentAssignment } = exPlatClient;
+const exPlatClientReactHelpers = createExPlatClientReactHelpers( exPlatClient );
+export const { useExperiment, Experiment, ProvideExperimentData } = exPlatClientReactHelpers;

--- a/projects/js-packages/explat/package.json
+++ b/projects/js-packages/explat/package.json
@@ -1,0 +1,37 @@
+{
+	"private": true,
+	"name": "@automattic/jetpack-explat",
+	"version": "0.1.0-alpha",
+	"description": "Jetpack ExPlat RNA component and utils for A/B testing.",
+	"homepage": "https://jetpack.com",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./!(node_modules)/**/test/*.@(jsx|js)'"
+	},
+	"engines": {
+		"node": "^14.17.6 || ^16.7.0",
+		"pnpm": "^6.5.0",
+		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	},
+	"exports": {
+		".": "./index.ts"
+	},
+	"dependencies": {
+		"@automattic/explat-client": "0.0.2",
+		"@automattic/explat-client-react-helpers": "0.0.2",
+		"cookie": "^0.4.1",
+		"jetpack-js-test-runner": "workspace:*",
+		"qs": "6.9.6"
+	},
+	"devDependencies": {
+		"@types/cookie": "0.4.1"
+	}
+}

--- a/projects/js-packages/explat/src/anon.ts
+++ b/projects/js-packages/explat/src/anon.ts
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { parse as CookieParser } from 'cookie';
+
+let initializeAnonIdPromise: null | Promise< string | null > = null;
+const anonIdPollingIntervalMilliseconds = 50;
+const anonIdPollingIntervalMaxAttempts = 100; // 50 * 100 = 5000 = 5 seconds
+
+/**
+ * Gather w.js anonymous cookie, tk_ai
+ */
+export const readAnonCookie = (): string | null => {
+	return CookieParser( document.cookie ).tk_ai || null;
+};
+
+/**
+ * Initializes the anonId:
+ * - Polls for AnonId receival
+ * - Should only be called once at startup
+ * - Happens to be safe to call multiple times if it is necessary to reset the anonId - something like this was necessary for testing.
+ *
+ * This purely for boot-time initialization, in usual circumstances it will be retrieved within 100-300ms, it happens in parallel booting
+ * so should only delay experiment loading that much for boot-time experiments. In some circumstances such as a very slow connection this
+ * can take a lot longer.
+ *
+ * The state of initializeAnonIdPromise should be used rather than the return of this function.
+ * The return is only avaliable to make this easier to test.
+ *
+ * Throws on error.
+ */
+export const initializeAnonId = async (): Promise< string | null > => {
+	let attempt = 0;
+	initializeAnonIdPromise = new Promise( res => {
+		const poll = () => {
+			const anonId = readAnonCookie();
+			if ( typeof anonId === 'string' && anonId !== '' ) {
+				res( anonId );
+				return;
+			}
+
+			if ( anonIdPollingIntervalMaxAttempts - 1 <= attempt ) {
+				res( null );
+				return;
+			}
+			attempt = attempt + 1;
+			setTimeout( poll, anonIdPollingIntervalMilliseconds );
+		};
+		poll();
+	} );
+
+	return initializeAnonIdPromise;
+};
+
+export const getAnonId = async (): Promise< string | null > => {
+	/* @todo Jetpack: can Jetpack users disable event tracking? */
+	if ( ! window.jetpackTracks?.isEnabled ) {
+		return null;
+	}
+
+	return await initializeAnonIdPromise;
+};

--- a/projects/js-packages/explat/src/assignment.ts
+++ b/projects/js-packages/explat/src/assignment.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { stringify } from 'qs';
+
+const EXPLAT_VERSION = '0.1.0';
+
+export const fetchExperimentAssignment = async ( {
+	experimentName,
+	anonId,
+}: {
+	experimentName: string;
+	anonId: string | null;
+} ): Promise< unknown > => {
+	/* @todo Jetpack: can Jetpack users disable event tracking? */
+	if ( ! window.jetpackTracks?.isEnabled ) {
+		throw new Error( `Tracking is disabled, can't fetch experimentAssignment` );
+	}
+
+	const params = stringify( {
+		experiment_name: experimentName,
+		anon_id: anonId ?? undefined,
+	} );
+
+	/* @todo Jetpack: dynamically replace "wpcom" with relevant platform. */
+	const response = await window.fetch(
+		`https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/wpcom?${ params }`
+	);
+
+	return await response.json();
+};

--- a/projects/js-packages/explat/src/error.ts
+++ b/projects/js-packages/explat/src/error.ts
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { isDevelopmentMode } from './utils';
+
+export const logError = ( error: Record< string, string > & { message: string } ): void => {
+	const onLoggingError = ( e: unknown ) => {
+		if ( isDevelopmentMode ) {
+			console.error( '[ExPlat] Unable to send error to server:', e ); // eslint-disable-line no-console
+		}
+	};
+
+	try {
+		const { message, ...properties } = error;
+		const logStashError = {
+			message,
+			properties: {
+				...properties,
+				context: 'explat',
+				/* @todo Jetpack: dynamically replace "wpcom" with relevant platform. */
+				explat_client: 'woocommerce',
+			},
+		};
+
+		if ( isDevelopmentMode ) {
+			console.error( '[ExPlat] ', error.message, error ); // eslint-disable-line no-console
+		} else {
+			if ( ! window.jetpackTracks?.isEnabled ) {
+				throw new Error( `Tracking is disabled, can't send error to the server` );
+			}
+
+			const body = new window.FormData();
+			body.append( 'error', JSON.stringify( logStashError ) );
+			window
+				.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error', {
+					method: 'POST',
+					body,
+				} )
+				.catch( onLoggingError );
+		}
+	} catch ( e ) {
+		onLoggingError( e );
+	}
+};

--- a/projects/js-packages/explat/src/error.ts
+++ b/projects/js-packages/explat/src/error.ts
@@ -18,7 +18,7 @@ export const logError = ( error: Record< string, string > & { message: string } 
 				...properties,
 				context: 'explat',
 				/* @todo Jetpack: dynamically replace "wpcom" with relevant platform. */
-				explat_client: 'woocommerce',
+				explat_client: 'wpcom',
 			},
 		};
 

--- a/projects/js-packages/explat/src/utils.ts
+++ b/projects/js-packages/explat/src/utils.ts
@@ -1,5 +1,4 @@
 /**
  * Boolean determining if environment is development.
  */
-// export const isDevelopmentMode = process.env.NODE_ENV === 'development';
-export const isDevelopmentMode = false;
+export const isDevelopmentMode = process.env.NODE_ENV === 'development';

--- a/projects/js-packages/explat/src/utils.ts
+++ b/projects/js-packages/explat/src/utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Boolean determining if environment is development.
+ */
+// export const isDevelopmentMode = process.env.NODE_ENV === 'development';
+export const isDevelopmentMode = false;

--- a/projects/js-packages/explat/test-main.jsx
+++ b/projects/js-packages/explat/test-main.jsx
@@ -1,0 +1,7 @@
+/**
+ * External dependencies
+ */
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+
+Enzyme.configure( { adapter: new Adapter() } );

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { __, _x } from '@wordpress/i18n';
 import { ProgressBar } from '@automattic/components';
+import { Experiment } from '@automattic/jetpack-explat';
 
 /**
  * Internal dependencies
@@ -102,10 +103,23 @@ const ProductSuggestionsComponent = props => {
 		</div>
 	);
 
+	const question = (
+		<Experiment
+			name="jetpack_plugin_implementation_test"
+			defaultExperience={ _x( 'Choose a plan', 'Recommendations Product Suggestions', 'jetpack' ) }
+			treatmentExperience={ _x(
+				'Select a plan',
+				'Recommendations Product Suggestions',
+				'jetpack'
+			) }
+			loadingExperience={ '⏰ Loading title... ⏰' }
+		/>
+	);
+
 	return (
 		<PromptLayout
 			progressBar={ <ProgressBar color={ '#00A32A' } value={ '33' } /> }
-			question={ _x( 'Choose a plan', 'Recommendations Product Suggestions', 'jetpack' ) }
+			question={ question }
 			description={ _x(
 				'These are the most popular Jetpack plans for sites like yours:',
 				'Recommendations Product Suggestions',

--- a/projects/plugins/jetpack/changelog/add-explat-package
+++ b/projects/plugins/jetpack/changelog/add-explat-package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added A/B test for product suggestions title

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -67,6 +67,7 @@
 		"@automattic/jetpack-api": "workspace:^0.3.0-alpha",
 		"@automattic/jetpack-components": "workspace:^0.3.1",
 		"@automattic/jetpack-connection": "workspace:^0.7.0-alpha",
+		"@automattic/jetpack-explat": "workspace:^0.1.0-alpha",
 		"@automattic/popup-monitor": "1.0.0",
 		"@automattic/request-external-access": "1.0.0",
 		"@automattic/social-previews": "1.1.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
### Description.

This PR aims to add a ExPlat React Component by porting the work done over at [WooCommerce/woocommerce-admin](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/explat).
This PR is partly related to #19596 but not really. It implements the new ExPlat system but for React and not PHP.

### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add ExPlat RNA component.

### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* p9dueE-3Cb-p2

### Usage example

```js
import { Experiment } from '@automattic/jetpack-explat';

const DefaultExperience = <div>Hello World!</div>;
const TreatmentExperience = <div>Hello Jetpack!</div>;
const LoadingExperience = <div>⏰</div>;

<Experiment
	name="jetpack_example_experiment"
	defaultExperience={ DefaultExperience }
	treatmentExperience={ TreatmentExperience }
	loadingExperience={ LoadingExperience }
/>;
```

### Remaining work

- [x] Add/register the package itself.
- [ ] Test `\Automattic\Jetpack\Tracking` compatibility.*
- [ ] Check that treatments/variants work.*
- [ ] Dynamic platform names.*
- [ ] Disable tracking.*
- [ ] TypeScript support*
- [ ] Publish the `@automattic/jetpack-explat` package? It's currently set to private in `package.json`.
- [ ] Update `README.md` with last information.
- [ ] Remove the Jetpack Plugin experiment when testing is done.

**Test `\Automattic\Jetpack\Tracking` compatibility.**
We want to make sure that we don't conflict with existing tracking logic which e.g. use the same "anonymous user" cookie. 

**Check that treatments/variants work**
I've created a new experiment in ExPlat named `jetpack_plugin_implementation_test` which will work from Oct. 13th, so from the 13th and forward, [the experiment I've set up in the assistant](https://github.com/Automattic/jetpack/pull/21372/commits/94f9193ff6518798ef9be774d41c660109924d97) should show different titles on the `/wp-admin/admin.php?page=jetpack#/recommendations/product-suggestions` step.

I've added it there since the experiment uses Jetpack product purchases as its metric, so if we make some Jetpack purchases through the recommendations flow, then we should be able to see A/B data in ExPlat.

**Dynamic platform names**

_If you don't know what a platform is, then I would suggest quickly going through the product discussion link._ 

It's possible to search for `/* @todo Jetpack: dynamically replace "wpcom" with relevant platform. */` in the new package and find all the places where we are temporarily using `wpcom` as the platform.
If we end up using a single platform for all RNA experiments, then this should just be replaced. If we start using different platforms for each plugin project, then this needs to be dynamically defined. 

**Disable tracking**

It's possible to search for  `/* @todo Jetpack: can Jetpack users disable event tracking? */` in the new package and find all instances where we listen for any "disable tracking" actions the Jetpack plugin might have.
I am not aware if we actually support this option, but it existed in the WooCommerce version so I wanted to let this be up to crew.

**TypeScript support?**

If you look at [the initial commit](https://github.com/Automattic/jetpack/pull/21372/commits/3173112d6df1224ee049a750a7827b2fe384ca73) you'll see that it was committed as "not verified" because of the listed linting errors.
The linting errors themselves could "hint" (🃏 ) that TS might not be fully supported in the monorepo. That being said, I did find some `.ts` files in the Boost plugin, so it's not the first time strict TS has been used.

### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

This PR is aimed to only add the `js-package/explat` package, so no changes are directly implemented. 

### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

_**This test will be changed at some point since we need to clean out the Jetpack Plugin "test" to only add the JS Package.**_

* Go to `/wp-admin/admin.php?page=jetpack#/recommendations/product-suggestions` and the "Select a Plan" title should show:
  1. Initial: A loading state.
  2. After load: Either "Choose a plan" or "Select a plan" based on the experiment test.