### PR TITLE
Photon: add support for HEIC file format.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-heic-format
+++ b/projects/plugins/jetpack/changelog/add-heic-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Image CDN: add support for HEIC file format.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1367,7 +1367,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			'thumbnails'  => array(),
 		);
 
-		if ( in_array( $ext, array( 'jpg', 'jpeg', 'png', 'gif', 'webp' ), true ) ) {
+		if ( in_array( $ext, array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'heic' ), true ) ) {
 			$metadata = wp_get_attachment_metadata( $media_item->ID );
 			if ( isset( $metadata['height'], $metadata['width'] ) ) {
 				$response['height'] = $metadata['height'];

--- a/projects/plugins/jetpack/class.photon.php
+++ b/projects/plugins/jetpack/class.photon.php
@@ -29,6 +29,7 @@ class Jetpack_Photon {
 		'jpeg',
 		'png',
 		'webp', // Jetpack assumes Photon_OpenCV backend class is being used on the server. See link in docblock.
+		'heic',
 	);
 
 	/**

--- a/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
+++ b/projects/plugins/jetpack/modules/search/instant-search/lib/hooks/use-photon.js
@@ -30,9 +30,9 @@ export function usePhoton( initialSrc, width, height, isPhotonEnabled = true ) {
 	const [ src, setSrc ] = useState( null );
 	const initialSrcWithoutQueryString = stripQueryString( initialSrc );
 
-	// Photon only supports GIF, JPG, PNG and WebP images
+	// Photon supports GIF, JPG, PNG, WebP, and HEIC images
 	// @see https://developer.wordpress.com/docs/photon/
-	const supportedImageTypes = [ 'gif', 'jpg', 'jpeg', 'png', 'webp' ];
+	const supportedImageTypes = [ 'gif', 'jpg', 'jpeg', 'png', 'webp', 'heic' ];
 	const fileExtension = initialSrcWithoutQueryString
 		?.substring( initialSrcWithoutQueryString.lastIndexOf( '.' ) + 1 )
 		.toLowerCase();

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -580,7 +580,7 @@ abstract class SAL_Post {
 			'thumbnails'   => array()
 		);
 
-		if ( in_array( $ext, array( 'jpg', 'jpeg', 'png', 'gif', 'webp' ), true ) ) {
+		if ( in_array( $ext, array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'heic' ), true ) ) {
 			$metadata = wp_get_attachment_metadata( $media_item->ID );
 			if ( isset( $metadata['height'], $metadata['width'] ) ) {
 				$response['height'] = $metadata['height'];

--- a/projects/plugins/jetpack/tests/php/test_class.jetpack_photon.php
+++ b/projects/plugins/jetpack/tests/php/test_class.jetpack_photon.php
@@ -1474,6 +1474,7 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 			'jpeg'    => array( 'http://example.com/example-150x150.jpeg', true ),
 			'png'     => array( 'http://example.com/example-150x150.png', true ),
 			'webp'    => array( 'http://example.com/example-150x150.webp', true ),
+			'heic'    => array( 'http://example.com/example-150x150.heic', true ),
 			'invalid' => array( 'http://example.com/example-150x150.invalid', false ),
 
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Photon now accepts files using the `heic` format, and will serve an image using a browser-compatible image mime type in return. Let's support that in the Jetpack plugin.


*******

Previous work for the WebP format: #20473 

#### Jetpack product discussion

* p3topS-Tn-p2#comment-3806
* pMz3w-dYl-p2 

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Download this image: `https://jeherve.com/w/wp-content/uploads/2021/10/IMG_2477.heic`
* Upload it to a site using Jetpack with Photon active.
* Go to Posts > Add New and create a new image block with that new image.
* You should see that image on the frontend, served with Photon.
* Go to Jetpack > Settings > Performance and ensure that Instant Search is active.
* Click to customize Instant Search and ensure that you are using the expanded mode, where thumbnails are displayed.
* Search for that post using the Instant Search interface.
* You should see the image appear in the search preview.