### PR TITLE
Use distinct query for Terms and Term Relationship tables.

### DIFF
--- a/projects/packages/sync/changelog/fix-term-relationship-count
+++ b/projects/packages/sync/changelog/fix-term-relationship-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync Checksums - Update distinct clause to use $wpdb-> table names to accouunt for differences in prefixes.

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -665,7 +665,7 @@ class Table_Checksum {
 
 		// Only make the distinct count when we know there can be multiple entries for the range column.
 		$distinct_count = '';
-		if ( count( $this->key_fields ) > 1 || 'terms' === $this->table || 'term_relationships' === $this->table ) {
+		if ( count( $this->key_fields ) > 1 || $wpdb->terms === $this->table || $wpdb->term_relationships === $this->table ) {
 			$distinct_count = 'DISTINCT';
 		}
 


### PR DESCRIPTION
Review after weekly release showed that the logic to add distinct to count querries in #21100 and #21329 was incorrect. The table names are not saved as shorthand but as the $wpdb->TABLE names in the $table property see https://github.com/Automattic/jetpack/blob/abf7cee9142beb258c96422f547fe1e8a9e71560/projects/packages/sync/src/replicastore/class-table-checksum.php#L335. 
This patch changes references of 'terms' to $wpdb->terms and 'term_relationships' to $wpdb->term_relationships

Changes proposed in this Pull Request:
Correctly add distinct clause for terms and term relationships table item counts

Does this pull request change what data or activity we track or use?
No

Testing instructions:
Go to 'wp shell' on the jetpack site
$store = new Automattic\Jetpack\Sync\Replicastore();
$store->checksum_histogram( 'term_relationships', 1, null, null, null, true, '', true, false, false );
$store->checksum_histogram( 'term_relationships', 1, null, null, null, true, '', false, true, false );
verify that the item_count returned from the first call of checksum_histogram equals the number of entries in the histogram returned in the second call.

$store->checksum_histogram( 'terms', 1, null, null, null, true, '', true, false, false );
$store->checksum_histogram( 'terms', 1, null, null, null, true, '', false, true, false );
verify that the item_count returned from the first call of checksum_histogram equals the number of entries in the histogram returned in the second call.