### PR TITLE
Search: Try rendering dashboard POC via class within helper package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       style-loader: 2.0.0_webpack@5.51.1
       webpack: 5.51.1
 
+  projects/packages/admin-ui:
+    specifiers: {}
+
   projects/packages/connection-ui:
     specifiers:
       '@automattic/calypso-build': 9.0.0
@@ -394,6 +397,55 @@ importers:
       eslint: 7.32.0
       webpack: 5.51.1
 
+  projects/packages/search:
+    specifiers:
+      '@automattic/calypso-build': 9.0.0
+      '@automattic/color-studio': 2.5.0
+      '@automattic/jetpack-api': workspace:^0.3.0-alpha
+      '@automattic/jetpack-components': workspace:0.3.1
+      '@automattic/jetpack-connection': workspace:^0.7.0-alpha
+      '@automattic/jetpack-idc': workspace:^0.2.0-alpha
+      '@babel/core': 7.15.0
+      '@babel/helper-module-imports': 7.14.5
+      '@babel/preset-env': 7.15.0
+      '@babel/register': 7.15.3
+      '@babel/runtime': 7.15.3
+      '@wordpress/data': 6.1.0
+      '@wordpress/dependency-extraction-webpack-plugin': 3.2.1
+      enzyme: 3.11.0
+      fancy-log: 1.3.3
+      gulp: 4.0.2
+      jest: 27.0.4
+      react: 17.0.2
+      react-dom: 17.0.2
+      react-redux: 6.0.1
+      static-site-generator-webpack-plugin: 3.4.2
+      webpack: 5.51.1
+    dependencies:
+      '@automattic/calypso-build': 9.0.0_1fe407fcee7f7b1b50bfdbf31ccbc0fe
+      '@automattic/color-studio': 2.5.0
+      '@automattic/jetpack-api': link:../../js-packages/api
+      '@automattic/jetpack-components': link:../../js-packages/components
+      '@automattic/jetpack-connection': link:../../js-packages/connection
+      '@automattic/jetpack-idc': link:../../js-packages/idc
+      '@babel/core': 7.15.0
+      '@babel/helper-module-imports': 7.14.5
+      '@babel/preset-env': 7.15.0_@babel+core@7.15.0
+      '@babel/register': 7.15.3_@babel+core@7.15.0
+      '@wordpress/data': 6.1.0_react@17.0.2
+      fancy-log: 1.3.3
+      gulp: 4.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-redux: 6.0.1_react@17.0.2
+      static-site-generator-webpack-plugin: 3.4.2
+      webpack: 5.51.1
+    devDependencies:
+      '@babel/runtime': 7.15.3
+      '@wordpress/dependency-extraction-webpack-plugin': 3.2.1_webpack@5.51.1
+      enzyme: 3.11.0
+      jest: 27.0.4
+
   projects/plugins/backup:
     specifiers:
       '@automattic/calypso-build': 9.0.0
@@ -489,14 +541,14 @@ importers:
     dependencies:
       '@wordpress/components': 17.0.0_@babel+core@7.15.0
       '@wordpress/element': 4.0.1
-      jetpack-boost-critical-css-gen: github.com/automattic/jetpack-boost-critical-css-gen/26df235cfd1bcc9003158d0bc8641a0450db796d
+      jetpack-boost-critical-css-gen: github.com/automattic/jetpack-boost-critical-css-gen/06b6b19c1e1208aacb26d54a304a4ea6741f0f21
     devDependencies:
       '@babel/core': 7.15.0
       '@babel/preset-env': 7.15.0_@babel+core@7.15.0
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.56.3
       '@rollup/plugin-node-resolve': 13.0.4_rollup@2.56.3
       '@rollup/plugin-typescript': 8.2.5_fb60d1099d0f1062e1f455c5bc85cce0
-      '@sveltejs/eslint-config': github.com/sveltejs/eslint-config/31fd4faeea88990069502460b023698b1c9c2d13_ae7c2b619eed51d24920213337b45f63
+      '@sveltejs/eslint-config': github.com/sveltejs/eslint-config/8a67624e4080bd7997606eb34981aa3346bc8de2_ae7c2b619eed51d24920213337b45f63
       '@tsconfig/svelte': 2.0.1
       '@typescript-eslint/eslint-plugin': 4.31.1_88f305769e96b090f653f547a92f5d5a
       '@typescript-eslint/parser': 4.31.1_eslint@7.32.0+typescript@4.3.5
@@ -1196,7 +1248,6 @@ packages:
 
   /@automattic/color-studio/2.5.0:
     resolution: {integrity: sha512-gZWaJbx3p1oennAIoJtMGluTmoM95Efk4rc44TSBxWSZZ8gH3Am2eh1o3i1NhrZmg2Zt3AiVFeZZ4AJccIpBKQ==}
-    dev: true
 
   /@automattic/components/1.0.0-alpha.3_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-6PgogtcbvKEM7dQDXMUBbnGkwhf+0h29p/6sd8jfNoDlSxJJylcfZCio0yWuVKiSLAm9KWozeY5cqgI0nRcuzg==}
@@ -2165,7 +2216,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
@@ -2173,6 +2223,14 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.15.0
+      '@babel/helper-plugin-utils': 7.14.5
+
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.15.5:
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.15.0:
@@ -2190,7 +2248,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -2303,6 +2360,14 @@ packages:
       '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.14.5
 
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.15.5:
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
@@ -2318,7 +2383,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.9:
     resolution: {integrity: sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==}
@@ -2372,7 +2436,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -2389,7 +2452,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.15.0:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -2406,7 +2468,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.9:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -2432,7 +2493,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -2449,7 +2509,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.15.0:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -2466,7 +2525,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -2504,7 +2562,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-syntax-typescript/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==}
@@ -2523,7 +2580,6 @@ packages:
     dependencies:
       '@babel/core': 7.15.5
       '@babel/helper-plugin-utils': 7.14.5
-    dev: true
 
   /@babel/plugin-transform-arrow-functions/7.14.5_@babel+core@7.15.0:
     resolution: {integrity: sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==}
@@ -4521,7 +4577,7 @@ packages:
     resolution: {integrity: sha512-xmB5vh81KK8DiiCMtI5vI59mP+GggNmc9BiN+fg4mKdQHV369+WuZc1Lq2xWFCOCsRPHt24D9h7Idp4YaMB1Ww==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       '@jest/types': 27.1.1
       babel-plugin-istanbul: 6.0.0
       chalk: 4.1.2
@@ -5129,7 +5185,7 @@ packages:
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@storybook/addons': 6.3.8_react@17.0.2
       '@storybook/api': 6.3.8_react@17.0.2
-      '@storybook/builder-webpack4': /@storybook/builder-webpack5/6.3.10_react@17.0.2
+      '@storybook/builder-webpack4': /@storybook/builder-webpack5/6.3.11_react@17.0.2
       '@storybook/client-api': 6.3.8_react@17.0.2
       '@storybook/client-logger': 6.3.8
       '@storybook/components': 6.3.8_react@17.0.2
@@ -5263,18 +5319,18 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addons/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-nrqyHPFGft6FhLXAB4xfebh3Xe/16574FSV3I96hyhcNwlxRs/ANLQriiDVElz3KfDqyFUIYMoskUBHZNRwWFA==}
+  /@storybook/addons/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-2Y03lOwzWDRB/glISa/4luBMM5uyYhkIBixbZF9miIb2SCWRlNmom5NCnKsR18Wu6g7zI7os3aAMfKr24aSofQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@storybook/api': 6.3.10_react@17.0.2
-      '@storybook/channels': 6.3.10
-      '@storybook/client-logger': 6.3.10
-      '@storybook/core-events': 6.3.10
-      '@storybook/router': 6.3.10_react@17.0.2
-      '@storybook/theming': 6.3.10_react@17.0.2
+      '@storybook/api': 6.3.11_react@17.0.2
+      '@storybook/channels': 6.3.11
+      '@storybook/client-logger': 6.3.11
+      '@storybook/core-events': 6.3.11
+      '@storybook/router': 6.3.11_react@17.0.2
+      '@storybook/theming': 6.3.11_react@17.0.2
       core-js: 3.18.0
       global: 4.4.0
       react: 17.0.2
@@ -5299,20 +5355,20 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/api/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-7fB6q718UWvgFI+ZqEU0QpXr5cHHli85bTq/w7kSz1VUWjV7vVqtxE3RTbIjMbKHkIVNkVUbZDeDi+r2soK9Tw==}
+  /@storybook/api/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-QmgXM613zy/DPrJLVRJnALT5Rh4VWgvxrHbdLxRWGDrMHNYlm3N1KA+a6ZtIM5Zl94B3y5o0SPCSleSbnA3viA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@reach/router': 1.3.4_react@17.0.2
-      '@storybook/channels': 6.3.10
-      '@storybook/client-logger': 6.3.10
-      '@storybook/core-events': 6.3.10
+      '@storybook/channels': 6.3.11
+      '@storybook/client-logger': 6.3.11
+      '@storybook/core-events': 6.3.11
       '@storybook/csf': 0.0.1
-      '@storybook/router': 6.3.10_react@17.0.2
+      '@storybook/router': 6.3.11_react@17.0.2
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.3.10_react@17.0.2
+      '@storybook/theming': 6.3.11_react@17.0.2
       '@types/reach__router': 1.3.9
       core-js: 3.18.0
       fast-deep-equal: 3.1.3
@@ -5357,8 +5413,8 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack5/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-fnDFS25dVaAapp5ECsnTPVQU0ws5Tpj/x8Lfa/wCqSmq5ia79O9pNFt5vQ+tumhjezYxSUeitI0vF1hHlQrJrg==}
+  /@storybook/builder-webpack5/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-ODBsR1cYjfDWg/P5sIkbij979BOMH43bHCe5cyjNA/5JhJh+NXadaldDWo25lK6tnEox64qHvdHIZnSuQXogSg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -5387,19 +5443,19 @@ packages:
       '@babel/preset-env': 7.15.6_@babel+core@7.15.5
       '@babel/preset-react': 7.14.5_@babel+core@7.15.5
       '@babel/preset-typescript': 7.15.0_@babel+core@7.15.5
-      '@storybook/addons': 6.3.10_react@17.0.2
-      '@storybook/api': 6.3.10_react@17.0.2
-      '@storybook/channel-postmessage': 6.3.10
-      '@storybook/channels': 6.3.10
-      '@storybook/client-api': 6.3.10_react@17.0.2
-      '@storybook/client-logger': 6.3.10
-      '@storybook/components': 6.3.10_react@17.0.2
-      '@storybook/core-common': 6.3.10_react@17.0.2
-      '@storybook/core-events': 6.3.10
-      '@storybook/node-logger': 6.3.10
-      '@storybook/router': 6.3.10_react@17.0.2
+      '@storybook/addons': 6.3.11_react@17.0.2
+      '@storybook/api': 6.3.11_react@17.0.2
+      '@storybook/channel-postmessage': 6.3.11
+      '@storybook/channels': 6.3.11
+      '@storybook/client-api': 6.3.11_react@17.0.2
+      '@storybook/client-logger': 6.3.11
+      '@storybook/components': 6.3.11_react@17.0.2
+      '@storybook/core-common': 6.3.11_react@17.0.2
+      '@storybook/core-events': 6.3.11
+      '@storybook/node-logger': 6.3.11
+      '@storybook/router': 6.3.11_react@17.0.2
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.3.10_react@17.0.2
+      '@storybook/theming': 6.3.11_react@17.0.2
       '@types/node': 14.17.17
       babel-loader: 8.2.2_80927b313c74087b681f254ee0e3e2fc
       babel-plugin-macros: 3.1.0
@@ -5509,12 +5565,12 @@ packages:
       - webpack-cli
     dev: true
 
-  /@storybook/channel-postmessage/6.3.10:
-    resolution: {integrity: sha512-LWzT0kvluQxMBOrVb6vPoZWx6GlFhmgoFRLJPsFhFmXS1FqmWolRvqKr2aIVHj+bpqS7ocngMKY8Zg+FuKwctQ==}
+  /@storybook/channel-postmessage/6.3.11:
+    resolution: {integrity: sha512-cXmDqs91CLrqPugLLVdmE6iPH0eWJ0LsO3uoYXGDIAkv+C1HJBn5VdO1/gBm/B+lpkZ++DYiZ0tRUOMKsuw8IQ==}
     dependencies:
-      '@storybook/channels': 6.3.10
-      '@storybook/client-logger': 6.3.10
-      '@storybook/core-events': 6.3.10
+      '@storybook/channels': 6.3.11
+      '@storybook/client-logger': 6.3.11
+      '@storybook/core-events': 6.3.11
       core-js: 3.18.0
       global: 4.4.0
       qs: 6.10.1
@@ -5533,8 +5589,8 @@ packages:
       telejson: 5.3.3
     dev: true
 
-  /@storybook/channels/6.3.10:
-    resolution: {integrity: sha512-olYxCiYjmhbCHtPe7HR1hdGYJZPuSowqVmhLbqrWMf4HFYqBkO3T7em1S+ztCvLPLKbIK6AM2JUom6ob1F8n4g==}
+  /@storybook/channels/6.3.11:
+    resolution: {integrity: sha512-slY3B1zRJaABrkFj2r89O0D6axQjeh6oyuJFrRZ7SoTK26ODi839LD+LwSpk40c4FoQAgT3pcJmjiFyUbBdtRg==}
     dependencies:
       core-js: 3.18.0
       ts-dedent: 2.2.0
@@ -5549,17 +5605,17 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/client-api/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-caqh/TJKQkKSjcBchx44+Fr5Mi9XjAmMvsIJHM2uZv6mV7KUzUqiZNIWj1gvIYeNBF9PXTWUIhEbu6xt65d0UA==}
+  /@storybook/client-api/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-YUiVZzQYaGqYCTp1Jcf7zviJSWq3no93wT8uCj2HLW7n56fa5Iwx1O29dY2lhBEGmJ3JjTPNeSrSrzoHb1AZRg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@storybook/addons': 6.3.10_react@17.0.2
-      '@storybook/channel-postmessage': 6.3.10
-      '@storybook/channels': 6.3.10
-      '@storybook/client-logger': 6.3.10
-      '@storybook/core-events': 6.3.10
+      '@storybook/addons': 6.3.11_react@17.0.2
+      '@storybook/channel-postmessage': 6.3.11
+      '@storybook/channels': 6.3.11
+      '@storybook/client-logger': 6.3.11
+      '@storybook/core-events': 6.3.11
       '@storybook/csf': 0.0.1
       '@types/qs': 6.9.7
       '@types/webpack-env': 1.16.2
@@ -5603,8 +5659,8 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/client-logger/6.3.10:
-    resolution: {integrity: sha512-fRwxPiwQBKHK83IJgA5VoFwbaEj9zHLdYGE1wxJXcBYP0hi5h5ZwnGkNumFDntw1xt+RUs5PsGQ16f+rzE3n+w==}
+  /@storybook/client-logger/6.3.11:
+    resolution: {integrity: sha512-U06IuAGZFOJYgtXH02dbNe5lHLcwsSo6JBdFLjcUP3C0WqtskoUGLA2XLUCYasl7OMB0mcLHy4GaZL4wtrW6+Q==}
     dependencies:
       core-js: 3.18.0
       global: 4.4.0
@@ -5617,16 +5673,16 @@ packages:
       global: 4.4.0
     dev: true
 
-  /@storybook/components/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-s9iOq0jT+h51hid4Vckmy84XAMm8aoZwD/QHpzWs4aRqrT5lqsen3jnlvqEEdEVUbMIoLPPNfOxOZsm4M/7zpQ==}
+  /@storybook/components/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-/iajr+kMXQLgXa6hr/nupcHFzdppZ4S/vdDgoyXW/L1jDeKzy5Bxzf4JjjoR/tY6jgiFRja1C1mUGFqceyb9ow==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@popperjs/core': 2.10.1
-      '@storybook/client-logger': 6.3.10
+      '@storybook/client-logger': 6.3.11
       '@storybook/csf': 0.0.1
-      '@storybook/theming': 6.3.10_react@17.0.2
+      '@storybook/theming': 6.3.11_react@17.0.2
       '@types/color-convert': 2.0.0
       '@types/overlayscrollbars': 1.12.1
       '@types/react-syntax-highlighter': 11.0.5
@@ -5687,8 +5743,8 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-client/6.3.10_react@17.0.2+webpack@5.51.1:
-    resolution: {integrity: sha512-UnVfFV7qvRI1o5P4lrMmp+DxEoogVYV0/QrlGJFrKotkG815e58OdVM00bQByMdbsId3Ao2TZM78uj1k2F5J7Q==}
+  /@storybook/core-client/6.3.11_react@17.0.2+webpack@5.51.1:
+    resolution: {integrity: sha512-GSVxt6ZnZPboZ0nRJ0b4+r8yL43l0uImgg6tsCwctxj/qvx4O9thh3zVfgu1i6BqG9auJoNby2dTZDaGkPLaIg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -5698,13 +5754,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/addons': 6.3.10_react@17.0.2
-      '@storybook/channel-postmessage': 6.3.10
-      '@storybook/client-api': 6.3.10_react@17.0.2
-      '@storybook/client-logger': 6.3.10
-      '@storybook/core-events': 6.3.10
+      '@storybook/addons': 6.3.11_react@17.0.2
+      '@storybook/channel-postmessage': 6.3.11
+      '@storybook/client-api': 6.3.11_react@17.0.2
+      '@storybook/client-logger': 6.3.11
+      '@storybook/core-events': 6.3.11
       '@storybook/csf': 0.0.1
-      '@storybook/ui': 6.3.10_react@17.0.2
+      '@storybook/ui': 6.3.11_react@17.0.2
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
       core-js: 3.18.0
@@ -5755,8 +5811,8 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-common/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-E6jlsSPJoISF8B/AwqDZpPNOviSeJTb+ODhnWqz/R4b6hSmuGSPp7LDdOMdQAjTURAxhhjLWQen4smDwuVNzHw==}
+  /@storybook/core-common/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-PR/TndBaItPjItoOMEYCE4rPZGF7dfuqh+SbL0pmk6yLqO5MTSPEVpLEutbKh3uYlt1mgb8cXLuTQ3ybkG5O+Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -5786,7 +5842,7 @@ packages:
       '@babel/preset-react': 7.14.5_@babel+core@7.15.5
       '@babel/preset-typescript': 7.15.0_@babel+core@7.15.5
       '@babel/register': 7.15.3_@babel+core@7.15.5
-      '@storybook/node-logger': 6.3.10
+      '@storybook/node-logger': 6.3.11
       '@storybook/semver': 7.3.2
       '@types/glob-base': 0.3.0
       '@types/micromatch': 4.0.2
@@ -5889,8 +5945,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@storybook/core-events/6.3.10:
-    resolution: {integrity: sha512-bw3HuqKIMDnEebVf2DG+TdX21D7z7LGFvr5rehNDnUTdnM9+pVLlZZfGkUU6LMRbIzr27CI5dXWdPRTA5kQIZg==}
+  /@storybook/core-events/6.3.11:
+    resolution: {integrity: sha512-wuWZsw2VB2qSuac+40SaeaZ40/4sQhYSnLSN+l944G1kkjZwZcVc1nBTaYBt9H7uH+INkmGblDbGNnme71KCjg==}
     dependencies:
       core-js: 3.18.0
     dev: true
@@ -5918,12 +5974,12 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.5
-      '@storybook/builder-webpack4': /@storybook/builder-webpack5/6.3.10_react@17.0.2
+      '@storybook/builder-webpack4': /@storybook/builder-webpack5/6.3.11_react@17.0.2
       '@storybook/builder-webpack5': 6.3.8_react@17.0.2
       '@storybook/core-client': 6.3.8_react@17.0.2+webpack@5.51.1
       '@storybook/core-common': 6.3.8_react@17.0.2
       '@storybook/csf-tools': 6.3.8_@babel+core@7.15.0
-      '@storybook/manager-webpack4': /@storybook/manager-webpack5/6.3.10_react@17.0.2
+      '@storybook/manager-webpack4': /@storybook/manager-webpack5/6.3.11_react@17.0.2
       '@storybook/manager-webpack5': 6.3.8_react@17.0.2
       '@storybook/node-logger': 6.3.8
       '@storybook/semver': 7.3.2
@@ -6021,8 +6077,8 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@storybook/manager-webpack5/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-wl57VS/iQl0pUxv4IOVO8BXn1HLeaIN9H62Ja2dJ1Nd3hKb8FiQdt9m81MB/Ig2wTqpclMq8Oribef8j9W4Vow==}
+  /@storybook/manager-webpack5/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-5QKzhyPIS73ZvjXSQLvAWh15aj/WFMulF0IQyZhXcA7e5bv/KDLuOJtJ8A6Ho71pWvl2LXYScVoky1TX5Bovjw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -6034,12 +6090,12 @@ packages:
       '@babel/core': 7.15.5
       '@babel/plugin-transform-template-literals': 7.14.5_@babel+core@7.15.5
       '@babel/preset-react': 7.14.5_@babel+core@7.15.5
-      '@storybook/addons': 6.3.10_react@17.0.2
-      '@storybook/core-client': 6.3.10_react@17.0.2+webpack@5.51.1
-      '@storybook/core-common': 6.3.10_react@17.0.2
-      '@storybook/node-logger': 6.3.10
-      '@storybook/theming': 6.3.10_react@17.0.2
-      '@storybook/ui': 6.3.10_react@17.0.2
+      '@storybook/addons': 6.3.11_react@17.0.2
+      '@storybook/core-client': 6.3.11_react@17.0.2+webpack@5.51.1
+      '@storybook/core-common': 6.3.11_react@17.0.2
+      '@storybook/node-logger': 6.3.11
+      '@storybook/theming': 6.3.11_react@17.0.2
+      '@storybook/ui': 6.3.11_react@17.0.2
       '@types/node': 14.17.17
       babel-loader: 8.2.2_80927b313c74087b681f254ee0e3e2fc
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -6131,8 +6187,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@storybook/node-logger/6.3.10:
-    resolution: {integrity: sha512-SqRoCCZxdyK/IJd5IWtNPWtK3g5xzoiFmX43ibPvL8qCl896m5U/+nhQ2vhaU+qd9BmH0LIZjU9QeUB3fsZAqg==}
+  /@storybook/node-logger/6.3.11:
+    resolution: {integrity: sha512-c6nsOk/AIux89/AVIydLA2ToqHWq4XoUKFkYJ/eOPJTLv3bdl7fV/5Vlx7EqRHqlXYCGbvTaDrMs+0tVHmp2vg==}
     dependencies:
       '@types/npmlog': 4.1.3
       chalk: 4.1.2
@@ -6232,14 +6288,14 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@storybook/router/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-cRyoNrBeBTOfiLYJumm0559cVJeO7z/ZDVcgLxi16uUjhu4nkio0chTwtdtrtTygKxJq8ibWq6LAjZAHDoeq8g==}
+  /@storybook/router/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-R9Den9xCGhU5CLx4wi79uHbJqKqpZO7QDpENZGL7bT/IDid7szqFldztrzvmC5LE1TBpU6VQjEGaITWMrG2tsw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@reach/router': 1.3.4_react@17.0.2
-      '@storybook/client-logger': 6.3.10
+      '@storybook/client-logger': 6.3.11
       '@types/reach__router': 1.3.9
       core-js: 3.18.0
       fast-deep-equal: 3.1.3
@@ -6298,8 +6354,8 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/theming/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-yX7qKrnFaa1otjrf21dP9HpMLJLw+iV7gcNo/RVkPSixWzglCIGgQ8T6vVjfjIgBUl6KbiE2qwqaFjLLe4fIYQ==}
+  /@storybook/theming/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-MbEaGYP9nqu/Sv/FBK/7jRRHGe34TZ7tmZj6ZWE0KZih4Ey39LjPY6XcJ1rMDZclrXmT98p3+KClzdwKD0/Tdw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -6307,7 +6363,7 @@ packages:
       '@emotion/core': 10.1.1_react@17.0.2
       '@emotion/is-prop-valid': 0.8.8
       '@emotion/styled': 10.0.27_33bb31e1d857102242df3642b32eda18
-      '@storybook/client-logger': 6.3.10
+      '@storybook/client-logger': 6.3.11
       core-js: 3.18.0
       deep-object-diff: 1.1.0
       emotion-theming: 10.0.27_33bb31e1d857102242df3642b32eda18
@@ -6340,22 +6396,22 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/ui/6.3.10_react@17.0.2:
-    resolution: {integrity: sha512-TkaHgpTBp0nBr6A/v04k1V2rbRy7ajAoL9bFSU7hLNXDyQInUzT/p13+4JMR2TANSzPAycJNa3zRbO7n1MgV5w==}
+  /@storybook/ui/6.3.11_react@17.0.2:
+    resolution: {integrity: sha512-Jy6J7GRCgcnCp6jOpGcGcjHfzMVqFJ8gnLzrvTPR6EQBl9sJlJMVvYyj/52fDTnrRj+mjs8+cnkQwUHg+U/yrA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@emotion/core': 10.1.1_react@17.0.2
-      '@storybook/addons': 6.3.10_react@17.0.2
-      '@storybook/api': 6.3.10_react@17.0.2
-      '@storybook/channels': 6.3.10
-      '@storybook/client-logger': 6.3.10
-      '@storybook/components': 6.3.10_react@17.0.2
-      '@storybook/core-events': 6.3.10
-      '@storybook/router': 6.3.10_react@17.0.2
+      '@storybook/addons': 6.3.11_react@17.0.2
+      '@storybook/api': 6.3.11_react@17.0.2
+      '@storybook/channels': 6.3.11
+      '@storybook/client-logger': 6.3.11
+      '@storybook/components': 6.3.11_react@17.0.2
+      '@storybook/core-events': 6.3.11
+      '@storybook/router': 6.3.11_react@17.0.2
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.3.10_react@17.0.2
+      '@storybook/theming': 6.3.11_react@17.0.2
       '@types/markdown-to-jsx': 6.11.3
       copy-to-clipboard: 3.3.1
       core-js: 3.18.0
@@ -7151,7 +7207,7 @@ packages:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     dependencies:
-      webpack: 5.51.1_webpack-cli@4.8.0
+      webpack: 5.51.1
       webpack-cli: 4.8.0_webpack@5.51.1
 
   /@webpack-cli/info/1.3.0_webpack-cli@4.8.0:
@@ -10060,6 +10116,25 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.15.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.15.0
       '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.15.0
+
+  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.15.5:
+    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.15.5
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.15.5
 
   /babel-preset-jest/27.2.0_@babel+core@7.15.0:
     resolution: {integrity: sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==}
@@ -16353,17 +16428,17 @@ packages:
     resolution: {integrity: sha512-8CTg2YrgZuQbPHW7G0YvLTj4yTRXLmSeEO+ka3eC5lbu5dsTRyoDNS1L7x7EFUTyYQhFH9HQG1/TNlbUgR9Lug==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.15.0
+      '@babel/core': 7.15.5
       '@babel/generator': 7.15.4
       '@babel/parser': 7.15.7
-      '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.15.0
+      '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.15.5
       '@babel/traverse': 7.15.4
       '@babel/types': 7.15.6
       '@jest/transform': 27.2.1
       '@jest/types': 27.1.1
       '@types/babel__traverse': 7.14.2
       '@types/prettier': 2.3.2
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.15.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.15.5
       chalk: 4.1.2
       expect: 27.2.1
       graceful-fs: 4.2.8
@@ -16397,7 +16472,7 @@ packages:
     dependencies:
       '@jest/types': 27.1.1
       '@types/node': 16.9.4
-      chalk: 4.1.1
+      chalk: 4.1.2
       graceful-fs: 4.2.8
       is-ci: 3.0.0
       picomatch: 2.3.0
@@ -19977,6 +20052,21 @@ packages:
 
   /react-pure-render/1.0.2:
     resolution: {integrity: sha1-nYqSjH8sN1E8LQZOV7Pjw1bp+rs=}
+    dev: false
+
+  /react-redux/6.0.1_react@17.0.2:
+    resolution: {integrity: sha512-T52I52Kxhbqy/6TEfBv85rQSDz6+Y28V/pf52vDWs1YRXG19mcFOGfHnY2HsNFHyhP+ST34Aih98fvt6tqwVcQ==}
+    peerDependencies:
+      react: ^16.4.0-0
+      redux: ^2.0.0 || ^3.0.0 || ^4.0.0-0
+    dependencies:
+      '@babel/runtime': 7.15.4
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      loose-envify: 1.4.0
+      prop-types: 15.7.2
+      react: 17.0.2
+      react-is: 16.13.1
     dev: false
 
   /react-redux/6.0.1_react@17.0.2+redux@4.0.5:
@@ -23575,7 +23665,7 @@ packages:
       interpret: 2.2.0
       rechoir: 0.7.1
       v8-compile-cache: 2.3.0
-      webpack: 5.51.1_webpack-cli@4.8.0
+      webpack: 5.51.1
       webpack-merge: 5.8.0
 
   /webpack-dev-middleware/4.3.0_webpack@5.51.1:
@@ -24084,8 +24174,8 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  github.com/automattic/jetpack-boost-critical-css-gen/26df235cfd1bcc9003158d0bc8641a0450db796d:
-    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/26df235cfd1bcc9003158d0bc8641a0450db796d}
+  github.com/automattic/jetpack-boost-critical-css-gen/06b6b19c1e1208aacb26d54a304a4ea6741f0f21:
+    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/06b6b19c1e1208aacb26d54a304a4ea6741f0f21}
     name: jetpack-boost-critical-css-gen
     version: 0.0.1
     prepare: true
@@ -24096,11 +24186,11 @@ packages:
       node-fetch: 2.6.2
     dev: false
 
-  github.com/sveltejs/eslint-config/31fd4faeea88990069502460b023698b1c9c2d13_ae7c2b619eed51d24920213337b45f63:
-    resolution: {tarball: https://codeload.github.com/sveltejs/eslint-config/tar.gz/31fd4faeea88990069502460b023698b1c9c2d13}
-    id: github.com/sveltejs/eslint-config/31fd4faeea88990069502460b023698b1c9c2d13
+  github.com/sveltejs/eslint-config/8a67624e4080bd7997606eb34981aa3346bc8de2_ae7c2b619eed51d24920213337b45f63:
+    resolution: {tarball: https://codeload.github.com/sveltejs/eslint-config/tar.gz/8a67624e4080bd7997606eb34981aa3346bc8de2}
+    id: github.com/sveltejs/eslint-config/8a67624e4080bd7997606eb34981aa3346bc8de2
     name: '@sveltejs/eslint-config'
-    version: 5.7.0
+    version: 5.8.0
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '>= 3'
       '@typescript-eslint/parser': '>= 3'

--- a/projects/packages/search/.gitignore
+++ b/projects/packages/search/.gitignore
@@ -1,1 +1,4 @@
+.cache/
+build/
 wordpress
+node_modules

--- a/projects/packages/search/babel.config.js
+++ b/projects/packages/search/babel.config.js
@@ -1,0 +1,40 @@
+/**
+ * A babel preset wrapper to set @babel/plugin-transform-runtime's absoluteRuntime to true.
+ *
+ * @param {string|Function} preset - The preset being wrapped.
+ * @returns {Function} The wrapped preset-function.
+ */
+function presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime(preset) {
+	if ('string' === typeof preset) {
+		preset = require(preset);
+	}
+	return (api, opts) => {
+		const ret = preset(api, opts);
+		// Override the configuration for @babel/plugin-transform-runtime to set absoluteRuntime true.
+		// This prevents it from blowing up when other workspace projects are symlinked.
+		ret.plugins.forEach(p => {
+			if (Array.isArray(p) && /[\\/]@babel[\\/]plugin-transform-runtime[\\/]/.test(p[0])) {
+				p[1].absoluteRuntime = true;
+			}
+		});
+		return ret;
+	};
+}
+
+const config = {
+	presets: [
+		presetOverrideBabelPluginTransformRuntimeAbsoluteRuntime(
+			'@automattic/calypso-build/babel/default'
+		),
+	],
+	plugins: ['@babel/plugin-proposal-nullish-coalescing-operator'],
+	overrides: [],
+	env: {
+		test: {
+			presets: [[require.resolve('@babel/preset-env'), { targets: { node: 'current' } }]],
+			plugins: [[require.resolve('@babel/plugin-transform-runtime'), { absoluteRuntime: true }]],
+		},
+	},
+};
+
+module.exports = config;

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -3,7 +3,10 @@
 	"description": "Tools to assist with enabling cloud search for Jetpack sites.",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"require": {},
+	"require": {
+		"automattic/jetpack-admin-ui": "0.1.x-dev",
+		"automattic/jetpack-tracking": "1.13.x-dev"
+	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^2.0",
 		"yoast/phpunit-polyfills": "1.0.1"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "jetpack-search",
+	"version": "0.0.1-alpha",
+	"description": "Jetpack Search Package",
+	"repository": "https://github.com/Automattic/jetpack-search",
+	"author": "Automattic",
+	"license": "GPL-2.0-or-later",
+	"scripts": {
+		"build": "pnpm run install-if-deps-outdated && pnpm run clean && pnpm run build-dashboard",
+		"build-dashboard": "webpack --config ./webpack.dashboard.js",
+		"clean": "rm -rf build/",
+		"install-if-deps-outdated": "pnpm install --no-prod --frozen-lockfile",
+		"watch": "pnpm run build"
+	},
+	"dependencies": {
+		"@automattic/calypso-build": "9.0.0",
+		"@automattic/color-studio": "2.5.0",
+		"@automattic/jetpack-api": "workspace:^0.3.0-alpha",
+		"@automattic/jetpack-components": "workspace:0.3.1",
+		"@automattic/jetpack-connection": "workspace:^0.7.0-alpha",
+		"@automattic/jetpack-idc": "workspace:^0.2.0-alpha",
+		"@babel/core": "7.15.0",
+		"@babel/helper-module-imports": "7.14.5",
+		"@babel/preset-env": "7.15.0",
+		"@babel/register": "7.15.3",
+		"@wordpress/data": "6.1.0",
+		"fancy-log": "1.3.3",
+		"gulp": "4.0.2",
+		"react": "17.0.2",
+		"react-dom": "17.0.2",
+		"react-redux": "6.0.1",
+		"static-site-generator-webpack-plugin": "3.4.2",
+		"webpack": "5.51.1"
+	},
+	"devDependencies": {
+		"@babel/runtime": "7.15.3",
+		"@wordpress/dependency-extraction-webpack-plugin": "3.2.1",
+		"enzyme": "3.11.0",
+		"jest": "27.0.4"
+	},
+	"engines": {
+		"node": "^14.17.6 || ^16.7.0",
+		"pnpm": "^6.5.0",
+		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	}
+}

--- a/projects/packages/search/src/class-dashboard.php
+++ b/projects/packages/search/src/class-dashboard.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Jetpack Search: Dashboard class
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Used to render the Search dashboard.
+ */
+class Dashboard {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$page_suffix = Admin_Menu::add_menu(
+			__( 'Search 2', 'jetpack-search' ),
+			__( 'Search 2', 'jetpack-search' ),
+			'manage_options',
+			'jetpack-search-2',
+			array( $this, 'render_dashboard_root' ),
+			99
+		);
+		add_action( 'load-' . $page_suffix, array( $this, 'enqueue_assets' ) );
+	}
+
+	/**
+	 * Main plugin settings page.
+	 */
+	public function render_dashboard_root() {
+		?>
+			<div id="jp-search-dashboard" class="jp-search-dashboard">
+				<div class="hide-if-js">
+					<?php esc_html_e( 'Your Search dashboard requires JavaScript to function properly.', 'jetpack' ); ?>
+				</div>
+			</div>
+		<?php
+	}
+
+	/**
+	 * Enqueue scripts and styles for the dashboard page.
+	 */
+	public function enqueue_assets() {
+		wp_enqueue_style(
+			'jp-search-dashboard',
+			plugins_url( 'build/dashboard.css', __DIR__ ),
+			array(),
+			JETPACK__VERSION
+		);
+
+		$script_deps_path    = dirname( __DIR__ ) . '/build/dashboard.asset.php';
+		$script_dependencies = array( 'react', 'react-dom', 'wp-polyfill' );
+		if ( file_exists( $script_deps_path ) ) {
+			$asset_manifest      = require_once $script_deps_path;
+			$script_dependencies = $asset_manifest['dependencies'];
+		}
+
+		// TODO: Reimplement in package context.
+		// if ( ! ( new \Automattic\Jetpack\Status() )->is_offline_mode() && \Jetpack::is_connection_ready() ) {
+		// 	// Required for Analytics.
+		// 	\Automattic\Jetpack\Tracking::register_tracks_functions_scripts( true );
+		// }
+
+		wp_enqueue_script(
+			'jp-search-dashboard',
+			plugins_url( 'build/dashboard.js', __DIR__ ),
+			$script_dependencies,
+			JETPACK__VERSION,
+			true
+		);
+
+		// Add objects to be passed to the initial state of the app.
+		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
+		wp_add_inline_script(
+			'jp-search-dashboard',
+			'var Initial_State=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( \Jetpack_Redux_State_Helper::get_initial_state() ) ) . '"));',
+			'before'
+		);
+
+		wp_set_script_translations( 'jp-search-dashboard', 'jetpack' );
+	}
+}

--- a/projects/packages/search/src/dashboard/_variables.scss
+++ b/projects/packages/search/src/dashboard/_variables.scss
@@ -1,0 +1,54 @@
+//
+// Variables
+//
+@import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
+@import './temp-copied-files/mixin_breakpoint.scss';
+@import './temp-copied-files/colors.scss';
+
+/********* RNA styles *********/
+// Copied from plugins/backup/src/js/components
+// We should extract this into a package
+
+$font-title-large: 36px;
+$font-title-small: 24px;
+$font-body: 16px;
+$font-label: 12px;
+
+$jp-black: #000000;
+$jp-black-80: #2c3338;
+$jp-white: #ffffff;
+$jp-white-off: #f9f9f6;
+$jp-gray: #dcdcde;
+$jp-gray-off: #e2e2df;
+
+$jp-green-primary: #069e08;
+$jp-green-secondary: #2fb41f;
+
+$jp-border-radius: 4px;
+$jp-menu-border-height: 1px;
+$jp-underline-thickness: 2px;
+/********* Generic styles *********/
+$wp-gray-dark: #23282d;
+
+/********* Mixins *********/
+@mixin for-phone-up {
+	@media (min-width: 600px) {
+		@content;
+	}
+}
+@mixin for-tablet-up {
+	@media (min-width: 960px) {
+		@content;
+	}
+}
+
+@mixin for-phone-down {
+	@media (max-width: 600px) {
+		@content;
+	}
+}
+@mixin for-tablet-down {
+	@media (max-width: 960px) {
+		@content;
+	}
+}

--- a/projects/packages/search/src/dashboard/components/instant-search-upsell-nudge.jsx
+++ b/projects/packages/search/src/dashboard/components/instant-search-upsell-nudge.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './instant-search-upsell-nudge.scss';
+
+const InstantSearchUpsellNudge = ( props = { upgrade: true } ) => {
+	return (
+		<a className="jp-instant-search-upsell-nudge jp-search-dashboard-cut" href={ props.href }>
+			<span>
+				{ __(
+					'Offer instant search results to your visitors as soon as they start typing. ',
+					'jetpack'
+				) }
+			</span>
+			<span>
+				{ props.upgrade && <b>{ __( 'Upgrade to Jetpack Instant Search now', 'jetpack' ) }</b> }
+				{ ! props.upgrade && <b>{ __( 'Purchase Jetpack Instant Search now', 'jetpack' ) }</b> }
+			</span>
+		</a>
+	);
+};
+
+export default InstantSearchUpsellNudge;

--- a/projects/packages/search/src/dashboard/components/instant-search-upsell-nudge.scss
+++ b/projects/packages/search/src/dashboard/components/instant-search-upsell-nudge.scss
@@ -1,0 +1,15 @@
+@import '../_variables.scss';
+
+$color-nudget-text: $black;
+
+.jp-instant-search-upsell-nudge {
+	color: $color-nudget-text;
+
+	font-size: 1em;
+	text-decoration: none;
+	&:hover {
+		color: $color-nudget-text;
+	}
+
+	cursor: pointer;
+}

--- a/projects/packages/search/src/dashboard/components/mocked-instant-search.jsx
+++ b/projects/packages/search/src/dashboard/components/mocked-instant-search.jsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+// import Gridicon from 'components/gridicon';
+import TextRowPlaceHolder from './placeholder';
+import './mocked-instant-search.scss';
+
+const Gridicon = () => <span></span>;
+
+/**
+ * Generate mocked instant search dialog
+ *
+ * @returns {React.Component}	Mocked Search instant dialog component.
+ */
+export default function MockedInstantSearch() {
+	const renderFilterOption = (val, key) => (
+		<div className="jp-mocked-instant-search__search-filter" key={key}>
+			<label>
+				<input type="checkbox" disabled="disabled" />{' '}
+				<TextRowPlaceHolder style={{ width: '30%' }} />
+			</label>
+		</div>
+	);
+
+	const renderSearchResult = (val, key) => (
+		<div className="jp-mocked-instant-search__search-result" key={key}>
+			<TextRowPlaceHolder
+				style={{
+					height: '2.5em',
+					width: '50%',
+					maxWidth: '200px',
+					margin: '0.1em 0.1em 1em 0.1em',
+				}}
+			/>
+			<TextRowPlaceHolder style={{ height: '1em', width: '90%', margin: '0.1em' }} />
+			<TextRowPlaceHolder style={{ height: '1em', width: '70%', margin: '0.1em' }} />
+		</div>
+	);
+
+	return (
+		<div className="jp-mocked-instant-search" aria-hidden="true">
+			<div className="jp-mocked-instant-search__search-controls">
+				<div className="jp-mocked-instant-search__search-icon">
+					<Gridicon icon="search" size={24} />
+				</div>
+				<div className="jp-mocked-instant-search__search-mock-input">
+					<TextRowPlaceHolder style={{ height: '50px', width: '80%', maxWidth: '212px' }} />
+				</div>
+				<div className="jp-mocked-instant-search__close-button">
+					<Gridicon icon="cross" size={24} />
+				</div>
+			</div>
+			<div className="jp-mocked-instant-search__search-results">
+				<div className="jp-mocked-instant-search__search-results-primary">
+					<div className="jp-mocked-instant-search__search-results-header">
+						<div className="jp-mocked-instant-search__result-statistics">
+							{
+								/* translators: %s is replaced with the number of search results */
+								sprintf(__('Found %s results', 'jetpack'), '27')
+							}
+						</div>
+						<div className="jp-mocked-instant-search__result-sort-list">
+							<span className="jp-mocked-instant-search__result-sort-selected">
+								{__('Relevance', 'jetpack')}
+							</span>
+							<span>&middot;</span>
+							<span>{__('Newest', 'jetpack')}</span>
+							<span>&middot;</span>
+							<span>{__('Oldest', 'jetpack')}</span>
+						</div>
+					</div>
+					<div className="jp-mocked-instant-search__search-results-content">
+						{Array.apply(null, Array(3)).map(renderSearchResult)}
+					</div>
+				</div>
+				<div className="jp-mocked-instant-search__search-results-secondary">
+					<div className="jp-mocked-instant-search__search-filter-header">
+						{__('Filter options', 'jetpack')}
+					</div>
+					<div className="jp-mocked-instant-search__search-filter-list">
+						{Array.apply(null, Array(2)).map(renderFilterOption)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/search/src/dashboard/components/mocked-instant-search.scss
+++ b/projects/packages/search/src/dashboard/components/mocked-instant-search.scss
@@ -1,0 +1,161 @@
+@import '../_variables.scss';
+
+$sidebar-width: 220px;
+$close-button-size: 60px;
+$close-button-size-mobile: 45px;
+$color-modal-background: $studio-white;
+$color-layout-borders: $studio-wordpress-blue-0;
+$color-text-lighter: $studio-gray-50;
+
+/* Mocked Search Container */
+.jp-mocked-instant-search {
+	background: $color-modal-background;
+	border-radius: 3px;
+	margin: 0 auto;
+	width: 100%;
+	height: 100%;
+	box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 25px;
+	user-select: none;
+	overflow: hidden;
+
+	font-size: 0.75em;
+}
+
+/* Search Controls */
+.jp-mocked-instant-search__search-controls {
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: space-between;
+	align-items: center;
+	border-bottom: 1px solid $color-layout-borders;
+}
+.jp-mocked-instant-search__search-icon {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: $close-button-size;
+	height: $close-button-size;
+	@include breakpoint('<660px') {
+		width: $close-button-size-mobile;
+		height: $close-button-size-mobile;
+	}
+}
+.jp-mocked-instant-search__search-mock-input {
+	width: calc(100% - #{$close-button-size} - #{$close-button-size});
+}
+.jp-mocked-instant-search__close-button {
+	display: flex;
+	align-items: center;
+	width: $close-button-size;
+	height: $close-button-size;
+	justify-content: center;
+	line-height: 1;
+	border-left: 1px solid $color-layout-borders;
+	background-color: transparent !important;
+
+	svg.gridicon {
+		fill: $color-text-lighter;
+	}
+	@include breakpoint('<660px') {
+		width: $close-button-size-mobile;
+		height: $close-button-size-mobile;
+	}
+}
+
+/* Search Result */
+.jp-mocked-instant-search__search-results {
+	display: flex;
+	position: relative;
+	height: 100%;
+}
+.jp-mocked-instant-search__search-results-primary {
+	width: 100%;
+	padding: 1em 4em;
+
+	@include breakpoint('>660px') {
+		max-width: calc(100% - #{$sidebar-width});
+	}
+	@include breakpoint('<660px') {
+		padding: 2em;
+	}
+}
+.jp-mocked-instant-search__search-results-header {
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: space-between;
+	align-items: center;
+
+	.jp-mocked-instant-search__result-statistics {
+		font-size: 1em;
+		font-weight: bold;
+		@include breakpoint('<480px') {
+			width: 100%;
+		}
+	}
+	.jp-mocked-instant-search__result-sort-list {
+		span {
+			font-size: 1em;
+			margin-left: 0.5em;
+			&:first-child {
+				margin-left: 0;
+			}
+		}
+		.jp-mocked-instant-search__result-sort-selected {
+			color: $color-plan;
+		}
+		@include breakpoint('<480px') {
+			width: 100%;
+		}
+	}
+}
+.jp-mocked-instant-search__search-result {
+	margin-top: 1em;
+}
+
+/**
+* Sidebar
+*/
+.jp-mocked-instant-search__search-results-secondary {
+	padding-left: 2em;
+	padding-top: 1em;
+	background: none;
+	border-left: 1px solid $color-layout-borders;
+	border-radius: 0;
+	bottom: 0;
+	box-shadow: none;
+	display: block;
+	flex: none;
+	position: static;
+	width: $sidebar-width;
+
+	@include breakpoint('<660px') {
+		display: none;
+	}
+}
+.jp-mocked-instant-search__search-filter-header {
+	font-weight: bold;
+}
+.jp-mocked-instant-search__search-filter {
+	label {
+		cursor: default;
+		input[type='checkbox'] {
+			border: 1px solid lavender;
+			border-radius: 5px;
+			cursor: default;
+		}
+	}
+	span {
+		display: inline-block;
+		margin-left: 1em;
+		line-height: 1.35;
+		background-color: lavender;
+		width: 50em;
+	}
+	input[type='checkbox'] {
+		height: 1em;
+		width: 1em;
+	}
+}
+.jp-mocked-instant-search__search-filter-list {
+	margin-top: 1em;
+}

--- a/projects/packages/search/src/dashboard/components/mocked-legacy-search.jsx
+++ b/projects/packages/search/src/dashboard/components/mocked-legacy-search.jsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+// import Gridicon from 'components/gridicon';
+import TextRowPlaceHolder from './placeholder';
+import './mocked-legacy-search.scss';
+
+const Gridicon = () => <span></span>;
+
+/**
+ * Generate mocked search dialog
+ *
+ * @returns {React.Component}	Mocked Search dialog component.
+ */
+export default function MockedLegacySearch() {
+	return (
+		<div className="jp-mocked-legacy-search" aria-hidden="true">
+			<div className="jp-mocked-legacy-search__search-controls">
+				<div className="jp-mocked-legacy-search__search-icon">
+					<Gridicon icon="search" size={24} />
+				</div>
+				<div className="jp-mocked-legacy-search__search-input">
+					<TextRowPlaceHolder style={{ height: '50px', width: '80%', maxWidth: '212px' }} />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/search/src/dashboard/components/mocked-legacy-search.scss
+++ b/projects/packages/search/src/dashboard/components/mocked-legacy-search.scss
@@ -1,0 +1,31 @@
+@import '../_variables.scss';
+
+$color-modal-background: $studio-white;
+$search-box-size: 60px;
+
+.jp-mocked-legacy-search {
+	border-radius: 3px;
+	margin: 0 auto;
+	width: 100%;
+
+	user-select: none;
+}
+.jp-mocked-legacy-search__search-controls {
+	display: flex;
+	flex-flow: row nowrap;
+	width: 100%;
+	background: $color-modal-background;
+	box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 25px;
+}
+.jp-mocked-legacy-search__search-icon {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: $search-box-size;
+	height: $search-box-size;
+}
+.jp-mocked-legacy-search__search-input {
+	width: 100%;
+	display: flex;
+	align-items: center;
+}

--- a/projects/packages/search/src/dashboard/components/mocked-search.jsx
+++ b/projects/packages/search/src/dashboard/components/mocked-search.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import MockedInstantSearch from './mocked-instant-search';
+import MockedLegacySearch from './mocked-legacy-search';
+// import { getPlanClass } from 'lib/plans/constants';
+
+const getPlanClass = () => '';
+
+/**
+ * State dependencies
+ */
+// import { getSitePlan, hasActiveSearchPurchase as selectHasActiveSearchPurchase } from 'state/site';
+
+/**
+ * Mocked Search component, which shows mocked Instant Search or legacy Search interface.
+ *
+ * @param {object} props - Component properties.
+ * @returns {React.Component} Mocked Search interface component.
+ */
+function MockedSearch(props) {
+	const { hasActiveSearchPurchase, isBusinessPlan } = props;
+	// We only want to show the legacy search mock to users with bussiness plan but no search subscription.
+	// For all other cases, we show our Instant Search experience mock.
+	const shouldShowMockedLegacySearch = isBusinessPlan && !hasActiveSearchPurchase;
+
+	return (
+		<Fragment>
+			{shouldShowMockedLegacySearch && <MockedLegacySearch />}
+			{!shouldShowMockedLegacySearch && <MockedInstantSearch />}
+		</Fragment>
+	);
+}
+
+// export default connect( state => {
+// 	const planClass = getPlanClass( getSitePlan( state ).product_slug );
+// 	return {
+// 		hasActiveSearchPurchase: selectHasActiveSearchPurchase( state ),
+// 		isBusinessPlan: 'is-business-plan' === planClass,
+// 	};
+// } )( MockedSearch );
+
+export default MockedSearch;

--- a/projects/packages/search/src/dashboard/components/module-control.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control.jsx
@@ -1,0 +1,255 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment, useCallback, useEffect } from 'react';
+import { connect } from 'react-redux';
+import { sprintf, __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+// import QuerySite from 'components/data/query-site';
+// import CompactFormToggle from 'components/form/form-toggle/compact';
+// import { ModuleToggle } from 'components/module-toggle';
+// import SettingsGroup from 'components/settings-group';
+// import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+// import Button from 'components/button';
+// import { getPlanClass } from 'lib/plans/constants';
+import InstantSearchUpsellNudge from './instant-search-upsell-nudge';
+// import analytics from '../../lib/analytics';
+import './rna-styles.scss';
+import './module-control.scss';
+
+/**
+ * State dependencies
+ */
+// import { isOfflineMode } from 'state/connection';
+// import { getUpgradeUrl, getSiteAdminUrl, arePromotionsActive } from 'state/initial-state';
+// import {
+// 	getSitePlan,
+// 	hasActiveSearchPurchase as selectHasActiveSearchPurchase,
+// 	isFetchingSitePurchases,
+// } from 'state/site';
+// import { hasUpdatedSetting, isSettingActivated, isUpdatingSetting } from 'state/settings';
+// import { getSiteID } from '../../state/site';
+
+const SEARCH_DESCRIPTION = __(
+	'Jetpack Search is an incredibly powerful and customizable replacement for the search capability built into WordPress that helps your visitors find the right content.',
+	'jetpack'
+);
+const INSTANT_SEARCH_DESCRIPTION = __(
+	'Instant search will allow your visitors to get search results as soon as they start typing. If deactivated, Jetpack Search will still optimize your search results but visitors will have to submit a search query before seeing any results.',
+	'jetpack'
+);
+const RETURN_PATH = 'admin.php?page=jetpack-search';
+const SEARCH_CUSTOMIZE_URL = 'admin.php?page=jetpack-search-configure';
+const WIDGETS_EDITOR_URL = 'customize.php?autofocus[panel]=widgets&return=%s';
+
+/**
+ * Search settings component to be used within the Performance section.
+ *
+ * @param  {object} props - Component properties.
+ * @returns {React.Component}	Search settings component.
+ */
+function Search(props) {
+	const {
+		failedToEnableSearch,
+		hasActiveSearchPurchase,
+		updateOptions,
+		siteAdminUrl,
+		isInstantSearchPromotionActive,
+	} = props;
+	const isModuleEnabled = props.getOptionValue('search');
+	const isInstantSearchEnabled = props.getOptionValue('instant_search_enabled', 'search');
+
+	const toggleSearchModule = useCallback(() => {
+		const newOption = { search: !isModuleEnabled };
+		if (hasActiveSearchPurchase && isInstantSearchEnabled !== !isModuleEnabled) {
+			newOption.instant_search_enabled = !isModuleEnabled;
+		}
+		updateOptions(newOption);
+		analytics.tracks.recordEvent('jetpack_search_module_toggle', newOption);
+	}, [hasActiveSearchPurchase, isModuleEnabled, updateOptions, isInstantSearchEnabled]);
+
+	const toggleInstantSearch = useCallback(() => {
+		const newOption = {
+			instant_search_enabled: hasActiveSearchPurchase && !isInstantSearchEnabled,
+		};
+		if (newOption.instant_search_enabled && !isModuleEnabled) {
+			newOption.search = true;
+		}
+		updateOptions(newOption);
+		analytics.tracks.recordEvent('jetpack_search_instant_toggle', newOption);
+	}, [hasActiveSearchPurchase, isInstantSearchEnabled, isModuleEnabled, updateOptions]);
+
+	useEffect(() => {
+		if (failedToEnableSearch && hasActiveSearchPurchase) {
+			updateOptions({ has_jetpack_search_product: true });
+			toggleSearchModule();
+		}
+	}, [failedToEnableSearch, hasActiveSearchPurchase, updateOptions, toggleSearchModule]);
+
+	const togglingModule = !!props.isSavingAnyOption('search');
+	const togglingInstantSearch = !!props.isSavingAnyOption('instant_search_enabled');
+	const isSavingEitherOption = togglingModule || togglingInstantSearch;
+	// Site has Legacy Search included in Business plan but doesn't have Jetpack Search subscription.
+	const hasOnlyLegacySearch = props.isBusinessPlan && !props.hasActiveSearchPurchase;
+	const hasEitherSearch = props.isBusinessPlan || props.hasActiveSearchPurchase;
+
+	const isInstantSearchCustomizeButtonDisabled =
+		isSavingEitherOption || !isModuleEnabled || !isInstantSearchEnabled || !hasActiveSearchPurchase;
+	const isWidgetsEditorButtonDisabled = isSavingEitherOption || !isModuleEnabled;
+	const returnUrl = encodeURIComponent(siteAdminUrl + RETURN_PATH);
+
+	const renderInstantSearchButtons = () => {
+		return (
+			<div className="jp-form-search-settings-group-buttons jp-search-dashboard-row">
+				<div className="lg-col-span-3 md-col-span-2 sm-col-span-1"></div>
+				<Button
+					className="jp-form-search-settings-group-buttons__button is-customize-search lg-col-span-4 md-col-span-5 sm-col-span-3"
+					href={!isInstantSearchCustomizeButtonDisabled && sprintf(SEARCH_CUSTOMIZE_URL, returnUrl)}
+					disabled={isInstantSearchCustomizeButtonDisabled}
+				>
+					<span>{__('Customize search results', 'jetpack')}</span>
+				</Button>
+				<div className="lg-col-span-0 md-col-span-1 sm-col-span-0"></div>
+
+				<div className="lg-col-span-0 md-col-span-2 sm-col-span-1"></div>
+				<Button
+					className="jp-form-search-settings-group-buttons__button is-widgets-editor lg-col-span-3 md-col-span-5 sm-col-span-3"
+					href={!isWidgetsEditorButtonDisabled && sprintf(WIDGETS_EDITOR_URL, returnUrl)}
+					disabled={isWidgetsEditorButtonDisabled}
+				>
+					<span>{__('Edit sidebar widgets', 'jetpack')}</span>
+				</Button>
+				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+			</div>
+		);
+	};
+
+	const renderSearchToggle = () => {
+		return (
+			<div className="jp-form-search-settings-group__toggle is-search jp-search-dashboard-wrap">
+				<div className="jp-search-dashboard-row">
+					<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+					<div className="jp-form-search-settings-group__toggle-container lg-col-span-1 md-col-span-1 sm-col-span-1">
+						<ModuleToggle
+							activated={isModuleEnabled && hasEitherSearch}
+							compact
+							disabled={
+								isSavingEitherOption || (!props.hasActiveSearchPurchase && !props.isBusinessPlan)
+							}
+							slug="search"
+							toggleModule={toggleSearchModule}
+							toggling={togglingModule}
+							className="is-search-admin"
+							aria-label={__('Enable Jetpack Search', 'jetpack')}
+						></ModuleToggle>
+					</div>
+					<div className="jp-form-search-settings-group__toggle_label lg-col-span-7 md-col-span-5 sm-col-span-3">
+						{__('Enable Jetpack Search', 'jetpack')}
+					</div>
+					<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+				</div>
+				<div className="jp-search-dashboard-row">
+					<div className="lg-col-span-3 md-col-span-2 sm-col-span-1"></div>
+					<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-3">
+						<p className="jp-form-search-settings-group__toggle-explanation">
+							{SEARCH_DESCRIPTION}
+						</p>
+					</div>
+					<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+				</div>
+			</div>
+		);
+	};
+
+	const renderInstantSearchToggle = () => {
+		return (
+			<div className="jp-form-search-settings-group__toggle is-instant-search jp-search-dashboard-wrap">
+				<div className="jp-search-dashboard-row">
+					<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+					<div className="jp-form-search-settings-group__toggle-container lg-col-span-1 md-col-span-1 sm-col-span-1">
+						<CompactFormToggle
+							checked={isModuleEnabled && isInstantSearchEnabled && props.hasActiveSearchPurchase}
+							disabled={isSavingEitherOption || !props.hasActiveSearchPurchase}
+							onChange={toggleInstantSearch}
+							toggling={togglingInstantSearch}
+							className="is-search-admin"
+							aria-label={__('Enable instant search experience (recommended)', 'jetpack')}
+						></CompactFormToggle>
+					</div>
+					<div className="jp-form-search-settings-group__toggle_label lg-col-span-7 md-col-span-5 sm-col-span-3">
+						{createInterpolateElement(
+							__('Enable instant search experience <span>(recommended)</span>', 'jetpack'),
+							{ span: <span /> }
+						)}
+					</div>
+				</div>
+				<div className="jp-search-dashboard-row">
+					<div className="lg-col-span-3 md-col-span-2 sm-col-span-1"></div>
+					<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-3">
+						{props.hasActiveSearchPurchase && (
+							<Fragment>
+								<p className="jp-form-search-settings-group__toggle-explanation">
+									{INSTANT_SEARCH_DESCRIPTION}
+								</p>
+							</Fragment>
+						)}
+						{!props.hasActiveSearchPurchase && isInstantSearchPromotionActive && (
+							<InstantSearchUpsellNudge href={props.upgradeUrl} upgrade={hasOnlyLegacySearch} />
+						)}
+					</div>
+					<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+				</div>
+				{props.hasActiveSearchPurchase && renderInstantSearchButtons()}
+			</div>
+		);
+	};
+
+	const renderToggles = () => {
+		return (
+			<div className="jp-form-search-settings-group-inside">
+				{renderSearchToggle()}
+				{renderInstantSearchToggle()}
+			</div>
+		);
+	};
+
+	return (
+		<Fragment>
+			<QuerySite />
+			<SettingsGroup
+				disableInOfflineMode
+				hasChild
+				module={{ module: 'search' }}
+				className="jp-form-search-settings-group"
+			>
+				{props.inOfflineMode && <p>__( 'Unavailable in Offline Mode', 'jetpack' )</p>}
+
+				{!props.inOfflineMode && props.isLoading && <p>__( 'Loading…', 'jetpack' )</p>}
+
+				{!props.inOfflineMode && !props.isLoading && renderToggles()}
+			</SettingsGroup>
+		</Fragment>
+	);
+}
+
+export default connect(state => {
+	const planClass = getPlanClass(getSitePlan(state).product_slug);
+	return {
+		hasActiveSearchPurchase: selectHasActiveSearchPurchase(state),
+		inOfflineMode: isOfflineMode(state),
+		isBusinessPlan: 'is-business-plan' === planClass,
+		isLoading: isFetchingSitePurchases(state),
+		failedToEnableSearch:
+			!isSettingActivated(state, 'search') &&
+			!isUpdatingSetting(state, 'search') &&
+			false === hasUpdatedSetting(state, 'search'),
+		siteID: getSiteID(state),
+		upgradeUrl: getUpgradeUrl(state, 'jetpack-search'),
+		siteAdminUrl: getSiteAdminUrl(state),
+		isInstantSearchPromotionActive: arePromotionsActive(state),
+	};
+})(withModuleSettingsFormHelpers(Search));

--- a/projects/packages/search/src/dashboard/components/module-control.scss
+++ b/projects/packages/search/src/dashboard/components/module-control.scss
@@ -1,0 +1,180 @@
+@import '../_variables.scss';
+
+$color-button-background: $black;
+$color-button-text: $white;
+$color-button-background-disabled: #dcdcde;
+$color-button-text-disabled: #a7aaad;
+$toggle-dot-radius: 0.9375em;
+$toggle-dot-padding: 0.1875em;
+$toggle-height: 1.5em;
+$toggle-width: 3em;
+
+.jp-form-search-settings-group {
+	width: 100%;
+	.dops-card {
+		box-shadow: none;
+		padding: 0;
+		padding-top: 4em;
+	}
+	.form-toggle__label {
+		margin: 0;
+	}
+}
+
+.jp-form-search-settings-group__toggle {
+	&.is-instant-search {
+		margin-top: 4em;
+	}
+	.form-toggle__label-content {
+		display: none;
+	}
+	.jp-form-search-settings-group__toggle-container {
+		display: flex;
+		@include for-tablet-down {
+			justify-content: center;
+		}
+	}
+}
+
+.jp-form-search-settings-group__toggle_label {
+	font-size: 1.5em;
+	line-height: 1.167;
+	font-weight: 600;
+	span {
+		font-weight: 400;
+	}
+}
+
+.jp-form-search-settings-group__toggle-description {
+	margin-top: 1em;
+}
+
+p.jp-form-search-settings-group__toggle-explanation {
+	line-height: 1.5;
+	font-size: 1em;
+	font-weight: 400;
+	margin-bottom: 0;
+}
+
+.jp-form-search-settings-group-buttons {
+	margin-top: 1.5em;
+}
+
+.jp-form-search-settings-group-buttons__button {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	min-height: 2.5em;
+	padding: 0.5em 1.5em;
+	text-align: center;
+
+	border-color: $color-button-background;
+	font-size: 1em;
+
+	&.is-customize-search {
+		color: $color-button-text;
+		background-color: $color-button-background;
+	}
+
+	&:disabled,
+	&[disabled] {
+		background-color: $color-button-background-disabled;
+		border-color: $color-button-background-disabled;
+		color: $color-button-text-disabled;
+		cursor: not-allowed;
+	}
+
+	&.is-widgets-editor {
+		color: $color-button-background;
+		background: transparent;
+		&:disabled,
+		&[disabled] {
+			color: $color-button-text-disabled;
+			background: transparent;
+		}
+	}
+}
+.form-toggle.is-search-admin.is-compact {
+	+ .form-toggle__label .form-toggle__switch {
+		border-radius: calc(#{$toggle-height}/ 2);
+		width: $toggle-width;
+		height: $toggle-height;
+
+		&:before,
+		&:after {
+			width: $toggle-dot-radius;
+			height: $toggle-dot-radius;
+			background-color: $black;
+		}
+		background: $white;
+		border: 2px solid $black;
+
+		&:focus {
+			box-shadow: 0 0 0 2px $blue-medium;
+		}
+	}
+
+	&:checked {
+		+ .form-toggle__label .form-toggle__switch {
+			background: $color-plan;
+			border-color: $color-plan;
+
+			&:after {
+				left: $toggle-height;
+				background-color: $white;
+			}
+		}
+	}
+
+	&.is-toggling + .form-toggle__label .form-toggle__switch:before,
+	&.is-toggling + .form-toggle__label .form-toggle__switch:after {
+		left: $toggle-height;
+	}
+
+	&.is-toggling:checked + .form-toggle__label .form-toggle__switch:before,
+	&.is-toggling:checked + .form-toggle__label .form-toggle__switch:after {
+		left: 0;
+	}
+}
+
+.jp-search-dashboard-cut {
+	position: relative;
+	display: block;
+	margin: 2em 0;
+	padding: 1em 4em 1em 1.5em;
+	border: 2px solid $jp-green-primary;
+	border-radius: $jp-border-radius;
+	text-decoration: none;
+
+	span {
+		display: block;
+
+		&:last-of-type {
+			font-weight: 600;
+		}
+	}
+
+	&:hover,
+	&:focus {
+		span:last-of-type {
+			text-decoration: underline;
+			text-decoration-thickness: $jp-underline-thickness;
+		}
+
+		&:after {
+			transform: translateY(-50%) translateX(8px);
+		}
+	}
+
+	&:after {
+		content: '→';
+		position: absolute;
+		top: 50%;
+		right: 1.5em;
+		font-size: 1.5em;
+		font-weight: 600;
+		color: $jp-green-primary;
+		transform: translateY(-50%);
+		transition: transform 0.15s ease-out;
+	}
+}

--- a/projects/packages/search/src/dashboard/components/placeholder.jsx
+++ b/projects/packages/search/src/dashboard/components/placeholder.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const TextRowPlaceHolder = props => {
+	const defaultStyles = {
+		display: 'inline-block',
+		borderRadius: '10px',
+		maxHeight: '1.5em',
+		width: '100%',
+		height: '1em',
+		backgroundColor: '#E9EFF3',
+	};
+
+	return (
+		<div
+			className="jp-search-dashboard__text-row-placeholder"
+			style={ { ...defaultStyles, ...props.style } }
+		/>
+	);
+};
+
+export default TextRowPlaceHolder;

--- a/projects/packages/search/src/dashboard/entry.js
+++ b/projects/packages/search/src/dashboard/entry.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import ReactDOM from 'react-dom';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SearchDashboard from './index';
+
+/**
+ * Mounts the Search Dashboard to #jp-search-dashboard if available.
+ */
+function init() {
+	const container = document.getElementById('jp-search-dashboard');
+
+	if (container === null) {
+		return;
+	}
+
+	ReactDOM.render(<SearchDashboard />, container);
+}
+
+// Initialize the dashboard when DOMContentLoaded is fired, or immediately if it already has been.
+if (document.readyState !== 'loading') {
+	init();
+} else {
+	document.addEventListener('DOMContentLoaded', init);
+}

--- a/projects/packages/search/src/dashboard/index.jsx
+++ b/projects/packages/search/src/dashboard/index.jsx
@@ -1,0 +1,165 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment, useMemo } from 'react';
+// import { connect } from 'react-redux';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+import { JetpackFooter, JetpackLogo } from '@automattic/jetpack-components';
+import restApi from '@automattic/jetpack-api';
+// import LoadingPlaceHolder from 'components/loading-placeholder';
+// import ModuleControl from './components/module-control';
+import MockedSearch from './components/mocked-search';
+// import analytics from '../../lib/analytics';
+import './rna-styles.scss';
+import './style.scss';
+
+const ModuleControl = () => null;
+
+/**
+ * State dependencies
+ */
+// import { isFetchingSitePurchases } from 'state/site';
+// import {
+// 	setInitialState,
+// 	getApiNonce,
+// 	getApiRootUrl,
+// 	getSiteAdminUrl,
+// 	getTracksUserData,
+// 	getCurrentVersion,
+// } from 'state/initial-state';
+
+const useComponentWillMount = func => {
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	useMemo(func, []);
+};
+
+/**
+ * SearchDashboard component definition.
+ *
+ * @param {object} props - Component properties.
+ * @returns {React.Component} Search dashboard component.
+ */
+function SearchDashboard(props) {
+	// NOTE: API root and nonce must be set before any components are mounted!
+	const {
+		apiRootUrl,
+		apiNonce,
+		setInitialState: setSearchDashboardInitialState,
+		siteAdminUrl,
+	} = props;
+
+	// const initializeAnalytics = () => {
+	// 	const tracksUser = props.tracksUserData;
+
+	// 	if (tracksUser) {
+	// 		analytics.initialize(tracksUser.userid, tracksUser.username, {
+	// 			blog_id: tracksUser.blogid,
+	// 		});
+	// 	}
+	// };
+
+	useComponentWillMount(() => {
+		apiRootUrl && restApi.setApiRoot(apiRootUrl);
+		apiNonce && restApi.setApiNonce(apiNonce);
+		setSearchDashboardInitialState && setSearchDashboardInitialState();
+		// initializeAnalytics();
+		// analytics.tracks.recordEvent('jetpack_search_admin_page_view', {
+		// 	current_version: props.currentVersion,
+		// });
+	});
+
+	const aboutPageUrl = siteAdminUrl + 'admin.php?page=jetpack_about';
+
+	const renderHeader = () => {
+		return (
+			<div className="jp-search-dashboard-header jp-search-dashboard-wrap">
+				<div className="jp-search-dashboard-row">
+					<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
+						<div className="jp-search-dashboard-header__logo-container">
+							<JetpackLogo className="jp-search-dashboard-header__masthead" />
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	};
+
+	const renderMockedSearchInterface = () => {
+		return (
+			<div className="jp-search-dashboard-top jp-search-dashboard-wrap">
+				<div className="jp-search-dashboard-row">
+					<div className="jp-search-dashboard-top__title lg-col-span-6 md-col-span-7 sm-col-span-4">
+						<h1>
+							{__("Help your visitors find exactly what they're looking for, fast", 'jetpack')}
+						</h1>
+					</div>
+					<div className=" lg-col-span-6 md-col-span-1 sm-col-span-0"></div>
+				</div>
+				<div className="jp-search-dashboard-row" aria-hidden="true">
+					<div className="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
+					<div className="jp-search-dashboard-top__mocked-search-interface lg-col-span-10 md-col-span-6 sm-col-span-4">
+						<MockedSearch />
+					</div>
+					<div className="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
+				</div>
+			</div>
+		);
+	};
+
+	const renderAdminSection = () => {
+		return (
+			<div className="jp-search-dashboard-bottom">
+				<ModuleControl />
+			</div>
+		);
+	};
+
+	const renderFooter = () => {
+		return (
+			<div className="jp-search-dashboard-footer jp-search-dashboard-wrap">
+				<div className="jp-search-dashboard-row">
+					<JetpackFooter
+						a8cLogoHref={aboutPageUrl}
+						moduleName={__('Jetpack Search', 'jetpack')}
+						className="lg-col-span-12 md-col-span-8 sm-col-span-4"
+					/>
+				</div>
+			</div>
+		);
+	};
+
+	return (
+		<div className="jp-search-dashboard-page">
+			{props.isLoading && <LoadingPlaceHolder />}
+			{!props.isLoading && (
+				<Fragment>
+					{renderHeader()}
+					{renderMockedSearchInterface()}
+					{renderAdminSection()}
+					{renderFooter()}
+				</Fragment>
+			)}
+		</div>
+	);
+}
+
+// export default connect(
+// 	state => {
+// 		return {
+// 			apiRootUrl: getApiRootUrl(state),
+// 			apiNonce: getApiNonce(state),
+// 			isLoading: isFetchingSitePurchases(state),
+// 			siteAdminUrl: getSiteAdminUrl(state),
+// 			tracksUserData: getTracksUserData(state),
+// 			currentVersion: getCurrentVersion(state),
+// 		};
+// 	},
+// 	{ setInitialState }
+// )(SearchDashboard);
+
+export default SearchDashboard;

--- a/projects/packages/search/src/dashboard/rna-styles.scss
+++ b/projects/packages/search/src/dashboard/rna-styles.scss
@@ -1,0 +1,74 @@
+@import './_variables.scss';
+
+.jp-search-dashboard-wrap {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-flow: column nowrap;
+	width: 100%;
+	margin: 0 auto;
+}
+
+.jp-search-dashboard-row {
+	display: grid;
+	grid-gap: 24px;
+	grid-template-columns: repeat( 4, 1fr );
+	width: calc( 100% - 32px );
+	margin: 0 16px;
+
+	@include for-phone-up {
+		grid-template-columns: repeat( 8, 1fr );
+		width: calc( 100% - 36px );
+		margin: 0 18px;
+	}
+
+	@include for-tablet-up {
+		grid-template-columns: repeat( 12, 1fr );
+		max-width: 1128px;
+		width: calc( 100% - 48px );
+		margin: 0 24px;
+	}
+
+	@for $i from 1 through 4 {
+		.sm-col-span-#{$i} {
+			grid-column-end: span #{$i};
+		}
+	}
+
+	@include for-phone-up {
+		@for $i from 1 through 8 {
+			.md-col-span-#{$i} {
+				grid-column-end: span #{$i};
+			}
+		}
+	}
+
+	@include for-tablet-up {
+		@for $i from 1 through 12 {
+			.lg-col-span-#{$i} {
+				grid-column-end: span #{$i};
+			}
+		}
+	}
+
+	@include for-tablet-up {
+		.lg-col-span-0 {
+			display: none;
+		}
+	}
+
+	@include for-tablet-down {
+		.md-col-span-0 {
+			display: none;
+		}
+	}
+
+	@include for-phone-down {
+		.sm-col-span-0 {
+			display: none;
+		}
+		.sm-col-span-1 {
+			display: block;
+		}
+	}
+}

--- a/projects/packages/search/src/dashboard/style.scss
+++ b/projects/packages/search/src/dashboard/style.scss
@@ -1,0 +1,68 @@
+@import './_variables.scss';
+
+* {
+	box-sizing: border-box;
+}
+
+body {
+	min-height: 100%;
+	margin: 0;
+	padding: 0;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu',
+		'Cantarell', 'Helvetica Neue', sans-serif;
+}
+
+#screen-meta,
+#screen-meta-links {
+	display: none;
+}
+
+#jp-search-dashboard {
+	min-height: 100vh;
+
+	color: $black;
+	font-size: 16px;
+
+	.jp-masthead__logo-link {
+		pointer-events: none;
+	}
+
+	.jp-search-dashboard-top {
+		background-color: #f9f9f6;
+
+		overflow: hidden;
+	}
+
+	.jp-search-dashboard-top__title {
+		padding: 2.5em 0;
+		h1 {
+			line-height: 1.111;
+			font-size: 2.25em;
+			margin: 0;
+		}
+	}
+
+	.jp-search-dashboard-top__mocked-search-interface {
+		height: 15.625em;
+
+		display: flex;
+		flex-flow: column;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.jp-search-dashboard-bottom {
+		background-color: $white;
+	}
+
+	.jp-search-dashboard-header,
+	.jp-search-dashboard-footer {
+		padding: 2.5em 0;
+
+		background-color: $white;
+	}
+
+	@include for-phone-down {
+		font-size: 14px;
+	}
+}

--- a/projects/packages/search/src/dashboard/temp-copied-files/colors.scss
+++ b/projects/packages/search/src/dashboard/temp-copied-files/colors.scss
@@ -1,0 +1,143 @@
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+
+// Add percentage of white to a color
+// Copyright © 2011–2015 thoughtbot. See CREDITS.md#L3
+@function tint($color, $percent) {
+	@return mix(white, $color, $percent);
+}
+
+// Add percentage of black to a color
+// Copyright © 2011–2015 thoughtbot. See CREDITS.md#L3
+@function shade($color, $percent) {
+	@return mix(black, $color, $percent);
+}
+
+// ==========================================================================
+// WordPress.com Colors
+// ==========================================================================
+
+// Primary Accent (Blues)
+$blue-wordpress: #0087be;
+$blue-light: #78dcfa;
+$blue-medium: #3582c4;
+$blue-dark: #005082;
+
+// Grays
+$gray-original: #87a6bc;
+$gray: desaturate($gray-original, 100%); // Intermediary transform to match dotcom's colors
+
+$gray-light: lighten($gray, 33%); //#f6f6f6
+$gray-dark: darken($gray, 38%); //#404040
+
+// Text blues
+$blue-heading: #668eaa;
+$blue-text: #537994;
+$blue-dark-text: #2e4453;
+
+// $gray-text: ideal for standard, non placeholder text
+// $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
+$gray-text: $gray-dark;
+$gray-text-min: darken($gray, 18%); //#537994
+
+// $gray color functions:
+// lighten( $gray, 10% )
+// lighten( $gray, 20% )
+// lighten( $gray, 30% )
+// darken( $gray, 10% )
+// darken( $gray, 20% )
+// darken( $gray, 30% )
+//
+// See wordpress.com/design-handbook/colors/ for more info.
+
+// Product types
+$color-product: #3895ba; // $studio-wordpress-blue-30
+$color-bundle: #984a9c; // $studio-purple-50
+$color-plan: #069e08; // $studio-jetpack-green-40
+$color-plan-dark: #007117; // $studio-jetpack-green-60
+
+// Secondary Accent (Oranges)
+$orange-jazzy: #f0821e;
+$orange-fire: #d63638;
+
+// Alerts
+$alert-yellow: #f0b849;
+$alert-red: #d94f4f;
+$alert-green: #4ab866;
+$alert-purple: #855da6;
+$alert-hot-red: #eb0001; // 2019
+
+// Link hovers
+$link-highlight: tint($blue-medium, 20%);
+
+// Essentials
+$black: #000000;
+$white: rgba(255, 255, 255, 1);
+$transparent: rgba(255, 255, 255, 0);
+
+// Uncommon
+$border-ultra-light-gray: #e8f0f5;
+
+// Layout
+$masterbar-color: $blue-wordpress;
+$sidebar-bg-color: lighten($gray, 30%);
+$sidebar-text-color: $gray-dark;
+$sidebar-selected-color: $gray;
+
+// Dashboard
+$dashboard-number-border: #cbd7e1;
+
+//Social media colors
+$color-facebook: #1877f2;
+$color-twitter: #55acee;
+$color-gplus: #df4a32;
+$color-tumblr: #35465c;
+$color-linkedin: #0976b4;
+$color-path: #df3b2f;
+$color-instagram: #e12f67;
+$color-eventbrite: #ff8000;
+$color-stumbleupon: #eb4924;
+$color-reddit: #5f99cf;
+$color-pinterest: #cc2127;
+$color-pocket: #ee4256;
+$color-email: #f8f8f8;
+$color-print: #f8f8f8;
+$color-skype: #00aff0;
+$color-telegram: #0088cc;
+$color-whatsapp: #43d854;
+$color-google: #4285f4;
+
+// ==========================================================================
+// Jetpack Specific Colors
+// ==========================================================================
+
+$green-primary: #00be28;
+$green-secondary: #00a523;
+$green-dark: #008b1d;
+
+// ==========================================================================
+// WP-ADMIN Specific Colors
+// full color list here: http://codepen.io/hugobaeta/full/RNOzoV/
+// ==========================================================================
+
+$wpui-gray-light: #f6f7f7;
+$wpui-dark-medium-gray: #50575e;
+$wpui-header-dark: #1d2327;

--- a/projects/packages/search/src/dashboard/temp-copied-files/mixin_breakpoint.scss
+++ b/projects/packages/search/src/dashboard/temp-copied-files/mixin_breakpoint.scss
@@ -1,0 +1,55 @@
+// ==========================================================================
+// Breakpoint Mixin
+// See https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md#media-queries
+// ==========================================================================
+
+$breakpoints: 480px, 660px, 960px, 1040px; // Think very carefully before adding a new breakpoint
+
+@mixin breakpoint($size) {
+	@if type-of($size) == string {
+		$approved-value: 0;
+		@each $breakpoint in $breakpoints {
+			$and-larger: '>' + $breakpoint;
+			$and-smaller: '<' + $breakpoint;
+
+			@if $size == $and-smaller {
+				$approved-value: 1;
+				@media (max-width: $breakpoint) {
+					@content;
+				}
+			} @else {
+				@if $size == $and-larger {
+					$approved-value: 2;
+					@media (min-width: $breakpoint + 1) {
+						@content;
+					}
+				} @else {
+					@each $breakpoint-end in $breakpoints {
+						$range: $breakpoint + '-' + $breakpoint-end;
+						@if $size == $range {
+							$approved-value: 3;
+							@media (min-width: $breakpoint + 1) and (max-width: $breakpoint-end) {
+								@content;
+							}
+						}
+					}
+				}
+			}
+		}
+		@if $approved-value == 0 {
+			$sizes: '';
+			@each $breakpoint in $breakpoints {
+				$sizes: $sizes + ' ' + $breakpoint;
+			}
+			// TODO - change this to use @error, when it is supported by node-sass
+			@warn "ERROR in breakpoint( #{ $size } ): You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+		}
+	} @else {
+		$sizes: '';
+		@each $breakpoint in $breakpoints {
+			$sizes: $sizes + ' ' + $breakpoint;
+		}
+		// TODO - change this to use @error, when it is supported by node-sass
+		@warn "ERROR in breakpoint( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+	}
+}

--- a/projects/packages/search/webpack.dashboard.js
+++ b/projects/packages/search/webpack.dashboard.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+const DependencyExtractionWebpackPlugin = require('@wordpress/dependency-extraction-webpack-plugin');
+const getBaseWebpackConfig = require('@automattic/calypso-build/webpack.config.js');
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
+const path = require('path');
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+const baseWebpackConfig = getBaseWebpackConfig(
+	{ WP: false },
+	{
+		entry: {}, // We'll override later
+		'output-filename': '[name].js',
+		'output-chunk-filename': '[name].[contenthash].js',
+		'output-path': path.join(__dirname, 'build'),
+		// Calypso-build defaults this to "window", which breaks things if no library.name is set.
+		'output-library-target': '',
+	}
+);
+
+module.exports = [
+	{
+		...baseWebpackConfig,
+		devtool: isDevelopment ? 'source-map' : false,
+		entry: {
+			dashboard: path.join(__dirname, './src/dashboard/entry.js'),
+		},
+		node: {},
+		optimization: {
+			...baseWebpackConfig.optimization,
+			// This optimization sometimes causes webpack to drop `__()` and such.
+			concatenateModules: false,
+		},
+		plugins: [
+			...baseWebpackConfig.plugins,
+			new NodePolyfillPlugin(),
+			new DependencyExtractionWebpackPlugin({ injectPolyfill: true }),
+		],
+		resolve: {
+			...baseWebpackConfig.resolve,
+			modules: ['node_modules'],
+			// We want the compiled version, not the "calypso:src" sources.
+			mainFields: baseWebpackConfig.resolve.mainFields.filter(entry => 'calypso:src' !== entry),
+			alias: {
+				...baseWebpackConfig.resolve.alias,
+				fs: false,
+			},
+		},
+	},
+];

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -40,6 +40,8 @@ class Jetpack_Admin {
 		jetpack_require_lib( 'admin-pages/class-jetpack-search-dashboard-page' );
 		$this->jetpack_search = new Jetpack_Search_Dashboard_Page();
 
+		$this->jetpack_search2 = new Automattic\Jetpack\Search\Dashboard();
+
 		add_action( 'admin_init', array( $this->jetpack_react, 'react_redirects' ), 0 );
 		add_action( 'admin_menu', array( $this->jetpack_react, 'add_actions' ), 998 );
 		add_action( 'admin_menu', array( $this->jetpack_search, 'add_actions' ), 999 );

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -115,6 +115,63 @@
             }
         },
         {
+            "name": "automattic/jetpack-admin-ui",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/admin-ui",
+                "reference": "ec067e4463b937c43eb075c0bae335d393a19133"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^2.0",
+                "automattic/wordbless": "dev-master",
+                "yoast/phpunit-polyfills": "1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-admin-ui",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-admin-menu.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "@composer install",
+                    "phpdbg -d memory_limit=2048M -d max_execution_time=900 -qrr ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer install",
+                    "@composer phpunit"
+                ],
+                "post-update-cmd": [
+                    "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Generic Jetpack wp-admin UI elements",
+            "transport-options": {
+                "monorepo": true,
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-assets",
             "version": "dev-master",
             "dist": {
@@ -1309,7 +1366,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "bdefbd2d669ebb3a249f3d80b133d12a0df17c88"
+                "reference": "e27aa3023a7aa4553a0c9dad6a604ac2356735e2"
+            },
+            "require": {
+                "automattic/jetpack-admin-ui": "0.1.x-dev",
+                "automattic/jetpack-tracking": "1.13.x-dev"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^2.0",


### PR DESCRIPTION
Follow-up for #21339.

#### Changes proposed in this Pull Request:
This is a proof-of-concept PR.

* Adds a Dashboard PHP class to the Search package.
* Adds a Webpack build process for the Dashboard within the Search package.
* Adds a (duplicated) functioning Search Dashboard to wp-admin. Note that this Dashboard lacks the data layer integration necessary for enabling/disabling Search and Instant Search.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your local Jetpack installation.
* Build the Search package via `pnpm build` in `projects/packages/search/`.
* Build the Jetpack plugin via `pnpm build` in `projects/plugins/jetpack/`.
* Navigate to `/wp-admin`. Ensure that there's a "Search 2" submenu within the Jetpack admin menu.
* Ensure that the Search 2 submenu renders a(n) (incomplete version of) the Jetpack Search dashboard.
