### PR TITLE
Heartbeat: fix typo in README

### DIFF
--- a/projects/packages/heartbeat/README.md
+++ b/projects/packages/heartbeat/README.md
@@ -6,7 +6,7 @@ These are internal usage stats for Automattic, not visible to site owners.
 
 ## Usage
 
-### 1. Make sure Hearbeat is initialized:
+### 1. Make sure Heartbeat is initialized:
 
 ```php
 Automattic\Jetpack\Heartbeat::init();

--- a/projects/packages/heartbeat/changelog/fix-typo-heartbeat
+++ b/projects/packages/heartbeat/changelog/fix-typo-heartbeat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Heartbeat: fix typo in README
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fix typo in Heartbeat readme. This was originally spotted by an OSS contributor @lukecav in https://github.com/Automattic/jetpack/pull/21404.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Check README doesn't have any typos on "Heartbeat".