### PR TITLE
actions: Add action to build and push the Docker Dev Env

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,9 +8,6 @@ on:
       - 'tools/docker/config/*'
       - '.github/versions.sh'
       - '.github/workflows/build-docker.yml'
-  # Temporarily run on pull request, for testing the PR. Remove this before merging.
-  pull_request:
-    branches: [ 'master' ]
 concurrency:
   group: build-docker-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
PR #21124 broke Docker Hub's auto-building, as it doesn't know what to
supply for the added ARGs. And we've been meaning to move away from
their auto-builder anyway since they changed it to require a paid plan.
GitHub Actions can do the build and push the image.

We'll try pushing to both Docker Hub and GitHub Packages, see how each
works.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1634160831460400-slack-CBG1CP4EN
p9dueE-3CT-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See if the action runs and publishes correct images.
  * Looks like it did: https://hub.docker.com/r/automattic/jetpack-wordpress-dev is updated, and https://github.com/Automattic/jetpack/pkgs/container/jetpack-wordpress-dev exists.
  * Note the latter shows the monorepo readme rather than the image's readme. Unless we want to mirror repo it and so on, we'll have to wait for GitHub to [start using the metadata field pointing to the correct readme](https://github.community/t/github-container-registry-points-to-incorrect-readme/176437).
* Merge this, then merge something else (not touching Docker stuff), and see that the action doesn't run in response.
* Merge this, them create and merge a PR that does touch the Docker stuff, and see that the action does run in response.