### PR TITLE
cli: Fix generation of js-packages to not include a "require-dev "

### DIFF
--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -385,7 +385,6 @@ async function createComposerJson( composerJson, answers ) {
 			composerJson.type = 'wordpress-plugin';
 			break;
 		case 'js-package':
-			composerJson[ 'require-dev ' ] = { 'automattic/jetpack-changelogger': '^2.0' };
 			composerJson.scripts = {
 				'test-js': [ 'Composer\\Config::disableProcessTimeout', 'pnpm install', 'pnpm run test' ],
 				'test-coverage': [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Not sure why this was even there in the first place. We already get the
dep on changelogger from the skeleton file. If it was supposed to be
removing the yoast/phpunit-polyfills dep, that would be better done by
an overriding skeleton file or a use of the `delete` operator so as to
avoid having another place where the changelogger version is specified.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do `jetpack generate js-packages` and answer the prompts. The generated `composer.json` should not contain a "require-dev " (note the trailing space) key, and should have "require-dev" (no space) depend on the current version of changelogger.