### PR TITLE
Stats: do not update the WPCOM blog details

### DIFF
--- a/projects/plugins/jetpack/changelog/update-stats_update_blog_details
+++ b/projects/plugins/jetpack/changelog/update-stats_update_blog_details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Stats: remove the wpcom blog details update that occurs when the stats module is first activated

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -395,8 +395,6 @@ function stats_upgrade_options( $options ) {
 		return false;
 	}
 
-	stats_update_blog();
-
 	return $new_options;
 }
 
@@ -943,12 +941,18 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 }
 
 /**
+ *
+ * Deprecated. The stats module should not update blog details. This is handled by Sync.
+ *
  * Stats Update Blog.
  *
  * @access public
  * @return void
+ *
+ * @deprecated since 10.3.
  */
 function stats_update_blog() {
+	deprecated_function( __METHOD__, 'jetpack-10.3' );
 	XMLRPC_Async_Call::add_call( 'jetpack.updateBlog', 0, stats_get_blog() );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Currently, it's possible for the Stats module to change the WPCOM side `siteurl` value when the site is in an identity crisis, which is not the expected behavior. Only the Identity Crisis process should update the WPCOM side `siteurl` and `home` option values. Also, the data that is sent by the Stats module is handled by the Sync process, so it shouldn't be necessary for the Stats module to send it.

 * Deprecate the `stats_update_blog()` function.
 * Remove the `stats_update_blog()` call from `stats_upgrade_options()`.

An alternate approach to this solve the identity crisis problem would be to just remove the `siteurl` option from the data that's sent in the `jetpack.updateBlog` request. However, it seems redundant to send any of this data since Sync handles it.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Suggested code review:
Confirm that the `jetpack.updateBlog` request sends data that is handled by Sync. The values that are sent by the call to `jetpack.updateBlog` are found in the `stats_get_blog` [function](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/modules/stats.php#L961). The default options that are sent by Sync are found in the `Defaults::default_options_whitelist` [property](https://github.com/Automattic/jetpack/blob/master/projects/packages/sync/src/class-defaults.php#L22). The `siteurl` option is synced via the `site_url` callable [here](https://github.com/Automattic/jetpack/blob/master/projects/packages/sync/src/class-defaults.php#L288).



##### Manual test:
1. Install and activate this branch of Jetpack.
2. Connect to WPCOM.
3. Get the blog id for your test site.
4. Using your sandbox, verify that that your test [site's options that were updated](https://github.com/Automattic/jetpack/blob/3ce345489bf54d94e455650b5a0ffeb195c06124/projects/plugins/jetpack/modules/stats.php#L961) by the call to `jetpack.updateBlog` are correct. (`blogname`, `siteurl`, `stats_api`, `stats_options`, etc.)