### PR TITLE
Connection: fixing the bug with connect button not appearing for secondary users

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/connection/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/connection/reducer.js
@@ -43,6 +43,10 @@ export const status = (
 			return assign( {}, state, { siteConnected: action.siteConnected } );
 		case DISCONNECT_SITE_SUCCESS:
 			return assign( {}, state, { siteConnected: action.siteConnected } );
+		case UNLINK_USER_SUCCESS:
+			return assign( {}, state, {
+				siteConnected: { ...state.siteConnected, isUserConnected: false },
+			} );
 		case USER_CONNECTION_DATA_FETCH_SUCCESS:
 			if ( true === action.userConnectionData?.currentUser?.isConnected ) {
 				return assign( {}, state, {

--- a/projects/plugins/jetpack/changelog/fix-secondary-user-connect-button
+++ b/projects/plugins/jetpack/changelog/fix-secondary-user-connect-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix the connect button disappearing bug for secondary users.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fix the bug with connection not appearing for secondary users after disconnect.
After secondary user gets disconnected, connection status in the state doesn't get properly updated. This PR fixes it by updating the state properly.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
_We'll start with reproducing the bug to make sure we're actually fixing it._
1. Checkout the `master` branch, connect Jetpack.
2. Log in as secondary user (admin or non-admin), connect to WP.com
3. Go to Jetpack Dashboard, click "Disconnect your WordPress.com account".
4. The link to "Connect your WordPress.com account" should appear, click it.
5. The connection screen should appear, confirm that the "Connect your user account" button is not there.
6. Checkout the branch for this PR, reload Jetpack Dashboard, connect the user.
7. Repeat steps 3-5, confirm that the "Connect your user account" button appears this time.