### PR TITLE
My Plan: Update realtime backup storage amounts

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -31,8 +31,8 @@ import {
 import License from './license';
 import MyPlanCard from '../my-plan-card';
 
-const BACKUP_STORAGE_GB = 200;
-const BACKUP_PRO_STORAGE_TB = 2;
+const BACKUP_STORAGE_GB = 10;
+const BACKUP_PRO_STORAGE_TB = 1;
 
 class MyPlanHeader extends React.Component {
 	getProductProps( productSlug ) {

--- a/projects/plugins/jetpack/changelog/update-realtime-backup-storage-amounts
+++ b/projects/plugins/jetpack/changelog/update-realtime-backup-storage-amounts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updates the display of Jetpack Backup storage amounts. (Not yet user facing.)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The amounts of storage for the different Jetpack Backup Realtime tiers were changed to 10GB and 1TB, and this updates that display.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
paZw9k-aD-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Make a site that has either the Jetpack Backup (10GB) product or the Jetpack Backup (1TB) product.
2. Visit `/wp-admin/admin.php?page=jetpack#/my-plan` and verify that the plan card displays either 10GB or 1TB.