### PR TITLE
Tiled Gallery Block: Hooking up settings with attributes on block

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
@@ -26,12 +26,12 @@ import { useResizeObserver } from '@wordpress/compose';
 import { ALLOWED_MEDIA_TYPES } from './constants';
 import { icon } from '.';
 import styles from './styles.scss';
-import TiledGallerySettings, { DEFAULT_COLUMNS } from './settings';
+import TiledGallerySettings, { DEFAULT_COLUMNS, MAX_COLUMNS } from './settings';
 
 const TILE_SPACING = 8;
 
 export function defaultColumnsNumber( images ) {
-	return Math.min( 3, images.length );
+	return Math.min( MAX_COLUMNS, images.length );
 }
 
 const TiledGalleryEdit = props => {
@@ -95,10 +95,9 @@ const TiledGalleryEdit = props => {
 
 	useEffect( () => {
 		if ( ! columns ) {
-			const col = Math.min( images.length, DEFAULT_COLUMNS );
-			setAttributes( { columns: Math.max( col, 1 ) } );
+			setAttributes( { columns: DEFAULT_COLUMNS } );
 		}
-	}, [ images, columns, setAttributes ] );
+	}, [ columns, setAttributes ] );
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{},

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/settings.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/settings.native.js
@@ -18,7 +18,7 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import styles from './styles.scss';
 
 const MIN_COLUMNS = 1;
-const MAX_COLUMNS = 3;
+export const MAX_COLUMNS = 8;
 export const DEFAULT_COLUMNS = 2;
 const MIN_ROUNDED_CORNERS = 0;
 const MAX_ROUNDED_CORNERS = 20;


### PR DESCRIPTION
Allowing changes to settings for Tiled Gallery Block to reflect in the block's attributes (and thus are serialized out).

#### Changes proposed in this Pull Request:
* Uses `setAttributes` to save the settings (columns, rounded corners) to the Tiled Gallery Block's attributes.

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
1. Create tiled gallery block and add two pictures.
2. Open block settings bottom sheet.
3. Change the columns number to 1.
4. Note that the editor changes the columns to 1, stacking the two pictures.
5. Open HTML editor and see that the block comment has `"columns": 1` in the HTML.
6. Repeat for rounded corners.

#### Screenshot

https://user-images.githubusercontent.com/13263478/138056172-d6bb62d4-cc1f-4e76-818b-de8b8ac22beb.mp4

