### PR TITLE
E2E tests: rename user-less connection test

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-rename-connection-test
+++ b/projects/plugins/jetpack/changelog/e2e-rename-connection-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+E2E tests: renamed test

--- a/projects/plugins/jetpack/tests/e2e/specs/connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/connection.test.js
@@ -22,7 +22,7 @@ describe( 'Connection', () => {
 		await prerequisitesBuilder().withCleanEnv().build();
 	} );
 
-	it( 'User-less', async () => {
+	it( 'Site only', async () => {
 		await testStep( 'Can clean up WPCOM cookie', async () => {
 			await ( await Sidebar.init( page ) ).removeCookieByName( 'wordpress_logged_in' );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Rename connection e2e test from user-less to site-only.

#### Jetpack product discussion
https://app.asana.com/0/1156386383419466/1200426311901547

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Tests pass
