### PR TITLE
Jetpack: Add Backup Tier 1 & Tier 2 to realtime list

### DIFF
--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -395,6 +395,8 @@ export function containsBackupDaily( planClass ) {
 export function containsBackupRealtime( planClass ) {
 	return [
 		'is-business-plan',
+		'is-backup-t1-plan',
+		'is-backup-t2-plan',
 		'is-security-t1-plan',
 		'is-security-t2-plan',
 		'is-complete-plan',

--- a/projects/plugins/jetpack/changelog/update-tiered-backups-contain-realtime
+++ b/projects/plugins/jetpack/changelog/update-tiered-backups-contain-realtime
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Doesn't affect anything user-facing yet.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds Jetpack Backup Tier 1 and Tier 2 to the list of realtime products.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Get a site that has a Jetpack Backup (10GB) or Jetpack Backup (1TB) plan, and does not have server credentials added.
2. Visit `/wp-admin/admin.php?page=jetpack#/recommendations/summary` and verify that the "Enable one click restores" prompt displays Real-time Backups:

<img width="315" alt="image" src="https://user-images.githubusercontent.com/42627630/138153963-fb6a7b82-f3de-4518-a730-09b89d57fd08.png">

