### PR TITLE
Jetpack Tiled Gallery Block: `save` functionality

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
@@ -90,14 +90,14 @@ const TiledGalleryEdit = props => {
 
 		const newIds = images?.map( image => image.id );
 		setAttributes( { ids: newIds } );
-	}, [ images ] );
+	}, [ images, setAttributes, updateBlockAttributes ] );
 
 	useEffect( () => {
 		if ( ! columns ) {
 			const col = Math.min( images.length, DEFAULT_COLUMNS );
 			setAttributes( { columns: Math.max( col, 1 ) } );
 		}
-	}, [ images ] );
+	}, [ columns, images, setAttributes ] );
 
 	const populateInnerBlocksWithImages = ( imgs, replace = false ) => {
 		const newBlocks = imgs.map( image => {
@@ -117,7 +117,7 @@ const TiledGalleryEdit = props => {
 			setAttributes( { columns: DEFAULT_COLUMNS } );
 		}
 	}, [ columns, setAttributes ] );
-	
+
 	if ( attributeImages.length && ! images.length ) {
 		populateInnerBlocksWithImages( attributeImages, true );
 	}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/save.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { isBlobURL } from '@wordpress/blob';
+import { Platform } from '@wordpress/element';
 
 export default function GalleryImageSave( props ) {
 	const { alt, ariaLabel, imageFilter, height, id, link, linkTo, origUrl, url, width } = props;
@@ -31,7 +32,7 @@ export default function GalleryImageSave( props ) {
 			data-url={ origUrl }
 			data-width={ width }
 			src={ url }
-			aria-label={ ariaLabel }
+			aria-label={ Platform.OS === 'web' ? undefined : ariaLabel }
 		/>
 	);
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Platform } from '@wordpress/element';
 import classnames from 'classnames';
 
 /**
@@ -47,10 +47,13 @@ export default class Layout extends Component {
 
 		const { src, srcSet } = photonizedImgProps( img, { layoutStyle } );
 
+		const isWeb = Platform.OS === 'web';
+
 		return (
 			<Image
 				alt={ img.alt }
-				ariaLabel={ ariaLabel }
+				aria-label={ isWeb ? ariaLabel : undefined }
+				ariaLabel={ isWeb ? undefined : ariaLabel }
 				columns={ columns }
 				height={ img.height }
 				id={ img.id }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/square.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/square.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { chunk, drop, take } from 'lodash';
+import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,14 +16,16 @@ export default function Square( { columns, renderedImages } ) {
 	const columnCount = Math.min( MAX_COLUMNS, columns );
 
 	const remainder = renderedImages.length % columnCount;
-
 	return (
 		<Gallery>
 			{ [
 				...( remainder ? [ take( renderedImages, remainder ) ] : [] ),
 				...chunk( drop( renderedImages, remainder ), columnCount ),
 			].map( ( imagesInRow, rowIndex ) => (
-				<Row key={ rowIndex }>
+				<Row
+					key={ rowIndex }
+					className={ Platform.OS === 'web' ? `columns-${ imagesInRow.length }` : undefined }
+				>
 					{ imagesInRow.map( ( image, colIndex ) => (
 						<Column key={ colIndex }>{ image }</Column>
 					) ) }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
@@ -3,11 +3,6 @@
  */
 import Layout from './layout';
 import { defaultColumnsNumber } from './edit';
-import { getActiveStyleName } from '../../shared/block-styles';
-import { LAYOUT_STYLES } from './constants';
-
-import classnames from 'classnames';
-import { RichText, useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 export default function TiledGallerySave( { attributes, innerBlocks } ) {
 	if ( ! innerBlocks.length ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/utils/index.js
@@ -4,6 +4,7 @@
 import photon from 'photon';
 import { format as formatUrl, parse as parseUrl } from 'url';
 import { isBlobURL } from '@wordpress/blob';
+import { Platform } from '@wordpress/element';
 import { range } from 'lodash';
 
 /**
@@ -66,16 +67,17 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 	 * We don't know what the viewport size will be like. Use full size src.
 	 */
 
+	const isWeb = Platform.OS === 'web';
 	let src;
-	// if ( isSquareishLayout( layoutStyle ) && width && height ) {
-	// 	// Layouts with 1:1 width/height ratio should be made square
-	// 	const size = Math.min( PHOTON_MAX_RESIZE, width, height );
-	// 	src = photonImplementation( url, {
-	// 		resize: `${ size },${ size }`,
-	// 	} );
-	// } else {
-	src = photonImplementation( url );
-	// }
+	if ( isSquareishLayout( layoutStyle ) && width && height && isWeb ) {
+		// Layouts with 1:1 width/height ratio should be made square
+		const size = Math.min( PHOTON_MAX_RESIZE, width, height );
+		src = photonImplementation( url, {
+			resize: `${ size },${ size }`,
+		} );
+	} else {
+		src = photonImplementation( url );
+	}
 
 	/**
 	 * Build a sensible `srcSet` that will let the browser get an optimized image based on


### PR DESCRIPTION
Adding workaround to allow for loading of serialized HTML into the mobile editor. Currently using the workaround to unblock the rest of the block functionality that still needs to be done; will revisit in the future. One known bug is that loading a 1-column HTML still shows "Problem Displaying Block".

See issues:
- [Jetpack Tiled Gallery: Workaround used for save functionality #4137](https://github.com/wordpress-mobile/gutenberg-mobile/issues/4137)
- [Jetpack Tiled Gallery: Fix the save function when a single column is used #4142](https://github.com/wordpress-mobile/gutenberg-mobile/issues/4142)

#### Changes proposed in this Pull Request:
Allows us to load serialized HTML for the mobile app so that the saved Tiled Gallery Block shows up on the editor.

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
1. Create a tiled gallery block.
2. Add 2 images to the block.
3. Switch to HTML view.
4. Select all of the serialized HTML and cut.
5. Switch back to visual mode.
6. Switch to HTML mode again (these steps force the visual editor to update).
7. Paste in the HTML that was cut.
8. Switch back to visual mode.
9. See that the correct Tiled Gallery Block shows up.

#### Screenshots:

https://user-images.githubusercontent.com/13263478/138168422-70867268-561e-4edf-a8c5-ddfd43ac4e65.mp4

