### PR TITLE
At-a-Glance: Show realtime backups for tiered backup products

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
@@ -21,6 +21,7 @@ import DashItem from 'components/dash-item';
 import JetpackBanner from 'components/jetpack-banner';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
 import {
+	containsBackupRealtime,
 	getPlanClass,
 	getJetpackProductUpsellByFeature,
 	FEATURE_SITE_BACKUPS_JETPACK,
@@ -217,7 +218,7 @@ class DashBackups extends Component {
 					</React.Fragment>
 				);
 			case 'active':
-				const message = [ 'is-business-plan', 'is-realtime-backup-plan' ].includes( planClass )
+				const message = containsBackupRealtime( planClass )
 					? __( 'We are backing up your site in real-time.', 'jetpack' )
 					: __( 'We are backing up your site daily.', 'jetpack' );
 

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
@@ -27,7 +27,7 @@ import {
 	FEATURE_SITE_BACKUPS_JETPACK,
 } from 'lib/plans/constants';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
-import { getSitePlan } from 'state/site';
+import { getActiveBackupPurchase, getSitePlan, hasActiveBackupPurchase } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressData } from 'state/at-a-glance';
 import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
@@ -289,7 +289,9 @@ export default connect(
 		return {
 			vaultPressData: getVaultPressData( state ),
 			sitePlan,
-			planClass: getPlanClass( sitePlan ),
+			planClass: hasActiveBackupPurchase( state )
+				? getPlanClass( getActiveBackupPurchase( state ).product_slug )
+				: getPlanClass( sitePlan.product_slug ),
 			isOfflineMode: isOfflineMode( state ),
 			isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
 			showBackups: showBackups( state ),

--- a/projects/plugins/jetpack/changelog/update-aag-realtime-backups
+++ b/projects/plugins/jetpack/changelog/update-aag-realtime-backups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Displays realtime backups in AAG for tiered backup products (Not yet user facing)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This updates the Backup card on the AAG page to display realtime backups for the new tiered backup products.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a site with one of the new tiered backup products and add credentials.
2. Visit `/wp-admin/admin.php?page=jetpack#/dashboard` and verify that the backup card states that backups are real-time.
