### PR TITLE
E2E tests: Update Plans page placeholder CSS class

### DIFF
--- a/tools/e2e-commons/pages/wpcom/pick-a-plan.js
+++ b/tools/e2e-commons/pages/wpcom/pick-a-plan.js
@@ -10,7 +10,7 @@ export default class PickAPlanPage extends WpPage {
 
 	async waitForPage() {
 		await super.waitForPage();
-		await this.waitForElementToBeHidden( '.jetpack-product-card-alt__price-placeholder' );
+		await this.waitForElementToBeHidden( '.display-price__price-placeholder' );
 	}
 
 	async select( product = 'free' ) {


### PR DESCRIPTION
At some point, the plan pricing placeholder has changed. This PR updates the locator. Also, there is a new type of E2E flakiness that could be related to an invalid locator: On free plan selection, Calypso assumes that the user does not have a connected site yet.


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* check if CI is green
*
