### PR TITLE
Identity Crisis: Remove the unused jetpack_idc_option transient

### DIFF
--- a/projects/packages/identity-crisis/changelog/update-remove_unused_idc_transient
+++ b/projects/packages/identity-crisis/changelog/update-remove_unused_idc_transient
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove the unused jetpack_idc_option transient
+
+

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -481,8 +481,6 @@ class Identity_Crisis {
 			$returned_values[ $key ] = $normalized_url;
 		}
 
-		set_transient( 'jetpack_idc_option', $returned_values, MINUTE_IN_SECONDS );
-
 		return $returned_values;
 	}
 

--- a/projects/plugins/debug-helper/changelog/update-remove_unused_idc_transient
+++ b/projects/plugins/debug-helper/changelog/update-remove_unused_idc_transient
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Rmove the unusaed jetpack_idc_option transient from the UI

--- a/projects/plugins/debug-helper/modules/class-idc-simulator.php
+++ b/projects/plugins/debug-helper/modules/class-idc-simulator.php
@@ -137,9 +137,6 @@ class IDC_Simulator {
 		<h3>jetpack_idc_local</h3>
 		<pre><?php var_dump( get_transient( 'jetpack_idc_local' ) ); //phpcs:ignore ?></pre>
 
-		<h3>jetpack_idc_option</h3>
-		<pre><?php var_dump( get_transient( 'jetpack_idc_option' ) ); //phpcs:ignore ?></pre>
-
 		<hr>
 		<?php
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The `jetpack_idc_option` transient is set in the `Identity_Crisis::get_sync_error_idc_option` method, but it's never used. Let's remove it.
* We also display the value of the transient in the IDC Simulator module in the Debug Helper plugin. Since the transient will no longer be set, remove it from the IDC simulator UI.

##### History
It looks like we stopped using the `jetpack_idc_option` transient in PR #8101.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Verify that the `jetpack_idc_option` transient is not used.
