### PR TITLE
Settings: Show backups-only settings card for tiered backup products

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/index.jsx
@@ -95,8 +95,12 @@ export class Security extends Component {
 		const isPersonalPlan = 'is-personal-plan' === planClass;
 		const isFreePlanWithBackup =
 			'is-free-plan' === planClass &&
-			( activePlanClasses.includes( 'is-daily-backup-plan' ) ||
-				activePlanClasses.includes( 'is-realtime-backup-plan' ) );
+			[
+				'is-daily-backup-plan',
+				'is-realtime-backup-plan',
+				'is-backup-t1-plan',
+				'is-backup-t2-plan',
+			].filter( plan => activePlanClasses.includes( plan ) ).length > 0;
 
 		const backupsOnly = isPersonalPlan || isFreePlanWithBackup;
 

--- a/projects/plugins/jetpack/changelog/update-show-jetpack-backup-settings-for-tiered-products
+++ b/projects/plugins/jetpack/changelog/update-show-jetpack-backup-settings-for-tiered-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Make the Backups only settings card show for tiered backup products (not yet user facing)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR makes the backups-only settings card show for the new tiered backup products.

<img width="755" alt="image" src="https://user-images.githubusercontent.com/42627630/138350309-7880dcd9-149c-4845-9f07-b1b038f059ce.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a site with either Jetpack Backup (10GB) or Jetpack Backup (1TB).
2. Visit `/wp-admin/admin.php?page=jetpack#/settings`
3. Verify that the Backup settings card only mentions Jetpack Backup, and not Backup & Scan.
