### PR TITLE
Debug Helper IDC Simulator: Add the ability to spoof the home url

### DIFF
--- a/projects/plugins/debug-helper/changelog/2021-10-23-02-27-17-913006
+++ b/projects/plugins/debug-helper/changelog/2021-10-23-02-27-17-913006
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+IDC Simulatore: add the ability to spoof the home option value

--- a/projects/plugins/debug-helper/modules/class-idc-simulator.php
+++ b/projects/plugins/debug-helper/modules/class-idc-simulator.php
@@ -46,22 +46,39 @@ class IDC_Simulator {
 	 *
 	 * @param string $url the siteurl value.
 	 */
-	public static function spoof_siteurl( $url ) {
+	public static function spoof_url( $url ) {
 		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
 			return $url;
 		}
 
-		$settings                   = self::get_stored_settings();
-		$settings['idc_simulation'] = $settings['idc_simulation'] ?
-			true : false;
-		$settings['idc_siteurl']    = ( ! empty( $settings['idc_siteurl'] ) && is_string( $settings['idc_siteurl'] ) ) ?
-			$settings['idc_siteurl'] : 'https://example.org/';
+		$settings = self::get_stored_settings();
 
-		if ( false === $settings['idc_simulation'] ) {
+		if ( ! $settings['idc_simulation'] || ! self::should_spoof_url( $settings ) ) {
 			return $url;
 		}
 
+		$settings['idc_siteurl'] = ( ! empty( $settings['idc_siteurl'] ) && is_string( $settings['idc_siteurl'] ) ) ?
+			$settings['idc_siteurl'] : 'https://example.org/';
+
 		return $settings['idc_siteurl'];
+	}
+
+	/**
+	 * Determines whether the filtered url should be spoofed based on the IDC simulator settings.
+	 *
+	 * @param array $settings The IDC simulator settings.
+	 *
+	 * @return bool Whether the filtered siteurl or home values should be spoofed.
+	 */
+	public static function should_spoof_url( $settings ) {
+		$filter_name = current_filter();
+
+		if ( ( 'jetpack_sync_site_url' === $filter_name && ! $settings['idc_spoof_siteurl'] )
+			|| ( 'jetpack_sync_home_url' === $filter_name && ! $settings['idc_spoof_home'] ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -100,8 +117,8 @@ class IDC_Simulator {
 		<p>Cause an IDC on your site without having to clone it</p>
 
 		<h2>Current ICD simulation settings:</h2>
-		<p>Site URL spoofing: <?php echo esc_html( $settings['idc_simulation'] ); ?></p>
-		<p>Site URL value: <?php echo esc_html( $settings['idc_siteurl'] ); ?></p>
+		<p>URL spoofing: <?php echo esc_html( $settings['idc_simulation'] ); ?></p>
+		<p>URL value: <?php echo esc_html( $settings['idc_siteurl'] ); ?></p>
 
 		<hr>
 
@@ -121,6 +138,13 @@ class IDC_Simulator {
 			<tr>
 				<th scope="row"><label for="idc_siteurl">Spoof URL</label></th>
 				<td><input name="idc_siteurl" type="text" id="blogname" value="<?php echo esc_attr( $settings['idc_siteurl'] ); ?>" class="regular-text"></td>
+			</tr>
+			<tr>
+				<th scope="row">URLs to spoof</th>
+				<td>
+					<label><input type="checkbox" name="idc_spoof_siteurl" <?php echo ( $settings['idc_spoof_siteurl'] ? 'checked="checked"' : '' ); ?>> Site URL</label><br>
+					<label><input type="checkbox" name="idc_spoof_home" <?php echo ( $settings['idc_spoof_home'] ? 'checked="checked"' : '' ); ?>> Home URL</label><br>
+				</td>
 			</tr>
 
 			</tbody>
@@ -150,8 +174,10 @@ class IDC_Simulator {
 		update_option(
 			self::STORED_OPTIONS_KEY,
 			array(
-				'idc_siteurl'    => $_POST['idc_siteurl'],
-				'idc_simulation' => $_POST['idc_simulation'],
+				'idc_siteurl'       => $_POST['idc_siteurl'],
+				'idc_simulation'    => $_POST['idc_simulation'],
+				'idc_spoof_siteurl' => isset( $_POST['idc_spoof_siteurl'] ) ? true : false,
+				'idc_spoof_home'    => isset( $_POST['idc_spoof_home'] ) ? true : false,
 			)
 		);
 
@@ -178,8 +204,10 @@ class IDC_Simulator {
 		return wp_parse_args(
 			get_option( self::STORED_OPTIONS_KEY ),
 			array(
-				'idc_siteurl'    => '',
-				'idc_simulation' => false,
+				'idc_siteurl'       => '',
+				'idc_simulation'    => false,
+				'idc_spoof_siteurl' => true,
+				'idc_spoof_home'    => true,
 			)
 		);
 	}
@@ -188,7 +216,8 @@ class IDC_Simulator {
 	 * Early initialization needed for some option value spoofing.
 	 */
 	public static function early_init() {
-		add_filter( 'jetpack_sync_site_url', array( 'IDC_Simulator', 'spoof_siteurl' ) );
+		add_filter( 'jetpack_sync_site_url', array( 'IDC_Simulator', 'spoof_url' ) );
+		add_filter( 'jetpack_sync_home_url', array( 'IDC_Simulator', 'spoof_url' ) );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The Debug Helper plugin's IDC Simulator module allows the user to spoof the siteurl value. Let's add the ability to also spoof the home value. To do this, add two checkboxes that allow the user to choose whether to spoof the siteurl and/or home values. These checkboxes should be checked by default because the most common use case will be to spoof both values.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install, activate, and connect Jetpack.
2. Install and activate this branch of the Debug Helper plugin.
3. Enable the IDC Simulator module of the Debug Helper plugin.
4. You can observe the spoofed URLs by:
    a. Pointing your server requests to your sandbox by setting the `JETPACK__SANDBOX_DOMAIN` constant. This will record request urls in `debug.log`.
    b. Causing a sync action to occur to trigger the sync request (for example, edit a post). Sync requests will include the siteurl and home values, so you can verify that they change as expected. 
    c. Note that your site will stop sending sync requests if it goes into an identity crisis. I prevent this by just leaving my server sandbox disabled.
4. Test different IDC Simulator settings (spoof siteurl alone, home alone :smile:, both siteurl and home, and neither) and verify that the URLs are correct in the sync requests.