### PR TITLE
Debug Helper IDC Simulator: display the IDC options.

### DIFF
--- a/projects/plugins/debug-helper/changelog/update-idc_simulator_display_options
+++ b/projects/plugins/debug-helper/changelog/update-idc_simulator_display_options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Display the IDC option values (sync_error_idc, migrate_for_idc, and safe_mode_confirmed)

--- a/projects/plugins/debug-helper/modules/class-idc-simulator.php
+++ b/projects/plugins/debug-helper/modules/class-idc-simulator.php
@@ -156,12 +156,33 @@ class IDC_Simulator {
 		</form>
 
 		<hr>
+		<hr>
 
-		<h2>Current IDC transient values</h2>
-		<h3>jetpack_idc_local</h3>
+		<?php $this->display_idc_transients_options(); ?>
+
+		<?php
+	}
+
+	/**
+	 * Display the IDC transient and option values.
+	 */
+	private function display_idc_transients_options() {
+		?>
+		<h2>Information about IDC</h2>
+		<h3>Current IDC transient values</h3>
+		<h4>jetpack_idc_local</h4>
 		<pre><?php var_dump( get_transient( 'jetpack_idc_local' ) ); //phpcs:ignore ?></pre>
 
 		<hr>
+
+		<h3>Current IDC option values</h3>
+		<h4>jetpack_sync_error_idc</h4>
+		<pre><?php var_dump( get_option( 'jetpack_sync_error_idc' ) ); //phpcs:ignore ?></pre>
+		<h4>jetpack_migrate_for_idc</h4>
+		<pre><?php var_dump( get_option( 'jetpack_migrate_for_idc' ) ); //phpcs:ignore ?></pre>
+		<h4>jetpack_safe_mode_confirmed</h4>
+		<pre><?php var_dump( get_option( 'jetpack_safe_mode_confirmed' ) ); //phpcs:ignore ?></pre>
+
 		<?php
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Display the values of the following IDC options on the IDC Simulator page:
 * `jetpack_sync_error_idc`
 * `jetpack_migrate_for_idc`
 * `jetpack_safe_mode_confirmed`

Making these values visible on the IDC Simulator page will help with testing.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install, activate, and connect Jetpack.
2. Install and activate this branch of the Debug Helper plugin.
3. Enable the IDC Simulator module.
4. On a site without and IDC, verify that the displayed options are empty.
5. Cause an IDC by turning on the IDC Simulator and causing a sync action (for example, edit a post).
6. Reload the IDC Simulator page and verify that the `jetpack_sync_error_idc` option value is displayed.
7. Put the site into Safe Mode by clicking the Safe Mode button in the IDC UI.
8. Reload the IDC Simulator page and verify that the `jetpack_safe_mode_confirmed` option value is '1'.
9. Take the site out of Safe Mode by clicking the `Jetpack Safe Mode` text in the top toolbar.
10. In the IDC UI, click the "Fix Jetpack's Connection" button.
11. Click the "Migrate Stats and Subscribers" button.
12. Reload the IDC Simulator page and verify that the `jetpack_sync_error_idc` value is now empty and that the `jetpack_migrate_for_idc` option value is '1'.