### PR TITLE
Connection: inform connect plugin on registration

### DIFF
--- a/projects/js-packages/api/changelog/fix-inform_connect_plugin_on_register
+++ b/projects/js-packages/api/changelog/fix-inform_connect_plugin_on_register
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added from parameter to the registerSite method to inform the plugin that is performing the registration

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -73,9 +73,10 @@ function JetpackRestApiClient( root, nonce ) {
 			cacheBusterCallback = callback;
 		},
 
-		registerSite: ( registrationNonce, redirectUri ) => {
+		registerSite: ( registrationNonce, redirectUri, from = '' ) => {
 			const params = {
 				registration_nonce: registrationNonce,
+				from: from,
 				no_iframe: true,
 			};
 

--- a/projects/js-packages/connection/changelog/fix-inform_connect_plugin_on_register
+++ b/projects/js-packages/connection/changelog/fix-inform_connect_plugin_on_register
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve inline docs

--- a/projects/js-packages/connection/components/connect-button/index.jsx
+++ b/projects/js-packages/connection/components/connect-button/index.jsx
@@ -22,7 +22,7 @@ import ConnectUser from '../connect-user';
  * @param {string} props.registrationNonce -- Separate registration nonce, required.
  * @param {Function} props.onRegistered -- The callback to be called upon registration success.
  * @param {string} props.redirectUri -- The redirect admin URI.
- * @param {string} props.from -- Where the connection request is coming from.
+ * @param {string} props.from -- Indicates where the registration action was triggered for tracking/segmentation purposes (e.g. the plugin slug).
  * @param {object} props.connectionStatus -- The connection status object.
  * @param {boolean} props.connectionStatusIsFetching -- The flag indicating that connection status is being fetched.
  * @param {boolean} props.autoTrigger -- Whether to initiate the connection process automatically upon rendering the component.
@@ -73,7 +73,7 @@ const ConnectButton = props => {
 			setIsRegistering( true );
 
 			restApi
-				.registerSite( registrationNonce, redirectUri )
+				.registerSite( registrationNonce, redirectUri, from )
 				.then( response => {
 					setIsRegistering( false );
 
@@ -97,6 +97,7 @@ const ConnectButton = props => {
 			onRegistered,
 			registrationNonce,
 			redirectUri,
+			from,
 		]
 	);
 

--- a/projects/js-packages/connection/components/connect-screen/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/index.jsx
@@ -22,7 +22,7 @@ import './style.scss';
  * @param {string} props.apiNonce -- API Nonce, required.
  * @param {string} props.registrationNonce -- Separate registration nonce, required.
  * @param {string} props.redirectUri -- The redirect admin URI.
- * @param {string} props.from -- Where the connection request is coming from.
+ * @param {string} props.from -- Indicates where the registration action was triggered for tracking/segmentation purposes (e.g. the plugin slug).
  * @param {string} props.title -- Page title.
  * @param {Array} props.images -- Images to display on the right side.
  * @param {string} props.assetBaseUrl -- The assets base URL.

--- a/projects/packages/connection/changelog/fix-inform_connect_plugin_on_register
+++ b/projects/packages/connection/changelog/fix-inform_connect_plugin_on_register
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Use the `from` parameter to inform the first plugin to register the site in the v4/register endpoint


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

When the `ConnectButton` uses the `api` js-package's `registerSite` method, it makes a call to `v4/register` without any identification of which is the plugin making that request.

The registration is done with a generic instance of the Connection Manager and, as consequence, the `connect_plugin` argument is not sent to the registration endpoint in WPCOM. 

The result is that we don't have the information of which plugin performed the registration.

The `from` argument is already being passed and used. `ConnectScreen` gets it as a prop and pass it over to `ConnectButton`, but, so far, this is only used in the user authorization step.

This argument is used form tracking purposes. For example, the partner provisioning scripts inform a `jetpack-start` value so we can segment the connections they do.

Backup is already passing the `from` parameter correctly. Even though it has been used to something else, it seems right to use this parameter to also identify the plugin making the connection. I didn't find any collisions.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use the `from` parameter to inform the first plugin to register the site in the v4/register endpoint

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1191179647901802-as-1201167654915231

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it fixes some cases in which information we already track was not being properly sent

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do you agree with the general approach? Or should we have a dedicated parameter for this?

* Set up a new site with only Jetpack the plugin and connect it
* In your sandbox, verify that the `jetpack_first_connected_plugin` was added to the cache site with the correct slug (in this case, `jetpack`)
* Repeat the above with only the Backup plugin active, and Boost, and all combinations you can come up with. Make sure the value of the `jetpack_first_connected_plugin` option always match the slug of the plugin you used to establish the connection.
*