### PR TITLE
cli: Fix docker sftp volume mapping

### DIFF
--- a/tools/cli/helpers/docker-config.js
+++ b/tools/cli/helpers/docker-config.js
@@ -177,9 +177,7 @@ const setMappings = ( argv, config ) => {
 
 	if ( argv.type === 'dev' ) {
 		mappingsCompose.services.sftp = {
-			volumes: volumesMapping.map( vol =>
-				vol.startsWith( '/var/www/html' ) ? '/home/wordpress' + vol : vol
-			),
+			volumes: volumesMapping.map( vol => vol.replace( ':', ':/home/wordpress' ) ),
 		};
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The previous code was not mapping the volumes correctly. It seemed to be
assuming it was mapping over the target paths rather than the
"src:target" strings.

Also it seems we need to put everything under /home/wordpress, otherwise
the symlinks fail.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up sftp in your docker environment. Then sftp in and see if /var/www/html/wp-content/plugins/jetpack/ has Jetpack.
