### PR TITLE
Publicize: Update the logic for enabling the form

### DIFF
--- a/projects/plugins/jetpack/changelog/update-publicize-form-logic
+++ b/projects/plugins/jetpack/changelog/update-publicize-form-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Updated the logic to enable the Publicize form in the editor

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -95,7 +95,8 @@ const PublicizePanel = ( { prePublish } ) => {
 	 */
 	const isPublicizeDisabledBySitePlan =
 		isPostPublished && isRePublicizeFeatureUpgradable && isRePublicizeFeatureEnabled;
-	const isPublicizeEnabled = isPublicizeEnabledFromConfig && ! isPublicizeDisabledBySitePlan;
+	const isPublicizeEnabled =
+		( isPostPublished || isPublicizeEnabledFromConfig ) && ! isPublicizeDisabledBySitePlan;
 
 	// Refresh connections when the post is just published.
 	usePostJustPublished(

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/share-post/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/share-post/index.js
@@ -64,7 +64,7 @@ export function SharePostButton() {
 	 * - is sharing post
 	 */
 	const isButtonDisabled =
-		! isPublicizeEnabled || ! hasEnabledConnections || ! isPostPublished || isFetching;
+		( ! isPostPublished && ! isPublicizeEnabled ) || ! hasEnabledConnections || isFetching;
 
 	return (
 		<Button


### PR DESCRIPTION
If the post was published with sharing disabled, then the form would
remain disabled, and couldn't be repbulicized.

This changes the logic to make sure that the connections can be toggled
and the share button is enabled after the post is published.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
