### PR TITLE
Update PHPUnit coverage configs

### DIFF
--- a/projects/packages/a8c-mc-stats/changelog/fix-phpunit-configs
+++ b/projects/packages/a8c-mc-stats/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/a8c-mc-stats/phpunit.xml.dist
+++ b/projects/packages/a8c-mc-stats/phpunit.xml.dist
@@ -6,12 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">views</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/abtest/changelog/fix-phpunit-configs
+++ b/projects/packages/abtest/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/abtest/phpunit.xml.dist
+++ b/projects/packages/abtest/phpunit.xml.dist
@@ -6,13 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">views</directory>
-				<directory suffix=".php">wordpress</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/admin-ui/changelog/fix-phpunit-configs
+++ b/projects/packages/admin-ui/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/admin-ui/phpunit.xml.dist
+++ b/projects/packages/admin-ui/phpunit.xml.dist
@@ -6,12 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">wordpress</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/assets/changelog/fix-phpunit-configs
+++ b/projects/packages/assets/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/assets/phpunit.xml.dist
+++ b/projects/packages/assets/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -243,7 +243,7 @@ class AssetsTest extends TestCase {
 	/**
 	 * Test whether static resources are properly updated to use a WordPress.com static domain.
 	 *
-	 * @covers Automattic\Jetpack\Status::staticize_subdomain
+	 * @covers Automattic\Jetpack\Assets::staticize_subdomain
 	 * @dataProvider get_resources_urls
 	 *
 	 * @param string $original       Source URL.

--- a/projects/packages/backup/changelog/fix-phpunit-configs
+++ b/projects/packages/backup/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/backup/phpunit.xml.dist
+++ b/projects/packages/backup/phpunit.xml.dist
@@ -6,11 +6,8 @@
 	</testsuites>
 	<filter>
 		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
+			<file>actions.php</file>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/blocks/changelog/fix-phpunit-configs
+++ b/projects/packages/blocks/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/blocks/phpunit.xml.dist
+++ b/projects/packages/blocks/phpunit.xml.dist
@@ -6,12 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">wordpress</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/changelogger/changelog/fix-phpunit-configs
+++ b/projects/packages/changelogger/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/changelogger/phpunit.xml.dist
+++ b/projects/packages/changelogger/phpunit.xml.dist
@@ -6,11 +6,8 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">lib</directory>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/codesniffer/changelog/fix-phpunit-configs
+++ b/projects/packages/codesniffer/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/codesniffer/phpunit.xml.dist
+++ b/projects/packages/codesniffer/phpunit.xml.dist
@@ -6,11 +6,8 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">hacks</directory>
+			<directory suffix=".php">Jetpack</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/connection/changelog/fix-phpunit-configs
+++ b/projects/packages/connection/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/connection/phpunit.xml.dist
+++ b/projects/packages/connection/phpunit.xml.dist
@@ -6,12 +6,8 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">wordpress</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
+			<directory suffix=".php">legacy</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/connection/tests/php/test_Manager_unit.php
+++ b/projects/packages/connection/tests/php/test_Manager_unit.php
@@ -557,7 +557,7 @@ class ManagerTest extends TestCase {
 	/**
 	 * Test disconnecting the site will remove tracked package verions.
 	 *
-	 * @covers Automattic\Jetpack\Connection\Manager::test_disconnect_site
+	 * @covers Automattic\Jetpack\Connection\Manager::disconnect_site
 	 */
 	public function test_disconnect_site_will_remove_tracked_package_versions() {
 		$this->manager->method( 'disconnect_site_wpcom' )

--- a/projects/packages/constants/changelog/fix-phpunit-configs
+++ b/projects/packages/constants/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/constants/phpunit.xml.dist
+++ b/projects/packages/constants/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/device-detection/changelog/fix-phpunit-configs
+++ b/projects/packages/device-detection/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/device-detection/phpunit.xml.dist
+++ b/projects/packages/device-detection/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/error/changelog/fix-phpunit-configs
+++ b/projects/packages/error/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/error/phpunit.xml.dist
+++ b/projects/packages/error/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/identity-crisis/changelog/fix-phpunit-configs
+++ b/projects/packages/identity-crisis/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/identity-crisis/phpunit.xml.dist
+++ b/projects/packages/identity-crisis/phpunit.xml.dist
@@ -6,12 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">views</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/jitm/changelog/fix-phpunit-configs
+++ b/projects/packages/jitm/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/jitm/phpunit.xml.dist
+++ b/projects/packages/jitm/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/lazy-images/changelog/fix-phpunit-configs
+++ b/projects/packages/lazy-images/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/lazy-images/phpunit.xml.dist
+++ b/projects/packages/lazy-images/phpunit.xml.dist
@@ -6,12 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">wordpress</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/licensing/changelog/fix-phpunit-configs
+++ b/projects/packages/licensing/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/licensing/phpunit.xml.dist
+++ b/projects/packages/licensing/phpunit.xml.dist
@@ -6,12 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">wordpress</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/logo/changelog/fix-phpunit-configs
+++ b/projects/packages/logo/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/logo/phpunit.xml.dist
+++ b/projects/packages/logo/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/partner/changelog/fix-phpunit-configs
+++ b/projects/packages/partner/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/partner/phpunit.xml.dist
+++ b/projects/packages/partner/phpunit.xml.dist
@@ -11,11 +11,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/partner/tests/php/test-partner.php
+++ b/projects/packages/partner/tests/php/test-partner.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
  * Class Partner_Test
  *
  * @package Automattic\Jetpack
+ * @covers Automattic\Jetpack\Partner
  */
 class Partner_Test extends TestCase {
 
@@ -33,8 +34,6 @@ class Partner_Test extends TestCase {
 
 	/**
 	 * Tests the class returns the instance.
-	 *
-	 * @covers Automattic\Jetpack\Partner->init();
 	 */
 	public function test_init_returns_instance() {
 		$this->assertInstanceOf( Partner::class, Partner::init() );
@@ -71,8 +70,6 @@ class Partner_Test extends TestCase {
 	 * @param string $option_name Option and filter name.
 	 *
 	 * @throws Monkey\Expectation\Exception\ExpectationArgsRequired Function requires args.
-	 *
-	 * @covers Automattic\Partner->get_partner_code();
 	 */
 	public function test_partner_code_is_empty_by_default( $code_type, $option_name ) {
 		Functions\expect( 'get_option' )->once()->with( $option_name )->andReturn( '' );
@@ -88,8 +85,6 @@ class Partner_Test extends TestCase {
 	 * @param string $option_name Option and filter name.
 	 *
 	 * @throws Monkey\Expectation\Exception\ExpectationArgsRequired Function requires args.
-	 *
-	 * @covers Automattic\Partner->get_partner_code();
 	 */
 	public function test_partner_code_is_set_via_option( $code_type, $option_name ) {
 		Functions\expect( 'get_option' )->once()->with( $option_name, '' )->andReturn( self::TEST_CODE );
@@ -105,8 +100,6 @@ class Partner_Test extends TestCase {
 	 * @param string $option_name Option and filter name.
 	 *
 	 * @throws Monkey\Expectation\Exception\ExpectationArgsRequired Function requires args.
-	 *
-	 * @covers Automattic\Partner->get_partner_code();
 	 */
 	public function test_partner_code_is_set_via_filter( $code_type, $option_name ) {
 		Functions\expect( 'get_option' )->once()->with( $option_name )->andReturn( '' );

--- a/projects/packages/password-checker/changelog/fix-phpunit-configs
+++ b/projects/packages/password-checker/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/password-checker/phpunit.xml.dist
+++ b/projects/packages/password-checker/phpunit.xml.dist
@@ -6,12 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">views</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/post-list/changelog/fix-phpunit-configs
+++ b/projects/packages/post-list/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/post-list/phpunit.xml.dist
+++ b/projects/packages/post-list/phpunit.xml.dist
@@ -6,12 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">wordpress</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/redirect/changelog/fix-phpunit-configs
+++ b/projects/packages/redirect/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/redirect/phpunit.xml.dist
+++ b/projects/packages/redirect/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/roles/changelog/fix-phpunit-configs
+++ b/projects/packages/roles/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/roles/phpunit.xml.dist
+++ b/projects/packages/roles/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/search/changelog/fix-phpunit-configs
+++ b/projects/packages/search/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/search/phpunit.xml.dist
+++ b/projects/packages/search/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/status/changelog/fix-phpunit-configs
+++ b/projects/packages/status/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/status/phpunit.xml.dist
+++ b/projects/packages/status/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/sync/changelog/fix-phpunit-configs
+++ b/projects/packages/sync/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/sync/phpunit.xml.dist
+++ b/projects/packages/sync/phpunit.xml.dist
@@ -6,12 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">views</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/terms-of-service/changelog/fix-phpunit-configs
+++ b/projects/packages/terms-of-service/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/terms-of-service/phpunit.xml.dist
+++ b/projects/packages/terms-of-service/phpunit.xml.dist
@@ -6,11 +6,7 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/tracking/changelog/fix-phpunit-configs
+++ b/projects/packages/tracking/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/packages/tracking/phpunit.xml.dist
+++ b/projects/packages/tracking/phpunit.xml.dist
@@ -6,11 +6,8 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
+			<directory suffix=".php">legacy</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/packages/tracking/tests/php/test-tracking.php
+++ b/projects/packages/tracking/tests/php/test-tracking.php
@@ -39,12 +39,12 @@ class Test_Tracking extends TestCase {
 	}
 
 	/**
-	 * Tests the  Automattic\Jetpack\Tracking::should_enabled_tracking() method.
+	 * Tests the  Automattic\Jetpack\Tracking::should_enable_tracking() method.
 	 *
 	 * @param array   $inputs The test input values.
-	 * @param boolean $expected_output The expected output of Automattic\Jetpack\Tracking::should_enabled_tracking().
+	 * @param boolean $expected_output The expected output of Automattic\Jetpack\Tracking::should_enable_tracking().
 	 *
-	 * @covers Automattic\Jetpack\Tracking::should_enabled_tracking
+	 * @covers Automattic\Jetpack\Tracking::should_enable_tracking
 	 * @dataProvider data_provider_test_should_enable_tracking
 	 */
 	public function test_should_enable_tracking( $inputs, $expected_output ) {

--- a/projects/plugins/backup/changelog/fix-phpunit-configs
+++ b/projects/plugins/backup/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/plugins/backup/phpunit.xml.dist
+++ b/projects/plugins/backup/phpunit.xml.dist
@@ -6,12 +6,8 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">wordpress</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
+			<file>jetpack-backup.php</file>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/plugins/boost/changelog/fix-phpunit-configs
+++ b/projects/plugins/boost/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/plugins/boost/phpunit.xml.dist
+++ b/projects/plugins/boost/phpunit.xml.dist
@@ -16,16 +16,8 @@
 
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">./</directory>
-			<exclude>
-				<file>./index.php</file>
-                <file>./jetpack-boost.php</file>
-				<directory suffix=".php">./node_modules</directory>
-				<directory suffix=".php">./tests</directory>
-				<directory suffix=".php">./vendor</directory>
-				<directory suffix=".php">./package</directory>
-                <directory suffix=".php">./.github</directory>
-			</exclude>
+			<directory suffix=".php">app</directory>
+			<directory suffix=".php">compatibility</directory>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/projects/plugins/jetpack/changelog/fix-phpunit-configs
+++ b/projects/plugins/jetpack/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix `@covers` directives in various tests.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/markdown/test-class-wpcom-ghf-markdown-parser.php
@@ -17,7 +17,6 @@ class WP_Test_WPCom_GHF_Markdown_Parser extends WP_UnitTestCase {
 	/**
 	 * Test that links are preserved when going through the Markdown parser.
 	 *
-	 * @covers WPCom_GHF_Markdown_Parser->transform
 	 * @dataProvider get_text_urls
 	 *
 	 * @since 9.2.0

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/test-class.pinterest.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/test-class.pinterest.php
@@ -15,7 +15,7 @@ class WP_Test_Pinterest extends \WP_UnitTestCase {
 	/**
 	 * Test the Pin type detected for a given Pinterest URL.
 	 *
-	 * @covers Automattic\Jetpack\Extensions\Pinterest::pin_type
+	 * @covers ::Automattic\Jetpack\Extensions\Pinterest\pin_type
 	 * @dataProvider get_pinterest_urls
 	 *
 	 * @since 9.2.0
@@ -31,8 +31,6 @@ class WP_Test_Pinterest extends \WP_UnitTestCase {
 
 	/**
 	 * URL variations to be used by the Pinterest block.
-	 *
-	 * @covers Automattic\Jetpack\Extensions\Pinterest::pin_type
 	 */
 	public function get_pinterest_urls() {
 		return array(

--- a/projects/plugins/jetpack/tests/php/general/test_class.jetpack-client-server.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.jetpack-client-server.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Tests for Jetpack_Client_Server.
+ *
+ * @covers Jetpack_Client_Server
+ */
 class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 
 	/**
@@ -21,7 +26,6 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers Jetpack_Client_Server::authorize
 	 * @since 3.2
 	 */
 	public function test_jetpack_client_server_authorize_role_cap() {
@@ -42,7 +46,6 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers Jetpack_Client_Server::authorize
 	 * @since 3.2
 	 */
 	public function test_jetpack_client_server_authorize_no_role() {
@@ -62,7 +65,6 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers Jetpack_Client_Server::authorize
 	 * @since 3.2
 	 */
 	public function test_jetpack_client_server_authorize_data_error() {
@@ -82,7 +84,6 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers Jetpack_Client_Server::deactivate_plugin
 	 * @since 3.2
 	 */
 	public function test_jetpack_client_server_deactivate_plugin() {
@@ -95,7 +96,6 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers Jetpack_Client_Server::get_token
 	 * @since 3.2
 	 */
 	public function test_jetpack_client_server_get_token() {

--- a/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
@@ -46,6 +46,11 @@ class MockJetpack_XMLRPC_Server extends Jetpack_XMLRPC_Server {
 	}
 }
 
+/**
+ * Tests for the Jetpack monolith-class.
+ *
+ * @covers Jetpack
+ */
 class WP_Test_Jetpack extends WP_UnitTestCase {
 
 	static $admin_id = 0;
@@ -77,7 +82,6 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 
 	/**
 	 * @author blobaugh
-	 * @covers Jetpack::init
 	 * @since 2.3.3
 	 */
 	public function test_init() {
@@ -86,7 +90,6 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers Jetpack::sort_modules
 	 * @since 3.2
 	 */
 	public function test_sort_modules_with_equal_sort_values() {
@@ -101,7 +104,6 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers Jetpack::sort_modules
 	 * @since 3.2
 	 */
 	public function test_sort_modules_with_different_sort_values() {
@@ -118,7 +120,6 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 
 	/**
 	 * @author georgestephanis
-	 * @covers Jetpack::absolutize_css_urls
 	 */
 	public function test_absolutize_css_urls_properly_handles_use_cases() {
 
@@ -173,7 +174,6 @@ EXPECTED;
 
 	/*
 	 * @author tonykova
-	 * @covers Jetpack::implode_frontend_css
 	 */
 	public function test_implode_frontend_css_enqueues_bundle_file_handle() {
 		global $wp_styles;
@@ -206,7 +206,6 @@ EXPECTED;
 
 	/**
 	 * @author tonykova
-	 * @covers Jetpack::implode_frontend_css
 	 * @since 3.2.0
 	 */
 	public function test_implode_frontend_css_does_not_enqueue_bundle_when_disabled_through_filter() {
@@ -401,8 +400,6 @@ EXPECTED;
 
 	/**
 	 * Tests is_offline_mode filter.
-	 *
-	 * @covers \Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_filter() {
 		add_filter( 'jetpack_offline_mode', '__return_true' );
@@ -412,8 +409,6 @@ EXPECTED;
 
 	/**
 	 * Tests is_offline_mode filter's bool type casting.
-	 *
-	 * @covers \Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_bool() {
 		add_filter( 'jetpack_offline_mode', '__return_zero' );
@@ -485,7 +480,6 @@ EXPECTED;
 
 	/**
 	 * @author tyxla
-	 * @covers Jetpack::get_assumed_site_creation_date()
 	 */
 	function test_get_assumed_site_creation_date_user_earliest() {
 		$user_id = $this->factory->user->create( array(
@@ -505,7 +499,6 @@ EXPECTED;
 
 	/**
 	 * @author tyxla
-	 * @covers Jetpack::get_assumed_site_creation_date()
 	 */
 	function test_get_assumed_site_creation_date_post_earliest() {
 		$user_id = $this->factory->user->create( array(
@@ -525,7 +518,6 @@ EXPECTED;
 
 	/**
 	 * @author tyxla
-	 * @covers Jetpack::get_assumed_site_creation_date()
 	 */
 	function test_get_assumed_site_creation_date_only_admins() {
 		$admin_id = $this->factory->user->create( array(
@@ -1060,7 +1052,6 @@ EXPECTED;
 	 * @param string  $set_screen The $current_screen->base test value.
 	 * @param boolean $expected_output The expected output of Jetpack::should_set_cookie().
 	 *
-	 * @covers Jetpack::should_set_cookie
 	 * @dataProvider should_set_cookie_provider
 	 */
 	public function test_should_set_cookie( $key, $set_screen, $expected_output ) {

--- a/projects/plugins/jetpack/tests/php/modules/infinite-scroll/test_class.infinite-scroll.php
+++ b/projects/plugins/jetpack/tests/php/modules/infinite-scroll/test_class.infinite-scroll.php
@@ -1,6 +1,11 @@
 <?php
 require dirname( __FILE__ ) . '/../../../../modules/infinite-scroll/infinity.php';
 
+/**
+ * Tests for The_Neverending_Home_Page.
+ *
+ * @covers The_Neverending_Home_Page
+ */
 class WP_Test_The_Neverending_Home_Page extends WP_UnitTestCase {
 
 	/**
@@ -23,7 +28,6 @@ class WP_Test_The_Neverending_Home_Page extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_posts_per_page_in_request_data
 	 * @author fgiannar
-	 * @covers ::posts_per_page
 	 *
 	 * @param mixed $posts_per_page_query_arg The $_REQUEST['query_args']['posts_per_page'] value.
 	 * @param int   $expected The expected return value of the posts_per_page method.

--- a/projects/plugins/jetpack/tests/php/modules/protect/test-shared-functions.php
+++ b/projects/plugins/jetpack/tests/php/modules/protect/test-shared-functions.php
@@ -16,8 +16,8 @@ class WP_Test_Jetpack_Protect_Shared_Functions extends WP_UnitTestCase {
 	/**
 	 * Test `jetpack_protect_get_ip` and `jetpack_clean_ip`.
 	 *
-	 * @covers jetpack_protect_get_ip
-	 * @covers jetpack_clean_ip
+	 * @covers ::jetpack_protect_get_ip
+	 * @covers ::jetpack_clean_ip
 	 * @dataProvider provide_jetpack_protect_get_ip
 	 * @param string|false $expect Expected output.
 	 * @param array        $server Data for `$_SERVER`.

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.smartframe.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/trait.http-request-cache.php';
 /**
  * Implements unit tests for smartframe embedding
  *
- * @covers ::shortcode_smartframe
+ * @covers ::jetpack_smartframe_shortcode
  */
 class WP_Test_Jetpack_Shortcodes_SmartFrame extends WP_UnitTestCase {
 	use Automattic\Jetpack\Tests\HttpRequestCacheTrait;

--- a/projects/plugins/jetpack/tests/php/modules/theme-tools/test_functions.devicepx.php
+++ b/projects/plugins/jetpack/tests/php/modules/theme-tools/test_functions.devicepx.php
@@ -5,14 +5,14 @@ require_once JETPACK__PLUGIN_DIR . '/modules/theme-tools/devicepx.php';
 class WP_Test_Jetpack_Theme_Tools_Devicepx extends WP_UnitTestCase {
 
 	/**
-	 * @covers jetpack_devicepx_init
+	 * @covers ::jetpack_devicepx_init
 	 */
 	public function test_devicepx_not_enqueued_by_default() {
 		$this->assertFalse( current_theme_supports( 'jetpack-devicepx' ) );
 	}
 
 	/**
-	 * @covers jetpack_devicepx_init
+	 * @covers ::jetpack_devicepx_init
 	 */
 	public function test_devicepx_can_be_enabled() {
 		// Enable the feature.

--- a/projects/plugins/search/changelog/fix-phpunit-configs
+++ b/projects/plugins/search/changelog/fix-phpunit-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.

--- a/projects/plugins/search/phpunit.xml.dist
+++ b/projects/plugins/search/phpunit.xml.dist
@@ -6,12 +6,8 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">wordpress</directory>
-			</exclude>
+			<directory suffix=".php">src</directory>
+			<file>jetpack-search.php</file>
 		</whitelist>
 	</filter>
 </phpunit>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In general it's better to include just what needs to be covered, rather
than including everything then trying to exclude things that don't.
PHPUnit's exclusions work by file, so including "." then excluding
"tests" and "vendor" and so on still requires that PHPUnit scan every
file in "tests" and "vendor" before excluding it. In extreme cases, it
can get lost in recursive directory loops (cf. #21218 and #18878).

While doing this, I found at least four cases where WorDBLess was being
used but wasn't being excluded, so coverage was being generated for all
of WordPress.

I also took the time to fix various broken `@covers` directives as I
came across them while verifying that these changes still covered
everything that had been covered before.

I didn't update plugins/jetpack or plugins/vaultpress to avoid
exclusions, as they have too many `.php` files in their root
directories.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Maybe #21555.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that coverage is still being reported correctly for everything.