### PR TITLE
Search: hide search menu for atomic sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-hide-search-menu-for-atomic-sites
+++ b/projects/plugins/jetpack/changelog/fix-hide-search-menu-for-atomic-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: hide Calypso Jetpack Search page link for Atomic sites.

--- a/projects/plugins/jetpack/changelog/fix-hide-search-menu-for-atomic-sites
+++ b/projects/plugins/jetpack/changelog/fix-hide-search-menu-for-atomic-sites
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Search: hide Calypso Jetpack Search page link for Atomic sites.
+Search: hide Calypso Jetpack Search menu item for Atomic sites.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -381,6 +381,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * We have search dashboard for Atomic/JP sites, so we need to hide the duplicated menu item.
 	 */
 	public function hide_search_menu_for_calypso() {
-		$this->hide_submenu_page( 'jetpack', 'search' );
+		remove_submenu_page( 'jetpack', 'search' );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -376,10 +376,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	/**
 	 * Hide Calypso Search menu for Atomic sites.
 	 *
-	 * For Atomic sites, the admin-menu is originated from the sites and forwarded by
-	 * WPCOM `public-api`. We have search dashboard for Atomic/JP sites already, so we
-	 * need to hide the duplicated menu. For simple sites, where search dashboard doesn't
-	 * exist, we fallback to Calypso Jetpack Search page.
+	 * For simple sites, where search dashboard doesn't exist, we use the Calypso page / menu item.
+	 * For Atomic sites, the admin-menu is originated from the sites and forwarded by WPCOM `public-api`.
+	 * We have search dashboard for Atomic/JP sites, so we need to hide the duplicated menu item.
 	 */
 	public function hide_search_menu_for_calypso() {
 		$this->hide_submenu_page( 'jetpack', 'search' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -381,6 +381,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * We have search dashboard for Atomic/JP sites, so we need to hide the duplicated menu item.
 	 */
 	public function hide_search_menu_for_calypso() {
-		remove_submenu_page( 'jetpack', 'search' );
+		$this->hide_submenu_page( 'jetpack', 'https://wordpress.com/jetpack-search/' . $this->domain );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -65,6 +65,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		$this->add_my_home_menu();
 		$this->add_inbox_menu();
+		$this->hide_search_menu_for_calypso();
 
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request ) {
@@ -370,5 +371,17 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		);
 
 		wp_die();
+	}
+
+	/**
+	 * Hide Calypso Search menu for Atomic sites.
+	 *
+	 * For Atomic sites, the admin-menu is originated from the sites and forwarded by
+	 * WPCOM `public-api`. We have search dashboard for Atomic/JP sites already, so we
+	 * need to hide the duplicated menu. For simple sites, where search dashboard doesn't
+	 * exist, we fallback to Calypso Jetpack Search page.
+	 */
+	public function hide_search_menu_for_calypso() {
+		$this->hide_submenu_page( 'jetpack', 'search' );
 	}
 }


### PR DESCRIPTION
Fixes #21443 
The issue is also reported in https://github.com/Automattic/wp-calypso/issues/56741.

#### Changes proposed in this Pull Request:
* Hide Calypso search menu for Atomic sites

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to mc: `/atomic/ephemeral-sites/`
* Create a ephemeral site and connect Jetpack
* SSH to the site and apply the change from the branch (any better ways?)
* Visit `https://wordpress.com/view/ephemeral-xxxxx.atomicsites.blog`
* Ensure there is only one Search submenu under Jetpack
* Ensure the Calypso search menu is still available for Simple sites.
![image](https://user-images.githubusercontent.com/1425433/139183892-bf938972-d676-49cd-933f-b3b6891a0009.png)


