### PR TITLE
Publicize: Handling feature availability information and upgrading

### DIFF
--- a/projects/plugins/jetpack/changelog/update-publicize-adjust-jetpack-paid-plan-behavior
+++ b/projects/plugins/jetpack/changelog/update-publicize-adjust-jetpack-paid-plan-behavior
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Publicize: handle plan upgrade considering feature availability, whether the nudge is enable, and post status

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -87,6 +87,7 @@ const PublicizePanel = ( { prePublish } ) => {
 		isPublicizeEnabled: isPublicizeEnabledFromConfig, // <- usually handled by the UI
 		isRePublicizeFeatureUpgradable, // <- defined by the `republicize` feature availability check
 		togglePublicizeFeature,
+		isRePublicizeFeatureAvailable,
 	} = usePublicizeConfig();
 
 	/*
@@ -96,6 +97,16 @@ const PublicizePanel = ( { prePublish } ) => {
 	 */
 	const isPublicizeDisabledBySitePlan =
 		isPostPublished && isRePublicizeFeatureUpgradable && isRePublicizeFeatureEnabled;
+
+	/*
+	 * When the site doesn't have the feature available
+	 * becouse of the site plan and / or product feature,
+	 * when it is not upgradable, and when the post is already published,
+	 * it needs to hide part of the Publicize feature.
+	 */
+	const hideRePublicizeFeature =
+		isPostPublished && ! isRePublicizeFeatureAvailable && ! isRePublicizeFeatureUpgradable;
+
 	const isPublicizeEnabled = isPublicizeEnabledFromConfig && ! isPublicizeDisabledBySitePlan;
 
 	// Refresh connections when the post is just published.
@@ -136,31 +147,37 @@ const PublicizePanel = ( { prePublish } ) => {
 
 			<UpsellNotice isPostPublished={ isPostPublished } />
 
-			{ isRePublicizeFeatureEnabled && ! isPostPublished && (
-				<PanelRowWithDisabled>
-					<ToggleControl
-						className="jetpack-publicize-toggle"
-						label={
-							isPublicizeEnabled && ! isPublicizeDisabledBySitePlan
-								? __( 'Share when publishing', 'jetpack' )
-								: __( 'Sharing is disabled', 'jetpack' )
-						}
-						onChange={ togglePublicizeFeature }
-						checked={ isPublicizeEnabled }
-						disabled={ ! hasConnections }
+			{ ! hideRePublicizeFeature && (
+				<Fragment>
+					{ isRePublicizeFeatureEnabled && ! isPostPublished && (
+						<PanelRowWithDisabled>
+							<ToggleControl
+								className="jetpack-publicize-toggle"
+								label={
+									isPublicizeEnabled && ! isPublicizeDisabledBySitePlan
+										? __( 'Share when publishing', 'jetpack' )
+										: __( 'Sharing is disabled', 'jetpack' )
+								}
+								onChange={ togglePublicizeFeature }
+								checked={ isPublicizeEnabled }
+								disabled={ ! hasConnections }
+							/>
+						</PanelRowWithDisabled>
+					) }
+
+					<PublicizeConnectionVerify />
+					<PublicizeForm
+						isPublicizeEnabled={ isPublicizeEnabled }
+						isRePublicizeFeatureEnabled={ isRePublicizeFeatureEnabled }
+						isPublicizeDisabledBySitePlan={ isPublicizeDisabledBySitePlan }
 					/>
-				</PanelRowWithDisabled>
+					{ ! isPublicizeDisabledBySitePlan && (
+						<PublicizeTwitterOptions prePublish={ prePublish } />
+					) }
+
+					<SharePostRow />
+				</Fragment>
 			) }
-
-			<PublicizeConnectionVerify />
-			<PublicizeForm
-				isPublicizeEnabled={ isPublicizeEnabled }
-				isRePublicizeFeatureEnabled={ isRePublicizeFeatureEnabled }
-				isPublicizeDisabledBySitePlan={ isPublicizeDisabledBySitePlan }
-			/>
-			{ ! isPublicizeDisabledBySitePlan && <PublicizeTwitterOptions prePublish={ prePublish } /> }
-
-			<SharePostRow />
 		</PanelWrapper>
 	);
 };

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -28,52 +28,6 @@ import usePublicizeConfig from '../../hooks/use-publicize-config';
 import { SharePostRow } from '../../components/share-post';
 import UpsellNotice from '../upsell';
 
-function getPanelDescription(
-	isPostPublished,
-	isRePublicizeFeatureEnabled,
-	isPublicizeEnabled,
-	hasConnections,
-	hasEnabledConnections
-) {
-	// Use constants when the string is used in multiple places.
-	const start_your_posts_string = __(
-		'Start sharing your posts by connecting your social media accounts.',
-		'jetpack'
-	);
-	const this_post_will_string = __(
-		'This post will be shared on all your enabled social media accounts the moment you publish the post.',
-		'jetpack'
-	);
-
-	// RePublicize feature is disabled.
-	if ( ! isRePublicizeFeatureEnabled ) {
-		if ( isPostPublished ) {
-			return start_your_posts_string;
-		}
-
-		return this_post_will_string;
-	}
-
-	// RePublicize feature is enabled.
-	// No connections.
-	if ( ! hasConnections ) {
-		return start_your_posts_string;
-	}
-
-	if ( ! isPublicizeEnabled || ! hasEnabledConnections ) {
-		return __( 'Use this tool to share your post on all your social media accounts.', 'jetpack' );
-	}
-
-	if ( isPublicizeEnabled && hasEnabledConnections && ! isPostPublished ) {
-		return this_post_will_string;
-	}
-
-	return __(
-		'Share this post on all your enabled social media accounts by clicking on the share post button.',
-		'jetpack'
-	);
-}
-
 const PublicizePanel = ( { prePublish } ) => {
 	const { refresh, hasConnections, hasEnabledConnections } = useSelectSocialMediaConnections();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
@@ -106,7 +60,10 @@ const PublicizePanel = ( { prePublish } ) => {
 	 * it needs to hide part of the Publicize feature.
 	 */
 	const hideRePublicizeFeature =
-		isPostPublished && ! isRePublicizeFeatureAvailable && ! isRePublicizeUpgradableViaUpsell;
+		isPostPublished &&
+		! isRePublicizeFeatureAvailable &&
+		! isRePublicizeUpgradableViaUpsell &&
+		isRePublicizeFeatureEnabled;
 
 	const isPublicizeEnabled = isPublicizeEnabledFromConfig && ! isPublicizeDisabledBySitePlan;
 
@@ -136,16 +93,6 @@ const PublicizePanel = ( { prePublish } ) => {
 
 	return (
 		<PanelWrapper { ...wrapperProps }>
-			<div>
-				{ getPanelDescription(
-					isPostPublished,
-					isRePublicizeFeatureEnabled,
-					isPublicizeEnabled,
-					hasConnections,
-					hasEnabledConnections
-				) }
-			</div>
-
 			<UpsellNotice isPostPublished={ isPostPublished } />
 
 			{ ! hideRePublicizeFeature && (

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -32,38 +32,13 @@ const PublicizePanel = ( { prePublish } ) => {
 	const { refresh, hasConnections, hasEnabledConnections } = useSelectSocialMediaConnections();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 
-	/*
-	 * Check whether the Republicize feature is enabled.
-	 * it can be defined via the `jetpack_block_editor_republicize_feature` backend filter.
-	 */
 	const {
-		isRePublicizeFeatureEnabled, // <- defined by the server-side feature flag check
+		isRePublicizeFeatureEnabled,
 		isPublicizeEnabled: isPublicizeEnabledFromConfig, // <- usually handled by the UI
-		isRePublicizeUpgradableViaUpsell, // <- defined by the `republicize` feature availability check
 		togglePublicizeFeature,
-		isRePublicizeFeatureAvailable,
+		isPublicizeDisabledBySitePlan,
+		hideRePublicizeFeature,
 	} = usePublicizeConfig();
-
-	/*
-	 * Publicize is enabled by toggling the control,
-	 * but also disabled when the post is already published,
-	 * and the feature is upgradable.
-	 */
-	const isPublicizeDisabledBySitePlan =
-		isPostPublished && isRePublicizeUpgradableViaUpsell && isRePublicizeFeatureEnabled;
-
-	/*
-	 * When the site doesn't have the feature available
-	 * because of the lack of site plan and/or product feature,
-	 * when it is not upgradable via an upsell,
-	 * and when the post is already published,
-	 * it needs to hide part of the Publicize feature.
-	 */
-	const hideRePublicizeFeature =
-		isPostPublished &&
-		! isRePublicizeFeatureAvailable &&
-		! isRePublicizeUpgradableViaUpsell &&
-		isRePublicizeFeatureEnabled;
 
 	const isPublicizeEnabled = isPublicizeEnabledFromConfig && ! isPublicizeDisabledBySitePlan;
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -134,7 +134,7 @@ const PublicizePanel = ( { prePublish } ) => {
 				) }
 			</div>
 
-			{ isPostPublished && <UpsellNotice /> }
+			<UpsellNotice isPostPublished={ isPostPublished } />
 
 			{ isRePublicizeFeatureEnabled && ! isPostPublished && (
 				<PanelRowWithDisabled>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/panel/index.js
@@ -85,7 +85,7 @@ const PublicizePanel = ( { prePublish } ) => {
 	const {
 		isRePublicizeFeatureEnabled, // <- defined by the server-side feature flag check
 		isPublicizeEnabled: isPublicizeEnabledFromConfig, // <- usually handled by the UI
-		isRePublicizeFeatureUpgradable, // <- defined by the `republicize` feature availability check
+		isRePublicizeUpgradableViaUpsell, // <- defined by the `republicize` feature availability check
 		togglePublicizeFeature,
 		isRePublicizeFeatureAvailable,
 	} = usePublicizeConfig();
@@ -96,16 +96,17 @@ const PublicizePanel = ( { prePublish } ) => {
 	 * and the feature is upgradable.
 	 */
 	const isPublicizeDisabledBySitePlan =
-		isPostPublished && isRePublicizeFeatureUpgradable && isRePublicizeFeatureEnabled;
+		isPostPublished && isRePublicizeUpgradableViaUpsell && isRePublicizeFeatureEnabled;
 
 	/*
 	 * When the site doesn't have the feature available
-	 * becouse of the site plan and / or product feature,
-	 * when it is not upgradable, and when the post is already published,
+	 * because of the lack of site plan and/or product feature,
+	 * when it is not upgradable via an upsell,
+	 * and when the post is already published,
 	 * it needs to hide part of the Publicize feature.
 	 */
 	const hideRePublicizeFeature =
-		isPostPublished && ! isRePublicizeFeatureAvailable && ! isRePublicizeFeatureUpgradable;
+		isPostPublished && ! isRePublicizeFeatureAvailable && ! isRePublicizeUpgradableViaUpsell;
 
 	const isPublicizeEnabled = isPublicizeEnabledFromConfig && ! isPublicizeDisabledBySitePlan;
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/share-post/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/share-post/index.js
@@ -88,7 +88,7 @@ export function SharePostButton() {
 }
 
 export function SharePostRow() {
-	const { isRePublicizeFeatureEnabled, isRePublicizeFeatureUpgradable } = usePublicizeConfig();
+	const { isRePublicizeFeatureEnabled, isRePublicizeUpgradableViaUpsell } = usePublicizeConfig();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 
 	// Do not render when RePublicize feature is not enabled.
@@ -105,7 +105,7 @@ export function SharePostRow() {
 	 * Do not render when the feature is upgradable.
 	 * We show the upsale notice instead.
 	 */
-	if ( isRePublicizeFeatureUpgradable ) {
+	if ( isRePublicizeUpgradableViaUpsell ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
@@ -46,7 +46,7 @@ export default function UpsellNotice( { isPostPublished } ) {
 
 	const isPureJetpackSite = ! isAtomicSite() && ! isSimpleSite();
 	const upgradeFeatureTitle = isPureJetpackSite
-		? __( 'Re-Sharing your content', 'jetpack' )
+		? __( 'Re-sharing your content', 'jetpack' )
 		: __( 'Share Your Content Again', 'jetpack' );
 
 	// Doc page URL.

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
@@ -92,7 +92,7 @@ export default function UpsellNotice( { isPostPublished } ) {
 			<div className="jetpack-publicize__upsell-description">
 				{ sprintf(
 					/* translators: placeholder is the product name of the plan. */
-					__( 'To re publicize a post, you need to upgrade to the %s plan', 'jetpack' ),
+					__( 'To re-share a post, you need to upgrade to the %s plan', 'jetpack' ),
 					planName
 				) }
 			</div>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
@@ -54,6 +54,14 @@ export default function UpsellNotice( { isPostPublished } ) {
 		? 'https://jetpack.com/support/publicize/#re-sharing-your-content'
 		: 'https://wordpress.com/support/publicize/#share-your-content-again';
 
+	const buttonText = planData?.formatted_price
+		? sprintf(
+				/* translators: placeholder is the price for upgrading. */
+				'Upgrade now for %s',
+				planData.formatted_price
+		  )
+		: __( 'Upgrade now', 'jetpack' );
+
 	/*
 	 * Render an info message when the feature is not available
 	 * and when it shouldn't show upgrade notices.
@@ -99,13 +107,7 @@ export default function UpsellNotice( { isPostPublished } ) {
 				} ) }
 				isBusy={ isRedirecting }
 			>
-				{ isRedirecting
-					? __( 'Redirecting…', 'jetpack' )
-					: sprintf(
-							/* translators: placeholder is the price for upgrading. */
-							'Upgrade now for %s',
-							planData?.formatted_price
-					  ) }
+				{ isRedirecting ? __( 'Redirecting…', 'jetpack' ) : buttonText }
 			</Button>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
@@ -17,11 +17,15 @@ import { getRequiredPlan } from '../../../../shared/plan-utils';
 import useUpgradeFlow from '../../../../shared/use-upgrade-flow';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 
-export default function UpsellNotice() {
+export default function UpsellNotice( { isPostPublished } ) {
 	const { isRePublicizeFeatureEnabled, isRePublicizeFeatureUpgradable } = usePublicizeConfig();
-
 	const requiredPlan = getRequiredPlan( 'republicize' );
 	const [ checkoutUrl, goToCheckoutPage, isRedirecting, planData ] = useUpgradeFlow( requiredPlan );
+
+	// Nothing to show here. Move on...
+	if ( ! isPostPublished ) {
+		return null;
+	}
 
 	/*
 	 * Do not render either when the feature is not enabled,

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
@@ -22,16 +22,21 @@ export default function UpsellNotice( { isPostPublished } ) {
 	const requiredPlan = getRequiredPlan( 'republicize' );
 	const [ checkoutUrl, goToCheckoutPage, isRedirecting, planData ] = useUpgradeFlow( requiredPlan );
 
-	// Nothing to show here. Move on...
+	/*
+	 * When post is not published,
+	 * there is nothing to show here. Move on...
+	 */
 	if ( ! isPostPublished ) {
 		return null;
 	}
 
-	/*
-	 * Do not render either when the feature is not enabled,
-	 * or when the feature is enabled and not upgradable.
-	 */
-	if ( ! isRePublicizeFeatureEnabled || ! isRePublicizeFeatureUpgradable ) {
+	// Bail early with null when feature flag is not enabled.
+	if ( ! isRePublicizeFeatureEnabled ) {
+		return null;
+	}
+
+	// Bail early when the feature is not upgradable.
+	if ( ! isRePublicizeFeatureUpgradable ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
@@ -116,13 +116,7 @@ export default function UpsellNotice( { isPostPublished } ) {
 		? 'https://jetpack.com/support/publicize/#re-sharing-your-content'
 		: 'https://wordpress.com/support/publicize/#share-your-content-again';
 
-	const buttonText = planData?.formatted_price
-		? sprintf(
-				/* translators: placeholder is the price for upgrading. */
-				'Upgrade now for %s',
-				planData.formatted_price
-		  )
-		: __( 'Upgrade now', 'jetpack' );
+	const buttonText = __( 'Upgrade now', 'jetpack' );
 
 	/*
 	 * Render an info message when the feature is not available

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
@@ -55,8 +55,9 @@ export default function UpsellNotice( { isPostPublished } ) {
 		: 'https://wordpress.com/support/publicize/#share-your-content-again';
 
 	/*
-	 * Render an info message when the feature is not available,
-	 * but also when it isn't available (pure Jetpack site escenario).
+	 * Render an info message when the feature is not available
+	 * and when it shouldn't show upgrade notices.
+	 * (pure Jetpack sites, for instance).
 	 */
 	if ( ! isRePublicizeFeatureAvailable && ! isRePublicizeUpgradableViaUpsell ) {
 		return (

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
@@ -85,7 +85,11 @@ export default function UpsellNotice( { isPostPublished } ) {
 	 * or when the feature flag is disabled,
 	 * just show the feature description and bail early.
 	 */
-	if ( ! isPostPublished || ! isRePublicizeFeatureEnabled ) {
+	if (
+		! isPostPublished ||
+		! isRePublicizeFeatureEnabled ||
+		( isPostPublished && isRePublicizeFeatureAvailable )
+	) {
 		return (
 			<div>
 				{ getPanelDescription(
@@ -100,7 +104,7 @@ export default function UpsellNotice( { isPostPublished } ) {
 	}
 
 	// Define plan name, with a fallback value.
-	const planName = planData?.product_name || __( 'Paid', 'jetpack' );
+	const planName = planData?.product_name || __( 'paid', 'jetpack' );
 
 	const isPureJetpackSite = ! isAtomicSite() && ! isSimpleSite();
 	const upgradeFeatureTitle = isPureJetpackSite

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/upsell/index.js
@@ -21,7 +21,7 @@ import { isAtomicSite, isSimpleSite } from '../../../../shared/site-type-utils';
 export default function UpsellNotice( { isPostPublished } ) {
 	const {
 		isRePublicizeFeatureEnabled,
-		isRePublicizeFeatureUpgradable,
+		isRePublicizeUpgradableViaUpsell,
 		isRePublicizeFeatureAvailable,
 	} = usePublicizeConfig();
 	const requiredPlan = getRequiredPlan( 'republicize' );
@@ -58,7 +58,7 @@ export default function UpsellNotice( { isPostPublished } ) {
 	 * Render an info message when the feature is not available,
 	 * but also when it isn't available (pure Jetpack site escenario).
 	 */
-	if ( ! isRePublicizeFeatureAvailable && ! isRePublicizeFeatureUpgradable ) {
+	if ( ! isRePublicizeFeatureAvailable && ! isRePublicizeUpgradableViaUpsell ) {
 		return (
 			<div className="jetpack-publicize__upsell">
 				<strong>{ upgradeFeatureTitle }</strong>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/editor.scss
@@ -64,10 +64,6 @@
 	margin: 15px 0;
 }
 
-.jetpack-publicize__upsell {
-	margin: 10px 0;
-	padding: 5px 0;
-}
 
 .jetpack-publicize__upsell-description {
 	margin-bottom: 10px;

--- a/projects/plugins/jetpack/extensions/plugins/publicize/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/editor.scss
@@ -64,6 +64,9 @@
 	margin: 15px 0;
 }
 
+.jetpack-publicize__upsell {
+	margin-bottom: 13px;
+}
 
 .jetpack-publicize__upsell-description {
 	margin-bottom: 10px;

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-publicize-config/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-publicize-config/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /*
  * Internal dependencies
@@ -13,20 +14,81 @@ const republicizeFeatureName = 'republicize';
 
 export default function usePublicizeConfig() {
 	const { togglePublicizeFeature } = useDispatch( 'jetpack/publicize' );
-	const { available } = getJetpackExtensionAvailability( republicizeFeatureName );
+	const { available: isRePublicizeFeatureAvailable } = getJetpackExtensionAvailability(
+		republicizeFeatureName
+	);
+	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 
-	const isPublicizeEnabled = useSelect(
+	/*
+	 * isPublicizeEnabledMeta:
+	 * It's stored in the jetpack_publicize_feature_enabled post metadata,
+	 * and usually is handled from the UI (main toggle control),
+	 * dispathicng the togglePublicizeFeature() action (jetpack/publicize).
+	 */
+	const isPublicizeEnabledMeta = useSelect(
 		select => select( 'jetpack/publicize' ).getFeatureEnableState(),
 		[]
 	);
 
+	/*
+	 * isRePublicizeFeatureEnabled:
+	 * Feature flag, defined by the server-side.
+	 * it can be defined via the `jetpack_block_editor_republicize_feature` backend filter.
+	 */
+	const isRePublicizeFeatureEnabled = !! window?.Jetpack_Editor_Initial_State.jetpack
+		?.republicize_enabled;
+
+	/*
+	 * isRePublicizeUpgradableViaUpsell:
+	 * True when the republicize feature is upgradable according to the store product (republicize),
+	 * but also whether the upgrade nudge is enable
+	 * in the site context/platform (Simple, Atomic, Jetpack, etc...).
+	 */
+
+	const isRePublicizeUpgradableViaUpsell =
+		isUpgradable( republicizeFeatureName ) && isUpgradeNudgeEnabled();
+
+	/*
+	 * isPublicizeEnabled:
+	 * Althought the feature is enabled by the post meta,
+	 * it also depends on whether the product feature.
+	 * Also, it's tied to the post status (draft, published, etc.).
+	 */
+	const isPublicizeEnabled =
+		( isPublicizeEnabledMeta &&
+			! ( isRePublicizeUpgradableViaUpsell && isRePublicizeFeatureEnabled ) ) ||
+		isPostPublished;
+
+	/*
+	 * isPublicizeDisabledBySitePlan:
+	 * Depending on the site plan and type, the republicize feature
+	 * would get dissabled.
+	 */
+	const isPublicizeDisabledBySitePlan =
+		isRePublicizeFeatureEnabled && isPostPublished && isRePublicizeUpgradableViaUpsell;
+
+	/*
+	 * hideRePublicizeFeature:
+	 * When the site doesn't have the feature available
+	 * because of the lack of site plan and/or product,
+	 * when it is not upgradable via an upsell,
+	 * and when the post is already published,
+	 * it needs to hide part of the Publicize feature.
+	 */
+	const hideRePublicizeFeature =
+		isPostPublished &&
+		! isRePublicizeFeatureAvailable &&
+		! isRePublicizeUpgradableViaUpsell &&
+		isRePublicizeFeatureEnabled;
+
 	return {
-		isRePublicizeFeatureEnabled: !! window?.Jetpack_Editor_Initial_State.jetpack
-			?.republicize_enabled,
+		isPublicizeEnabledMeta,
+		isRePublicizeFeatureEnabled,
 		isPublicizeEnabled,
 		togglePublicizeFeature,
-		isRePublicizeFeatureAvailable: available,
-		isRePublicizeUpgradableViaUpsell:
-			isUpgradable( republicizeFeatureName ) && isUpgradeNudgeEnabled(),
+		isPublicizeDisabledBySitePlan,
+		isRePublicizeFeatureAvailable,
+		isRePublicizeUpgradableViaUpsell,
+		hideRePublicizeFeature,
 	};
 }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-publicize-config/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-publicize-config/index.js
@@ -8,7 +8,7 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import getJetpackExtensionAvailability from '../../../../shared/get-jetpack-extension-availability';
-import { isUpgradable, isUpgradeNudgeEnabled } from '../../../../shared/plan-utils';
+import { isUpgradable } from '../../../../shared/plan-utils';
 
 const republicizeFeatureName = 'republicize';
 
@@ -44,9 +44,7 @@ export default function usePublicizeConfig() {
 	 * but also whether the upgrade nudge is enable
 	 * in the site context/platform (Simple, Atomic, Jetpack, etc...).
 	 */
-
-	const isRePublicizeUpgradableViaUpsell =
-		isUpgradable( republicizeFeatureName ) && isUpgradeNudgeEnabled();
+	const isRePublicizeUpgradableViaUpsell = isUpgradable( republicizeFeatureName );
 
 	/*
 	 * isPublicizeEnabled:

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-publicize-config/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-publicize-config/index.js
@@ -12,11 +12,9 @@ import { isUpgradable, isUpgradeNudgeEnabled } from '../../../../shared/plan-uti
 const republicizeFeatureName = 'republicize';
 
 export default function usePublicizeConfig() {
-	// Actions.
 	const { togglePublicizeFeature } = useDispatch( 'jetpack/publicize' );
 	const { available } = getJetpackExtensionAvailability( republicizeFeatureName );
 
-	// Data.
 	const isPublicizeEnabled = useSelect(
 		select => select( 'jetpack/publicize' ).getFeatureEnableState(),
 		[]
@@ -28,7 +26,7 @@ export default function usePublicizeConfig() {
 		isPublicizeEnabled,
 		togglePublicizeFeature,
 		isRePublicizeFeatureAvailable: available,
-		isRePublicizeFeatureUpgradable:
+		isRePublicizeUpgradableViaUpsell:
 			isUpgradable( republicizeFeatureName ) && isUpgradeNudgeEnabled(),
 	};
 }

--- a/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-publicize-config/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/hooks/use-publicize-config/index.js
@@ -53,9 +53,8 @@ export default function usePublicizeConfig() {
 	 * Also, it's tied to the post status (draft, published, etc.).
 	 */
 	const isPublicizeEnabled =
-		( isPublicizeEnabledMeta &&
-			! ( isRePublicizeUpgradableViaUpsell && isRePublicizeFeatureEnabled ) ) ||
-		isPostPublished;
+		( isPostPublished && ! ( isRePublicizeUpgradableViaUpsell && isRePublicizeFeatureEnabled ) ) ||
+		isPublicizeEnabledMeta;
 
 	/*
 	 * isPublicizeDisabledBySitePlan:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

This PR improves the way that the implementation shows information depending on the RePublicize feature availability.
It takes into consideration mainly two data:

* availability: when the feature is available or not according to the site plan/product feature.
* upgradability: whether the feature can be upgradable via an upsell, or not.

Sometimes we'd like to show an upsell notice to provide to the user a way to get the proper plan/feature. Sometimes we just want to show additional information about the limitation of the site.

Fixes https://github.com/Automattic/jetpack/issues/21528

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Publicize: Handling feature availability information and upgrading

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

When the post hasn't been published, you shouldn't see any kind of information about availability, upgrades, etc

<img src="https://user-images.githubusercontent.com/77539/139241571-a6c5ba6b-d51f-4426-b3a8-c0cc1ae5a35e.png" width="300px" />


Once the post has been published, confirm the following cases.

Simple site | Atomic Site | Jetpack site
----|-----|-----
![image](https://user-images.githubusercontent.com/77539/139241723-75e0d481-2ab2-40a6-ab6b-bbe2ed692f6f.png) | ![image](https://user-images.githubusercontent.com/77539/139241723-75e0d481-2ab2-40a6-ab6b-bbe2ed692f6f.png) | ![image](https://user-images.githubusercontent.com/77539/139463017-abeb8ce6-32c7-4ba5-a16c-48be8ce5f664.png)






