### PR TITLE
Admin page: Fix pricing/currency displayed on the upgrade page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/product-descriptions/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/index.jsx
@@ -10,9 +10,9 @@ import { isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
-import QuerySiteProducts from 'components/data/query-site-products';
+import QueryProducts from 'components/data/query-products';
 import { JetpackLoadingIcon } from 'components/jetpack-loading-icon';
-import { isFetchingSiteProducts } from 'state/site-products';
+import { isFetchingProducts as isFetchingProductsSelector } from 'state/products';
 import { arePromotionsActive, getProductsForPurchase } from 'state/initial-state';
 import { PRODUCT_DESCRIPTION_PRODUCTS as SUPPORTED_PRODUCTS } from './constants';
 import ProductDescription from './product-description';
@@ -49,7 +49,7 @@ const ProductDescriptions = props => {
 
 	return (
 		<>
-			<QuerySiteProducts />
+			<QueryProducts />
 			{ isLoading ? (
 				<div className="jp-product-descriptions__loading">
 					<JetpackLoadingIcon />
@@ -70,6 +70,6 @@ ProductDescriptions.propTypes = {
 
 export default connect( state => ( {
 	arePromotionsActive: arePromotionsActive( state ),
-	isFetchingProducts: isFetchingSiteProducts( state ),
+	isFetchingProducts: isFetchingProductsSelector( state ),
 	products: getProductsForPurchase( state ),
 } ) )( ProductDescriptions );

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
@@ -79,7 +79,7 @@ export function buildInitialState() {
 					}
 				}
 			},
-			siteProducts: {
+			products: {
 				"items": {
 					"jetpack_security_daily": {
 						"product_slug": "jetpack_security_daily",

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -9,7 +9,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
  */
 import { JETPACK_SET_INITIAL_STATE, MOCK_SWITCH_USER_PERMISSIONS } from 'state/action-types';
 import { getPlanDuration } from 'state/plans/reducer';
-import { getSiteProducts } from 'state/site-products';
+import { getProducts } from 'state/products';
 import { isCurrentUserLinked } from 'state/connection';
 
 export const initialState = ( state = window.Initial_State, action ) => {
@@ -474,7 +474,7 @@ export const getUpgradeUrl = ( state, source, userId = '', planDuration = false 
  */
 export function getProductsForPurchase( state ) {
 	const staticProducts = get( state.jetpack.initialState, 'products', {} );
-	const siteProducts = getSiteProducts( state );
+	const jetpackProducts = getProducts( state );
 	const products = {};
 
 	for ( const [ key, product ] of Object.entries( staticProducts ) ) {
@@ -484,12 +484,12 @@ export function getProductsForPurchase( state ) {
 			key: key,
 			description: product.description,
 			features: product.features,
-			available: get( siteProducts, [ product.slug, 'available' ], false ),
-			currencyCode: get( siteProducts, [ product.slug, 'currency_code' ], '' ),
+			available: get( jetpackProducts, [ product.slug, 'available' ], false ),
+			currencyCode: get( jetpackProducts, [ product.slug, 'currency_code' ], '' ),
 			showPromotion: product.show_promotion,
 			promotionPercentage: product.discount_percent,
 			includedInPlans: product.included_in_plans,
-			fullPrice: get( siteProducts, [ product.slug, 'cost' ], '' ),
+			fullPrice: get( jetpackProducts, [ product.slug, 'cost' ], '' ),
 			upgradeUrl: getRedirectUrl( 'jetpack-product-description-checkout', {
 				path: product.slug,
 			} ),

--- a/projects/plugins/jetpack/changelog/fix-jetpack-upgrade-page-currency
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-upgrade-page-currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes the prices and currencies to be based on user's preferences on the WPA upgrade page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes 1201210512993648-as-1201296766183112

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes the data source and the API request to retrieve the products information based on user's information.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Context: 1201210512993648-as-1201296766183112

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a site with this branch 
* Go to an upgrade page, such as `/wp-admin/admin.php?page=jetpack#/product/search`
* Make sure the currency matches your user currency settings, not your site settings