### PR TITLE
Tiled Gallery Block: Fixing Problem Displaying Block Error when >1 Row

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
@@ -5,14 +5,26 @@ import Layout from './layout';
 import { defaultColumnsNumber } from './edit';
 
 export default function TiledGallerySave( { attributes, innerBlocks } ) {
-	if ( ! innerBlocks.length ) {
+	if ( ! attributes.images.length && ! innerBlocks.length ) {
 		return null;
 	}
+
+	const imageData = innerBlocks.length ? innerBlocks : attributes.images;
+	const images = imageData.map( image => {
+		if ( image.attributes ) {
+			return {
+				...image.attributes,
+				width: 100,
+				height: 100,
+			};
+		}
+		return image;
+	} );
 
 	const {
 		align,
 		className,
-		columns = defaultColumnsNumber( innerBlocks ),
+		columns = defaultColumnsNumber( images ),
 		linkTo,
 		roundedCorners,
 		columnWidths,
@@ -24,11 +36,7 @@ export default function TiledGallerySave( { attributes, innerBlocks } ) {
 			align={ align }
 			className={ className }
 			columns={ columns }
-			images={ innerBlocks.map( innerBlock => ( {
-				...innerBlock.attributes,
-				height: 100,
-				width: 100,
-			} ) ) }
+			images={ images }
 			isSave
 			layoutStyle={ 'square' }
 			linkTo={ linkTo }


### PR DESCRIPTION
Allows `getSaveContent` in validation to go through entire `TiledGallerySave` function when loading serialized HTML.

Before, since there were no inner blocks loaded when loading serialized HTML, `TiledGallerySave` was always returning `null`. Now, we add a condition that checks if we have images loaded into the block's `attributes.images` array, and if so, still goes through the entire function.

This ensures that both loading serialized HTML and creating new blocks and adding them manually via the editor results in the same code path taken.

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
1. Add tiled gallery block.
2. Add two images.
3. Open settings and change columns to 1.
4. Switch to HTML mode.
5. Select all, cut.
6. Switch back to visual mode.
7. Switch back to HTML mode.
8. Paste the cut HTML.
9. Switch back to visual mode and see that the block loads with 2 images in 1 column.

#### Screenshots

https://user-images.githubusercontent.com/13263478/139508270-60c01de5-252e-4c42-b01f-ded7922a73ab.mp4


