### PR TITLE
eslint-changed: Use API for running ESLint

### DIFF
--- a/projects/js-packages/eslint-changed/README.md
+++ b/projects/js-packages/eslint-changed/README.md
@@ -34,8 +34,8 @@ The following options are used with manual mode:
 
 ### With git
 
-In git mode, `eslint-changed` needs to be able to run `git` and `eslint`. If these are not available by those names in the shell path,
-set environment variables `GIT` and/or `ESLINT` as appropriate.
+In git mode, `eslint-changed` needs to be able to run `git`. If this is not available by that name in the shell path,
+set environment variable `GIT` as appropriate.
 
 The following options are used with manual mode:
 

--- a/projects/js-packages/eslint-changed/changelog/update-eslint-changed-use-eslint-api
+++ b/projects/js-packages/eslint-changed/changelog/update-eslint-changed-use-eslint-api
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Run ESLint via its node API rather than shelling out, mainly because they dropped the static `getFormatter()` from the API in 8.0. This drops support for ESLint < 7.0.0.

--- a/projects/js-packages/eslint-changed/package.json
+++ b/projects/js-packages/eslint-changed/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/eslint-changed",
-	"version": "1.0.2-alpha",
+	"version": "2.0.0-alpha",
 	"description": "Run eslint on files, but only report warnings and errors from lines that were changed.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/eslint-changed/README.md#readme",
 	"bugs": {
@@ -30,7 +30,7 @@
 		"nyc": "15.1.0"
 	},
 	"peerDependencies": {
-		"eslint": ">=1.1.0"
+		"eslint": ">=7.0.0"
 	},
 	"engines": {
 		"node": "^14.17.6 || ^16.7.0",

--- a/projects/js-packages/eslint-changed/tests/bin/eslint-changed.js
+++ b/projects/js-packages/eslint-changed/tests/bin/eslint-changed.js
@@ -406,19 +406,6 @@ describe( 'bin/eslint-changed.js', () => {
 			);
 		} );
 
-		it( 'Fails gracefully without ESLint', async () => {
-			const proc = await runEslintChanged( [ '--format=json', '--git' ], {
-				cwd: tmpdir,
-				env: { GIT: 'true', ESLINT: 'this-command-really-should-not-exist-either' },
-			} );
-			const data = await awaitExit( proc );
-			assert.strictEqual( data.exitCode, 1, 'Exit code is 1' );
-			assert.strictEqual(
-				data.stderr,
-				'error: failed to execute ESLint as `this-command-really-should-not-exist-either`. Use environment variable `ESLINT` to override.\n'
-			);
-		} );
-
 		it( 'Works in git mode, --git-staged is the default', async () => {
 			await mktmpdirgit( ...standardRepo );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We had been using ESLint's API just to call `CLIEngine.getFormatter()`,
which they deprecated in 7.0.0 and removed in 8.0.0. There's no direct
replacement; they have `loadFormatter()`, but not as a static method.

Since we're having to instantiate ESLint now anyway to get the
formatter, let's switch over to its API to do the actual linting too
instead of shelling out.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. Came up in #21604 as a problem for eslint 8 support.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Try it out, does it still work?