### PR TITLE
[RNMobile] Tiled Gallery Block: Use default colour for block icon

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/index.js
@@ -198,10 +198,7 @@ export const name = 'tiled-gallery';
 
 export const icon = (
 	<SVG viewBox="0 0 24 24" width={ 24 } height={ 24 }>
-		<Path
-			fill="currentColor"
-			d="M19 5v2h-4V5h4M9 5v6H5V5h4m10 8v6h-4v-6h4M9 17v2H5v-2h4M21 3h-8v6h8V3zM11 3H3v10h8V3zm10 8h-8v10h8V11zm-10 4H3v6h8v-6z"
-		/>
+		<Path d="M19 5v2h-4V5h4M9 5v6H5V5h4m10 8v6h-4v-6h4M9 17v2H5v-2h4M21 3h-8v6h8V3zM11 3H3v10h8V3zm10 8h-8v10h8V11zm-10 4H3v6h8v-6z" />
 	</SVG>
 );
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4158

#### Changes proposed in this Pull Request:
* The `fill` parameter is [removed from the icon's `Path` element](https://github.com/Automattic/jetpack/pull/21618/files#diff-025ac7803bd106aa93c59895bc274e4a297c5f27934dc461334ed2692cb045f9L202). The fact that this parameter was setting the icon's fill to `currentColor` was causing it to appear as the wrong colour in the apps. By removing this parameter, the icon now reverts back to the default colour that all other blocks use for their icons. 

**Mobile Gutenberg PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/4193

#### Jetpack product discussion

Main project thread for the Tiled Gallery block on mobile: p9ugOq-1Tb-p2

#### Does this pull request change what data or activity we track or use?

No, it doesn't.

#### Testing instructions:

To test, it should be verified that:

1. The icon colour now matches up with other icons within the Android and iOS app.
2. The icon colour remains unaffected on the web.

##### Apps

* With these branches checked out and the Gutenberg Mobile demo app running, open the block inserter menu by tapping the + icon in the editor's toolbar.
* Verify that the icon colour for the Tiled Gallery block matches up with the icons for the other blocks.

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/139908623-210cb6d1-418c-4ee8-ac17-02fce784b0b0.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/139908266-34975ce7-03d1-42bf-9563-6eb5c9231662.png" width="100%"> |

##### Web

* Navigate to the editor on a Jetpack-connected site (not a WordPress.com site) and add the Tiled Gallery block.
* Verify that the icon appears green within the block inserter menu and the default dark grey/black within the empty block.

https://user-images.githubusercontent.com/2998162/140200405-1215e965-3200-44b8-87c5-8c804bea7485.mov
