### PR TITLE
[RNMobile] Tiled Gallery Block: Update placeholder text

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
@@ -149,6 +149,7 @@ const TiledGalleryEdit = props => {
 			labels={ {
 				title: __( 'Tiled Gallery', 'jetpack' ),
 				name: __( 'images', 'jetpack' ),
+				instructions: __( 'ADD MEDIA', 'jetpack' ),
 			} }
 			onSelect={ populateInnerBlocksWithImages }
 			accept="image/*"


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4195

With this PR, the placeholder text is changed from "ADD IMAGE" to "ADD MEDIA". This is to bring consistency with the text that's seen in other, similar blocks, such as the Gallery and Story blocks.

**Gutenberg Mobile PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/4194

#### Changes proposed in this Pull Request:
* The MediaPlaceholder component's [`instructions` prop is used](https://github.com/Automattic/jetpack/pull/21620/files#diff-33587eede7ad93ef2a32666df26302b46dfd9d688d44ecf330efcb2e67606b27R152) to update the block's default placeholder text. This matches up with [how the placeholder text is set here in the Story block](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/extensions/blocks/story/edit.native.js#L188).

#### Jetpack product discussion
Main project thread for the Tiled Gallery block on mobile: p9ugOq-1Tb-p2

#### Does this pull request change what data or activity we track or use?
No, it doesn't.

#### Testing instructions:

With these branches checked out and the Gutenberg Mobile demo app running, add the Tiled Gallery block. The placeholder text can be found within the default, empty block. It should be verified that the text reads "ADD MEDIA".

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/139917918-bc45fabd-8b90-467e-a385-feef7e46af53.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/139918175-3037091e-74c5-4a52-9863-d71996de2d90.png" width="100%"> |