### PR TITLE
jetpack: Fix PHP 8.1 deprecation warnings

### DIFF
--- a/projects/packages/connection/changelog/fix-jetpack-php8.1-deprecations
+++ b/projects/packages/connection/changelog/fix-jetpack-php8.1-deprecations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP 8.1 deprecation warning.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.12';
+	const PACKAGE_VERSION = '1.30.13-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -438,6 +438,11 @@ class REST_Connector {
 		$wpcom_user_data   = $connection->get_connected_user_data();
 
 		// Add connected user gravatar to the returned wpcom_user_data.
+		// Probably we shouldn't do this when $wpcom_user_data is false, but we have been since 2016 so
+		// clients probably expect that by now.
+		if ( false === $wpcom_user_data ) {
+			$wpcom_user_data = array();
+		}
 		$wpcom_user_data['avatar'] = ( ! empty( $wpcom_user_data['email'] ) ?
 		get_avatar_url(
 			$wpcom_user_data['email'],

--- a/projects/packages/sync/changelog/fix-jetpack-php8.1-deprecations
+++ b/projects/packages/sync/changelog/fix-jetpack-php8.1-deprecations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP 8.1 deprecation warnings.

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -452,7 +452,7 @@ class Actions {
 				$error_log = array_slice( $error_log, -4, null, true );
 			}
 			// Add new error indexed to time.
-			$error_log[ microtime( true ) ] = $rpc->get_jetpack_error();
+			$error_log[ (string) microtime( true ) ] = $rpc->get_jetpack_error();
 			// Update the error log.
 			update_option( self::ERROR_LOG_PREFIX . $queue_id, $error_log );
 
@@ -838,7 +838,7 @@ class Actions {
 	 * @param string $new_version New version of the plugin.
 	 * @param string $old_version Old version of the plugin.
 	 */
-	public static function cleanup_on_upgrade( $new_version = null, $old_version = null ) {
+	public static function cleanup_on_upgrade( $new_version = '', $old_version = '' ) {
 		if ( wp_next_scheduled( 'jetpack_sync_send_db_checksum' ) ) {
 			wp_clear_scheduled_hook( 'jetpack_sync_send_db_checksum' );
 		}

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.27.1';
+	const PACKAGE_VERSION = '1.27.2-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -381,6 +381,11 @@ function jetpack_current_user_data() {
 	$dotcom_data       = $jetpack_connection->get_connected_user_data();
 
 	// Add connected user gravatar to the returned dotcom_data.
+	// Probably we shouldn't do this when $dotcom_data is false, but we have been since 2016 so
+	// clients probably expect that by now.
+	if ( false === $dotcom_data ) {
+		$dotcom_data = array();
+	}
 	$dotcom_data['avatar'] = ( ! empty( $dotcom_data['email'] ) ?
 		get_avatar_url(
 			$dotcom_data['email'],

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2815,7 +2815,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_boolean( $value, $request, $param ) {
-		if ( ! is_bool( $value ) && ! ( ( ctype_digit( $value ) || is_numeric( $value ) ) && in_array( $value, array( 0, 1 ) ) ) ) {
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict -- Other code depends on loose comparison here.
+		if ( ! is_bool( $value ) && ! ( ctype_digit( (string) $value ) && in_array( $value, array( 0, 1 ) ) ) ) {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be true, false, 0 or 1.', 'jetpack' ), $param ) );
 		}
 		return true;

--- a/projects/plugins/jetpack/_inc/lib/class.media-summary.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-summary.php
@@ -417,7 +417,7 @@ class Jetpack_Media_Summary {
 	 * @return array Array of words.
 	 */
 	public static function split_content_in_words( $text ) {
-		$words = preg_split( '/[\s!?;,.]+/', $text, null, PREG_SPLIT_NO_EMPTY );
+		$words = preg_split( '/[\s!?;,.]+/', $text, -1, PREG_SPLIT_NO_EMPTY );
 
 		// Return an empty array if the split above fails.
 		return $words ? $words : array();

--- a/projects/plugins/jetpack/changelog/fix-jetpack-php8.1-deprecations
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-php8.1-deprecations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix PHP 8.1 deprecation warnings.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3930,7 +3930,7 @@ p {
 	 * @return string
 	 */
 	public function login_url( $login_url, $redirect ) {
-		parse_str( wp_parse_url( $redirect, PHP_URL_QUERY ), $redirect_parts );
+		parse_str( (string) wp_parse_url( $redirect, PHP_URL_QUERY ), $redirect_parts );
 		if ( ! empty( $redirect_parts[ self::$jetpack_redirect_login ] ) ) {
 			$login_url = add_query_arg( self::$jetpack_redirect_login, 'true', $login_url );
 		}

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -258,8 +258,8 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 	// Get POST body data
 	function input( $return_default_values = true, $cast_and_filter = true ) {
-		$input        = trim( $this->api->post_body );
-		$content_type = $this->api->content_type;
+		$input        = trim( (string) $this->api->post_body );
+		$content_type = (string) $this->api->content_type;
 		if ( $content_type ) {
 			list ( $content_type ) = explode( ';', $content_type );
 		}

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/pinterest.php
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/pinterest.php
@@ -29,7 +29,7 @@ const REMAINING_URL_PATH_WITH_SUBPATH_REGEX = '/^\/([^\/]+)\/([^\/]+)\/?$/';
  * @returns {string} The pin type. Empty string if it isn't a valid Pinterest URL.
  */
 function pin_type( $url ) {
-	if ( ! preg_match( PINTEREST_URL_REGEX, $url ) ) {
+	if ( null === $url || ! preg_match( PINTEREST_URL_REGEX, $url ) ) {
 		return '';
 	}
 

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -114,7 +114,7 @@ class Grunion_Contact_Form_Plugin {
 				$data_without_tags[ $index ] = $value;
 			}
 		} else {
-			$data_without_tags = wp_kses( $data_with_tags, array() );
+			$data_without_tags = wp_kses( (string) $data_with_tags, array() );
 			$data_without_tags = str_replace( '&amp;', '&', $data_without_tags ); // undo damage done by wp_kses_normalize_entities()
 		}
 
@@ -657,7 +657,10 @@ class Grunion_Contact_Form_Plugin {
 	}
 
 	static function sanitize_value( $value ) {
-		return preg_replace( '=((<CR>|<LF>|0x0A/%0A|0x0D/%0D|\\n|\\r)\S).*=i', null, $value );
+		if ( null === $value ) {
+			return '';
+		}
+		return preg_replace( '=((<CR>|<LF>|0x0A/%0A|0x0D/%0D|\\n|\\r)\S).*=i', '', $value );
 	}
 
 	/**
@@ -1811,9 +1814,9 @@ class Crunion_Contact_Form_Shortcode {
 	function parse_content( $content ) {
 		if ( is_null( $content ) ) {
 			$this->body = null;
+		} else {
+			$this->body = do_shortcode( $content );
 		}
-
-		$this->body = do_shortcode( $content );
 	}
 
 	/**
@@ -1857,7 +1860,8 @@ class Crunion_Contact_Form_Shortcode {
 		// For back-compat with old Grunion encoding
 		// Also, unencode commas
 		$value = strtr(
-			$value, array(
+			(string) $value,
+			array(
 				'%26' => '&',
 				'%25' => '%',
 			)
@@ -2806,7 +2810,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		$vars = array( 'comment_author', 'comment_author_email', 'comment_author_url', 'contact_form_subject', 'comment_author_IP' );
 		foreach ( $vars as $var ) {
-			$$var = str_replace( array( "\n", "\r" ), '', $$var );
+			$$var = str_replace( array( "\n", "\r" ), '', (string) $$var );
 		}
 
 		// Ensure that Akismet gets all of the relevant information from the contact form,

--- a/projects/plugins/jetpack/modules/geo-location/class.jetpack-geo-location.php
+++ b/projects/plugins/jetpack/modules/geo-location/class.jetpack-geo-location.php
@@ -376,7 +376,7 @@ class Jetpack_Geo_Location {
 			'is_public'    => (bool) $this->sanitize_public( $this->get_meta_value( $post_id, 'public' ) ),
 			'latitude'     => $this->sanitize_coordinate( $this->get_meta_value( $post_id, 'latitude' ) ),
 			'longitude'    => $this->sanitize_coordinate( $this->get_meta_value( $post_id, 'longitude' ) ),
-			'label'        => trim( $this->get_meta_value( $post_id, 'address' ) ),
+			'label'        => trim( (string) $this->get_meta_value( $post_id, 'address' ) ),
 			'is_populated' => false,
 		);
 

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -422,7 +422,7 @@ class Jetpack_Likes_Settings {
 	function get_options() {
 		$setting             = array();
 		$setting['disabled'] = get_option( 'disabled_likes'  );
-		$sharing             = get_option( 'sharing-options' );
+		$sharing             = get_option( 'sharing-options', array() );
 
 		// Default visibility settings
 		if ( ! isset( $sharing['global']['show'] ) ) {

--- a/projects/plugins/jetpack/sal/class.json-api-links.php
+++ b/projects/plugins/jetpack/sal/class.json-api-links.php
@@ -197,8 +197,10 @@ class WPCOM_JSON_API_Links {
 				}
 
 				// Make sure the endpoint exists at the same version
-				if ( version_compare( $this->api->version, $endpoint['min_version'], '>=') &&
-					 version_compare( $this->api->version, $endpoint['max_version'], '<=') ) {
+				if ( null !== $this->api->version &&
+					version_compare( $this->api->version, $endpoint['min_version'], '>=' ) &&
+					version_compare( $this->api->version, $endpoint['max_version'], '<=' )
+				) {
 					array_push(
 						$matches_by_version[ $this->api->version ],
 						(object) array( 'version' => $this->api->version, 'regex' => $endpoint_path_regex )

--- a/projects/plugins/jetpack/tests/php/modules/google-analytics/test-class.google-analytics.php
+++ b/projects/plugins/jetpack/tests/php/modules/google-analytics/test-class.google-analytics.php
@@ -38,6 +38,9 @@ class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 		add_filter(
 			'pre_option_jetpack_wga',
 			function( $option ) {
+				if ( false === $option ) {
+					$option = array();
+				}
 				$option['code'] = self::UA_ID;
 				return $option;
 			}

--- a/projects/plugins/jetpack/tests/php/test_class.jetpack_photon.php
+++ b/projects/plugins/jetpack/tests/php/test_class.jetpack_photon.php
@@ -1055,7 +1055,7 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$sample_html      = '<img src="http://example.com/test.png" class="test" data-width="100" data-height="200" />';
 		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
 		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
-		$query_str        = wp_parse_url( $attributes['src']['value'], PHP_URL_QUERY );
+		$query_str        = (string) wp_parse_url( $attributes['src']['value'], PHP_URL_QUERY );
 		parse_str( $query_str, $query_params );
 
 		$this->assertArrayNotHasKey( 'resize', $query_params );

--- a/projects/plugins/jetpack/tests/php/test_functions.photon.php
+++ b/projects/plugins/jetpack/tests/php/test_functions.photon.php
@@ -42,7 +42,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 */
 	public function test_photonizing_http_image_no_ssl_query_arg() {
 		$url = jetpack_photon_url( 'http://example.com/images/photon.jpg' );
-		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $args );
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $args );
 		$this->assertArrayNotHasKey( 'ssl', $args, 'HTTP image source should not have an ssl query string.' );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Many additions of cast to string where builtin functions will no
  longer accept null. A few added null checks instead.
* Change a few cases where null was passed to mean "default behavior" to
  now pass whatever value is the actual default.
* A few checks for false where array autovivification will no longer
  turn that into an array.

One notable behavior change: In Sync, a string cast is added in
`$error_log[ microtime( true ) ]`, which is technically a behavior
change. But I'm guessing it was intended to get microsecond accuracy,
since if whoever wrote it had wanted just the seconds they'd have just
used `time()`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None to link to.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See that things touched still work?
* Unfortunately we can't really look at the 8.1 CI job, since WordPress core still has failures that cause the test run to abort before it begins.