### PR TITLE
RNA Connection Screen: update styles

### DIFF
--- a/projects/js-packages/components/components/jetpack-logo/index.jsx
+++ b/projects/js-packages/components/components/jetpack-logo/index.jsx
@@ -23,7 +23,7 @@ class JetpackLogo extends React.Component {
 		className: '',
 		height: 32,
 		showText: true,
-		logoColor: '#00BE28',
+		logoColor: '#069e08',
 	};
 
 	render() {

--- a/projects/js-packages/connection/components/connect-screen/basic/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/basic/style.scss
@@ -9,17 +9,27 @@
 
 	&__tos {
 		margin-top: 28px;
-		max-width: 360px;
+		font-size: 12px;
+		line-height: 20px;
+		color: var( --jp-gray-60 );
+
+		@include break-small {
+			max-width: 360px;
+		}
 	}
 
 	.jp-action-button {
 		margin-top: 40px;
 
 		button {
-			max-width: 100%;
+			width: 100%;
 
 			&:disabled {
 				color: hsla(0,0%,100%,.4);
+			}
+
+			@include break-small {
+				width: 220px;
 			}
 		}
 	}

--- a/projects/js-packages/connection/components/connect-screen/layout/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/layout/style.scss
@@ -2,6 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 
 .jp-connection__connect-screen-layout {
+	max-width: 1128px;
 	background: var( --jp-white );
 	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 	border-radius: 4px;
@@ -15,10 +16,10 @@
 	}
 
 	&__left {
-		padding: 25px;
+		padding: 24px;
 
 		@include break-small {
-			padding: 64px 96px;
+			padding: 64px;
 		}
 
 		.jetpack-logo {
@@ -41,7 +42,7 @@
 			font-size: 24px;
 			line-height: 32px;
 			color: var( --jp-black );
-			margin-top: 32px;
+			margin-top: 16px;
 			margin-bottom: 0;
 		}
 
@@ -55,6 +56,10 @@
 		p {
 			color: #101517;
 			margin: 16px 0;
+		}
+
+		li {
+			font-size: 14px;
 		}
 
 		a {
@@ -91,7 +96,6 @@
 	}
 
 	&__right {
-		padding: 64px 0;
 
 		img {
 			max-width: 100%;

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -3,7 +3,7 @@
 
 .jp-connection__connect-screen-layout__left {
 	@include break-xlarge {
-		width: 70%;
+		width: 60%;
 	}
 }
 
@@ -18,11 +18,13 @@
 	}
 
 	&__pricing-card {
+		margin-top: 24px;
 
 		@include break-xlarge {
 			position: absolute;
 			top: 14%;
 			left: 62%;
+			margin-top: 0;
 		}
 
 		.components-button  {
@@ -30,9 +32,6 @@
 			height: auto;
 			font-size: 18px;
 			font-weight: 500;
-			background: var( --jp-black ) !important;
-			color: var( --jp-white ) !important;
-			border-radius: var( --jp-border-radius );
 			padding: 14px 24px;
 			margin: 24px 0px 32px;
 			justify-content: center;
@@ -51,29 +50,12 @@
 			display: inline;
 			font-size: var( --font-title-small );
 			line-height: 20px;
-			color: var( --jp-black ) !important;
-			background: inherit !important;
-			text-decoration: underline;
+			font-size: 12px;
 
 			width: auto;
 			height: auto;
 			font: inherit;
 			padding: 0;
-
-			&:hover {
-			background: inherit;
-				text-decoration-thickness: var( --jp-underline-thickness );
-			}
-
-			&:focus {
-				background: inherit;
-				box-shadow: none !important;
-			}
-		}
-
-		.jp-components-spinner__inner, .jp-components-spinner__outer {
-			border-top-color: var( --jp-black ); 
-			border-right-color: var( --jp-black ); 
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Updates styles on all connection screens, with and without required plan.
* Updates the default Jetpack logo color to #069e08 (Color Studio 40).

A couple of notes for @sergeymitr and @fgiannar:
- I've removed some button-specific styles from this code but we should get merged https://github.com/Automattic/jetpack/pull/21496 first to make sure the styles cascade down.
- For the image on the right side of _Connect Screen_, it would be cool if we could apply it as `background-image` rather than an `<img />` tag so the wrapper height is always defined by the content on the left side. However, that involves changing the components and I wasn't totally comfortable doing that.

#### Jetpack product discussion

p1HpG7-daR-p2#comment-49996

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Go to the Storybook folder `cd projects/js-packages/storybook`
* Run `pnpm install`
* Run `pnpm run storybook:dev`
* Storybook should open in your browser.
* Go to Connection → _Connect Screen_ / _Connect Screen with Required Plan_ and play around with them.

#### Screenshots

_Connect Screen_
![image](https://user-images.githubusercontent.com/390760/139914652-5a918811-2bfe-4044-8f30-c7c5df8e592c.png)

_Connect Screen with Required Plan_
![image](https://user-images.githubusercontent.com/390760/139915312-b39912b7-0d2a-4222-93ef-cf81b405453d.png)


