### PR TITLE
Backup: removed backup-in-progress animation on small viewports

### DIFF
--- a/projects/plugins/backup/changelog/fix-remove-backup-animation-mobile
+++ b/projects/plugins/backup/changelog/fix-remove-backup-animation-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Backup: removed backup-in-progress animation on small viewports

--- a/projects/plugins/backup/src/js/components/Backups.js
+++ b/projects/plugins/backup/src/js/components/Backups.js
@@ -115,7 +115,7 @@ const Backups = () => {
 	const renderInProgressBackup = () => {
 		return (
 			<div class="jp-row">
-				<div class="lg-col-span-5 md-col-span-4 sm-col-span-4">
+				<div class="lg-col-span-5 md-col-span-8 sm-col-span-4">
 					<div class="backup__progress">
 						<div class="backup__progress-info">
 							<p>{ __( 'Backing up Your Groovy Site…', 'jetpack-backup' ) }</p>

--- a/projects/plugins/backup/src/js/components/backups-style.scss
+++ b/projects/plugins/backup/src/js/components/backups-style.scss
@@ -1,8 +1,9 @@
 @import 'rna-styles';
+@import 'masthead/calypso-mixins';
 
 .backup__card {
 	padding: 24px;
-	background:var( --jp-white );
+	background: var( --jp-white );
 	box-shadow: 0px 0px 40px rgba( 0, 0, 0, 0.08 );
 	border-radius: var( --jp-border-radius );
 }
@@ -56,7 +57,8 @@
 	align-items: center;
 	margin-bottom: 8px;
 
-	svg, img {
+	svg,
+	img {
 		min-width: 32px;
 		min-height: 32px;
 	}
@@ -74,6 +76,10 @@
 
 .backup__animation {
 	position: relative;
+
+	@include responsive( full-width ) {
+		display: none;
+	}
 }
 
 .backup__animation-el-1,
@@ -123,7 +129,7 @@
 	}
 	100% {
 		opacity: 0;
-		transform: translateY( -96px );	
+		transform: translateY( -96px );
 	}
 }
 
@@ -146,7 +152,7 @@
 	}
 	100% {
 		opacity: 0;
-		transform: translateY( -96px );	
+		transform: translateY( -96px );
 	}
 }
 
@@ -169,6 +175,6 @@
 	}
 	100% {
 		opacity: 0;
-		transform: translateY( -84px );	
+		transform: translateY( -84px );
 	}
 }


### PR DESCRIPTION
Fixes 1164141197617539-as-1201305007019351

#### Changes proposed in this Pull Request:
In the Backup plugin, the backup-in-progress animation hides the progress bar and the text around. This PR fixes this by hiding the animation on viewports narrower than 960px.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

- Download this PR and build the Backup plugin
- Launch your local testing site and makes sure it has the local version of the Backup plugin installed
- Get a subscription to Backup
- Visit the `Jetpack > Backup` section in WPadmin
- You should see the backup-in-progress animation once the first backup starts (*)
- Check that the animation is hidden for viewports narrower than 960px

_* If your site already has previous backups, you may not be able to visualize this screen. In that instance, force the call of `renderInProgressBackup` at the bottom of `Backup.js`, and rebuild the plugin_.

__Expected behaviour__



https://user-images.githubusercontent.com/1620183/139920545-d27d330e-d4ba-41f0-846d-666c72293036.mov




