### PR TITLE
Update usage of useInnerBlocksProps API

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
@@ -12,7 +12,7 @@ import {
 	BlockIcon,
 	MediaPlaceholder,
 	useBlockProps,
-	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';


### PR DESCRIPTION
This fixes an error caused by `__experimentalUseInnerBlocksProps` now becoming `useInnerBlocksProps`, which occurred in https://github.com/WordPress/gutenberg/pull/26031 (specifically [this line](https://github.com/WordPress/gutenberg/pull/26031/files#diff-8135527e43db4f10ace2a4a2ab9b0e826463e5846e238c715f05de18a48e2842R10)).

#### Changes proposed in this Pull Request:
* Update usage of `__experimentalUseInnerBlocksProps` to `useInnerBlocksProps`

#### Jetpack product discussion

p9ugOq-1Tb-p2

#### Does this pull request change what data or activity we track or use?

Not, it does not.

#### Testing instructions:

See https://github.com/wordpress-mobile/gutenberg-mobile/pull/4196