### PR TITLE
Boost: make progress bar corners round on small screens

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/score.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/score.scss
@@ -166,6 +166,7 @@ $no_boost_score_size: 28px;
 		position: relative;
 		@include breakpoint(xs) {
 			min-width: $bar_height + 1px;
+			border-radius: inherit;
 		}
 	}
 

--- a/projects/plugins/boost/changelog/fix-boost-progress-bar-round-corners
+++ b/projects/plugins/boost/changelog/fix-boost-progress-bar-round-corners
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost: make progress bar corners round on small screens


### PR DESCRIPTION
Fixes 1164141197617539-as-1201305007019341


#### Changes proposed in this Pull Request:
This PR fixes the styles of the progress bar in the Boost plugin, so that its corner are round on small screens as well.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

- Download this PR and build the Boost plugin
- Launch your local testing site and makes sure it has the local version of the Boost plugin installed
- Visit the `Jetpack > Boost` section in WPadmin
- Check that on small screens (width < 768px), progress bars have round corners on both sides
- Make sure that for wider screens, the progress bars still look like the capture below

_Small screens: before_

<img width="562" alt="Screen Shot 2021-11-02 at 2 35 15 PM" src="https://user-images.githubusercontent.com/1620183/139926720-b77ec3ba-1797-40b4-9f4c-780ae292722a.png">

_Small screens: after_


<img width="562" alt="Screen Shot 2021-11-02 at 2 39 58 PM" src="https://user-images.githubusercontent.com/1620183/139926736-fa0151fa-743b-4715-8ff5-36f9e06b45fe.png">

_Wide screens_
<img width="764" alt="Screen Shot 2021-11-02 at 2 41 17 PM" src="https://user-images.githubusercontent.com/1620183/139926759-528f3ab1-6089-477c-8148-47e1db9ddd06.png">


