### PR TITLE
Search Module: Remove extra WPcom gated code

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-wpcom-file-location-search-test
+++ b/projects/plugins/jetpack/changelog/remove-wpcom-file-location-search-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Removes unneeded WPCOM gated code
+
+

--- a/projects/plugins/jetpack/tests/php/modules/search/test-class.jetpack-search-helpers.php
+++ b/projects/plugins/jetpack/tests/php/modules/search/test-class.jetpack-search-helpers.php
@@ -1,9 +1,5 @@
 <?php
 
-if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-	require_once WPMU_PLUGIN_DIR . '/jetpack-plugin/vendor/autoload_packages.php';
-}
-
 use Automattic\Jetpack\Constants;
 
 require_jetpack_file( 'modules/search/class.jetpack-search.php' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes WP.com-gated code (matches D69492-code).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
In support of p9dueE-3mU-p2

This line shouldn't be needed in any case since the autoloader on WP.com loads very early as a mu-plugin.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* n/a -- Removing the calls to the old package locations in D69492-code.