### PR TITLE
P2: hide inbox admin menu link

### DIFF
--- a/projects/plugins/jetpack/changelog/update-p2-inbox-menu-item
+++ b/projects/plugins/jetpack/changelog/update-p2-inbox-menu-item
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+P2: Hide Inbox admin menu link on all P2s.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
@@ -142,6 +142,7 @@ class P2_Admin_Menu extends WPcom_Admin_Menu {
 		remove_menu_page( 'feedback' );
 		remove_menu_page( $this->plugins_slug );
 		remove_menu_page( 'https://wordpress.com/plugins/' . $this->domain );
+		remove_menu_page( 'https://wordpress.com/inbox/' . $this->domain );
 
 		remove_submenu_page( $this->tools_slug, 'https://wordpress.com/marketing/tools/' . $this->domain );
 		remove_submenu_page( $this->tools_slug, 'https://wordpress.com/earn/' . $this->domain );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This hides the Inbox link on P2s. Inbox is not available on P2s.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to any P2 and verify that you don't see the "Inbox" link in the admin menu.

