### PR TITLE
Nav Unification: Remove `preferred-view` param after update

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-nav-unification-preferred-view-param
+++ b/projects/plugins/jetpack/changelog/remove-nav-unification-preferred-view-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Nav Unification: Removes the `preferred-view` param from the URL after changing the preffered view. This fix only affects WP.com sites.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -639,14 +639,19 @@ abstract class Base_Admin_Menu {
 		 */
 		\do_action( 'jetpack_dashboard_switcher_changed_view', $current_screen, $preferred_view );
 
-		// Redirect to default view if that's the newly preferred view.
 		if ( self::DEFAULT_VIEW === $preferred_view ) {
+			// Redirect to default view if that's the newly preferred view.
 			$menu_mappings = require __DIR__ . '/menu-mappings.php';
 			if ( isset( $menu_mappings[ $current_screen ] ) ) {
 				// Using `wp_redirect` intentionally because we're redirecting to Calypso.
 				wp_redirect( $menu_mappings[ $current_screen ] . $this->domain ); // phpcs:ignore WordPress.Security.SafeRedirect
 				exit;
 			}
+		} elseif ( self::CLASSIC_VIEW === $preferred_view ) {
+			// Removes the `preferred-view` param from the URL to avoid issues with
+			// screens that don't expect this param to be present in the URL.
+			wp_safe_redirect( remove_query_arg( 'preferred-view' ) );
+			exit;
 		}
 		// phpcs:enable WordPress.Security.NonceVerification
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-base-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-base-admin-menu.php
@@ -143,6 +143,9 @@ class Test_Base_Admin_Menu extends WP_UnitTestCase {
 		global $pagenow;
 		$pagenow                = 'test.php';
 		$_GET['preferred-view'] = 'classic';
+
+		$this->expectException( ExitException::class );
+
 		static::$admin_menu->handle_preferred_view();
 
 		$this->assertSame( 'classic', static::$admin_menu->get_preferred_view( 'test.php' ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/54204.

#### Changes proposed in this Pull Request:
In order to change the preferred view of a screen, we rely on the `preferred-view` param that indicates what's the newly preferred view.

However, there are some WP Admin screens like `upload.php` which present issues if there are unexpected params in the URL.

To prevent these issues, this PR ensures that the `preferred-view` param is removed from the URL after the new preference has been updated.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Prepare the testing environment:
  - Simple sites: Apply D69520-code to your WP.com sandbox, and sandbox both the API and a Simple site.
  - Atomic sites: Install Jetpack Beta and switch to the `remove/nav-unification-preferred-view-param` branch.
- Go to https://wordpress.com and switch to your test site.
- Go to "Media > Add new".
- Open the "Screen Options" tab and switch to the classic view.
- Make sure the `preferred-view` param is removed from the URL.
- Make sure you can successfully upload a new media item, and the loading bar shows up during the upload.
