### PR TITLE
VideoPress: Prevent video from continuing to play in Media Library after Media Item modal is closed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-media-library-prevent-video-playing-after-modal-closed
+++ b/projects/plugins/jetpack/changelog/fix-media-library-prevent-video-playing-after-modal-closed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress videos in the Media Library will now stop playing in the background when the Media Item modal is closed.

--- a/projects/plugins/jetpack/modules/videopress/editor-media-view.php
+++ b/projects/plugins/jetpack/modules/videopress/editor-media-view.php
@@ -210,16 +210,16 @@ function videopress_override_media_templates() {
 				};
 			} else { /* console.log( 'media.video undefined' ); */ }
 
-			// override the media modal in order to exdent the escape method to unload the player on hide
+			// override the media modal in order to extend the escape method to unload the player on hide
 			var BaseMediaModal = wp.media.view.Modal;
 
-			wp.media.view.Modal = BaseMediaModal.extend({
-				escape() {
-					BaseMediaModal.prototype.escape.apply(this);
-					var playerIframe = document.getElementsByClassName("videopress-iframe")[0];
+			wp.media.view.Modal = BaseMediaModal.extend( {
+				escape: function () {
+					BaseMediaModal.prototype.escape.apply( this );
+					var playerIframe = document.getElementsByClassName( "videopress-iframe" )[0];
 					playerIframe.parentElement.removeChild( playerIframe );
 				}
-			});
+			} );
 		})( wp.media );
 	</script>
 	<?php

--- a/projects/plugins/jetpack/modules/videopress/editor-media-view.php
+++ b/projects/plugins/jetpack/modules/videopress/editor-media-view.php
@@ -170,7 +170,7 @@ function add_videopress_media_overrides() {
 function videopress_override_media_templates() {
 	?>
 	<script type="text/html" id="tmpl-videopress_iframe_vnext">
-		<iframe style="display: block; max-width: 100%; max-height: 100%;" width="{{ data.width }}" height="{{ data.height }}" src="https://videopress.com/embed/{{ data.guid }}?{{ data.urlargs }}" frameborder='0' allowfullscreen></iframe>
+		<iframe class="videopress-iframe" style="display: block; max-width: 100%; max-height: 100%;" width="{{ data.width }}" height="{{ data.height }}" src="https://videopress.com/embed/{{ data.guid }}?{{ data.urlargs }}" frameborder='0' allowfullscreen></iframe>
 	</script>
 	<script>
 		(function( media ){
@@ -210,6 +210,16 @@ function videopress_override_media_templates() {
 				};
 			} else { /* console.log( 'media.video undefined' ); */ }
 
+			// override the media modal in order to exdent the escape method to unload the player on hide
+			var BaseMediaModal = wp.media.view.Modal;
+
+			wp.media.view.Modal = BaseMediaModal.extend({
+				escape() {
+					BaseMediaModal.prototype.escape.apply(this);
+					var playerIframe = document.getElementsByClassName("videopress-iframe")[0];
+					playerIframe.parentElement.removeChild( playerIframe );
+				}
+			});
 		})( wp.media );
 	</script>
 	<?php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Currently, when playing a VideoPress video from the Media Library, when the modal is closed the video will continue playing in the background. This PR removes the video from the DOM once the modal is closed so it won't keep playing.

Fixes # 1008-gh-Automattic/greenhouse

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Extends the backbone.js Media modal in order to add functionality to the `escape` button, which is called by the `X`

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
nope

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a jetpack site with VideoPress enabled, go to the Media Library
* Select a VideoPress video (or upload a new one)
* Play the video in the Media Item modal/popup
* Click the `X` in the upper right of the popup while the video is player, the audio should NOT continue playing in the background
* Open another video and repeat to ensure nothing destructive happened to the modal
* The same should work for dismissing the modal in other ways (ex clicking somewhere outside the modal)