### PR TITLE
Boost: Fix the official name to the JavaScript word reference

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -36,12 +36,12 @@
 
 	<Module slug={'render-blocking-js'}>
 		<h3 slot="title">
-			{__( 'Defer Non-Essential Javascript', 'jetpack-boost' )}
+			{__( 'Defer Non-Essential JavaScript', 'jetpack-boost' )}
 		</h3>
 		<p slot="description">
 			<TemplatedString
 				template={__(
-					`Run non-essential javascript after the page has loaded so
+					`Run non-essential JavaScript after the page has loaded so
 					that styles and images can load more quickly. Read more on
 					<link>web.dev</link>.`,
 					'jetpack-boost'

--- a/projects/plugins/boost/changelog/fix-boost-javascript-wording
+++ b/projects/plugins/boost/changelog/fix-boost-javascript-wording
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fix the official name to the JavaScript word reference


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

While reviewing Boost in order to identify useful E2E tests, I have just noticed we are using the wrong reference to the JavaScript word. This PR fixes it.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Replace javascript with JavaScript

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
* Make sure the reference to JavaScript is correct.
