### PR TITLE
Pexels Integration: Make the initial image search for example query run only once

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-pexels-search
+++ b/projects/plugins/jetpack/changelog/fix-pexels-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Pexels Integration: Fix search query bug

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/pexels.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/pexels.js
@@ -55,7 +55,7 @@ function PexelsMedia( props ) {
 	);
 
 	// Load initial results for the random example query.
-	useEffect( getNextPage, [ getNextPage ] );
+	useEffect( getNextPage, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const searchFormEl = useRef( null );
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/pexels.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/pexels.js
@@ -54,7 +54,7 @@ function PexelsMedia( props ) {
 		[ getNextPage, searchQuery ]
 	);
 
-	// Load initial results for the random example query.
+	// Load initial results for the random example query. Only do it once.
 	useEffect( getNextPage, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const searchFormEl = useRef( null );


### PR DESCRIPTION
There are currently two issues that occur when we search in the Pexels image library:

1. If we hit `Enter` (submit the search form) too quickly after writing our search phrase, we get stuck at the previous search results ([reported in the Calypso repository](https://github.com/Automattic/wp-calypso/issues/57079)).
2. Every time we change the content of the search field (e.g. type one extra letter), a new random search results are addd at the end of the existing search results.

#### Changes proposed in this Pull Request:
This PR fixes both issues by making sure the `useEffect()` that triggers `getNextPage()` callback responsible for querying example search results is run only when the `PexelsMedia` component mounts initially (and not on every change of the search field - as it was originally).

**Before:**

https://user-images.githubusercontent.com/25105483/140293926-a5fbcae0-48e1-4bc6-b0fa-32d01cb3b6a5.mp4

**After:**

https://user-images.githubusercontent.com/25105483/140294008-3a245119-7aeb-456f-9d74-f0302600c296.mp4

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Create a new page or a post
2. Add an `Image` block into the content
3. Click on `Select Image` → `Pexels Free Photos`
4. Test searching for some keywords while submitting the form quickly - as soon as you finish typing. The correct search results should come up. It shouldn't be possible to reproduce [this issue](https://github.com/Automattic/wp-calypso/issues/57079)
5. Test other variations of actions, e.g. clicking on the `Load More` button on the bottom of existing search results. Everything should work as expected.

