### PR TITLE
js-tools: Add missing eslint plugin dep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -966,6 +966,7 @@ importers:
       eslint-plugin-lodash: 7.3.0
       eslint-plugin-prettier: 3.4.1
       eslint-plugin-react: 7.26.1
+      eslint-plugin-react-hooks: 4.2.0
       eslint-plugin-wpcalypso: 5.0.0
       glob: 7.1.6
       ignore: 5.1.8
@@ -995,6 +996,7 @@ importers:
       eslint-plugin-lodash: 7.3.0_eslint@7.32.0
       eslint-plugin-prettier: 3.4.1_36d06c6b3c8f3f25d1a2220e3ee44ebd
       eslint-plugin-react: 7.26.1_eslint@7.32.0
+      eslint-plugin-react-hooks: 4.2.0_eslint@7.32.0
       eslint-plugin-wpcalypso: 5.0.0_eslint@7.32.0
       glob: 7.1.6
       ignore: 5.1.8

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -28,6 +28,7 @@
 		"eslint-plugin-lodash": "7.3.0",
 		"eslint-plugin-prettier": "3.4.1",
 		"eslint-plugin-react": "7.26.1",
+		"eslint-plugin-react-hooks": "4.2.0",
 		"eslint-plugin-wpcalypso": "5.0.0",
 		"glob": "7.1.6",
 		"ignore": "5.1.8",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Eslint "sharable configs" are supposed to peer-depend on any plugins
they need. But people usually forget this because npm hoisting makes it
usually work anyway.

In this case, eslint-config-wpcalypso was missing a peer dep on
eslint-plugin-react-hooks.

This happened to work before because eslint-changed was shelling out to
eslint, which runs from `node_modules/.pnpm/eslint@7.32.0/node_modules/eslint`,
which was picking up the dep from `node_modules/.pnpm/node_modules` that
even pnpm puts in place to handle crap like this.

When #21606 switched eslint-changed to use eslint's API instead of
shelling out, it doesn't run from within `node_modules/.pnpm/` anymore
(because eslint-changed is in the monorepo), so
`node_modules/.pnpm/node_modules` is no longer in node's path, so it no
longer would find the plugin.

The solution is to add the missing plugin to js-tools's deps, because
`tools/js-tools/node_modules` will still be in the path with the way we
have things set up.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1635982454440000-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `git checkout 8cd0bd281db6d01e8fc73f2aeb59d6f4175221eb` (from #21474)
* `pnpm install`
* `pnpx eslint-changed --ext .js,.jsx,.cjs,.mjs,.ts,.tsx --git "--git-base=f6bb136d3c6101589303a4686a80851065fca426" projects/plugins/jetpack/_inc/client/state/licensing/reducer.js`
  * See that it fails with an error about "Failed to load plugin 'react-hooks'"
* `git cherry-pick fix/missing-eslint-plugin-dep`
* `pnpm install`
* `pnpx eslint-changed --ext .js,.jsx,.cjs,.mjs,.ts,.tsx --git "--git-base=f6bb136d3c6101589303a4686a80851065fca426" projects/plugins/jetpack/_inc/client/state/licensing/reducer.js`
   * Now it should work, producing no output because there are no lint errors.