### PR TITLE
Tiled Gallery Block - Matching `save` serialized HTML with web

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/save.js
@@ -3,10 +3,9 @@
  */
 import classnames from 'classnames';
 import { isBlobURL } from '@wordpress/blob';
-import { Platform } from '@wordpress/element';
 
 export default function GalleryImageSave( props ) {
-	const { alt, ariaLabel, imageFilter, height, id, link, linkTo, origUrl, url, width } = props;
+	const { alt, imageFilter, height, id, link, linkTo, origUrl, url, width } = props;
 
 	if ( isBlobURL( origUrl ) ) {
 		return null;
@@ -32,7 +31,7 @@ export default function GalleryImageSave( props ) {
 			data-url={ origUrl }
 			data-width={ width }
 			src={ url }
-			aria-label={ Platform.OS === 'web' ? undefined : ariaLabel }
+			data-amp-layout={ 'responsive' }
 		/>
 	);
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Component, Platform } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import classnames from 'classnames';
 
 /**
@@ -47,13 +47,10 @@ export default class Layout extends Component {
 
 		const { src, srcSet } = photonizedImgProps( img, { layoutStyle } );
 
-		const isWeb = Platform.OS === 'web';
-
 		return (
 			<Image
 				alt={ img.alt }
-				aria-label={ isWeb ? ariaLabel : undefined }
-				ariaLabel={ isWeb ? undefined : ariaLabel }
+				aria-label={ ariaLabel }
 				columns={ columns }
 				height={ img.height }
 				id={ img.id }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/square.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/square.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { chunk, drop, take } from 'lodash';
-import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,10 +21,7 @@ export default function Square( { columns, renderedImages } ) {
 				...( remainder ? [ take( renderedImages, remainder ) ] : [] ),
 				...chunk( drop( renderedImages, remainder ), columnCount ),
 			].map( ( imagesInRow, rowIndex ) => (
-				<Row
-					key={ rowIndex }
-					className={ Platform.OS === 'web' ? `columns-${ imagesInRow.length }` : undefined }
-				>
+				<Row key={ rowIndex } className={ `columns-${ imagesInRow.length }` }>
 					{ imagesInRow.map( ( image, colIndex ) => (
 						<Column key={ colIndex }>{ image }</Column>
 					) ) }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/utils/index.js
@@ -4,7 +4,6 @@
 import photon from 'photon';
 import { format as formatUrl, parse as parseUrl } from 'url';
 import { isBlobURL } from '@wordpress/blob';
-import { Platform } from '@wordpress/element';
 import { range } from 'lodash';
 
 /**
@@ -67,9 +66,8 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 	 * We don't know what the viewport size will be like. Use full size src.
 	 */
 
-	const isWeb = Platform.OS === 'web';
 	let src;
-	if ( isSquareishLayout( layoutStyle ) && width && height && isWeb ) {
+	if ( isSquareishLayout( layoutStyle ) && width && height ) {
 		// Layouts with 1:1 width/height ratio should be made square
 		const size = Math.min( PHOTON_MAX_RESIZE, width, height );
 		src = photonImplementation( url, {


### PR DESCRIPTION
Re-matching attributes that are serialized between mobile and web Jetpack Tiled Gallery implementations so that we can load serialized HTML from the web and vice versa.

**NOTE** that the URL from the web seems to be broken, but I'm not sure if that's because we're using the demo app to test or not. Will have to check this in detail after we get basic functionality in place.

<details>
  <summary>
**Initial HTML used:**</summary>

```
<!-- wp:jetpack/tiled-gallery {"className":"is-style-square","columnWidths":[["100.00000"]],"ids":[60]} -->
<div class="wp-block-jetpack-tiled-gallery aligncenter is-style-square"><div class="tiled-gallery__gallery"><div class="tiled-gallery__row columns-1"><div class="tiled-gallery__col"><figure class="tiled-gallery__item"><img alt="" data-height="49" data-id="60" data-link="https://sandbox1359387942.wpcomstaging.com/screen-shot-2021-03-08-at-2-51-29-pm/" data-url="https://sandbox1359387942.wpcomstaging.com/wp-content/uploads/2021/03/screen-shot-2021-03-08-at-2.51.29-pm.png" data-width="308" src="https://sandbox1359387942.wpcomstaging.com/wp-content/uploads/2021/03/screen-shot-2021-03-08-at-2.51.29-pm.png" data-amp-layout="responsive"/></figure></div></div></div></div>
<!-- /wp:jetpack/tiled-gallery -->
```
</details>


Fixes [#4137](https://github.com/wordpress-mobile/gutenberg-mobile/issues/4137)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Sets attributes that were changed for the `save` workaround back to match with the web's implementation. Effectively, removing most of `Platform` checks.

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
* Go to web and make a tiled gallery block.
* Copy HTML from web and paste into `initial-html.js`.
* Reload.
* See that `Problem Displaying Block` does not appear.
* Bonus: Add an image from mobile.
* Go to HTML view and cut the HTML.
* Switch to visual mode.
* Switch back to HTML view and paste the HTML.
* Switch back to visual mode and see that both images appear in the JTG with no `Problem Displaying Block`.

#### Screenshots:

https://user-images.githubusercontent.com/13263478/140326183-1e517517-69ab-4672-a5aa-741816316af3.mp4



