### PR TITLE
Full Sync :: limit to contributors and above

### DIFF
--- a/projects/packages/sync/changelog/fix-full-sync-user_level
+++ b/projects/packages/sync/changelog/fix-full-sync-user_level
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Full Sync : limit included users to contributors and above (based on wp_user_limit)

--- a/projects/packages/sync/src/modules/class-users.php
+++ b/projects/packages/sync/src/modules/class-users.php
@@ -670,7 +670,7 @@ class Users extends Module {
 	public function get_where_sql( $config ) {
 		global $wpdb;
 
-		$query = "meta_key = '{$wpdb->prefix}capabilities'";
+		$query = "meta_key = '{$wpdb->prefix}user_level' AND meta_value > 0";
 
 		// The $config variable is a list of user IDs to sync.
 		if ( is_array( $config ) ) {

--- a/projects/plugins/jetpack/changelog/fix-full-sync-user_level
+++ b/projects/plugins/jetpack/changelog/fix-full-sync-user_level
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Unit Tests : Update Full Sync tests to align with limitation on users that are synced.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -380,8 +380,8 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 
 		// let's create some users on the other blog
 		switch_to_blog( $other_blog_id );
-		$mu_blog_user_id       = $this->factory->user->create();
-		$added_mu_blog_user_id = $this->factory->user->create();
+		$mu_blog_user_id       = $this->factory->user->create( array( 'role' => 'contributor' ) );
+		$added_mu_blog_user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 		restore_current_blog();
 
 		// add one of the users to our current blog

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -312,10 +312,15 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		) );
 	}
 
+	/**
+	 * Full Sync is limited to contributor and above users based on wp_user_level.
+	 * This test verifies only contributors are sent.
+	 */
 	function test_full_sync_sends_all_users() {
-		$first_user_id = $this->factory->user->create();
+		$this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$first_user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 		for ( $i = 0; $i < 9; $i += 1 ) {
-			$user_id = $this->factory->user->create();
+			$user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 		}
 
 		update_user_meta( $user_id, 'locale', 'en_GB' );
@@ -1049,8 +1054,8 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_doesnt_send_deleted_posts() {
 		// previously, the behavior was to send false or throw errors - we
 		// should actively detect false values and remove them
-		$keep_post_id   = $this->factory->post->create();
-		$delete_post_id = $this->factory->post->create();
+		$keep_post_id   = $this->factory->post->create( array( 'role' => 'editor' ) );
+		$delete_post_id = $this->factory->post->create( array( 'role' => 'editor' ) );
 
 		$this->full_sync->start();
 
@@ -1090,8 +1095,8 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 
 		// previously, the behavior was to send false or throw errors - we
 		// should actively detect false values and remove them
-		$keep_user_id   = $this->factory->user->create();
-		$delete_user_id = $this->factory->user->create();
+		$keep_user_id   = $this->factory->user->create( array( 'role' => 'contributor' ) );
+		$delete_user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 
 		$this->full_sync->start();
 
@@ -1147,7 +1152,7 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		}
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
-		$this->assertEquals( 13, $this->server_replica_storage->user_count() );
+		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
 		$this->server_replica_storage->reset();
 		$this->assertEquals( 0, $this->server_replica_storage->user_count() );
 		$user_ids = Modules::get_module( 'users' )->get_initial_sync_user_config();

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -1031,9 +1031,9 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_can_sync_individual_users() {
-		$sync_user_id    = $this->factory->user->create();
-		$sync_user_id_2  = $this->factory->user->create();
-		$no_sync_user_id = $this->factory->user->create();
+		$sync_user_id   = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$sync_user_id_2 = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$this->factory->user->create( array( 'role' => 'editor' ) );
 
 		$this->full_sync->start( array( 'users' => array( $sync_user_id, $sync_user_id_2 ) ) );
 		$this->sender->do_full_sync();

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -368,7 +368,7 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 
 		$original_blog_id = get_current_blog_id();
 
-		$user_id = $this->factory->user->create();
+		$user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 
 		// NOTE this is necessary because WPMU causes certain assumptions about transients
 		// to be wrong, and tests to explode. @see: https://github.com/sheabunge/WordPress/commit/ff4f1bb17095c6af8a0f35ac304f79074f3c3ff6

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full.php
@@ -445,9 +445,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_users() {
-		$first_user_id = $this->factory->user->create();
+		$this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$first_user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 		for ( $i = 0; $i < 9; $i += 1 ) {
-			$user_id = $this->factory->user->create();
+			$user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 		}
 
 		update_user_meta( $user_id, 'locale', 'en_GB' );
@@ -474,7 +475,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		Settings::update_settings( array( 'max_queue_size_full_sync' => 1, 'max_enqueue_full_sync' => 10 ) );
 
 		for ( $i = 0; $i < 45; $i += 1 ) {
-			$user_ids[] = $this->factory->user->create();
+			$this->factory->user->create( array( 'role' => 'contributor' ) );
 		}
 
 		// The first event is for full sync start.
@@ -1276,9 +1277,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_can_sync_individual_users() {
-		$sync_user_id = $this->factory->user->create();
-		$sync_user_id_2 = $this->factory->user->create();
-		$no_sync_user_id = $this->factory->user->create();
+		$sync_user_id   = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$sync_user_id_2 = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$this->factory->user->create( array( 'role' => 'editor' ) );
 
 		$this->full_sync->start( array( 'users' => array( $sync_user_id, $sync_user_id_2) ) );
 		$this->sender->do_full_sync();
@@ -1338,13 +1339,13 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function test_full_sync_doesnt_send_deleted_users() {
 
-		$user_counts = count_users();
+		$user_counts         = count_users();
 		$existing_user_count = $user_counts['total_users'];
 
 		// previously, the behavior was to send false or throw errors - we
 		// should actively detect false values and remove them
-		$keep_user_id = $this->factory->user->create();
-		$delete_user_id = $this->factory->user->create();
+		$keep_user_id   = $this->factory->user->create( array( 'role' => 'contributor' ) );
+		$delete_user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 
 		$this->full_sync->start();
 
@@ -1499,7 +1500,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		}
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
-		$this->assertEquals( 13, $this->server_replica_storage->user_count() );
+		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
 		$this->server_replica_storage->reset();
 		$this->assertEquals( 0, $this->server_replica_storage->user_count() );
 		$user_ids = Modules::get_module( 'users' )->get_initial_sync_user_config();

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full.php
@@ -530,7 +530,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$original_blog_id = get_current_blog_id();
 
-		$user_id = $this->factory->user->create();
+		$user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 
 		// NOTE this is necessary because WPMU causes certain assumptions about transients
 		// to be wrong, and tests to explode. @see: https://github.com/sheabunge/WordPress/commit/ff4f1bb17095c6af8a0f35ac304f79074f3c3ff6
@@ -542,8 +542,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// let's create some users on the other blog
 		switch_to_blog( $other_blog_id );
-		$mu_blog_user_id       = $this->factory->user->create();
-		$added_mu_blog_user_id = $this->factory->user->create();
+		$mu_blog_user_id       = $this->factory->user->create( array( 'role' => 'contributor' ) );
+		$added_mu_blog_user_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 		restore_current_blog();
 
 		// add one of the users to our current blog


### PR DESCRIPTION
Reduce included users in Full Syncs to contributor and above users. This is performed by an explicit check of the {$wpdb->prefix}user_level meta which correlates to a non 0 value.

Fixes https://wp.me/p9dueE-3JV

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Limit the scope of User Full Syncs to contributor and above users.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
NO

#### Testing instructions:

Create several users on your site, subscribers, contributors, admins, etc
Pre applying patch 
* wp shell
* $um = Automattic\Jetpack\Sync\Modules::get_module( 'full-sync' );  // get full sync module.
* $um->start( [ 'users'=>1 ] ); // initiate a full sync of users.
* $um->get_status(); // returns current status
* // Verify that the "total" for users matches # of users on the site regardless of capabilities.

Post applying patch
* wp shell
* $um = Automattic\Jetpack\Sync\Modules::get_module( 'full-sync' );  // get full sync module.
* $um->start( [ 'users'=>1 ] ); // initiate a full sync of users.
* $um->get_status(); // returns current status
* // Verify that the "total" for users matches # of users on the site with contributor or above role
