### PR TITLE
Tests: Run block fixtures through KSES

### DIFF
--- a/projects/plugins/jetpack/changelog/block-fixture-kses-tests
+++ b/projects/plugins/jetpack/changelog/block-fixture-kses-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+General: Run all block fixtures through KSES, to help ensure they save correctly.

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/class-block-fixture-testcase.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/class-block-fixture-testcase.php
@@ -76,4 +76,44 @@ abstract class Jetpack_Block_Fixture_TestCase extends WP_UnitTestCase {
 		}
 		// phpcs:enable WordPress.WP.AlternativeFunctions
 	}
+
+	/**
+	 * Tests that running the serialised block content through KSES doesn't cause the
+	 * HTML to change.
+	 *
+	 * @dataProvider data_block_fixtures
+	 */
+	function test_kses_doesnt_change_fixtures( $block, $filename ) {
+
+		// KSES doesn't allow data: URLs, so we need to replace any of them in fixtures.
+		// $block = preg_replace( "/src=['\"]data:[^'\"]+['\"]/", 'src="https://wordpress.org/foo.jpg"', $block );
+		// $block = preg_replace( "/href=['\"]data:[^'\"]+['\"]/", 'href="https://wordpress.org/foo.jpg"', $block );
+		// $block = preg_replace( '/url\(data:[^)]+\)/', 'url(https://wordpress.org/foo.jpg)', $block );
+
+		$kses_block = wp_kses_post( $block );
+
+		// KSES adds a space at the end of self-closing tags, add it to the original to match.
+		$block = preg_replace( '|([^ ])/>|', '$1 />', $block );
+
+		// KSES removes the last semi-colon from style attributes, remove it from the original to match.
+		$block = preg_replace( '/style="([^"]*);"/', 'style="$1"', $block );
+
+		$this->assertSame( $block, $kses_block, "Failed to match $filename" );
+	}
+
+	function data_block_fixtures() {
+		$fixtures_path = "extensions/blocks/*/test/fixtures/";
+		$file_pattern  = '*.serialized.html';
+		$files         = glob( JETPACK__PLUGIN_DIR . $fixtures_path . $file_pattern );
+
+		$data = array();
+
+		foreach ( $files as $file ) {
+			$filename = basename( $file );
+			$block    = file_get_contents( $file );
+			$data[]   = array( $block, $filename );
+		}
+
+		return $data;
+	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/class-block-fixture-testcase.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/class-block-fixture-testcase.php
@@ -76,44 +76,4 @@ abstract class Jetpack_Block_Fixture_TestCase extends WP_UnitTestCase {
 		}
 		// phpcs:enable WordPress.WP.AlternativeFunctions
 	}
-
-	/**
-	 * Tests that running the serialised block content through KSES doesn't cause the
-	 * HTML to change.
-	 *
-	 * @dataProvider data_block_fixtures
-	 */
-	function test_kses_doesnt_change_fixtures( $block, $filename ) {
-
-		// KSES doesn't allow data: URLs, so we need to replace any of them in fixtures.
-		// $block = preg_replace( "/src=['\"]data:[^'\"]+['\"]/", 'src="https://wordpress.org/foo.jpg"', $block );
-		// $block = preg_replace( "/href=['\"]data:[^'\"]+['\"]/", 'href="https://wordpress.org/foo.jpg"', $block );
-		// $block = preg_replace( '/url\(data:[^)]+\)/', 'url(https://wordpress.org/foo.jpg)', $block );
-
-		$kses_block = wp_kses_post( $block );
-
-		// KSES adds a space at the end of self-closing tags, add it to the original to match.
-		$block = preg_replace( '|([^ ])/>|', '$1 />', $block );
-
-		// KSES removes the last semi-colon from style attributes, remove it from the original to match.
-		$block = preg_replace( '/style="([^"]*);"/', 'style="$1"', $block );
-
-		$this->assertSame( $block, $kses_block, "Failed to match $filename" );
-	}
-
-	function data_block_fixtures() {
-		$fixtures_path = "extensions/blocks/*/test/fixtures/";
-		$file_pattern  = '*.serialized.html';
-		$files         = glob( JETPACK__PLUGIN_DIR . $fixtures_path . $file_pattern );
-
-		$data = array();
-
-		foreach ( $files as $file ) {
-			$filename = basename( $file );
-			$block    = file_get_contents( $file );
-			$data[]   = array( $block, $filename );
-		}
-
-		return $data;
-	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/test-class-fixtures.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/test-class-fixtures.php
@@ -19,10 +19,6 @@ class Block_Fixture_Test extends \WP_UnitTestCase {
 
 		// KSES doesn't allow data: URLs, so we need to replace any of them in fixtures.
 
-		// $block = preg_replace( "/src=['\"]data:[^'\"]+['\"]/", 'src="https://wordpress.org/foo.jpg"', $block );
-		// $block = preg_replace( "/href=['\"]data:[^'\"]+['\"]/", 'href="https://wordpress.org/foo.jpg"', $block );
-		// $block = preg_replace( '/url\(data:[^)]+\)/', 'url(https://wordpress.org/foo.jpg)', $block );
-
 		$kses_block = wp_kses_post( $block );
 
 		// KSES adds a space at the end of self-closing tags, add it to the original to match.
@@ -30,6 +26,9 @@ class Block_Fixture_Test extends \WP_UnitTestCase {
 
 		// KSES removes the last semi-colon from style attributes, remove it from the original to match.
 		$block = preg_replace( '/style="([^"]*);"/', 'style="$1"', $block );
+
+		// KSES turns \u0026 into \u0026amp;, revert that.
+		$kses_block = str_replace( '\u0026amp;', '\u0026', $kses_block );
 
 		$this->assertSame( $block, $kses_block, "Failed to match $filename" );
 	}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/test-class-fixtures.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/test-class-fixtures.php
@@ -1,0 +1,55 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Test block fixtures in PHP.
+ *
+ * @package automattic/jetpack
+ */
+class Block_Fixture_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Tests that running the serialised block content through KSES doesn't cause the
+	 * HTML to change.
+	 *
+	 * @param string $block    The serialised block content.
+	 * @param string $filename The serialised block filename.
+	 *
+	 * @dataProvider data_block_fixtures
+	 */
+	public function test_kses_doesnt_change_fixtures( $block, $filename ) {
+
+		// KSES doesn't allow data: URLs, so we need to replace any of them in fixtures.
+
+		// $block = preg_replace( "/src=['\"]data:[^'\"]+['\"]/", 'src="https://wordpress.org/foo.jpg"', $block );
+		// $block = preg_replace( "/href=['\"]data:[^'\"]+['\"]/", 'href="https://wordpress.org/foo.jpg"', $block );
+		// $block = preg_replace( '/url\(data:[^)]+\)/', 'url(https://wordpress.org/foo.jpg)', $block );
+
+		$kses_block = wp_kses_post( $block );
+
+		// KSES adds a space at the end of self-closing tags, add it to the original to match.
+		$block = preg_replace( '|([^ ])/>|', '$1 />', $block );
+
+		// KSES removes the last semi-colon from style attributes, remove it from the original to match.
+		$block = preg_replace( '/style="([^"]*);"/', 'style="$1"', $block );
+
+		$this->assertSame( $block, $kses_block, "Failed to match $filename" );
+	}
+
+	/**
+	 * Data provider for test_kses_doesnt_change_fixtures.
+	 */
+	public function data_block_fixtures() {
+		$fixtures_path = 'extensions/blocks/*/test/fixtures/';
+		$file_pattern  = '*.serialized.html';
+		$files         = glob( JETPACK__PLUGIN_DIR . $fixtures_path . $file_pattern );
+
+		$data = array();
+
+		foreach ( $files as $file ) {
+			$filename = basename( $file );
+			$block    = file_get_contents( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$data[]   = array( $block, $filename );
+		}
+
+		return $data;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Runs block fixtures through KSES, to ensure they save properly for non-admin users.

Related: WordPress/gutenberg#35611.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* See PHP unit tests.