### PR TITLE
Allow /sites/${site}/external-media/copy/pexels to insert post meta data 

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -21,53 +21,55 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 	 * @var array
 	 */
 	public $media_schema = array(
-		'type'       => 'object',
-		'required'   => true,
-		'properties' => array(
-			'caption' => array(
-				'type' => 'string',
-			),
-			'guid'    => array(
-				'items' => array(
-					'caption' => array(
-						'type' => 'string',
-					),
-					'name'    => array(
-						'type' => 'string',
-					),
-					'title'   => array(
-						'type' => 'string',
-					),
-					'url'     => array(
-						'format' => 'uri',
-						'type'   => 'string',
+		'type'  => 'array',
+		'items' => array(
+			'type'       => 'object',
+			'required'   => true,
+			'properties' => array(
+				'caption' => array(
+					'type' => 'string',
+				),
+				'guid'    => array(
+					'type'       => 'object',
+					'properties' => array(
+						'caption' => array(
+							'type' => 'string',
+						),
+						'name'    => array(
+							'type' => 'string',
+						),
+						'title'   => array(
+							'type' => 'string',
+						),
+						'url'     => array(
+							'format' => 'uri',
+							'type'   => 'string',
+						),
 					),
 				),
-				'type'  => 'array',
-			),
-			'title'   => array(
-				'type' => 'string',
-			),
-			'meta'    => array(
-				'type'                 => 'object',
-				'additionalProperties' => false,
-				'properties'           => array(
-					'vertical_id'   => array(
-						'type'   => 'string',
-						'format' => 'text-field',
-					),
-					'pexels_object' => array(
-						'type' => 'object',
-					),
-					'orientations'  => array(
-						'type'        => 'array',
-						'items'       => array(
-							'type' => 'string',
-							'enum' => array( 'landscape', 'portrait', 'square' ),
+				'title'   => array(
+					'type' => 'string',
+				),
+				'meta'    => array(
+					'type'       => 'object',
+					'properties' => array(
+						'vertical_id'   => array(
+							'type'   => 'string',
+							'format' => 'text-field',
 						),
-						'minItems'    => 1,
-						'maxItems'    => 3,
-						'uniqueItems' => true,
+						'pexels_object' => array(
+							'type' => 'object',
+						),
+						'orientations'  => array(
+							'type'        => 'array',
+							'items'       => array(
+								'type' => 'string',
+								'enum' => array( 'landscape', 'portrait', 'square' ),
+							),
+							'minItems'    => 1,
+							'maxItems'    => 3,
+							'uniqueItems' => true,
+						),
 					),
 				),
 			),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -51,8 +51,9 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 					'type' => 'string',
 				),
 				'meta'    => array(
-					'type'       => 'object',
-					'properties' => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
 						'vertical_id'   => array(
 							'type'   => 'string',
 							'format' => 'text-field',
@@ -494,12 +495,7 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 		);
 
 		if ( ! empty( $item['meta'] ) ) {
-			// Only allow meta properties defined in the schema.
-			// None of the validation or sanitization functions are doing this for me.
-			$meta_allowed  = array_keys( $this->media_schema['properties']['meta']['properties'] );
-			$meta_filtered = array_intersect_key( $item['meta'], array_flip( $meta_allowed ) );
-
-			foreach ( $meta_filtered as $meta_key => $meta_value ) {
+			foreach ( $item['meta'] as $meta_key => $meta_value ) {
 				update_post_meta( $id, $meta_key, $meta_value );
 			}
 		}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -60,8 +60,14 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 						'type' => 'object',
 					),
 					'orientations'  => array(
-						'type' => 'array',
-						'enum' => array( 'landscape', 'portrait', 'square' ),
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'string',
+							'enum' => array( 'landscape', 'portrait', 'square' ),
+						),
+						'minItems'    => 1,
+						'maxItems'    => 3,
+						'uniqueItems' => true,
 					),
 				),
 			),
@@ -234,6 +240,16 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 	 */
 	public function validate_media( $param ) {
 		$param = $this->prepare_media_param( $param );
+
+		// Workaround: rest_validate_value_from_schema() only goes one level
+		// deep, so validate 'meta' separately.
+		$meta_schema = $this->media_schema['properties']['meta'];
+		foreach ( array_keys( $param ) as $i ) {
+			$param[ $i ]['meta'] = rest_validate_value_from_schema( $param[ $i ]['meta'], $meta_schema, 'meta' );
+			if ( $param[ $i ]['meta'] instanceof WP_Error ) {
+				return $param[ $i ]['meta'];
+			}
+		}
 
 		return rest_validate_value_from_schema( $param, $this->media_schema, 'media' );
 	}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -48,6 +48,24 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 			'title'   => array(
 				'type' => 'string',
 			),
+			'meta'    => array(
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => array(
+					'vertical_id'   => array(
+						'type' => 'string',
+					),
+					'vertical_name' => array(
+						'type' => 'string',
+					),
+					'pexels_object' => array(
+						'type' => 'object',
+					),
+					'orientations'  => array(
+						'type' => 'array',
+					),
+				),
+			),
 		),
 	);
 
@@ -467,6 +485,17 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 				'post_excerpt' => $item['caption'],
 			)
 		);
+
+		if ( ! empty( $item['meta'] ) ) {
+			// Only allow meta properties defined in the schema.
+			// None of the validation or sanization functions are doing this for me.
+			$meta_allowed  = array_keys( $this->media_schema['properties']['meta']['properties'] );
+			$meta_filtered = array_intersect_key( $item['meta'], array_flip( $meta_allowed ) );
+
+			foreach ( $meta_filtered as $meta_key => $meta_value ) {
+				update_post_meta( $id, $meta_key, $meta_value );
+			}
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -485,7 +485,7 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 
 		if ( ! empty( $item['meta'] ) ) {
 			// Only allow meta properties defined in the schema.
-			// None of the validation or sanization functions are doing this for me.
+			// None of the validation or sanitization functions are doing this for me.
 			$meta_allowed  = array_keys( $this->media_schema['properties']['meta']['properties'] );
 			$meta_filtered = array_intersect_key( $item['meta'], array_flip( $meta_allowed ) );
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -55,9 +55,6 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 					'vertical_id'   => array(
 						'type' => 'string',
 					),
-					'vertical_name' => array(
-						'type' => 'string',
-					),
 					'pexels_object' => array(
 						'type' => 'object',
 					),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -243,16 +243,6 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 	public function validate_media( $param ) {
 		$param = $this->prepare_media_param( $param );
 
-		// Workaround: rest_validate_value_from_schema() only goes one level
-		// deep, so validate 'meta' separately.
-		$meta_schema = $this->media_schema['properties']['meta'];
-		foreach ( array_keys( $param ) as $i ) {
-			$param[ $i ]['meta'] = rest_validate_value_from_schema( $param[ $i ]['meta'], $meta_schema, 'meta' );
-			if ( $param[ $i ]['meta'] instanceof WP_Error ) {
-				return $param[ $i ]['meta'];
-			}
-		}
-
 		return rest_validate_value_from_schema( $param, $this->media_schema, 'media' );
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -53,13 +53,15 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 				'additionalProperties' => false,
 				'properties'           => array(
 					'vertical_id'   => array(
-						'type' => 'string',
+						'type'   => 'string',
+						'format' => 'text-field',
 					),
 					'pexels_object' => array(
 						'type' => 'object',
 					),
 					'orientations'  => array(
 						'type' => 'array',
+						'enum' => array( 'landscape', 'portrait', 'square' ),
 					),
 				),
 			),

--- a/projects/plugins/jetpack/changelog/add-external-media-copy-meta
+++ b/projects/plugins/jetpack/changelog/add-external-media-copy-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Allow /sites/$site/external-media/copy/pexels to insert post meta data

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -220,6 +220,56 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_External_Media extends WP_Test_Jetpack_
 	}
 
 	/**
+	 * Tests copy response with pexels while setting metadata: Invalid meta keys should fail.
+	 */
+	public function test_copy_image_meta_invalid_meta_key() {
+		$tmp_name = $this->get_temp_name( static::$image_path );
+		if ( file_exists( $tmp_name ) ) {
+			unlink( $tmp_name );
+		}
+
+		add_filter( 'pre_http_request', array( $this, 'mock_image_data' ), 10, 3 );
+		add_filter( 'wp_handle_sideload_prefilter', array( $this, 'copy_image' ) );
+		add_filter( 'wp_check_filetype_and_ext', array( $this, 'mock_extensions' ) );
+
+		$request = wp_rest_request( Requests::POST, '/wpcom/v2/external-media/copy/pexels' );
+		$request->set_body_params(
+			array(
+				'media' => array(
+					array(
+						'guid' => wp_json_encode(
+							array(
+								'url'  => static::$image_path,
+								'name' => $this->image_name,
+							)
+						),
+						'meta' => array(
+							'vertical_id'   => 'v1234',
+							'pexels_object' => array(
+								'information' => 'goes here',
+							),
+							'orientations'  => array(
+								'landscape',
+								'square',
+							),
+							'this_meta_key' => 'is_not_allowed',
+						),
+					),
+				),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_image_data' ) );
+		remove_filter( 'wp_handle_sideload_prefilter', array( $this, 'copy_image' ) );
+		remove_filter( 'wp_check_filetype_and_ext', array( $this, 'mock_extensions' ) );
+
+		$this->assertEquals( $response->status, 400 );
+		$this->assertEquals( $response->data['data']['params']['media'], 'this_meta_key is not a valid property of Object.' );
+	}
+
+	/**
 	 * Tests connection response for Google Photos.
 	 */
 	public function test_connection_google_photos() {

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -102,7 +102,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_External_Media extends WP_Test_Jetpack_
 	}
 
 	/**
-	 * Tests list response with unauthenticated Google Photos.
+	 * Tests copy response with pexels while not setting metadata.
 	 */
 	public function test_copy_image() {
 		$tmp_name = $this->get_temp_name( static::$image_path );
@@ -145,6 +145,79 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_External_Media extends WP_Test_Jetpack_
 		$this->assertIsInt( $data['id'] );
 		$this->assertEmpty( $data['caption'] );
 		$this->assertEmpty( $data['alt'] );
+	}
+
+	/**
+	 * Tests copy response with pexels while setting metadata.
+	 */
+	public function test_copy_image_meta() {
+		$tmp_name = $this->get_temp_name( static::$image_path );
+		if ( file_exists( $tmp_name ) ) {
+			unlink( $tmp_name );
+		}
+
+		add_filter( 'pre_http_request', array( $this, 'mock_image_data' ), 10, 3 );
+		add_filter( 'wp_handle_sideload_prefilter', array( $this, 'copy_image' ) );
+		add_filter( 'wp_check_filetype_and_ext', array( $this, 'mock_extensions' ) );
+
+		$request = wp_rest_request( Requests::POST, '/wpcom/v2/external-media/copy/pexels' );
+		$request->set_body_params(
+			array(
+				'media' => array(
+					array(
+						'guid' => wp_json_encode(
+							array(
+								'url'  => static::$image_path,
+								'name' => $this->image_name,
+							)
+						),
+						'meta' => array(
+							'vertical_id'     => 'v1234',
+							'pexels_object'   => array(
+								'information' => 'goes here',
+							),
+							'orientations'    => array(
+								'landscape',
+								'square',
+							),
+							'not_allowed_key' => 'should not be saved to meta',
+						),
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data()[0];
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_image_data' ) );
+		remove_filter( 'wp_handle_sideload_prefilter', array( $this, 'copy_image' ) );
+		remove_filter( 'wp_check_filetype_and_ext', array( $this, 'mock_extensions' ) );
+
+		// Check API response.
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertArrayHasKey( 'caption', $data );
+		$this->assertArrayHasKey( 'alt', $data );
+		$this->assertArrayHasKey( 'type', $data );
+		$this->assertArrayHasKey( 'url', $data );
+		$this->assertEquals( 'image', $data['type'] );
+		$this->assertIsInt( $data['id'] );
+		$this->assertEmpty( $data['caption'] );
+		$this->assertEmpty( $data['alt'] );
+
+		// Look inside the post_meta of the post added.
+		$meta = get_post_meta( $data['id'] );
+		$this->assertArrayHasKey( 'vertical_id', $meta );
+		$this->assertArrayHasKey( 'pexels_object', $meta );
+		$this->assertArrayHasKey( 'orientations', $meta );
+		$this->assertArrayNotHasKey( 'not_allowed_key', $meta );
+		$this->assertEquals( $meta['vertical_id'][0], 'v1234' );
+
+		$orientations = maybe_unserialize( $meta['orientations'][0] );
+		$this->assertEquals( $orientations[0], 'landscape' );
+		$this->assertEquals( $orientations[1], 'square' );
+
+		$pexels_object = maybe_unserialize( $meta['pexels_object'][0] );
+		$this->assertEquals( $pexels_object['information'], 'goes here' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -172,15 +172,14 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_External_Media extends WP_Test_Jetpack_
 							)
 						),
 						'meta' => array(
-							'vertical_id'     => 'v1234',
-							'pexels_object'   => array(
+							'vertical_id'   => 'v1234',
+							'pexels_object' => array(
 								'information' => 'goes here',
 							),
-							'orientations'    => array(
+							'orientations'  => array(
 								'landscape',
 								'square',
 							),
-							'not_allowed_key' => 'should not be saved to meta',
 						),
 					),
 				),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Allow /sites/${site}/external-media/copy/pexels to insert post meta data 

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions (Jetpack):

* N/A

#### Testing Instructions (Unit Tests):

* `jetpack docker phpunit -- --filter=Endpoint_External_Media`

#### Testing instructions (WPCOM):

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Apply D69692-code to sandbox
* Visit internal vertical-images tool (See: D69577-code for full instructions)
* Choose a vertical
* Enter a search term (example: "building") and press enter or click on magnifying glass
* See photos
* Click on at least on image to select it
* Click on the "Add 1 photos to VERTICAL" button
* see no feedback but use devtools to see that the POST happened :)
* sandbox PduBjF-5-p2 (See: D69577-code for full instructions)
* Visit https://<vertical site>/wp-admin/upload.php (See: D69577-code for full instructions)
* click on the photo you uploaded
* click on edit more details
* On sandbox, edit wp-admin/post.php and add

```
$meta = get_post_meta( $post_id );
l(compact('meta'));
```

around line 37, inside the `if ( $post_id ) {` block
* F5 the url (should look like `https://<vertical site>/wp-admin/post.php?post=49&action=edit`) and `tail -f /tmp/php-errors`
* Expect to see the metadata