### PR TITLE
Display Nav Unification Quick switcher on edit.php?post_type=post

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-quick-switcher-mapping
+++ b/projects/plugins/jetpack/changelog/fix-quick-switcher-mapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Display Nav Unification Quick switcher in edit.php?post_type=post page for sites with Nav unification enabled.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
@@ -11,6 +11,7 @@ $common_mappings = array(
 	'edit-comments.php'                      => 'https://wordpress.com/comments/',
 	'import.php'                             => 'https://wordpress.com/import/',
 	'edit.php?post_type=page'                => 'https://wordpress.com/pages/',
+	'edit.php?post_type=post'                => 'https://wordpress.com/posts/',
 	'users.php'                              => 'https://wordpress.com/people/team/',
 	'options-general.php'                    => 'https://wordpress.com/settings/general/',
 	'options-discussion.php'                 => 'https://wordpress.com/settings/discussion/',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/54920
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Display the Nav-Unification Quick switcher on edit.php?post_type=post page.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Jetpack Beta and switch to this branch
* Apply D69799-code on your sandbox
* Go to WP-Admin/edit.php (for Posts)
* Click on a Post (doesn't matter which one)
* Click on the WordPress menu logo (Block editor sidebar) and click on "All Posts" link.
* You'll be redirected to edit.php?post_type=post
* Click on "Screen options" and notice that the button for switching to Calypso interface is not missing.

