### PR TITLE
Fix propTypes and add story

### DIFF
--- a/projects/js-packages/components/components/decorative-card/index.jsx
+++ b/projects/js-packages/components/components/decorative-card/index.jsx
@@ -56,7 +56,7 @@ DecorativeCard.propTypes = {
 	/** The format of the card (horizontal or vertical) */
 	format: PropTypes.oneOf( [ 'horizontal', 'vertical' ] ),
 	/** An icon slug that can be used to show an icon (options are limited to what is in the stylesheet) */
-	icon: PropTypes.string,
+	icon: PropTypes.oneOf( [ 'unlink' ] ),
 	/** URL for an image to show in the card. */
 	imageUrl: PropTypes.string,
 };

--- a/projects/js-packages/components/components/decorative-card/index.jsx
+++ b/projects/js-packages/components/components/decorative-card/index.jsx
@@ -52,13 +52,17 @@ const DecorativeCard = props => {
 	);
 };
 
-DecorativeCard.PropTypes = {
+DecorativeCard.propTypes = {
 	/** The format of the card (horizontal or vertical) */
-	format: PropTypes.string,
+	format: PropTypes.oneOf( [ 'horizontal', 'vertical' ] ),
 	/** An icon slug that can be used to show an icon (options are limited to what is in the stylesheet) */
 	icon: PropTypes.string,
 	/** URL for an image to show in the card. */
 	imageUrl: PropTypes.string,
+};
+
+DecorativeCard.defaultProps = {
+	format: 'horizontal',
 };
 
 export default DecorativeCard;

--- a/projects/js-packages/components/components/decorative-card/stories/index.jsx
+++ b/projects/js-packages/components/components/decorative-card/stories/index.jsx
@@ -14,3 +14,8 @@ const Template = args => <DecorativeCard { ...args } />;
 
 // Export Default story
 export const _default = Template.bind( {} );
+
+export const Unlink = Template.bind( {} );
+Unlink.args = {
+	icon: 'unlink',
+};

--- a/projects/js-packages/components/components/decorative-card/stories/index.jsx
+++ b/projects/js-packages/components/components/decorative-card/stories/index.jsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import DecorativeCard from '../index.jsx';
+
+export default {
+	title: 'Playground/Decorative Card',
+	component: DecorativeCard,
+};
+
+// Export additional stories using pre-defined values
+const Template = args => <DecorativeCard { ...args } />;
+
+// Export Default story
+export const _default = Template.bind( {} );


### PR DESCRIPTION
Quick PR to add the new DecorativeCard component to Storybook.

Also fixed the `propTypes` declaration (first `p` should be lowercase)

Suggested using `oneOf` as a type for the format. Should we do the same for `icon` and consider `unlink` the only possible value for now? (apart from empty)

### Testing

* Go to `js-packages/storybook` folder
* `pnpm install`
* `pnpm run storybook:dev`
* in the browser, look at Playgoround > Decorative Card. (Default and Unlink)