### PR TITLE
Status: add a function_exists check before calling wp_get_environment_type

### DIFF
--- a/projects/packages/status/changelog/2021-11-09-16-21-32-086404
+++ b/projects/packages/status/changelog/2021-11-09-16-21-32-086404
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add a function_exists check before calling wp_get_environment_type

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -141,8 +141,9 @@ class Status {
 		// Check for localhost and sites using an IP only first.
 		$is_local = site_url() && false === strpos( site_url(), '.' );
 
+		// @todo Remove function_exists when the package has a documented minimum WP version.
 		// Use Core's environment check, if available. Added in 5.5.0 / 5.5.1 (for `local` return value).
-		if ( 'local' === wp_get_environment_type() ) {
+		if ( function_exists( 'wp_get_environment_type' ) && 'local' === wp_get_environment_type() ) {
 			$is_local = true;
 		}
 
@@ -184,8 +185,9 @@ class Status {
 	 * @return bool
 	 */
 	public function is_staging_site() {
+		// @todo Remove function_exists when the package has a documented minimum WP version.
 		// Core's wp_get_environment_type allows for a few specific options. We should default to bowing out gracefully for anything other than production or local.
-		$is_staging = ! in_array( \wp_get_environment_type(), array( 'production', 'local' ), true );
+		$is_staging = function_exists( 'wp_get_environment_type' ) && ! in_array( wp_get_environment_type(), array( 'production', 'local' ), true );
 
 		$known_staging = array(
 			'urls'      => array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The `wp_get_environment_type` function was added in WordPress 5.5. Consumer plugins may not be enforcing a minimum WP version of 5.5. Using this package on sites with WP <5.5 will cause a fatal error if `wp_get_environnment_type` is called..

We intend to define minimum WP requirements for the packages in the future.

In the meantime, check that the `wp_get_environment_type` function exists before calling it.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
#### Test with WP 5.4
1. Create a test site with WP 5.4.
2. Install and attempt to activate the master branch of Jetpack. Notice that Jetpack can't be activated because of the minimum WP version.
3. Manually change the value of the `JETPACK__MINIMUM_WP_VERSION` [constant](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/jetpack.php#L33) to 5.4.
4. The site should crash with a fatal error because the `wp_get_environment_type` function doesn't exist.
5. Change the `JETPACK__MINIMUM_WP_VERSION` constant back to 5.7.
6. Install and activate this branch.
7. Manually change the value of the `JETPACK__MINIMUM_WP_VERSION` [constant](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/jetpack.php#L33) to 5.4.
8. The site should not experience a fatal error.

#### Test with WP 5.8
This is just a quick check for unexpected regressions.
1. Create a test site with WP 5.8.
2. Install and activate this branch of Jetpack.
3. Call the changed methods in `wp shell`:
    a. `return (new Automattic\Jetpack\Status())->is_local_site();`
    b. `return (new Automattic\Jetpack\Status())->is_staging_site();`