### PR TITLE
SVN release: automate the tag copy commit message

### DIFF
--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -176,7 +176,7 @@ info "Updating trunk"
 svn commit -m "Updating trunk to version $TAG"
 success "Done!"
 info "Tagging $TAG"
-svn cp ^/$WPSLUG/trunk ^/$WPSLUG/tags/$TAG
+svn cp ^/$WPSLUG/trunk ^/$WPSLUG/tags/$TAG -m "Creating the $TAG tag"
 success "Done!"
 if [[ "$TAG" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
 	info "Updating stable tag in readme.txt in SVN tags/$TAG"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
﻿
Follow-up to #21574.

When running `svn cp`, we have to provide a commit message. Let's pass it as part of the command so this is done automatically.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* I don't know that it can easily be tested until the next Alpha?
