### PR TITLE
Admin: reduce bottom padding of admin footer

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -243,6 +243,12 @@ abstract class Jetpack_Admin_Page {
 				background-color: #f6f6f6;
 			}
 
+			@media (max-width: 782px) {
+				#wpbody-content {
+					padding-bottom: 50px;
+				}
+			}
+
 			#jp-plugin-container .wrap {
 				margin: 0 auto;
 				max-width:45rem;

--- a/projects/plugins/jetpack/changelog/fix-jetpack-plugin-footer-size
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-plugin-footer-size
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Jetpacj plugin: reduce bottom padding of admin footer
+Admin: reduce bottom padding of admin footer

--- a/projects/plugins/jetpack/changelog/fix-jetpack-plugin-footer-size
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-plugin-footer-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpacj plugin: reduce bottom padding of admin footer


### PR DESCRIPTION
Fixes 1164141197617539-as-1201305007019301

#### Changes proposed in this Pull Request:
This PR reduces the size of the footer bottom padding, in WP admin.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

- Download this PR.
- Launch your local testing site.
- Visit the `Jetpack` section in WP admin.
- Check that the footer has a bottom padding of 50px for screens narrower than 782px.

_Before_
<img width="398" alt="Screen Shot 2021-11-09 at 1 01 00 PM" src="https://user-images.githubusercontent.com/1620183/140983971-4f54e432-e06f-40a1-8bc0-a23d27290f7b.png">


_After_
<img width="412" alt="Screen Shot 2021-11-09 at 1 08 30 PM" src="https://user-images.githubusercontent.com/1620183/140983984-b969d738-a9d6-4633-8e35-842ff6488f30.png">