### PR TITLE
[RNMobile] Tiled Gallery layout selection basic implementation

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
@@ -173,6 +173,8 @@ const TiledGalleryEdit = props => {
 				linkTo={ linkTo }
 				columns={ columns }
 				roundedCorners={ roundedCorners }
+				clientId={ clientId }
+				className={ props.attributes.className }
 			/>
 			<View { ...innerBlocksProps } />
 			<View style={ [ styles.galleryAppender ] }>{ mediaPlaceholder }</View>

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout-picker.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout-picker.native.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { Text } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { Icon, chevronRight } from '@wordpress/icons';
+import { BottomSheet } from '@wordpress/components';
+import { BlockStyles } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
+import { settings } from './index';
+
+const LayoutPicker = props => {
+	const [ showSubSheet, setShowSubSheet ] = useState( false );
+	const navigation = useNavigation();
+
+	const goBack = () => {
+		setShowSubSheet( false );
+		navigation.goBack();
+	};
+
+	const openSubSheet = () => {
+		navigation.navigate( BottomSheet.SubSheet.screenName );
+		setShowSubSheet( true );
+	};
+
+	const currentStyleName = props.className
+		? settings.styles.find( style => `is-style-${ style.name }` === props.className ).label
+		: null;
+
+	return (
+		<BottomSheet.SubSheet
+			navigationButton={
+				<BottomSheet.Cell
+					cellRowContainerStyle={ styles.cellRowStyles }
+					labelStyle={ styles.galleryLayoutTitle }
+					label={ __( 'Gallery style', 'jetpack' ) }
+					separatorType="none"
+					onPress={ openSubSheet }
+					accessibilityRole={ 'button' }
+					accessibilityLabel={ __( 'Gallery style', 'jetpack' ) }
+					accessibilityHint={ __( 'Navigates to layout selection screen', 'jetpack' ) }
+				>
+					<Text>{ currentStyleName }</Text>
+					<Icon icon={ chevronRight }></Icon>
+				</BottomSheet.Cell>
+			}
+			showSheet={ showSubSheet }
+		>
+			<>
+				<BottomSheet.NavBar>
+					<BottomSheet.NavBar.BackButton onPress={ goBack } />
+					<BottomSheet.NavBar.Heading>
+						{ __( 'Gallery style', 'jetpack' ) }
+					</BottomSheet.NavBar.Heading>
+				</BottomSheet.NavBar>
+				<BlockStyles clientId={ props.clientId } />
+			</>
+		</BottomSheet.SubSheet>
+	);
+};
+
+export default LayoutPicker;

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/settings.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/settings.native.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls } from '@wordpress/block-editor';
+import { BlockStyles, InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import {
@@ -16,6 +16,8 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
  * Internal dependencies
  */
 import styles from './styles.scss';
+import { LAYOUT_CIRCLE, LAYOUT_STYLES } from './constants';
+import { getActiveStyleName } from '../../shared/block-styles';
 
 const MIN_COLUMNS = 1;
 export const MAX_COLUMNS = 8;
@@ -30,7 +32,7 @@ const TiledGallerySettings = props => {
 		styles.horizontalBorderDark
 	);
 
-	const { setAttributes, linkTo, columns, roundedCorners } = props;
+	const { setAttributes, linkTo, columns, roundedCorners, clientId, className } = props;
 	const [ columnNumber, setColumnNumber ] = useState( columns ?? DEFAULT_COLUMNS );
 	useEffect( () => {
 		setColumnNumber( columns );
@@ -50,9 +52,14 @@ const TiledGallerySettings = props => {
 		},
 	};
 
+	const layoutStyle = getActiveStyleName( LAYOUT_STYLES, className );
+
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Tiled gallery settings', 'jetpack' ) } />
+			<PanelBody style={ styles.panelBody }>
+				<BlockStyles clientId={ clientId } url={ `https://placekitten.com/${ 300 }/${ 300 }` } />
+			</PanelBody>
 			<PanelBody>
 				<UnitControl
 					label={ __( 'Columns', 'jetpack' ) }
@@ -65,18 +72,20 @@ const TiledGallerySettings = props => {
 					} }
 				/>
 			</PanelBody>
-			<PanelBody style={ horizontalSettingsDivider }>
-				<RangeControl
-					label={ __( 'Rounded corners', 'jetpack' ) }
-					minimumValue={ MIN_ROUNDED_CORNERS }
-					maximumValue={ MAX_ROUNDED_CORNERS }
-					value={ roundedCornerRadius }
-					onChange={ value => {
-						setRoundedCornerRadius( value );
-						setAttributes( { roundedCorners: value } );
-					} }
-				/>
-			</PanelBody>
+			{ layoutStyle !== LAYOUT_CIRCLE && (
+				<PanelBody style={ horizontalSettingsDivider }>
+					<RangeControl
+						label={ __( 'Rounded corners', 'jetpack' ) }
+						minimumValue={ MIN_ROUNDED_CORNERS }
+						maximumValue={ MAX_ROUNDED_CORNERS }
+						value={ roundedCornerRadius }
+						onChange={ value => {
+							setRoundedCornerRadius( value );
+							setAttributes( { roundedCorners: value } );
+						} }
+					/>
+				</PanelBody>
+			) }
 			<PanelBody>
 				<LinkSettingsNavigation
 					url={ linkToURL }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/settings.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/settings.native.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { BlockStyles, InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import {
@@ -18,6 +18,7 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import styles from './styles.scss';
 import { LAYOUT_CIRCLE, LAYOUT_STYLES } from './constants';
 import { getActiveStyleName } from '../../shared/block-styles';
+import LayoutPicker from './layout-picker.native';
 
 const MIN_COLUMNS = 1;
 export const MAX_COLUMNS = 8;
@@ -57,8 +58,9 @@ const TiledGallerySettings = props => {
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Tiled gallery settings', 'jetpack' ) } />
-			<PanelBody style={ styles.panelBody }>
-				<BlockStyles clientId={ clientId } url={ `https://placekitten.com/${ 300 }/${ 300 }` } />
+
+			<PanelBody>
+				<LayoutPicker clientId={ clientId } className={ className } />
 			</PanelBody>
 			<PanelBody>
 				<UnitControl

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/styles.native.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/styles.native.scss
@@ -15,3 +15,9 @@
 .is-style-squared {
 	aspect-ratio: 1;
 }
+
+.panelBody {
+	padding-left: 0;
+	padding-right: 0;
+	padding-bottom: $grid-unit;
+}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/styles.native.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/styles.native.scss
@@ -16,8 +16,10 @@
 	aspect-ratio: 1;
 }
 
-.panelBody {
-	padding-left: 0;
-	padding-right: 0;
-	padding-bottom: $grid-unit;
+.cellRowStyles {
+	flex-shrink: 1;
+}
+
+.galleryLayoutTitle {
+	text-align: left;
 }


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/4192

Related:
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4221

#### Changes proposed in this Pull Request:
- Allow users to change the Tiled Gallery's layout
- Layout selection is implemented using Gutenberg's `BlockStyles` component
- Layout selection is displayed in a bottom sheet sub-sheet

Because we want to unblock work on other layouts, this PR only addresses the above issue's most critical points (i.e. layout selection UI, hiding Corner Radius setting for Circle layout, etc). What was explicitly left out is:
- Visual previews of each layout: For the time being, blank previews are shown above each layout's name
- A grid layout for visual previews: Instead, we're showing all layouts in a single, scrollable row
- An icon next to the current layout's name: On the settings bottom sheet, for now we're just showing the name of the current layout (without the icon that's shown in the design) 
- Font size for current layout's name: Again on the settings bottom sheet, the layout's name doesn't use the correct font

#### Jetpack product discussion

p9ugOq-1Tb-p2

#### Does this pull request change what data or activity we track or use?

No, it does not.

#### Testing instructions:

It's possible to test that layout selection works by simply inspecting the block's HTML using the editor's HTML mode. However, to further verify that the layout's CSS is working, it's best to test in the main apps.

1. Checkout the Gutenberg Mobile branch: if using `gh`, run `gh pr checkout --recurse-submodules add/tiled-gallery-block-circle-layout`
2. Run the packager: `npm run start:reset`
3. Run the WPiOS app's `develop` branch
4. Open the editor and expect it to load from the running packager
5. Add a Tiled Gallery block and add images to it
6. Switch to the Circle layout and use the editor Preview to verify that the images are circles on the site's frontend
7. Run the WPAndroid app's `develop` branch
8. Repeat steps 4 to 6

#### Demos

##### WPAndroid

https://user-images.githubusercontent.com/1898325/141013806-50bd510e-ad15-4a83-a650-edfd0c562804.mov

##### WPiOS

https://user-images.githubusercontent.com/1898325/141015518-bfc143d9-6532-473f-b15f-d84f22516062.mov





