### PR TITLE
Device Detection: Verify HTTP_USER_AGENT exists

### DIFF
--- a/projects/packages/device-detection/changelog/fix-device-detection-http-user-agent
+++ b/projects/packages/device-detection/changelog/fix-device-detection-http-user-agent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verify $_SERVER['HTTP_USER_AGENT'] exists before use.

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -206,7 +206,7 @@ class User_Agent_Info {
 		} elseif ( $this->is_Nintendo_3DS() ) {
 			return 'nintendo-3ds';
 		} else {
-			$agent       = strtolower( $_SERVER['HTTP_USER_AGENT'] );
+			$agent       = $this->useragent;
 			$dumb_agents = $this->dumb_agents;
 			foreach ( $dumb_agents as $dumb_agent ) {
 				if ( false !== strpos( $agent, $dumb_agent ) ) {
@@ -1262,6 +1262,9 @@ class User_Agent_Info {
 	 * The is_blackberry_10() method can be used to check the User Agent for a BlackBerry 10 device.
 	 */
 	public static function is_blackberry_10() {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
 		$agent = strtolower( $_SERVER['HTTP_USER_AGENT'] );
 		return ( strpos( $agent, 'bb10' ) !== false ) && ( strpos( $agent, 'mobile' ) !== false );
 	}
@@ -1478,6 +1481,10 @@ class User_Agent_Info {
 	 */
 	public static function is_bot() {
 		static $is_bot = null;
+
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
 
 		if ( is_null( $is_bot ) ) {
 			$is_bot = self::is_bot_user_agent( $_SERVER['HTTP_USER_AGENT'] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes `Undefined index: HTTP_USER_AGENT in /srv/www/html/wp-content/plugins/jetpack-dev/vendor/automattic/jetpack-device-detection/src/class-user-agent-info.php on line 1265`

Discovered this while looking through error logs.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Verify array key exists in a couple instances where we weren't checking before.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None from me yet.
*
