### PR TITLE
Nav Unification: migrate new Site Editor location

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-site-editor-nav-link
+++ b/projects/plugins/jetpack/changelog/fix-site-editor-nav-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+map new Site Editor location from Gutenberg 11.9 to Calypso

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -458,6 +458,12 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 
 		$this->update_menu( 'gutenberg-edit-site', 'https://wordpress.com/site-editor/' . $this->domain, null, null, null, 59 );
+
+		// Gutenberg 11.9 moves the Site Editor to an Appearance submenu as Editor.
+		$submenus_to_update = array(
+			'gutenberg-edit-site' => 'https://wordpress.com/site-editor/' . $this->domain,
+		);
+		$this->update_submenus( 'themes.php', $submenus_to_update );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -464,6 +464,10 @@ class Admin_Menu extends Base_Admin_Menu {
 			'gutenberg-edit-site' => 'https://wordpress.com/site-editor/' . $this->domain,
 		);
 		$this->update_submenus( 'themes.php', $submenus_to_update );
+		// Gutenberg 11.9 adds an redundant site editor entry point that requires some calypso work
+		// before it can be exposed.  Note, there are also already discussions to remove this excess
+		// item in Gutenberg.
+		$this->hide_submenu_page( 'themes.php', 'gutenberg-edit-site&styles=open' );
 	}
 
 	/**


### PR DESCRIPTION
Gutenberg 11.9 moves the Site Editor from being a top-level menu to an Appearance submenu. This retains the mapping to wordpress.com/site-editor/YOURSITE

Fixes #

#### Changes proposed in this Pull Request:
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1636417237235700-slack-C7YPUHBB2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* apply this patch to your sandbox with the autogenerated Diff thingy
* Verify that Appearance -> Editor (Beta) links within Calypso and loads properly