### PR TITLE
[RNMobile] [WIP] Tiled Gallery: Hide inner block settings

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/index.js
@@ -228,7 +228,7 @@ export const settings = {
 		align: [ 'center', 'wide', 'full' ],
 		customClassName: false,
 		html: false,
-		__experimentalExposeControlsToChildren: false,
+		__experimentalHideChildBlockControls: true,
 	},
 	title: __( 'Tiled Gallery', 'jetpack' ),
 	transforms: {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/index.js
@@ -228,6 +228,7 @@ export const settings = {
 		align: [ 'center', 'wide', 'full' ],
 		customClassName: false,
 		html: false,
+		__experimentalExposeControlsToChildren: false,
 	},
 	title: __( 'Tiled Gallery', 'jetpack' ),
 	transforms: {


### PR DESCRIPTION
Partial fix for https://github.com/wordpress-mobile/gutenberg-mobile/issues/4190 (note, this PR won't hide the image's caption, only the settings toggle)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `__experimentalHideChildBlockControls` is set to `true`, so that a settings toggle/control isn't available for each individual image within the main Tiled Gallery block. 
* The code builds on the work outlined in https://github.com/wordpress-mobile/gutenberg-mobile/pull/4225.

#### Jetpack product discussion

p9ugOq-1Tb-p2 

#### Does this pull request change what data or activity we track or use?

No, it doesn't.

#### Testing instructions:

_Prerequisite: The following testing instructions rely on the code in https://github.com/WordPress/gutenberg/pull/36371, which hasn't been merged into Gutenberg's `trunk` at the time of writing. Please make sure to check out the branch that the code is on if it's not merged into `trunk`._

* With these branches checked out and the Gutenberg Mobile demo app running, add the Tiled Gallery block then upload a few images to it.
* Select an image and verify that the settings control no longer displays alongside it.

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/141148875-aeb1f97f-22b2-466b-b553-44c9c524e406.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/141147581-724bda7b-7204-40b5-be83-a8ce6bf5d867.png" width="100%"> |
