### PR TITLE
Jetpack mobile navigation: make sure correct dropdown item is selected

### DIFF
--- a/projects/plugins/jetpack/_inc/client/admin.js
+++ b/projects/plugins/jetpack/_inc/client/admin.js
@@ -59,6 +59,9 @@ function render() {
 						<Route path="/plans">
 							<Main routeName={ getRouteName( '/plans' ) } />
 						</Route>
+						<Route path="/recommendations">
+							<Main routeName={ getRouteName( '/recommendations' ) } />
+						</Route>
 						<Route path="/plans-prompt">
 							<Main routeName={ getRouteName( '/plans-prompt' ) } />
 						</Route>
@@ -113,6 +116,8 @@ export function getRouteName( path ) {
 			return _x( 'My Plan', 'Navigation item.', 'jetpack' );
 		case '/plans':
 			return _x( 'Plans', 'Navigation item.', 'jetpack' );
+		case '/recommendations':
+			return _x( 'Recommendations', 'Navigation item.', 'jetpack' );
 		case '/plans-prompt':
 			return _x( 'Plans', 'Navigation item.', 'jetpack' );
 		case '/settings':

--- a/projects/plugins/jetpack/changelog/fix-recommendation-nav-item-not-selected
+++ b/projects/plugins/jetpack/changelog/fix-recommendation-nav-item-not-selected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Navigation: make sure correct dropdown item is selected when visiting Recommendation section on mobile


### PR DESCRIPTION
Fixes 1164141197617539-as-1201305007019315

#### Changes proposed in this Pull Request:
When visiting the _Recommendations_ section in WP admin on mobile, the navigation dropdown keeps showing _At a Glance_ as the selected section. This PR fixes that.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Download the PR and build the `jetpack` plugin
- Launch your local testing site and makes sure it has the local version of the plugin installed
- Set your browser width to less than 480px
- Visit `/wp-admin/admin.php?page=jetpack#/recommendations/site-type`, and check that the dropdown shows _Recommendations_
- Switch section, and verify that the dropdown behaves as expected
- Finally, check that the navigation still works as expected on wider viewports

#### Capture
<img width="451" alt="Screen Shot 2021-11-10 at 12 15 44 PM" src="https://user-images.githubusercontent.com/1620183/141161184-64381fd8-d500-4787-a59a-dee00c3f5b16.png">


