### PR TITLE
Jetpack Assistant: hide background image on small viewports

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/style.scss
@@ -13,6 +13,7 @@
 
 	@include breakpoint( '<660px' ) {
 		grid-template-columns: 100% 0%;
+		background: #fff;
 	}
 
 	background: linear-gradient(

--- a/projects/plugins/jetpack/changelog/fix-reco-assistant-background-on-mobile
+++ b/projects/plugins/jetpack/changelog/fix-reco-assistant-background-on-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Assistant: hide background image on small viewports


### PR DESCRIPTION
Fixes 1164141197617539-as-1201305007019321

#### Changes proposed in this Pull Request:
This PR hides the background image of the Jetpack Assistant on mobile. On small viewports, links that overlap with the image are not properly readable.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

- Download the PR and build the jetpack plugin
- Launch your local testing site and make sure it has the local version of the plugin installed
- Set your browser width to less than 660px
- Visit `/wp-admin/admin.php?page=jetpack#/recommendations/`, and check that the background image is not visible in any step of the assistant, while making sure it is visible with wider viewports

_Before_
<img width="631" alt="Screen Shot 2021-11-10 at 1 47 08 PM" src="https://user-images.githubusercontent.com/1620183/141177799-3c7bb306-57a6-4ebc-80e9-998cf4aecaa6.png">

_After_

<img width="625" alt="Screen Shot 2021-11-10 at 1 47 22 PM" src="https://user-images.githubusercontent.com/1620183/141177817-1e6f88fe-190a-4934-8bfb-8a8e6c772cd8.png">


