### PR TITLE
Jetpack Assistant: align info icon

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/index.jsx
@@ -103,7 +103,7 @@ const SummaryComponent = props => {
 				) }
 			</div>
 			<div className="jp-recommendations-summary__more-features">
-				<Gridicon icon="info-outline" size={ 28 } />
+				<Gridicon icon="info-outline" />
 				<p>
 					{ createInterpolateElement(
 						__(

--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/style.scss
@@ -58,20 +58,25 @@
 
 .jp-recommendations-summary__more-features {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	border-top: 1px solid $studio-gray-5;
-	padding: 32px 48px;
+	padding: 40px 48px;
 
 	@include breakpoint( '<480px' ) {
-		padding: 32px 16px;
+		padding: 40px 16px;
 	}
 
 	.gridicons-info-outline {
 		fill: $studio-gray-40;
 		margin-right: 18px;
+		flex: 0 0 24px;
 	}
 
 	.gridicons-external {
 		margin-left: 0.25rem;
+	}
+
+	> p {
+		margin: 1px 0 0 0;
 	}
 }

--- a/projects/plugins/jetpack/changelog/fix-jetpack-assistant-icon-alignment
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-assistant-icon-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Assistant: align info icon


### PR DESCRIPTION
Fixes 1164141197617539-as-1201305007019329

#### Changes proposed in this Pull Request:
This PR aligns to the top the information icon that appears in the last screen of the Jetpack Assistant.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Download the PR and build the jetpack plugin
- Launch your local testing site and make sure it has the local version of the plugin installed
- Visit `/wp-admin/admin.php?page=jetpack#/recommendations/`, and complete the Assistant wizard
- In the last step, check that the information icon is aligned with the top of the text element, as shown in the captures below

_Before_
<img width="509" alt="Screen Shot 2021-11-10 at 2 27 43 PM" src="https://user-images.githubusercontent.com/1620183/141183196-b9bcf5e5-b2af-49c3-a8de-09c35ec2867f.png">

_After_
<img width="621" alt="Screen Shot 2021-11-10 at 2 45 37 PM" src="https://user-images.githubusercontent.com/1620183/141183228-f7fa2180-25c8-48e6-b4fc-4719ac267333.png">
<img width="413" alt="Screen Shot 2021-11-10 at 2 45 50 PM" src="https://user-images.githubusercontent.com/1620183/141183229-73d92feb-9c4d-4fe7-8790-75368a25edfa.png">

