### PR TITLE
Gardening: ensure it can use Composer

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -42,8 +42,6 @@ jobs:
 
       - name: Setup tools
         uses: ./.github/actions/tool-setup
-        with:
-          php: false
 
       - name: Building Action
         run: composer build-development


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
﻿
Since #21697, we remove PHP tools such as Composer from tools that do not require PHP.

The Gardening action relies on Composer to build the action, so we'll need composer and thus PHP here.


#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Does the Gardening action test work once we merge this PR? (I don't think we can test with this PR since the changes need to be in the `master` branch to be available to the action).
