### PR TITLE
Boost: Implement support for loading stylesheets when JavaScript is disabled in the context Critical CSS being enabled

### DIFF
--- a/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
+++ b/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
@@ -668,7 +668,12 @@ class Critical_CSS extends Module {
 		// Convert stylesheets intended for screens.
 		if ( in_array( $media, $async_media, true ) ) {
 			$media_replacement = 'media="not all" onload="this.media=\'all\'"';
+			$html_no_script    = '<noscript>' . $html . '</noscript>';
 			$html              = preg_replace( '~media=[\'"]?[^\'"\s]+[\'"]?~', $media_replacement, $html );
+
+			// Append to the HTML stylesheet tag the same untouched HTML stylesheet tag within the noscript tag before
+			// to support the rendering of the style when JavaScript is disabled.
+			$html = $html_no_script . $html;
 		}
 
 		return $html;

--- a/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
+++ b/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
@@ -671,8 +671,8 @@ class Critical_CSS extends Module {
 			$html_no_script    = '<noscript>' . $html . '</noscript>';
 			$html              = preg_replace( '~media=[\'"]?[^\'"\s]+[\'"]?~', $media_replacement, $html );
 
-			// Append to the HTML stylesheet tag the same untouched HTML stylesheet tag within the noscript tag before
-			// to support the rendering of the style when JavaScript is disabled.
+			// Append to the HTML stylesheet tag the same untouched HTML stylesheet tag within the noscript tag
+			// to support the rendering of the stylesheet when JavaScript is disabled.
 			$html = $html_no_script . $html;
 		}
 

--- a/projects/plugins/boost/changelog/fix-boost-critical-css-without-javascript
+++ b/projects/plugins/boost/changelog/fix-boost-critical-css-without-javascript
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Implement support for loading stylesheets when JavaScript is disabled in the context Critical CSS being enabled


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #21545

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Append to the HTML stylesheet tag the same untouched HTML stylesheet tag within the noscript tag to support the rendering of the stylesheet when JavaScript is disabled.

It is a pretty straightforward solution but there might be some side effects I have not considered except for some few bytes it adds to the document.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
* Install the "Newsup" theme and its demo content
* Generate Critical CSS
* Open an incognito browser, open the dev tools and disable JavaScript
* Go on a post with a comment box
* With this patch notice that the style is still rendered, try without it and see that the style is not rendered.

See video:
https://user-images.githubusercontent.com/927932/141303115-2696b727-091a-4b19-8703-04d697761adb.mp4

