### PR TITLE
Backup: Replace daily backup references/upsell links with new real-time products

### DIFF
--- a/projects/plugins/backup/changelog/update-backup-plugin-for-new-realtime-backups
+++ b/projects/plugins/backup/changelog/update-backup-plugin-for-new-realtime-backups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+The Admin page now promotes the new real-time Backup products.

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -104,7 +104,7 @@ Jetpack’s off-site backup storage allows you to restore a clean version of you
 
 = How do I create a WordPress backup for my site? =
 
-If you don’t have Backups as part of your Jetpack plan, go to your WP Admin and then go to **Jetpack > Dashboard > Plans**. Depending on your plan, you can get daily or real-time WordPress backups. Daily backups are archived for 30 days, and real-time backups have unlimited storage.
+If you don’t have Backups as part of your Jetpack plan, go to your WP Admin and then go to **Jetpack > Dashboard > Plans**.
 
 As soon as you purchase Jetpack Backup, it will be activated, and the first backup will be completed. There are barely any settings to configure, and you don’t need coding experience.
 

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -104,7 +104,7 @@ Jetpack’s off-site backup storage allows you to restore a clean version of you
 
 = How do I create a WordPress backup for my site? =
 
-If you don’t have Backups as part of your Jetpack plan, visit Jetpack.com to learn more and purchase.
+If you don’t have Backups as part of your Jetpack plan, [visit Jetpack.com to learn more and purchase](https://jetpack.com/upgrade/backup).
 
 As soon as you purchase Jetpack Backup, it will be activated, and the first backup will be completed. There are barely any settings to configure, and you don’t need coding experience.
 

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -104,7 +104,7 @@ Jetpack’s off-site backup storage allows you to restore a clean version of you
 
 = How do I create a WordPress backup for my site? =
 
-If you don’t have Backups as part of your Jetpack plan, go to your WP Admin and then go to **Jetpack > Dashboard > Plans**.
+If you don’t have Backups as part of your Jetpack plan, visit Jetpack.com to learn more and purchase.
 
 As soon as you purchase Jetpack Backup, it will be activated, and the first backup will be completed. There are barely any settings to configure, and you don’t need coding experience.
 

--- a/projects/plugins/backup/src/js/components/Admin.js
+++ b/projects/plugins/backup/src/js/components/Admin.js
@@ -65,8 +65,6 @@ const Admin = () => {
 								'Get peace of mind knowing your work will be saved, add backups today.',
 								'jetpack-backup'
 							) }
-							<br />
-							{ __( 'Choose from real time or daily backups.', 'jetpack-backup' ) }
 						</p>
 						<a
 							class="button"

--- a/projects/plugins/backup/src/js/components/Admin.js
+++ b/projects/plugins/backup/src/js/components/Admin.js
@@ -68,7 +68,7 @@ const Admin = () => {
 						</p>
 						<a
 							class="button"
-							href={ getRedirectUrl( 'backup-plugin-upgrade-daily', { site: domain } ) }
+							href={ getRedirectUrl( 'backup-plugin-upgrade-10gb', { site: domain } ) }
 							target="_blank"
 							rel="noreferrer"
 						>


### PR DESCRIPTION
Resolves `1200412004370260-as-1201360140051272`, `p1HpG7-dA5-p2`.

#### Changes proposed in this Pull Request:

* Update the FAQ in readme.txt to remove references to daily backups.
* Remove reference to daily backups from the Admin page when the site currently doesn't have backup capabilities.
* Update the link to add Backup on the Admin page so that it redirects to checkout with Backup (10 GB) yearly instead of Backup Daily.

#### Jetpack product discussion

`pbtFFM-XN-p2`, `p1HpG7-dA5-p2`

#### Does this pull request change what data or activity we track or use?

No change 👍 

#### Testing instructions:

1. Open `readme.txt`. Verify there are no longer any references to daily backups.
2. For a site without Backup, open the Admin page. Verify the page no longer contains any references to daily backups.
3. On the same page, click the link to "Upgrade now." Verify you are sent to checkout on WordPress.com, and Backup (10 GB) is in the cart with a yearly billing term.

#### Reference screenshot

![image](https://user-images.githubusercontent.com/670067/141308508-4f24989c-ff32-48dc-a380-0ab894f0a9ed.png)