### PR TITLE
Post List: Fix the response after saving a Quick Edit.

### DIFF
--- a/projects/packages/post-list/changelog/fix-post-list-quick-edit
+++ b/projects/packages/post-list/changelog/fix-post-list-quick-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensured that the thumbnail and Share action are included in the quick edit response.

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -40,8 +40,8 @@ class Post_List {
 			add_action( 'current_screen', array( $this, 'add_filters_and_actions_for_screen' ) );
 			add_filter( 'default_hidden_columns', array( $this, 'adjust_default_columns' ), 10, 2 );
 
-			if ( wp_doing_ajax() && ! empty( $_POST['action'] ) && 'inline-save' === $_POST['action'] && wp_verify_nonce( 'inlineeditnonce', '_inline_edit' ) ) {
-				add_action( 'admin_init', array( $this, 'add_filters_and_actions_quick_edit' ) );
+			if ( wp_doing_ajax() && ! empty( $_POST['action'] ) && 'inline-save' === $_POST['action'] && check_ajax_referer( 'inlineeditnonce', '_inline_edit' ) ) {
+				$this->add_filters_and_actions_quick_edit();
 			}
 
 			/**
@@ -141,7 +141,7 @@ class Post_List {
 	 * the methods to register the actions.
 	 */
 	public function add_filters_and_actions_quick_edit() {
-		// We've alread verified the nonce in the register method above, and we're not performing
+		// We've already verified the nonce in the register method above, and we're not performing
 		// any action on these POST arguments.
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( ! empty( $_POST['screen'] ) && 'edit-' === substr( $_POST['screen'], 0, 5 ) && ! empty( $_POST['post_type'] ) ) {
@@ -240,4 +240,3 @@ class Post_List {
 		return $cols;
 	}
 }
-

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -37,8 +37,12 @@ class Post_List {
 	public function register() {
 		if ( ! did_action( 'jetpack_on_posts_list_init' ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-			add_action( 'current_screen', array( $this, 'add_filters_and_actions' ) );
+			add_action( 'current_screen', array( $this, 'add_filters_and_actions_for_screen' ) );
 			add_filter( 'default_hidden_columns', array( $this, 'adjust_default_columns' ), 10, 2 );
+
+			if ( wp_doing_ajax() && ! empty( $_POST['action'] ) && 'inline-save' === $_POST['action'] && wp_verify_nonce( 'inlineeditnonce', '_inline_edit' ) ) {
+				add_action( 'admin_init', array( $this, 'add_filters_and_actions_quick_edit' ) );
+			}
 
 			/**
 			 * Action called after initializing Post_List Admin resources.
@@ -71,17 +75,14 @@ class Post_List {
 	}
 
 	/**
-	 * If the current_screen has 'edit' as the base, add filters and actions to change the post list tables.
+	 * Checks the current post type and customizes the post
+	 * list columns if it is appropriate to do so.
 	 *
-	 * @param object $current_screen The current screen.
+	 * @param string $post_type The post type associated with the current request.
 	 */
-	public function add_filters_and_actions( $current_screen ) {
-		if ( 'edit' !== $current_screen->base ) {
-			return;
-		}
-
+	public function maybe_customize_columns( $post_type ) {
 		// Add the thumbnail column if this is specifically "Posts" or "Pages".
-		if ( in_array( $current_screen->post_type, array( 'post', 'page' ), true ) ) {
+		if ( in_array( $post_type, array( 'post', 'page' ), true ) ) {
 			// Add the thumbnail column to the "Posts" admin table.
 			add_filter( 'manage_posts_columns', array( $this, 'add_thumbnail_column' ), 10, 2 );
 			add_action( 'manage_posts_custom_column', array( $this, 'populate_thumbnail_rows' ), 10, 2 );
@@ -90,11 +91,19 @@ class Post_List {
 			add_filter( 'manage_pages_columns', array( $this, 'add_thumbnail_column' ) );
 			add_action( 'manage_pages_custom_column', array( $this, 'populate_thumbnail_rows' ), 10, 2 );
 		}
+	}
 
+	/**
+	 * Checks the current post type and adds the Share post
+	 * action if it is appropriate to do so.
+	 *
+	 * @param string $post_type The post type associated with the current request.
+	 */
+	public function maybe_add_share_action( $post_type ) {
 		// Add Share action if post type supports 'publicize', uses the 'block editor', and the feature flag is true.
 		if (
-			post_type_supports( $current_screen->post_type, 'publicize' ) &&
-			use_block_editor_for_post_type( $current_screen->post_type ) &&
+			post_type_supports( $post_type, 'publicize' ) &&
+			use_block_editor_for_post_type( $post_type ) &&
 			/**
 			 * Determine whether we should show the share action for this post type.
 			 * The default is false.
@@ -104,12 +113,42 @@ class Post_List {
 			 * @param boolean Whether we should show the share action for this post type.
 			 * @param string  The current post type.
 			 */
-			apply_filters( 'jetpack_post_list_display_share_action', false, $current_screen->post_type )
+			apply_filters( 'jetpack_post_list_display_share_action', false, $post_type )
 		) {
 			// Add Share post action.
 			add_filter( 'post_row_actions', array( $this, 'add_share_action' ), 20, 2 );
 			add_filter( 'page_row_actions', array( $this, 'add_share_action' ), 20, 2 );
 		}
+	}
+
+	/**
+	 * If the current_screen has 'edit' as the base, add filters and actions to change the post list tables.
+	 *
+	 * @param object $current_screen The current screen.
+	 */
+	public function add_filters_and_actions_for_screen( $current_screen ) {
+		if ( 'edit' !== $current_screen->base ) {
+			return;
+		}
+
+		$this->maybe_customize_columns( $current_screen->post_type );
+		$this->maybe_add_share_action( $current_screen->post_type );
+	}
+
+	/**
+	 * Checks if the current quick edit save is for a post list
+	 * where we want to customize the columns. If so, then we call
+	 * the methods to register the actions.
+	 */
+	public function add_filters_and_actions_quick_edit() {
+		// We've alread verified the nonce in the register method above, and we're not performing
+		// any action on these POST arguments.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( ! empty( $_POST['screen'] ) && 'edit-' === substr( $_POST['screen'], 0, 5 ) && ! empty( $_POST['post_type'] ) ) {
+			$this->maybe_customize_columns( $_POST['post_type'] );
+			$this->maybe_add_share_action( $_POST['post_type'] );
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 
 	/**

--- a/projects/packages/post-list/tests/php/test-post-list.php
+++ b/projects/packages/post-list/tests/php/test-post-list.php
@@ -38,14 +38,14 @@ class Test_Post_List extends BaseTestCase {
 
 		// Assert our action has not been added yet.
 		$this->assertFalse( has_action( 'admin_enqueue_scripts', array( $post_list, 'enqueue_scripts' ) ) );
-		$this->assertFalse( has_action( 'current_screen', array( $post_list, 'add_filters_and_actions' ) ) );
+		$this->assertFalse( has_action( 'current_screen', array( $post_list, 'add_filters_and_actions_for_screen' ) ) );
 
 		// Set up our action callbacks using the register() method.
 		$post_list->register();
 
 		// Assert the action was added.
 		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', array( $post_list, 'enqueue_scripts' ) ) );
-		$this->assertNotFalse( has_action( 'current_screen', array( $post_list, 'add_filters_and_actions' ) ) );
+		$this->assertNotFalse( has_action( 'current_screen', array( $post_list, 'add_filters_and_actions_for_screen' ) ) );
 
 		// Confirm it was only fired once even though we call it twice.
 		$post_list->register();
@@ -68,9 +68,9 @@ class Test_Post_List extends BaseTestCase {
 	}
 
 	/**
-	 * As a control when testing add_filters_and_actions() make sure it always starts clean.
+	 * As a control when testing add_filters_and_actions_for_screen() make sure it always starts clean.
 	 */
-	private function confirm_add_filters_and_actions_starts_clean() {
+	private function confirm_add_filters_and_actions_for_screen_starts_clean() {
 		$this->assertFalse( has_filter( 'manage_posts_columns' ) );
 		$this->assertFalse( has_action( 'manage_posts_custom_column' ) );
 		$this->assertFalse( has_filter( 'manage_pages_columns' ) );
@@ -80,13 +80,13 @@ class Test_Post_List extends BaseTestCase {
 	}
 
 	/**
-	 * Test add_filters_and_actions() with "Pages".
+	 * Test add_filters_and_actions_for_screen() with "Pages".
 	 * Thumbnail should show up on "Pages", but Share should not, because 'publicize' is not supported on "Pages".
 	 */
-	public function test_add_filters_and_actions_thumbnail() {
+	public function test_add_filters_and_actions_for_screen_thumbnail() {
 		$post_list = Post_List::get_instance();
 
-		$this->confirm_add_filters_and_actions_starts_clean();
+		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
 
 		$current_screen = (object) array(
 			'base'      => 'edit',
@@ -96,7 +96,7 @@ class Test_Post_List extends BaseTestCase {
 		// Turn on the flag that allows the Share action if applicable.
 		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
 
-		$post_list->add_filters_and_actions( $current_screen );
+		$post_list->add_filters_and_actions_for_screen( $current_screen );
 
 		// Assert that our style, filter, and action has been added.
 		$this->assertTrue( has_filter( 'manage_posts_columns' ) );
@@ -108,14 +108,14 @@ class Test_Post_List extends BaseTestCase {
 	}
 
 	/**
-	 * Test add_filters_and_actions() with a custom post type.
+	 * Test add_filters_and_actions_for_screen() with a custom post type.
 	 * Thumbnail should ONLY show up on "Posts" and "Pages". However, the Share action should show up on custom post
 	 * types that support publicize and the block editor.
 	 */
-	public function test_add_filters_and_actions_share() {
+	public function test_add_filters_and_actions_for_screen_share() {
 		$post_list = Post_List::get_instance();
 
-		$this->confirm_add_filters_and_actions_starts_clean();
+		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
 
 		// Create a custom post type.
 		register_post_type(
@@ -135,7 +135,7 @@ class Test_Post_List extends BaseTestCase {
 		// Turn on the flag that allows the Share action if applicable.
 		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
 
-		$post_list->add_filters_and_actions( $current_screen );
+		$post_list->add_filters_and_actions_for_screen( $current_screen );
 
 		// Assert that only the Share action was enabled.
 		$this->assertFalse( has_filter( 'manage_posts_columns' ) );
@@ -147,13 +147,13 @@ class Test_Post_List extends BaseTestCase {
 	}
 
 	/**
-	 * Test the add_filters_and_actions() with "Posts".
+	 * Test the add_filters_and_actions_for_screen() with "Posts".
 	 * The thumbnail and Share action should be available on "Posts".
 	 */
-	public function test_add_filters_and_actions_thumbnail_and_share() {
+	public function test_add_filters_and_actions_for_screen_thumbnail_and_share() {
 		$post_list = Post_List::get_instance();
 
-		$this->confirm_add_filters_and_actions_starts_clean();
+		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
 
 		$current_screen = (object) array(
 			'base'      => 'edit',
@@ -164,7 +164,7 @@ class Test_Post_List extends BaseTestCase {
 		// Turn on the flag that allows the Share action if applicable.
 		add_filter( 'jetpack_post_list_display_share_action', '__return_true' );
 
-		$post_list->add_filters_and_actions( $current_screen );
+		$post_list->add_filters_and_actions_for_screen( $current_screen );
 
 		// Assert that our style, filter, and action has been added.
 		$this->assertTrue( has_filter( 'manage_posts_columns' ) );
@@ -176,14 +176,14 @@ class Test_Post_List extends BaseTestCase {
 	}
 
 	/**
-	 * Test the add_filters_and_actions() with "Posts".
+	 * Test the add_filters_and_actions_for_screen() with "Posts".
 	 * The thumbnail and Share action should be available on "Posts", but we don't set the share flag to true, so only
 	 * thumbnails show up.
 	 */
-	public function test_add_filters_and_actions_share_flag_disabled() {
+	public function test_add_filters_and_actions_for_screen_share_flag_disabled() {
 		$post_list = Post_List::get_instance();
 
-		$this->confirm_add_filters_and_actions_starts_clean();
+		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
 
 		$current_screen = (object) array(
 			'base'      => 'edit',
@@ -191,7 +191,7 @@ class Test_Post_List extends BaseTestCase {
 		);
 		add_post_type_support( 'post', 'publicize' );
 
-		$post_list->add_filters_and_actions( $current_screen );
+		$post_list->add_filters_and_actions_for_screen( $current_screen );
 
 		// Assert that our style, filter, and action has been added.
 		$this->assertTrue( has_filter( 'manage_posts_columns' ) );
@@ -203,15 +203,15 @@ class Test_Post_List extends BaseTestCase {
 	}
 
 	/**
-	 * Test the add_filters_and_actions() method doesn't add thumbnails or Share if screen not 'edit' base.
+	 * Test the add_filters_and_actions_for_screen() method doesn't add thumbnails or Share if screen not 'edit' base.
 	 */
-	public function test_add_filters_and_actions_wrong_screen() {
+	public function test_add_filters_and_actions_for_screen_wrong_screen() {
 		$post_list      = Post_List::get_instance();
 		$current_screen = (object) array(
 			'base'      => 'edit-tags',
 			'post_type' => 'post',
 		);
-		$post_list->add_filters_and_actions( $current_screen );
+		$post_list->add_filters_and_actions_for_screen( $current_screen );
 
 		$this->assertFalse( has_filter( 'manage_posts_columns' ) );
 		$this->assertFalse( has_action( 'manage_posts_custom_column' ) );


### PR DESCRIPTION
The customizations that to the post list screen were being made on hooks
that only ran as the page/screen loaded. If a quick edit was made, the
table row returned in the result didn't include the necessary
customizations and would break the table.

There appears to be a WordPress bug where the post actions are not
hidden after a quick edit too. I also noticed the Copy post action was
missing, which might be another issue in Jetpack.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #21671

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Enable the post list package
* Perform a quick edit on a post or page
* Without this PR, the row will be missing the thumbnail and the table will look broken
* With this PR, it should render correctly
