### PR TITLE
smarter get connection status resolver

### DIFF
--- a/projects/js-packages/connection/state/resolvers.jsx
+++ b/projects/js-packages/connection/state/resolvers.jsx
@@ -1,10 +1,20 @@
 /**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import actions from './actions';
+import { STORE_ID } from './store';
 
 const connectionResolvers = {
 	*getConnectionStatus() {
+		const existingStatus = select( STORE_ID ).getConnectionStatus();
+		if ( existingStatus.hasOwnProperty( 'isRegistered' ) ) {
+			return existingStatus;
+		}
 		yield actions.setConnectionStatusIsFetching( true );
 		const result = yield actions.fetchConnectionStatus();
 		yield actions.setConnectionStatusIsFetching( false );

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -576,9 +576,7 @@ export default connect(
 	withDispatch( dispatch => {
 		return {
 			setConnectionStatus: connectionStatus => {
-				dispatch( CONNECTION_STORE_ID ).startResolution( 'getConnectionStatus', [] );
 				dispatch( CONNECTION_STORE_ID ).setConnectionStatus( connectionStatus );
-				dispatch( CONNECTION_STORE_ID ).finishResolution( 'getConnectionStatus', [] );
 			},
 		};
 	} )( withRouter( Main ) )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

In this PR I make the getConnectionStatus resolver a bit smarter.

It checks and see if there's already a value populated for `connectionStatus` in the state and will not make an API request if there is.

This makes our public API simpler, as the consumer don't have to worry about setting the resolver as finished.

Also, it prepares the terrain for a following experiment, which is consuming a initialState provided by the connection composer package. If there's a initial state in the store, no need for a API request either...

This works because the selector actually returns the value when it's called, and the resolver is called async.

* So we call the selector the first time and it invokes the resolver.
* We call the selector again from inside the resolver and it gets the value from state
* The resolver is not invoked again in an infinite loop because it knows it's already running

This idea came from a discussion here -> p1636650774025000-slack-C0926NEBC

I'd love to hear some thoughts about it

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*