### PR TITLE
Search: fix unexpected output in webpack asset dependency file

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-add-unminimized-plugin
+++ b/projects/plugins/jetpack/changelog/fix-search-add-unminimized-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fixed broken asset dependency file in build

--- a/projects/plugins/jetpack/tools/webpack.helpers.js
+++ b/projects/plugins/jetpack/tools/webpack.helpers.js
@@ -58,7 +58,8 @@ function defineReadableJSAssetsPluginForSearch() {
 			for ( const [ file, source ] of compilation.unminifiedAssets ) {
 				await fs.promises.writeFile(
 					path.join( compilation.options.output.path, file ),
-					'/* eslint-disable */\n' + source.replace( /\r\n/g, '\n' )
+					( file.toLowerCase().endsWith( '.js' ) ? '/* eslint-disable */\n' : '' ) +
+						source.replace( /\r\n/g, '\n' )
 				);
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
In order to disable eslint check for the built unminimized JS files, `/* eslint-disable */` is prepended to all built files, which breaks the PHP dependency file or potentially other non-js assets.

Interestingly this issue didn't break the Instant Search and Customberg experience, otherwise which would be caught before releasing.

e.g. in `projects/plugins/jetpack/_inc/build/instant-search/jp-search-configure-main.min.asset.php`
```PHP
/* eslint-disable */
<?php return array('dependencies' => array('lodash', 'react', 'react-dom', 'wp-block-editor', 'wp-components', 'wp-core-data', 'wp-data', 'wp-element', 'wp-i18n', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-viewport'), 'version' => '810dec37c3b77dffb0735ed20fcf8842');
```

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Run `jetpack build plugins/search`
- Ensure string`/* eslint-disable */` doesn't show on the first line in `projects/plugins/jetpack/_inc/build/instant-search/jp-search-configure-main.min.asset.php` or `projects/plugins/jetpack/_inc/build/instant-search/jp-search-main.bundle.min.asset.php`
- Ensure Instant Search and Customberg still work