### PR TITLE
jetpack: Don't set Webpack's `output.pathinfo` in production builds

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-webpack-output-pathinfo-in-prod-builds
+++ b/projects/plugins/jetpack/changelog/remove-webpack-output-pathinfo-in-prod-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Don't set Webpack's `output.pathinfo` in production builds.

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -209,7 +209,6 @@ module.exports = [
 			...sharedWebpackConfig.output,
 			filename: '[name].js',
 			chunkFilename: '[name].[contenthash].js',
-			pathinfo: true,
 			libraryTarget: 'commonjs2',
 		},
 		plugins: [

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -103,7 +103,6 @@ module.exports = [
 		entry: { static: path.join( __dirname, '../_inc/client', 'static.jsx' ) },
 		output: {
 			...sharedWebpackConfig.output,
-			pathinfo: true,
 			libraryTarget: 'commonjs2',
 		},
 		plugins: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
There's no point to it, the generated comments just bloat the
CSS and license.txt files.

Note Webpack already defaults it to true for `mode: development` builds,
where it makes a little more sense for the comments to be present.

It's not clear why it was ever being set in the first place,
neither #12463 nor #13070 seem to have any discussion about the
additions.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-3MG-p2#comment-6619

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the built license.txt and css files. There should be fewer comments holding just paths.