### PR TITLE
CSS Tidy: check current_screen for block editor

### DIFF
--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -1601,7 +1601,7 @@ class Jetpack_Safe_CSS {
 		$csstidy->set_cfg( 'css_level', 'CSS3.0' );
 
 		// Turn off css shorthands and leading zero removal when in block editor context as it breaks block validation.
-		if ( true === isset( $_REQUEST['_gutenberg_nonce'] ) && wp_verify_nonce( $_REQUEST['_gutenberg_nonce'], 'gutenberg_request' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		if ( self::is_block_editor_screen() ) {
 			$csstidy->set_cfg( 'optimise_shorthands', 0 );
 			$csstidy->set_cfg( 'preserve_leading_zeros', true );
 		}
@@ -1620,6 +1620,15 @@ class Jetpack_Safe_CSS {
 			return '';
 
 		return $matches[1];
+	}
+	/**
+	 * Check if the current screen is the Block Editor.
+	 *
+	 * @return boolean
+	 */
+	private static function is_block_editor_screen() {
+		global $current_screen;
+		return ( $current_screen instanceof WP_Screen ) && $current_screen->is_block_editor();
 	}
 }
 


### PR DESCRIPTION
An experiment to check the global `$current_screen` for the block editor screen in order to set css tidy parameters that prevent block invalidation errors.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
