### PR TITLE
Development Environment Docs: Update recommended version on composer update command

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -129,7 +129,7 @@ You'll need all the tools below to work in the Jetpack monorepo.
 		The latest composer in Homebrew at the time of writing is 2.1.x, but we currently require 2.0.x. If you need to downgrade to a specific version, we suggest these instructions:
 
 		```sh
-		composer self-update 2.0.14
+		composer self-update 2.1.8
 		```
 
 	 * ##### Installing Composer on other systems


### PR DESCRIPTION
Got this from running `tools/check-development-environment.sh` after updating to 2.0.14:
```
* Usable version of Composer               ... too old

  Composer at /usr/local/bin/composer is version 2.0.14. Version 2.1.0 or later is required; 2.1.8 or later is recommended.

  See https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md#composer
```

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates recommended self-update command in `development-environment.md`.

#### Testing instructions:

* Check the section [Composer](https://github.com/Automattic/jetpack/blob/update/dev-env-docs-composer-version/docs/development-environment.md#composer) of the rendered version of this README and confirm the changes make sense

#### Does this pull request change what data or activity we track or use?

No