### PR TITLE
Identity Crisis: add unit tests for has_identity_crisis and get_mismatched_urls

### DIFF
--- a/projects/packages/identity-crisis/changelog/update-add_idc_unit_tests
+++ b/projects/packages/identity-crisis/changelog/update-add_idc_unit_tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add unit tests for a few methods
+
+

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.4.1",
+	"version": "0.4.2-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-identity-crisis",

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -1226,7 +1226,14 @@ class Identity_Crisis {
 
 		$data = static::check_identity_crisis();
 
-		if ( ! $data ) {
+		if ( ! $data ||
+			! isset( $data['error_code'] ) ||
+			! isset( $data['wpcom_home'] ) ||
+			! isset( $data['home'] ) ||
+			! isset( $data['wpcom_siteurl'] ) ||
+			! isset( $data['siteurl'] )
+			) {
+			// The jetpack_sync_error_idc option is missing a key.
 			return false;
 		}
 

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -28,7 +28,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.4.1';
+	const PACKAGE_VERSION = '0.4.2-alpha';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
+++ b/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
@@ -713,6 +713,174 @@ class Test_Identity_Crisis extends BaseTestCase {
 	}
 
 	/**
+	 * Test the has_identity_crisis method.
+	 *
+	 * @param bool $check_identity_crisis The value that Identity_Crisis::check_identity_crisis should return.
+	 * @param bool $safe_mode_confirmed   The value of the Identity_Crisis::$safe_mode_confirmed property.
+	 * @param bool $expected_result       The value expected to be returned by the call to the has_identity_crisis method.
+	 *
+	 * @dataProvider data_provider_test_has_identity_crisis
+	 */
+	public function test_has_identity_crisis( $check_identity_crisis, $safe_mode_confirmed, $expected_result ) {
+		if ( $check_identity_crisis ) {
+			$this->check_identity_crisis_return_error( array( 'test' ) );
+		}
+
+		Identity_Crisis::$is_safe_mode_confirmed = $safe_mode_confirmed;
+
+		$result = Identity_Crisis::has_identity_crisis();
+
+		$this->clean_up_check_identity_crisis_return_error();
+		Identity_Crisis::$is_safe_mode_confirmed = false;
+
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * Data provider for the test_has_identity_crisis method.
+	 *
+	 * @return array The test data with the format:
+	 *   [
+	 *     'check_identity_crisis' => (bool) The value that Identity_Crisis::check_identity_crisis should return.
+	 *     'safe_mode_confirmed'   => (bool) The value of the Identity_Crisis::$safe_mode_confirmed property.
+	 *     'expected_result'       => (bool) The value expected to be returned by the call to the has_identity_crisis method.
+	 *   ]
+	 */
+	public function data_provider_test_has_identity_crisis() {
+		return array(
+			'check idc is true and safe mode is true'   => array(
+				'check_identity_crisis' => true,
+				'safe_mode_confirmed'   => true,
+				'expected_result'       => false,
+			),
+			'check idc is true and safe mode is false'  => array(
+				'check_identity_crisis' => true,
+				'safe_mode_confirmed'   => false,
+				'expected_result'       => true,
+			),
+			'check idc is false and safe mode is true'  => array(
+				'check_identity_crisis' => false,
+				'safe_mode_confirmed'   => true,
+				'expected_result'       => false,
+			),
+			'check idc is false and safe mode is false' => array(
+				'check_identity_crisis' => false,
+				'safe_mode_confirmed'   => false,
+				'expected_result'       => false,
+			),
+		);
+	}
+
+	/**
+	 * Test the get_mismatched_urls method.
+	 *
+	 * @param mixed $idc_error       The value of the jetpack_sync_idc_error option.
+	 * @param mixed $expected_result The value that the get_mismatched_value method should return.
+	 *
+	 * @dataProvider data_provider_test_get_mismatched_urls
+	 */
+	public function test_get_mismatched_urls( $idc_error, $expected_result ) {
+		$this->check_identity_crisis_return_error( $idc_error );
+		$result = Identity_Crisis::get_mismatched_urls();
+		$this->clean_up_check_identity_crisis_return_error();
+
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * Data providerd for the test_get_mismatched_urls method.
+	 *
+	 * @return array The test data with the format:
+	 *   [
+	 *     'idc_error'       => (mixed) The value of the jetpack_sync_idc_error option.
+	 *     'expected_result' => (mixed) The value that the get_mismatched_value method should return.
+	 *   ]
+	 */
+	public function data_provider_test_get_mismatched_urls() {
+		return array(
+			'false'                   => array(
+				'idc_error'       => false,
+				'expected_result' => false,
+			),
+			'empty array'             => array(
+				'idc_error'       => array(),
+				'expected_result' => false,
+			),
+			'no error+code key'       => array(
+				'idc_error'       => array(
+					'no_error_code' => 'test',
+					'wpcom_siteurl' => 'example.com/wpcom_siteurl',
+					'wpcom_home'    => 'example.com/wpcom_home',
+					'siteurl'       => 'example.com/remote_siteurl',
+					'home'          => 'example.com/remote_home',
+				),
+				'expected_result' => false,
+			),
+			'site_url_mismatch_error' => array(
+				'idc_error'       => array(
+					'error_code'    => 'jetpack_site_url_mismatch',
+					'wpcom_siteurl' => 'example.com/wpcom_siteurl',
+					'wpcom_home'    => 'example.com/wpcom_home',
+					'siteurl'       => 'example.com/remote_siteurl',
+					'home'          => 'example.com/remote_home',
+				),
+				'expected_result' => array(
+					'wpcom_url'   => 'example.com/wpcom_siteurl',
+					'current_url' => 'example.com/remote_siteurl',
+				),
+			),
+			'home_url_mismatch_error' => array(
+				'idc_error'       => array(
+					'error_code'    => 'jetpack_home_url_mismatch',
+					'wpcom_siteurl' => 'example.com/wpcom_siteurl',
+					'wpcom_home'    => 'example.com/wpcom_home',
+					'siteurl'       => 'example.com/remote_siteurl',
+					'home'          => 'example.com/remote_home',
+				),
+				'expected_result' => array(
+					'wpcom_url'   => 'example.com/wpcom_home',
+					'current_url' => 'example.com/remote_home',
+				),
+			),
+			'url_mismatch_error'      => array(
+				'idc_error'       => array(
+					'error_code'    => 'jetpack_url_mismatch',
+					'wpcom_siteurl' => 'example.com/wpcom_siteurl',
+					'wpcom_home'    => 'example.com/wpcom_home',
+					'siteurl'       => 'example.com/remote_siteurl',
+					'home'          => 'example.com/remote_home',
+				),
+				'expected_result' => array(
+					'wpcom_url'   => 'example.com/wpcom_home',
+					'current_url' => 'example.com/remote_home',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Forces the Identity_Crisis::check_identity_crisis method to return the input idc error array.
+	 *
+	 * @param array $idc_error The idc error array to be returned.
+	 */
+	private function check_identity_crisis_return_error( $idc_error ) {
+		\Jetpack_Options::update_option( 'id', 'test' );
+		\Jetpack_Options::update_option( 'blog_token', 'test' );
+		add_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
+		update_option( 'jetpack_sync_error_idc', $idc_error );
+	}
+
+	/**
+	 * Clean up the settings from the check_identity_crisis_return_error method.
+	 */
+	private function clean_up_check_identity_crisis_return_error() {
+		\Jetpack_Options::delete_option( 'id', 'test' );
+		\Jetpack_Options::update_option( 'blog_token', 'test' );
+		remove_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
+		delete_option( 'jetpack_sync_error_idc' );
+	}
+
+	/**
 	 * Return string '1'.
 	 *
 	 * @return string

--- a/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
+++ b/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
@@ -806,13 +806,49 @@ class Test_Identity_Crisis extends BaseTestCase {
 				'idc_error'       => array(),
 				'expected_result' => false,
 			),
-			'no error+code key'       => array(
+			'no error_code key'       => array(
 				'idc_error'       => array(
 					'no_error_code' => 'test',
 					'wpcom_siteurl' => 'example.com/wpcom_siteurl',
 					'wpcom_home'    => 'example.com/wpcom_home',
 					'siteurl'       => 'example.com/remote_siteurl',
 					'home'          => 'example.com/remote_home',
+				),
+				'expected_result' => false,
+			),
+			'no wpcom_siteurl key'    => array(
+				'idc_error'       => array(
+					'error_code' => 'jetpack_url_mismatch',
+					'wpcom_home' => 'example.com/wpcom_home',
+					'siteurl'    => 'example.com/remote_siteurl',
+					'home'       => 'example.com/remote_home',
+				),
+				'expected_result' => false,
+			),
+			'no wpcom_home key'       => array(
+				'idc_error'       => array(
+					'error_code'    => 'jetpack_url_mismatch',
+					'wpcom_siteurl' => 'example.com/wpcom_siteurl',
+					'siteurl'       => 'example.com/remote_siteurl',
+					'home'          => 'example.com/remote_home',
+				),
+				'expected_result' => false,
+			),
+			'no siteurl key'          => array(
+				'idc_error'       => array(
+					'error_code'    => 'jetpack_url_mismatch',
+					'wpcom_siteurl' => 'example.com/wpcom_siteurl',
+					'wpcom_home'    => 'example.com/wpcom_home',
+					'home'          => 'example.com/remote_home',
+				),
+				'expected_result' => false,
+			),
+			'no home key'             => array(
+				'idc_error'       => array(
+					'error_code'    => 'jetpack_url_mismatch',
+					'wpcom_siteurl' => 'example.com/wpcom_siteurl',
+					'wpcom_home'    => 'example.com/wpcom_home',
+					'siteurl'       => 'example.com/remote_siteurl',
 				),
 				'expected_result' => false,
 			),


### PR DESCRIPTION
Fixes #21656 

#### Changes proposed in this Pull Request:
* In `Identity_Crisis::get_mismatched_urls`, check that the `jetpack_sync_error_idc` option value has all of the required keys, and return false if it doesn't.
* Add unit tests for the `Identity_Crisis::has_identity_crisis` and `Identity_Crisis::get_mismatched_urls` methods.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

If testing with JN, you'll need [this plugin](https://gist.github.com/sergeymitr/bc005e1b893e778c03e4f43debb91c30) activated.

1. Install, activate, and connect this branch of Jetpack.
2. Install the Jetpack Debug Helper plugin.
3. In the Jetpack Debug dashboard, enable the Identity Crisis Simulation Utility module.
4. In the IDC Simulator, enable the IDC Simulation. The siteurl and home values will now be mocked as **example.org**.
5. Cause an IDC by editing a post.
6. Navigate to the Tools -> Connection Manager. The IDC UI should be displayed. Verify that the IDC UI displays the correct URLs.