### PR TITLE
Boost: Ensure that the media replacement retain the original media type

### DIFF
--- a/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
+++ b/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
@@ -667,7 +667,7 @@ class Critical_CSS extends Module {
 
 		// Convert stylesheets intended for screens.
 		if ( in_array( $media, $async_media, true ) ) {
-			$media_replacement = 'media="not all" onload="this.media=\'all\'"';
+			$media_replacement = 'media="not all" onload="this.media=\'' . $media . '\'"';
 			$html_no_script    = '<noscript>' . $html . '</noscript>';
 			$html              = preg_replace( '~media=[\'"]?[^\'"\s]+[\'"]?~', $media_replacement, $html );
 

--- a/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
+++ b/projects/plugins/boost/app/modules/critical-css/class-critical-css.php
@@ -667,7 +667,7 @@ class Critical_CSS extends Module {
 
 		// Convert stylesheets intended for screens.
 		if ( in_array( $media, $async_media, true ) ) {
-			$media_replacement = 'media="not all" onload="this.media=\'' . $media . '\'"';
+			$media_replacement = 'media="not all" data-media="' . $media . '" onload="this.media=\'' . $media . '\'; delete this.dataset.media;"';
 			$html_no_script    = '<noscript>' . $html . '</noscript>';
 			$html              = preg_replace( '~media=[\'"]?[^\'"\s]+[\'"]?~', $media_replacement, $html );
 
@@ -826,8 +826,9 @@ class Critical_CSS extends Module {
 					// Flip all media="not all" links to media="all".
 					document.querySelectorAll( 'link' ).forEach(
 						function( link ) {
-							if ( link.media === 'not all' ) {
-								link.media = 'all';
+							if ( link.media === 'not all' && link.dataset.media ) {
+								link.media = link.dataset.media;
+								delete link.dataset.media;
 							}
 						}
 					);
@@ -846,7 +847,7 @@ class Critical_CSS extends Module {
 		// Minified version of footer script. See above comment for unminified version.
 		?>
 		<script>window.addEventListener('load', function() {
-				document.querySelectorAll('link').forEach(function(e) {'not all' === e.media && (e.media = 'all');});
+				document.querySelectorAll('link').forEach(function(e) {'not all' === e.media && e.dataset.media && (e.media=e.dataset.media,delete e.dataset.media)});
 				var e = document.getElementById('jetpack-boost-critical-css');
 				e && (e.media = 'not all');
 			});</script>

--- a/projects/plugins/boost/changelog/fix-boost-critical-css-media-replacement
+++ b/projects/plugins/boost/changelog/fix-boost-critical-css-media-replacement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure that the media replacement retain the original media type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #21544

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make sure that the media type is retained when doing the replacement so the media type can be restored correctly.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:

* Enqueue a CSS with the `screen` media type
* Generate Critical CSS
* Look at the dev console and ensure the media type for that enqueued style is still `screen`
