### PR TITLE
(In Progress)[Plugin] Backup: Update Backup Segments section content.

### DIFF
--- a/projects/plugins/backup/changelog/update-backup-screens-text
+++ b/projects/plugins/backup/changelog/update-backup-screens-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update content shown on backup segments section.

--- a/projects/plugins/backup/src/js/components/Admin.js
+++ b/projects/plugins/backup/src/js/components/Admin.js
@@ -165,26 +165,23 @@ const Admin = () => {
 		return (
 			<div className="jp-row">
 				<div class="lg-col-span-6 md-col-span-4 sm-col-span-4">
-					<h2>{ __( 'Where are my backups stored?', 'jetpack-backup' ) }</h2>
+					<h2>{ __( 'Your cloud backups', 'jetpack-backup' ) }</h2>
 					<p>
 						{ __(
 							'All the backups are safely stored in the cloud and available for you at any time on Jetpack.com, with full details about status and content.',
 							'jetpack-backup'
 						) }
 					</p>
-					{ hasBackupPlan() && ! capabilities.includes( 'backup-realtime' ) && (
-						<a
-							class="jp-cut"
-							href={ getRedirectUrl( 'backup-plugin-realtime-upgrade', { site: domain } ) }
-						>
-							<span>
-								{ __(
-									'Your site is updated with new content several times a day',
-									'jetpack-backup'
-								) }
-							</span>
-							<span>{ __( 'Consider upgrading to real-time protection', 'jetpack-backup' ) }</span>
-						</a>
+					{ hasBackupPlan() && (
+						<p>
+							<a
+								href={ getRedirectUrl( 'jetpack-backup', { site: domain } ) }
+								target="_blank"
+								rel="noreferrer"
+							>
+								{ __( 'See all your backups', 'jetpack-backup' ) }
+							</a>
+						</p>
 					) }
 				</div>
 				<div class="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>


### PR DESCRIPTION
Modify the content shown on the Backup Segments section, right under the main content. 

#### TO DO:
- [x] Modify the cloud backups section and add link to backups
- [x] Remove the Upgrade to `Realtime prompt`
- [ ] Add the My Plan section

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Add the next modifications to the Backup Segments section:
- Change text on this block.
- Add link to see all backups on Jetpack Cloud.
- Remove the message to upgrade to realtime.

#### Jetpack product discussion
**Project Asana card:**
1201228005200946-as-1201373372830517

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
On a site running the code on this PR:
1- Create a site running the code of the plugin of this PR
2- Open the Jetpack Backup admin section
3- Check that the text under the main section matches the one on this screenshot:
![image](https://user-images.githubusercontent.com/16329583/141999257-e493c2ef-991c-4d76-82b4-677ecfc37029.png)
4- Confirm that the `See all your backups` link takes to the Backups section of your site on Jetpack Cloud. 
