### PR TITLE
Assets: do not use the new method yet

### DIFF
--- a/projects/packages/connection-ui/changelog/revert-assets-change
+++ b/projects/packages/connection-ui/changelog/revert-assets-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Assets: revert use of the new method added to register scripts

--- a/projects/packages/connection-ui/composer.json
+++ b/projects/packages/connection-ui/composer.json
@@ -4,7 +4,6 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-assets": "^1.12",
 		"automattic/jetpack-connection": "^1.30",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-device-detection": "^1.4",

--- a/projects/packages/connection-ui/src/class-admin.php
+++ b/projects/packages/connection-ui/src/class-admin.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\ConnectionUI;
 
-use Automattic\Jetpack\Assets;
-
 /**
  * The Connection UI Admin Area
  */
@@ -62,17 +60,14 @@ class Admin {
 	 */
 	public function enqueue_scripts( $hook ) {
 		if ( strpos( $hook, 'tools_page_wpcom-connection-manager' ) === 0 ) {
-			Assets::register_script(
-				'jetpack_connection_ui',
-				'../build/index.js',
-				__FILE__,
-				array(
-					'in_footer' => true,
-				)
-			);
-			Assets::enqueue_script( 'jetpack_connection_ui' );
-			wp_add_inline_script( 'jetpack_connection_ui', $this->get_initial_state(), 'before' );
-			wp_set_script_translations( 'jetpack_connection_ui', 'jetpack' );
+			$build_assets = require_once __DIR__ . '/../build/index.asset.php';
+			wp_enqueue_script( 'jetpack_connection_ui_script', plugin_dir_url( __DIR__ ) . 'build/index.js', $build_assets['dependencies'], $build_assets['version'], true );
+
+			wp_set_script_translations( 'react-jetpack_connection_ui_script', 'jetpack' );
+			wp_add_inline_script( 'jetpack_connection_ui_script', $this->get_initial_state(), 'before' );
+
+			wp_enqueue_style( 'jetpack_connection_ui_style', plugin_dir_url( __DIR__ ) . 'build/index.css', array( 'wp-components' ), $build_assets['version'] );
+			wp_style_add_data( 'jetpack_connection_ui_style', 'rtl', plugin_dir_url( __DIR__ ) . 'build/index.rtl.css' );
 		}
 	}
 

--- a/projects/packages/lazy-images/changelog/revert-assets-change
+++ b/projects/packages/lazy-images/changelog/revert-assets-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Assets: revert use of the new method added to register scripts

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -485,26 +485,33 @@ class Jetpack_Lazy_Images {
 	 * @return void
 	 */
 	public function enqueue_assets() {
-		Assets::register_script(
+		$script_path       = Assets::get_file_url_for_environment( '../dist/intersection-observer.min.js', '../dist/intersection-observer.src.js', __FILE__ );
+		$script_asset_path = '../dist/intersection-observer.min.assets.php';
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : array(
+			'dependencies' => array(),
+			'version'      => filemtime( __DIR__ . '/../dist/intersection-observer.min.js' ),
+		);
+		wp_enqueue_script(
 			'jetpack-lazy-images-polyfill-intersectionobserver',
-			'../dist/intersection-observer.min.js',
-			__FILE__,
-			array(
-				'nonmin_path' => '../dist/intersection-observer.src.js',
-				'in_footer'   => true,
-			)
+			$script_path,
+			$script_asset['dependencies'],
+			$script_asset['version'],
+			true
 		);
-		Assets::register_script(
+
+		$script_path       = Assets::get_file_url_for_environment( '../dist/lazy-images.min.js', 'js/lazy-images.js', __FILE__ );
+		$script_asset_path = '../dist/lazy-images.min.assets.php';
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : array(
+			'dependencies' => array(),
+			'version'      => filemtime( __DIR__ . '/../dist/lazy-images.min.js' ),
+		);
+		wp_enqueue_script(
 			'jetpack-lazy-images',
-			'../dist/lazy-images.min.js',
-			__FILE__,
-			array(
-				'nonmin_path'  => 'js/lazy-images.js',
-				'dependencies' => array( 'jetpack-lazy-images-polyfill-intersectionobserver' ),
-				'in_footer'    => true,
-			)
+			$script_path,
+			array_merge( $script_asset['dependencies'], array( 'jetpack-lazy-images-polyfill-intersectionobserver' ) ),
+			$script_asset['version'],
+			true
 		);
-		Assets::enqueue_script( 'jetpack-lazy-images' );
 		wp_localize_script(
 			'jetpack-lazy-images',
 			'jetpackLazyImagesL10n',

--- a/projects/plugins/backup/changelog/revert-assets-change
+++ b/projects/plugins/backup/changelog/revert-assets-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Assets: revert use of the new method added to register scripts

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -4,7 +4,6 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-assets": "1.12.x-dev",
 		"automattic/jetpack-admin-ui": "0.1.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
 		"automattic/jetpack-backup": "1.1.x-dev",

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3838d25ba2230fd2bd1d0e40b2c8afa1",
+    "content-hash": "14e4c924b82d06453649eb8a152b5f1b",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -401,10 +401,9 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "251c3511dadb5d4a7fb8c1e04253233ac759ef26"
+                "reference": "aa00d91d3efb13ff48b6a71cd0cfe0c276db48c4"
             },
             "require": {
-                "automattic/jetpack-assets": "^1.12",
                 "automattic/jetpack-connection": "^1.30",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-device-detection": "^1.4",
@@ -2160,20 +2159,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
             "autoload": {
@@ -2202,9 +2201,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4274,7 +4273,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-assets": 20,
         "automattic/jetpack-admin-ui": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-backup": 20,

--- a/projects/plugins/backup/src/php/class-jetpack-backup.php
+++ b/projects/plugins/backup/src/php/class-jetpack-backup.php
@@ -10,7 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
-use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 
@@ -83,16 +82,36 @@ class Jetpack_Backup {
 	 * Enqueue plugin admin scripts and styles.
 	 */
 	public function enqueue_admin_scripts() {
-		Assets::register_script(
-			'jetpack-backup',
-			'build/index.js',
-			JETPACK_BACKUP_PLUGIN_ROOT_FILE,
-			array( 'in_footer' => true )
+		$build_assets = require_once JETPACK_BACKUP_PLUGIN_DIR . '/build/index.asset.php';
+
+		// Main JS file.
+		wp_register_script(
+			'jetpack-backup-script',
+			plugins_url( 'build/index.js', JETPACK_BACKUP_PLUGIN_ROOT_FILE ),
+			$build_assets['dependencies'],
+			$build_assets['version'],
+			true
 		);
-		Assets::enqueue_script( 'jetpack-backup' );
+		wp_enqueue_script( 'jetpack-backup-script' );
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( 'jetpack-backup', $this->get_initial_state(), 'before' );
-		wp_set_script_translations( 'jetpack-backup', 'jetpack-backup' );
+		wp_add_inline_script( 'jetpack-backup-script', $this->get_initial_state(), 'before' );
+
+		// Translation assets.
+		wp_set_script_translations( 'jetpack-backup-script-translations', 'jetpack-backup' );
+
+		// Main CSS file.
+		wp_enqueue_style(
+			'jetpack-backup-style',
+			plugins_url( 'build/index.css', JETPACK_BACKUP_PLUGIN_ROOT_FILE ),
+			array( 'wp-components' ),
+			$build_assets['version']
+		);
+		// RTL CSS file.
+		wp_style_add_data(
+			'jetpack-backup-style',
+			'rtl',
+			plugins_url( 'build/index.rtl.css', JETPACK_BACKUP_PLUGIN_ROOT_FILE )
+		);
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/revert-assets-change
+++ b/projects/plugins/boost/changelog/revert-assets-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Assets: revert use of the new method added to register scripts

--- a/projects/plugins/jetpack/changelog/revert-assets-change
+++ b/projects/plugins/jetpack/changelog/revert-assets-change
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Janitorial: do not use new method to register scripts just yet.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -496,10 +496,9 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "251c3511dadb5d4a7fb8c1e04253233ac759ef26"
+                "reference": "aa00d91d3efb13ff48b6a71cd0cfe0c276db48c4"
             },
             "require": {
-                "automattic/jetpack-assets": "^1.12",
                 "automattic/jetpack-connection": "^1.30",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-device-detection": "^1.4",
@@ -2777,20 +2776,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
             "autoload": {
@@ -2819,9 +2818,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -6,7 +6,6 @@
  * @package automattic/jetpack
  */
 
-use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Search\Helper;
 use Automattic\Jetpack\Search\Options;
 
@@ -119,13 +118,18 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @param string $plugin_base_path - Base path for use in plugins_url.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
-		Assets::register_script(
-			'jetpack-instant-search',
-			$path_prefix . '_inc/build/instant-search/jp-search-main.bundle.min.js',
-			$plugin_base_path,
-			array( 'in_footer' => true )
-		);
-		Assets::enqueue_script( 'jetpack-instant-search' );
+		// We added `.min` to the file names of all minimized assets, and there's a non-minimized version for each asset.
+		// For example, there is a `_inc/build/instant-search/jp-search-main.bundle.js` for `_inc/build/instant-search/jp-search-main.bundle.min.js`.
+		// which is for the extraction of strings for translations as `.min.js` files are omitted.
+		$script_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-main.bundle.min.js';
+
+		if ( ! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
+			return;
+		}
+
+		$script_version = Helper::get_asset_version( $script_relative_path );
+		$script_path    = plugins_url( $script_relative_path, $plugin_base_path );
+		wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
 		wp_set_script_translations( 'jetpack-instant-search', 'jetpack' );
 		$this->load_and_initialize_tracks();
 		$this->inject_javascript_options();

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customberg.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customberg.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Search;
 
-use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
 use Jetpack;
@@ -122,16 +121,41 @@ class Jetpack_Search_Customberg {
 	 * @param string $plugin_base_path - Base path for plugin files.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
+		$style_relative_path    = $path_prefix . '_inc/build/instant-search/jp-search-configure-main.min.css';
+		$manifest_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-configure-main.min.asset.php';
+		$script_relative_path   = $path_prefix . '_inc/build/instant-search/jp-search-configure-main.min.js';
+
+		//
+		// Load styles.
 		\Jetpack_Admin_Page::load_wrapper_styles();
+		wp_enqueue_style(
+			'jp-search-configure',
+			plugins_url( $style_relative_path, $plugin_base_path ),
+			array(
+				'wp-components',
+				'wp-block-editor',
+			),
+			JETPACK__VERSION
+		);
+
+		//
+		// Load scripts.
+		$manifest_path       = plugin_dir_path( $plugin_base_path ) . $manifest_relative_path;
+		$script_dependencies = array();
+		if ( file_exists( $manifest_path ) ) {
+			$asset_manifest      = include $manifest_path;
+			$script_dependencies = $asset_manifest['dependencies'];
+		}
+
 		Tracking::register_tracks_functions_scripts( true );
 
-		Assets::register_script(
+		wp_enqueue_script(
 			'jp-search-configure',
-			$path_prefix . '_inc/build/instant-search/jp-search-configure-main.min.js',
-			$plugin_base_path,
-			array( 'in_footer' => true )
+			plugins_url( $script_relative_path, $plugin_base_path ),
+			$script_dependencies,
+			JETPACK__VERSION,
+			true
 		);
-		Assets::enqueue_script( 'jp-search-configure' );
 		wp_set_script_translations( 'jp-search-configure', 'jetpack' );
 
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -117,13 +117,22 @@ class Jetpack_Widget_Conditions {
 	 * Enqueue the block-based widget visibility scripts.
 	 */
 	public static function setup_block_controls() {
-		Assets::register_script(
+		$manifest_path       = JETPACK__PLUGIN_DIR . '_inc/build/widget-visibility/editor/index.min.asset.php';
+		$script_path         = plugins_url( '_inc/build/widget-visibility/editor/index.min.js', JETPACK__PLUGIN_FILE );
+		$script_dependencies = array( 'wp-polyfill' );
+		if ( file_exists( $manifest_path ) ) {
+			$asset_manifest      = include $manifest_path;
+			$script_dependencies = $asset_manifest['dependencies'];
+		}
+
+		// Enqueue built script.
+		wp_enqueue_script(
 			'widget-visibility-editor',
-			'_inc/build/widget-visibility/editor/index.min.js',
-			JETPACK__PLUGIN_FILE,
-			array( 'in_footer' => true )
+			$script_path,
+			$script_dependencies,
+			JETPACK__VERSION,
+			true
 		);
-		Assets::enqueue_script( 'widget-visibility-editor' );
 		wp_set_script_translations( 'widget-visibility-editor', 'jetpack' );
 	}
 


### PR DESCRIPTION
This reverts part of #21689

#### Changes proposed in this Pull Request:

Given the issues that were raised post merge on WordPress.com, let's refrain from using the new method just yet.

On WordPress.com, this was already reverted in D70135-code.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Does everything get reverted properly?
