### PR TITLE
Revert and fix "Revert "Assets: do not use the new method yet (#21760)""

### DIFF
--- a/projects/packages/connection-ui/changelog/fix-revert-revert-and-hack-around-bug
+++ b/projects/packages/connection-ui/changelog/fix-revert-revert-and-hack-around-bug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Revert #21760
+
+

--- a/projects/packages/connection-ui/composer.json
+++ b/projects/packages/connection-ui/composer.json
@@ -4,6 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"automattic/jetpack-assets": "^1.12",
 		"automattic/jetpack-connection": "^1.30",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-device-detection": "^1.4",

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "2.1.0",
+	"version": "2.1.1-alpha",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-connection-ui",

--- a/projects/packages/connection-ui/src/class-admin.php
+++ b/projects/packages/connection-ui/src/class-admin.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\ConnectionUI;
 
+use Automattic\Jetpack\Assets;
+
 /**
  * The Connection UI Admin Area
  */
@@ -60,14 +62,17 @@ class Admin {
 	 */
 	public function enqueue_scripts( $hook ) {
 		if ( strpos( $hook, 'tools_page_wpcom-connection-manager' ) === 0 ) {
-			$build_assets = require_once __DIR__ . '/../build/index.asset.php';
-			wp_enqueue_script( 'jetpack_connection_ui_script', plugin_dir_url( __DIR__ ) . 'build/index.js', $build_assets['dependencies'], $build_assets['version'], true );
-
-			wp_set_script_translations( 'react-jetpack_connection_ui_script', 'jetpack' );
-			wp_add_inline_script( 'jetpack_connection_ui_script', $this->get_initial_state(), 'before' );
-
-			wp_enqueue_style( 'jetpack_connection_ui_style', plugin_dir_url( __DIR__ ) . 'build/index.css', array( 'wp-components' ), $build_assets['version'] );
-			wp_style_add_data( 'jetpack_connection_ui_style', 'rtl', plugin_dir_url( __DIR__ ) . 'build/index.rtl.css' );
+			Assets::register_script(
+				'jetpack_connection_ui',
+				'../build/index.js',
+				__FILE__,
+				array(
+					'in_footer' => true,
+				)
+			);
+			Assets::enqueue_script( 'jetpack_connection_ui' );
+			wp_add_inline_script( 'jetpack_connection_ui', $this->get_initial_state(), 'before' );
+			wp_set_script_translations( 'jetpack_connection_ui', 'jetpack' );
 		}
 	}
 

--- a/projects/packages/lazy-images/changelog/fix-revert-revert-and-hack-around-bug
+++ b/projects/packages/lazy-images/changelog/fix-revert-revert-and-hack-around-bug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Revert #21760
+
+

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -485,33 +485,26 @@ class Jetpack_Lazy_Images {
 	 * @return void
 	 */
 	public function enqueue_assets() {
-		$script_path       = Assets::get_file_url_for_environment( '../dist/intersection-observer.min.js', '../dist/intersection-observer.src.js', __FILE__ );
-		$script_asset_path = '../dist/intersection-observer.min.assets.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : array(
-			'dependencies' => array(),
-			'version'      => filemtime( __DIR__ . '/../dist/intersection-observer.min.js' ),
-		);
-		wp_enqueue_script(
+		Assets::register_script(
 			'jetpack-lazy-images-polyfill-intersectionobserver',
-			$script_path,
-			$script_asset['dependencies'],
-			$script_asset['version'],
-			true
+			'../dist/intersection-observer.min.js',
+			__FILE__,
+			array(
+				'nonmin_path' => '../dist/intersection-observer.src.js',
+				'in_footer'   => true,
+			)
 		);
-
-		$script_path       = Assets::get_file_url_for_environment( '../dist/lazy-images.min.js', 'js/lazy-images.js', __FILE__ );
-		$script_asset_path = '../dist/lazy-images.min.assets.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : array(
-			'dependencies' => array(),
-			'version'      => filemtime( __DIR__ . '/../dist/lazy-images.min.js' ),
-		);
-		wp_enqueue_script(
+		Assets::register_script(
 			'jetpack-lazy-images',
-			$script_path,
-			array_merge( $script_asset['dependencies'], array( 'jetpack-lazy-images-polyfill-intersectionobserver' ) ),
-			$script_asset['version'],
-			true
+			'../dist/lazy-images.min.js',
+			__FILE__,
+			array(
+				'nonmin_path'  => 'js/lazy-images.js',
+				'dependencies' => array( 'jetpack-lazy-images-polyfill-intersectionobserver' ),
+				'in_footer'    => true,
+			)
 		);
+		Assets::enqueue_script( 'jetpack-lazy-images' );
 		wp_localize_script(
 			'jetpack-lazy-images',
 			'jetpackLazyImagesL10n',

--- a/projects/plugins/backup/changelog/revert-assets-change
+++ b/projects/plugins/backup/changelog/revert-assets-change
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Assets: revert use of the new method added to register scripts

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -4,6 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"automattic/jetpack-assets": "1.12.x-dev",
 		"automattic/jetpack-admin-ui": "0.1.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
 		"automattic/jetpack-backup": "1.1.x-dev",

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "14e4c924b82d06453649eb8a152b5f1b",
+    "content-hash": "3838d25ba2230fd2bd1d0e40b2c8afa1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -401,9 +401,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "aa00d91d3efb13ff48b6a71cd0cfe0c276db48c4"
+                "reference": "251c3511dadb5d4a7fb8c1e04253233ac759ef26"
             },
             "require": {
+                "automattic/jetpack-assets": "^1.12",
                 "automattic/jetpack-connection": "^1.30",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-device-detection": "^1.4",
@@ -2159,20 +2160,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -2201,9 +2202,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4273,6 +4274,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-assets": 20,
         "automattic/jetpack-admin-ui": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-backup": 20,

--- a/projects/plugins/backup/src/php/class-jetpack-backup.php
+++ b/projects/plugins/backup/src/php/class-jetpack-backup.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 
@@ -82,36 +83,16 @@ class Jetpack_Backup {
 	 * Enqueue plugin admin scripts and styles.
 	 */
 	public function enqueue_admin_scripts() {
-		$build_assets = require_once JETPACK_BACKUP_PLUGIN_DIR . '/build/index.asset.php';
-
-		// Main JS file.
-		wp_register_script(
-			'jetpack-backup-script',
-			plugins_url( 'build/index.js', JETPACK_BACKUP_PLUGIN_ROOT_FILE ),
-			$build_assets['dependencies'],
-			$build_assets['version'],
-			true
+		Assets::register_script(
+			'jetpack-backup',
+			'build/index.js',
+			JETPACK_BACKUP_PLUGIN_ROOT_FILE,
+			array( 'in_footer' => true )
 		);
-		wp_enqueue_script( 'jetpack-backup-script' );
+		Assets::enqueue_script( 'jetpack-backup' );
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( 'jetpack-backup-script', $this->get_initial_state(), 'before' );
-
-		// Translation assets.
-		wp_set_script_translations( 'jetpack-backup-script-translations', 'jetpack-backup' );
-
-		// Main CSS file.
-		wp_enqueue_style(
-			'jetpack-backup-style',
-			plugins_url( 'build/index.css', JETPACK_BACKUP_PLUGIN_ROOT_FILE ),
-			array( 'wp-components' ),
-			$build_assets['version']
-		);
-		// RTL CSS file.
-		wp_style_add_data(
-			'jetpack-backup-style',
-			'rtl',
-			plugins_url( 'build/index.rtl.css', JETPACK_BACKUP_PLUGIN_ROOT_FILE )
-		);
+		wp_add_inline_script( 'jetpack-backup', $this->get_initial_state(), 'before' );
+		wp_set_script_translations( 'jetpack-backup', 'jetpack-backup' );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/revert-assets-change
+++ b/projects/plugins/boost/changelog/revert-assets-change
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Assets: revert use of the new method added to register scripts

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-search-dashboard-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-search-dashboard-page.php
@@ -5,6 +5,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Status;
 
 /**
@@ -56,7 +57,6 @@ class Jetpack_Search_Dashboard_Page extends Jetpack_Admin_Page {
 	 * Enqueue and localize page specific scripts
 	 */
 	public function page_admin_scripts() {
-		$this->load_admin_styles();
 		$this->load_admin_scripts();
 	}
 
@@ -101,39 +101,27 @@ class Jetpack_Search_Dashboard_Page extends Jetpack_Admin_Page {
 	 * Enqueue admin styles.
 	 */
 	public function load_admin_styles() {
-		\Jetpack_Admin_Page::load_wrapper_styles();
-
-		wp_enqueue_style(
-			'jp-search-dashboard',
-			plugins_url( '_inc/build/search-dashboard.css', JETPACK__PLUGIN_FILE ),
-			array(),
-			JETPACK__VERSION
-		);
+		$this->load_admin_scripts();
 	}
 
 	/**
 	 * Enqueue admin scripts.
 	 */
 	public function load_admin_scripts() {
-		$script_deps_path    = JETPACK__PLUGIN_DIR . '_inc/build/search-dashboard.asset.php';
-		$script_dependencies = array( 'react', 'react-dom', 'wp-polyfill' );
-		if ( file_exists( $script_deps_path ) ) {
-			$asset_manifest      = include $script_deps_path;
-			$script_dependencies = $asset_manifest['dependencies'];
-		}
+		\Jetpack_Admin_Page::load_wrapper_styles();
 
 		if ( ! ( new Status() )->is_offline_mode() && Jetpack::is_connection_ready() ) {
 			// Required for Analytics.
 			Automattic\Jetpack\Tracking::register_tracks_functions_scripts( true );
 		}
 
-		wp_enqueue_script(
+		Assets::register_script(
 			'jp-search-dashboard',
-			plugins_url( '_inc/build/search-dashboard.js', JETPACK__PLUGIN_FILE ),
-			$script_dependencies,
-			JETPACK__VERSION,
-			true
+			'_inc/build/search-dashboard.js',
+			JETPACK__PLUGIN_FILE,
+			array( 'in_footer' => true )
 		);
+		Assets::enqueue_script( 'jp-search-dashboard' );
 
 		// Add objects to be passed to the initial state of the app.
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.

--- a/projects/plugins/jetpack/changelog/fix-revert-revert-and-hack-around-bug
+++ b/projects/plugins/jetpack/changelog/fix-revert-revert-and-hack-around-bug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Revert #21760
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -633,6 +633,13 @@ class Jetpack_Gutenberg {
 			"{$blocks_dir}editor{$blocks_env}.min.js",
 			JETPACK__PLUGIN_FILE
 		);
+
+		// Hack around #20357 (specifically, that the editor bundle depends on
+		// wp-edit-post but wp-edit-post's styles break the Widget Editor and
+		// Site Editor) until a real fix gets unblocked.
+		// @todo Remove this once #20357 is properly fixed.
+		wp_styles()->query( 'jetpack-blocks-editor', 'registered' )->deps = array();
+
 		Assets::enqueue_script( 'jetpack-blocks-editor' );
 
 		wp_localize_script(

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -6,6 +6,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
@@ -618,7 +619,6 @@ class Jetpack_Gutenberg {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 
-		$rtl              = is_rtl() ? '.rtl' : '';
 		$blocks_dir       = self::get_blocks_directory();
 		$blocks_variation = self::blocks_variation();
 
@@ -628,27 +628,12 @@ class Jetpack_Gutenberg {
 			$blocks_env = '';
 		}
 
-		$editor_script = plugins_url( "{$blocks_dir}editor{$blocks_env}.min.js", JETPACK__PLUGIN_FILE );
-		$editor_style  = plugins_url( "{$blocks_dir}editor{$blocks_env}.min{$rtl}.css", JETPACK__PLUGIN_FILE );
-
-		$editor_deps_path = JETPACK__PLUGIN_DIR . $blocks_dir . "editor{$blocks_env}.min.asset.php";
-		$editor_deps      = array( 'wp-polyfill' );
-		if ( file_exists( $editor_deps_path ) ) {
-			$asset_manifest = include $editor_deps_path;
-			$editor_deps    = $asset_manifest['dependencies'];
-		}
-
-		$version = Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . $blocks_dir . 'editor.min.js' )
-			? filemtime( JETPACK__PLUGIN_DIR . $blocks_dir . 'editor.min.js' )
-			: JETPACK__VERSION;
-
-		wp_enqueue_script(
+		Assets::register_script(
 			'jetpack-blocks-editor',
-			$editor_script,
-			$editor_deps,
-			$version,
-			false
+			"{$blocks_dir}editor{$blocks_env}.min.js",
+			JETPACK__PLUGIN_FILE
 		);
+		Assets::enqueue_script( 'jetpack-blocks-editor' );
 
 		wp_localize_script(
 			'jetpack-blocks-editor',
@@ -704,8 +689,6 @@ class Jetpack_Gutenberg {
 		);
 
 		wp_set_script_translations( 'jetpack-blocks-editor', 'jetpack' );
-
-		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
 	}
 
 	/**

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ10_4_a_5"
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ10_4_a_6"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-production",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -496,9 +496,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "aa00d91d3efb13ff48b6a71cd0cfe0c276db48c4"
+                "reference": "251c3511dadb5d4a7fb8c1e04253233ac759ef26"
             },
             "require": {
+                "automattic/jetpack-assets": "^1.12",
                 "automattic/jetpack-connection": "^1.30",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-device-detection": "^1.4",
@@ -2776,20 +2777,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -2818,9 +2819,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 10.4-a.5
+ * Version: 10.4-a.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '5.7' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '10.4-a.5' );
+define( 'JETPACK__VERSION', '10.4-a.6' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-instant-search.php
@@ -6,6 +6,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Search\Helper;
 use Automattic\Jetpack\Search\Options;
 
@@ -118,18 +119,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @param string $plugin_base_path - Base path for use in plugins_url.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
-		// We added `.min` to the file names of all minimized assets, and there's a non-minimized version for each asset.
-		// For example, there is a `_inc/build/instant-search/jp-search-main.bundle.js` for `_inc/build/instant-search/jp-search-main.bundle.min.js`.
-		// which is for the extraction of strings for translations as `.min.js` files are omitted.
-		$script_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-main.bundle.min.js';
-
-		if ( ! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
-			return;
-		}
-
-		$script_version = Helper::get_asset_version( $script_relative_path );
-		$script_path    = plugins_url( $script_relative_path, $plugin_base_path );
-		wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
+		Assets::register_script(
+			'jetpack-instant-search',
+			$path_prefix . '_inc/build/instant-search/jp-search-main.bundle.min.js',
+			$plugin_base_path,
+			array( 'in_footer' => true )
+		);
+		Assets::enqueue_script( 'jetpack-instant-search' );
 		wp_set_script_translations( 'jetpack-instant-search', 'jetpack' );
 		$this->load_and_initialize_tracks();
 		$this->inject_javascript_options();

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customberg.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customberg.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
 use Jetpack;
@@ -121,41 +122,16 @@ class Jetpack_Search_Customberg {
 	 * @param string $plugin_base_path - Base path for plugin files.
 	 */
 	public function load_assets_with_parameters( $path_prefix, $plugin_base_path ) {
-		$style_relative_path    = $path_prefix . '_inc/build/instant-search/jp-search-configure-main.min.css';
-		$manifest_relative_path = $path_prefix . '_inc/build/instant-search/jp-search-configure-main.min.asset.php';
-		$script_relative_path   = $path_prefix . '_inc/build/instant-search/jp-search-configure-main.min.js';
-
-		//
-		// Load styles.
 		\Jetpack_Admin_Page::load_wrapper_styles();
-		wp_enqueue_style(
-			'jp-search-configure',
-			plugins_url( $style_relative_path, $plugin_base_path ),
-			array(
-				'wp-components',
-				'wp-block-editor',
-			),
-			JETPACK__VERSION
-		);
-
-		//
-		// Load scripts.
-		$manifest_path       = plugin_dir_path( $plugin_base_path ) . $manifest_relative_path;
-		$script_dependencies = array();
-		if ( file_exists( $manifest_path ) ) {
-			$asset_manifest      = include $manifest_path;
-			$script_dependencies = $asset_manifest['dependencies'];
-		}
-
 		Tracking::register_tracks_functions_scripts( true );
 
-		wp_enqueue_script(
+		Assets::register_script(
 			'jp-search-configure',
-			plugins_url( $script_relative_path, $plugin_base_path ),
-			$script_dependencies,
-			JETPACK__VERSION,
-			true
+			$path_prefix . '_inc/build/instant-search/jp-search-configure-main.min.js',
+			$plugin_base_path,
+			array( 'in_footer' => true )
 		);
+		Assets::enqueue_script( 'jp-search-configure' );
 		wp_set_script_translations( 'jp-search-configure', 'jetpack' );
 
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -117,22 +117,13 @@ class Jetpack_Widget_Conditions {
 	 * Enqueue the block-based widget visibility scripts.
 	 */
 	public static function setup_block_controls() {
-		$manifest_path       = JETPACK__PLUGIN_DIR . '_inc/build/widget-visibility/editor/index.min.asset.php';
-		$script_path         = plugins_url( '_inc/build/widget-visibility/editor/index.min.js', JETPACK__PLUGIN_FILE );
-		$script_dependencies = array( 'wp-polyfill' );
-		if ( file_exists( $manifest_path ) ) {
-			$asset_manifest      = include $manifest_path;
-			$script_dependencies = $asset_manifest['dependencies'];
-		}
-
-		// Enqueue built script.
-		wp_enqueue_script(
+		Assets::register_script(
 			'widget-visibility-editor',
-			$script_path,
-			$script_dependencies,
-			JETPACK__VERSION,
-			true
+			'_inc/build/widget-visibility/editor/index.min.js',
+			JETPACK__PLUGIN_FILE,
+			array( 'in_footer' => true )
 		);
+		Assets::enqueue_script( 'widget-visibility-editor' );
 		wp_set_script_translations( 'widget-visibility-editor', 'jetpack' );
 	}
 

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "10.4.0-a.5",
+	"version": "10.4.0-a.6",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The new `Assets::register_script` wrapper worked great. In fact, a bit
too good: it picked up a style dependency that was missing from the
editor JS, which broke the Widget Editor and the Site Editor because
that dependency is specifically not supposed to be loaded there
(see #20357).

This reverts #21760 and adds a hack around the way that #20357 made
things break with the new wrapper.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1637032971357200-slack-CBG1CP4EN
p9dueE-3MG-p2#comment-6658

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the Widget Editor and Site Editor are happy now, and everything else is still happy.