### PR TITLE
[RNMobile] Tiled Gallery Mosaic layout basic implementation

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
@@ -23,10 +23,11 @@ import { useResizeObserver } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { ALLOWED_MEDIA_TYPES } from './constants';
+import { ALLOWED_MEDIA_TYPES, LAYOUT_STYLES } from './constants';
 import { icon } from '.';
 import styles from './styles.scss';
 import TiledGallerySettings, { DEFAULT_COLUMNS, MAX_COLUMNS } from './settings';
+import { getActiveStyleName } from '../../shared/block-styles';
 
 const TILE_SPACING = 8;
 
@@ -100,13 +101,15 @@ const TiledGalleryEdit = props => {
 	}, [ columns, images, setAttributes ] );
 
 	const populateInnerBlocksWithImages = ( imgs, replace = false ) => {
+		const layoutStyle = getActiveStyleName( LAYOUT_STYLES, className );
+
 		const newBlocks = imgs.map( image => {
 			return createBlock( 'core/image', {
 				id: image.id,
 				url: image.url,
 				caption: image.caption,
 				alt: image.alt,
-				className: styles[ 'is-style-squared' ],
+				className: styles[ `is-style-${ layoutStyle }` ],
 			} );
 		} );
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Component, createRef } from '@wordpress/element';
+import { Component, createRef, Platform } from '@wordpress/element';
 import ResizeObserver from 'resize-observer-polyfill';
 
 /**
@@ -10,7 +10,7 @@ import ResizeObserver from 'resize-observer-polyfill';
 import Column from '../column';
 import Gallery from '../gallery';
 import Row from '../row';
-import { getGalleryRows, handleRowResize } from './resize';
+import { getGalleryRows, handleRowResize, getColumnWidths } from './resize';
 import { imagesToRatios, ratiosToColumns, ratiosToMosaicRows } from './ratios';
 
 export default class Mosaic extends Component {
@@ -84,13 +84,18 @@ export default class Mosaic extends Component {
 	}
 
 	render() {
-		const { align, columns, images, layoutStyle, renderedImages, columnWidths } = this.props;
+		const { align, columns, images, layoutStyle, renderedImages } = this.props;
 
 		const ratios = imagesToRatios( images );
 		const rows =
 			'columns' === layoutStyle
 				? ratiosToColumns( ratios, columns )
 				: ratiosToMosaicRows( ratios, { isWide: [ 'full', 'wide' ].includes( align ) } );
+
+		const columnWidths = Platform.select( {
+			web: this.props.columnWidths,
+			native: getColumnWidths( rows, renderedImages, 1000 ),
+		} );
 
 		let cursor = 0;
 		return (

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { Platform } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { GUTTER_WIDTH } from '../../constants';
@@ -32,18 +37,39 @@ function getRowRatio( row ) {
 	return result;
 }
 
+export function getColumnWidths( rows, images, width ) {
+	let cursor = 0;
+	const content = rows.map( row => {
+		return row.map( colSize => {
+			const columnImages = images.slice( cursor, cursor + colSize );
+			cursor += colSize;
+			return columnImages;
+		} );
+	} );
+
+	const result = content.map( row => handleRowResize( row, width ) );
+	return result;
+}
+
 export function getGalleryRows( gallery ) {
 	return Array.from( gallery.querySelectorAll( '.tiled-gallery__row' ) );
 }
 
 function getRowCols( row ) {
-	return Array.from( row.querySelectorAll( '.tiled-gallery__col' ) );
+	return Platform.select( {
+		web: () => Array.from( row.querySelectorAll( '.tiled-gallery__col' ) ),
+		native: () => row,
+	} )();
 }
 
 function getColImgs( col ) {
-	return Array.from(
-		col.querySelectorAll( '.tiled-gallery__item > img, .tiled-gallery__item > a > img' )
-	);
+	return Platform.select( {
+		web: () =>
+			Array.from(
+				col.querySelectorAll( '.tiled-gallery__item > img, .tiled-gallery__item > a > img' )
+			),
+		native: () => col.map( img => img.props ),
+	} )();
 }
 
 function getColumnRatio( col ) {
@@ -59,36 +85,53 @@ function getColumnRatio( col ) {
 }
 
 function getImageRatio( img ) {
-	const w = parseInt( img.dataset.width, 10 );
-	const h = parseInt( img.dataset.height, 10 );
+	const w = Platform.select( {
+		web: () => parseInt( img.dataset.width, 10 ),
+		native: () => img.width,
+	} )();
+	const h = Platform.select( {
+		web: () => parseInt( img.dataset.height, 10 ),
+		native: () => img.height,
+	} )();
 	const result = w && ! Number.isNaN( w ) && h && ! Number.isNaN( h ) ? w / h : 1;
 	return result;
 }
 
 function applyRowRatio( row, [ ratio, weightedRatio ], width ) {
-	const rawHeight =
-		( 1 / ratio ) * ( width - GUTTER_WIDTH * ( row.childElementCount - 1 ) - weightedRatio );
+	const colCount = Platform.select( {
+		web: () => row.childElementCount,
+		native: () => row.length,
+	} )();
+	const rawHeight = ( 1 / ratio ) * ( width - GUTTER_WIDTH * ( colCount - 1 ) - weightedRatio );
 
 	return applyColRatio( row, {
 		rawHeight,
-		rowWidth: width - GUTTER_WIDTH * ( row.childElementCount - 1 ),
+		rowWidth: width - GUTTER_WIDTH * ( colCount - 1 ),
 	} );
 }
 
 function applyColRatio( row, { rawHeight, rowWidth } ) {
 	const cols = getRowCols( row );
 
-	const colWidths = cols.map(
-		col => ( rawHeight - GUTTER_WIDTH * ( col.childElementCount - 1 ) ) * getColumnRatio( col )[ 0 ]
-	);
+	const colWidths = cols.map( col => {
+		const imgCount = Platform.select( {
+			web: () => col.childElementCount,
+			native: () => col.length,
+		} )();
+		return ( rawHeight - GUTTER_WIDTH * ( imgCount - 1 ) ) * getColumnRatio( col )[ 0 ];
+	} );
 
 	const adjustedWidths = adjustFit( colWidths, rowWidth );
 
 	cols.forEach( ( col, i ) => {
 		const rawWidth = colWidths[ i ];
 		const width = adjustedWidths[ i ];
+		const imgCount = Platform.select( {
+			web: () => col.childElementCount,
+			native: () => col.length,
+		} )();
 		applyImgRatio( col, {
-			colHeight: rawHeight - GUTTER_WIDTH * ( col.childElementCount - 1 ),
+			colHeight: rawHeight - GUTTER_WIDTH * ( imgCount - 1 ),
 			width,
 			rawWidth,
 		} );
@@ -105,9 +148,13 @@ function applyImgRatio( col, { colHeight, width, rawWidth } ) {
 	const imgHeights = getColImgs( col ).map( img => rawWidth / getImageRatio( img ) );
 	const adjustedHeights = adjustFit( imgHeights, colHeight );
 
-	// Set size of col children, not the <img /> element
-	Array.from( col.children ).forEach( ( item, i ) => {
-		const height = adjustedHeights[ i ];
-		item.setAttribute( 'style', `height:${ height }px;width:${ width }px;` );
+	Platform.select( {
+		web: () => {
+			// Set size of col children, not the <img /> element
+			Array.from( col.children ).forEach( ( item, i ) => {
+				const height = adjustedHeights[ i ];
+				item.setAttribute( 'style', `height:${ height }px;width:${ width }px;` );
+			} );
+		},
 	} );
 }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
@@ -3,6 +3,8 @@
  */
 import Layout from './layout';
 import { defaultColumnsNumber } from './edit';
+import { getActiveStyleName } from '../../shared/block-styles';
+import { LAYOUT_STYLES } from './constants';
 
 export default function TiledGallerySave( { attributes, innerBlocks } ) {
 	if ( ! attributes.images.length && ! innerBlocks.length ) {
@@ -31,6 +33,8 @@ export default function TiledGallerySave( { attributes, innerBlocks } ) {
 		ids,
 	} = attributes;
 
+	const layoutStyle = getActiveStyleName( LAYOUT_STYLES, className );
+
 	return (
 		<Layout
 			align={ align }
@@ -38,7 +42,7 @@ export default function TiledGallerySave( { attributes, innerBlocks } ) {
 			columns={ columns }
 			images={ images }
 			isSave
-			layoutStyle={ 'square' }
+			layoutStyle={ layoutStyle }
 			linkTo={ linkTo }
 			roundedCorners={ roundedCorners }
 			columnWidths={ columnWidths }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/styles.native.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/styles.native.scss
@@ -16,6 +16,10 @@
 	aspect-ratio: 1;
 }
 
+.is-style-rectangular {
+	aspect-ratio: 1;
+}
+
 .cellRowStyles {
 	flex-shrink: 1;
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4228

Related:
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4249

#### Changes proposed in this Pull Request:
* A first iteration of the the Mosaic layout for the WordPress mobile port of the Tiled Gallery block.

#### Jetpack product discussion

p9ugOq-1Tb-p2

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions


It's possible to test that Mosaic layout by inspecting the block's HTML using the editor's HTML mode. However, to further verify that the layout's CSS is working, it's best to test in the main WordPress mobile apps.

1. Checkout the Gutenberg Mobile branch: (tip: if using `gh`, run `gh pr checkout --recurse-submodules add/tiled-gallery-block-mosaic-layout`)
2. Run the packager: `npm run start:reset`
3. Run the WPiOS app's `develop` branch
4. Open the editor and expect it to load from the running packager
5. Add a Tiled Gallery block and add images to it
6. Switch to the Tiled layout and use the editor Preview to verify that the images are laid out in a Mosaic on the site's frontend
7. Run the WPAndroid app's `develop` branch
8. Repeat steps 4 to 6

#### Demo

##### Android

https://user-images.githubusercontent.com/1898325/143322569-467cc430-38cf-4d4d-b5b2-903b794597af.mov

##### iOS

https://user-images.githubusercontent.com/1898325/143322838-14dddc87-cacf-4e04-8fd2-6257cdec92c0.mov




