### PR TITLE
Revert "WPCOM no longer forces home_urls to be http"

### DIFF
--- a/projects/plugins/jetpack/changelog/wpcom-no-longer-forces-http
+++ b/projects/plugins/jetpack/changelog/wpcom-no-longer-forces-http
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WPCOM will no longer force home_urls to be http

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -184,6 +184,13 @@ class WPCOM_JSON_API {
 
 		$this->exit = (bool) $exit;
 
+		// This was causing problems with Jetpack, but is necessary for wpcom
+		// @see https://github.com/Automattic/jetpack/pull/2603
+		// @see r124548-wpcom
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			add_filter( 'home_url', array( $this, 'ensure_http_scheme_of_home_url' ), 10, 3 );
+		}
+
 		add_filter( 'user_can_richedit', '__return_true' );
 
 		add_filter( 'comment_edit_pre', array( $this, 'comment_edit_pre' ) );
@@ -581,6 +588,14 @@ class WPCOM_JSON_API {
 		}
 
 		return $response;
+	}
+
+	function ensure_http_scheme_of_home_url( $url, $path, $original_scheme ) {
+		if ( $original_scheme ) {
+			return $url;
+		}
+
+		return preg_replace( '#^https:#', 'http:', $url );
 	}
 
 	function comment_edit_pre( $comment_content ) {


### PR DESCRIPTION
Reverts Automattic/jetpack#21747 (which contained only wpcom changes)

> Barry pointed out that not all wpcom sites have valid certificates. I was able to find at least one where the /sites/ API with this patch returned https:// but it was invalid.

#### Does this pull request change what data or activity we track or use?

no.

#### Testing instructions:
* https://developer.wordpress.com/docs/api/console/
* wp.com api | v1.2 | `/sites/144771104`
* URL should begin with http, not https

The patch that is reverted makes no changes on jetpack sites, only wpcom; and the revert is already on wpcom, so there's really nothing to test.