### PR TITLE
Remove special cases for calling changelogger on packages/changelogger

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -98,9 +98,6 @@ for SLUG in "${SLUGS[@]}"; do
 	# Update the changelog, if applicable.
 	if [[ -x 'vendor/bin/changelogger' ]]; then
 		CHANGELOGGER=vendor/bin/changelogger
-	elif [[ -x 'bin/changelogger' ]]; then
-		# Changelogger itself doesn't have itself in vendor/.
-		CHANGELOGGER=bin/changelogger
 	elif jq -e '.["require-dev"]["automattic/jetpack-changelogger"] // false' composer.json > /dev/null; then
 		# Some plugins might build with `composer install --no-dev`.
 		CHANGELOGGER="$BASE/projects/packages/changelogger/bin/changelogger"

--- a/projects/packages/changelogger/changelog/remove-special-cases-for-changelogger-in-changelogger
+++ b/projects/packages/changelogger/changelog/remove-special-cases-for-changelogger-in-changelogger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change to the local environment only, to have `vendor/bin/changelogger` exist within packages/changelogger itself.
+
+

--- a/projects/packages/changelogger/composer.json
+++ b/projects/packages/changelogger/composer.json
@@ -39,7 +39,9 @@
 		"test-php": [
 			"@composer update",
 			"@composer phpunit"
-		]
+		],
+		"post-install-cmd": "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }",
+		"post-update-cmd": "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
 	},
 	"repositories": [
 		{

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '3.0.2';
+	const VERSION = '3.0.3-alpha';
 
 	/**
 	 * Constructor.

--- a/projects/plugins/backup/changelog/remove-special-cases-for-changelogger-in-changelogger
+++ b/projects/plugins/backup/changelog/remove-special-cases-for-changelogger-in-changelogger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1153,7 +1153,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "636f2cdc240ff78935b7b0f26b5834691bfa0bd9"
+                "reference": "d219e673c8cb1b6b9ce85dac0f6df570a2af4af8"
             },
             "require": {
                 "php": ">=5.6",
@@ -1205,6 +1205,12 @@
                 "test-php": [
                     "@composer update",
                     "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
+                ],
+                "post-update-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
                 ]
             },
             "license": [

--- a/projects/plugins/beta/changelog/remove-special-cases-for-changelogger-in-changelogger
+++ b/projects/plugins/beta/changelog/remove-special-cases-for-changelogger-in-changelogger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -203,7 +203,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "636f2cdc240ff78935b7b0f26b5834691bfa0bd9"
+                "reference": "d219e673c8cb1b6b9ce85dac0f6df570a2af4af8"
             },
             "require": {
                 "php": ">=5.6",
@@ -255,6 +255,12 @@
                 "test-php": [
                     "@composer update",
                     "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
+                ],
+                "post-update-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
                 ]
             },
             "license": [

--- a/projects/plugins/boost/changelog/remove-special-cases-for-changelogger-in-changelogger
+++ b/projects/plugins/boost/changelog/remove-special-cases-for-changelogger-in-changelogger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -962,7 +962,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "636f2cdc240ff78935b7b0f26b5834691bfa0bd9"
+                "reference": "d219e673c8cb1b6b9ce85dac0f6df570a2af4af8"
             },
             "require": {
                 "php": ">=5.6",
@@ -1014,6 +1014,12 @@
                 "test-php": [
                     "@composer update",
                     "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
+                ],
+                "post-update-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
                 ]
             },
             "license": [

--- a/projects/plugins/debug-helper/changelog/remove-special-cases-for-changelogger-in-changelogger
+++ b/projects/plugins/debug-helper/changelog/remove-special-cases-for-changelogger-in-changelogger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "636f2cdc240ff78935b7b0f26b5834691bfa0bd9"
+                "reference": "d219e673c8cb1b6b9ce85dac0f6df570a2af4af8"
             },
             "require": {
                 "php": ">=5.6",
@@ -65,6 +65,12 @@
                 "test-php": [
                     "@composer update",
                     "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
+                ],
+                "post-update-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
                 ]
             },
             "license": [

--- a/projects/plugins/jetpack/changelog/remove-special-cases-for-changelogger-in-changelogger
+++ b/projects/plugins/jetpack/changelog/remove-special-cases-for-changelogger-in-changelogger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1718,7 +1718,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "636f2cdc240ff78935b7b0f26b5834691bfa0bd9"
+                "reference": "d219e673c8cb1b6b9ce85dac0f6df570a2af4af8"
             },
             "require": {
                 "php": ">=5.6",
@@ -1770,6 +1770,12 @@
                 "test-php": [
                     "@composer update",
                     "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
+                ],
+                "post-update-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
                 ]
             },
             "license": [

--- a/projects/plugins/search/changelog/remove-special-cases-for-changelogger-in-changelogger
+++ b/projects/plugins/search/changelog/remove-special-cases-for-changelogger-in-changelogger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "636f2cdc240ff78935b7b0f26b5834691bfa0bd9"
+                "reference": "d219e673c8cb1b6b9ce85dac0f6df570a2af4af8"
             },
             "require": {
                 "php": ">=5.6",
@@ -65,6 +65,12 @@
                 "test-php": [
                     "@composer update",
                     "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
+                ],
+                "post-update-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
                 ]
             },
             "license": [

--- a/projects/plugins/vaultpress/changelog/remove-special-cases-for-changelogger-in-changelogger
+++ b/projects/plugins/vaultpress/changelog/remove-special-cases-for-changelogger-in-changelogger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/vaultpress/composer.lock
+++ b/projects/plugins/vaultpress/composer.lock
@@ -122,7 +122,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "636f2cdc240ff78935b7b0f26b5834691bfa0bd9"
+                "reference": "d219e673c8cb1b6b9ce85dac0f6df570a2af4af8"
             },
             "require": {
                 "php": ">=5.6",
@@ -174,6 +174,12 @@
                 "test-php": [
                     "@composer update",
                     "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
+                ],
+                "post-update-cmd": [
+                    "[ -e vendor/bin/changelogger ] || { cd vendor/bin && ln -s ../../bin/changelogger; }"
                 ]
             },
             "license": [

--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -109,8 +109,6 @@ function releaseProject {
 	local CL
 	if [[ -x vendor/bin/changelogger ]]; then
 		CL=vendor/bin/changelogger
-	elif [[ -x bin/changelogger ]]; then
-		CL=bin/changelogger
 	else
 		yellow "${I}No changelogger! Skipping."
 		return
@@ -191,8 +189,6 @@ if [[ "$SLUG" == plugins/* ]]; then
 	VER=
 	if [[ -x "projects/$SLUG/vendor/bin/changelogger" ]]; then
 		VER=$(cd "projects/$SLUG" && vendor/bin/changelogger version current)
-	elif [[ -x "projects/$SLUG/bin/changelogger" ]]; then
-		VER=$(cd "projects/$SLUG" && bin/changelogger version current)
 	fi
 	if [[ -n "$VER" ]]; then
 		cat <<-EOM

--- a/tools/changelogger-validate-all.sh
+++ b/tools/changelogger-validate-all.sh
@@ -97,8 +97,6 @@ for FILE in projects/*/*/composer.json; do
 
 	if [[ -x vendor/bin/changelogger ]]; then
 		CHANGELOGGER=vendor/bin/changelogger
-	elif [[ "$DIR" == "projects/packages/changelogger" ]]; then
-		CHANGELOGGER=bin/changelogger
 	elif jq -e '.["require"]["automattic/jetpack-changelogger"] // .["require-dev"]["automattic/jetpack-changelogger"] // false' composer.json > /dev/null; then
 		CHANGELOGGER="$BASE/projects/packages/changelogger/bin/changelogger"
 	else

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -508,10 +508,6 @@ function validatePath( argv, dir ) {
 	if ( ! fs.existsSync( dir ) ) {
 		throw new Error( chalk.red( `Project doesn't exist! Typo?` ) );
 	}
-	if ( argv.project === 'packages/changelogger' ) {
-		argv.cmdPath = 'bin/changelogger';
-		return;
-	}
 	if ( fs.existsSync( dir + `/vendor/bin/changelogger` ) ) {
 		argv.cmdPath = 'vendor/bin/changelogger';
 		return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We have special cases in a number of our tools to account for the fact
that Composer doesn't create a `vendor/bin/changelogger` symlink in
packages/changelogger's vendor dir.

Instead, let's use post-install and post-upgrade scripts to ensure that
the link exists, so we don't have to special case it everywhere else.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do `jetpack install packages/changelogger`. See that `projects/packages/changelogger/vendor/bin/changelogger` exists and points to a correct location.