### PR TITLE
licensing: jetpack-js-test-runner is a dev dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,9 +254,9 @@ importers:
       '@wordpress/element': 4.0.3
       '@wordpress/i18n': 4.2.3
       '@wordpress/icons': 6.1.0
-      jetpack-js-test-runner: link:../../../tools/js-test-runner
       prop-types: 15.7.2
     devDependencies:
+      jetpack-js-test-runner: link:../../../tools/js-test-runner
       react: 17.0.2
       react-test-renderer: 17.0.2_react@17.0.2
 

--- a/projects/js-packages/licensing/changelog/fix-licensing-js-test-runner
+++ b/projects/js-packages/licensing/changelog/fix-licensing-js-test-runner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+jetpack-js-test-runner is a dev dependency.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -17,6 +17,7 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./!(node_modules)/**/test/*.@(jsx|js)'"
 	},
 	"devDependencies": {
+		"jetpack-js-test-runner": "workspace:*",
 		"react": "17.0.2",
 		"react-test-renderer": "17.0.2"
 	},
@@ -34,7 +35,6 @@
 		"@automattic/jetpack-components": "workspace:^0.6.2-alpha",
 		"@wordpress/i18n": "4.2.3",
 		"@wordpress/element": "4.0.3",
-		"jetpack-js-test-runner": "workspace:*",
 		"prop-types": "^15.7.2",
 		"@wordpress/components": "19.0.1",
 		"@wordpress/icons": "6.1.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
That's why D70048-code is breaking, the munging in the build there
doesn't expect to find it as a non-dev dep.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. Sigh.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This should do nothing here. Merging the change here with the change in D70048-code should allow that to pass tests.
