### PR TITLE
Fix Action button width

### DIFF
--- a/projects/js-packages/components/changelog/fix-action-button-min-width
+++ b/projects/js-packages/components/changelog/fix-action-button-min-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Action button supports larger labels

--- a/projects/js-packages/components/components/action-button/style.scss
+++ b/projects/js-packages/components/components/action-button/style.scss
@@ -8,7 +8,7 @@
 		font-size: 14px;
 		line-height: 18px;
 		text-align: center;
-		width: 264px;
+		min-width: 264px;
 		height: 40px;
 		display: block;
 	}

--- a/projects/js-packages/connection/changelog/fix-action-button-min-width
+++ b/projects/js-packages/connection/changelog/fix-action-button-min-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+revert button width change in favor of the fix in the visual element

--- a/projects/js-packages/connection/components/connect-screen/basic/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/basic/style.scss
@@ -18,10 +18,6 @@
 		button {
 			max-width: 100%;
 
-			&:not( :disabled ) {
-				width: auto;
-			}
-
 			&:disabled {
 				color: hsla(0,0%,100%,.4);
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes the button width to have a minimum width after a regression introduced by https://github.com/Automattic/jetpack/pull/21711

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes the Action button so it supports longer labels and reverts the fix to the Connect Screen that was breaking the button width

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the action button on Storybook and test it with a very long label
* See instructions in https://github.com/Automattic/jetpack/pull/21711
