### PR TITLE
Stats: remove ASCII art from alt text

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.jetpack-search-performance-logger.php
+++ b/projects/plugins/jetpack/_inc/lib/class.jetpack-search-performance-logger.php
@@ -77,7 +77,7 @@ class Jetpack_Search_Performance_Logger {
 			$encoded_json = '{%22beacons%22:[' . implode(',', $beacons ) . ']}';
 			$encoded_site_url = urlencode( site_url() );
 			$url = "https://pixel.wp.com/boom.gif?v=0.9&u={$encoded_site_url}&json={$encoded_json}";
-			echo '<img src="' . esc_html( $url ) . '" width="1" height="1" style="display:none;" alt=""/>';
+			echo '<img src="' . esc_url( $url ) . '" width="1" height="1" style="display:none;" alt=""/>';
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/lib/class.jetpack-search-performance-logger.php
+++ b/projects/plugins/jetpack/_inc/lib/class.jetpack-search-performance-logger.php
@@ -77,7 +77,7 @@ class Jetpack_Search_Performance_Logger {
 			$encoded_json = '{%22beacons%22:[' . implode(',', $beacons ) . ']}';
 			$encoded_site_url = urlencode( site_url() );
 			$url = "https://pixel.wp.com/boom.gif?v=0.9&u={$encoded_site_url}&json={$encoded_json}";
-			echo '<img src="' . $url . '" width="1" height="1" style="display:none;" alt=":)"/>';
+			echo '<img src="' . esc_html( $url ) . '" width="1" height="1" style="display:none;" alt=""/>';
 		}
 	}
 }

--- a/projects/plugins/jetpack/changelog/remove-smiley-alt-ascii-art
+++ b/projects/plugins/jetpack/changelog/remove-smiley-alt-ascii-art
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Stats: remove ASCII art from the stats pixel alt tag for improved accessibility.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Supports #2856

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* For the Search Performance stats pixel, use an empty alt tag.

Alt tags are required, but empty ones are allowed (and suggested) for things like decoration or stats pixels.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I'm not immediately sure how to trigger Search Perfomance Logging, but the change is pretty direct.
