### PR TITLE
REST API: Return user ID for comment author if present.

### DIFF
--- a/projects/plugins/jetpack/changelog/issue-populate-comment-author-id
+++ b/projects/plugins/jetpack/changelog/issue-populate-comment-author-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+REST API Return user ID for comment author if present

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1170,7 +1170,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$ip_address = isset( $author->comment_author_IP ) ? $author->comment_author_IP : '';
 
 		if ( isset( $author->comment_author_email ) ) {
-			$ID          = ( isset( $author->user_id ) && $author->user_id ) ? $author->user_id : 0;
+			$id          = ( isset( $author->user_id ) && $author->user_id ) ? $author->user_id : 0;
 			$login       = '';
 			$email       = $author->comment_author_email;
 			$name        = $author->comment_author;
@@ -1210,7 +1210,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
 				$post_id    = $author->ID;
 				if ( $is_jetpack && ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
-					$ID         = get_post_meta( $post_id, '_jetpack_post_author_external_id', true );
+					$id         = get_post_meta( $post_id, '_jetpack_post_author_external_id', true );
 					$email      = get_post_meta( $post_id, '_jetpack_author_email', true );
 					$login      = '';
 					$name       = get_post_meta( $post_id, '_jetpack_author', true );
@@ -1223,14 +1223,14 @@ abstract class WPCOM_JSON_API_Endpoint {
 				}
 			}
 
-			if ( ! isset( $ID ) ) {
+			if ( ! isset( $id ) ) {
 				$user = get_user_by( 'id', $author );
 				if ( ! $user || is_wp_error( $user ) ) {
 					trigger_error( 'Unknown user', E_USER_WARNING );
 
 					return null;
 				}
-				$ID         = $user->ID;
+				$id         = $user->ID;
 				$email      = $user->user_email;
 				$login      = $user->user_login;
 				$name       = $user->display_name;
@@ -1240,7 +1240,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$nice       = $user->user_nicename;
 			}
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! $is_jetpack ) {
-				$active_blog = get_active_blog_for_user( $ID );
+				$active_blog = get_active_blog_for_user( $id );
 				$site_id     = $active_blog->blog_id;
 				if ( $site_id > -1 ) {
 					$site_visible = (
@@ -1266,7 +1266,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		}
 
 		$author = array(
-			'ID'          => (int) $ID,
+			'ID'          => (int) $id,
 			'login'       => (string) $login,
 			'email'       => $email, // (string|bool)
 			'name'        => (string) $name,

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1170,7 +1170,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$ip_address = isset( $author->comment_author_IP ) ? $author->comment_author_IP : '';
 
 		if ( isset( $author->comment_author_email ) ) {
-			$ID          = 0;
+			$ID          = ( isset( $author->user_id ) && $author->user_id ) ? $author->user_id : 0;
 			$login       = '';
 			$email       = $author->comment_author_email;
 			$name        = $author->comment_author;


### PR DESCRIPTION
This is a change to the wpcom a REST API in a file that is shipped with Jetpack.  My understanding is currently the preferred workflow is to start with Jetpack and let the change be ported back to wpcom. 

For additional context see the slack conversation and thread at slack-reader-p1637182998015000 cc @khaykov , @westi 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR modifies the response returned for a comment author's ID. 
Currently if a comment author's `comment_author_email` field is set the author's ID is always zero.  With this change, the correct user ID for the author will be returned. 

This change will aid in identifying comments belonging to a post's author. 

#### Testing instructions:
(To test this, I applied the change directly to the wpcom endpoints and tested via a wpcom sandbox. For self-hosted/jetpack sites I appended the "&force=wpcom" query param to the API calls. If there is a better way let me know!)

Apply this change to the WPCom REST API.  Test the following endpoints with internal P2, wpcom, and Jetpack sites. 
/sites/%s/comments
/sites/%s/comments/%d
/sites/%s/posts/%d/replies

Confirm that the author's ID is correctly returned for a wpcom user. 
Confirm that the author's ID remains zero for a jetpack/self-hosted/anonymous user.


#### Does this pull request change what data or activity we track or use?
No

