### PR TITLE
Verification tools: remove old Tools interface

### DIFF
--- a/projects/plugins/jetpack/changelog/rm-verification-tools-wp-admin
+++ b/projects/plugins/jetpack/changelog/rm-verification-tools-wp-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Verification tools: remove old interface in the Tools menu, in favor of the newer settings in the Jetpack dashboard.

--- a/projects/plugins/jetpack/modules/verification-tools/blog-verification-tools.php
+++ b/projects/plugins/jetpack/modules/verification-tools/blog-verification-tools.php
@@ -1,7 +1,5 @@
 <?php
 
-use Automattic\Jetpack\Redirect;
-
 // Edit here to add new services
 function jetpack_verification_services() {
 	return array(
@@ -77,16 +75,3 @@ function jetpack_verification_print_meta() {
 	}
 }
 add_action( 'wp_head', 'jetpack_verification_print_meta', 1 );
-
-function jetpack_verification_tool_box() {
-	?>
-		<div class="jp-verification-tools card">
-			<h3 class="title"><?php esc_html_e( 'Website Verification Services', 'jetpack' ); ?>&nbsp;<a href="<?php echo esc_url( Redirect::get_url( 'jetpack-support-site-verification-tools' ) ); ?>" rel="noopener noreferrer" target="_blank">(?)</a></h3>
-			<p>
-				<?php printf( __( 'You can verify your site using the <a href="%s">"Site verification" tool in Jetpack Settings</a>.', 'jetpack' ), esc_url( admin_url( 'admin.php?page=jetpack#/traffic' ) ) ); ?>
-			</p>
-		</div>
-	<?php
-}
-
-add_action( 'tool_box', 'jetpack_verification_tool_box', 25 );


### PR DESCRIPTION
Fixes #21823

#### Changes proposed in this Pull Request:

* The tools have lived in the Jetpack dashboard for more than 3 years, since #10039. Let's retire that redirection now.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Jetpack > Settings > Traffic, and enable Site Verification tools.
* Go to the Tools menu.
* You should not see any settings anymore.
