### PR TITLE
Admin Menu: Make API tests compatible with WPCOM

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-admin-menu-tests-wpcom-2
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-tests-wpcom-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Made admin menu API tests compatible with WPCOM environment

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -70,28 +70,52 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	}
 
 	/**
+	 * Basically just a data provider to other tests that rely on a successful response.
+	 *
+	 * Since the API endpoint relies on file inclusion to create its response,
+	 * it can't be run multiple times within the same "request". This test
+	 * makes that request once and then passes it on so other tests can depend
+	 * on it.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function test_successful_request() {
+		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/admin-menu' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		return $response;
+	}
+
+	/**
 	 * Tests get item.
 	 *
 	 * @covers ::get_item_permissions_check
 	 * @covers ::get_item
 	 * @covers ::prepare_menu_for_response
+	 * @depends test_successful_request
+	 *
+	 * @param WP_REST_Response $response Admin Menu API response.
 	 */
-	public function test_get_item() {
-		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/admin-menu' );
-		$response = $this->server->dispatch( $request );
-
-		$this->assertTrue( rest_validate_value_from_schema( $response->get_data(), ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->get_public_item_schema() ) );
+	public function test_get_item( WP_REST_Response $response ) {
+		$this->assertTrue(
+			rest_validate_value_from_schema(
+				$response->get_data(),
+				( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->get_public_item_schema()
+			)
+		);
 	}
 
 	/**
 	 * Tests that submenu items get promoted when the user doesn't have the caps for the top-level menu item.
 	 *
 	 * @covers ::prepare_menu_for_response
+	 * @depends test_successful_request
+	 *
+	 * @param WP_REST_Response $response Admin Menu API response.
 	 */
-	public function test_parent_menu_item_always_exists() {
-		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/admin-menu' );
-		$response = $this->server->dispatch( $request );
-
+	public function test_parent_menu_item_always_exists( WP_REST_Response $response ) {
 		$menu      = wp_list_filter( $response->get_data(), array( 'title' => 'Settings' ) );
 		$menu_item = array_pop( $menu );
 
@@ -227,7 +251,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 					'slug'   => 'upload-php',
 					'title'  => 'Library\'s',
 					'type'   => 'submenu-item',
-					'url'    => 'http://example.org/wp-admin/upload.php',
+					'url'    => admin_url( 'upload.php' ),
 				),
 			),
 			// Submenu item with update count.
@@ -281,7 +305,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 			'slug'  => 'foo',
 			'title' => 'Foo',
 			'type'  => 'menu-item',
-			'url'   => 'http://example.org/wp-admin/admin.php?page=sharing',
+			'url'   => admin_url( 'admin.php?page=sharing' ),
 		);
 
 		$this->assertSame(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Creates a test that other tests can depend on to get a successful API response to work with
* Uses `admin_url()` to generate URLs based on the current environment.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-3LL-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Should be covered by automated tests. No changes in production code.
