### PR TITLE
assets: Stop doing `_doing_it_wrong` wrong

### DIFF
--- a/projects/packages/assets/changelog/fix-doing-it-wrong-wrong
+++ b/projects/packages/assets/changelog/fix-doing-it-wrong-wrong
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Call `_doing_it_wrong` correctly.

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -361,7 +361,8 @@ class Assets {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s is the script handle. */
-				esc_html( sprintf( __( 'Script "%s" depends on wp-i18n but does not specify "textdomain"', 'jetpack' ), $handle ) )
+				esc_html( sprintf( __( 'Script "%s" depends on wp-i18n but does not specify "textdomain"', 'jetpack' ), $handle ) ),
+				''
 			);
 		}
 

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -612,7 +612,7 @@ class AssetsTest extends TestCase {
 						'ver-from-everything',
 						false,
 					),
-					'_doing_it_wrong'    => array( Assets::class . '::register_script', 'Script &quot;everything&quot; depends on wp-i18n but does not specify &quot;textdomain&quot;' ),
+					'_doing_it_wrong'    => array( Assets::class . '::register_script', 'Script &quot;everything&quot; depends on wp-i18n but does not specify &quot;textdomain&quot;', '' ),
 					'wp_register_style'  => array( 'everything', "$url_base/everything.css?minify=false", array( 'wp-components' ), 'ver-from-everything', 'all' ),
 					'wp_script_add_data' => array( 'everything', 'Jetpack::Assets::hascss', true ),
 				),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
`$version` parameter can't be omitted.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/21831#discussion_r754626441

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do it wrong, then see if this does `_doing_it_wrong()` right.