### PR TITLE
RePublicize: Enable the block editor UI by default

### DIFF
--- a/projects/plugins/jetpack/changelog/update-enable-republicize-by-default
+++ b/projects/plugins/jetpack/changelog/update-enable-republicize-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enable the RePublicize UI in the block editor context.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -684,9 +684,9 @@ class Jetpack_Gutenberg {
 					 *
 					 * @since 10.3.0
 					 *
-					 * @param bool false Enable the RePublicize UI in the block editor context. Defaults to false.
+					 * @param bool true Enable the RePublicize UI in the block editor context. Defaults to true.
 					 */
-					'republicize_enabled'       => apply_filters( 'jetpack_block_editor_republicize_feature', false ),
+					'republicize_enabled'       => apply_filters( 'jetpack_block_editor_republicize_feature', true ),
 				),
 				'siteFragment'     => $status->get_site_suffix(),
 				'adminUrl'         => esc_url( admin_url() ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Enable the RePublicize block editor UI by default

RePublicize is an extension of Publicize that lets users on paid plans to re-share their posts whenever they want.

Before this change, Jetpack users could only do so through Calypso.
With this change, the RePublicize UI is added to the block editor's Jetpack Sidebar as well.

<img width="469" alt="Screenshot 2021-11-23 at 12 43 55" src="https://user-images.githubusercontent.com/2070010/143026136-dcd0bff4-c09e-4fed-baca-87b154b1c0b5.png">

Note: we chose to keep the filter defaulting to `true` instead of removing it in order to be able to selectively turn RePublicize off at will on different environments.

#### Jetpack product discussion

More info in the CfT: p7DVsv-cZY-p2

#### Does this pull request change what data or activity we track or use?

No.
RePublicize is simply an extension of Publicize, and it reuses the same data.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a free Jetpack site.
* Go to Settings -> Sharing, and turn on "Automatically share your posts to social networks" in the "Publicize connections" section.
* Click on "Connect your social media accounts" which will send you to Calypso (Tools -> Marketing -> Connections).
* Connect a social network account in the "Publicize posts" section.
* Navigate back to the posts list and edit a post (or create one first).
* Once in the block editor, open the Jetpack sidebar.
* ⚠️ Make sure there is a "Share this post" section, containing a prompt to upgrade to a paid plan.
* Upgrade your site to a paid plan (Security or higher).
* Edit the post again, and open the Jetpack sidebar.
* ⚠️ Make sure there is a "Share this post" section, containing the connected social network account, a textarea, and a "Share Post" button.
* Share the post.
* ⚠️ Make sure the post is shared successfully.
  * A confirmation popup should show up in the bottom left corner of the editor.
  * Check in the connected social network if the post has been shared.
