### PR TITLE
JITM: Sideload Jetpack Boost functionality 

### DIFF
--- a/projects/packages/jitm/changelog/add-jitm-sideload-boost-plugin
+++ b/projects/packages/jitm/changelog/add-jitm-sideload-boost-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+JITM: Added ability to sideload Jetpack Boost plugin.

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -196,6 +196,40 @@ class Post_Connection_JITM extends JITM {
 	}
 
 	/**
+	 * A special filter used in the CTA of a JITM offering to install the Jetpack Boost plugin.
+	 *
+	 * @return string The new CTA
+	 */
+	public static function jitm_jetpack_boost_install() {
+		return wp_nonce_url(
+			add_query_arg(
+				array(
+					'jetpack-boost-action' => 'install',
+				),
+				admin_url( 'admin.php?page=jetpack' )
+			),
+			'jetpack-boost-install'
+		);
+	}
+
+	/**
+	 * A special filter used in the CTA of a JITM offering to activate the Jetpack Boost plugin.
+	 *
+	 * @return string The new CTA
+	 */
+	public static function jitm_jetpack_boost_activate() {
+		return wp_nonce_url(
+			add_query_arg(
+				array(
+					'jetpack-boost-action' => 'activate',
+				),
+				admin_url( 'admin.php?page=jetpack' )
+			),
+			'jetpack-boost-install'
+		);
+	}
+
+	/**
 	 * This is an entire admin notice dedicated to messaging and handling of the case where a user is trying to delete
 	 * the connection owner.
 	 */
@@ -403,6 +437,10 @@ class Post_Connection_JITM extends JITM {
 		// Jetpack Backup.
 		add_filter( 'jitm_jetpack_backup_install', array( $this, 'jitm_jetpack_backup_install' ) );
 		add_filter( 'jitm_jetpack_backup_activate', array( $this, 'jitm_jetpack_backup_activate' ) );
+
+		// Jetpack Boost.
+		add_filter( 'jitm_jetpack_boost_install', array( $this, 'jitm_jetpack_boost_install' ) );
+		add_filter( 'jitm_jetpack_boost_activate', array( $this, 'jitm_jetpack_boost_activate' ) );
 
 		$user = wp_get_current_user();
 

--- a/projects/plugins/jetpack/3rd-party/3rd-party.php
+++ b/projects/plugins/jetpack/3rd-party/3rd-party.php
@@ -25,6 +25,7 @@ function load_3rd_party() {
 		'class-jetpack-modules-overrides.php', // Special case. Tools to be used to override module settings.
 		'creative-mail.php',
 		'jetpack-backup.php',
+		'jetpack-boost.php',
 		'debug-bar.php',
 		'class-domain-mapping.php',
 		'crowdsignal.php',

--- a/projects/plugins/jetpack/3rd-party/jetpack-boost.php
+++ b/projects/plugins/jetpack/3rd-party/jetpack-boost.php
@@ -37,7 +37,7 @@ function try_install() {
 	$redirect_on_error = admin_url( 'plugin-install.php?s=jetpack-boost&tab=search&type=term' );
 
 	// Attempt to install and activate the plugin.
-	if ( false && current_user_can( 'activate_plugins' ) ) {
+	if ( current_user_can( 'activate_plugins' ) ) {
 		switch ( $_GET['jetpack-boost-action'] ) {
 			case 'install':
 				$result = install_and_activate();

--- a/projects/plugins/jetpack/3rd-party/jetpack-boost.php
+++ b/projects/plugins/jetpack/3rd-party/jetpack-boost.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Compatibility functions for the Jetpack Boost plugin.
+ * https://wordpress.org/plugins/jetpack-boost/
+ *
+ * @since 10.4
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Jetpack_Boost;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const PLUGIN_SLUG = 'jetpack-boost';
+const PLUGIN_FILE = 'jetpack-boost/jetpack-boost.php';
+
+add_action( 'admin_notices', __NAMESPACE__ . '\error_notice' );
+add_action( 'admin_init', __NAMESPACE__ . '\try_install' );
+
+/**
+ * Verify the intent to install Jetpack Boost, and kick off installation.
+ *
+ * This works in tandem with a JITM set up in the JITM package.
+ */
+function try_install() {
+	if ( ! isset( $_GET['jetpack-boost-action'] ) ) {
+		return;
+	}
+
+	check_admin_referer( 'jetpack-boost-install' );
+
+	$result = false;
+	// If the plugin install fails, redirect to plugin install page pre-populated with jetpack-boost search term.
+	$redirect_on_error = admin_url( 'plugin-install.php?s=jetpack-boost&tab=search&type=term' );
+
+	// Attempt to install and activate the plugin.
+	if ( false && current_user_can( 'activate_plugins' ) ) {
+		switch ( $_GET['jetpack-boost-action'] ) {
+			case 'install':
+				$result = install_and_activate();
+				break;
+			case 'activate':
+				$result = activate();
+				break;
+		}
+	}
+
+	if ( $result ) {
+		/** This action is already documented in _inc/lib/class.core-rest-api-endpoints.php */
+		do_action( 'jetpack_activated_plugin', PLUGIN_FILE, 'jitm' );
+		$redirect = admin_url( 'admin.php?page=jetpack-boost' );
+	} else {
+		$redirect = add_query_arg( 'jetpack-boost-install-error', true, $redirect_on_error );
+	}
+
+	wp_safe_redirect( $redirect );
+
+	exit;
+}
+
+/**
+ * Install and activate the Jetpack Boost plugin.
+ *
+ * @return bool result of installation
+ */
+function install_and_activate() {
+	jetpack_require_lib( 'plugins' );
+	$result = \Jetpack_Plugins::install_and_activate_plugin( PLUGIN_SLUG );
+
+	if ( is_wp_error( $result ) ) {
+		return false;
+	} else {
+		return true;
+	}
+}
+
+/**
+ * Activate the Jetpack Boost plugin.
+ *
+ * @return bool result of activation
+ */
+function activate() {
+	$result = activate_plugin( PLUGIN_FILE );
+
+	// Activate_plugin() returns null on success.
+	return is_null( $result );
+}
+
+/**
+ * Notify the user that the installation of Jetpack Boost failed.
+ */
+function error_notice() {
+	if ( empty( $_GET['jetpack-boost-install-error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+
+	?>
+	<div class="notice notice-error is-dismissible">
+		<p><?php esc_html_e( 'There was an error installing Jetpack Boost. Please try again.', 'jetpack' ); ?></p>
+	</div>
+	<?php
+}

--- a/projects/plugins/jetpack/changelog/add-jitm-sideload-boost-plugin
+++ b/projects/plugins/jetpack/changelog/add-jitm-sideload-boost-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+JITM: Added ability to sideload Jetpack Boost plugin.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds the logic necessary to enable installing and activating the Jetpack Boost plugin via JITM. It mimics the behavior and code pattern of the CreativeMail JITM sideloading and is pretty much a copy paste of the JITM for backups merged in #21719 

This is in preparation of enabling the JITM in wpcom later when we're ready, so that we don't need to wait for another release. The wpcom diff linked below is not up for review, but is useful for testing the PR. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
[p1HpG7-dzq-p2](pbNhbs-1yJ-p2)

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Set up: 
- Connect to wpcom sandbox
- Apply D70536-code to sandbox
- Make sure Jetpack Boost is not installed on the Jetpack site
- You'll see the JITM on the main wp-admin dashboard as well as the Jetpack dashboard. 

Successful install: 
- Clicking it should install/activate and navigate you to the Jetpack Boost plugin UI. 

Failed install: 
- Force a failure in try_install(). I tested by manually modifying the code. 
- Click the JITM to install. You should get redirected to the plugin search page in wp-admin with jetpack-backup results pre-populated. 
- You should see a wp-admin notice telling you about the failure.