### PR TITLE
Add Busy State to License Activation Flow Button

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,7 +686,7 @@ importers:
       '@automattic/jetpack-api': workspace:^0.7.1-alpha
       '@automattic/jetpack-components': workspace:^0.6.3
       '@automattic/jetpack-connection': workspace:^0.10.3-alpha
-      '@automattic/jetpack-licensing': workspace:^0.1.1-alpha
+      '@automattic/jetpack-licensing': workspace:^0.2.0-alpha
       '@automattic/jetpack-webpack-config': workspace:^0.3.0
       '@automattic/popup-monitor': 1.0.0
       '@automattic/remove-asset-webpack-plugin': workspace:^0.1.0-alpha

--- a/projects/js-packages/licensing/changelog/add-license-activate-busy-state
+++ b/projects/js-packages/licensing/changelog/add-license-activate-busy-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add busy state to activation button when disabled for license request.

--- a/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
@@ -19,7 +19,7 @@ import './style.scss';
  *
  * @param {object} props -- The properties.
  * @param {Function} props.activateLicense -- function to handle submitting a license
- * @param {boolean} props.disabled -- should the controls be disabled
+ * @param {boolean} props.isActivating -- should the controls be disabled
  * @param {string} props.license -- the license code to edit or submit
  * @param {?string} props.licenseError -- any error that occurred while activating a license
  * @param {Function} props.onLicenseChange -- function to handle changes to license
@@ -27,7 +27,7 @@ import './style.scss';
  * @returns {React.Component} The `ActivationScreenControls` component.
  */
 const ActivationScreenControls = props => {
-	const { activateLicense, disabled, license, licenseError, onLicenseChange, siteUrl } = props;
+	const { activateLicense, isActivating, license, licenseError, onLicenseChange, siteUrl } = props;
 
 	const hasLicenseError = licenseError !== null && licenseError !== undefined;
 
@@ -61,7 +61,7 @@ const ActivationScreenControls = props => {
 					placeholder="jp-Product34623432423423"
 					value={ license }
 					onChange={ onLicenseChange }
-					disabled={ disabled }
+					disabled={ isActivating }
 				/>
 				{ hasLicenseError && (
 					<div className="jp-license-activation-screen-controls--license-field-error">
@@ -74,9 +74,10 @@ const ActivationScreenControls = props => {
 				<Button
 					className="jp-license-activation-screen-controls--button"
 					onClick={ activateLicense }
-					disabled={ license.length <= 0 || disabled }
+					disabled={ license.length <= 0 || isActivating }
+					isBusy={ isActivating }
 				>
-					{ __( 'Activate', 'jetpack' ) }
+					{ isActivating ? __( 'Working...', 'jetpack' ) : __( 'Activate', 'jetpack' ) }
 				</Button>
 			</div>
 		</div>
@@ -85,7 +86,7 @@ const ActivationScreenControls = props => {
 
 ActivationScreenControls.propTypes = {
 	activateLicense: PropTypes.func.isRequired,
-	disabled: PropTypes.bool.isRequired,
+	isActivating: PropTypes.bool.isRequired,
 	license: PropTypes.string.isRequired,
 	licenseError: PropTypes.string,
 	onLicenseChange: PropTypes.func.isRequired,

--- a/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
@@ -77,7 +77,7 @@ const ActivationScreenControls = props => {
 					disabled={ license.length <= 0 || isActivating }
 					isBusy={ isActivating }
 				>
-					{ isActivating ? __( 'Working...', 'jetpack' ) : __( 'Activate', 'jetpack' ) }
+					{ isActivating ? __( 'Working… 'jetpack' ) : __( 'Activate', 'jetpack' ) }
 				</Button>
 			</div>
 		</div>

--- a/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
@@ -77,7 +77,7 @@ const ActivationScreenControls = props => {
 					disabled={ license.length <= 0 || isActivating }
 					isBusy={ isActivating }
 				>
-					{ isActivating ? __( 'Working… 'jetpack' ) : __( 'Activate', 'jetpack' ) }
+					{ isActivating ? __( 'Working…', 'jetpack' ) : __( 'Activate', 'jetpack' ) }
 				</Button>
 			</div>
 		</div>

--- a/projects/js-packages/licensing/components/activation-screen-controls/style.scss
+++ b/projects/js-packages/licensing/components/activation-screen-controls/style.scss
@@ -1,41 +1,40 @@
 @import '~@automattic/jetpack-base-styles/style';
 
 .jp-license-activation-screen-controls {
-	background: var( --jp-white );
+	background: var(--jp-white);
 	padding: 32px;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 
 	h1 {
-		font-size: var( --font-title-large );
+		font-size: var(--font-title-large);
 		font-weight: 700;
 	}
 
 	p {
-		font-size: var( --font-body );
+		font-size: var(--font-body);
 	}
 
 	label {
 		font-weight: 600;
-		font-size: var( --font-body );
+		font-size: var(--font-body);
 	}
 
-	@media screen and ( min-width: 780px ) {
+	@media screen and (min-width: 780px) {
 		padding: 64px;
 	}
-
 }
 
 .jp-license-activation-screen-controls--license-field,
 .jp-license-activation-screen-controls--license-field-with-error {
 	label {
 		font-weight: 600;
-		font-size: var( --font-body );
+		font-size: var(--font-body);
 	}
 
 	input.components-text-control__input {
-		border-radius: var( --jp-border-radius );
+		border-radius: var(--jp-border-radius);
 		border: 1px solid #787c82;
 		font-size: 18px;
 		line-height: 24px;
@@ -52,7 +51,7 @@
 
 .jp-license-activation-screen-controls--license-field-with-error {
 	input.components-text-control__input {
-		border: 1px solid var( --jp-red );
+		border: 1px solid var(--jp-red);
 	}
 }
 
@@ -60,25 +59,25 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	color: var( --jp-red );
+	color: var(--jp-red);
 
 	svg {
 		margin-right: 4px;
-		fill: var( --jp-red );
+		fill: var(--jp-red);
 	}
 
 	span {
-		font-size: var( --font-body );
+		font-size: var(--font-body);
 	}
 }
 
 .jp-license-activation-screen-controls--button {
-	font-size: var( --font-body );
+	font-size: var(--font-body);
 
-	background-color: var( --jp-green-primary );
-	border-color: var( --jp-green-primary );
-	border-radius: var( --jp-border-radius );
-	color: var( --jp-white );
+	background-color: var(--jp-green-primary);
+	border-color: var(--jp-green-primary);
+	border-radius: var(--jp-border-radius);
+	color: var(--jp-white);
 
 	padding: 13.5px 45px 13.5px 45px;
 	min-height: 48px;
@@ -89,34 +88,52 @@
 	justify-content: center;
 	width: 100%;
 
+	@media screen and (min-width: 480px) {
+		justify-content: flex-start;
+		width: auto;
+	}
+
 	&:hover {
-		background-color: var( --jp-green-60 );
-		border-color: var( --jp-green-60 );
-		color: var( --jp-white );
+		background-color: var(--jp-green-60);
+		border-color: var(--jp-green-60);
+		color: var(--jp-white);
 	}
 
 	&:focus {
-		background-color: var( --jp-green-70 );
-		border-color: var( --jp-white );
-		box-shadow: 0 0 0 1px var( --jp-green-70 );
-		color: var( --jp-white );
+		background-color: var(--jp-green-70);
+		border-color: var(--jp-white);
+		box-shadow: 0 0 0 1px var(--jp-green-70);
+		color: var(--jp-white);
 	}
 
 	&:active {
-		background: var( --jp-green-60 );
-		border-color: var( --jp-green-60 );
-		color: var( --jp-white );
+		background: var(--jp-green-60);
+		border-color: var(--jp-green-60);
+		color: var(--jp-white);
 	}
 
 	&[disabled],
 	&:disabled {
-		background: var( --jp-gray );
+		background: var(--jp-gray);
 		color: #a7aaad;
-		border-color: var( --jp-gray );
+		border-color: var(--jp-gray);
 	}
 
-	@media screen and ( min-width: 480px ) {
-		justify-content: flex-start;
-		width: auto;
+	&.is-busy,
+	&.is-busy:disabled,
+	&.is-busy[aria-disabled='true'] {
+		color: var(--jp-white);
+		background-size: 100px 100%;
+		// Disable reason: This function call looks nicer when each argument is on its own line.
+		/* stylelint-disable */
+		background-image: linear-gradient(
+			-45deg,
+			var(--jp-green-60) 33%,
+			var(--jp-green-80) 33%,
+			var(--jp-green-80) 70%,
+			var(--jp-green-60) 70%
+		);
+		/* stylelint-enable */
+		border-color: var(--jp-green);
 	}
 }

--- a/projects/js-packages/licensing/components/activation-screen-controls/test/component.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/test/component.jsx
@@ -33,7 +33,7 @@ describe( 'ActivationScreenControls', () => {
 	describe( 'Render the ActivationScreenControls disabled', () => {
 		const testProps = {
 			activateLicense: () => null,
-			disabled: true,
+			isActivating: true,
 			license: 'test',
 			onLicenseChange: () => null,
 			siteUrl: 'jetpack.com',

--- a/projects/js-packages/licensing/components/activation-screen/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen/index.jsx
@@ -113,7 +113,7 @@ const ActivationScreen = props => {
 				activateLicense={ activateLicense }
 				siteUrl={ siteRawUrl }
 				licenseError={ licenseError }
-				disabled={ isSaving }
+				isActivating={ isSaving }
 			/>
 			<ActivationScreenIllustration imageUrl={ assetBaseUrl + lockImage } showSupportLink />
 		</div>

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.1.1-alpha",
+	"version": "0.2.0-alpha",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/jetpack/changelog/add-license-activate-busy-state
+++ b/projects/plugins/jetpack/changelog/add-license-activate-busy-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -66,7 +66,7 @@
 		"@automattic/jetpack-analytics": "workspace:^0.1.3",
 		"@automattic/jetpack-components": "workspace:^0.6.3",
 		"@automattic/jetpack-connection": "workspace:^0.10.3-alpha",
-		"@automattic/jetpack-licensing": "workspace:^0.1.1-alpha",
+		"@automattic/jetpack-licensing": "workspace:^0.2.0-alpha",
 		"@automattic/popup-monitor": "1.0.0",
 		"@automattic/request-external-access": "1.0.0",
 		"@automattic/social-previews": "1.1.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a Busy State and "Working..." text to button while activation request is in-progress

<img width="964" alt="Screen Shot 2021-11-23 at 12 02 38" src="https://user-images.githubusercontent.com/2810519/143111238-dea8aa93-879b-45c2-8edd-5062a5bfc63d.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1HpG7-cSg-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/license/activation`
* Submit either any text or a valid license
* Verify the button switches to a busy state matching the screenshot above
* Verify it returns to the previous state when the activation fails.
