### PR TITLE
Fixed an issue with screen resolutions of under 783px that caused the…

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-navbar-collapse-style
+++ b/projects/plugins/jetpack/changelog/fix-navbar-collapse-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed nav-unification on lower resolutions for wp-admin.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -328,6 +328,14 @@
 		padding-left: 42px;
 	}
 
+	.wp-responsive-open #wpbody {
+		right: inherit;
+	}
+
+	.wp-responsive-open #wpcontent {
+		margin-left: 272px;
+	}
+
 	.auto-fold #adminmenu, .auto-fold #adminmenuback, .auto-fold #adminmenuwrap {
 		width: 272px;
 	}


### PR DESCRIPTION
Nav unification: Overlaps content on lower resolution WP Admin screens.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #19695

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Modified styles for the 782px media query so that when the navbar is expanded the main content gets offset by the same amount of space as the navbar's width.
* Removed an unnecessary right alignment of the content body.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
For Atomic sites, install Jetpack beta plugin and switch to this branch
For Simple Sites, apply to your sandbox the following patch: {xxxxx-code}

1. Go to a WP-Admin page.
2. Resize your window to a width lower than 783px.
3. Click on "My Sites" menu.
4. The navigation should not overlap the content area.

**Screenshots**
https://user-images.githubusercontent.com/995955/116522048-63c49b00-a8dd-11eb-9bb4-e5c2a0c9f734.mov


