### PR TITLE
ConnectScreen RNA component: Fix custom grid and background

### DIFF
--- a/projects/js-packages/connection/changelog/update-connect-screen-component
+++ b/projects/js-packages/connection/changelog/update-connect-screen-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+ConnectScreen: Fix custom grid and background color.

--- a/projects/js-packages/connection/components/connect-screen/layout/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/layout/index.jsx
@@ -46,8 +46,6 @@ const ConnectScreenLayout = props => {
 					<ImageSlider images={ images } assetBaseUrl={ assetBaseUrl } />
 				</div>
 			) : null }
-
-			<div className="jp-connection__connect-screen-layout__clearfix"></div>
 		</div>
 	);
 };

--- a/projects/js-packages/connection/components/connect-screen/layout/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/layout/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
+@import '~@automattic/jetpack-base-styles/style';
 
 .jp-connection__connect-screen-layout {
 	background: var( --jp-white );
@@ -99,18 +100,21 @@
 	}
 
 	&__two-columns {
+		display: flex;
+    	flex-wrap: wrap;
+
 		.jp-connection__connect-screen-layout__left {
-			float: left;
-			width: 100%;
+			flex-grow: 1;
+			flex-basis: 100%;
 
 			@include break-xlarge {
-				width: 52%;
+				flex-basis: 52%;
 			}
 		}
 
 		.jp-connection__connect-screen-layout__right {
-			float: right;
-			width: 47%;
+			flex-grow: 1;
+			flex-basis: 47%;
 			background: #F9F9F6;
 			display: none;
 
@@ -118,9 +122,5 @@
 				display: block;
 			}
 		}
-	}
-
-	&__clearfix {
-		clear: both;
 	}
 }


### PR DESCRIPTION
ConnectScreen RNA component: Fixes the custom grid and background color.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* ConnectScreenLayout: Use flexbox approach instead of floating elements to ensure same height
* ConnectScreenLayout: Add missing base-styles dependency to fix the missing background color

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
* Setup a new JN site with Jetpack-the-plugin and Backup plugin active.
* Go to Jetpack and make sure the left side of the `ConnectScreen` is white and shares the same height with right side.
* Go to Backup and make sure nothing has changed in the `ConnectScreen`
