### PR TITLE
Improve the copy of the license activation banner

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/index.jsx
@@ -280,7 +280,7 @@ class JetpackNotices extends React.Component {
 					/>
 				) }
 				{ ! isUserLicenseActivationScreen && ! this.props.isAtomicSite && (
-					<UserLicenseActivationNotice />
+					<UserLicenseActivationNotice pathname={ this.props.location.pathname } />
 				) }
 			</div>
 		);

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/style.scss
@@ -5,3 +5,9 @@
 		}
 	}
 }
+
+.jp-license-activation-notice__external-link {
+	svg.gridicons-external {
+		margin-left: 0.25rem;
+	}
+}

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
@@ -44,8 +44,8 @@ const UserLicenseActivationNotice = props => {
 		last_dismissed_time: lastDismissedDateTime,
 	} = activationNoticeDismissInfo;
 
-	// TODO: Update this link to point to the user-license activation route.
 	const USER_LICENSE_ACTIVATION_ROUTE = `${ siteAdminUrl }admin.php?page=jetpack#/license/activation`;
+    const USER_PURCHASES_URL = 'https://wordpress.com/me/purchases';
 
 	const userHasDetachedLicenses = !! detachedLicensesCount;
 	const userHasNewDetachedLicenses = detachedLicensesCount > ( lastDetachedCount || 0 );
@@ -65,11 +65,15 @@ const UserLicenseActivationNotice = props => {
 		}
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
-	const trackClick = useCallback( () => {
+	const trackLicenseActivationClick = useCallback( () => {
 		analytics.tracks.recordJetpackClick( {
 			target: 'licensing_activation_notice',
 			path: 'licensing/activation',
 		} );
+	}, [] );
+
+	const trackUserPurchasesClick = useCallback( () => {
+		analytics.tracks.recordJetpackClick( 'licensing_activation_notice_user_purchases' );
 	}, [] );
 
 	const onNoticeDismiss = useCallback( () => {
@@ -89,11 +93,15 @@ const UserLicenseActivationNotice = props => {
 				showDismiss={ true }
 				onDismissClick={ onNoticeDismiss }
 				text={ createInterpolateElement(
-					__( 'You have an inactive product. <a>Activate now</a>', 'jetpack' ),
+					__( 'You have an available product license key. <activateLink>Activate it now</activateLink> or <purchasesLink>view all your purchases</purchasesLink>.', 'jetpack' ),
 					{
-						a: createElement( 'a', {
+						activateLink: createElement( 'a', {
 							href: USER_LICENSE_ACTIVATION_ROUTE,
-							onClick: trackClick,
+							onClick: trackLicenseActivationClick,
+						} ),
+						purchasesLink: createElement( 'a', {
+							href: USER_PURCHASES_URL,
+							onClick: trackUserPurchasesClick,
 						} ),
 					}
 				) }

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
@@ -6,10 +6,12 @@ import React, { createElement, useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
 import analytics from 'lib/analytics';
 import { getSiteAdminUrl } from 'state/initial-state';
 import {
@@ -45,7 +47,6 @@ const UserLicenseActivationNotice = props => {
 	} = activationNoticeDismissInfo;
 
 	const USER_LICENSE_ACTIVATION_ROUTE = `${ siteAdminUrl }admin.php?page=jetpack#/license/activation`;
-    const USER_PURCHASES_URL = 'https://wordpress.com/me/purchases';
 
 	const userHasDetachedLicenses = !! detachedLicensesCount;
 	const userHasNewDetachedLicenses = detachedLicensesCount > ( lastDetachedCount || 0 );
@@ -73,7 +74,10 @@ const UserLicenseActivationNotice = props => {
 	}, [] );
 
 	const trackUserPurchasesClick = useCallback( () => {
-		analytics.tracks.recordJetpackClick( 'licensing_activation_notice_user_purchases' );
+		analytics.tracks.recordJetpackClick( {
+			target: 'calypso_purchases_link',
+			page: 'my-plan',
+        } );
 	}, [] );
 
 	const onNoticeDismiss = useCallback( () => {
@@ -93,15 +97,18 @@ const UserLicenseActivationNotice = props => {
 				showDismiss={ true }
 				onDismissClick={ onNoticeDismiss }
 				text={ createInterpolateElement(
-					__( 'You have an available product license key. <activateLink>Activate it now</activateLink> or <purchasesLink>view all your purchases</purchasesLink>.', 'jetpack' ),
+					__( 'You have an available product license key. <activateLink>Activate it now</activateLink> or <purchasesLink>view all your purchases</purchasesLink>', 'jetpack' ),
 					{
 						activateLink: createElement( 'a', {
 							href: USER_LICENSE_ACTIVATION_ROUTE,
 							onClick: trackLicenseActivationClick,
 						} ),
-						purchasesLink: createElement( 'a', {
-							href: USER_PURCHASES_URL,
+						purchasesLink: createElement( ExternalLink, {
+                            className: 'jp-license-activation-notice__external-link',
+							href: getRedirectUrl( 'calypso-purchases' ),
 							onClick: trackUserPurchasesClick,
+							target: '_blank',
+							icon: true,
 						} ),
 					}
 				) }

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
@@ -39,7 +39,7 @@ const UserLicenseActivationNotice = props => {
 		detachedLicensesCount,
 		activationNoticeDismissInfo,
 		updateLicensingActivationNoticeDismiss,
-        pathname,
+		pathname,
 		siteAdminUrl,
 	} = props;
 

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
@@ -25,6 +25,7 @@ import SimpleNotice from 'components/notice';
  * Jetpack "user"-licenses activation notice. (a license key is available for activation)
  *
  * @param {object} props - The properties.
+ * @param {number} props.pathname - The path of a URL.
  * @param {number} props.detachedLicensesCount - The user's number of "detached" licenses.
  * @param {object} props.activationNoticeDismissInfo - Object containing `last_detached_count` and `last_dismissed_time`.
  * @param {Function} props.updateLicensingActivationNoticeDismiss - Function to update the notification dismiss info.
@@ -38,6 +39,7 @@ const UserLicenseActivationNotice = props => {
 		detachedLicensesCount,
 		activationNoticeDismissInfo,
 		updateLicensingActivationNoticeDismiss,
+        pathname,
 		siteAdminUrl,
 	} = props;
 
@@ -69,16 +71,17 @@ const UserLicenseActivationNotice = props => {
 	const trackLicenseActivationClick = useCallback( () => {
 		analytics.tracks.recordJetpackClick( {
 			target: 'licensing_activation_notice',
+			page: pathname,
 			path: 'licensing/activation',
 		} );
-	}, [] );
+	}, [ pathname ] );
 
 	const trackUserPurchasesClick = useCallback( () => {
 		analytics.tracks.recordJetpackClick( {
 			target: 'calypso_purchases_link',
-			page: 'my-plan',
+			page: pathname,
 		} );
-	}, [] );
+	}, [ pathname ] );
 
 	const onNoticeDismiss = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_wpa_licensing_activation_notice_dismiss' );
@@ -124,6 +127,7 @@ UserLicenseActivationNotice.propTypes = {
 		last_detached_count: PropTypes.number.isRequired,
 		last_dismiss_time: PropTypes.string.isRequired,
 	} ),
+	pathname: PropTypes.string.isRequired,
 	siteAdminUrl: PropTypes.string.isRequired,
 };
 

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
@@ -77,7 +77,7 @@ const UserLicenseActivationNotice = props => {
 		analytics.tracks.recordJetpackClick( {
 			target: 'calypso_purchases_link',
 			page: 'my-plan',
-        } );
+		} );
 	}, [] );
 
 	const onNoticeDismiss = useCallback( () => {
@@ -104,7 +104,7 @@ const UserLicenseActivationNotice = props => {
 							onClick: trackLicenseActivationClick,
 						} ),
 						purchasesLink: createElement( ExternalLink, {
-                            className: 'jp-license-activation-notice__external-link',
+							className: 'jp-license-activation-notice__external-link',
 							href: getRedirectUrl( 'calypso-purchases' ),
 							onClick: trackUserPurchasesClick,
 							target: '_blank',

--- a/projects/plugins/jetpack/changelog/update-jetpack-license-activation-banner-copy
+++ b/projects/plugins/jetpack/changelog/update-jetpack-license-activation-banner-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update the copy of the license activation banner to make it clear that the user has an available license that can be activated on the site.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Asana task: 1201096622142517-as-1201427659384414

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the copy of the license activation banner to make it clear that the user has an available license that can be activated on the site.
* Add to the same banner a link to the user's purchases on WordPress.com.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* This improvement came from feedback left on the project's call for testing p2 post: p1HpG7-dIr-p2#comment-50719.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* It tracks the clicking on the new link that leads to the user's purchases section on WordPress.com.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a site using this Jetpack branch.
* Connect Jetpack to your A8C WordPress.com account.
* Enable the A8c Proxy.
* Go to https://cloud.jetpack.com/pricing.
* Select a paid Jetpack product other than Jetpack Search.
* Complete checkout.
* On the "Thank you for purchasing [product-name]!" page, just stop there.. (Don't enter a site URL in the input box).
* Back in your Jetpack site, go to the Jetpack Dashboard. ( /wp-admin/admin.php?page=jetpack#/dashboard ).
* Verify that you can see the "You have an available product license key. Activate it now or view all your purchases." notice at the top of the page.
* Click on "Activate it now".
* Verify that you're redirected to the new activation flow.
* Go back to the Jetpack Dashboard.
* Now, click on "view all your purchases".
* Verify that you're redirected to https://wordpress.com/me/purchases.

![image](https://user-images.githubusercontent.com/3418513/143465039-901b5abd-ba61-466f-bb25-67ff4480608c.png)
