### PR TITLE
Don't render Critical CSS while generating CritCSS.

### DIFF
--- a/projects/plugins/boost/changelog/fix-generate-flag-check
+++ b/projects/plugins/boost/changelog/fix-generate-flag-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed issue with re-serving Critical CSS during generation process


### PR DESCRIPTION
The flag `generating_critical_css` was being set _after_ the decision to render Critical CSS, causing Critical CSS (and all of its page changes) to be rendered while generating Critical CSS.

This PR fixes the issue by replacing the `generating_critical_css` flag with a method called `is_generating_critical_css` which checks the generate nonce the first time it's called, and caches the result for the remainder of the pageload in a static var.

That way, initialization order doesn't matter for this flag.

#### Changes proposed in this Pull Request:
* Replace `generating_critical_css` flag with `is_generating_critical_css` method, which calculates the value as needed.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Generate Critical CSS with the Network tab open in your browser tools
* Grab a URL from the Critical CSS generation process in the Network tab with `?jb-generate-critical-css` in it, and open it in a new browser tab.
* View the source of the generation page, and ensure it doesn't contain Critical CSS, or any of the media changes that go along with Critical CSS.
* View the source of your site without the `?jb-generate-critical-css` flag, and ensure that Critical CSS is rendered properly.