### PR TITLE
Support site_intent for `/me/sites` endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-site-intent
+++ b/projects/plugins/jetpack/changelog/add-site-intent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Expose site intent from get site API to show different content in the future

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -157,6 +157,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_cloud_eligible',
 		'selected_features',
 		'anchor_podcast',
+		'site_intent',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -668,6 +669,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'anchor_podcast':
 					$options[ $key ] = $site->get_anchor_podcast();
+					break;
+				case 'site_intent':
+					$options[ $key ] = $site->get_site_intent();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -726,4 +726,11 @@ abstract class SAL_Site {
 	public function get_anchor_podcast() {
 		return get_option( 'anchor_podcast' );
 	}
+
+	/**
+	 * Get the option of site intent which value is coming from the Hero Flow
+	 */
+	public function get_site_intent() {
+		return get_option( 'site_intent', '' );
+	}
 }


### PR DESCRIPTION
Summary:
As we need to show different support articles according to the site intent, add `site_intent` into options list so that we can query from the `/me/sites` endpoint

Related to https://github.com/Automattic/wp-calypso/pull/58486

Test Plan:
1. Go to API Console
2. Select WP.COM API > v1.2
3. Use `/me/sites?fields=options&options=site_intent`
4. Check the response of sites contains `site_intent`

Also, you can follow the testing instructions from https://github.com/Automattic/wp-calypso/pull/58486

Reviewers: #ganon_team, philipmjackson

Reviewed By: #ganon_team, philipmjackson

Subscribers: philipmjackson

Tags: #touches_jetpack_files

Differential Revision: D70637-code

This commit syncs r235663-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
