### PR TITLE
[RNMobile] Tiled Gallery: Remove "link to" settings and references

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.native.js
@@ -45,7 +45,7 @@ const TiledGalleryEdit = props => {
 		noticeUI,
 		onFocus,
 		setAttributes,
-		attributes: { columns, images: attributeImages, linkTo, roundedCorners },
+		attributes: { columns, images: attributeImages, roundedCorners },
 	} = props;
 
 	const { replaceInnerBlocks, updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -173,7 +173,6 @@ const TiledGalleryEdit = props => {
 			{ resizeObserver }
 			<TiledGallerySettings
 				setAttributes={ props.setAttributes }
-				linkTo={ linkTo }
 				columns={ columns }
 				roundedCorners={ roundedCorners }
 				clientId={ clientId }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
@@ -27,7 +27,6 @@ export default function TiledGallerySave( { attributes, innerBlocks } ) {
 		align,
 		className,
 		columns = defaultColumnsNumber( images ),
-		linkTo,
 		roundedCorners,
 		columnWidths,
 		ids,
@@ -43,7 +42,6 @@ export default function TiledGallerySave( { attributes, innerBlocks } ) {
 			images={ images }
 			isSave
 			layoutStyle={ layoutStyle }
-			linkTo={ linkTo }
 			roundedCorners={ roundedCorners }
 			columnWidths={ columnWidths }
 			ids={ ids }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/settings.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/settings.native.js
@@ -4,12 +4,7 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import {
-	LinkSettingsNavigation,
-	PanelBody,
-	RangeControl,
-	UnitControl,
-} from '@wordpress/components';
+import { PanelBody, RangeControl, UnitControl } from '@wordpress/components';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 
 /**
@@ -33,7 +28,7 @@ const TiledGallerySettings = props => {
 		styles.horizontalBorderDark
 	);
 
-	const { setAttributes, linkTo, columns, roundedCorners, clientId, className } = props;
+	const { setAttributes, columns, roundedCorners, clientId, className } = props;
 	const [ columnNumber, setColumnNumber ] = useState( columns ?? DEFAULT_COLUMNS );
 	useEffect( () => {
 		setColumnNumber( columns );
@@ -42,16 +37,6 @@ const TiledGallerySettings = props => {
 	const [ roundedCornerRadius, setRoundedCornerRadius ] = useState(
 		roundedCorners ?? DEFAULT_ROUNDED_CORNERS
 	);
-	const [ linkToURL, setLinkToURL ] = useState( linkTo ?? '' );
-
-	const linkSettingsOptions = {
-		url: {
-			label: __( 'Link URL', 'jetpack' ),
-			placeholder: __( 'Add URL', 'jetpack' ),
-			autoFocus: true,
-			autoFill: true,
-		},
-	};
 
 	const layoutStyle = getActiveStyleName( LAYOUT_STYLES, className );
 
@@ -88,18 +73,6 @@ const TiledGallerySettings = props => {
 					/>
 				</PanelBody>
 			) }
-			<PanelBody>
-				<LinkSettingsNavigation
-					url={ linkToURL }
-					setAttributes={ value => {
-						setLinkToURL( value.url );
-					} }
-					withBottomSheet={ false }
-					hasPicker
-					options={ linkSettingsOptions }
-					showIcon={ false }
-				/>
-			</PanelBody>
 		</InspectorControls>
 	);
 };

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/styles.native.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/styles.native.scss
@@ -4,7 +4,6 @@
 
 .horizontalBorder {
 	border-top-width: $border-width;
-	border-bottom-width: $border-width;
 	border-color: $light-gray-400;
 }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4281

Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4304

As we're not implementing "link to" functionality in this phase of the native Tiled Gallery block (see https://github.com/wordpress-mobile/gutenberg-mobile/issues/4156), this PR removes the setting from the block's bottom sheet as well as all references to it in the code.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* [The `LinkSettingsNavigation` component is removed](https://github.com/Automattic/jetpack/blob/653cbbe14644daecf9927faee158f5683dbacec8/projects/plugins/jetpack/extensions/blocks/tiled-gallery/settings.native.js#L92-L101) from the Tiled Gallery's settings. 
* To support the removal of the `LinkSettingsNavigation` component, all references to `linkTo` have also been removed throughout the Tiled Gallery's files.

#### Jetpack product discussion

p9ugOq-1Tb-p2 

#### Does this pull request change what data or activity we track or use?

No, it doesn't.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With these branches checked out and the Gutenberg Mobile demo app running, add the Tiled Gallery block.
* Select the block's settings cog/gear icon and verify that the "link to" option doesn't appear.

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/143615565-1227c310-9085-479d-8749-31759b97a761.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/143615584-c2a5587c-dfc2-4518-9ce3-343bfd55dc39.png" width="100%"> |