### PR TITLE
Twitter Timeline widget: widget deprecation

### DIFF
--- a/projects/plugins/jetpack/changelog/update-twitter-timeline-widget-deprecate
+++ b/projects/plugins/jetpack/changelog/update-twitter-timeline-widget-deprecate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Twitter Timeline widget: Hide widget from the block inserter and Legacy widget block drop-down menu (WPCOM)

--- a/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
+++ b/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
@@ -41,6 +41,18 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		}
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+	}
+
+	/**
+	 * Remove "Twitter Timeline" widget from Legacy Widget block.
+	 *
+	 * @param array $widget_types Widget type data.
+	 * This only applies to new blocks being added.
+	 */
+	public function hide_widget_in_block_editor( $widget_types ) {
+		$widget_types[] = 'twitter_timeline';
+		return $widget_types;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The proposed change hides the [Twitter Timeline widget](https://wordpress.com/support/widgets/twitter-timeline-widget/) from the block inserter and the Legacy widget block drop-down menu.

**Before**

  Block inserter  |  Legacy Widget block
:-------------------------:|:-------------------------:
![Markup on 2021-11-29 at 10:47:57](https://user-images.githubusercontent.com/25105483/143845165-e473072d-bb47-47fe-b39d-bf58c45d7215.png) | ![Markup on 2021-11-29 at 10:42:54](https://user-images.githubusercontent.com/25105483/143845248-e31324ed-2d9e-4c71-9c75-1ea4fe78ad8e.png)

**After**

  Block inserter  |  Legacy Widget block
:-------------------------:|:-------------------------:
![Markup on 2021-11-29 at 10:40:54](https://user-images.githubusercontent.com/25105483/143845978-a6762d71-f49d-4259-8e64-4fa96ca6b8d0.png) | ![Markup on 2021-11-29 at 10:45:36](https://user-images.githubusercontent.com/25105483/143846025-7b01f6d2-e775-49df-8de9-7c78211c54e6.png)

Users that already have the widget on their site can keep using it. Others can rely on the [Twitter block](https://wordpress.com/support/wordpress-editor/blocks/twitter-block/) instead.

The main purpose of this PR is to reduce the confusion that can come from having multiple blocks with similar features available.

It is worth noting that the Twitter block doesn't have granular settings that are currently provided by the Twitter Timeline widget. There's an issue opened that tracks the interest of users having extra Twitter block settings available. I left there an additional comment:  https://github.com/WordPress/gutenberg/issues/2744#issuecomment-979252410.

#### Jetpack product discussion

This PR is part of the Legacy Widgets Migration project (pdf5j4-4C-p2).

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
There shouldn't be any change to the self-hosted Jetpack sites (these sites don't have the Twitter Timeline widget available already). The change should be visible on WPCOM sites only.

1. Apply the WPCOM patch
2. Navigate to Customizer → Widgets
3. Add the Legacy block and take a look at the dropdown menu. The Twitter Timeline widget should not be available.
4. Try to search for the widget in the block inserter in Customizer as well. It should not come up.