### PR TITLE
Disable CSSTidy property shorthand optimization in the editor or headstart

### DIFF
--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -1600,11 +1600,9 @@ class Jetpack_Safe_CSS {
 		$csstidy->set_cfg( 'remove_last_;', false );
 		$csstidy->set_cfg( 'css_level', 'CSS3.0' );
 
-		// Turn off css shorthands and leading zero removal when in block editor context as it breaks block validation.
-		if ( true === isset( $_REQUEST['_gutenberg_nonce'] ) && wp_verify_nonce( $_REQUEST['_gutenberg_nonce'], 'gutenberg_request' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			$csstidy->set_cfg( 'optimise_shorthands', 0 );
-			$csstidy->set_cfg( 'preserve_leading_zeros', true );
-		}
+		// Turn off css shorthands and leading zero removal as it breaks block validation.
+		$csstidy->set_cfg( 'optimise_shorthands', 0 );
+		$csstidy->set_cfg( 'preserve_leading_zeros', true );
 
 		$css = preg_replace( '/\\\\([0-9a-fA-F]{4})/', '\\\\\\\\$1', $css );
 		$css = wp_kses_split( $css, array(), array() );


### PR DESCRIPTION
Summary:
This fixes block validation errors, shown in the editor on a blank page load and also fixes block validation issues associated with the `pub/payton` homepage starter content.

Building on the work in D69931-code and D70357-code

The gutenberg editor does not support property shorthands such as `padding: 10px 20px;` instead, the property must be specified in long form `padding-top:10px; padding-right:20px;` etc.

The CSSTidy processor is used to optimise css both when page content is fetched, and when headstart is run. We are currently questioning whether it is still a useful part of wordpress.com https://[private link]

We override CSSTidy's `filter_attr` function and there is already some code with the intention of disabling the shorthand optimization in the gutenberg editor. But it only checks whether the `_gutenberg_nonce` is present. It appears that other requests are made when the editor is loaded that do not contain the nonce, but that will still be validated by gutenberg. I haven't determined the source of these requests, but I believe that they are the requests to load block patterns for the editor. In any case, they are returning shorthand properties to the block editor which, as a result, is logging validation errors to the console.

This investigation was originally started to debug validation errors with the `pub/payton` theme. p1635985973066500-slack-CBTN58FTJ. Disabling the shorthand property optimization for headstart prevents the block validation issues specific to the `pub/payton` theme.

Test Plan:
with a sandboxed test site:

Install the payton theme to a test site
`wp theme activate pub/payton --url=[mytestsite][private link]`

Sandbox the `headstart_copy_attachment` job, with the following code. in `0-sandbox.php`
```
function sandbox_async_job_filter( $sandboxed, $type ) {
    return in_array( $type, array(
        'headstart_copy_attachment',
    ) );
}

add_filter( 'sandbox_async_job', 'sandbox_async_job_filter', 10, 2 );
```

Run headstart (delting existing content!)
`wp headstart run --url=[mytestsite][private link] --user=myusername --delete-content`

then in the php error log there will be three lines as follows
```
[24-Nov-2021 05:50:30 UTC] Sandboxed Job # 65711505536 (headstart_copy_attachment_sandboxed) (prefix: wpj_) - run with ~/public_html/async-jobs/tester.php 65711505536 wpj_
[24-Nov-2021 05:50:30 UTC] Sandboxed Job # 65711505609 (headstart_copy_attachment_sandboxed) (prefix: wpj_) - run with ~/public_html/async-jobs/tester.php 65711505609 wpj_
[24-Nov-2021 05:50:34 UTC] Sandboxed Job # 65711507043 (headstart_copy_attachment_sandboxed) (prefix: wpj_) - run with ~/public_html/async-jobs/tester.php 65711507043 wpj_
```
Copy the tester.php commands and run the jobs.

Then check that the content of the homepage is valid!

Open the homepage in the editor.
All blocks should load successfully
Open the js console.
There should be no block validation errors.

Reviewers: arthur791004, philipmjackson, ramonopoly, fullofcaffeine

Reviewed By: arthur791004, philipmjackson, fullofcaffeine

Subscribers: fullofcaffeine, simison, philipmjackson, arthur791004, ramonopoly

Tags: #touches_jetpack_files

Differential Revision: D70425-code

This commit syncs r235710-wpcom.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disables CSSTidy properties that lead to block breakage.

#### Jetpack product discussion
p1635985973066500-slack-CBTN58FTJ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
* Tested a lot on WP.com already; see above.
*