### PR TITLE
Handle the intermittent occurrence of null in `columnWidths[ rowIndex ]` array  in TiledGallery

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-conversion
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-conversion
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: It's a pretty simple bugfix
+
+

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/layout/mosaic/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/layout/mosaic/index.js
@@ -35,7 +35,7 @@ export default class Mosaic extends Component {
 							return (
 								<Column
 									key={ colIndex }
-									width={ columnWidths ? columnWidths[ rowIndex ][ colIndex ] : undefined }
+									width={ columnWidths?.[ rowIndex ]?.[ colIndex ] }
 								>
 									{ columnImages }
 								</Column>

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -101,10 +101,7 @@ export default class Mosaic extends Component {
 							const columnImages = renderedImages.slice( cursor, cursor + colSize );
 							cursor += colSize;
 							return (
-								<Column
-									key={ colIndex }
-									width={ columnWidths ? columnWidths[ rowIndex ][ colIndex ] : undefined }
-								>
+								<Column key={ colIndex } width={ columnWidths?.[ rowIndex ]?.[ colIndex ] }>
 									{ columnImages }
 								</Column>
 							);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/56922

#### Changes proposed in this Pull Request:
* When looking for the columns' width, we currently only handle the case when `columnWidths` array is null, but not the case when `columnWidths[rowIndex]` is null. This PR handles both cases and fixes https://github.com/Automattic/wp-calypso/issues/56922.


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Please repeat the steps in the issue and make sure they're not reproducible. 