### PR TITLE
Plugin Install: Bump MC stat on success or fail.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/plugins.php
+++ b/projects/plugins/jetpack/_inc/lib/plugins.php
@@ -41,7 +41,6 @@ class Jetpack_Plugins {
 		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return new WP_Error( 'not_allowed', __( 'You are not allowed to activate plugins on this site.', 'jetpack' ) );
 		}
-
 		$activated = activate_plugin( $plugin_id );
 		if ( is_wp_error( $activated ) ) {
 			return $activated;
@@ -70,7 +69,11 @@ class Jetpack_Plugins {
 
 		$result = $upgrader->install( $zip_url );
 
+		// Will use ->stat() for recording success/fails.
+		$jetpack = Jetpack::init();
+
 		if ( is_wp_error( $result ) ) {
+			$jetpack->stat( 'install-plugin', "fail-$slug" );
 			return $result;
 		}
 
@@ -92,9 +95,11 @@ class Jetpack_Plugins {
 				$error_code = 'no_package';
 			}
 
+			$jetpack->stat( 'install-plugin', "fail-$slug" );
 			return new WP_Error( $error_code, $error, 400 );
 		}
 
+		$jetpack->stat( 'install-plugin', "success-$slug" );
 		return (array) $upgrader->skin->get_upgrade_messages();
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/plugins.php
+++ b/projects/plugins/jetpack/_inc/lib/plugins.php
@@ -29,15 +29,11 @@ class Jetpack_Plugins {
 	 */
 	public static function install_and_activate_plugin( $slug ) {
 		$plugin_id = self::get_plugin_id_by_slug( $slug );
-		$mc_stats  = new A8c_Mc_Stats();
 
 		if ( ! $plugin_id ) {
 			$installed = self::install_plugin( $slug );
 			if ( is_wp_error( $installed ) ) {
-				$mc_stats->add( 'install-plugin', "fail-$slug" );
 				return $installed;
-			} else {
-				$mc_stats->add( 'install-plugin', "success-$slug" );
 			}
 			$plugin_id = self::get_plugin_id_by_slug( $slug );
 		} elseif ( is_plugin_active( $plugin_id ) ) {
@@ -49,10 +45,7 @@ class Jetpack_Plugins {
 		}
 		$activated = activate_plugin( $plugin_id );
 		if ( is_wp_error( $activated ) ) {
-			$mc_stats->add( 'activate-plugin', "fail-$slug" );
 			return $activated;
-		} else {
-			$mc_stats->add( 'activate-plugin', "success-$slug" );
 		}
 
 		return true;
@@ -75,10 +68,12 @@ class Jetpack_Plugins {
 		$skin     = new Jetpack_Automatic_Install_Skin();
 		$upgrader = new Plugin_Upgrader( $skin );
 		$zip_url  = self::generate_wordpress_org_plugin_download_link( $slug );
+		$mc_stats = new A8c_Mc_Stats();
 
 		$result = $upgrader->install( $zip_url );
 
 		if ( is_wp_error( $result ) ) {
+			$mc_stats->add( 'install-plugin', "fail-$slug" );
 			return $result;
 		}
 
@@ -100,9 +95,11 @@ class Jetpack_Plugins {
 				$error_code = 'no_package';
 			}
 
+			$mc_stats->add( 'install-plugin', "fail-$slug" );
 			return new WP_Error( $error_code, $error, 400 );
 		}
 
+		$mc_stats->add( 'install-plugin', "success-$slug" );
 		return (array) $upgrader->skin->get_upgrade_messages();
 	}
 

--- a/projects/plugins/jetpack/changelog/update-install-plugins-mc-stats
+++ b/projects/plugins/jetpack/changelog/update-install-plugins-mc-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Bump stat on plugin installs.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
Follow-up of the feedback in https://github.com/Automattic/jetpack/pull/21719#discussion_r755386165

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This bumps an MC stat when Jetpack tries to install a plugin. This install is used in the JITM sideloading functionality. I've only added stats to install as it's most likely to fail (vs activating). We're interested to see how many sites have trouble "sideloading" plugins through this API, particularly as #21719 and #21719 are merged and will likely get activated from wpcom soon after this release. 

Stat group: `jetpack-install-plugin`
Stat name: `fail-$slug` || `success-$slug`

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Related discussions
p1HpG7-dzq-p2
https://github.com/Automattic/jetpack/pull/21719#discussion_r755386165
p1HpG7-dHF-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, but it's non-identifying data. Just an incremental stat count. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You should be able to test this with our existing JITMs for WC Services and CreativeMail. 
- Activate Jetpack Contact Form
- Navigate to /wp-admin/edit.php?post_type=feedback
- See the JITM to install CreativeMail
- Click it
- Verify the stat was bumped in MC Stats. 