### PR TITLE
Milestone widget: Fix CSS styles in Customizer (widget preview)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-milestone-widget-enqueue-styles
+++ b/projects/plugins/jetpack/changelog/fix-milestone-widget-enqueue-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Milestone widget: Fix an issue that prevented styles from loading until the widget is saved

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -105,6 +105,7 @@ class Jetpack {
 		'jetpack-simple-payments-widget-style',
 		'jetpack-widget-social-icons-styles',
 		'wpcom_instagram_widget',
+		'milestone-widget',
 	);
 
 	/**

--- a/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
@@ -49,6 +49,7 @@ class Milestone_Widget extends WP_Widget {
 		);
 
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
 		add_action( 'wp_footer', array( $this, 'localize_script' ) );
 	}
@@ -177,7 +178,6 @@ class Milestone_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		$instance = wp_parse_args( $instance, $this->defaults() );
 
-		$this->enqueue_scripts();
 		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */

--- a/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
@@ -120,44 +120,6 @@ class Milestone_Widget extends WP_Widget {
 	--milestone-bg-color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	--milestone-border-color:<?php echo self::sanitize_color_hex( $colors['border'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 }
-.milestone-content {
-	line-height: 2;
-	margin-top: 5px;
-	max-width: 100%;
-	padding: 0;
-	text-align: center;
-}
-.milestone-header {
-	background-color: var(--milestone-text-color);
-	color: var(--milestone-bg-color);
-	line-height: 1.3;
-	margin: 0;
-	padding: .8em;
-}
-.milestone-header .event,
-.milestone-header .date {
-	display: block;
-}
-.milestone-header .event {
-	font-size: 120%;
-}
-.milestone-countdown .difference {
-	display: block;
-	font-size: 500%;
-	font-weight: bold;
-	line-height: 1.2;
-}
-.milestone-countdown,
-.milestone-message {
-	background-color: var(--milestone-bg-color);
-	border: 1px solid var(--milestone-border-color);
-	border-top: 0;
-	color: var(--milestone-text-color);
-	padding-bottom: 1em;
-}
-.milestone-message {
-	padding-top: 1em
-}
 </style>
 		<?php
 	}

--- a/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
@@ -51,10 +51,6 @@ class Milestone_Widget extends WP_Widget {
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
 		add_action( 'wp_footer', array( $this, 'localize_script' ) );
-
-		if ( is_active_widget( false, false, $this->id_base, true ) || is_active_widget( false, false, 'monster', true ) || is_customize_preview() ) {
-			add_action( 'wp_head', array( __class__, 'styles_template' ) );
-		}
 	}
 
 	/**
@@ -96,66 +92,6 @@ class Milestone_Widget extends WP_Widget {
 			'20201113',
 			true
 		);
-	}
-
-	/**
-	 * Output the frontend styling.
-	 */
-	public static function styles_template() {
-		global $themecolors;
-		$colors = wp_parse_args(
-			$themecolors,
-			array(
-				'bg'     => 'ffffff',
-				'border' => 'cccccc',
-				'text'   => '333333',
-			)
-		);
-		?>
-<style>
-.milestone-widget {
-	margin-bottom: 1em;
-}
-.milestone-content {
-	line-height: 2;
-	margin-top: 5px;
-	max-width: 100%;
-	padding: 0;
-	text-align: center;
-}
-.milestone-header {
-	background-color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-	color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-	line-height: 1.3;
-	margin: 0;
-	padding: .8em;
-}
-.milestone-header .event,
-.milestone-header .date {
-	display: block;
-}
-.milestone-header .event {
-	font-size: 120%;
-}
-.milestone-countdown .difference {
-	display: block;
-	font-size: 500%;
-	font-weight: bold;
-	line-height: 1.2;
-}
-.milestone-countdown,
-.milestone-message {
-	background-color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-	border: 1px solid <?php echo self::sanitize_color_hex( $colors['border'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-	border-top: 0;
-	color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-	padding-bottom: 1em;
-}
-.milestone-message {
-	padding-top: 1em
-}
-</style>
-		<?php
 	}
 
 	/**
@@ -241,6 +177,7 @@ class Milestone_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		$instance = wp_parse_args( $instance, $this->defaults() );
 
+		$this->enqueue_scripts();
 		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
@@ -281,6 +218,18 @@ class Milestone_Widget extends WP_Widget {
 
 		/** This action is documented in modules/widgets/gravatar-profile.php */
 		do_action( 'jetpack_stats_extra', 'widget_view', 'milestone' );
+	}
+
+	/**
+	 * Enqueue widget styles
+	 */
+	public function enqueue_scripts() {
+		wp_enqueue_style(
+			'milestone-widget',
+			plugins_url( 'milestone-widget.css', __FILE__ ),
+			array(),
+			JETPACK__VERSION
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
@@ -116,6 +116,9 @@ class Milestone_Widget extends WP_Widget {
 <style>
 .milestone-widget {
 	margin-bottom: 1em;
+	--milestone-text-color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	--milestone-bg-color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	--milestone-border-color:<?php echo self::sanitize_color_hex( $colors['border'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 }
 .milestone-content {
 	line-height: 2;
@@ -125,8 +128,8 @@ class Milestone_Widget extends WP_Widget {
 	text-align: center;
 }
 .milestone-header {
-	background-color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-	color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	background-color: var(--milestone-text-color);
+	color: var(--milestone-bg-color);
 	line-height: 1.3;
 	margin: 0;
 	padding: .8em;
@@ -146,10 +149,10 @@ class Milestone_Widget extends WP_Widget {
 }
 .milestone-countdown,
 .milestone-message {
-	background-color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-	border: 1px solid <?php echo self::sanitize_color_hex( $colors['border'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	background-color: var(--milestone-bg-color);
+	border: 1px solid var(--milestone-border-color);
 	border-top: 0;
-	color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	color: var(--milestone-text-color);
 	padding-bottom: 1em;
 }
 .milestone-message {

--- a/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
@@ -52,6 +52,10 @@ class Milestone_Widget extends WP_Widget {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
 		add_action( 'wp_footer', array( $this, 'localize_script' ) );
+
+		if ( is_active_widget( false, false, $this->id_base, true ) || is_active_widget( false, false, 'monster', true ) || is_customize_preview() ) {
+			add_action( 'wp_head', array( __class__, 'styles_template' ) );
+		}
 	}
 
 	/**
@@ -93,6 +97,66 @@ class Milestone_Widget extends WP_Widget {
 			'20201113',
 			true
 		);
+	}
+
+	/**
+	 * Output the frontend styling.
+	 */
+	public static function styles_template() {
+		global $themecolors;
+		$colors = wp_parse_args(
+			$themecolors,
+			array(
+				'bg'     => 'ffffff',
+				'border' => 'cccccc',
+				'text'   => '333333',
+			)
+		);
+		?>
+<style>
+.milestone-widget {
+	margin-bottom: 1em;
+}
+.milestone-content {
+	line-height: 2;
+	margin-top: 5px;
+	max-width: 100%;
+	padding: 0;
+	text-align: center;
+}
+.milestone-header {
+	background-color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	line-height: 1.3;
+	margin: 0;
+	padding: .8em;
+}
+.milestone-header .event,
+.milestone-header .date {
+	display: block;
+}
+.milestone-header .event {
+	font-size: 120%;
+}
+.milestone-countdown .difference {
+	display: block;
+	font-size: 500%;
+	font-weight: bold;
+	line-height: 1.2;
+}
+.milestone-countdown,
+.milestone-message {
+	background-color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	border: 1px solid <?php echo self::sanitize_color_hex( $colors['border'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	border-top: 0;
+	color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+	padding-bottom: 1em;
+}
+.milestone-message {
+	padding-top: 1em
+}
+</style>
+		<?php
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
@@ -115,7 +115,6 @@ class Milestone_Widget extends WP_Widget {
 		?>
 <style>
 .milestone-widget {
-	margin-bottom: 1em;
 	--milestone-text-color: <?php echo self::sanitize_color_hex( $colors['text'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	--milestone-bg-color: <?php echo self::sanitize_color_hex( $colors['bg'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	--milestone-border-color:<?php echo self::sanitize_color_hex( $colors['border'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;

--- a/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
@@ -49,7 +49,6 @@ class Milestone_Widget extends WP_Widget {
 		);
 
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
 		add_action( 'wp_footer', array( $this, 'localize_script' ) );
 
@@ -205,6 +204,8 @@ class Milestone_Widget extends WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		$instance = wp_parse_args( $instance, $this->defaults() );
+
+		$this->enqueue_scripts();
 
 		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/projects/plugins/jetpack/modules/widgets/milestone/milestone-widget.css
+++ b/projects/plugins/jetpack/modules/widgets/milestone/milestone-widget.css
@@ -9,8 +9,8 @@
 	text-align: center;
 }
 .milestone-header {
-	background-color: #333;
-	color: #fff;
+	background-color: var(--milestone-text-color, #111);
+	color: var(--milestone-bg-color, #fff);
 	line-height: 1.3;
 	margin: 0;
 	padding: .8em;
@@ -30,10 +30,10 @@
 }
 .milestone-countdown,
 .milestone-message {
-	background-color: #fff;
-	border: 1px solid #767676;
+	background-color: var(--milestone-bg-color, #fff);
+	border: 1px solid var(--milestone-border-color, #767676);
 	border-top: 0;
-	color: #111;
+	color: var(--milestone-text-color, #111);
 	padding-bottom: 1em;
 }
 .milestone-message {

--- a/projects/plugins/jetpack/modules/widgets/milestone/milestone-widget.css
+++ b/projects/plugins/jetpack/modules/widgets/milestone/milestone-widget.css
@@ -1,0 +1,41 @@
+.milestone-widget {
+	margin-bottom: 1em;
+}
+.milestone-content {
+	line-height: 2;
+	margin-top: 5px;
+	max-width: 100%;
+	padding: 0;
+	text-align: center;
+}
+.milestone-header {
+	background-color: #333;
+	color: #fff;
+	line-height: 1.3;
+	margin: 0;
+	padding: .8em;
+}
+.milestone-header .event,
+.milestone-header .date {
+	display: block;
+}
+.milestone-header .event {
+	font-size: 120%;
+}
+.milestone-countdown .difference {
+	display: block;
+	font-size: 500%;
+	font-weight: bold;
+	line-height: 1.2;
+}
+.milestone-countdown,
+.milestone-message {
+	background-color: #fff;
+	border: 1px solid #767676;
+	border-top: 0;
+	color: #111;
+	padding-bottom: 1em;
+}
+.milestone-message {
+	padding-top: 1em;
+}

--- a/projects/plugins/jetpack/tools/builder/frontend-css.js
+++ b/projects/plugins/jetpack/tools/builder/frontend-css.js
@@ -52,6 +52,7 @@ export const frontendCSSSeparateFilesList = [
 	'modules/widgets/search/css/search-widget-frontend.css',
 	'modules/widgets/simple-payments/style.css',
 	'modules/widgets/social-icons/social-icons.css',
+	'modules/widgets/milestone/milestone-widget.css',
 ];
 
 /**


### PR DESCRIPTION
This PR fixes an issue where the styles don't load in the Customizer (widget preview in the sidebar) until the changes are saved.

  Before  |  After
:-------------------------:|:-------------------------:
![Markup on 2021-11-30 at 13:22:08](https://user-images.githubusercontent.com/25105483/144046766-d6402ebe-f9f0-4872-89d5-f7a997ff7189.png) | ![Markup on 2021-11-30 at 13:23:11](https://user-images.githubusercontent.com/25105483/144046803-1fd40d13-77b2-4e9c-8530-147bc52b0839.png)

#### Changes proposed in this Pull Request:

The legacy widgets (like Milestone) are previewed in the Customizer with the help of an `iframe`. This iframe doesn't have access to styles set in a way that some of the legacy widgets use. Therefore, the widget preview is missing styles until we save the widget settings and reload Customizer (when the styles are loaded in the iframe as well).

The proposed change enqueues default CSS styles for the Milestone widget. These new styles come from a newly-created file `milestone-widget.css`. The preview iframe has access to these styles even before the widget is saved.

The new default CSS styles rely on CSS variables with fallback. This means that the Milestone widget will load the default styles until the CSS variables become available (when the user saves the changes in Customizer and reloads the page / comes back to the Customizer later).

Here is an example to better illustrate:

##### How the proposed changes work (an example with the `Button 2` theme)
1. When we add the Milestone block to a site, the default styles (defined in `milestone-widget.css`) are loaded first. These styles include a couple of default fallback colors and are used for the block preview in the left sidebar of the Customizer.

![before-saved](https://user-images.githubusercontent.com/25105483/144402727-f7890ad0-bed3-4b65-879f-b4e210c55574.jpg)

2. As soon as we save the changes and reload the Customizer, the colors defined in the widget itself become available and are used instead.

![after-saved](https://user-images.githubusercontent.com/25105483/144402731-1620b102-9d5b-479d-8b4a-5270b6bdcf2a.jpg)

Please note that:
- not all themes have custom colors set
- WPCOM has an extra layer of color overrides and Customizer can also have an additional color settings set.

Examples of how the colors can be overridden on multiple levels:

  Example 1  |  Example 2  |  Example 3
:-------------------------:|:-------------------------:|:-------------------------:
![fix-in-action](https://user-images.githubusercontent.com/25105483/144397822-9125bd3b-89cc-4f1c-bcc8-8ed71e6520e6.png) | ![Markup on 2021-12-02 at 09:55:58](https://user-images.githubusercontent.com/25105483/144397828-bfa54ffc-4939-4630-a4dd-245d8ac2cb43.png) | ![Markup on 2021-12-02 at 10:02:38](https://user-images.githubusercontent.com/25105483/144397835-b1842776-4aa9-4c79-965e-3aacce226cee.png)

As a result, the behavior of each theme may be slightly different (plus there's a difference between WPCOM site and a Jetpack site that is running the same theme). But in all cases, at least the default styles should be loaded (as can be seen in the "After" screenshot above).

The proposed changes also fix the view on the widgets page (`wp-admin/widgets.php`).

---

#### Jetpack product discussion
This PR is part of the Legacy Widgets Migration/Fix project (pdf5j4-4C-p2).

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:

General steps:
1. Pick a theme you like (you can test multiple)
2. Navigate to Customizer → Widgets
3. Add the Milestone widget
4. Adjust the widget settings if you like
5. Click away from the widget without saving the changes
6. The widget preview should load properly with default colors
7. Save the changes and reload the page; custom theme colors (if available) should be applied

Before the Milestone widget is added to the site, there should be no Milestone-related CSS enqueued. We can check for this in the browser inspector searching for `milestone-widget.css` or `milestone-widget-css` references. Only after the widget is added to the site, the styles should load in a form similar to the following:

```html
<link rel="stylesheet" id="milestone-widget-css" href="http://localhost/wp-content/plugins/jetpack/modules/widgets/milestone/milestone-widget.css?ver=10.5-a.0" media="all">
```

or

```html
<link rel="stylesheet" id="milestone-widget-css" href="https://randomsite.random/wp-content/mu-plugins/widgets/milestone/milestone-widget.css?m=1638543000h&amp;ver=wpcom" media="all">
```

When testing on the WPCOM sandbox, it is necessary to sandbox the following:
- the site itself
- `public-api.wordpress.com`
- `s0.wp.com`
- `s1.wp.com`
- `s2.wp.com`