### PR TITLE
Beta: Handle exception when no Internet connection

### DIFF
--- a/projects/plugins/beta/changelog/update-beta-soft-fail-on-no-internet
+++ b/projects/plugins/beta/changelog/update-beta-soft-fail-on-no-internet
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Improved exception handling when network access to a8c servers is impaired.

--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -49,7 +49,7 @@
 	"prefer-stable": true,
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_0_4_alpha"
+		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_1_0_alpha"
 	},
 	"extra": {
 		"autotagger": true,

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 3.0.4-alpha
+ * Version: 3.1.0-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'JPBETA__PLUGIN_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
-define( 'JPBETA_VERSION', '3.0.4-alpha' );
+define( 'JPBETA_VERSION', '3.1.0-alpha' );
 
 define( 'JETPACK_BETA_PLUGINS_URL', 'https://betadownload.jetpack.me/plugins.json' );
 

--- a/projects/plugins/beta/src/class-clicommand.php
+++ b/projects/plugins/beta/src/class-clicommand.php
@@ -65,7 +65,11 @@ class CliCommand extends WP_CLI_Command {
 		$this->validation_checks();
 
 		if ( ! $args ) {
-			$plugins = Plugin::get_all_plugins( true );
+			try {
+				$plugins = Plugin::get_all_plugins( true );
+			} catch ( PluginDataException $ex ) {
+				WP_CLI::error( $ex->getMessage() );
+			}
 			if ( ! $plugins ) {
 				WP_CLI::error( __( 'No plugins are available', 'jetpack-beta' ) );
 			}

--- a/projects/plugins/beta/src/class-hooks.php
+++ b/projects/plugins/beta/src/class-hooks.php
@@ -349,7 +349,19 @@ class Hooks {
 
 		// Add child items for each active plugin.
 		$any_dev = false;
-		foreach ( Plugin::get_all_plugins() as $slug => $plugin ) {
+		try {
+			$plugins = Plugin::get_all_plugins();
+		} catch ( PluginDataException $ex ) {
+			$plugins = array();
+			// Add a child item to our parent item.
+			$args = array(
+				'id'     => 'jetpack-beta_version_error',
+				'title'  => $ex->getMessage(),
+				'parent' => 'jetpack-beta_admin_bar',
+			);
+			$wp_admin_bar->add_node( $args );
+		}
+		foreach ( $plugins as $slug => $plugin ) {
 			if ( is_plugin_active( $plugin->plugin_file() ) ) {
 				$is_dev   = false;
 				$version  = $plugin->stable_pretty_version();

--- a/projects/plugins/beta/src/class-plugin.php
+++ b/projects/plugins/beta/src/class-plugin.php
@@ -170,13 +170,16 @@ class Plugin {
 	 * Get a map of plugin files.
 	 *
 	 * @return string[] Map from dev to non-dev plugin files, and vice versa.
-	 * @throws PluginDataException If the plugin data cannot be fetched or is invalid.
 	 */
 	public static function get_plugin_file_map() {
 		if ( null === self::$file_map ) {
 			self::$file_map = get_option( 'jetpack_beta_plugin_file_map', null );
 			if ( null === self::$file_map ) {
-				self::get_all_plugins();
+				try {
+					self::get_all_plugins();
+				} catch ( PluginDataException $ex ) {
+					return array();
+				}
 			}
 		}
 		return self::$file_map;

--- a/projects/plugins/beta/src/class-plugin.php
+++ b/projects/plugins/beta/src/class-plugin.php
@@ -110,13 +110,14 @@ class Plugin {
 	/**
 	 * Get instances for all known plugins.
 	 *
-	 * @param bool $no_cache Set true to bypass the transients cache.
+	 * @param bool $bypass_cache Set true to bypass the transients cache.
+	 *
 	 * @return Plugin[]
 	 * @throws PluginDataException If the plugin data cannot be fetched or is invalid.
 	 */
-	public static function get_all_plugins( $no_cache = false ) {
+	public static function get_all_plugins( $bypass_cache = false ) {
 		if ( null === self::$instances ) {
-			$data = Utils::get_remote_data( JETPACK_BETA_PLUGINS_URL, 'plugins_json', $no_cache );
+			$data = Utils::get_remote_data( JETPACK_BETA_PLUGINS_URL, 'plugins_json', $bypass_cache );
 			if ( ! is_object( $data ) ) {
 				throw new PluginDataException( __( 'Failed to download list of plugins. Check your Internet connection.', 'jetpack-beta' ) );
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

There are some other instances where uncaught exceptions might exist, but focusing on what caught us today.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Catch exception thrown when there is no network connection for rendering the admin bar or the CLI list command.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1638297422231800-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a test site, install the "Airplane Mode" plugin by Norcross in the w.org repo (makes it easy to test no connection to our servers).
* Install a transient plugin, such as the Transient Manager by Pippin.
* Install the Beta plugin.
* Activate Airplane Mode so the site won't connect to our servers.
* Suspend or clear all transients, at least our `jetpack_beta_plugins_json` transient.
* Reload /wp-admin

Before this PR, it would fatal with an uncaught exception. After, wp-admin renders. The Jetpack Beta menu in the admin bar appears with the nice message from the now-caught exception.
![2021-11-30 at 2 08 PM](https://user-images.githubusercontent.com/88897/144120437-7e0b2034-6fc0-4c92-911c-7230e468bc96.png)

* For CLI, similar to the above except the Airplane Mode won't work. I was using this locally so I just killed my wifi long enough to test via `jetpack docker wp jetpack-beta list` after ensuring the transient was not present.
![2021-11-30 at 2 10 PM](https://user-images.githubusercontent.com/88897/144120529-15fd5d7d-a66e-4367-a638-ee6036837d95.png)





