### PR TITLE
Hide licenses activation route when user account not linked.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -27,6 +27,7 @@ import {
 	getSiteConnectionStatus,
 	isCurrentUserLinked,
 	isSiteConnected,
+	isConnectionOwner,
 	isConnectingUser,
 	resetConnectUser,
 	isReconnectingSite,
@@ -467,16 +468,21 @@ class Main extends React.Component {
 				);
 				break;
 			case '/license/activation':
-				navComponent = null;
-				pageComponent = (
-					<ActivationScreen
-						assetBaseUrl={ this.props.pluginBaseUrl }
-						lockImage="/images/jetpack-license-activation-with-lock.png"
-						siteRawUrl={ this.props.siteRawUrl }
-						successImage="/images/jetpack-license-activation-with-success.png"
-						onActivationSuccess={ this.onLicenseActivationSuccess }
-					/>
-				);
+				if ( this.props.isLinked && this.props.isConnectionOwner ) {
+					navComponent = null;
+					pageComponent = (
+						<ActivationScreen
+							assetBaseUrl={ this.props.pluginBaseUrl }
+							lockImage="/images/jetpack-license-activation-with-lock.png"
+							siteRawUrl={ this.props.siteRawUrl }
+							successImage="/images/jetpack-license-activation-with-success.png"
+							onActivationSuccess={ this.onLicenseActivationSuccess }
+						/>
+					);
+				} else {
+					this.props.history.replace( '/dashboard' );
+					pageComponent = this.getAtAGlance();
+				}
 				break;
 			case '/recommendations':
 			case '/recommendations/site-type':
@@ -712,6 +718,7 @@ export default connect(
 			isLinked: isCurrentUserLinked( state ),
 			isConnectingUser: isConnectingUser( state ),
 			hasConnectedOwner: hasConnectedOwner( state ),
+			isConnectionOwner: isConnectionOwner( state ),
 			siteRawUrl: getSiteRawUrl( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
 			searchTerm: getSearchTerm( state ),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -1486,7 +1486,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return true;
 		}
 
-		return new WP_Error( 'invalid_permission_manage_user_licenses', self::$user_permissions_error_msg, array( 'status' => rest_authorization_required_code() ) );
+		return new WP_Error( 'invalid_permission_manage_user_licenses', REST_Connector::get_user_permissions_error_msg(), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-no-connection-hide-licensing
+++ b/projects/plugins/jetpack/changelog/fix-no-connection-hide-licensing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Hide license activation route if user not linked and connection owner.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
This PR disables the `/license/activation` route (`/wp-admin/admin.php?page=jetpack#/license/activation`) when the site is not 'user' connected or if the connected user is not the connection owner.

The licensing activation flow requires a user-level connection to work properly.

Asana task: 1201096622142517-as-1201400491645534/f

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Only show the `/license/activation` route if `isLinked` and if `isConnectionOwner`.
* Fixed small bug where a 403 response from API route `jetpack/v4/licensing/attach-licenses` was returning `null` as the error message.  Not a 403 response returns the generic user permission error message, "You do not have the correct user permissions to perform this action. Please contact your site admin if you think this is a mistake."

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-cSg-p2
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Make sure you have an available license key

Ideally you should have one or more available license key(s) associated with your wordpress.com account. If you already have an available license key, skip down to the **Test this PR** section.
If you do not have a license key available for activation, follow these instructions first:

1. Enable the A8c Proxy.
1. Go to https://cloud.jetpack.com/pricing.
1. Select Jetpack Backup or Security or scan.
1. On the "Thank you for purchase!" page, in the dropdown, select "I don't see my site, let me configure it manually."
1. Click continue, and click continue again, until you see your license key.

#### Test this PR
1. Either spin up your local Jetpack environment using this branch, or spin up a JN site using Jetpack Beta plugin set to this branch.
1. Connect Jetpack with 'site-only' connection. (do not connect/link your wordpress.com user account).
1. On your site, visit `/wp-admin/admin.php?page=jetpack#/license/activation`.
1. Verify you are immediately redirected back to the Jetpack Dashboard (At a glance) page. The license activation UI should be disabled.
1. Now 'user-connect' Jetpack to your wordpress.com account.
1. Go to the Jetpack Dashboard page.
1. Verify you can see the "**You have an inactive product license key. Activate now or view all your purchases.**" notice at the top of the page.
1. Visit `/wp-admin/admin.php?page=jetpack#/license/activation`. Or click the `Activate now` link in the notice.
1. Verify you can now see the licenses activation UI.