### PR TITLE
VideoPress: fix empty video block copy/paste 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-gutenberg-block-copy-paste
+++ b/projects/plugins/jetpack/changelog/fix-videopress-gutenberg-block-copy-paste
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: fix copy/paste of empty video blocks not containing the proper attribute set.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -100,7 +100,7 @@ const addVideoPressSupport = ( settings, name ) => {
 		return settings;
 	}
 
-	const { attributes, deprecated, edit, save, supports, transforms } = settings;
+	const { deprecated, edit, save, supports, transforms } = settings;
 	const { available, unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
 
 	// Check if VideoPress is unavailable and filter the mediaplaceholder to limit options
@@ -129,74 +129,76 @@ const addVideoPressSupport = ( settings, name ) => {
 		available ||
 		[ 'missing_plan', 'missing_module', 'unknown' ].includes( unavailableReason )
 	) {
+		const attributesDefinition = {
+			autoplay: {
+				type: 'boolean',
+			},
+			caption: {
+				type: 'string',
+				source: 'html',
+				selector: 'figcaption',
+			},
+			controls: {
+				type: 'boolean',
+				default: true,
+			},
+			maxWidth: {
+				type: 'string',
+				default: '100%',
+			},
+			guid: {
+				type: 'string',
+			},
+			id: {
+				type: 'number',
+			},
+			loop: {
+				type: 'boolean',
+			},
+			muted: {
+				type: 'boolean',
+			},
+			playsinline: {
+				type: 'boolean',
+			},
+			poster: {
+				type: 'string',
+			},
+			preload: {
+				type: 'string',
+				default: 'metadata',
+			},
+			seekbarPlayedColor: {
+				type: 'string',
+				default: '',
+			},
+			seekbarLoadingColor: {
+				type: 'string',
+				default: '',
+			},
+			seekbarColor: {
+				type: 'string',
+				default: '',
+			},
+			src: {
+				type: 'string',
+			},
+			videoPressTracks: {
+				type: 'array',
+				items: {
+					type: 'object',
+				},
+				default: [],
+			},
+			videoPressClassNames: {
+				type: 'string',
+			},
+		};
+
 		return {
 			...settings,
 
-			attributes: {
-				autoplay: {
-					type: 'boolean',
-				},
-				caption: {
-					type: 'string',
-					source: 'html',
-					selector: 'figcaption',
-				},
-				controls: {
-					type: 'boolean',
-					default: true,
-				},
-				maxWidth: {
-					type: 'string',
-					default: '100%',
-				},
-				guid: {
-					type: 'string',
-				},
-				id: {
-					type: 'number',
-				},
-				loop: {
-					type: 'boolean',
-				},
-				muted: {
-					type: 'boolean',
-				},
-				playsinline: {
-					type: 'boolean',
-				},
-				poster: {
-					type: 'string',
-				},
-				preload: {
-					type: 'string',
-					default: 'metadata',
-				},
-				seekbarPlayedColor: {
-					type: 'string',
-					default: '',
-				},
-				seekbarLoadingColor: {
-					type: 'string',
-					default: '',
-				},
-				seekbarColor: {
-					type: 'string',
-					default: '',
-				},
-				src: {
-					type: 'string',
-				},
-				videoPressTracks: {
-					type: 'array',
-					items: {
-						type: 'object',
-					},
-					default: [],
-				},
-				videoPressClassNames: {
-					type: 'string',
-				},
-			},
+			attributes: attributesDefinition,
 
 			transforms: {
 				...transforms,
@@ -241,7 +243,7 @@ const addVideoPressSupport = ( settings, name ) => {
 				...( deprecated || [] ),
 				deprecatedV3,
 				{
-					attributes,
+					attributes: attributesDefinition,
 					isEligible: attrs => ! attrs.guid,
 					save,
 					supports,


### PR DESCRIPTION
Fixes Automattic/greenhouse#1035

#### Changes proposed in this Pull Request:

When pasting an empty video block, some attributes are not set by default.
This PR fixes a defective migration not using the right attribute set.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* On a sandboxed Jetpack site with VideoPress enabled
* Create or edit an existing post
* Add a /video block
* Notice "playback controls" being enabled on the right hand side of the screen
![Capture d’écran 2021-12-01 à 15 20 13](https://user-images.githubusercontent.com/1420594/144250904-2644ef1e-78cc-4121-b0bf-1539f497da37.png)
* Copy the block by clicking on it and CMD+C
* Paste the block
* ✅ The block should be created, empty and should also have the same attribute set selected
* You can also play around with different settings to make sure things are saved properly
 