### PR TITLE
pre-commit: Run `eslint --fix` like we do `phpcbf`

### DIFF
--- a/tools/js-tools/git-hooks/pre-commit-hook.js
+++ b/tools/js-tools/git-hooks/pre-commit-hook.js
@@ -48,7 +48,8 @@ function loadEslintExcludeList() {
 function parseGitDiffToPathArray( command ) {
 	return execSync( command, { encoding: 'utf8' } )
 		.split( '\n' )
-		.map( name => name.trim() );
+		.map( name => name.trim() )
+		.filter( file => file !== '' );
 }
 
 /**
@@ -155,6 +156,21 @@ function capturePreCommitTreeHash() {
 }
 
 /**
+ * Run `prettier` over a list of files.
+ *
+ * @param {Array} toPrettify - List of files to prettify.
+ */
+function runPrettier( toPrettify ) {
+	if ( toPrettify.length > 0 ) {
+		execSync(
+			`pnpx prettier --config .prettierrc.js --ignore-path .eslintignore --write ${ toPrettify.join(
+				' '
+			) }`
+		);
+	}
+}
+
+/**
  * Spawns a eslint process against list of files
  *
  * @param {Array} toLintFiles - List of files to lint
@@ -187,6 +203,34 @@ function runEslint( toLintFiles ) {
 		// If we get here, required files have failed eslint. Let's return early and avoid the duplicate information.
 		checkFailed();
 		exit( exitCode );
+	}
+}
+
+/**
+ * Runs `eslint --fix` against checked JS files.
+ *
+ * @param {Array} toFixFiles - List of files to fix.
+ */
+function runEslintFix( toFixFiles ) {
+	if ( toFixFiles.length === 0 ) {
+		return;
+	}
+
+	spawnSync( 'pnpm', [ 'run', 'lint-file', '--', '--fix', ...toFixFiles ], {
+		shell: true,
+		stdio: 'inherit',
+	} );
+
+	// Unlike phpcbf, eslint seems to give no indication as to whether it did anything.
+	// It doesn't even print a summary of what it fixed. Sigh.
+	const newDirty = parseGitDiffToPathArray(
+		'git -c core.quotepath=off diff --name-only --diff-filter=ACMR'
+	).filter( file => checkFileAgainstDirtyList( file, dirtyFiles ) );
+	if ( newDirty.length > 0 ) {
+		// Re-prettify, just in case eslint unprettified.
+		runPrettier( newDirty );
+		spawnSync( 'git', [ 'add', '-v', '--', ...newDirty ], { shell: true, stdio: 'inherit' } );
+		console.log( chalk.yellow( 'JS issues detected and automatically fixed via eslint.' ) );
 	}
 }
 
@@ -392,22 +436,21 @@ dirtyFiles.forEach( file =>
 
 // Start JS work—linting, prettify, etc.
 
+const jsOnlyFiles = jsFiles.filter( file => ! file.endsWith( '.json' ) );
+const eslintFiles = jsOnlyFiles.filter( filterEslintFiles );
+const eslintFixFiles = eslintFiles.filter( file => checkFileAgainstDirtyList( file, dirtyFiles ) );
+
 const toPrettify = jsFiles.filter( file => checkFileAgainstDirtyList( file, dirtyFiles ) );
 toPrettify.forEach( file => console.log( `Prettier formatting staged file: ${ file }` ) );
 
 if ( toPrettify.length ) {
-	execSync(
-		`pnpx prettier --config .prettierrc.js --ignore-path .eslintignore --write ${ toPrettify.join(
-			' '
-		) }`
-	);
+	runPrettier( toPrettify );
 	execSync( `git add ${ toPrettify.join( ' ' ) }` );
 }
 
 // linting should happen after formatting
-const jsOnlyFiles = jsFiles.filter( file => ! file.endsWith( '.json' ) );
-const eslintFiles = jsOnlyFiles.filter( filterEslintFiles );
 if ( eslintFiles.length > 0 ) {
+	runEslintFix( eslintFixFiles );
 	runEslint( eslintFiles );
 }
 if ( jsOnlyFiles.length > 0 ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Said someone in Slack:

> Whenever I commit:
> ESLint: we fixed a few hundred formatting issues, refactored everything, and fixed a couple of bugs.
> Also ESLint: `Invalid JSDoc @param type "function"; prefer: "Function"`

The first bit was actually prettier, not eslint. But it should also be
eslint, so let's make that happen.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1638369236025800-slack-G78B6FYE7

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try adding some fixable eslint things to non-excluded files, then try committing them.