### PR TITLE
VideoPress: keep blockSettings in the DOM tree while refreshing preview

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-settings-collapse
+++ b/projects/plugins/jetpack/changelog/fix-videopress-settings-collapse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: keep expanded/collapsed state of settings panel when reloading video preview.


### PR DESCRIPTION
Fixes Automattic/greenhouse#1036

#### Changes proposed in this Pull Request:

VideoPress block InspectorControls were not keeping their collapsed/expanded state when a video preview was reloaded.
This PR tries to keep the InspectorControls in the tree by avoiding render branching once we have a valid preview.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* On a sandboxed Jetpack site with VideoPress enabled
* Create or edit an existing post
* Add a /video block
* Upload a video or select an existing one (uploaded on VideoPress) from your Media Library
* Open the "Progress colors" panel
* Change a setting requiring a video reload (Playback controls, PG rating, etc...)
* ✅ The preview should be reloaded and the "Progress colors" panel should stay opened.
* Change PG rating to "R"
* ✅ The preview should be reloaded, the "Progress colors" panel should stay opened and an age gate should appear.
* Change PR rating to "G" or "PG-13"
* ✅ The previe should be reloaded, the "Progress colors" panel should stay opened and the age gate should disappear.
