### PR TITLE
Legacy widgets: Fix the `hide_widget_in_block_editor()` comment block to follow the DocBlock standards

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-legacy-widgets-deprecation-comments
+++ b/projects/plugins/jetpack/changelog/fix-legacy-widgets-deprecation-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix the comment block on the `hide_widget_in_block_editor()` to follow the DocBlock standards

--- a/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/class-jetpack-instagram-widget.php
@@ -78,10 +78,10 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Remove Instagram widget from Legacy Widget block.
+	 * Remove the "Instagram" widget from the Legacy Widget block
 	 *
-	 * @param array $widget_types Widget type data.
-	 * This only applies to new blocks being added.
+	 * @param array $widget_types List of widgets that are currently removed from the Legacy Widget block.
+	 * @return array $widget_types New list of widgets that will be removed.
 	 */
 	public function hide_widget_in_block_editor( $widget_types ) {
 		$widget_types[] = self::ID_BASE;

--- a/projects/plugins/jetpack/modules/widgets/contact-info.php
+++ b/projects/plugins/jetpack/modules/widgets/contact-info.php
@@ -52,10 +52,10 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		}
 
 		/**
-		 * Remove "Contact info and Map" widget from Legacy Widget block.
+		 * Remove the "Contact info and Map" widget from the Legacy Widget block
 		 *
-		 * @param array $widget_types Widget type data.
-		 * This only applies to new blocks being added.
+		 * @param array $widget_types List of widgets that are currently removed from the Legacy Widget block.
+		 * @return array $widget_types New list of widgets that will be removed.
 		 */
 		public function hide_widget_in_block_editor( $widget_types ) {
 			$widget_types[] = 'widget_contact_info';

--- a/projects/plugins/jetpack/modules/widgets/social-icons.php
+++ b/projects/plugins/jetpack/modules/widgets/social-icons.php
@@ -61,10 +61,10 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	}
 
 	/**
-	 * Remove Social Icons widget from Legacy Widget block.
+	 * Remove the "Social Icons" widget from the Legacy Widget block
 	 *
-	 * @param array $widget_types Widget type data.
-	 * This only applies to new blocks being added.
+	 * @param array $widget_types List of widgets that are currently removed from the Legacy Widget block.
+	 * @return array $widget_types New list of widgets that will be removed.
 	 */
 	public function hide_widget_in_block_editor( $widget_types ) {
 		$widget_types[] = self::ID_BASE;

--- a/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
+++ b/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
@@ -45,10 +45,10 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Remove "Twitter Timeline" widget from Legacy Widget block.
+	 * Remove the "Twitter Timeline" widget from the Legacy Widget block
 	 *
-	 * @param array $widget_types Widget type data.
-	 * This only applies to new blocks being added.
+	 * @param array $widget_types List of widgets that are currently removed from the Legacy Widget block.
+	 * @return array $widget_types New list of widgets that will be removed.
 	 */
 	public function hide_widget_in_block_editor( $widget_types ) {
 		$widget_types[] = 'twitter_timeline';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The proposed changes fix the comment blocks related to the `hide_widget_in_block_editor()` function that is used in multiple widget files. The goal is to follow the [DocBlock standards](https://docs.phpdoc.org/guide/guides/docblocks.html).

There are no functional/code changes.

#### Jetpack product discussion

This PR is part of the Legacy Widgets Migration project (pdf5j4-4C-p2).

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
Since there are no functional/code changes, we can review the proposed comments blocks.

