### PR TITLE
Add i18n-loader-webpack-plugin project

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
 			"matchPackageNames": [
 				"@automattic/eslint-changed",
 				"@automattic/eslint-config-target-es",
+				"@automattic/i18n-loader-webpack-plugin",
 				"@automattic/jetpack-analytics",
 				"@automattic/jetpack-api",
 				"@automattic/jetpack-base-styles",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,25 @@ importers:
       eslint-plugin-es: 4.1.0_eslint@7.32.0
       jest: 27.3.1
 
+  projects/js-packages/i18n-loader-webpack-plugin:
+    specifiers:
+      '@wordpress/dependency-extraction-webpack-plugin': 3.2.1
+      '@wordpress/i18n': 4.2.4
+      debug: ^4.3.2
+      jest: 27.3.1
+      md5-es: ^1.8.2
+      schema-utils: ^3.1.1
+      webpack: 5.64.1
+    dependencies:
+      debug: 4.3.2
+      md5-es: 1.8.2
+      schema-utils: 3.1.1
+    devDependencies:
+      '@wordpress/dependency-extraction-webpack-plugin': 3.2.1_webpack@5.64.1
+      '@wordpress/i18n': 4.2.4
+      jest: 27.3.1
+      webpack: 5.64.1
+
   projects/js-packages/idc:
     specifiers:
       '@automattic/jetpack-analytics': workspace:^0.1.3
@@ -16238,6 +16257,10 @@ packages:
       micromatch: 3.1.10
       resolve: 1.20.0
       stack-trace: 0.0.10
+
+  /md5-es/1.8.2:
+    resolution: {integrity: sha512-LKq5jmKMhJYhsBFUh2w+J3C4bMiC5uQie/UYJ429UATmMnFr6iANO2uQq5HXAZSIupGp0WO2mH3sNfxR4XO40Q==}
+    dev: false
 
   /md5.js/1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}

--- a/projects/js-packages/i18n-loader-webpack-plugin/.gitattributes
+++ b/projects/js-packages/i18n-loader-webpack-plugin/.gitattributes
@@ -1,0 +1,4 @@
+# Files to exclude from the mirror repo
+.gitattributes    production-exclude
+/changelog/**     production-exclude
+/tests/**         production-exclude

--- a/projects/js-packages/i18n-loader-webpack-plugin/.gitignore
+++ b/projects/js-packages/i18n-loader-webpack-plugin/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+node_modules/
+tests/fixtures/*/dist/

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/js-packages/i18n-loader-webpack-plugin/README.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/README.md
@@ -1,0 +1,109 @@
+# i18n-loader-webpack-plugin
+
+A Webpack plugin to load WordPress translation data for [@wordpress/i18n] when Webpack lazy-loads a bundle.
+
+## Installation
+
+Generally you'll install this via your package manager, e.g.
+
+```
+npm install --save-dev @automattic/i18n-loader-webpack-plugin
+```
+
+## Usage
+
+### Basic usage
+
+This goes in the `plugins` section of your Webpack config, e.g.
+```js
+{
+	plugins: [
+		new I18nLoaderWebpackPlugin( {
+			textdomain: 'mydomain',
+		} ),
+	],
+};
+```
+
+Parameters recognized by the plugin are:
+
+- `textdomain`: The text domain used in the JavaScript code. This is required, unless nothing in your JS actually uses [@wordpress/i18n].
+- `stateModule`: The name of a module supplying the i18n state. See [State module](#state-module) below for details.
+- `target`: The target of the build: 'plugin' (the default), 'theme', or 'core'. This is used to determine where in WordPress's languages directory to look for the translation files.
+- `path`: See [Webpack context](#webpack-context) and [Use in Composer packages](#use-in-composer-packages) below for details.
+- `ignoreModules`: If some bundles in your build depend on [@wordpress/i18n] for purposes other than translating strings, i18n-loader-webpack-plugin will none the less count them as "using @wordpress/i18n" which may result in it trying to load translations for bundles that do not need it. This option may be used to ignore the relevant source files when examining the bundles.
+
+  The value may be a function, which will be passed the file path relative to [Webpack's context] and the Webpack Module object and which should return true if the file should be ignored, or a string or RegExp to be compared with the relative file path, or an array of such strings, RegExps, and/or functions.
+
+### Use of [@wordpress/i18n]
+
+For best results, each JavaScript file translating strings should import @wordpress/i18n directly to access `__()` and similar methods.
+The use of @wordpress/i18n in the lazy bundle may not be detected if `__()` is imported indirectly or used by accessing the global `wp.i18n`.
+
+Of course, you don't actually want @wordpress/i18n included in the bundle. The recommended way to handle this is to use [@wordpress/dependency-extraction-webpack-plugin] in your Webpack configuration.
+But if for some reason you want to do it manually, something like this in your Webpack config should work:
+```js
+{
+	externals: {
+		'@wordpress/i18n': [ 'window wp', 'i18n' ],
+	}
+}
+```
+
+### State module
+
+In order to load the translations, the generated bundle needs to be provided with some state at runtime. This is handled by loading a module that must be externalized by your Webpack configuration.
+
+The default module name is `@wordpress/jp-i18n-state`, which will automatically be externalized by [@wordpress/dependency-extraction-webpack-plugin], which will also register it as a dependency for "wp-jp-i18n-state" in the generated `.asset.php` file. That, in turn, is provided by the [automattic/jetpack-assets] Composer package (which also provides an `Automattic\Jetpack\Assets::register_script()` function to easily consume the `.asset.php` file).
+
+But if for some reason you don't want to use those packages, you can set the plugin's `stateModule` option to point to a different module name, use [Webpack's externals configuration] to externalize it, and appropriate PHP code to provide the corresponding global variable for your externals configuration to retrieve. The state is a JavaScript object with the following properties:
+
+- `baseUrl`: The base URL from which to fetch the translations, probably something like `https://yoursite.example.com/wp-content/languages/`. The trailing slash is required.
+- `locale`: The locale used on the page.
+- `domainMap`: An object mapping textdomains. See [Use in Composer packages](#use-in-composer-packages) below for details.
+
+### Webpack context
+
+WordPress's translation infrastructure generates a file for each JS script named like "_textdomain_-_locale_-_hash_.json". The _hash_ is an MD5 hash of the path of the script file relative to the plugin's root.
+
+I18n-loader-webpack-plugin assumes that [Webpack's context] is the base of the WordPress plugin in which the bundles will be included.
+If this is not the case, you'll need to set the plugin's `path` parameter to the relative path from the plugin's root to Webpack's `output.path`.
+
+### Other useful Webpack configuration
+
+If you're having Webpack minify your bundle, you'll likely also want to do the following:
+
+* Be sure that you're not naming the output files with an extension `.min.js`, as that will cause the WordPress translation infrastructure to ignore them.
+* Set `optimization.concatenateModules` to false, as that optimization can mangle the i18n method names.
+* Configure Terser to not mangle `__`, `_n`, `_nx`, and `_x`.
+* Use [@automattic/babel-plugin-preserve-i18n](https://www.npmjs.com/package/@automattic/babel-plugin-preserve-i18n) to help further preserve those method names.
+* Configure Terser to preserve comments starting with "Translators" or "translators" in the output.
+* Check your code to avoid [certain constructs](https://github.com/Automattic/jetpack/tree/master/projects/js-packages/webpack-config#minification-and-i18n-translator-comments) that will dissociate translator comments from the i18n method calls when the minifier rearranges the code.
+
+### Use in Composer packages
+
+Composer packages are useful for holding shared code, but when it comes to WordPress plugin i18n there are some problems.
+
+WordPress's plugin infrastructure doesn't natively support Composer packages, so the usual thing to do is to include the `vendor/` directory in the push to the WordPress.org SVN.
+That won't work for packages needing translation, though, as WordPress's translation infrastructure ignores the `vendor/` directory when looking for strings to be translated.
+You'll need to use something like [automattic/jetpack-composer-plugin] so that the composer packages with translated strings are installed to a different path.
+
+Then, for Webpack builds in the Composer package, you'll need to set i18n-loader-webpack-plugin's `path` option to the path relative to the _plugin's_ root directory. For example, if your Composer package is named "automattic/foobar", will be used with [automattic/jetpack-composer-plugin] which will install the package to `jetpack_vendor/` rather than `vendor/`, and Webpack is building to a `build/` directory within the package, you'd need to set `path` to `jetpack_vendor/automattic/foobat/build/` as that's where the built files will end up relative to the plugin.
+
+The consuming plugin will also need to arrange for the [state module](#state-module)'s `domainMap` to include a mapping from your Composer package's textdomain to the plugin's textdomain (prefixed with "plugins/"), as that's where the translations will end up.
+<!-- @todo: Mention how to do that with automattic/jetpack-assets once we finish https://github.com/Automattic/jetpack/issues/21690. -->
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+i18n-loader-webpack-plugin is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+
+[@wordpress/i18n]: https://www.npmjs.com/package/@wordpress/i18n
+[@wordpress/dependency-extraction-webpack-plugin]: https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin
+[automattic/jetpack-assets]: https://packagist.org/packages/automattic/jetpack-assets
+[automattic/jetpack-composer-plugin]: https://packagist.org/packages/automattic/jetpack-composer-plugin
+[Webpack's context]: https://webpack.js.org/configuration/entry-context/#context
+[Webpack's externals configuration]: https://webpack.js.org/configuration/externals/

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/add-i18n-loader-webpack-plugin
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/add-i18n-loader-webpack-plugin
@@ -1,0 +1,4 @@
+Significance: major
+Type: added
+
+Initial release.

--- a/projects/js-packages/i18n-loader-webpack-plugin/composer.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/composer.json
@@ -1,0 +1,41 @@
+{
+	"name": "automattic/i18n-loader-webpack-plugin",
+	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"require-dev": {
+		"automattic/jetpack-changelogger": "^3.0"
+	},
+	"scripts": {
+		"test-js": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm install",
+			"pnpm run test"
+		],
+		"test-coverage": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm install",
+			"pnpm run test-coverage"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"npmjs-autopublish": true,
+		"mirror-repo": "Automattic/i18n-loader-webpack-plugin",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v${old}...v${new}"
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "@automattic/i18n-loader-webpack-plugin",
+	"version": "0.1.0-alpha",
+	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
+	"homepage": "https://jetpack.com",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"test": "jest tests",
+		"test-coverage": "jest tests --coverage --collectCoverageFrom='src/**/*.js' --coverageDirectory=\"$COVERAGE_DIR\" --coverageReporters=clover"
+	},
+	"dependencies": {
+		"debug": "^4.3.2",
+		"md5-es": "^1.8.2",
+		"schema-utils": "^3.1.1"
+	},
+	"devDependencies": {
+		"@wordpress/dependency-extraction-webpack-plugin": "3.2.1",
+		"@wordpress/i18n": "4.2.4",
+		"jest": "27.3.1",
+		"webpack": "5.64.1"
+	},
+	"peerDependencies": {
+		"webpack": "^5.29.0"
+	},
+	"engines": {
+		"node": "^14.17.6 || ^16.7.0",
+		"pnpm": "^6.5.0",
+		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	},
+	"exports": {
+		".": "./src/I18nLoaderPlugin.js"
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/src/I18nLoaderModuleDependency.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/src/I18nLoaderModuleDependency.js
@@ -1,0 +1,11 @@
+const webpack = require( 'webpack' );
+
+/**
+ * Dependency class.
+ *
+ * Webpack requires a Dependency subclass to idenitfy modules to build and to locate
+ * the built modules, and doesn't provide a usable generic class of its own.
+ */
+class I18nLoaderModuleDependency extends webpack.dependencies.ModuleDependency {}
+
+module.exports = I18nLoaderModuleDependency;

--- a/projects/js-packages/i18n-loader-webpack-plugin/src/I18nLoaderPlugin.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/src/I18nLoaderPlugin.js
@@ -1,0 +1,341 @@
+const { validate } = require( 'schema-utils' );
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+const { RuntimeGlobals } = webpack;
+
+const PLUGIN_NAME = require( './plugin-name' );
+const debug = require( 'debug' )( PLUGIN_NAME );
+const I18nLoaderModuleDependency = require( './I18nLoaderModuleDependency' );
+const I18nLoaderRuntimeModule = require( './I18nLoaderRuntimeModule' );
+
+const schema = {
+	title: `${ PLUGIN_NAME } plugin options`,
+	type: 'object',
+	additionalProperties: false,
+	definitions: {
+		ModuleFilter: {
+			description: 'Filter for modules to ignore.',
+			anyOf: [
+				{
+					instanceof: 'RegExp',
+					tsType: 'RegExp',
+				},
+				{
+					type: 'string',
+					absolutePath: false,
+				},
+				{
+					instanceof: 'Function',
+					tsType: '((path: string, module: object) => boolean)',
+				},
+			],
+		},
+	},
+	properties: {
+		stateModule: {
+			description: 'Externalized module supplying the i18n state.',
+			type: 'string',
+		},
+		textdomain: {
+			description: 'I18n textdomain to load.',
+			type: 'string',
+		},
+		target: {
+			description: 'Building for use in a plugin (default), a theme, or WordPress core.',
+			enum: [ 'plugin', 'theme', 'core' ],
+		},
+		path: {
+			description: 'Path (relative to the plugin) to locate the output assets.',
+			type: 'string',
+		},
+		ignoreModules: {
+			description: 'Modules to ignore when looking for uses of @wordpress/i18n.',
+			anyOf: [
+				{
+					$ref: '#/definitions/ModuleFilter',
+				},
+				{
+					type: 'array',
+					items: {
+						$ref: '#/definitions/ModuleFilter',
+					},
+				},
+			],
+		},
+	},
+};
+
+/**
+ * Webpack plugin for the i18n loader.
+ *
+ * The plugin hooks into Webpack to manipulate modules and add the
+ * I18nLoaderRuntimeModule as appropriate.
+ */
+class I18nLoaderPlugin {
+	constructor( options = {} ) {
+		validate( schema, options, {
+			name: PLUGIN_NAME,
+			baseDataPath: 'options',
+		} );
+
+		this.options = {
+			target: 'plugin',
+			stateModule: '@wordpress/jp-i18n-state',
+			...options,
+		};
+
+		if ( options.ignoreModules ) {
+			const filters = ( Array.isArray( options.ignoreModules )
+				? options.ignoreModules
+				: [ options.ignoreModules ]
+			).map( filter => {
+				if ( typeof filter === 'string' ) {
+					return request => request === filter;
+				}
+				if ( filter instanceof RegExp ) {
+					return request => filter.test( request );
+				}
+				return filter;
+			} );
+			this.options.ignoreModules = ( module, context ) =>
+				filters.some( f => f( path.relative( context, module.request || '' ), module ) );
+		} else {
+			this.options.ignoreModules = () => false;
+		}
+	}
+
+	apply( compiler ) {
+		// Register the dependency class.
+		compiler.hooks.compilation.tap( PLUGIN_NAME, ( compilation, { normalModuleFactory } ) => {
+			compilation.dependencyFactories.set( I18nLoaderModuleDependency, normalModuleFactory );
+			compilation.dependencyTemplates.set(
+				I18nLoaderModuleDependency,
+				new I18nLoaderModuleDependency.Template()
+			);
+		} );
+
+		// At the "make" hook, inject Dependency objects into the build so we can get the modules we need.
+		const stateModuleDep = new I18nLoaderModuleDependency( this.options.stateModule );
+		stateModuleDep.optional = true;
+		const i18nModuleDep = new I18nLoaderModuleDependency( '@wordpress/i18n' );
+		i18nModuleDep.optional = true;
+		compiler.hooks.make.tapPromise( PLUGIN_NAME, compilation => {
+			return Promise.all( [
+				new Promise( ( resolve, reject ) => {
+					compilation.addModuleChain( compiler.context, stateModuleDep, ( err, module ) => {
+						if ( err ) {
+							return reject( err );
+						}
+						// Webpack bug; Until 5.51.0 it didn't pass the module to the callback.
+						if ( ! module && ! compilation.moduleGraph.getModule( stateModuleDep ) ) {
+							// prettier-ignore
+							let msg = `${ PLUGIN_NAME }:\nFailed to add state module ${ this.options.stateModule } to the build.\n`;
+							if ( this.options.stateModule.startsWith( '@wordpress/' ) ) {
+								msg +=
+									"You'll need to add @wordpress/dependency-extraction-webpack-plugin or an appropriate externals directive to your Webpack config.";
+							} else {
+								msg +=
+									"You'll need to add the appropriate externals directive to your Webpack config.";
+							}
+							compilation.errors.push( new webpack.WebpackError( msg ) );
+						}
+						resolve();
+					} );
+				} ),
+				new Promise( ( resolve, reject ) => {
+					compilation.addModuleChain( compiler.context, i18nModuleDep, ( err, module ) => {
+						if ( err ) {
+							return reject( err );
+						}
+						// Webpack bug; Until 5.51.0 it didn't pass the module to the callback.
+						if ( ! module && ! compilation.moduleGraph.getModule( i18nModuleDep ) ) {
+							compilation.errors.push(
+								new webpack.WebpackError(
+									`${ PLUGIN_NAME }:\nFailed to add i18n module @wordpress/i18n to the build.\n` +
+										"You'll need to add @wordpress/dependency-extraction-webpack-plugin or an appropriate externals directive to your Webpack config, or add @wordpress/i18n to your package.json."
+								)
+							);
+						}
+						resolve();
+					} );
+				} ),
+			] );
+		} );
+
+		compiler.hooks.thisCompilation.tap( PLUGIN_NAME, compilation => {
+			/**
+			 * Fetch stuff we need for the various callbacks.
+			 *
+			 * @returns {object} Stuff.
+			 */
+			function getStuff() {
+				const stateModule = compilation.moduleGraph.getModule( stateModuleDep );
+				const i18nModule = compilation.moduleGraph.getModule( i18nModuleDep );
+
+				const i18nModules = new Set( [ i18nModule ] );
+				for ( const module of compilation.modules ) {
+					// rawRequest is for a NormalModule. userRequest is for an ExternalModule. Other types we don't really care about.
+					if (
+						module.rawRequest === '@wordpress/i18n' ||
+						module.userRequest === '@wordpress/i18n'
+					) {
+						i18nModules.add( module );
+					}
+				}
+				const i18nModulesArr = [ ...i18nModules ];
+
+				return { stateModule, i18nModule, i18nModulesArr, chunkGraph: compilation.chunkGraph };
+			}
+
+			// After chunks have been optimized (e.g. chunk splitting happened), determine which chunks need
+			// our deps and inject them.
+			compilation.hooks.afterOptimizeChunks.tap( PLUGIN_NAME, chunks => {
+				const { stateModule, i18nModule, i18nModulesArr, chunkGraph } = getStuff();
+				if ( ! stateModule ) {
+					debug( "State module is missing, can't run." );
+					return;
+				}
+				if ( ! i18nModule || i18nModulesArr.length <= 0 ) {
+					debug( "I18n module is missing, can't run." );
+					return;
+				}
+
+				debug( 'Checking for async chunks with i18n:' );
+				for ( const chunk of chunks ) {
+					if ( ! chunk.hasRuntime() ) {
+						debug(
+							// prettier-ignore
+							` -- Chunk ${ chunk.name || chunk.id || chunk.debugId } has no runtime, skipping.`
+						);
+						continue;
+					}
+
+					// Determine if we need to inject into this chunk.
+					let any = false;
+					loop: for ( const subchunk of chunk.getAllAsyncChunks() ) {
+						for ( const module of chunkGraph.getChunkModules( subchunk ) ) {
+							// rawRequest is for a NormalModule. userRequest is for an ExternalModule. Other types we don't really care about.
+							if ( this.options.ignoreModules( module, compiler.context ) ) {
+								// Ignore.
+							} else if (
+								module.rawRequest === '@wordpress/i18n' ||
+								module.userRequest === '@wordpress/i18n' ||
+								module.dependencies.some( d => d.request === '@wordpress/i18n' )
+							) {
+								debug(
+									// prettier-ignore
+									` ✅ Chunk ${ chunk.name || chunk.id || chunk.debugId } has an async chunk ${ subchunk.name || subchunk.id || subchunk.debugId } using @wordpress/i18n!`
+								);
+								any = true;
+								break loop;
+							}
+						}
+					}
+					if ( ! any ) {
+						debug(
+							// prettier-ignore
+							` ❌ Chunk ${ chunk.name || chunk.id || chunk.debugId } has no async chunks using @wordpress/i18n!`
+						);
+						continue;
+					}
+
+					// Inject into the chunk!
+					if ( chunkGraph.isModuleInChunk( stateModule, chunk ) ) {
+						debug( `    Already had ${ this.options.stateModule }` );
+					} else {
+						chunkGraph.connectChunkAndModule( chunk, stateModule );
+						chunkGraph.addModuleRuntimeRequirements(
+							stateModule,
+							chunk.runtime,
+							new Set( [ RuntimeGlobals.module ] )
+						);
+					}
+					if ( ! i18nModulesArr.some( m => chunkGraph.isModuleInChunk( m, chunk ) ) ) {
+						debug( "    Didn't itself use @wordpress/i18n" );
+						chunkGraph.connectChunkAndModule( chunk, i18nModule );
+					}
+
+					// Any chunk using this as a runtime doesn't itself need the injected modules.
+					for ( const c of chunk.getAllReferencedChunks() ) {
+						if ( c === chunk ) {
+							continue;
+						}
+						if ( chunkGraph.isModuleInChunk( stateModule, c ) ) {
+							debug(
+								// prettier-ignore
+								`    Removing redundant ${ this.options.stateModule } from chunk ${ c.name || c.id || c.debugId }`
+							);
+							chunkGraph.disconnectChunkAndModule( c, stateModule );
+						}
+						for ( const m of i18nModulesArr ) {
+							if ( chunkGraph.isModuleInChunk( m, c ) ) {
+								debug(
+									// prettier-ignore
+									`    Removing redundant @wordpress/i18n from chunk ${ c.name || c.id || c.debugId }`
+								);
+								chunkGraph.disconnectChunkAndModule( c, m );
+							}
+						}
+					}
+				}
+			} );
+
+			// This is just for debugging, to see if later optimizations removed our modules.
+			compilation.hooks.afterOptimizeChunkModules.tap( PLUGIN_NAME, chunks => {
+				const { stateModule, i18nModulesArr, chunkGraph } = getStuff();
+				if ( ! stateModule || i18nModulesArr.length <= 0 ) {
+					return;
+				}
+
+				debug( 'After optimizations,' );
+				for ( const chunk of chunks ) {
+					if ( chunkGraph.isModuleInChunk( stateModule, chunk ) ) {
+						debug(
+							// prettier-ignore
+							` ✅ Chunk ${ chunk.name || chunk.id || chunk.debugId } contains ${ this.options.stateModule }`
+						);
+					} else {
+						debug(
+							// prettier-ignore
+							` ❌ Chunk ${ chunk.name || chunk.id || chunk.debugId } does not contain ${ this.options.stateModule }`
+						);
+					}
+					if ( i18nModulesArr.some( m => chunkGraph.isModuleInChunk( m, chunk ) ) ) {
+						debug(
+							// prettier-ignore
+							` ✅ Chunk ${ chunk.name || chunk.id || chunk.debugId } contains @wordpress/i18n`
+						);
+					} else {
+						debug(
+							// prettier-ignore
+							` ❌ Chunk ${ chunk.name || chunk.id || chunk.debugId } does not contain @wordpress/i18n`
+						);
+					}
+				}
+			} );
+
+			// And add our runtime module to the chunks that may need it.
+			compilation.hooks.runtimeRequirementInTree
+				.for( webpack.RuntimeGlobals.ensureChunkHandlers )
+				.tap( PLUGIN_NAME, ( chunk, set ) => {
+					const { stateModule, i18nModulesArr } = getStuff();
+					if ( ! stateModule || i18nModulesArr.length <= 0 ) {
+						return;
+					}
+
+					debug( `Queuing runtime module for ${ chunk.name || chunk.id || chunk.debugId }.` );
+					compilation.addRuntimeModule(
+						chunk,
+						new I18nLoaderRuntimeModule( set, {
+							...this.options,
+							stateModuleName: this.options.stateModule,
+							stateModule,
+							i18nModulesArr,
+						} )
+					);
+				} );
+		} );
+	}
+}
+
+module.exports = I18nLoaderPlugin;

--- a/projects/js-packages/i18n-loader-webpack-plugin/src/I18nLoaderRuntimeModule.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/src/I18nLoaderRuntimeModule.js
@@ -1,0 +1,205 @@
+const { default: md5 } = require( 'md5-es' );
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+const { Template, RuntimeGlobals } = webpack;
+
+const PLUGIN_NAME = require( './plugin-name' );
+const debug = require( 'debug' )( PLUGIN_NAME );
+
+/**
+ * Webpack RuntimeModule for the i18n loader.
+ *
+ * The runtime module supplies the code that winds up in the Webpack runtime
+ * chunk. It gets added to chunks as appropriate by the plugin.
+ */
+class I18nLoaderRuntimeModule extends webpack.RuntimeModule {
+	constructor( set, options ) {
+		super( `loading ${ PLUGIN_NAME }` );
+		this.runtimeRequirements = set;
+		this.runtimeOptions = options;
+	}
+
+	/**
+	 * Get the path for a chunk.
+	 *
+	 * @param {webpack.Chunk} chunk - Chunk.
+	 * @returns {string} Chunk path
+	 */
+	getChunkPath( chunk ) {
+		const compilation = this.compilation;
+		return path.join(
+			this.runtimeOptions.path ||
+				path.relative( compilation.compiler.context, compilation.outputOptions.path ),
+			compilation.getPath(
+				chunk.filenameTemplate ||
+					( chunk.canBeInitial()
+						? compilation.outputOptions.filename
+						: compilation.outputOptions.chunkFilename ),
+				{
+					chunk,
+					contentHashType: 'javascript',
+				}
+			)
+		);
+	}
+
+	/**
+	 * Get info for chunks we need to care about.
+	 *
+	 * @returns {Map} Map of chunk ID to data.
+	 */
+	getChunkInfo() {
+		const ret = new Map();
+		const { chunkGraph } = this.compilation;
+
+		for ( const chunk of this.chunk.getAllAsyncChunks() ) {
+			for ( const module of chunkGraph.getChunkModules( chunk ) ) {
+				if ( this.runtimeOptions.ignoreModules( module, this.compilation.compiler.context ) ) {
+					// Ignore
+				} else if (
+					module.rawRequest === '@wordpress/i18n' ||
+					module.userRequest === '@wordpress/i18n' ||
+					module.dependencies.some( d => d.request === '@wordpress/i18n' )
+				) {
+					const [ chunkPath, query ] = this.getChunkPath( chunk ).split( '?', 2 );
+					ret.set( chunk.id, {
+						chunkPath,
+						query,
+						hash: md5.hash( chunkPath ),
+					} );
+					continue;
+				}
+			}
+		}
+		return ret;
+	}
+
+	generate() {
+		const { chunk, compilation, runtimeOptions, runtimeRequirements } = this;
+		const { stateModule, stateModuleName, i18nModulesArr, textdomain } = runtimeOptions;
+		const { chunkGraph, runtimeTemplate } = compilation;
+		const chunkInfo = this.getChunkInfo();
+
+		if ( ! chunkInfo.size ) {
+			debug( `No async submodules using @wordpress/i18n in ${ this.getChunkPath( chunk ) }.` );
+			return null;
+		}
+		debug( `Adding i18n-loading runtime for ${ this.getChunkPath( chunk ) }.` );
+
+		// The hooks should have injected the state and i18n modules. Check to make sure they're still there.
+		if ( ! chunkGraph.isModuleInChunk( stateModule, chunk ) ) {
+			throw new webpack.WebpackError(
+				// prettier-ignore
+				`Chunk ${ chunk.name || chunk.id || chunk.debugId } (${ this.getChunkPath( chunk ) }) has submodules using @wordpress/i18n, but is missing the state module ${ stateModuleName }.`
+			);
+		}
+		let i18nModule;
+		for ( const m of i18nModulesArr ) {
+			if ( chunkGraph.isModuleInChunk( m, chunk ) ) {
+				i18nModule = m;
+				break;
+			}
+		}
+		if ( ! i18nModule ) {
+			throw new webpack.WebpackError(
+				// prettier-ignore
+				`Chunk ${ chunk.name || chunk.id || chunk.debugId } (${ this.getChunkPath( chunk ) }) has submodules using @wordpress/i18n, but is itself missing @wordpress/i18n.`
+			);
+		}
+
+		// Check that we have a textdomain.
+		if ( ! textdomain ) {
+			throw new webpack.WebpackError(
+				// prettier-ignore
+				`Chunk ${ this.getChunkPath( chunk ) } has submodules using @wordpress/i18n, but no textdomain was passed to ${ PLUGIN_NAME }. Please fix your Webpack configuration.`
+			);
+		}
+
+		// Determine the WordPress module name that @wordpress/dependency-extraction-webpack-plugin will (by default) use.
+		let depName = stateModuleName;
+		if ( depName.startsWith( '@wordpress/' ) ) {
+			// prettier-ignore
+			depName = 'wp.' + depName.substring( 11 ).replace( /-([a-z])/g, ( _, letter ) => letter.toUpperCase() );
+		}
+
+		const targetcode = {
+			plugin: '"plugins/" + ',
+			theme: '"themes/" + ',
+			core: '',
+		}[ this.runtimeOptions.target ];
+		const domaincode = `state.domainMap[textdomain] || ( ${ targetcode }textdomain )`;
+
+		// Build the runtime code.
+		// prettier-ignore
+		return Template.asString( [
+			`var textdomain = ${ JSON.stringify( textdomain ) };`,
+			'var chunkInfo = {',
+			Template.indent(
+				Array.from( chunkInfo.entries(), ( [ k, v ] ) => {
+					const items = [
+						Template.toNormalComment( v.chunkPath ) + ' ' + JSON.stringify( v.hash ),
+						v.query ? JSON.stringify( '?' + v.query ) : '""',
+					];
+					return `${ JSON.stringify( k ) }: [ ${ items.join( ', ' ) } ]`;
+				} ).join( ',\n' )
+			),
+			'};',
+			'',
+			'var loadI18n = ' +
+				runtimeTemplate.basicFunction( 'info', [
+					'var i18n = ' + runtimeTemplate.moduleExports( {
+						module: i18nModule,
+						chunkGraph,
+						request: '@wordpress/i18n',
+						runtimeRequirements,
+					} ) + ';',
+					'var state = ' + runtimeTemplate.moduleExports( {
+						module: stateModule,
+						chunkGraph,
+						request: stateModuleName,
+						runtimeRequirements,
+					} ) + ';',
+					`if ( ! state ) return Promise.reject( new Error( ${ JSON.stringify( 'I18n state is not available. Check that WordPress is exporting ' + depName + '.' ) } ) );`,
+					`if ( state.locale === "en_US" ) return Promise.resolve();`,
+					'if ( typeof fetch === "undefined" ) return Promise.reject( new Error( "Fetch API is not available." ) );',
+					'return fetch(',
+					Template.indent( [
+						runtimeTemplate.supportTemplateLiteral()
+							? '`${ state.baseUrl }${ ' + domaincode + ' }-${ state.locale }-${ info[0] }.json${ info[1] }`'
+							: 'state.baseUrl + ( ' + domaincode + ' ) + "-" + state.locale + "-" + info[0] + ".json" + info[1]',
+					] ),
+					').then( ' + runtimeTemplate.basicFunction( 'res', [
+						'if ( ! res.ok ) throw new Error( "HTTP request failed: " + res.status + " " + res.statusText );',
+						'return res.json();',
+					] ) + ' ).then( ' + runtimeTemplate.basicFunction( 'data', [
+						'var data2 = data.locale_data;',
+						'var localeData = data2[ textdomain ] || data2.messages;',
+						'localeData[""].domain = textdomain;',
+						'i18n.setLocaleData( localeData, textdomain );',
+					] ) + ' );',
+				] ) + ';',
+			'',
+			'var installedChunks = {};',
+			`${ RuntimeGlobals.ensureChunkHandlers }.wpI18n = ` + runtimeTemplate.basicFunction( 'chunkId, promises', [
+				'if ( installedChunks[chunkId] ) {',
+				Template.indent( 'promises.push( installedChunks[chunkId] );' ),
+				'} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {',
+				Template.indent( [
+					'promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then( ',
+					Template.indent( [
+						runtimeTemplate.basicFunction( '', [ 'installedChunks[chunkId] = 0;' ] ) + ',',
+						runtimeTemplate.basicFunction( 'e', [
+							'delete installedChunks[chunkId];',
+							"// Log only, we don't want i18n failure to break the entire page.",
+							'console.error( "Failed to fetch i18n data:", e );',
+						] ),
+					] ),
+					') );',
+				] ),
+				'}',
+			] ) + ';',
+		] );
+	}
+}
+
+module.exports = I18nLoaderRuntimeModule;

--- a/projects/js-packages/i18n-loader-webpack-plugin/src/plugin-name.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/src/plugin-name.js
@@ -1,0 +1,1 @@
+module.exports = require( '../package.json' ).name;

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/__snapshots__/build.test.js.snap
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/__snapshots__/build.test.js.snap
@@ -1,0 +1,1545 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Webpack \`basic-test\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`basic-test\` Build results: Webpack build files 1`] = `
+Object {
+  "bar.asset.php": Object {},
+  "bar.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "baz.asset.php": Object {},
+  "baz.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "main.asset.php": Object {},
+  "main.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"basic-test\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* dist/hasI18n.js */ \\"c7c3968298452ee95564fb9c05e2de50\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "noI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+}
+`;
+
+exports[`Webpack \`basic-test\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`fetch-failures\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`fetch-failures\` Build results: Webpack build files 1`] = `
+Object {
+  "a.asset.php": Object {},
+  "a.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"fetch-failures\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* dist/hasI18n.js */ \\"c7c3968298452ee95564fb9c05e2de50\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+}
+`;
+
+exports[`Webpack \`fetch-failures\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`ignore-modules\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`ignore-modules\` Build results: Webpack build files 1`] = `
+Object {
+  "array/hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "array/hasI18n2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "array/main.asset.php": Object {},
+  "array/main.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "array/main2.asset.php": Object {},
+  "array/main2.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"ignore-modules\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n2\\": [ /* dist/array/hasI18n2.js */ \\"e4f47276932fd5fd64de200952c28fa0\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "array/md5.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "array/noI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "function/hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "function/hasI18n2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "function/main.asset.php": Object {},
+  "function/main.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "function/main2.asset.php": Object {},
+  "function/main2.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"ignore-modules\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n2\\": [ /* dist/function/hasI18n2.js */ \\"2f34b700832755e4f97db2c8639d355f\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "function/md5.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "function/noI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "regex/hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "regex/hasI18n2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "regex/main.asset.php": Object {},
+  "regex/main.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "regex/main2.asset.php": Object {},
+  "regex/main2.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"ignore-modules\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n2\\": [ /* dist/regex/hasI18n2.js */ \\"b9b66de4c25a21524d7efa38f93bbf38\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "regex/md5.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "regex/noI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "string/hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "string/hasI18n2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "string/main.asset.php": Object {},
+  "string/main.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "string/main2.asset.php": Object {},
+  "string/main2.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"ignore-modules\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n2\\": [ /* dist/string/hasI18n2.js */ \\"8ccd788351d9b86e5ae5a8a7bb8acd02\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "string/md5.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "string/noI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+}
+`;
+
+exports[`Webpack \`ignore-modules\` Build results: Webpack build stats 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "errors": Array [],
+      "name": undefined,
+      "warnings": Array [],
+    },
+    Object {
+      "errors": Array [],
+      "name": undefined,
+      "warnings": Array [],
+    },
+    Object {
+      "errors": Array [],
+      "name": undefined,
+      "warnings": Array [],
+    },
+    Object {
+      "errors": Array [],
+      "name": undefined,
+      "warnings": Array [],
+    },
+  ],
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`manual-externals\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`manual-externals\` Build results: Webpack build files 1`] = `
+Object {
+  "hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "main.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!******************************!*\\\\
+  !*** external \\"jpI18nState\\" ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = global[\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"manual-externals\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* dist/hasI18n.js */ \\"c7c3968298452ee95564fb9c05e2de50\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!*************************!*\\\\
+  !*** external \\"wpI18n\\" ***!
+  \\\\*************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = global[\\"wpI18n\\"];
+",
+  },
+  "main2.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!**********************************************************************************************!*\\\\
+  !*** external \\"{\\\\\\"baseUrl\\\\\\":\\\\\\"http://example.org/\\\\\\",\\\\\\"locale\\\\\\":\\\\\\"en_US\\\\\\",\\\\\\"domainMap\\\\\\":{}}\\" ***!
+  \\\\**********************************************************************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+if(typeof {\\"baseUrl\\":\\"http://example.org/\\",\\"locale\\":\\"en_US\\",\\"domainMap\\":{}} === 'undefined') { var e = new Error(\\"Cannot find module '{\\\\\\"baseUrl\\\\\\":\\\\\\"http://example.org/\\\\\\",\\\\\\"locale\\\\\\":\\\\\\"en_US\\\\\\",\\\\\\"domainMap\\\\\\":{}}'\\"); e.code = 'MODULE_NOT_FOUND'; throw e; }
+
+module.exports = {\\"baseUrl\\":\\"http://example.org/\\",\\"locale\\":\\"en_US\\",\\"domainMap\\":{}};
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"manual-externals\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* dist/hasI18n.js */ \\"c7c3968298452ee95564fb9c05e2de50\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!*************************!*\\\\
+  !*** external \\"wpI18n\\" ***!
+  \\\\*************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = global[\\"wpI18n\\"];
+",
+  },
+  "main3.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!**************************************************************************************************************************************!*\\\\
+  !*** external \\"{\\\\\\"baseUrl\\\\\\":\\\\\\"http://example.org/\\\\\\",\\\\\\"locale\\\\\\":\\\\\\"en_us\\\\\\",\\\\\\"domainMap\\\\\\":{\\\\\\"manual-externals\\\\\\":\\\\\\"themes/remapped\\\\\\"}}\\" ***!
+  \\\\**************************************************************************************************************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+if(typeof {\\"baseUrl\\":\\"http://example.org/\\",\\"locale\\":\\"en_us\\",\\"domainMap\\":{\\"manual-externals\\":\\"themes/remapped\\"}} === 'undefined') { var e = new Error(\\"Cannot find module '{\\\\\\"baseUrl\\\\\\":\\\\\\"http://example.org/\\\\\\",\\\\\\"locale\\\\\\":\\\\\\"en_us\\\\\\",\\\\\\"domainMap\\\\\\":{\\\\\\"manual-externals\\\\\\":\\\\\\"themes/remapped\\\\\\"}}'\\"); e.code = 'MODULE_NOT_FOUND'; throw e; }
+
+module.exports = {\\"baseUrl\\":\\"http://example.org/\\",\\"locale\\":\\"en_us\\",\\"domainMap\\":{\\"manual-externals\\":\\"themes/remapped\\"}};
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"manual-externals\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* dist/hasI18n.js */ \\"c7c3968298452ee95564fb9c05e2de50\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!*************************!*\\\\
+  !*** external \\"wpI18n\\" ***!
+  \\\\*************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = global[\\"wpI18n\\"];
+",
+  },
+}
+`;
+
+exports[`Webpack \`manual-externals\` Build results: Webpack build stats 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "errors": Array [],
+      "name": undefined,
+      "warnings": Array [],
+    },
+    Object {
+      "errors": Array [],
+      "name": undefined,
+      "warnings": Array [],
+    },
+    Object {
+      "errors": Array [],
+      "name": undefined,
+      "warnings": Array [],
+    },
+  ],
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`missing-externals\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`missing-externals\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "message": "@automattic/i18n-loader-webpack-plugin:
+Failed to add state module @wordpress/jp-i18n-state to the build.
+You'll need to add @wordpress/dependency-extraction-webpack-plugin or an appropriate externals directive to your Webpack config.",
+    },
+  ],
+  "warnings": Array [
+    Object {
+      "loc": "",
+      "message": "Module not found: Error: Can't resolve '@wordpress/jp-i18n-state' in '/usr/local/src/automattic/jetpack/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/missing-externals'",
+    },
+  ],
+}
+`;
+
+exports[`Webpack \`multiple-runtime\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`multiple-runtime\` Build results: Webpack build files 1`] = `
+Object {
+  "bar.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "baz.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "hasI18n2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "main.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "main2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "noI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "runtime~bar.asset.php": Object {},
+  "runtime~bar.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "runtime~baz.asset.php": Object {},
+  "runtime~baz.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "runtime~main.asset.php": Object {},
+  "runtime~main.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"multiple-runtime\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* dist/hasI18n.js */ \\"c7c3968298452ee95564fb9c05e2de50\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "runtime~main2.asset.php": Object {},
+  "runtime~main2.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"multiple-runtime\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* dist/hasI18n.js */ \\"c7c3968298452ee95564fb9c05e2de50\\", \\"\\" ],
+/******/ 			\\"hasI18n2\\": [ /* dist/hasI18n2.js */ \\"71d7bd53fc0961d2785c69cde5d9fead\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+}
+`;
+
+exports[`Webpack \`multiple-runtime\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`nested-includes\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`nested-includes\` Build results: Webpack build files 1`] = `
+Object {
+  "hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "indirect1.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "indirect2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "main.asset.php": Object {},
+  "main.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"nested-includes\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* dist/hasI18n.js */ \\"c7c3968298452ee95564fb9c05e2de50\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+}
+`;
+
+exports[`Webpack \`nested-includes\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`no-textdomain\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`no-textdomain\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "message": "Chunk dist/main.js has submodules using @wordpress/i18n, but no textdomain was passed to @automattic/i18n-loader-webpack-plugin. Please fix your Webpack configuration.",
+      "moduleIdentifier": "webpack/runtime/loading @automattic/i18n-loader-webpack-plugin",
+      "moduleName": "webpack/runtime/loading @automattic/i18n-loader-webpack-plugin",
+    },
+  ],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`no-textdomain-no-i18n\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`no-textdomain-no-i18n\` Build results: Webpack build files 1`] = `
+Object {
+  "bar.asset.php": Object {},
+  "bar.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "baz.asset.php": Object {},
+  "baz.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "noI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+}
+`;
+
+exports[`Webpack \`no-textdomain-no-i18n\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`options\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`options\` Build results: Webpack build files 1`] = `
+Object {
+  "hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "main.js": Object {
+    "jpI18nState": null,
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"options\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* jetpack_vendor/automattic/jetpack-foobar/dist/hasI18n.js */ \\"e54fa518d005a9d82f46a567822e8600\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! state */ \\"state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting state.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!*************************!*\\\\
+  !*** external \\"wpI18n\\" ***!
+  \\\\*************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = global[\\"wpI18n\\"];
+",
+  },
+}
+`;
+
+exports[`Webpack \`options\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`single-runtime\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`single-runtime\` Build results: Webpack build files 1`] = `
+Object {
+  "bar.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "baz.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "hasI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "hasI18n2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "main.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "main2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "noI18n.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "runtime.asset.php": Object {},
+  "runtime.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"single-runtime\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"hasI18n\\": [ /* dist/hasI18n.js */ \\"c7c3968298452ee95564fb9c05e2de50\\", \\"\\" ],
+/******/ 			\\"hasI18n2\\": [ /* dist/hasI18n2.js */ \\"71d7bd53fc0961d2785c69cde5d9fead\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+}
+`;
+
+exports[`Webpack \`single-runtime\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`Webpack \`splitting\` Build results: Webpack build error 1`] = `null`;
+
+exports[`Webpack \`splitting\` Build results: Webpack build files 1`] = `
+Object {
+  "indirect1.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "indirect2.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+  "main.asset.php": Object {},
+  "main.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"splitting\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"src_hasI18n_js-src_hasI18n2_js\\": [ /* dist/src_hasI18n_js-src_hasI18n2_js.js */ \\"ec0e6fc1bae1bb5c76db79838b127a36\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "main2.asset.php": Object {},
+  "main2.js": Object {
+    "jpI18nState": "/***/ \\"@wordpress/jp-i18n-state\\":
+/*!*************************************!*\\\\
+  !*** external [\\"wp\\",\\"jpI18nState\\"] ***!
+  \\\\*************************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"jpI18nState\\"];
+",
+    "loader": "/******/ 	/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */
+/******/ 	(() => {
+/******/ 		var textdomain = \\"splitting\\";
+/******/ 		var chunkInfo = {
+/******/ 			\\"src_hasI18n_js-src_hasI18n2_js\\": [ /* dist/src_hasI18n_js-src_hasI18n2_js.js */ \\"ec0e6fc1bae1bb5c76db79838b127a36\\", \\"\\" ]
+/******/ 		};
+/******/ 		
+/******/ 		var loadI18n = (info) => {
+/******/ 			var i18n = __webpack_require__(/*! @wordpress/i18n */ \\"@wordpress/i18n\\");
+/******/ 			var state = __webpack_require__(/*! @wordpress/jp-i18n-state */ \\"@wordpress/jp-i18n-state\\");
+/******/ 			if ( ! state ) return Promise.reject( new Error( \\"I18n state is not available. Check that WordPress is exporting wp.jpI18nState.\\" ) );
+/******/ 			if ( state.locale === \\"en_US\\" ) return Promise.resolve();
+/******/ 			if ( typeof fetch === \\"undefined\\" ) return Promise.reject( new Error( \\"Fetch API is not available.\\" ) );
+/******/ 			return fetch(
+/******/ 				state.baseUrl + ( state.domainMap[textdomain] || ( \\"plugins/\\" + textdomain ) ) + \\"-\\" + state.locale + \\"-\\" + info[0] + \\".json\\" + info[1]
+/******/ 			).then( (res) => {
+/******/ 				if ( ! res.ok ) throw new Error( \\"HTTP request failed: \\" + res.status + \\" \\" + res.statusText );
+/******/ 				return res.json();
+/******/ 			} ).then( (data) => {
+/******/ 				var data2 = data.locale_data;
+/******/ 				var localeData = data2[ textdomain ] || data2.messages;
+/******/ 				localeData[\\"\\"].domain = textdomain;
+/******/ 				i18n.setLocaleData( localeData, textdomain );
+/******/ 			} );
+/******/ 		};
+/******/ 		
+/******/ 		var installedChunks = {};
+/******/ 		__webpack_require__.f.wpI18n = (chunkId, promises) => {
+/******/ 			if ( installedChunks[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] );
+/******/ 			} else if ( installedChunks[chunkId] !== 0 && chunkInfo[chunkId] ) {
+/******/ 				promises.push( installedChunks[chunkId] = loadI18n( chunkInfo[chunkId] ).then(
+/******/ 					() => {
+/******/ 						installedChunks[chunkId] = 0;
+/******/ 					},
+/******/ 					(e) => {
+/******/ 						delete installedChunks[chunkId];
+/******/ 						// Log only, we don't want i18n failure to break the entire page.
+/******/ 						console.error( \\"Failed to fetch i18n data:\\", e );
+/******/ 					}
+/******/ 				) );
+/******/ 			}
+/******/ 		};
+/******/ 	})();",
+    "wpI18n": "/***/ \\"@wordpress/i18n\\":
+/*!******************************!*\\\\
+  !*** external [\\"wp\\",\\"i18n\\"] ***!
+  \\\\******************************/
+/***/ ((module) => {
+
+\\"use strict\\";
+module.exports = window[\\"wp\\"][\\"i18n\\"];
+",
+  },
+  "src_hasI18n_js-src_hasI18n2_js.js": Object {
+    "jpI18nState": null,
+    "loader": null,
+    "wpI18n": null,
+  },
+}
+`;
+
+exports[`Webpack \`splitting\` Build results: Webpack build stats 1`] = `
+Object {
+  "errors": Array [],
+  "warnings": Array [],
+}
+`;

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/build.test.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/build.test.js
@@ -1,0 +1,113 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+
+require( './globals' );
+
+/**
+ * Extract a section from a string.
+ *
+ * @param {string} content - String to extract from.
+ * @param {string} start - Starting line.
+ * @param {string} end - Line to end before.
+ * @returns {string|null} Section.
+ */
+function extractSection( content, start, end ) {
+	const s = content.indexOf( '\n' + start );
+	if ( s < 0 ) {
+		return null;
+	}
+	const e = content.indexOf( '\n' + end, s + 1 );
+	return content.substring( s + 1, e > s ? e : content.length );
+}
+
+/**
+ * Find all files in a path.
+ *
+ * @param {string} dir - Path.
+ * @returns {string[]} Promise resolving to a list of files.
+ */
+function lsFiles( dir ) {
+	const ret = [];
+	for ( const dirent of fs.readdirSync( dir, { withFileTypes: true } ) ) {
+		if ( dirent.isDirectory() ) {
+			for ( const file of lsFiles( path.join( dir, dirent.name ) ) ) {
+				ret.push( path.join( dirent.name, file ) );
+			}
+		} else {
+			ret.push( dirent.name );
+		}
+	}
+	return ret;
+}
+
+beforeEach( () => {
+	fetch.urls = {};
+} );
+
+const fixturesPath = path.join( __dirname, 'fixtures' );
+const configFixtures = fs.readdirSync( fixturesPath ).sort();
+
+describe.each( configFixtures )( 'Webpack `%s`', fixture => {
+	const testdir = path.join( fixturesPath, fixture );
+	const builddir = path.join( testdir, 'dist' );
+	fs.rmSync( builddir, { force: true, recursive: true } );
+
+	const config = require( path.join( testdir, 'webpack.config.js' ) );
+	if ( Array.isArray( config ) ) {
+		for ( const c of config ) {
+			c.context = c.context || testdir;
+			c.output.path = builddir;
+		}
+	} else {
+		config.context = config.context || testdir;
+		config.output.path = builddir;
+	}
+
+	let err, stats;
+	beforeAll( async () => {
+		[ err, stats ] = await new Promise( resolve => {
+			// eslint-disable-next-line no-shadow
+			webpack( config, ( err, stats ) => {
+				resolve( [ err, stats ] );
+			} );
+		} );
+	} );
+
+	test( 'Build results', () => {
+		expect( err ).toMatchSnapshot( 'Webpack build error' );
+		expect( stats.toJson( { all: false, errors: true, warnings: true } ) ).toMatchSnapshot(
+			'Webpack build stats'
+		);
+
+		if ( err !== null || stats.hasErrors() ) {
+			return;
+		}
+
+		const files = {};
+		for ( const file of lsFiles( builddir ) ) {
+			const data = {};
+			if ( file.endsWith( '.js' ) ) {
+				const content = fs.readFileSync( path.join( builddir, file ), { encoding: 'utf8' } );
+				data.wpI18n = extractSection( content, '/***/ "@wordpress/i18n":\n', '/***/ })' );
+				data.jpI18nState = extractSection(
+					content,
+					'/***/ "@wordpress/jp-i18n-state":\n',
+					'/***/ })'
+				);
+				data.loader = extractSection(
+					content,
+					'/******/ \t/* webpack/runtime/loading @automattic/i18n-loader-webpack-plugin */',
+					'/******/ \t\n'
+				);
+			}
+			files[ file ] = data;
+		}
+		expect( files ).toMatchSnapshot( 'Webpack build files' );
+	} );
+
+	const testfile = path.join( testdir, 'tests.js' );
+	if ( fs.existsSync( testfile ) ) {
+		require( testfile );
+	}
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/en_piglatin.json
@@ -1,0 +1,13 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/bar.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/bar.js
@@ -1,0 +1,1 @@
+module.exports = 'No submodules here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/baz.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/baz.js
@@ -1,0 +1,3 @@
+module.exports = {
+	noI18n: async () => ( await import( /* webpackChunkName: "noI18n" */ './noI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'basic-test' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	noI18n: async () => ( await import( /* webpackChunkName: "noI18n" */ './noI18n.js' ) ).default,
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/noI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/src/noI18n.js
@@ -1,0 +1,1 @@
+module.exports = 'No i18n here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/tests.js
@@ -1,0 +1,19 @@
+test( 'Tests', async () => {
+	const main = require( './dist/main.js' );
+	const bar = require( './dist/bar.js' );
+	const baz = require( './dist/baz.js' );
+	const translations = require( './en_piglatin.json' );
+
+	expect( await main.noI18n() ).toEqual( 'No i18n here' );
+
+	fetch.expectUrl(
+		'http://test.example.com/wp-content/languages/plugins/basic-test-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+		translations
+	);
+	expect( await main.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+	expect( await main.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+
+	expect( bar ).toEqual( 'No submodules here' );
+
+	expect( await baz.noI18n() ).toEqual( 'No i18n here' );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/basic-test/webpack.config.js
@@ -1,0 +1,23 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+const DependencyExtractionPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		main: './src/index.js',
+		bar: './src/bar.js',
+		baz: './src/baz.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	plugins: [
+		new I18nLoaderPlugin( { textdomain: 'basic-test' } ),
+		new DependencyExtractionPlugin(),
+	],
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/en_piglatin.json
@@ -1,0 +1,13 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'fetch-failures' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/src/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/tests.js
@@ -1,0 +1,84 @@
+/* global wpI18n */
+
+describe( 'Tests', () => {
+	let spy;
+
+	beforeEach( () => {
+		spy = jest.spyOn( global.console, 'error' ).mockImplementation( () => {} );
+		wpI18n.resetLocaleData( {}, 'fetch-failures' );
+	} );
+	afterEach( () => {
+		spy.mockRestore();
+	} );
+
+	const getBundle = () => {
+		let a;
+		jest.isolateModules( () => {
+			a = require( './dist/a.js' );
+		} );
+		return a;
+	};
+
+	test( 'Control', async () => {
+		const a = getBundle();
+		fetch.expectUrl(
+			'http://test.example.com/wp-content/languages/plugins/fetch-failures-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+			require( './en_piglatin.json' )
+		);
+		expect( await a.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'No fetch', async () => {
+		const a = getBundle();
+		const fetch = global.fetch;
+		try {
+			delete global.fetch;
+			expect( await a.hasI18n() ).toEqual( 'This is translated' );
+		} finally {
+			global.fetch = fetch;
+		}
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( spy ).toHaveBeenCalledWith( 'Failed to fetch i18n data:', expect.any( Error ) );
+		expect( spy.mock.calls[ 0 ][ 1 ].message ).toEqual( 'Fetch API is not available.' );
+	} );
+
+	test( 'An HTTP 404 error', async () => {
+		const a = getBundle();
+		fetch.expectUrl(
+			'http://test.example.com/wp-content/languages/plugins/fetch-failures-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+			'The specified document was not found.',
+			{ status: 404, statusText: 'Not found' }
+		);
+		expect( await a.hasI18n() ).toEqual( 'This is translated' );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( spy ).toHaveBeenCalledWith( 'Failed to fetch i18n data:', expect.any( Error ) );
+		expect( spy.mock.calls[ 0 ][ 1 ].message ).toEqual( 'HTTP request failed: 404 Not found' );
+	} );
+
+	test( 'A fetch error', async () => {
+		const a = getBundle();
+		const err = new Error( 'Test error' );
+		fetch.expectError(
+			'http://test.example.com/wp-content/languages/plugins/fetch-failures-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+			err
+		);
+		expect( await a.hasI18n() ).toEqual( 'This is translated' );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( spy ).toHaveBeenCalledWith( 'Failed to fetch i18n data:', err );
+	} );
+
+	test( 'Invalid JSON data', async () => {
+		const a = getBundle();
+		fetch.expectUrl(
+			'http://test.example.com/wp-content/languages/plugins/fetch-failures-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+			'Invalid JSON'
+		);
+		expect( await a.hasI18n() ).toEqual( 'This is translated' );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( spy ).toHaveBeenCalledWith( 'Failed to fetch i18n data:', expect.any( Error ) );
+		expect( spy.mock.calls[ 0 ][ 1 ].message ).toEqual(
+			'Unexpected token I in JSON at position 0'
+		);
+	} );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/fetch-failures/webpack.config.js
@@ -1,0 +1,21 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+const DependencyExtractionPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		a: './src/index.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	plugins: [
+		new I18nLoaderPlugin( { textdomain: 'fetch-failures' } ),
+		new DependencyExtractionPlugin(),
+	],
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/en_piglatin.json
@@ -1,0 +1,14 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ],
+			"This is translated too": [ "is-Thay is-way anslated-tray oo-tay" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'ignore-modules' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/hasI18n2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/hasI18n2.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated too', 'ignore-modules' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+	md5: async () => ( await import( /* webpackChunkName: "md5" */ 'md5-es' ) ).default.hash,
+	noI18n: async () => ( await import( /* webpackChunkName: "noI18n" */ './noI18n.js' ) ).default,
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/index2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/index2.js
@@ -1,0 +1,5 @@
+module.exports = {
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+	hasI18n2: async () =>
+		( await import( /* webpackChunkName: "hasI18n2" */ './hasI18n2.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/noI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/src/noI18n.js
@@ -1,0 +1,1 @@
+module.exports = 'No i18n here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/tests.js
@@ -1,0 +1,25 @@
+/* global wpI18n */
+const { default: md5 } = require( 'md5-es' );
+
+describe( 'Test ignoreModules as', () => {
+	beforeEach( () => {
+		wpI18n.resetLocaleData( {}, 'ignore-modules' );
+	} );
+
+	const whats = [ 'string', 'regex', 'function', 'array' ];
+	test.each( whats )( 'a %s', async what => {
+		const main = require( `./dist/${ what }/main.js` );
+		const main2 = require( `./dist/${ what }/main2.js` );
+		const hash = md5.hash( `dist/${ what }/hasI18n2.js` );
+
+		expect( await main.noI18n() ).toEqual( 'No i18n here' );
+		expect( await main.hasI18n() ).toEqual( 'This is translated' );
+
+		expect( await main2.hasI18n() ).toEqual( 'This is translated' );
+		fetch.expectUrl(
+			`http://test.example.com/wp-content/languages/plugins/ignore-modules-en_piglatin-${ hash }.json`,
+			require( './en_piglatin.json' )
+		);
+		expect( await main2.hasI18n2() ).toEqual( 'is-Thay is-way anslated-tray oo-tay' );
+	} );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/ignore-modules/webpack.config.js
@@ -1,0 +1,33 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+const DependencyExtractionPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+const filters = {
+	string: 'src/hasI18n.js',
+	regex: /\/hasI18n(?:\.js)?$/,
+	function: n => n.endsWith( '/hasI18n.js' ),
+	array: [ 'src/hasI18n.js' ],
+};
+
+module.exports = Object.entries( filters ).map( ( [ k, v ] ) => ( {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		main: './src/index.js',
+		main2: './src/index2.js',
+	},
+	output: {
+		filename: k + '/[name].js',
+		chunkFilename: k + '/[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	plugins: [
+		new I18nLoaderPlugin( {
+			textdomain: 'ignore-modules',
+			ignoreModules: v,
+		} ),
+		new DependencyExtractionPlugin(),
+	],
+} ) );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/en_piglatin.json
@@ -1,0 +1,13 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/en_us.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/en_us.json
@@ -1,0 +1,13 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "Thus us trunslutud" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'manual-externals' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/src/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/tests.js
@@ -1,0 +1,30 @@
+/* global wpI18n */
+
+describe( 'Tests', () => {
+	afterEach( () => {
+		wpI18n.resetLocaleData( {}, 'manual-externals' );
+	} );
+
+	test( 'External from the global', async () => {
+		const main = require( './dist/main.js' );
+		fetch.expectUrl(
+			'http://test.example.com/wp-content/languages/plugins/manual-externals-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+			require( './en_piglatin.json' )
+		);
+		expect( await main.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+	} );
+
+	test( 'Hard-coded "external", with locale en_US', async () => {
+		const main2 = require( './dist/main2.js' );
+		expect( await main2.hasI18n() ).toEqual( 'This is translated' );
+	} );
+
+	test( 'Hard-coded "external", with different baseUrl, locale, and domainMap', async () => {
+		const main3 = require( './dist/main3.js' );
+		fetch.expectUrl(
+			'http://example.org/themes/remapped-en_us-c7c3968298452ee95564fb9c05e2de50.json',
+			require( './en_us.json' )
+		);
+		expect( await main3.hasI18n() ).toEqual( 'Thus us trunslutud' );
+	} );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/manual-externals/webpack.config.js
@@ -1,0 +1,61 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+
+const shared = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	plugins: [ new I18nLoaderPlugin( { textdomain: 'manual-externals' } ) ],
+};
+
+module.exports = [
+	{
+		...shared,
+		entry: {
+			main: './src/index.js',
+		},
+		externals: {
+			'@wordpress/i18n': 'global wpI18n',
+			'@wordpress/jp-i18n-state': 'global jpI18nState',
+		},
+	},
+	{
+		...shared,
+		entry: {
+			main2: './src/index.js',
+		},
+		externals: {
+			'@wordpress/i18n': 'global wpI18n',
+			'@wordpress/jp-i18n-state':
+				'var ' +
+				JSON.stringify( {
+					baseUrl: 'http://example.org/',
+					locale: 'en_US',
+					domainMap: {},
+				} ),
+		},
+	},
+	{
+		...shared,
+		entry: {
+			main3: './src/index.js',
+		},
+		externals: {
+			'@wordpress/i18n': 'global wpI18n',
+			'@wordpress/jp-i18n-state':
+				'var ' +
+				JSON.stringify( {
+					baseUrl: 'http://example.org/',
+					locale: 'en_us',
+					domainMap: {
+						'manual-externals': 'themes/remapped',
+					},
+				} ),
+		},
+	},
+];

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/missing-externals/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/missing-externals/en_piglatin.json
@@ -1,0 +1,13 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/missing-externals/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/missing-externals/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'missing-externals' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/missing-externals/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/missing-externals/src/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/missing-externals/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/missing-externals/webpack.config.js
@@ -1,0 +1,20 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		main: './src/index.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	plugins: [ new I18nLoaderPlugin( { textdomain: 'missing-externals' } ) ],
+	externals: {
+		'@wordpress/i18n': 'global wpI18n',
+	},
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/en_piglatin.json
@@ -1,0 +1,14 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ],
+			"This is translated too": [ "is-Thay is-way anslated-tray oo-tay" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/bar.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/bar.js
@@ -1,0 +1,1 @@
+module.exports = 'No submodules here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/baz.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/baz.js
@@ -1,0 +1,3 @@
+module.exports = {
+	noI18n: async () => ( await import( /* webpackChunkName: "noI18n" */ './noI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'multiple-runtime' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/hasI18n2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/hasI18n2.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated too', 'multiple-runtime' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	noI18n: async () => ( await import( /* webpackChunkName: "noI18n" */ './noI18n.js' ) ).default,
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/index2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/index2.js
@@ -1,0 +1,5 @@
+module.exports = {
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+	hasI18n2: async () =>
+		( await import( /* webpackChunkName: "hasI18n2" */ './hasI18n2.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/noI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/src/noI18n.js
@@ -1,0 +1,1 @@
+module.exports = 'No i18n here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/tests.js
@@ -1,0 +1,30 @@
+test( 'Tests', async () => {
+	const main = require( './dist/main.js' );
+	const main2 = require( './dist/main2.js' );
+	const bar = require( './dist/bar.js' );
+	const baz = require( './dist/baz.js' );
+	const translations = require( './en_piglatin.json' );
+
+	expect( await main.noI18n() ).toEqual( 'No i18n here' );
+
+	fetch.expectUrl(
+		'http://test.example.com/wp-content/languages/plugins/multiple-runtime-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+		translations
+	);
+	expect( await main.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+
+	fetch.expectUrl(
+		'http://test.example.com/wp-content/languages/plugins/multiple-runtime-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+		translations
+	);
+	expect( await main2.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+	fetch.expectUrl(
+		'http://test.example.com/wp-content/languages/plugins/multiple-runtime-en_piglatin-71d7bd53fc0961d2785c69cde5d9fead.json',
+		translations
+	);
+	expect( await main2.hasI18n2() ).toEqual( 'is-Thay is-way anslated-tray oo-tay' );
+
+	expect( bar ).toEqual( 'No submodules here' );
+
+	expect( await baz.noI18n() ).toEqual( 'No i18n here' );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/multiple-runtime/webpack.config.js
@@ -1,0 +1,27 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+const DependencyExtractionPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		main: './src/index.js',
+		main2: './src/index2.js',
+		bar: './src/bar.js',
+		baz: './src/baz.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	optimization: {
+		runtimeChunk: true,
+	},
+	plugins: [
+		new I18nLoaderPlugin( { textdomain: 'multiple-runtime' } ),
+		new DependencyExtractionPlugin(),
+	],
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/en_piglatin.json
@@ -1,0 +1,13 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'nested-includes' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/src/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	hasI18n: () =>
+		import( /* webpackChunkName: "indirect1" */ './indirect1.js' ).then( v => v.default() ),
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/src/indirect1.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/src/indirect1.js
@@ -1,0 +1,2 @@
+module.exports = () =>
+	import( /* webpackChunkName: "indirect2" */ './indirect2.js' ).then( v => v.default() );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/src/indirect2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/src/indirect2.js
@@ -1,0 +1,2 @@
+module.exports = () =>
+	import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ).then( v => v.default );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/tests.js
@@ -1,0 +1,9 @@
+test( 'Tests', async () => {
+	const main = require( './dist/main.js' );
+
+	fetch.expectUrl(
+		'http://test.example.com/wp-content/languages/plugins/nested-includes-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+		require( './en_piglatin.json' )
+	);
+	expect( await main.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/nested-includes/webpack.config.js
@@ -1,0 +1,21 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+const DependencyExtractionPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		main: './src/index.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	plugins: [
+		new I18nLoaderPlugin( { textdomain: 'nested-includes' } ),
+		new DependencyExtractionPlugin(),
+	],
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/src/bar.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/src/bar.js
@@ -1,0 +1,1 @@
+module.exports = 'No submodules here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/src/baz.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/src/baz.js
@@ -1,0 +1,3 @@
+module.exports = {
+	noI18n: async () => ( await import( /* webpackChunkName: "noI18n" */ './noI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/src/noI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/src/noI18n.js
@@ -1,0 +1,1 @@
+module.exports = 'No i18n here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/tests.js
@@ -1,0 +1,7 @@
+test( 'Tests', async () => {
+	const bar = require( './dist/bar.js' );
+	const baz = require( './dist/baz.js' );
+
+	expect( bar ).toEqual( 'No submodules here' );
+	expect( await baz.noI18n() ).toEqual( 'No i18n here' );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain-no-i18n/webpack.config.js
@@ -1,0 +1,19 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+const DependencyExtractionPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		bar: './src/bar.js',
+		baz: './src/baz.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	plugins: [ new I18nLoaderPlugin(), new DependencyExtractionPlugin() ],
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'no-textdomain' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain/src/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	noI18n: async () => ( await import( /* webpackChunkName: "noI18n" */ './noI18n.js' ) ).default,
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain/src/noI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain/src/noI18n.js
@@ -1,0 +1,1 @@
+module.exports = 'No i18n here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/no-textdomain/webpack.config.js
@@ -1,0 +1,18 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+const DependencyExtractionPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		main: './src/index.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	plugins: [ new I18nLoaderPlugin(), new DependencyExtractionPlugin() ],
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/en_piglatin.json
@@ -1,0 +1,13 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'options' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/src/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/tests.js
@@ -1,0 +1,8 @@
+test( 'Tests', async () => {
+	const main = require( './dist/main.js' );
+	fetch.expectUrl(
+		'http://example.org/options-en_piglatin-e54fa518d005a9d82f46a567822e8600.json',
+		require( './en_piglatin.json' )
+	);
+	expect( await main.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/options/webpack.config.js
@@ -1,0 +1,34 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		main: './src/index.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	plugins: [
+		new I18nLoaderPlugin( {
+			textdomain: 'options',
+			stateModule: 'state',
+			target: 'core',
+			path: 'jetpack_vendor/automattic/jetpack-foobar/dist',
+		} ),
+	],
+	externals: {
+		'@wordpress/i18n': 'global wpI18n',
+		state:
+			'var ' +
+			JSON.stringify( {
+				baseUrl: 'http://example.org/',
+				locale: 'en_piglatin',
+				domainMap: {},
+			} ),
+	},
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/en_piglatin.json
@@ -1,0 +1,14 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ],
+			"This is translated too": [ "is-Thay is-way anslated-tray oo-tay" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/bar.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/bar.js
@@ -1,0 +1,1 @@
+module.exports = 'No submodules here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/baz.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/baz.js
@@ -1,0 +1,3 @@
+module.exports = {
+	noI18n: async () => ( await import( /* webpackChunkName: "noI18n" */ './noI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'single-runtime' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/hasI18n2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/hasI18n2.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated too', 'single-runtime' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/index.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	noI18n: async () => ( await import( /* webpackChunkName: "noI18n" */ './noI18n.js' ) ).default,
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/index2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/index2.js
@@ -1,0 +1,5 @@
+module.exports = {
+	hasI18n: async () => ( await import( /* webpackChunkName: "hasI18n" */ './hasI18n.js' ) ).default,
+	hasI18n2: async () =>
+		( await import( /* webpackChunkName: "hasI18n2" */ './hasI18n2.js' ) ).default,
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/noI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/src/noI18n.js
@@ -1,0 +1,1 @@
+module.exports = 'No i18n here';

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/tests.js
@@ -1,0 +1,26 @@
+test( 'Tests', async () => {
+	const main = require( './dist/main.js' );
+	const main2 = require( './dist/main2.js' );
+	const bar = require( './dist/bar.js' );
+	const baz = require( './dist/baz.js' );
+	const translations = require( './en_piglatin.json' );
+
+	expect( await main.noI18n() ).toEqual( 'No i18n here' );
+
+	fetch.expectUrl(
+		'http://test.example.com/wp-content/languages/plugins/single-runtime-en_piglatin-c7c3968298452ee95564fb9c05e2de50.json',
+		translations
+	);
+	expect( await main.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+
+	fetch.expectUrl(
+		'http://test.example.com/wp-content/languages/plugins/single-runtime-en_piglatin-71d7bd53fc0961d2785c69cde5d9fead.json',
+		translations
+	);
+	expect( await main2.hasI18n() ).toEqual( 'is-Thay is-way anslated-tray' );
+	expect( await main2.hasI18n2() ).toEqual( 'is-Thay is-way anslated-tray oo-tay' );
+
+	expect( bar ).toEqual( 'No submodules here' );
+
+	expect( await baz.noI18n() ).toEqual( 'No i18n here' );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/single-runtime/webpack.config.js
@@ -1,0 +1,27 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+const DependencyExtractionPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		main: './src/index.js',
+		main2: './src/index2.js',
+		bar: './src/bar.js',
+		baz: './src/baz.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	optimization: {
+		runtimeChunk: 'single',
+	},
+	plugins: [
+		new I18nLoaderPlugin( { textdomain: 'single-runtime' } ),
+		new DependencyExtractionPlugin(),
+	],
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/en_piglatin.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/en_piglatin.json
@@ -1,0 +1,14 @@
+{
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": {
+				"domain": "messages",
+				"lang": "en",
+				"plural-forms": "nplurals=2; plural=(n != 1);"
+			},
+			"This is translated": [ "is-Thay is-way anslated-tray" ],
+			"This is translated too": [ "is-Thay is-way anslated-tray oo-tay" ]
+		}
+	}
+}

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/hasI18n.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/hasI18n.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated', 'splitting' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/hasI18n2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/hasI18n2.js
@@ -1,0 +1,3 @@
+const i18n = require( '@wordpress/i18n' );
+
+module.exports = i18n.__( 'This is translated too', 'splitting' );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/index1.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/index1.js
@@ -1,0 +1,2 @@
+module.exports = () =>
+	import( /* webpackChunkName: "indirect1" */ './indirect1.js' ).then( v => v.default );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/index2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/index2.js
@@ -1,0 +1,2 @@
+module.exports = () =>
+	import( /* webpackChunkName: "indirect2" */ './indirect2.js' ).then( v => v.default );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/indirect1.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/indirect1.js
@@ -1,0 +1,4 @@
+module.exports = {
+	a: require( './hasI18n' ),
+	b: require( './hasI18n2' ),
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/indirect2.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/src/indirect2.js
@@ -1,0 +1,4 @@
+module.exports = {
+	x: require( './hasI18n' ),
+	y: require( './hasI18n2' ),
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/tests.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/tests.js
@@ -1,0 +1,19 @@
+test( 'Tests', async () => {
+	const main = require( './dist/main.js' );
+	const main2 = require( './dist/main2.js' );
+	const translations = require( './en_piglatin.json' );
+
+	fetch.expectUrl(
+		'http://test.example.com/wp-content/languages/plugins/splitting-en_piglatin-ec0e6fc1bae1bb5c76db79838b127a36.json',
+		translations
+	);
+	expect( ( await main() ).a ).toEqual( 'is-Thay is-way anslated-tray' );
+	expect( ( await main() ).b ).toEqual( 'is-Thay is-way anslated-tray oo-tay' );
+
+	fetch.expectUrl(
+		'http://test.example.com/wp-content/languages/plugins/splitting-en_piglatin-ec0e6fc1bae1bb5c76db79838b127a36.json',
+		translations
+	);
+	expect( ( await main2() ).x ).toEqual( 'is-Thay is-way anslated-tray' );
+	expect( ( await main2() ).y ).toEqual( 'is-Thay is-way anslated-tray oo-tay' );
+} );

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/webpack.config.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/fixtures/splitting/webpack.config.js
@@ -1,0 +1,27 @@
+const I18nLoaderPlugin = require( '../../../src/I18nLoaderPlugin.js' );
+const DependencyExtractionPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	target: 'async-node',
+	mode: 'development',
+	devtool: false,
+	entry: {
+		main: './src/index1.js',
+		main2: './src/index2.js',
+	},
+	output: {
+		chunkFilename: '[name].js',
+		library: {
+			type: 'commonjs2',
+		},
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 1,
+		},
+	},
+	plugins: [
+		new I18nLoaderPlugin( { textdomain: 'splitting' } ),
+		new DependencyExtractionPlugin(),
+	],
+};

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/globals.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/globals.js
@@ -1,0 +1,69 @@
+// Some globals the tests will probably want.
+global.wpI18n = require( '@wordpress/i18n' );
+global.jpI18nState = {
+	baseUrl: 'http://test.example.com/wp-content/languages/',
+	locale: 'en_piglatin',
+	domainMap: {},
+};
+global.window = {
+	...global.window,
+	wp: {
+		i18n: global.wpI18n,
+		jpI18nState: global.jpI18nState,
+	},
+};
+
+// Simple fetch mock, sufficient for our purposes.
+global.fetch = jest.fn( url => {
+	const ret = fetch.urls[ url ];
+	if ( typeof ret === 'undefined' ) {
+		throw new Error( `Unexpected URL ${ url }` );
+	}
+	if ( ret === null ) {
+		throw new Error( `URL ${ url } was requested multiple times` );
+	}
+	fetch.urls[ url ] = null;
+	return ret;
+} );
+fetch.urls = {};
+
+/**
+ * Mock a URL.
+ *
+ * @param {string} url - URL.
+ * @param {*}      body - Response body. If not a string, it will be passed through `JSON.stringify()`.
+ * @param {object} init - Additional response data.
+ * @param {number} init.status - Response status. Default 200.
+ * @param {string} init.statusText - Response status text. Default "OK".
+ */
+fetch.expectUrl = ( url, body, init = {} ) => {
+	const status = parseInt( init.status || 200 );
+	const statusText = init.statusText || 'OK';
+
+	let rbody = body;
+	if ( typeof rbody !== 'string' ) {
+		rbody = JSON.stringify( rbody );
+	}
+	if ( status < 200 || status > 599 ) {
+		throw new Error( `Invalid status: ${ init.status }` );
+	}
+
+	fetch.urls[ url ] = Promise.resolve( {
+		body: rbody,
+		ok: status < 300,
+		status: status,
+		statusText: statusText,
+		url: url,
+		json: () => JSON.parse( rbody ),
+	} );
+};
+
+/**
+ * Mock a fetch error.
+ *
+ * @param {string} url - URL.
+ * @param {Error}  err - Error.
+ */
+fetch.expectError = ( url, err ) => {
+	fetch.urls[ url ] = Promise.reject( err );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This Webpack plugin will allow Webpack lazy-loaded bundles to also load
the WordPress translation data for the bundle.

A followup will add necessary infrastructure to Assets and will have
Jetpack's Instant Search module make use of it.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: p9dueE-3MG-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Does the documentation make sense?