### PR TITLE
Blog Subscription widget: Fix the DocBlock structure of `hide_widget_in_block_editor()`

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blog-subscription-widget-deprecation-comment
+++ b/projects/plugins/jetpack/changelog/fix-blog-subscription-widget-deprecation-comment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blog Subscription widget: Fix the comment block on the `hide_widget_in_block_editor()` to follow the DocBlock standards

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -64,10 +64,10 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Remove Social Icons widget from Legacy Widget block.
+	 * Remove the "Blog Subscription" widget from the Legacy Widget block
 	 *
-	 * @param array $widget_types Widget type data.
-	 * This only applies to new blocks being added.
+	 * @param array $widget_types List of widgets that are currently removed from the Legacy Widget block.
+	 * @return array $widget_types New list of widgets that will be removed.
 	 */
 	public function hide_widget_in_block_editor( $widget_types ) {
 		$widget_types[] = self::ID_BASE;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The proposed change fixes the comment block related to the `hide_widget_in_block_editor()` function to make it follow the [DocBlock standards](https://docs.phpdoc.org/guide/guides/docblocks.html).

This is a follow-up to the recent PR https://github.com/Automattic/jetpack/pull/21931.

#### Jetpack product discussion
This PR is part of the Legacy Widgets Migration project (pdf5j4-4C-p2).

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
Since there are no functional/code changes, we can review the proposed comment block.
