### PR TITLE
IDC: content customization

### DIFF
--- a/projects/js-packages/idc/changelog/update-idc-customize-again
+++ b/projects/js-packages/idc/changelog/update-idc-customize-again
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC screen content customization.

--- a/projects/js-packages/idc/components/card-fresh/index.jsx
+++ b/projects/js-packages/idc/components/card-fresh/index.jsx
@@ -14,6 +14,7 @@ import { Spinner } from '@automattic/jetpack-components';
  */
 import { STORE_ID } from '../../state/store';
 import extractHostname from '../../tools/extract-hostname';
+import customContentShape from '../../tools/custom-content-shape';
 
 /**
  * The "start fresh" card.
@@ -22,7 +23,7 @@ import extractHostname from '../../tools/extract-hostname';
  * @returns {React.Component} The `ConnectScreen` component.
  */
 const CardFresh = props => {
-	const { isStartingFresh, startFreshCallback } = props;
+	const { isStartingFresh, startFreshCallback, customContent } = props;
 
 	const wpcomHostName = extractHostname( props.wpcomHomeUrl );
 	const currentHostName = extractHostname( props.currentUrl );
@@ -34,23 +35,27 @@ const CardFresh = props => {
 	return (
 		<div className="jp-idc__idc-screen__card-action-base">
 			<div className="jp-idc__idc-screen__card-action-top">
-				<h4>{ __( 'Treat each site as independent sites', 'jetpack' ) }</h4>
+				<h4>
+					{ customContent.startFreshCardTitle ||
+						__( 'Treat each site as independent sites', 'jetpack' ) }
+				</h4>
 
 				<p>
-					{ createInterpolateElement(
-						sprintf(
-							/* translators: %1$s: The current site domain name. %2$s: The original site domain name. */
-							__(
-								'<hostname>%1$s</hostname> settings, stats, and subscribers will start fresh. <hostname>%2$s</hostname> will keep its data as is.',
-								'jetpack'
+					{ customContent.startFreshCardBodyText ||
+						createInterpolateElement(
+							sprintf(
+								/* translators: %1$s: The current site domain name. %2$s: The original site domain name. */
+								__(
+									'<hostname>%1$s</hostname> settings, stats, and subscribers will start fresh. <hostname>%2$s</hostname> will keep its data as is.',
+									'jetpack'
+								),
+								currentHostName,
+								wpcomHostName
 							),
-							currentHostName,
-							wpcomHostName
-						),
-						{
-							hostname: <strong />,
-						}
-					) }
+							{
+								hostname: <strong />,
+							}
+						) }
 				</p>
 			</div>
 
@@ -81,11 +86,14 @@ CardFresh.propTypes = {
 	isStartingFresh: PropTypes.bool.isRequired,
 	/** "Start Fresh" callback. */
 	startFreshCallback: PropTypes.func.isRequired,
+	/** Custom text content. */
+	customContent: PropTypes.shape( customContentShape ),
 };
 
 CardFresh.defaultProps = {
 	isStartingFresh: false,
 	startFreshCallback: () => {},
+	customContent: {},
 };
 
 export default CardFresh;

--- a/projects/js-packages/idc/components/card-migrate/index.jsx
+++ b/projects/js-packages/idc/components/card-migrate/index.jsx
@@ -14,6 +14,7 @@ import { Spinner } from '@automattic/jetpack-components';
  */
 import { STORE_ID } from '../../state/store';
 import extractHostname from '../../tools/extract-hostname';
+import customContentShape from '../../tools/custom-content-shape';
 
 /**
  * The "migrate" card.
@@ -27,30 +28,31 @@ const CardMigrate = props => {
 
 	const isActionInProgress = useSelect( select => select( STORE_ID ).getIsActionInProgress(), [] );
 
-	const { isMigrating, migrateCallback } = props;
+	const { isMigrating, migrateCallback, customContent } = props;
 
 	const buttonLabel = __( 'Move your settings', 'jetpack' );
 
 	return (
 		<div className="jp-idc__idc-screen__card-action-base">
 			<div className="jp-idc__idc-screen__card-action-top">
-				<h4>{ __( 'Move Jetpack data', 'jetpack' ) }</h4>
+				<h4>{ customContent.migrateCardTitle || __( 'Move Jetpack data', 'jetpack' ) }</h4>
 
 				<p>
-					{ createInterpolateElement(
-						sprintf(
-							/* translators: %1$s: The current site domain name. %2$s: The original site domain name. */
-							__(
-								'Move all your settings, stats and subscribers to your other <hostname>%1$s</hostname>. <hostname>%2$s</hostname> will be disconnected from Jetpack.',
-								'jetpack'
+					{ customContent.migrateCardBodyText ||
+						createInterpolateElement(
+							sprintf(
+								/* translators: %1$s: The current site domain name. %2$s: The original site domain name. */
+								__(
+									'Move all your settings, stats and subscribers to your other <hostname>%1$s</hostname>. <hostname>%2$s</hostname> will be disconnected from Jetpack.',
+									'jetpack'
+								),
+								currentHostName,
+								wpcomHostName
 							),
-							currentHostName,
-							wpcomHostName
-						),
-						{
-							hostname: <strong />,
-						}
-					) }
+							{
+								hostname: <strong />,
+							}
+						) }
 				</p>
 			</div>
 
@@ -81,11 +83,14 @@ CardMigrate.propTypes = {
 	isMigrating: PropTypes.bool.isRequired,
 	/** Migration callback. */
 	migrateCallback: PropTypes.func.isRequired,
+	/** Custom text content. */
+	customContent: PropTypes.shape( customContentShape ),
 };
 
 CardMigrate.defaultProps = {
 	isMigrating: false,
 	migrateCallback: () => {},
+	customContent: {},
 };
 
 export default CardMigrate;

--- a/projects/js-packages/idc/components/idc-screen/index.jsx
+++ b/projects/js-packages/idc/components/idc-screen/index.jsx
@@ -14,6 +14,7 @@ import trackAndBumpMCStats from '../../tools/tracking';
 import useMigration from '../../hooks/use-migration';
 import useMigrationFinished from '../../hooks/use-migration-finished';
 import useStartFresh from '../../hooks/use-start-fresh';
+import customContentShape from '../../tools/custom-content-shape';
 
 /**
  * The IDC screen component.
@@ -24,7 +25,7 @@ import useStartFresh from '../../hooks/use-start-fresh';
 const IDCScreen = props => {
 	const {
 		logo,
-		headerText,
+		customContent,
 		wpcomHomeUrl,
 		currentUrl,
 		apiNonce,
@@ -76,7 +77,7 @@ const IDCScreen = props => {
 	return (
 		<IDCScreenVisual
 			logo={ logo }
-			headerText={ headerText }
+			customContent={ customContent }
 			wpcomHomeUrl={ wpcomHomeUrl }
 			currentUrl={ currentUrl }
 			redirectUri={ redirectUri }
@@ -94,8 +95,8 @@ const IDCScreen = props => {
 IDCScreen.propTypes = {
 	/** The screen logo. */
 	logo: PropTypes.object,
-	/** The header text. */
-	headerText: PropTypes.string,
+	/** Custom text content. */
+	customContent: PropTypes.shape( customContentShape ),
 	/** The original site URL. */
 	wpcomHomeUrl: PropTypes.string.isRequired,
 	/** The current site URL. */
@@ -110,6 +111,10 @@ IDCScreen.propTypes = {
 	tracksUserData: PropTypes.object,
 	/** WordPress.com event tracking information. */
 	tracksEventData: PropTypes.object,
+};
+
+IDCScreen.defaultProps = {
+	customContent: {},
 };
 
 export default IDCScreen;

--- a/projects/js-packages/idc/components/idc-screen/screen-main.jsx
+++ b/projects/js-packages/idc/components/idc-screen/screen-main.jsx
@@ -13,6 +13,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import CardMigrate from '../card-migrate';
 import CardFresh from '../card-fresh';
 import SafeMode from '../safe-mode';
+import customContentShape from '../../tools/custom-content-shape';
 
 /**
  * Retrieve the main screen body.
@@ -28,15 +29,32 @@ const ScreenMain = props => {
 		migrateCallback,
 		isStartingFresh,
 		startFreshCallback,
-		title,
-		mainBodyText,
+		customContent,
 	} = props;
 
 	return (
 		<React.Fragment>
-			<h2>{ title }</h2>
+			<h2>{ customContent.mainTitle || __( 'Safe Mode has been activated', 'jetpack' ) }</h2>
 
-			<p>{ mainBodyText }</p>
+			<p>
+				{ customContent.mainBodyText ||
+					createInterpolateElement(
+						__(
+							'Your site is in Safe Mode because you have 2 Jetpack-powered sites that appear to be duplicates. ' +
+								'2 sites that are telling Jetpack they’re the same site. <safeModeLink>Learn more about safe mode.</safeModeLink>',
+							'jetpack'
+						),
+						{
+							safeModeLink: (
+								<a
+									href={ getRedirectUrl( 'jetpack-support-safe-mode' ) }
+									rel="noopener noreferrer"
+									target="_blank"
+								/>
+							),
+						}
+					) }
+			</p>
 
 			<h3>{ __( 'Please select an option', 'jetpack' ) }</h3>
 
@@ -46,6 +64,7 @@ const ScreenMain = props => {
 					currentUrl={ currentUrl }
 					isMigrating={ isMigrating }
 					migrateCallback={ migrateCallback }
+					customContent={ customContent }
 				/>
 				<div className="jp-idc__idc-screen__cards-separator">or</div>
 				<CardFresh
@@ -53,6 +72,7 @@ const ScreenMain = props => {
 					currentUrl={ currentUrl }
 					isStartingFresh={ isStartingFresh }
 					startFreshCallback={ startFreshCallback }
+					customContent={ customContent }
 				/>
 			</div>
 
@@ -74,32 +94,14 @@ ScreenMain.propTypes = {
 	isStartingFresh: PropTypes.bool.isRequired,
 	/** "Start Fresh" callback. */
 	startFreshCallback: PropTypes.func,
-	/** The main screen title. */
-	title: PropTypes.string.isRequired,
-	/** The main screen body text. */
-	mainBodyText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ).isRequired,
+	/** Custom text content. */
+	customContent: PropTypes.shape( customContentShape ),
 };
 
 ScreenMain.defaultProps = {
 	isMigrating: false,
 	isStartingFresh: false,
-	title: __( 'Safe Mode has been activated', 'jetpack' ),
-	mainBodyText: createInterpolateElement(
-		__(
-			'Your site is in Safe Mode because you have 2 Jetpack-powered sites that appear to be duplicates. ' +
-				'2 sites that are telling Jetpack they’re the same site. <safeModeLink>Learn more about safe mode.</safeModeLink>',
-			'jetpack'
-		),
-		{
-			safeModeLink: (
-				<a
-					href={ getRedirectUrl( 'jetpack-support-safe-mode' ) }
-					rel="noopener noreferrer"
-					target="_blank"
-				/>
-			),
-		}
-	),
+	customContent: {},
 };
 
 export default ScreenMain;

--- a/projects/js-packages/idc/components/idc-screen/screen-migrated.jsx
+++ b/projects/js-packages/idc/components/idc-screen/screen-migrated.jsx
@@ -12,6 +12,7 @@ import { Spinner } from '@automattic/jetpack-components';
  * Internal dependencies
  */
 import extractHostname from '../../tools/extract-hostname';
+import customContentShape from '../../tools/custom-content-shape';
 
 /**
  * Retrieve the migrated screen body.
@@ -20,7 +21,7 @@ import extractHostname from '../../tools/extract-hostname';
  * @returns {React.Component} The ScreenMigrated component.
  */
 const ScreenMigrated = props => {
-	const { finishCallback, isFinishing } = props;
+	const { finishCallback, isFinishing, customContent } = props;
 
 	const wpcomHostName = extractHostname( props.wpcomHomeUrl );
 	const currentHostName = extractHostname( props.currentUrl );
@@ -29,22 +30,26 @@ const ScreenMigrated = props => {
 
 	return (
 		<React.Fragment>
-			<h2>{ __( 'Your Jetpack settings have migrated successfully', 'jetpack' ) }</h2>
+			<h2>
+				{ customContent.migratedTitle ||
+					__( 'Your Jetpack settings have migrated successfully', 'jetpack' ) }
+			</h2>
 
 			<p>
-				{ createInterpolateElement(
-					sprintf(
-						/* translators: %1$s: The current site domain name. */
-						__(
-							'Safe Mode has been switched off for <hostname>%1$s</hostname> website and Jetpack is fully functional.',
-							'jetpack'
+				{ customContent.migratedBodyText ||
+					createInterpolateElement(
+						sprintf(
+							/* translators: %1$s: The current site domain name. */
+							__(
+								'Safe Mode has been switched off for <hostname>%1$s</hostname> website and Jetpack is fully functional.',
+								'jetpack'
+							),
+							currentHostName
 						),
-						currentHostName
-					),
-					{
-						hostname: <strong />,
-					}
-				) }
+						{
+							hostname: <strong />,
+						}
+					) }
 			</p>
 
 			<div className="jp-idc__idc-screen__card-migrated">
@@ -79,11 +84,14 @@ ScreenMigrated.propTypes = {
 	finishCallback: PropTypes.func,
 	/** Whether the migration finishing process is in progress. */
 	isFinishing: PropTypes.bool.isRequired,
+	/** Custom text content. */
+	customContent: PropTypes.shape( customContentShape ),
 };
 
 ScreenMigrated.defaultProps = {
 	finishCallback: () => {},
 	isFinishing: false,
+	customContent: {},
 };
 
 export default ScreenMigrated;

--- a/projects/js-packages/idc/components/idc-screen/visual.jsx
+++ b/projects/js-packages/idc/components/idc-screen/visual.jsx
@@ -11,14 +11,13 @@ import { JetpackLogo } from '@automattic/jetpack-components';
  */
 import ScreenMain from './screen-main';
 import ScreenMigrated from './screen-migrated';
+import customContentShape from '../../tools/custom-content-shape';
 import './style.scss';
 
 const IDCScreenVisual = props => {
 	const {
 		logo,
-		headerText,
-		title,
-		mainBodyText,
+		customContent,
 		wpcomHomeUrl,
 		currentUrl,
 		redirectUri,
@@ -35,7 +34,9 @@ const IDCScreenVisual = props => {
 		<div className={ 'jp-idc__idc-screen' + ( isMigrated ? ' jp-idc__idc-screen__success' : '' ) }>
 			<div className="jp-idc__idc-screen__header">
 				<div className="jp-idc__idc-screen__logo">{ logo }</div>
-				<div className="jp-idc__idc-screen__logo-label">{ headerText }</div>
+				<div className="jp-idc__idc-screen__logo-label">
+					{ customContent.headerText || __( 'Safe Mode', 'jetpack' ) }
+				</div>
 			</div>
 
 			{ isMigrated ? (
@@ -44,14 +45,14 @@ const IDCScreenVisual = props => {
 					currentUrl={ currentUrl }
 					finishCallback={ finishMigrationCallback }
 					isFinishing={ isFinishingMigration }
+					customContent={ customContent }
 				/>
 			) : (
 				<ScreenMain
 					wpcomHomeUrl={ wpcomHomeUrl }
 					currentUrl={ currentUrl }
 					redirectUri={ redirectUri }
-					title={ title }
-					mainBodyText={ mainBodyText }
+					customContent={ customContent }
 					isMigrating={ isMigrating }
 					migrateCallback={ migrateCallback }
 					isStartingFresh={ isStartingFresh }
@@ -64,19 +65,15 @@ const IDCScreenVisual = props => {
 
 IDCScreenVisual.propTypes = {
 	/** The screen logo, Jetpack by default. */
-	logo: PropTypes.object,
-	/** The header text, 'Safe Mode' by default. */
-	headerText: PropTypes.string,
+	logo: PropTypes.object.isRequired,
+	/** Custom text content. */
+	customContent: PropTypes.shape( customContentShape ),
 	/** The original site URL. */
 	wpcomHomeUrl: PropTypes.string.isRequired,
 	/** The current site URL. */
 	currentUrl: PropTypes.string.isRequired,
 	/** The redirect URI to redirect users back to after connecting. */
 	redirectUri: PropTypes.string.isRequired,
-	/** The main screen title. */
-	title: PropTypes.string,
-	/** The main screen body text. */
-	mainBodyText: PropTypes.string,
 	/** Whether the migration is in progress. */
 	isMigrating: PropTypes.bool.isRequired,
 	/** Migration callback. */
@@ -95,11 +92,11 @@ IDCScreenVisual.propTypes = {
 
 IDCScreenVisual.defaultProps = {
 	logo: <JetpackLogo height={ 24 } />,
-	headerText: __( 'Safe Mode', 'jetpack' ),
 	isMigrated: false,
 	isFinishingMigration: false,
 	isMigrating: false,
 	isStartingFresh: false,
+	customContent: {},
 };
 
 export default IDCScreenVisual;

--- a/projects/js-packages/idc/tools/custom-content-shape.jsx
+++ b/projects/js-packages/idc/tools/custom-content-shape.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+export default {
+	/** The header text, 'Safe Mode' by default. */
+	headerText: PropTypes.string,
+	/** The main screen title. */
+	mainTitle: PropTypes.string,
+	/** The main screen body text. */
+	mainBodyText: PropTypes.string,
+	/** The "migration finished" screen title. */
+	migratedTitle: PropTypes.string,
+	/** The "migration finished" screen body text. */
+	migratedBodyText: PropTypes.string,
+	/** The migration card title. */
+	migrateCardTitle: PropTypes.string,
+	/** The migration card body. */
+	migrateCardBodyText: PropTypes.string,
+	/** The "start fresh" card title. */
+	startFreshCardTitle: PropTypes.string,
+	/** The "start fresh" card body. */
+	startFreshCardBodyText: PropTypes.string,
+};


### PR DESCRIPTION
Partially extracted from #21873

#### Changes proposed in this Pull Request:
- add the `customContent` property to customize text content of the IDC banner

#### Jetpack product discussion
p9dueE-3Mn-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

##### Basic IDC functionality
1. Rebuild the Connection Manager package: `jetpack build packages/connection-ui`.
2. Connect Jetpack, go to Jetpack Debug and activate the IDC Simulator.
3. Go to "Jetpack Debug -> IDC Simulator", enable "IDC Simulation" and enter a "Spoof URL".
4. Edit a post and save to make the site sync. Wait a few seconds.
5. Go to "Tools -> Connection Manager", confirm that the RNA IDC screen appears.
6. Click "Move your settings". The "migrated successfully" screen should appear, click "Got it".
7. The page should reload, IDC banners should disappear.

##### Storybook
_The IDC banner on the "Docs" tab will not properly transition to the smaller width (the cards won't rearrange vertically). This is a Storybook issue, which displays the banner inside a small-sized div, this doesn't happen in WordPress._

8. Go to `projects/js-packages/storybook`, run `pnpm install` and `pnpm run storybook:dev`.
9. When the Storybook loads, navigate to "Identity Crisis -> Admin Screen", two stories should be available: "Default" and "Migrated". Click on both and confirm that they both get loaded correctly.
10. Switch to the "Docs" tab and locate the property `customContent`. Set the following value:
```
{
  "headerText": "Sample Header",
  "mainTitle": "Sample main title",
  "mainBodyText": "Sample main body text",
  "migratedTitle": "Sample migrated title",
  "migratedBodyText": "Sample migrated body text",
  "migrateCardTitle": "Sample migrate card title",
  "migrateCardBodyText": "Sample migrate card body text",
  "startFreshCardTitle": "Sample start fresh card title",
  "startFreshCardBodyText": "Sample start fresh card body"
}
```
11. Look at the rendered "Admin Screen" and confirm that all the text except button labels has been customized.
12. Switch the property `isMigrated` to `true`, and confirm that the "Admin Screen" now displays the "Migrated" screen, and all the text except for the button label was customized.