### PR TITLE
E2E tests: disable slow tests warnings

### DIFF
--- a/tools/e2e-commons/config/playwright.config.default.cjs
+++ b/tools/e2e-commons/config/playwright.config.default.cjs
@@ -47,6 +47,7 @@ const playwrightConfig = {
 		userAgent:
 			'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_2) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36 wp-e2e-tests',
 	},
+	reportSlowTests: null,
 };
 
 module.exports = playwrightConfig;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Disabled the slow tests warnings in e2e tests, introduced by #21848 

#### Jetpack product discussion
pd5faL-2m-p2#comment-53

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- E2E tests should pass, there should be no slow tests warnings.