### PR TITLE
E2E tests: fix connection run group running too many tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,13 +25,12 @@ jobs:
       - uses: actions/checkout@v2
       - id: create-matrix
         run: |
-          MATRIX='[{"group":"pre-connection","tests":"pre-connection"},{"group":"connection","tests":"connection"},{"group":"post-connection","tests":"post-connection"}]'
+          MATRIX='[{"group":"pre-connection","tests":"pre-connection"},{"group":"connection","tests":"specs/connection"},{"group":"post-connection","tests":"post-connection"}]'
           if [ "$GITHUB_EVENT_NAME" == schedule ]; then
             MATRIX=$(echo $MATRIX | jq '. + [{"group": "gutenberg","tests": "blocks"}]' | jq -c .)
           fi
           echo $MATRIX
           echo "::set-output name=matrix::$MATRIX"
-
 
   e2e-tests:
     name: "E2E ${{ matrix.group }} tests"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: create-matrix
         run: |
-          MATRIX='[{"group":"pre-connection","tests":"pre-connection"},{"group":"connection","tests":"specs/connection"},{"group":"post-connection","tests":"post-connection"}]'
+          MATRIX='[{"group":"pre-connection","tests":"specs/pre-connection"},{"group":"connection","tests":"specs/connection"},{"group":"post-connection","tests":"specs/post-connection"}]'
           if [ "$GITHUB_EVENT_NAME" == schedule ]; then
             MATRIX=$(echo $MATRIX | jq '. + [{"group": "gutenberg","tests": "blocks"}]' | jq -c .)
           fi


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Since #21848 the e2e tests `connection` matrix group is running all tests having "connection" in their path, meaning also `pre-connection` and `post-connection` folders. This is a simple fix to address that.

#### Jetpack product discussion
1156386383419466-as-1201474418952822

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- E2E tests should pass. The job `E2E connection tests` should only include the 2 tests from the connection spec.