### PR TITLE
Fix some styling inconsistencies in the disconnect flow

### DIFF
--- a/projects/js-packages/connection/changelog/fix-style-conflicts-in-disconnect-flow
+++ b/projects/js-packages/connection/changelog/fix-style-conflicts-in-disconnect-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Style updates to improve disconnect flow appearance when Gutenberg plugin is active

--- a/projects/js-packages/connection/components/disconnect-dialog/style.scss
+++ b/projects/js-packages/connection/components/disconnect-dialog/style.scss
@@ -61,6 +61,11 @@
 			display: flex;
 			flex-direction: column;
 			flex-grow: 1;
+			margin: 0;
+
+			&::before {
+				display: none;
+			}
 		}
 
 		&__header{
@@ -182,7 +187,6 @@
 		height: 900px;
 		display: flex;
 		flex-direction: column;
-		flex-grow: 1;
 
 		h1 {
 			font-size: var( --font-title-large );

--- a/projects/js-packages/connection/components/disconnect-dialog/style.scss
+++ b/projects/js-packages/connection/components/disconnect-dialog/style.scss
@@ -166,10 +166,13 @@
 }
 
 @media (min-width: 600px){
-	.jp-connection__disconnect-dialog {
+	.jp-connection__disconnect-dialog,
+	.jp-connection__disconnect-dialog.components-modal__frame {
 		width: 100%;
 		max-width: calc( 100% - 32px );
+	}
 
+	.jp-connection__disconnect-dialog {
 		&__content {
 			padding: 2rem;
 		}
@@ -182,12 +185,15 @@
 
 
 @media (min-width: 960px){
-	.jp-connection__disconnect-dialog{
+	.jp-connection__disconnect-dialog,
+	.jp-connection__disconnect-dialog.components-modal__frame {
 		width: 1200px;
 		height: 900px;
 		display: flex;
 		flex-direction: column;
+	}
 
+	.jp-connection__disconnect-dialog {
 		h1 {
 			font-size: var( --font-title-large );
 		}


### PR DESCRIPTION
This PR fixes a few styling inconsistencies that affect the disconnect flow when the Gutenberg plugin is active.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR includes CSS changes to fix some styling inconsistencies that appear in the disconnect flow when the Gutenberg plugin is active.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Jetpack test site, test first with the master branch to see the issue.
* On your test site, install the Gutenberg plugin: https://wordpress.org/plugins/gutenberg/
* Activate the Gutenberg plugin
* From the Jetpack Dashboard, in the "Site Connections" area, click on the "Manage site connection" link to open the disconnect flow.
* You should see the disconnect flow modal that looks like this:
![Screen Shot 2021-12-06 at 9 40 26 AM](https://user-images.githubusercontent.com/18016357/144869438-ec678d11-fd63-47ac-911e-7a5f36f1a003.png)
* Notice that there is extra whitespace at the top of the modal and that the modal is not width-limited, it scales with the width of the screen. As a consequence of the modal scaling, the CTA buttons appear to be aligned incorrectly - they should be on the left side of the modal.
* Now, deactivate the Gutenberg plugin and open the disconnect flow by repeating the steps above. Notice that the additional whitespace at the top of the modal is gone and the modal is limited to a max width of 1200px:
![Screen Shot 2021-12-06 at 9 40 54 AM](https://user-images.githubusercontent.com/18016357/144869897-9ca871ef-f1fc-4e92-8fcc-95175fe885c8.png)

* Switch now to this branch on your test site and activate the Gutenberg plugin. Even with the Gutenberg plugin active, the disconnect modal should look like the second screenshot with no styling inconsistencies.
* Test the remainder of the flow by disconnecting and providing feedback. Ensure that the width of the modal remains consistent and there is no additional whitespace showing at the top of the modal.
