### PR TITLE
Block performance tests: fix jetpack-connect script

### DIFF
--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -3,9 +3,6 @@ name: Jetpack block performance
 on:
   schedule:
     - cron:  '0 */12 * * *'
-  pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   block-performance:

--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -71,11 +71,15 @@ jobs:
           npm run test-performance packages/e2e-tests/specs/performance/post-editor.test.js
           mv packages/e2e-tests/specs/performance/post-editor.test.results.json ../tools/e2e-commons/results/base.test.results.json
 
-      - name: Set up Jetpack connection
+      - name: Environment reset
         working-directory: tools/e2e-commons
         run: |
           pnpm env:reset
           pnpm tunnel:reset
+
+      - name: Set up Jetpack connection
+        working-directory: tools/e2e-commons
+        run: |
           pnpm jetpack-connect
           pnpx jetpack docker --type e2e --name t1 wp jetpack module deactivate sso
           pnpx jetpack docker --type e2e --name t1 wp -- user create admin admin@example.com --role=administrator --user_pass=password

--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -94,7 +94,7 @@ jobs:
         working-directory: tools/e2e-commons
         continue-on-error: true
         run: |
-          pnpm run tunnel-off
+          pnpm run tunnel:off
 
       - name: Upload test artifacts
         if: ${{ always() }}

--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -3,6 +3,9 @@ name: Jetpack block performance
 on:
   schedule:
     - cron:  '0 */12 * * *'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   block-performance:

--- a/tools/e2e-commons/package.json
+++ b/tools/e2e-commons/package.json
@@ -18,7 +18,7 @@
 		"config:encrypt": "openssl enc -md sha1 -aes-256-cbc -pass env:CONFIG_KEY -in config/local.cjs -out ./config/encrypted.enc",
 		"preinstall": "pnpm --prefix ../cli install",
 		"postinstall": "pnpm playwright install",
-		"jetpack-connect": "NODE_ENV=test pnpm exec babel-node bin/e2e-jetpack-connector.js"
+		"jetpack-connect": "node bin/e2e-jetpack-connector.js"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.16.3",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Looks like with #21848 the npm jetpack-connect script was missed, causing block performance tests workflow to fail.
I also fixed the wrong `tunnel-off` command in causing the environment teardown step to return non 0 exit code.

#### Jetpack product discussion
1156386383419466-as-1201474418952825

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Cannot be tested before merging with the current workflow triggers. I tested it by changing the trigger, see [this run](https://github.com/Automattic/jetpack/runs/4433315514?check_suite_focus=true)