### PR TITLE
Draft: Update Backup to consume Admin components...

### DIFF
--- a/projects/js-packages/components/changelog/update-use-my-jetpack-in-backups
+++ b/projects/js-packages/components/changelog/update-use-my-jetpack-in-backups
@@ -1,0 +1,5 @@
+git Significance: patch
+Type: changed
+Comment: internal change on component not used anywhere
+
+

--- a/projects/js-packages/components/components/admin-page/index.jsx
+++ b/projects/js-packages/components/components/admin-page/index.jsx
@@ -21,13 +21,13 @@ import AdminPageFooter from './footer';
  * @returns {React.Component} AdminPage component.
  */
 const AdminPage = props => {
-	const { children, moduleName, a8cLogoHref } = props;
+	const { children, moduleName, a8cLogoHref, withHeader = true, withFooter = true } = props;
 
 	return (
 		<div class="jp-admin-page">
-			<AdminPageHeader />
+			{ withHeader && <AdminPageHeader /> }
 			{ children }
-			<AdminPageFooter moduleName={ moduleName } a8cLogoHref={ a8cLogoHref } />
+			{ withFooter && <AdminPageFooter moduleName={ moduleName } a8cLogoHref={ a8cLogoHref } /> }
 		</div>
 	);
 };
@@ -42,6 +42,8 @@ AdminPage.propTypes = {
 	a8cLogoHref: PropTypes.string,
 	/** Name of the module, e.g. 'Jetpack Search' that will be displayed in the footer. */
 	moduleName: PropTypes.string,
+	withHeader: PropTypes.boolean,
+	withFooter: PropTypes.boolean,
 };
 
 export default AdminPage;

--- a/projects/js-packages/components/components/admin-section/basic/index.jsx
+++ b/projects/js-packages/components/components/admin-section/basic/index.jsx
@@ -18,11 +18,7 @@ const AdminSection = props => {
 	const { children } = props;
 	return (
 		<div className="jp-admin-section">
-			<div className="jp-wrap">
-				<div class="jp-row">
-					<div class="lg-col-span-12 md-col-span-8 sm-col-span-4">{ children }</div>
-				</div>
-			</div>
+			<div className="jp-wrap">{ children }</div>
 		</div>
 	);
 };

--- a/projects/js-packages/components/components/admin-section/basic/style.scss
+++ b/projects/js-packages/components/components/admin-section/basic/style.scss
@@ -1,7 +1,6 @@
 @import '~@automattic/jetpack-base-styles/style';
 
 .jp-admin-section {
-	padding: 64px 0px;
 	background-color: white;
 
 	h1, h2, h3, h4, h5, h6 {

--- a/projects/js-packages/components/components/admin-section/hero/index.jsx
+++ b/projects/js-packages/components/components/admin-section/hero/index.jsx
@@ -18,11 +18,7 @@ const AdminSectionHero = props => {
 	const { children } = props;
 	return (
 		<div className="jp-admin-section-hero">
-			<div className="jp-wrap">
-				<div class="jp-row">
-					<div class="lg-col-span-12 md-col-span-8 sm-col-span-4">{ children }</div>
-				</div>
-			</div>
+			<div className="jp-wrap">{ children }</div>
 		</div>
 	);
 };

--- a/projects/plugins/backup/changelog/update-use-my-jetpack-in-backups
+++ b/projects/plugins/backup/changelog/update-use-my-jetpack-in-backups
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: testing stuff only
+
+

--- a/projects/plugins/backup/src/js/components/Admin.js
+++ b/projects/plugins/backup/src/js/components/Admin.js
@@ -5,7 +5,12 @@ import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useSelect } from '@wordpress/data';
-import { JetpackFooter, JetpackLogo, getRedirectUrl } from '@automattic/jetpack-components';
+import {
+	AdminSection,
+	AdminSectionHero,
+	AdminPage,
+	getRedirectUrl,
+} from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -56,26 +61,23 @@ const Admin = () => {
 
 	const renderNoBackupCapabilities = () => {
 		return (
-			<div className="jp-wrap">
-				<div className="jp-row">
-					<div class="lg-col-span-8 md-col-span-8 sm-col-span-4">
-						<h1>{ __( 'Your site does not have backups', 'jetpack-backup' ) }</h1>
-						<p>
-							{ __(
-								'Get peace of mind knowing your work will be saved, add backups today.',
-								'jetpack-backup'
-							) }
-						</p>
-						<a
-							class="button"
-							href={ getRedirectUrl( 'backup-plugin-upgrade-10gb', { site: domain } ) }
-							target="_blank"
-							rel="noreferrer"
-						>
-							{ __( 'Upgrade now', 'jetpack-backup' ) }
-						</a>
-					</div>
-					<div class="lg-col-span-4 md-col-span-0 sm-col-span-0"></div>
+			<div className="jp-row">
+				<div className="lg-col-span-8 md-col-span-8 sm-col-span-4">
+					<h1>{ __( 'Your site does not have backups', 'jetpack-backup' ) }</h1>
+					<p>
+						{ __(
+							'Get peace of mind knowing your work will be saved, add backups today.',
+							'jetpack-backup'
+						) }
+					</p>
+					<a
+						class="button"
+						href={ getRedirectUrl( 'backup-plugin-upgrade-10gb', { site: domain } ) }
+						target="_blank"
+						rel="noreferrer"
+					>
+						{ __( 'Upgrade now', 'jetpack-backup' ) }
+					</a>
 				</div>
 			</div>
 		);
@@ -92,10 +94,8 @@ const Admin = () => {
 			}
 
 			return (
-				<div className="jp-wrap">
-					<div className="jp-row">
-						<div class="lg-col-span-12 md-col-span-8 sm-col-span-4">{ renderConnectScreen() }</div>
-					</div>
+				<div className="jp-row">
+					<div class="lg-col-span-12 md-col-span-8 sm-col-span-4">{ renderConnectScreen() }</div>
 				</div>
 			);
 		}
@@ -119,43 +119,6 @@ const Admin = () => {
 		}
 
 		return renderNoBackupCapabilities();
-	};
-
-	const renderHeader = () => {
-		if ( showHeaderFooter ) {
-			return (
-				<div className="jp-wrap">
-					<div className="jp-row">
-						<div class="lg-col-span-12 md-col-span-8 sm-col-span-4">
-							<div className="jp-masthead">
-								<div className="jp-masthead__inside-container">
-									<div className="jp-masthead__logo-container">
-										<JetpackLogo className="jetpack-logo__masthead" />
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			);
-		}
-	};
-
-	const renderFooter = () => {
-		if ( showHeaderFooter ) {
-			return (
-				<div className="jp-wrap">
-					<div className="jp-row">
-						<div class="lg-col-span-12 md-col-span-8 sm-col-span-4">
-							<JetpackFooter
-								moduleName={ __( 'Jetpack Backup', 'jetpack-backup' ) }
-								a8cLogoHref="https://www.jetpack.com"
-							/>
-						</div>
-					</div>
-				</div>
-			);
-		}
 	};
 
 	// Renders additional segments under the jp-hero area condition on having a backup plan
@@ -215,20 +178,23 @@ const Admin = () => {
 	const renderContent = () => {
 		return (
 			<div className="content">
-				<div className="jp-hero">{ renderLoadedState() }</div>
-				<div className="jp-section">
-					<div className="jp-wrap">{ isFullyConnected() && renderBackupSegments() }</div>
-				</div>
+				<AdminSectionHero>{ renderLoadedState() }</AdminSectionHero>
+				<AdminSection>{ isFullyConnected() && renderBackupSegments() }</AdminSection>
 			</div>
 		);
 	};
 
 	return (
-		<div id="jetpack-backup-admin-container" className="jp-content">
-			{ renderHeader() }
-			{ renderContent() }
-			{ renderFooter() }
-		</div>
+		<AdminPage
+			withHeader={ showHeaderFooter }
+			withFooter={ showHeaderFooter }
+			moduleName={ __( 'Jetpack Backup', 'jetpack-backup' ) }
+			a8cLogoHref="https://www.jetpack.com"
+		>
+			<div id="jetpack-backup-admin-container" className="jp-content">
+				{ renderContent() }
+			</div>
+		</AdminPage>
 	);
 };
 

--- a/projects/plugins/backup/src/js/components/admin-style.scss
+++ b/projects/plugins/backup/src/js/components/admin-style.scss
@@ -37,7 +37,7 @@
 		font-weight: 500;
 	}
 
-	.jp-section {
+	.jp-admin-section {
 		h2, h3 {
 			margin-bottom: 16px;
 		}
@@ -105,10 +105,8 @@
 	}
 }
 
-.jp-hero {
+.jp-admin-section-hero {
 	margin-bottom: 64px;
-	padding: 64px 0;
-	background: var( --jp-white-off );
 
 	&.is-backup-performing {
 		background-image: url("data:image/svg+xml,%3Csvg width='624' height='400' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M624 88.387C575.321 34.082 504.674 0 426 0 323.405 0 234.3 58.22 189.925 143.42 83.07 154.78 0 245.305 0 355c0 38.16 10.072 73.999 27.698 105H624V88.387z' fill='%23fff'/%3E%3C/svg%3E");


### PR DESCRIPTION
Tries out the Admin components introduced in 21826 consuming them fromn the Backup plugin

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Updates the `AdminPage` component to accept withHeader and withFooter boolean props
* Removes row and column rendering from admin section and admin section hero components
* Updates Jetpack Backup as an example on how to take advantage of admin components

#### Jetpack product discussion

Work towards P1HpG7-dRX-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
