### PR TITLE
tools: Fix changelogger-release.sh logic

### DIFF
--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -174,6 +174,9 @@ for SLUG in "${SLUGS[@]}"; do
 	fi
 done
 
+debug "  Updating pnpm.lock..."
+pnpm install --silent
+
 cat <<-EOM
 
 	You can examine the changelogs with

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -89,6 +89,7 @@ function get_packages {
 
 get_packages
 
+DO_PNPM_LOCK=true
 SLUGS=()
 if [[ $# -le 0 ]]; then
 	# Use a temp variable so pipefail works
@@ -99,6 +100,7 @@ if [[ $# -le 0 ]]; then
 	mapfile -t -O ${#SLUGS[@]} SLUGS <<<"$TMP"
 else
 	SLUGS=( "$@" )
+	DO_PNPM_LOCK=false
 fi
 
 if $UPDATE; then
@@ -244,12 +246,16 @@ for SLUG in "${SLUGS[@]}"; do
 done
 
 if $ANYJS; then
-	spin
-	debug "Updating pnpm-lock.yaml"
-	if [[ -n "$CI" ]]; then
-		pnpm install --no-frozen-lockfile
+	if $DO_PNPM_LOCK; then
+		spin
+		debug "Updating pnpm-lock.yaml"
+		if [[ -n "$CI" ]]; then
+			pnpm install --no-frozen-lockfile
+		else
+			pnpm install --silent
+		fi
 	else
-		pnpm install --silent
+		debug "Skipping pnpm-lock.yaml update because we were passed a list of packages"
 	fi
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When changelogger-release.sh calls check-intra-monorepo-deps.sh to
update projects individually, we need to not have
check-intra-monorepo-deps.sh try to update pnpm-lock.yaml because the
dependencies may not be in a consistent state until it has finished
updating all projects.

So when check-intra-monorepo-deps.sh is called with a list of projects
to update, rely on the caller (changelogger-release.sh) to do the pnpm
lock file update.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1638824435259700-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out c8edd919ccc23891ddd6c0157835ad7241ed7dbc, cherry-pick this PR, then run `tools/changelogger-release.sh js-packages/connection; echo "Exit status was $?"`. It should complete successfully (with a 0 exit status).