### PR TITLE
[Ads]: Add action for manual placing of top header ad. Allow leaderboard size for Ads Widget

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wordads-header-ad
+++ b/projects/plugins/jetpack/changelog/update-wordads-header-ad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add hook for placing header ad. Allow leaderboard size when displaying ad widget.

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
@@ -17,7 +17,7 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 	 *
 	 * @var string[]
 	 */
-	private static $allowed_tags = array( 'mrec', 'wideskyscraper' );
+	private static $allowed_tags = array( 'mrec', 'wideskyscraper', 'leaderboard' );
 
 	/**
 	 * Number of widgets.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fixes issue with top header ad markup being added to the the `<head>` instead of in the `<body>`. The ad will now be placed before the first-child element of the `<body>` by default.
* Adds a `wordads_header_ad` action that can be used in the template to place the top header ad. When the action is used, the default placement in the `<body>` will be suppressed. The action will only be allowed once per page.
* Adds `leaderboard` to the allowed sizes when placing the Ads Widget.

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Visit ads enabled site with the `Top of each page` additional ad placement turned on.
* Verify the top ad markup is the first element in `<body>`.
* Add `do_action( 'wordads_header_ad' );` to your theme template.
* Verify the top ad markup displays at the correct location where the action was fired.
* Verify no default top ad as the first element in `<body>`.
* Add second `do_action( 'wordads_header_ad' );` action to your theme template.
* Verify that only `one` top header ad appears.
* Add an Ads Widget to your page.
* Verify that `leaderboard` is an available size option.
