### PR TITLE
Search package: search plan update on heartbeat and new method `ever_supported_search`

### DIFF
--- a/projects/packages/search/changelog/update-search-plan-update-and-supported_method
+++ b/projects/packages/search/changelog/update-search-plan-update-and-supported_method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search package: add new methods and update timing for `Plan` class

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -84,7 +84,7 @@ class Plan {
 	 */
 	public function supports_instant_search() {
 		$plan_info = $this->get_plan_info();
-		return ( isset( $plan_info['supports_instant_search'] ) && $plan_info['supports_instant_search'] );
+		return isset( $plan_info['supports_instant_search'] ) && $plan_info['supports_instant_search'];
 	}
 
 	/**
@@ -92,7 +92,7 @@ class Plan {
 	 */
 	public function supports_search() {
 		$plan_info = $this->get_plan_info();
-		return ( isset( $plan_info['supports_search'] ) && $plan_info['supports_search'] );
+		return isset( $plan_info['supports_search'] ) && $plan_info['supports_search'];
 	}
 
 	/**

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -84,7 +84,7 @@ class Plan {
 	 */
 	public function supports_instant_search() {
 		$plan_info = $this->get_plan_info();
-		return ( isset( $plan_info['supports_instant_search'] ) && $plan_info['supports_instant_search'] ) || $this->has_jetpack_search_product();
+		return ( isset( $plan_info['supports_instant_search'] ) && $plan_info['supports_instant_search'] );
 	}
 
 	/**
@@ -92,7 +92,7 @@ class Plan {
 	 */
 	public function supports_search() {
 		$plan_info = $this->get_plan_info();
-		return ( isset( $plan_info['supports_search'] ) && $plan_info['supports_search'] ) || $this->has_jetpack_search_product();
+		return ( isset( $plan_info['supports_search'] ) && $plan_info['supports_search'] );
 	}
 
 	/**

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -24,7 +24,7 @@ class Plan {
 	 *
 	 * @var boolean
 	 */
-	protected static $hooks_inited = false;
+	protected static $update_plan_hook_initialized = false;
 
 	/**
 	 * Init hooks for updating plan info
@@ -32,9 +32,9 @@ class Plan {
 	public function init_hooks() {
 		// Update plan info from WPCOM on Jetpack heartbeat.
 		// TODO: implement heartbeart for search.
-		if ( ! static::$hooks_inited ) {
+		if ( ! static::$update_plan_hook_initialized ) {
 			add_action( 'jetpack_heartbeat', array( $this, 'get_plan_info_from_wpcom' ) );
-			static::$hooks_inited = true;
+			static::$update_plan_hook_initialized = true;
 		}
 	}
 

--- a/projects/packages/search/tests/php/test-plan.php
+++ b/projects/packages/search/tests/php/test-plan.php
@@ -25,6 +25,7 @@ class Test_Plan extends Search_Test_Case {
 	 */
 	public static function set_up_before_class() {
 		static::$plan = new Plan();
+		static::$plan->init_hooks();
 	}
 
 	/**
@@ -94,6 +95,37 @@ class Test_Plan extends Search_Test_Case {
 		static::$plan->update_search_plan_info( $response );
 		$this->assertEquals( json_decode( $response['body'], true ), static::$plan->get_plan_info() );
 		$this->assertFalse( static::$plan->has_jetpack_search_product() );
+	}
+
+	/**
+	 * Test `ever_supported_search`
+	 */
+	public function test_ever_supported_search() {
+		$this->assertTrue( static::$plan->ever_supported_search() );
+
+		add_filter( 'option_' . Plan::JETPACK_SEARCH_EVER_SUPPORTED_SEARCH, '__return_false' );
+		add_filter( 'option_has_jetpack_search_product', '__return_false' );
+		add_filter( 'option_' . Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY, '__return_false' );
+		$this->assertFalse( static::$plan->ever_supported_search() );
+		remove_filter( 'option_' . Plan::JETPACK_SEARCH_EVER_SUPPORTED_SEARCH, '__return_false' );
+		remove_filter( 'option_has_jetpack_search_product', '__return_false' );
+		remove_filter( 'option_' . Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY, '__return_false' );
+
+		add_filter( 'option_' . Plan::JETPACK_SEARCH_EVER_SUPPORTED_SEARCH, '__return_false' );
+		add_filter( 'option_has_jetpack_search_product', '__return_false' );
+		$this->assertTrue( static::$plan->ever_supported_search() );
+		remove_filter( 'option_' . Plan::JETPACK_SEARCH_EVER_SUPPORTED_SEARCH, '__return_false' );
+		remove_filter( 'option_has_jetpack_search_product', '__return_false' );
+	}
+
+	/**
+	 * Test update data on heartbeat
+	 */
+	public function test_update_data_on_heartbeat() {
+		delete_option( Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY );
+		$this->assertEmpty( get_option( Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY ) );
+		do_action( 'jetpack_heartbeat' );
+		$this->assertNotEmpty( get_option( Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY ) );
 	}
 
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR proposes changes to add `ever_supported_search` for the determination of Search submenu item visibility, i.e. if the site ever had/have a plan supporting Search then the menu is shown. The PR also added plan data updating on Jetpack heartbeat.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Run `jetpack install --all`
* `(cd projects/packages/search && composer phpunit)`
* Ensure all tests pass
