### PR TITLE
Plans: Update intro discount percentages from 40 to 50

### DIFF
--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
@@ -8,7 +8,7 @@ export function buildInitialState() {
 						"slug": "jetpack_backup_daily",
 						"description": "Never lose a word, image, page, or time worrying about your site with automated backups & one-click restores.",
 						"show_promotion": true,
-						"discount_percent": 40,
+						"discount_percent": 50,
 						"included_in_plans": [
 							"security"
 						],
@@ -24,7 +24,7 @@ export function buildInitialState() {
 						"slug": "jetpack_scan",
 						"description": "Automatic scanning and one-click fixes keep your site one step ahead of security threats and malware.",
 						"show_promotion": true,
-						"discount_percent": 40,
+						"discount_percent": 50,
 						"included_in_plans": [
 							"security"
 						],
@@ -39,7 +39,7 @@ export function buildInitialState() {
 						"slug": "jetpack_search",
 						"description": "Help your site visitors find answers instantly so they keep reading and buying. Great for sites with a lot of content.",
 						"show_promotion": true,
-						"discount_percent": 40,
+						"discount_percent": 50,
 						"included_in_plans": [],
 						"features": [
 							"Instant search and indexing",
@@ -53,7 +53,7 @@ export function buildInitialState() {
 						"slug": "jetpack_anti_spam",
 						"description": "Save time and get better responses by automatically blocking spam from your comments and forms.",
 						"show_promotion": true,
-						"discount_percent": 40,
+						"discount_percent": 50,
 						"included_in_plans": [
 							"security"
 						],
@@ -69,7 +69,7 @@ export function buildInitialState() {
 						"slug": "jetpack_security_daily",
 						"description": "Comprehensive site security, including Backup, Scan, and Anti-spam.",
 						"show_promotion": true,
-						"discount_percent": 40,
+						"discount_percent": 50,
 						"included_in_plans": [],
 						"features": [
 							"Real-time cloud backups with 10GB storage",

--- a/projects/plugins/jetpack/changelog/update-product-discount-percentages
+++ b/projects/plugins/jetpack/changelog/update-product-discount-percentages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update introductory discount percentages from 40% to 50%, to reflect new pricing structure..

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -7117,7 +7117,7 @@ endif;
 			'slug'              => 'jetpack_backup_t1_yearly',
 			'description'       => __( 'Never lose a word, image, page, or time worrying about your site with automated backups & one-click restores.', 'jetpack' ),
 			'show_promotion'    => true,
-			'discount_percent'  => 40,
+			'discount_percent'  => 50,
 			'included_in_plans' => array( 'security' ),
 			'features'          => array(
 				_x( 'Real-time cloud backups', 'Backup Product Feature', 'jetpack' ),
@@ -7132,7 +7132,7 @@ endif;
 			'slug'              => 'jetpack_scan',
 			'description'       => __( 'Automatic scanning and one-click fixes keep your site one step ahead of security threats and malware.', 'jetpack' ),
 			'show_promotion'    => true,
-			'discount_percent'  => 40,
+			'discount_percent'  => 50,
 			'included_in_plans' => array( 'security' ),
 			'features'          => array(
 				_x( 'Automated daily scanning', 'Scan Product Feature', 'jetpack' ),
@@ -7146,7 +7146,7 @@ endif;
 			'slug'              => 'jetpack_search',
 			'description'       => __( 'Help your site visitors find answers instantly so they keep reading and buying. Great for sites with a lot of content.', 'jetpack' ),
 			'show_promotion'    => true,
-			'discount_percent'  => 40,
+			'discount_percent'  => 50,
 			'included_in_plans' => array(),
 			'features'          => array(
 				_x( 'Instant search and indexing', 'Search Product Feature', 'jetpack' ),
@@ -7161,7 +7161,7 @@ endif;
 			'slug'              => 'jetpack_anti_spam',
 			'description'       => __( 'Save time and get better responses by automatically blocking spam from your comments and forms.', 'jetpack' ),
 			'show_promotion'    => true,
-			'discount_percent'  => 40,
+			'discount_percent'  => 50,
 			'included_in_plans' => array( 'security' ),
 			'features'          => array(
 				_x( 'Comment and form spam protection', 'Anti-Spam Product Feature', 'jetpack' ),
@@ -7176,7 +7176,7 @@ endif;
 			'slug'              => 'jetpack_security_t1_yearly',
 			'description'       => __( 'Comprehensive site security, including Backup, Scan, and Anti-spam.', 'jetpack' ),
 			'show_promotion'    => true,
-			'discount_percent'  => 40,
+			'discount_percent'  => 50,
 			'included_in_plans' => array(),
 			'features'          => array(
 				_x( 'Real-time cloud backups with 10GB storage', 'Security Tier 1 Feature', 'jetpack' ),
@@ -7191,7 +7191,7 @@ endif;
 			'slug'              => 'jetpack_videopress',
 			'description'       => __( 'High-quality, ad-free video built specifically for WordPress.', 'jetpack' ),
 			'show_promotion'    => true,
-			'discount_percent'  => 40,
+			'discount_percent'  => 50,
 			'included_in_plans' => array(),
 			'features'          => array(
 				_x( '1TB of storage', 'VideoPress Product Feature', 'jetpack' ),


### PR DESCRIPTION
Fixes `1201295898168937-as-1201466911979531`.

#### Changes proposed in this Pull Request:

* Update the `discount_percent` property on all promoted Jetpack products to be 50% instead of 40%, so we can show updated prices in our Recommendations section.
* Update the `discount_percent` property in testing fixtures to match these changes.

#### Jetpack product discussion

`p1HpG7-drT-p2`

#### Does this pull request change what data or activity we track or use?

Nope 👍 

#### Testing instructions:

1. Activate this branch (`update/product-discount-percentages`) on a self-hosted Jetpack site (e.g., using the Jetpack Beta plugin).
2. Connect Jetpack to your site if it's not already connected.
3. Visit `/wp-admin/admin.php?page=jetpack#/product/<slug>`, where `<slug>` is any of the following:
  * `akismet`
  * `backup`
  * `scan`
  * `search`
  * `security`
  * `videopress`
4. Verify the discounted yearly price of the product you selected is half that of the crossed-out original price (see below screenshots). Test this in multiple currencies if at all possible, especially non-USD currencies.

<img height="260" alt="image" src="https://user-images.githubusercontent.com/670067/145066185-65fe3893-c17d-49cc-927c-02763d102911.png"> <img height="260" alt="image" src="https://user-images.githubusercontent.com/670067/145066120-3af0e0df-181b-4b6d-aa42-8d2f492b55ca.png">