### PR TITLE
My Jetpack: do not ship scss and jsx files in production build.

### DIFF
--- a/projects/packages/my-jetpack/.gitattributes
+++ b/projects/packages/my-jetpack/.gitattributes
@@ -9,7 +9,9 @@ package.json      export-ignore
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.
-.gitignore        production-exclude
-changelog/**      production-exclude
-phpunit.xml.dist  production-exclude
-tests/**          production-exclude
+.gitignore          production-exclude
+changelog/**        production-exclude
+phpunit.xml.dist    production-exclude
+tests/**            production-exclude
+src/**/*.scss       production-exclude
+src/**/*.jsx        production-exclude

--- a/projects/packages/my-jetpack/.gitattributes
+++ b/projects/packages/my-jetpack/.gitattributes
@@ -4,8 +4,7 @@
 package.json      export-ignore
 
 # Files to include in the mirror repo, but excluded via gitignore
-# Remember to end all directories with `/**` to properly tag every file.
-# /src/js/example.min.js  production-include
+/build/**          production-include
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-ignore-raw-files
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-ignore-raw-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: do not ship scss and jsx files in production build.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "0.1.3",
+	"version": "0.1.4-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* We do not need to ship dev files in the production version of the package.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here, this should just stop us from having files like this one in the production build:
https://github.com/Automattic/jetpack-my-jetpack/blob/8390e0b1eebd5a220091689d92911d7ab9eeedfc/_inc/components/my-jetpack-screen/style.scss
