### PR TITLE
IDC UI: update the default text in the migrate card

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
       react-dom: 17.0.2
       react-test-renderer: 17.0.2
     dependencies:
-      '@automattic/format-currency': 1.0.0-alpha.0_react@17.0.2
+      '@automattic/format-currency': 1.0.0-alpha.0
       '@wordpress/browserslist-config': 4.1.0
       '@wordpress/components': 19.1.1_react-dom@17.0.2+react@17.0.2
       '@wordpress/i18n': 4.2.4
@@ -315,7 +315,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:^0.1.1
       '@automattic/jetpack-components': workspace:^0.8.0
       '@automattic/jetpack-connection': workspace:^0.11.2
-      '@automattic/jetpack-idc': workspace:^0.6.0
+      '@automattic/jetpack-idc': workspace:^0.6.1-alpha
       '@babel/core': 7.16.0
       '@babel/plugin-syntax-jsx': 7.16.0
       '@babel/runtime-corejs3': 7.16.3
@@ -450,7 +450,7 @@ importers:
     specifiers:
       '@automattic/jetpack-api': workspace:^0.8.0
       '@automattic/jetpack-connection': workspace:^0.11.2
-      '@automattic/jetpack-idc': workspace:^0.6.0
+      '@automattic/jetpack-idc': workspace:^0.6.1-alpha
       '@automattic/jetpack-webpack-config': workspace:^0.4.0
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
@@ -953,7 +953,7 @@ importers:
     dependencies:
       '@automattic/calypso-color-schemes': 2.1.1
       '@automattic/components': 1.0.0-alpha.3_react-dom@17.0.2+react@17.0.2
-      '@automattic/format-currency': 1.0.0-alpha.0_react@17.0.2
+      '@automattic/format-currency': 1.0.0-alpha.0
       '@automattic/jetpack-analytics': link:../../js-packages/analytics
       '@automattic/jetpack-api': link:../../js-packages/api
       '@automattic/jetpack-components': link:../../js-packages/components
@@ -1302,17 +1302,16 @@ packages:
       react-modal: 3.14.3_react-dom@17.0.2+react@17.0.2
     dev: false
 
-  /@automattic/format-currency/1.0.0-alpha.0_react@17.0.2:
+  /@automattic/format-currency/1.0.0-alpha.0:
     resolution: {integrity: sha512-Y5An5nsNtskdLN3mbh5UWKvsS3C5PHbOcBU5D58dmjc96z5WAa99gSNYkN87FjqrJKGM4J2JhE5d1gIadYU++A==}
     dependencies:
-      i18n-calypso: 5.0.0_react@17.0.2
+      i18n-calypso: 4.1.0
     transitivePeerDependencies:
       - '@types/react'
-      - react
       - supports-color
     dev: false
 
-  /@automattic/interpolate-components/1.2.0_react@17.0.2:
+  /@automattic/interpolate-components/1.2.0_react@16.14.0:
     resolution: {integrity: sha512-qpprRrFddOnGEgLy74Eyno0tz9sHyTE+6grtKuTsasjOnfzzNlKv57sFlJU/1WlfQ7kDncRgaxM1iH247EBfyQ==}
     peerDependencies:
       '@types/react': '>=16.1.0'
@@ -1321,7 +1320,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      react: 17.0.2
+      react: 16.14.0
     dev: false
 
   /@automattic/popup-monitor/1.0.0:
@@ -7500,6 +7499,26 @@ packages:
       - redux
     dev: false
 
+  /@wordpress/compose/3.25.3_react@16.14.0:
+    resolution: {integrity: sha512-tCO2EnJCkCH548OqA0uU8V1k/1skz2QwBlHs8ZQSpimqUS4OWWsAlndCEFe4U4vDTqFt2ow7tzAir+05Cw8MAg==}
+    dependencies:
+      '@babel/runtime': 7.16.3
+      '@wordpress/deprecated': 2.12.3
+      '@wordpress/dom': 2.18.0
+      '@wordpress/element': 2.20.3
+      '@wordpress/is-shallow-equal': 3.1.3
+      '@wordpress/keycodes': 2.19.3
+      '@wordpress/priority-queue': 1.11.2
+      clipboard: 2.0.8
+      lodash: 4.17.21
+      memize: 1.1.0
+      mousetrap: 1.6.5
+      react-resize-aware: 3.1.1_react@16.14.0
+      use-memo-one: 1.1.2_react@16.14.0
+    transitivePeerDependencies:
+      - react
+    dev: false
+
   /@wordpress/compose/3.25.3_react@17.0.2:
     resolution: {integrity: sha512-tCO2EnJCkCH548OqA0uU8V1k/1skz2QwBlHs8ZQSpimqUS4OWWsAlndCEFe4U4vDTqFt2ow7tzAir+05Cw8MAg==}
     dependencies:
@@ -8036,7 +8055,7 @@ packages:
     resolution: {integrity: sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.16.0
+      '@babel/runtime': 7.16.3
       '@wordpress/hooks': 2.12.3
       gettext-parser: 1.4.0
       lodash: 4.17.21
@@ -8274,7 +8293,7 @@ packages:
   /@wordpress/priority-queue/1.11.2:
     resolution: {integrity: sha512-ulwmUOklY3orn1xXpcPnTyGWV5B/oycxI+cHZ6EevBVgM5sq+BW3xo0PKLR/MMm6UNBtFTu/71QAJrNZcD6V1g==}
     dependencies:
-      '@babel/runtime': 7.16.0
+      '@babel/runtime': 7.16.3
     dev: false
 
   /@wordpress/priority-queue/2.2.3:
@@ -14240,23 +14259,20 @@ packages:
       which-pm-runs: 1.0.0
     dev: true
 
-  /i18n-calypso/5.0.0_react@17.0.2:
-    resolution: {integrity: sha512-YgqLgshNiBOiifWxr4s33ODWQ4JIaHoBPWtgFyqcRy0+WGMX2CmTDbXaeZHkHxuIjzsGP+YrVTPNp7lfbiot4g==}
-    peerDependencies:
-      react: ^16.8
+  /i18n-calypso/4.1.0:
+    resolution: {integrity: sha512-ynS9sLdpN0TgZ2Zb3GI1psI06yrvV6u/7EOiJDySEgUDmugbUmy9TgAmFnLo0vNWyGEcBtji1zRk5ZJuNiXmhQ==}
     dependencies:
-      '@babel/runtime': 7.16.3
       '@tannin/sprintf': 1.2.0
-      '@wordpress/compose': 3.25.3_react@17.0.2
+      '@wordpress/compose': 3.25.3_react@16.14.0
       debug: 4.3.2
       events: 3.3.0
       hash.js: 1.1.7
-      interpolate-components: /@automattic/interpolate-components/1.2.0_react@17.0.2
+      interpolate-components: /@automattic/interpolate-components/1.2.0_react@16.14.0
       lodash: 4.17.21
       lru: 3.1.0
-      react: 17.0.2
+      react: 16.14.0
       tannin: 1.2.0
-      use-subscription: 1.5.1_react@17.0.2
+      use-subscription: 1.5.1_react@16.14.0
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
@@ -22231,13 +22247,13 @@ packages:
     dependencies:
       react: 17.0.2
 
-  /use-subscription/1.5.1_react@17.0.2:
+  /use-subscription/1.5.1_react@16.14.0:
     resolution: {integrity: sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       object-assign: 4.1.1
-      react: 17.0.2
+      react: 16.14.0
     dev: false
 
   /use/3.1.1:

--- a/projects/js-packages/idc/changelog/update-idc_text
+++ b/projects/js-packages/idc/changelog/update-idc_text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix the text in the migrate card
+
+

--- a/projects/js-packages/idc/components/card-migrate/index.jsx
+++ b/projects/js-packages/idc/components/card-migrate/index.jsx
@@ -43,7 +43,7 @@ const CardMigrate = props => {
 							sprintf(
 								/* translators: %1$s: The current site domain name. %2$s: The original site domain name. */
 								__(
-									'Move all your settings, stats and subscribers to your other <hostname>%1$s</hostname>. <hostname>%2$s</hostname> will be disconnected from Jetpack.',
+									'Move all your settings, stats and subscribers to your other URL, <hostname>%1$s</hostname>. <hostname>%2$s</hostname> will be disconnected from Jetpack.',
 									'jetpack'
 								),
 								currentHostName,

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.6.0",
+	"version": "0.6.1-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/storybook/changelog/update-idc_text
+++ b/projects/js-packages/storybook/changelog/update-idc_text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -29,7 +29,7 @@
 		"@automattic/jetpack-components": "workspace:^0.8.0",
 		"@automattic/jetpack-connection": "workspace:^0.11.2",
 		"@automattic/jetpack-base-styles": "workspace:^0.1.1",
-		"@automattic/jetpack-idc": "workspace:^0.6.0",
+		"@automattic/jetpack-idc": "workspace:^0.6.1-alpha",
 		"@babel/core": "7.16.0",
 		"@babel/plugin-syntax-jsx": "7.16.0",
 		"@babel/runtime-corejs3": "7.16.3",

--- a/projects/packages/connection-ui/changelog/update-idc_text
+++ b/projects/packages/connection-ui/changelog/update-idc_text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "2.1.4",
+	"version": "2.1.5-alpha",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-connection-ui",
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"@automattic/jetpack-api": "workspace:^0.8.0",
 		"@automattic/jetpack-connection": "workspace:^0.11.2",
-		"@automattic/jetpack-idc": "workspace:^0.6.0",
+		"@automattic/jetpack-idc": "workspace:^0.6.1-alpha",
 		"@wordpress/data": "6.1.4"
 	},
 	"devDependencies": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Update the text in the migrate card.

#### Jetpack product discussion
* p9dueE-3pz-p2

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Checkout this branch.
2. Build the connection manager UI: `jetpack build packages/connection-ui`
3. Install and activate the Debug Helper plugin.
4. Navigate to the IDC Simulation page of the Debug Helper plugin, and enable the IDC Simulation.
5. Cause a sync action by editing a post. (This causes the IDC to be detected.)
6. Navigate to Tools -> Connection Manager. The IDC UI should be displayed.
7. Verify that the migrate card text is "Move all your settings, stats and subscribers to your other URL, _{your new url}_. _{your old url}_ will be disconnected from Jetpack.