### PR TITLE
Search E2E: add search plan data fixture

### DIFF
--- a/tools/e2e-commons/pages/search-homepage.js
+++ b/tools/e2e-commons/pages/search-homepage.js
@@ -7,6 +7,7 @@ export default class SearchHomepage extends WpPage {
 	constructor( page ) {
 		const url = `${ resolveSiteUrl() }/?result_format=expanded`;
 		super( page, { expectedSelectors: [ '.site-title' ], url } );
+		this.timeout = 30000; // 30s.
 	}
 
 	async focusSearchInput() {

--- a/tools/e2e-commons/plugins/e2e-plan-data-interceptor.php
+++ b/tools/e2e-commons/plugins/e2e-plan-data-interceptor.php
@@ -53,5 +53,13 @@ function e2e_intercept_plan_data_request( $return, $r, $url ) {
 			'body'     => $json_data,
 		);
 	}
+
+	if ( false !== stripos( $url, sprintf( '/sites/%d/jetpack-search/plan', $site_id ) ) ) {
+		return array(
+			'response' => array( 'code' => 200 ),
+			'body'     => sprintf( '{"search_subscriptions":[{"ID":"123","user_id":"456","blog_id":"%d","product_id":"2104","expiry":"2125-05-17","subscribed_date":"2021-05-17 05:34:09","renew":false,"auto_renew":true,"ownership_id":"123","most_recent_renew_date":"","subscription_status":"active","product_name":"Jetpack Search","product_name_en":"Jetpack Search","product_slug":"jetpack_search","product_type":"search","cost":50,"currency":"USD","bill_period":"365","available":"yes","multi":true,"support_document":null,"is_instant_search":true,"tier":"up_to_100_records"}],"supports_instant_search":true,"supports_only_classic_search":false,"supports_search":true,"default_upgrade_bill_period":"yearly"}', $site_id ),
+		);
+	}
+
 	return $return;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The PR proposed search plan data fixture for E2E, and changed the search page timeout to 30s.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Ensure E2E tests pass on Github actions
