### PR TITLE
assets: Provide the `wp-jp-i18n-state` script

### DIFF
--- a/projects/packages/assets/actions.php
+++ b/projects/packages/assets/actions.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Action Hooks for Jetpack Assets module.
+ *
+ * @package automattic/jetpack-assets
+ */
+
+// If WordPress's plugin API is available already, use it. If not,
+// drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'wp_default_scripts', array( Automattic\Jetpack\Assets::class, 'wp_default_scripts_hook' ) );
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$wp_filter['wp_default_scripts'][10][] = array(
+		'accepted_args' => 1,
+		'function'      => array( Automattic\Jetpack\Assets::class, 'wp_default_scripts_hook' ),
+	);
+}

--- a/projects/packages/assets/changelog/add-use-i18n-loader-webpack-plugin
+++ b/projects/packages/assets/changelog/add-use-i18n-loader-webpack-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Generate `wp-jp-i18n-state` script.

--- a/projects/packages/assets/composer.json
+++ b/projects/packages/assets/composer.json
@@ -12,6 +12,9 @@
 		"automattic/jetpack-changelogger": "^3.0"
 	},
 	"autoload": {
+		"files": [
+			"actions.php"
+		],
 		"classmap": [
 			"src/"
 		]

--- a/projects/packages/assets/composer.json
+++ b/projects/packages/assets/composer.json
@@ -50,7 +50,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.13.x-dev"
+			"dev-master": "1.14.x-dev"
 		}
 	}
 }

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -403,4 +403,59 @@ class Assets {
 		}
 	}
 
+	/**
+	 * 'wp_default_scripts' action handler.
+	 *
+	 * This registers the `wp-jp-i18n-state` script for use by Webpack bundles built with
+	 * `@automattic/i18n-loader-webpack-plugin`.
+	 *
+	 * @since $$next-version$$
+	 * @param \WP_Scripts $wp_scripts WP_Scripts instance.
+	 */
+	public static function wp_default_scripts_hook( $wp_scripts ) {
+		$data = array(
+			'baseUrl'   => false,
+			'locale'    => determine_locale(),
+			'domainMap' => array(),
+		);
+
+		$lang_dir = Jetpack_Constants::get_constant( 'WP_LANG_DIR' );
+		$abspath  = Jetpack_Constants::get_constant( 'ABSPATH' );
+
+		if ( strpos( $lang_dir, $abspath ) === 0 ) {
+			$data['baseUrl'] = site_url( substr( trailingslashit( $lang_dir ), strlen( untrailingslashit( $abspath ) ) ) );
+		}
+
+		/**
+		 * Filters the i18n state data for use by Webpack bundles built with
+		 * `@automattic/i18n-loader-webpack-plugin`.
+		 *
+		 * @since $$next-version$$
+		 * @package assets
+		 * @param array $data The state data to generate. Expected fields are:
+		 *  - `baseUrl`: (string|false) The URL to the languages directory. False if no URL could be determined.
+		 *  - `locale`: (string) The locale for the page.
+		 *  - `domainMap`: (string[]) A mapping from Composer package textdomains to the corresponding
+		 *    `plugins/textdomain` or `themes/textdomain` (or core `textdomain`, but that's unlikely).
+		 */
+		$data = apply_filters( 'jetpack_i18n_state', $data );
+
+		if ( ! is_array( $data ) ||
+			! isset( $data['baseUrl'] ) || ! ( is_string( $data['baseUrl'] ) || false === $data['baseUrl'] ) ||
+			! isset( $data['locale'] ) || ! is_string( $data['locale'] ) ||
+			! isset( $data['domainMap'] ) || ! is_array( $data['domainMap'] )
+		) {
+			$js = 'console.warn( "I18n state deleted by jetpack_i18n_state hook" );';
+		} elseif ( ! $data['baseUrl'] ) {
+			$js = 'console.warn( "Failed to determine languages base URL. Is WP_LANG_DIR in the WordPress root?" );';
+		} else {
+			$data['domainMap'] = (object) $data['domainMap']; // Ensure it becomes a json object.
+			$js                = 'wp.jpI18nState = ' . wp_json_encode( $data, JSON_UNESCAPED_SLASHES ) . ';';
+		}
+
+		// Depend on wp-i18n to ensure global `wp` exists and because anything needing this will need that too.
+		$wp_scripts->add( 'wp-jp-i18n-state', null, array( 'wp-i18n' ) );
+		$wp_scripts->add_inline_script( 'wp-jp-i18n-state', $js, 'before' );
+	}
+
 }

--- a/projects/packages/connection-ui/changelog/add-assets-support-for-i18n-loader
+++ b/projects/packages/connection-ui/changelog/add-assets-support-for-i18n-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/composer.json
+++ b/projects/packages/connection-ui/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-assets": "^1.13",
+		"automattic/jetpack-assets": "^1.14",
 		"automattic/jetpack-connection": "^1.33",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-device-detection": "^1.4",

--- a/projects/packages/jitm/changelog/add-assets-support-for-i18n-loader
+++ b/projects/packages/jitm/changelog/add-assets-support-for-i18n-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-a8c-mc-stats": "^1.4",
-		"automattic/jetpack-assets": "^1.13",
+		"automattic/jetpack-assets": "^1.14",
 		"automattic/jetpack-connection": "^1.33",
 		"automattic/jetpack-device-detection": "^1.4",
 		"automattic/jetpack-logo": "^1.5",

--- a/projects/packages/lazy-images/changelog/add-assets-support-for-i18n-loader
+++ b/projects/packages/lazy-images/changelog/add-assets-support-for-i18n-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/lazy-images/composer.json
+++ b/projects/packages/lazy-images/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-constants": "^1.6",
-		"automattic/jetpack-assets": "^1.13"
+		"automattic/jetpack-assets": "^1.14"
 	},
 	"require-dev": {
 		"automattic/wordbless": "dev-master",

--- a/projects/packages/my-jetpack/changelog/add-assets-support-for-i18n-loader
+++ b/projects/packages/my-jetpack/changelog/add-assets-support-for-i18n-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-admin-ui": "^0.1",
-		"automattic/jetpack-assets": "^1.13"
+		"automattic/jetpack-assets": "^1.14"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.2",

--- a/projects/packages/post-list/changelog/add-assets-support-for-i18n-loader
+++ b/projects/packages/post-list/changelog/add-assets-support-for-i18n-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/post-list/composer.json
+++ b/projects/packages/post-list/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-assets": "^1.13"
+		"automattic/jetpack-assets": "^1.14"
 	},
 	"require-dev": {
 		"automattic/wordbless": "@dev",

--- a/projects/packages/tracking/changelog/add-assets-support-for-i18n-loader
+++ b/projects/packages/tracking/changelog/add-assets-support-for-i18n-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-assets": "^1.13",
+		"automattic/jetpack-assets": "^1.14",
 		"automattic/jetpack-options": "^1.14",
 		"automattic/jetpack-status": "^1.9",
 		"automattic/jetpack-terms-of-service": "^1.9"

--- a/projects/plugins/backup/changelog/add-assets-support-for-i18n-loader
+++ b/projects/plugins/backup/changelog/add-assets-support-for-i18n-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -4,7 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-assets": "1.13.x-dev",
+		"automattic/jetpack-assets": "1.14.x-dev",
 		"automattic/jetpack-admin-ui": "0.1.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
 		"automattic/jetpack-backup": "1.1.x-dev",

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7bf10c48c7e6145eff1931623919beb",
+    "content-hash": "942f5f58e0f9a368197afd54aedb0517",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -119,7 +119,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "aec06d5a1d91bcca146382363909478d70d1be9d"
+                "reference": "79f3118db7691394547c3b21105a6e34efb919f0"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -137,10 +137,13 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.13.x-dev"
+                    "dev-master": "1.14.x-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -401,10 +404,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "83b712b43e18d676b2cbd9028682a1cf405f596b"
+                "reference": "f640616a4351f4aebedca66cbf85f17bfdd732eb"
             },
             "require": {
-                "automattic/jetpack-assets": "^1.13",
+                "automattic/jetpack-assets": "^1.14",
                 "automattic/jetpack-connection": "^1.33",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-device-detection": "^1.4",
@@ -722,11 +725,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "daafacd0034d1fb79d8fe7beba35ddedb1d69bc4"
+                "reference": "4ff3bd578db2c0620325f0d007130827372a553b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.1",
-                "automattic/jetpack-assets": "^1.13"
+                "automattic/jetpack-assets": "^1.14"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -1159,10 +1162,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "5f510754224ac5477409960fa9f82f6d52cfb3e6"
+                "reference": "6ca70d07e77418303bb798c4cd430906af03509e"
             },
             "require": {
-                "automattic/jetpack-assets": "^1.13",
+                "automattic/jetpack-assets": "^1.14",
                 "automattic/jetpack-options": "^1.14",
                 "automattic/jetpack-status": "^1.9",
                 "automattic/jetpack-terms-of-service": "^1.9"

--- a/projects/plugins/boost/changelog/add-assets-support-for-i18n-loader
+++ b/projects/plugins/boost/changelog/add-assets-support-for-i18n-loader
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -119,7 +119,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "aec06d5a1d91bcca146382363909478d70d1be9d"
+                "reference": "79f3118db7691394547c3b21105a6e34efb919f0"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -137,10 +137,13 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.13.x-dev"
+                    "dev-master": "1.14.x-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -478,10 +481,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/lazy-images",
-                "reference": "846776653bcb61b97ccbc9b40ac67dad057204cf"
+                "reference": "8ad70d0affc48b1fac679e0784bcf1c8d672b966"
             },
             "require": {
-                "automattic/jetpack-assets": "^1.13",
+                "automattic/jetpack-assets": "^1.14",
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
@@ -798,10 +801,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "5f510754224ac5477409960fa9f82f6d52cfb3e6"
+                "reference": "6ca70d07e77418303bb798c4cd430906af03509e"
             },
             "require": {
-                "automattic/jetpack-assets": "^1.13",
+                "automattic/jetpack-assets": "^1.14",
                 "automattic/jetpack-options": "^1.14",
                 "automattic/jetpack-status": "^1.9",
                 "automattic/jetpack-terms-of-service": "^1.9"

--- a/projects/plugins/jetpack/changelog/add-assets-support-for-i18n-loader
+++ b/projects/plugins/jetpack/changelog/add-assets-support-for-i18n-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -13,7 +13,7 @@
 		"ext-openssl": "*",
 		"automattic/jetpack-a8c-mc-stats": "1.4.x-dev",
 		"automattic/jetpack-abtest": "1.9.x-dev",
-		"automattic/jetpack-assets": "1.13.x-dev",
+		"automattic/jetpack-assets": "1.14.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
 		"automattic/jetpack-backup": "1.1.x-dev",
 		"automattic/jetpack-blocks": "1.4.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5be0fa4e9425b1aaae5f2db5bda53bf5",
+    "content-hash": "3ce6619b35fb60e618b8fc1713e5f05f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -177,7 +177,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "aec06d5a1d91bcca146382363909478d70d1be9d"
+                "reference": "79f3118db7691394547c3b21105a6e34efb919f0"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -195,10 +195,13 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.13.x-dev"
+                    "dev-master": "1.14.x-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -608,10 +611,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "83b712b43e18d676b2cbd9028682a1cf405f596b"
+                "reference": "f640616a4351f4aebedca66cbf85f17bfdd732eb"
             },
             "require": {
-                "automattic/jetpack-assets": "^1.13",
+                "automattic/jetpack-assets": "^1.14",
                 "automattic/jetpack-connection": "^1.33",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-device-detection": "^1.4",
@@ -929,11 +932,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "ebf95a27dfb86e28a5c00394c595c12cf78d3a42"
+                "reference": "fefedd87770502b5f74998fd91a8abeb1c11d627"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
-                "automattic/jetpack-assets": "^1.13",
+                "automattic/jetpack-assets": "^1.14",
                 "automattic/jetpack-connection": "^1.33",
                 "automattic/jetpack-device-detection": "^1.4",
                 "automattic/jetpack-logo": "^1.5",
@@ -1003,10 +1006,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/lazy-images",
-                "reference": "846776653bcb61b97ccbc9b40ac67dad057204cf"
+                "reference": "8ad70d0affc48b1fac679e0784bcf1c8d672b966"
             },
             "require": {
-                "automattic/jetpack-assets": "^1.13",
+                "automattic/jetpack-assets": "^1.14",
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
@@ -1177,11 +1180,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "daafacd0034d1fb79d8fe7beba35ddedb1d69bc4"
+                "reference": "4ff3bd578db2c0620325f0d007130827372a553b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.1",
-                "automattic/jetpack-assets": "^1.13"
+                "automattic/jetpack-assets": "^1.14"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -1739,10 +1742,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "5f510754224ac5477409960fa9f82f6d52cfb3e6"
+                "reference": "6ca70d07e77418303bb798c4cd430906af03509e"
             },
             "require": {
-                "automattic/jetpack-assets": "^1.13",
+                "automattic/jetpack-assets": "^1.14",
                 "automattic/jetpack-options": "^1.14",
                 "automattic/jetpack-status": "^1.9",
                 "automattic/jetpack-terms-of-service": "^1.9"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This script is the one expected by the default configuration of the new
`@automattic/i18n-loader-webpack-plugin`.
    
Note the `domainMap` is currently empty. Code to fill that in will come
later, as part of #21690, once we figure out the exact form of it.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: p9dueE-3MG-p2
Split from #21936

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not much to test here, this just lays groundwork for #21936.