### PR TITLE
Backup & My Jetpack: add watch command to the plugin and package.

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-watch-backup-plugin
+++ b/projects/packages/my-jetpack/changelog/add-watch-backup-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Janitorial: add watch command to the plugin.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -35,6 +35,10 @@
 		"build-production": [
 			"Composer\\Config::disableProcessTimeout",
 			"pnpm run build"
+		],
+		"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run watch"
 		]
 	},
 	"repositories": [

--- a/projects/plugins/backup/changelog/add-watch-backup-plugin
+++ b/projects/plugins/backup/changelog/add-watch-backup-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Janitorial: add watch command to the plugin.

--- a/projects/plugins/backup/changelog/add-watch-backup-plugin#2
+++ b/projects/plugins/backup/changelog/add-watch-backup-plugin#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -33,6 +33,10 @@
 		"build-production": [
 			"Composer\\Config::disableProcessTimeout",
 			"pnpm run build-production-concurrently"
+		],
+		"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run watch"
 		]
 	},
 	"repositories": [

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -725,7 +725,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4ff3bd578db2c0620325f0d007130827372a553b"
+                "reference": "769378531a7cb936e4f201d869306056ac558620"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.1",
@@ -770,6 +770,10 @@
                 "build-production": [
                     "Composer\\Config::disableProcessTimeout",
                     "pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/jetpack/changelog/add-watch-backup-plugin
+++ b/projects/plugins/jetpack/changelog/add-watch-backup-plugin
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1180,7 +1180,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4ff3bd578db2c0620325f0d007130827372a553b"
+                "reference": "769378531a7cb936e4f201d869306056ac558620"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.1",
@@ -1225,6 +1225,10 @@
                 "build-production": [
                     "Composer\\Config::disableProcessTimeout",
                     "pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* ﻿That should allow us to use the Jetpack CLI tool to watch for changes in the plugin, by running `jetpack watch plugins/backup`, as well as changes to the "My Jetpack" package: `jetpack watch packages/my-jetpack`.

#### Jetpack product discussion

* p1639141827208200-slack-G78B6FYE7

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Run `jetpack watch plugins/backup`
* Run `jetpack watch packages/my-jetpack`
* Does it work?
