### PR TITLE
babel-plugin-replace-textdomain: Replace missing domains too

### DIFF
--- a/projects/js-packages/babel-plugin-replace-textdomain/README.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/README.md
@@ -25,7 +25,7 @@ In your Babel config, you might include the plugin something like this:
 
 Plugin options are:
 
-- `textdomain`: Specify the replacement text domain. The value may be a string, which will replace all domains; an object, to map specific domains (leaving any others untouched); or a function, which will be passed the existing domain and is expected to return the new domain (or null).
+- `textdomain`: Specify the replacement text domain. The value may be a string, which will replace all domains; an object, to map specific domains (leaving any others untouched); or a function, which will be passed the existing domain (empty string if the domain is missing entirely) and is expected to return the new domain (or null).
 - `functions`: Specify the functions that take domain arguments. This is an object mapping function names to the (zero-based) index of the domain argument.
 
   The default function list handles the `__`, `_x`, `_n`, and `_nx` functions provided by [@wordpress/i18n]. This list may be accessed as `require( '@automattic/babel-plugin-replace-textdomain' ).defaultFunctions`.

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/fix-babel-replace-textdomain-when-missing
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/fix-babel-replace-textdomain-when-missing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Replace missing domains too.

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/__snapshots__/plugin.test.js.snap
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/__snapshots__/plugin.test.js.snap
@@ -45,58 +45,120 @@ __.not('foo', 'srcdomain');
 
 exports[`@automattic/babel-plugin-replace-textdomain Custom functions list: debug calls 1`] = `Array []`;
 
-exports[`@automattic/babel-plugin-replace-textdomain Handling of calls with bad args: Handling of calls with bad args 1`] = `
+exports[`@automattic/babel-plugin-replace-textdomain Doesn't try to handle \`toString()\` or the like: Doesn't try to handle \`toString()\` or the like 1`] = `
+
+x.toString();
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+x.toString();
+
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Doesn't try to handle \`toString()\` or the like: debug calls 1`] = `Array []`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Expression domain: Expression domain 1`] = `
+
+__( 'Expression', 'dom' + 'ain' );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+__('Expression', 'dom' + 'ain');
+
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Expression domain: debug calls 1`] = `
+Array [
+  Array [
+    Domain argument should be a StringLiteral, not BinaryExpression
+> 1 | __( 'Expression', 'dom' + 'ain' );
+    |                   ^^^^^^^^^^^^^,
+  ],
+]
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Missing context and domain parameters, no replacement: Missing context and domain parameters, no replacement 1`] = `
+
+_x( 'No domain' );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_x('No domain');
+
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Missing context and domain parameters, no replacement: debug calls 1`] = `
+Array [
+  Array [
+    Domain argument (index 3) is missing
+> 1 | _x( 'No domain' );
+    | ^^^^^^^^^^^^^^^^^,
+  ],
+]
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Missing context and domain parameters: Missing context and domain parameters 1`] = `
+
+_x( 'No domain' );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_x('No domain', undefined, 'new-domain');
+
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Missing context and domain parameters: debug calls 1`] = `
+Array [
+  Array [
+    Domain argument (index 3) is missing
+> 1 | _x( 'No domain' );
+    | ^^^^^^^^^^^^^^^^^,
+  ],
+]
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Missing domain parameter, no replacement: Missing domain parameter, no replacement 1`] = `
 
 __( 'No domain' );
-__( 'Non-literal domain', domain );
-__( 'Template-string domain', \`domain\` );
-__( 'Expression domain', 'domain' + 'x' );
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 __('No domain');
 
-__('Non-literal domain', domain);
-
-__('Template-string domain', \`domain\`);
-
-__('Expression domain', 'domain' + 'x');
-
 
 `;
 
-exports[`@automattic/babel-plugin-replace-textdomain Handling of calls with bad args: debug calls 1`] = `
+exports[`@automattic/babel-plugin-replace-textdomain Missing domain parameter, no replacement: debug calls 1`] = `
 Array [
   Array [
     Domain argument (index 2) is missing
 > 1 | __( 'No domain' );
-    | ^^^^^^^^^^^^^^^^^
-  2 | __( 'Non-literal domain', domain );
-  3 | __( 'Template-string domain', \`domain\` );
-  4 | __( 'Expression domain', 'domain' + 'x' );,
+    | ^^^^^^^^^^^^^^^^^,
   ],
+]
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Missing domain parameter: Missing domain parameter 1`] = `
+
+__( 'No domain' );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+__('No domain', 'new-domain');
+
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Missing domain parameter: debug calls 1`] = `
+Array [
   Array [
-    Domain argument should be a StringLiteral, not Identifier
-  1 | __( 'No domain' );
-> 2 | __( 'Non-literal domain', domain );
-    |                           ^^^^^^
-  3 | __( 'Template-string domain', \`domain\` );
-  4 | __( 'Expression domain', 'domain' + 'x' );,
-  ],
-  Array [
-    Domain argument should be a StringLiteral, not TemplateLiteral
-  1 | __( 'No domain' );
-  2 | __( 'Non-literal domain', domain );
-> 3 | __( 'Template-string domain', \`domain\` );
-    |                               ^^^^^^^^
-  4 | __( 'Expression domain', 'domain' + 'x' );,
-  ],
-  Array [
-    Domain argument should be a StringLiteral, not BinaryExpression
-  2 | __( 'Non-literal domain', domain );
-  3 | __( 'Template-string domain', \`domain\` );
-> 4 | __( 'Expression domain', 'domain' + 'x' );
-    |                          ^^^^^^^^^^^^^^,
+    Domain argument (index 2) is missing
+> 1 | __( 'No domain' );
+    | ^^^^^^^^^^^^^^^^^,
   ],
 ]
 `;
@@ -258,6 +320,27 @@ Array [
 ]
 `;
 
+exports[`@automattic/babel-plugin-replace-textdomain Non-literal domain: Non-literal domain 1`] = `
+
+__( 'Non-literal domain', domain );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+__('Non-literal domain', domain);
+
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Non-literal domain: debug calls 1`] = `
+Array [
+  Array [
+    Domain argument should be a StringLiteral, not Identifier
+> 1 | __( 'Non-literal domain', domain );
+    |                           ^^^^^^,
+  ],
+]
+`;
+
 exports[`@automattic/babel-plugin-replace-textdomain Simple test: Simple test 1`] = `
 
 __( 'foo', 'srcdomain' );
@@ -302,3 +385,58 @@ __.not('foo', 'srcdomain');
 `;
 
 exports[`@automattic/babel-plugin-replace-textdomain Simple test: debug calls 1`] = `Array []`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Template-string domain with expression: Template-string domain with expression 1`] = `
+
+__( 'Template-string domain', \`domain \${ x }\` );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+__('Template-string domain', \`domain \${x}\`);
+
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Template-string domain with expression: debug calls 1`] = `
+Array [
+  Array [
+    Domain argument should be a StringLiteral, not TemplateLiteral
+> 1 | __( 'Template-string domain', \`domain \${ x }\` );
+    |                               ^^^^^^^^^^^^^^^,
+  ],
+]
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Template-string domain, no replacement: Template-string domain, no replacement 1`] = `
+
+__( 'Template-string domain', \`domain\` );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+__('Template-string domain', \`domain\`);
+
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Template-string domain, no replacement: debug calls 1`] = `
+Array [
+  Array [
+    No mapping for textdomain domain (first instance)
+> 1 | __( 'Template-string domain', \`domain\` );
+    |                               ^^^^^^^^,
+  ],
+]
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Template-string domain: Template-string domain 1`] = `
+
+__( 'Template-string domain', \`domain\` );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+__('Template-string domain', 'new-domain');
+
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain Template-string domain: debug calls 1`] = `Array []`;

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/fixtures/bad-args.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/fixtures/bad-args.js
@@ -1,4 +1,0 @@
-__( 'No domain' );
-__( 'Non-literal domain', domain );
-__( 'Template-string domain', `domain` );
-__( 'Expression domain', 'domain' + 'x' );

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
@@ -68,10 +68,84 @@ pluginTester( {
 				},
 			},
 		},
+
 		{
-			title: 'Handling of calls with bad args',
+			title: 'Missing domain parameter',
 			setup,
-			fixture: 'fixtures/bad-args.js',
+			code: `__( 'No domain' );`,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+		{
+			title: 'Missing domain parameter, no replacement',
+			setup,
+			code: `__( 'No domain' );`,
+			pluginOptions: {
+				textdomain: () => null,
+			},
+		},
+		{
+			title: 'Missing context and domain parameters',
+			setup,
+			code: `_x( 'No domain' );`,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+		{
+			title: 'Missing context and domain parameters, no replacement',
+			setup,
+			code: `_x( 'No domain' );`,
+			pluginOptions: {
+				textdomain: () => null,
+			},
+		},
+		{
+			title: 'Non-literal domain',
+			setup,
+			code: `__( 'Non-literal domain', domain );`,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+		{
+			title: 'Template-string domain',
+			setup,
+			code: "__( 'Template-string domain', `domain` );",
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+		{
+			title: 'Template-string domain, no replacement',
+			setup,
+			code: "__( 'Template-string domain', `domain` );",
+			pluginOptions: {
+				textdomain: () => null,
+			},
+		},
+		{
+			title: 'Template-string domain with expression',
+			setup,
+			code: "__( 'Template-string domain', `domain ${ x }` );",
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+		{
+			title: 'Expression domain',
+			setup,
+			code: `__( 'Expression', 'dom' + 'ain' );`,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+
+		{
+			title: "Doesn't try to handle `toString()` or the like",
+			setup,
+			code: `x.toString();`,
 			pluginOptions: {
 				textdomain: 'new-domain',
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It should also fix up calls with no domain parameter at all, like
`__('foo')`.

Also, clean up the code a bit, and actually replace the nodes instead of
munging the value (which I'm not sure is actually supported).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: p9dueE-3MG-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?