### PR TITLE
Prevent issues returning to Inbox on update.

### DIFF
--- a/.github/workflows/issues-to-projects.yml
+++ b/.github/workflows/issues-to-projects.yml
@@ -19,11 +19,10 @@ jobs:
 
     steps:
       # Jetpack Boost: Push to Boost Maintenance Board if labelled "[Plugin] Boost"
-      - uses: leonsteinhaeuser/project-beta-automations@v1.0.2
+      - uses: thingalon/project-beta-automations@v1.0.3
         if: contains(github.event.issue.labels.*.name, '[Plugin] Boost')
         with:
           gh_token: ${{ secrets.PUSH_ISSUES_TO_PROJECT_TOKEN }}
           organization: 'automattic'
           project_id: 322
           resource_node_id: ${{ github.event.issue.node_id }}
-          status_value: 'Inbox'


### PR DESCRIPTION
Jetpack Boost issues were snapping back to our Project Board's "inbox" column every time they were updated. Unfortunately, the Action we were using always overwrote the project status field on every update.

I [forked the Action](https://github.com/thingalon/project-beta-automations/) and [added support to leave out the `status_value` field](https://github.com/thingalon/project-beta-automations/commit/fe39095d46d75295cad645e99d595aafd49ccb9d). With this fork, issues which are not on the board yet will get pushed into the default (inbox) status column - and existing items on the board will not be affected on update.

I've tested it on another internal repository, and it works well. I've also [submitted my changes upstream](https://github.com/leonsteinhaeuser/project-beta-automations/pull/19).

This PR just switches our project board pusher to use my fork, and turns off status overwrites by removing the `status_value` setting.

#### Changes proposed in this Pull Request:
* Use my fork of `project-beta-automations` to avoid overwriting project board status field on each update.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Merge it
* Check that new Boost issues get added to the Boost project board.
* Check that existing Boost issues on the project board don't change status on update.
