### PR TITLE
Search package: Add activation / deactivation API

### DIFF
--- a/projects/packages/search/changelog/add-more-search-api
+++ b/projects/packages/search/changelog/add-more-search-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search API: activation and deactivation API

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -61,7 +61,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "0.4.x-dev"
+			"dev-master": "0.5.x-dev"
 		}
 	}
 }

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.4.1-alpha",
+	"version": "0.5.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -178,7 +178,7 @@ class Module_Control {
 			return new WP_Error( 'search_module_inactive', __( 'Search module needs to be activated before enabling instant search.', 'jetpack-search-pkg' ) );
 		}
 		if ( ! $this->plan->supports_instant_search() ) {
-			return new WP_Error( 'not_supported', __( 'Your plan does not support Instant Search.', 'jetpack' ) );
+			return new WP_Error( 'not_supported', __( 'Your plan does not support Instant Search.', 'jetpack-search-pkg' ) );
 		}
 		return update_option( self::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY, true );
 	}

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -177,6 +177,9 @@ class Module_Control {
 		if ( ! $this->is_active() ) {
 			return new WP_Error( 'search_module_inactive', __( 'Search module needs to be activated before enabling instant search.', 'jetpack-search-pkg' ) );
 		}
+		if ( ! $this->plan->supports_instant_search() ) {
+			return new WP_Error( 'not_supported', __( 'Your plan does not support Instant Search.', 'jetpack' ) );
+		}
 		return update_option( self::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY, true );
 	}
 

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -114,16 +114,17 @@ class Plan {
 	 * Update `has_jetpack_search_product` regarding the plan information
 	 *
 	 * @param array|WP_Error $response - Resopnse from WPCOM.
+	 * @return bool - true on success, false on failure.
 	 */
 	public function update_search_plan_info( $response ) {
 		if ( is_wp_error( $response ) ) {
-			return null;
+			return false;
 		}
 		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
 		$status_code = wp_remote_retrieve_response_code( $response );
 
 		if ( 200 !== $status_code ) {
-			return null;
+			return false;
 		}
 
 		return $this->set_plan_options( $body );
@@ -136,7 +137,7 @@ class Plan {
 	 */
 	public function set_plan_options( $plan_info ) {
 		if ( ! isset( $plan_info['supports_instant_search'] ) ) {
-			return null;
+			return false;
 		}
 		// set option whether has Jetpack Search plan for capability reason.
 		if ( get_option( 'has_jetpack_search_product' ) !== (bool) $plan_info['supports_instant_search'] ) {

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -122,19 +122,33 @@ class Plan {
 		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
 		$status_code = wp_remote_retrieve_response_code( $response );
 
-		if ( 200 !== $status_code || ! isset( $body['supports_instant_search'] ) ) {
+		if ( 200 !== $status_code ) {
+			return null;
+		}
+
+		return $this->set_plan_options( $body );
+	}
+
+	/**
+	 * Set plan info to options table
+	 *
+	 * @param array $plan_info - the decoded plan info array.
+	 */
+	public function set_plan_options( $plan_info ) {
+		if ( ! isset( $plan_info['supports_instant_search'] ) ) {
 			return null;
 		}
 		// set option whether has Jetpack Search plan for capability reason.
-		if ( get_option( 'has_jetpack_search_product' ) !== (bool) $body['supports_instant_search'] ) {
-			update_option( 'has_jetpack_search_product', (bool) $body['supports_instant_search'] );
+		if ( get_option( 'has_jetpack_search_product' ) !== (bool) $plan_info['supports_instant_search'] ) {
+			update_option( 'has_jetpack_search_product', (bool) $plan_info['supports_instant_search'] );
 		}
 		// We use this option to determine the visibility of search submenu.
 		// If the site ever had search subscription, then we record it and show the menu after.
-		if ( $body['supports_instant_search'] ) {
+		if ( $plan_info['supports_instant_search'] ) {
 			update_option( self::JETPACK_SEARCH_EVER_SUPPORTED_SEARCH, true, false );
 		}
-		update_option( self::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY, $body );
+		update_option( self::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY, $plan_info );
+		return true;
 	}
 
 }

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -269,7 +269,7 @@ class REST_Controller {
 		// TODO: need to revist the logic here when Instant Search migration is finished.
 		// We will either to make sure the auto config process is idempotent or call it only once.
 		// Automatically configure necessary settings for instant search.
-		// Automattic\Jetpack\Search\Instant_Search::instanace()->auto_config_search();.
+		// Automattic\Jetpack\Search\Instant_Search::instanace()->auto_config_search();//.
 
 		return rest_ensure_response(
 			array(

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -265,11 +265,12 @@ class REST_Controller {
 		if ( is_wp_error( $ret ) ) {
 			return $ret;
 		}
-		// TODO change to use `Automattic\Jetpack\Search\Instant_Search`.
+
+		// TODO: need to revist the logic here when Instant Search migration is finished.
+		// We will either to make sure the auto config process is idempotent or call it only once.
 		// Automatically configure necessary settings for instant search.
-		if ( class_exists( '\Jetpack_Instant_Search' ) ) {
-			\Jetpack_Instant_Search::instance()->auto_config_search();
-		}
+		// Automattic\Jetpack\Search\Instant_Search::instanace()->auto_config_search();.
+
 		return rest_ensure_response(
 			array(
 				'code' => 'success',

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -249,7 +249,7 @@ class REST_Controller {
 		// We do this to avoid another call to WPCOM and reduce latency.
 		$plan_info = $request->get_json_params();
 		if ( ! $this->plan->set_plan_options( $plan_info ) ) {
-			return new WP_Error( 'invalid_request', esc_html__( 'Plan info does not exist in request', 'jetpack' ), array( 'status' => 400 ) );
+			return new WP_Error( 'invalid_request', esc_html__( 'Plan info could not be fetched from Jetpack.com', 'jetpack' ), array( 'status' => 400 ) );
 		}
 		// Activate module.
 		$ret = $this->search_module->activate();

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -94,7 +94,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'activate_plan' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => array( $this, 'search_permissions_callback' ),
 			)
 		);
 		register_rest_route(
@@ -103,7 +103,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'deactivate_plan' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => array( $this, 'search_permissions_callback' ),
 			)
 		);
 	}

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -58,7 +58,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_search_plan' ),
-				'permission_callback' => array( $this, 'search_permissions_callback' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
 		register_rest_route(
@@ -67,7 +67,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_settings' ),
-				'permission_callback' => array( $this, 'search_permissions_callback' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
 		register_rest_route(
@@ -76,7 +76,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_settings' ),
-				'permission_callback' => array( $this, 'search_permissions_callback' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
 		register_rest_route(
@@ -94,7 +94,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'activate_plan' ),
-				'permission_callback' => array( $this, 'search_permissions_callback' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
 		register_rest_route(
@@ -103,7 +103,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'deactivate_plan' ),
-				'permission_callback' => array( $this, 'search_permissions_callback' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
 	}
@@ -113,7 +113,7 @@ class REST_Controller {
 	 *
 	 * @return bool|WP_Error True if a blog token was used to sign the request, WP_Error otherwise.
 	 */
-	public function search_permissions_callback() {
+	public function require_admin_privilege_callback() {
 		if ( current_user_can( 'manage_options' ) ) {
 			return true;
 		}
@@ -188,7 +188,7 @@ class REST_Controller {
 			);
 		}
 
-		return $this->get_settings();
+		return rest_ensure_response( $this->get_settings() );
 	}
 
 	/**
@@ -212,9 +212,11 @@ class REST_Controller {
 	 * GET `jetpack/v4/search/settings`
 	 */
 	public function get_settings() {
-		return array(
-			'module_active'          => $this->search_module->is_active(),
-			'instant_search_enabled' => $this->search_module->is_instant_search_enabled(),
+		return rest_ensure_response(
+			array(
+				'module_active'          => $this->search_module->is_active(),
+				'instant_search_enabled' => $this->search_module->is_instant_search_enabled(),
+			)
 		);
 	}
 
@@ -233,7 +235,7 @@ class REST_Controller {
 			sprintf( '/sites/%d/search', absint( $blog_id ) )
 		);
 		$response = Client::wpcom_json_api_request_as_user( $path, '1.3', array(), null, 'rest' );
-		return $this->make_proper_response( $response );
+		return rest_ensure_response( $this->make_proper_response( $response ) );
 	}
 
 	/**
@@ -265,8 +267,10 @@ class REST_Controller {
 		if ( class_exists( '\Jetpack_Instant_Search' ) ) {
 			\Jetpack_Instant_Search::instance()->auto_config_search();
 		}
-		return array(
-			'code' => 'success',
+		return rest_ensure_response(
+			array(
+				'code' => 'success',
+			)
 		);
 	}
 
@@ -280,8 +284,10 @@ class REST_Controller {
 	public function deactivate_plan() {
 		// Instant Search would be disabled along with search module.
 		$this->search_module->deactivate();
-		return array(
-			'code' => 'success',
+		return rest_ensure_response(
+			array(
+				'code' => 'success',
+			)
 		);
 	}
 

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -9,6 +9,7 @@
 namespace Automattic\Jetpack\Search;
 
 use Automattic\Jetpack\Connection\Client;
+use Jetpack_Instant_Search;
 use Jetpack_Options;
 use WP_Error;
 use WP_REST_Request;
@@ -37,10 +38,12 @@ class REST_Controller {
 	 *
 	 * @param bool                $is_wpcom - Whether it's run on WPCOM.
 	 * @param Module_Control|null $module_control - Module_Control object if any.
+	 * @param Plan|null           $plan - Plan object if any.
 	 */
-	public function __construct( $is_wpcom = false, $module_control = null ) {
+	public function __construct( $is_wpcom = false, $module_control = null, $plan = null ) {
 		$this->is_wpcom      = $is_wpcom;
 		$this->search_module = is_null( $module_control ) ? new Module_Control() : $module_control;
+		$this->plan          = is_null( $plan ) ? new Plan() : $plan;
 	}
 
 	/**
@@ -84,6 +87,24 @@ class REST_Controller {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_search_results' ),
 				'permission_callback' => 'is_user_logged_in',
+			)
+		);
+		register_rest_route(
+			'jetpack/v4',
+			'/search/plan/activate',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'activate_plan' ),
+				'permission_callback' => array( $this, 'search_permissions_callback' ),
+			)
+		);
+		register_rest_route(
+			'jetpack/v4',
+			'/search/plan/deactivate',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'deactivate_plan' ),
+				'permission_callback' => array( $this, 'search_permissions_callback' ),
 			)
 		);
 	}
@@ -214,6 +235,37 @@ class REST_Controller {
 		);
 		$response = Client::wpcom_json_api_request_as_user( $path, '1.3', array(), null, 'rest' );
 		return $this->make_proper_response( $response );
+	}
+
+	/**
+	 * Activate plan and do initial configuration
+	 */
+	public function activate_plan() {
+		// Update plan data.
+		$this->plan->get_plan_info_from_wpcom();
+		// Activate module.
+		$ret = $this->search_module->activate();
+		if ( is_wp_error( $ret ) ) {
+			return $ret;
+		}
+		$ret = $this->search_module->enable_instant_search();
+		if ( is_wp_error( $ret ) ) {
+			return $ret;
+		}
+		// Automatically configure necessary settings for instant search.
+		Jetpack_Instant_Search::instance()->auto_config_search();
+		return true;
+	}
+
+	/**
+	 * Deactivate plan and turn off module
+	 */
+	public function deactivate_plan() {
+		// Update plan data.
+		$this->plan->get_plan_info_from_wpcom();
+		// Instant Search would be disabled along with search module.
+		$this->search_module->deactivate();
+		return true;
 	}
 
 	/**

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -251,13 +251,15 @@ class REST_Controller {
 		// We do this to avoid another call to WPCOM and reduce latency.
 		$plan_info = $request->get_json_params();
 		if ( ! $this->plan->set_plan_options( $plan_info ) ) {
-			return new WP_Error( 'invalid_request', esc_html__( 'Plan info could not be fetched from Jetpack.com', 'jetpack' ), array( 'status' => 400 ) );
+			$this->plan->get_plan_info_from_wpcom();
 		}
 		// Activate module.
+		// Eligibility is checked in `activate` function.
 		$ret = $this->search_module->activate();
 		if ( is_wp_error( $ret ) ) {
 			return $ret;
 		}
+		// Eligibility is checked in `enable_instant_search` function.
 		$ret = $this->search_module->enable_instant_search();
 		if ( is_wp_error( $ret ) ) {
 			return $ret;

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -266,9 +266,9 @@ class REST_Controller {
 			return $ret;
 		}
 
-		// TODO: need to revist the logic here when Instant Search migration is finished.
-		// We will either to make sure the auto config process is idempotent or call it only once.
 		// Automatically configure necessary settings for instant search.
+		// TODO: need to revist the logic here when Instant Search migration is finished.
+		// We will either to make sure the auto config process idempotent or call it only once.
 		// Automattic\Jetpack\Search\Instant_Search::instanace()->auto_config_search();//.
 
 		return rest_ensure_response(

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -259,6 +259,7 @@ class REST_Controller {
 		if ( is_wp_error( $ret ) ) {
 			return $ret;
 		}
+		// Enable Instant Search.
 		// Eligibility is checked in `enable_instant_search` function.
 		$ret = $this->search_module->enable_instant_search();
 		if ( is_wp_error( $ret ) ) {

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -254,7 +254,7 @@ class REST_Controller {
 		// TODO change to use `Automattic\Jetpack\Search\Instant_Search`.
 		// Automatically configure necessary settings for instant search.
 		if ( class_exists( '\Jetpack_Instant_Search' ) ) {
-			Jetpack_Instant_Search::instance()->auto_config_search();
+			\Jetpack_Instant_Search::instance()->auto_config_search();
 		}
 		return true;
 	}

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -9,7 +9,6 @@
 namespace Automattic\Jetpack\Search;
 
 use Automattic\Jetpack\Connection\Client;
-use Jetpack_Instant_Search;
 use Jetpack_Options;
 use WP_Error;
 use WP_REST_Request;
@@ -252,8 +251,11 @@ class REST_Controller {
 		if ( is_wp_error( $ret ) ) {
 			return $ret;
 		}
+		// TODO change to use `Automattic\Jetpack\Search\Instant_Search`.
 		// Automatically configure necessary settings for instant search.
-		Jetpack_Instant_Search::instance()->auto_config_search();
+		if ( class_exists( '\Jetpack_Instant_Search' ) ) {
+			Jetpack_Instant_Search::instance()->auto_config_search();
+		}
 		return true;
 	}
 

--- a/projects/packages/search/tests/php/class-test-case.php
+++ b/projects/packages/search/tests/php/class-test-case.php
@@ -16,6 +16,7 @@ use WorDBless\Users as WorDBless_Users;
  * Base Test_Case class which intercepts API calls and basic options.
  */
 class Test_Case extends TestCase {
+	const PLAN_INFO_FIXTURE = '{"search_subscriptions":[{"ID":"1","user_id":"1","blog_id":"1","product_id":"2001","expiry":"2117-06-30","subscribed_date":"2017-06-30 16:07:06","renew":true,"auto_renew":true,"ownership_id":"9698106","most_recent_renew_date":"","subscription_status":"active","product_name":"Jetpack Professional","product_name_en":"Jetpack Professional","product_slug":"jetpack_business","product_type":"bundle","cost":0,"currency":"USD","bill_period":"365","available":"yes","multi":false,"support_document":null,"is_instant_search":false,"tier":null}],"supports_instant_search":false,"supports_only_classic_search":true,"supports_search":true,"default_upgrade_bill_period":"yearly"}';
 	/**
 	 * An Admin user id
 	 *
@@ -111,7 +112,7 @@ class Test_Case extends TestCase {
 					'code'    => 200,
 					'message' => 'ok',
 				),
-				'body'     => '{"search_subscriptions":[{"ID":"1","user_id":"1","blog_id":"1","product_id":"2001","expiry":"2117-06-30","subscribed_date":"2017-06-30 16:07:06","renew":true,"auto_renew":true,"ownership_id":"9698106","most_recent_renew_date":"","subscription_status":"active","product_name":"Jetpack Professional","product_name_en":"Jetpack Professional","product_slug":"jetpack_business","product_type":"bundle","cost":0,"currency":"USD","bill_period":"365","available":"yes","multi":false,"support_document":null,"is_instant_search":false,"tier":null}],"supports_instant_search":false,"supports_only_classic_search":true,"supports_search":true,"default_upgrade_bill_period":"yearly"}',
+				'body'     => self::PLAN_INFO_FIXTURE,
 			);
 		}
 		if ( strpos( $url, '/search' ) !== false && strpos( $url, 'v1.3/sites/' ) !== false ) {

--- a/projects/packages/search/tests/php/test-module-control.php
+++ b/projects/packages/search/tests/php/test-module-control.php
@@ -28,6 +28,7 @@ class Test_Module_Control extends TestCase {
 
 		$plan = $this->createMock( Plan::class );
 		$plan->method( 'supports_search' )->willReturn( true );
+		$plan->method( 'supports_instant_search' )->willReturn( true );
 
 		static::$search_module = new Module_Control( $plan );
 	}

--- a/projects/packages/search/tests/php/test-module-control.php
+++ b/projects/packages/search/tests/php/test-module-control.php
@@ -19,6 +19,13 @@ class Test_Module_Control extends TestCase {
 	protected static $search_module;
 
 	/**
+	 * Module_Control object which doesn't support instant search
+	 *
+	 * @var Module_Control
+	 */
+	protected static $search_module_no_instant;
+
+	/**
 	 * Setting up the test.
 	 *
 	 * @before
@@ -31,6 +38,12 @@ class Test_Module_Control extends TestCase {
 		$plan->method( 'supports_instant_search' )->willReturn( true );
 
 		static::$search_module = new Module_Control( $plan );
+
+		$plan = $this->createMock( Plan::class );
+		$plan->method( 'supports_search' )->willReturn( true );
+		$plan->method( 'supports_instant_search' )->willReturn( false );
+
+		static::$search_module_no_instant = new Module_Control( $plan );
 	}
 
 	/**
@@ -112,12 +125,22 @@ class Test_Module_Control extends TestCase {
 	public function test_enable_instant_search() {
 		delete_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY );
 		static::$search_module->enable_instant_search();
-		// plan doesn't support instant search.
+		// plan doesn't support search.
 		$this->assertFalse( get_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY ) );
 		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
 		static::$search_module->enable_instant_search();
 		$this->assertTrue( get_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY ) );
 		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
+	}
+
+	/**
+	 * Test static::$search_module->enable_instant_search()
+	 */
+	public function test_enable_instant_search_not_supported() {
+		delete_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY );
+		static::$search_module_no_instant->enable_instant_search();
+		// plan doesn't support instant search.
+		$this->assertFalse( get_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY ) );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/test-plan.php
+++ b/projects/packages/search/tests/php/test-plan.php
@@ -87,9 +87,9 @@ class Test_Plan extends Search_Test_Case {
 	 * Test `update_search_plan_info`
 	 */
 	public function test_update_search_plan_info() {
-		$this->assertNull( static::$plan->update_search_plan_info( new WP_Error() ) );
-		$this->assertNull( static::$plan->update_search_plan_info( array( 'response' => array( 'code' => 500 ) ) ) );
-		$this->assertNull( static::$plan->update_search_plan_info( array() ) );
+		$this->assertFalse( static::$plan->update_search_plan_info( new WP_Error() ) );
+		$this->assertFalse( static::$plan->update_search_plan_info( array( 'response' => array( 'code' => 500 ) ) ) );
+		$this->assertFalse( static::$plan->update_search_plan_info( array() ) );
 
 		$response = $this->plan_http_response_fixture( null, null, '/jetpack-search/plan' );
 		static::$plan->update_search_plan_info( $response );

--- a/projects/packages/search/tests/php/test-rest-controller.php
+++ b/projects/packages/search/tests/php/test-rest-controller.php
@@ -293,22 +293,9 @@ class Test_REST_Controller extends Search_Test_Case {
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
 		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( Search_Test_Case::PLAN_INFO_FIXTURE );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
-	}
-
-	/**
-	 * Testing the `POST /jetpack/v4/search/plan/activate` endpoint with admin user.
-	 */
-	public function test_activate_plan_admin() {
-		wp_set_current_user( $this->admin_id );
-
-		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
-		$request->set_header( 'content-type', 'application/json' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertTrue( get_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY ) );
-		$this->assertTrue( $response->get_data() );
 	}
 
 	/**
@@ -319,8 +306,10 @@ class Test_REST_Controller extends Search_Test_Case {
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
 		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( Search_Test_Case::PLAN_INFO_FIXTURE );
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array( 'code' => 'success' ), $response->get_data() );
 	}
 
 	/**
@@ -336,20 +325,6 @@ class Test_REST_Controller extends Search_Test_Case {
 	}
 
 	/**
-	 * Testing the `POST /jetpack/v4/search/plan/deactivate` endpoint with admin user.
-	 */
-	public function test_deactivate_plan_admin() {
-		wp_set_current_user( $this->admin_id );
-
-		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/deactivate' );
-		$request->set_header( 'content-type', 'application/json' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertFalse( get_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY ) );
-		$this->assertTrue( $response->get_data() );
-	}
-
-	/**
 	 * Testing the `POST /jetpack/v4/search/plan/deactivate` endpoint with editor user.
 	 */
 	public function test_deactivate_plan_editor() {
@@ -358,7 +333,8 @@ class Test_REST_Controller extends Search_Test_Case {
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/deactivate' );
 		$request->set_header( 'content-type', 'application/json' );
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array( 'code' => 'success' ), $response->get_data() );
 	}
 
 }

--- a/projects/packages/search/tests/php/test-rest-controller.php
+++ b/projects/packages/search/tests/php/test-rest-controller.php
@@ -285,4 +285,80 @@ class Test_REST_Controller extends Search_Test_Case {
 		$this->assertEquals( 6, $response->get_data()['total'] );
 	}
 
+	/**
+	 * Testing the `POST /jetpack/v4/search/plan/activate` endpoint with no user.
+	 */
+	public function test_activate_plan_authorized() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/search/plan/activate` endpoint with admin user.
+	 */
+	public function test_activate_plan_admin() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( get_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY ) );
+		$this->assertTrue( $response->get_data() );
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/search/plan/activate` endpoint with editor user.
+	 */
+	public function test_activate_plan_editor() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/search/plan/deactivate` endpoint with no user.
+	 */
+	public function test_deactivate_plan_authorized() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/deactivate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/search/plan/deactivate` endpoint with admin user.
+	 */
+	public function test_deactivate_plan_admin() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/deactivate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( get_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY ) );
+		$this->assertTrue( $response->get_data() );
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/search/plan/deactivate` endpoint with editor user.
+	 */
+	public function test_deactivate_plan_editor() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/deactivate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
 }

--- a/projects/packages/search/tests/php/test-rest-controller.php
+++ b/projects/packages/search/tests/php/test-rest-controller.php
@@ -145,9 +145,9 @@ class Test_REST_Controller extends Search_Test_Case {
 		$this->assertEquals( 400, $response->get_status() );
 	}
 
-		/**
-		 * Testing the `POST /jetpack/v4/search/settings` endpoint with an admin user.
-		 */
+	/**
+	 * Testing the `POST /jetpack/v4/search/settings` endpoint with an admin user.
+	 */
 	public function test_update_search_settings_invalid_request_2() {
 		wp_set_current_user( $this->admin_id );
 		$new_settings = array();

--- a/projects/packages/search/tests/php/test-rest-controller.php
+++ b/projects/packages/search/tests/php/test-rest-controller.php
@@ -308,8 +308,7 @@ class Test_REST_Controller extends Search_Test_Case {
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body( Search_Test_Case::PLAN_INFO_FIXTURE );
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array( 'code' => 'success' ), $response->get_data() );
+		$this->assertEquals( 403, $response->get_status() );
 	}
 
 	/**
@@ -333,8 +332,7 @@ class Test_REST_Controller extends Search_Test_Case {
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/deactivate' );
 		$request->set_header( 'content-type', 'application/json' );
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array( 'code' => 'success' ), $response->get_data() );
+		$this->assertEquals( 403, $response->get_status() );
 	}
 
 }

--- a/projects/packages/search/tests/php/test-rest-controller.php
+++ b/projects/packages/search/tests/php/test-rest-controller.php
@@ -43,6 +43,7 @@ class Test_REST_Controller extends Search_Test_Case {
 
 		$plan = $this->createMock( Plan::class );
 		$plan->method( 'supports_search' )->willReturn( true );
+		$plan->method( 'supports_instant_search' )->willReturn( true );
 
 		$this->rest_controller = new REST_Controller( false, new Module_Control( $plan ) );
 

--- a/projects/plugins/jetpack/changelog/add-more-search-api
+++ b/projects/plugins/jetpack/changelog/add-more-search-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -36,7 +36,7 @@
 		"automattic/jetpack-partner": "1.6.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.4.x-dev",
+		"automattic/jetpack-search": "0.5.x-dev",
 		"automattic/jetpack-status": "1.9.x-dev",
 		"automattic/jetpack-sync": "1.28.x-dev",
 		"automattic/jetpack-terms-of-service": "1.9.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "792ab9c7ef300798fed1153b536004e5",
+    "content-hash": "85814f335c9c9b8cd1c2c66a8ed46303",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1520,7 +1520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "c59fe7d6110304239e25fc04ccbbcfc0889fedc9"
+                "reference": "58a18c9d8e957ddd9099e0d18a9b6210d7d995d9"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.34"
@@ -1539,7 +1539,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.4.x-dev"
+                    "dev-master": "0.5.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Note: `auto_config_search` call is removed and will be revisited when the major PRs merged.

#### Changes proposed in this Pull Request:
The PR adds two APIs for Jetpack Search - activation and deactivation APIs. 

The search plan activation process was done in Jetpack by updating three settings 'has_jetpack_search_product', 'instant_search_enabled' and 'search_auto_config' to `true` and then activate the search module. The deactivation is similar, but set these options to `false` and then deactivate the search module.

The PR combines these operations and proposes two APIs for future standalone plugin to use and makes the process simpler and with less API calls.

`D71473-code` needs to be merged to actually use these APIs, which will happen after major search PRs are merged.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Make sure tests pass `( cd projects/packages/search && composer phpunit )`

Test the APIs separately, I used [Rest Client i](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)n VSCode. Requests are like the following. You'll need to replace the nonce and cookie which could be get from Chrome dev tools. If you have better ways to test, please let me know 😄

##### Activate plan:

```
POST https://wordpress.local/?rest_route=/jetpack/v4/search/plan/activate HTTP/1.1
Content-Type: application/json
x-wp-nonce: {{nonce}}
cookie: {{cookie}}

{
	"search_subscriptions": [{
		"ID": "1",
		"user_id": "1",
		"blog_id": "1",
		"product_id": "2001",
		"expiry": "2117-06-30",
		"subscribed_date": "2017-06-30 16:07:06",
		"renew": true,
		"auto_renew": true,
		"ownership_id": "9698106",
		"most_recent_renew_date": "",
		"subscription_status": "active",
		"product_name": "Jetpack Professional",
		"product_name_en": "Jetpack Professional",
		"product_slug": "jetpack_business",
		"product_type": "bundle",
		"cost": 0,
		"currency": "USD",
		"bill_period": "365",
		"available": "yes",
		"multi": false,
		"support_document": null,
		"is_instant_search": false,
		"tier": null
	}],
	"supports_instant_search": false,
	"supports_only_classic_search": true,
	"supports_search": true,
	"default_upgrade_bill_period": "yearly"
}

```

##### Deactivate plan:

```
POST https://jasper.au.ngrok.io/?rest_route=/jetpack/v4/search/plan/deactivate HTTP/1.1
Content-Type: application/json
x-wp-nonce: {{nonce}}
cookie: {{cookie}}
```
