### PR TITLE
Contact Form: avoid PHP notices in submitted forms in some cases.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-php-notice-contact-form-value
+++ b/projects/plugins/jetpack/changelog/fix-php-notice-contact-form-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Contact Form: avoid PHP notices in submitted forms in some cases.

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -2382,6 +2382,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 					$value         = trim( $value );
 				}
 
+				// If we still do not have any value, bail.
+				if ( empty( $value ) ) {
+					continue;
+				}
+
 				$field_index                   = array_search( $field_ids[ $type ], $field_ids['all'] );
 				$compiled_form[ $field_index ] = sprintf(
 					'<b>%1$s:</b> %2$s<br /><br />',


### PR DESCRIPTION
Fixes #22079

#### Changes proposed in this Pull Request:

* Avoid a PHP notice in some edge-cases with the Contact form module.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I am not quite sure how to reproduce this, so I do not have detailed steps to test for that specific bug.

* Go to Jetpack > Settings and ensure that the contact form module is active.
* Go to Posts > Add New and create a new form block, with multiple different fields.
* Publish post, and submit a test form.
* Check the email you got; it should inlude all the fields you've submitted.
