### PR TITLE
Site Logo: Prevent logo markup being generated when logo id is not se…

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-22099-site-logo-attachment-bug-fix
+++ b/projects/plugins/jetpack/changelog/fix-22099-site-logo-attachment-bug-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Site Logo: Prevent logo markup being generated when logo id is not set

--- a/projects/plugins/jetpack/modules/theme-tools/site-logo/inc/functions.php
+++ b/projects/plugins/jetpack/modules/theme-tools/site-logo/inc/functions.php
@@ -138,6 +138,25 @@ function jetpack_the_site_logo() {
 		$logo_id = $jetpack_logo_id;
 	}
 
+	// Check if the logo id is set before generating the markup.
+	$logo_html = '';
+	if ( $logo_id ) {
+		$logo_html = sprintf(
+			'<a href="%1$s" class="site-logo-link" rel="home" itemprop="url">%2$s</a>',
+			esc_url( home_url( '/' ) ),
+			wp_get_attachment_image(
+				$logo_id,
+				$size,
+				false,
+				array(
+					'class'     => "site-logo attachment-$size",
+					'data-size' => $size,
+					'itemprop'  => 'logo',
+				)
+			)
+		);
+	}
+
 	/*
 	 * Reason: the output is escaped in the sprintf.
 	 * phpcs:disable WordPress.Security.EscapeOutput
@@ -155,20 +174,7 @@ function jetpack_the_site_logo() {
 	 */
 	echo apply_filters(
 		'jetpack_the_site_logo',
-		sprintf(
-			'<a href="%1$s" class="site-logo-link" rel="home" itemprop="url">%2$s</a>',
-			esc_url( home_url( '/' ) ),
-			wp_get_attachment_image(
-				$logo_id,
-				$size,
-				false,
-				array(
-					'class'     => "site-logo attachment-$size",
-					'data-size' => $size,
-					'itemprop'  => 'logo',
-				)
-			)
-		),
+		$logo_html,
 		// Return array format in filter for back compatibility.
 		array(
 			'id'    => $jetpack_logo_id,


### PR DESCRIPTION
…t. Co-authored-by: Maggie Cabrera <maggie.cabrera@automattic.com>

#### Testing instructions:

1. Activate Twenty Sixteen on a Simple site (make sure logo is not set). 
2. Navigate to the Media (`/wp-admin/upload.php`)
3. Click on an image and then click the View attachment page
4. Wait for the attachment page to open.
5. Confirm that the logo is not displaying the current page attachment image

Before:
<img width="1315" alt="before-6" src="https://user-images.githubusercontent.com/905781/146190779-a4d67c1b-60c2-4225-9fee-7f790d3fc0c4.png">

After:
<img width="1093" alt="after-2" src="https://user-images.githubusercontent.com/905781/146190786-ca0cbec9-c786-4052-ae00-611835512ead.png">

#### Does this pull request change what data or activity we track or use?

No

Closes #22099