### PR TITLE
Tools: Update get-contributor-list script to allow -beta

### DIFF
--- a/tools/get-contributor-list.sh
+++ b/tools/get-contributor-list.sh
@@ -46,7 +46,7 @@ while IFS= read -r VER; do
 		done
 		die "Could not find an existing branch for a version prior to $CURRENT_VERSION"
     fi
-done < <( sed -n -E -e 's/^## \[?([0-9.]+)\]? - .*$/\1/p' "projects/$1/CHANGELOG.md" )
+done < <( sed -n -E -e 's/^## \[?([0-9.]+)(-beta)?\]? - .*$/\1/p' "projects/$1/CHANGELOG.md" )
 [[ -n "$PREVIOUS_VERSION" ]] || die "Version $CURRENT_VERSION was not found or was the first version."
 
 echo "Getting contributors from $PREVIOUS_VERSION to $CURRENT_VERSION..."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When releasing a beta, the script currently won't let you check a version number in CHANGELOG.md such as 10.4-beta. This update will allow that match.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Easiest way is to go to Jetpack's CHANGELOG.md file and append `-beta` to the 10.4 release section, so it reads 10.4-beta.

Then try running `tools/get-contributor-list.sh plugins/jetpack 10.4`. Things should work fine. Without the extra regex, the script will fail.
