### PR TITLE
Remove Facebook share counter code for non-official buttons

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-facebook-share-count-code
+++ b/projects/plugins/jetpack/changelog/update-remove-facebook-share-count-code
@@ -1,0 +1,5 @@
+Significance: minor
+Type: bugfix
+
+Comment: The calls to facebook's graph API via SDK has stopped providing us with share counts, at least since 2019. The correct way to display share counts now is to rely on official buttons. 
+This change deals with removing the code that's in place to fetch share counts for non-official buttons. The code is being removed because it's not functional.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -937,7 +937,7 @@ function sharing_display( $text = '', $echo = false ) {
 			if ( defined( 'JETPACK__VERSION' ) ) {
 				$ver = JETPACK__VERSION;
 			} else {
-				$ver = '20201124';
+				$ver = '20211226';
 			}
 
 			// @todo: Investigate if we can load this JS in the footer instead.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.js
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.js
@@ -301,12 +301,6 @@
 								'//api.pinterest.com/v1/urls/count.json?callback=WPCOMSharing.update_pinterest_count&url=' +
 								encodeURIComponent( url ),
 						],
-						// Facebook protocol summing has been shown to falsely double counts, so we only request the current URL
-						facebook: [
-							window.location.protocol +
-								'//graph.facebook.com/?callback=WPCOMSharing.update_facebook_count&ids=' +
-								encodeURIComponent( url ),
-						],
 					};
 
 					for ( service in requests ) {
@@ -326,45 +320,6 @@
 					WPCOMSharing.done_urls[ id ] = true;
 				}
 			},
-
-			// get the version of the url that was stored in the dom
-			get_permalink: function ( url ) {
-				if ( 'https:' === window.location.protocol ) {
-					url = url.replace( /^http:\/\//i, 'https://' );
-				} else {
-					url = url.replace( /^https:\/\//i, 'http://' );
-				}
-
-				return url;
-			},
-			update_facebook_count: function ( data ) {
-				var url, permalink;
-
-				if ( ! data ) {
-					return;
-				}
-
-				for ( url in data ) {
-					if (
-						! Object.prototype.hasOwnProperty.call( data, url ) ||
-						! data[ url ].share ||
-						! data[ url ].share.share_count
-					) {
-						continue;
-					}
-
-					permalink = WPCOMSharing.get_permalink( url );
-
-					if ( ! ( permalink in WPCOM_sharing_counts ) ) {
-						continue;
-					}
-
-					WPCOMSharing.inject_share_count(
-						'sharing-facebook-' + WPCOM_sharing_counts[ permalink ],
-						data[ url ].share.share_count
-					);
-				}
-			},
 			update_pinterest_count: function ( data ) {
 				if ( 'undefined' !== typeof data.count && data.count * 1 > 0 ) {
 					WPCOMSharing.inject_share_count(
@@ -374,16 +329,17 @@
 				}
 			},
 			inject_share_count: function ( id, count ) {
-				forEachNode( document.querySelectorAll( 'a[data-shared=' + id + '] > span' ), function (
-					span
-				) {
-					var countNode = span.querySelector( '.share-count' );
-					removeNode( countNode );
-					var newNode = document.createElement( 'span' );
-					newNode.className = 'share-count';
-					newNode.textContent = WPCOMSharing.format_count( count );
-					span.appendChild( newNode );
-				} );
+				forEachNode(
+					document.querySelectorAll( 'a[data-shared=' + id + '] > span' ),
+					function ( span ) {
+						var countNode = span.querySelector( '.share-count' );
+						removeNode( countNode );
+						var newNode = document.createElement( 'span' );
+						newNode.className = 'share-count';
+						newNode.textContent = WPCOMSharing.format_count( count );
+						span.appendChild( newNode );
+					}
+				);
 			},
 			format_count: function ( count ) {
 				if ( count < 1000 ) {
@@ -457,11 +413,12 @@
 		// Touchscreen device: use click.
 		// Non-touchscreen device: use click if not already appearing due to a hover event
 
-		forEachNode( document.querySelectorAll( '.sharedaddy a.sharing-anchor' ), function (
-			buttonEl
-		) {
-			MoreButton.instantiateOrReuse( buttonEl );
-		} );
+		forEachNode(
+			document.querySelectorAll( '.sharedaddy a.sharing-anchor' ),
+			function ( buttonEl ) {
+				MoreButton.instantiateOrReuse( buttonEl );
+			}
+		);
 
 		if ( document.ontouchstart !== undefined ) {
 			document.body.classList.add( 'jp-sharing-input-touch' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The recommended way to display the share counter for Facebook posts is to use the official buttons. The non-official buttons used to display the share counters as well in the past, but have become nonfunctional, due to Facebook requiring us to send an access token for it. This PR will remove the non-functional code that's in place to display the share count for the non-official buttons. 

Fixes https://github.com/Automattic/jetpack/issues/22113

#### Changes proposed in this Pull Request:
- Remove the code in place to fetch shares for non-official facebook share button 

#### Jetpack product discussion
p7DVsv-6n6-p2


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Go to Jetpack->Settings->Sharing.
2. Under sharing buttons, enable the option "Add sharing buttons to your posts and pages".
3. Click on configure sharing buttons and choose any option except for "official buttons" as shown below.
4. Create a blog post and share it on Facebook. 
5. There will be no visible change on the UI since we are just removing non-functional code, but observe that no counter is displayed next to the share button. 
6. In step 3, change your selection to the "official buttons" option and go back to the post you shared, to observe that the counter is correctly displayed in case of official buttons. 

#### Testing instructions for Dotcom :

Repeat the same steps in the testing instructions except for the place where the option for the official button and nonofficial button is selected. 
1. Go to Tools->Marketing->Sharing Buttons.
2. Under edit sharing buttons, select the option "Official Buttons" and check if Facebook shares show up. 
3.  Under edit sharing buttons, select any option except "Official Buttons" and check if Facebook shares show up (it won't be showing up). 



How the official Facebook and Pinterest buttons should look (this is how they currently look as well, but just making sure no existing functionality is broken):

### Jetpack Screenshots

<img width="540" alt="Screenshot 2021-12-16 at 11 52 03 AM" src="https://user-images.githubusercontent.com/6594561/146318982-5a419841-15d4-4497-b75f-f441d2c08b12.png">

Non-official button view
(Pinterest is now  the only non official button for which we show the shares counter from our end)

<img width="261" alt="Screenshot 2021-12-16 at 12 10 26 PM" src="https://user-images.githubusercontent.com/6594561/146321035-c9ce3047-9acd-45fe-9ede-b9b9fce1517c.png">


### Dotcom Screenshots

Non-official buttons
<img width="509" alt="Screenshot 2021-12-16 at 12 13 10 PM" src="https://user-images.githubusercontent.com/6594561/146321949-344ba882-a96f-47b2-85fa-43664db42695.png">

Official buttons
<img width="740" alt="Screenshot 2021-12-16 at 12 12 26 PM" src="https://user-images.githubusercontent.com/6594561/146322015-5be85989-665d-4b1c-ac39-026b8c7c0dae.png">







