### PR TITLE
Improve accessibility and display of math fallback(Protect)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-protect-math-fallback-accessibility
+++ b/projects/plugins/jetpack/changelog/fix-protect-math-fallback-accessibility
@@ -1,0 +1,6 @@
+Significance: minor
+Type: bugfix
+
+Fixed math fallback's input accessibility and display
+
+

--- a/projects/plugins/jetpack/modules/protect/math-fallback.php
+++ b/projects/plugins/jetpack/modules/protect/math-fallback.php
@@ -147,14 +147,14 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			$salted_ans  = hash_hmac( 'sha1', $ans, $salt . $time_window );
 			?>
 			<div style="margin: 5px 0 20px;">
-				<label for="jetpack_protect_answer">
+				<label>
 					<?php esc_html_e( 'Prove your humanity', 'jetpack' ); ?>
 				</label>
 				<br/>
-				<span style="vertical-align:super;">
+				<label for="jetpack_protect_answer" style="vertical-align:super;">
 					<?php echo esc_html( "$num1 &nbsp; + &nbsp; $num2 &nbsp; = &nbsp;" ); ?>
-				</span>
-				<input type="text" id="jetpack_protect_answer" name="jetpack_protect_num" value="" size="2" style="width:30px;height:25px;vertical-align:middle;font-size:13px;" class="input" />
+				</label>
+				<input type="number" id="jetpack_protect_answer" name="jetpack_protect_num" value="" size="2" style="width:50px;height:25px;vertical-align:middle;font-size:13px;" class="input" />
 				<input type="hidden" name="jetpack_protect_answer" value="<?php echo esc_attr( $salted_ans ); ?>" />
 			</div>
 		<?php

--- a/projects/plugins/jetpack/modules/protect/math-fallback.php
+++ b/projects/plugins/jetpack/modules/protect/math-fallback.php
@@ -147,9 +147,9 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			$salted_ans  = hash_hmac( 'sha1', $ans, $salt . $time_window );
 			?>
 			<div style="margin: 5px 0 20px;">
-				<label>
+				<p class="message">
 					<?php esc_html_e( 'Prove your humanity', 'jetpack' ); ?>
-				</label>
+				</p>
 				<br/>
 				<label for="jetpack_protect_answer" style="vertical-align:super;">
 					<?php echo esc_html( "$num1 &nbsp; + &nbsp; $num2 &nbsp; = &nbsp;" ); ?>

--- a/projects/plugins/jetpack/modules/protect/math-fallback.php
+++ b/projects/plugins/jetpack/modules/protect/math-fallback.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			$salted_ans  = hash_hmac( 'sha1', $ans, $salt . $time_window );
 			?>
 			<div style="margin: 5px 0 20px;">
-				<p class="message">
+				<p style="font-size: 14px;">
 					<?php esc_html_e( 'Prove your humanity', 'jetpack' ); ?>
 				</p>
 				<br/>

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:21.04
 
 VOLUME ["/var/www/html"]
 


### PR DESCRIPTION
Fixes #6714 & [this display issue](https://twitter.com/WPThemeSpeed/status/1201695870317670400)

#### Changes proposed in this Pull Request:

- Moved math equation inside a label and tied it to input field using `for="jetpack_protect_answer"`
- Changed input field's type to number from text
- Increased input field's width from 30px to 45px to properly accommodate two digit number


**Does this pull request change what data or activity we track or use?**
No

#### Testing instructions:
PENDING


**Current dom screenshot**: 
<img width="1508" alt="math_protect_old" src="https://user-images.githubusercontent.com/95693514/146587927-b340e24e-672a-4569-bb2a-3c137c62abec.png">

**Current page Apple VoiceOver recording**

https://user-images.githubusercontent.com/95693514/146588132-6b447b30-99f9-4194-b8e7-3ad0ea7cff61.mov



**New dom screenshot**:
<img width="1393" alt="math_protect_new" src="https://user-images.githubusercontent.com/95693514/146587962-f15efc44-1e2b-4e88-bb1d-c06c5bd4835b.png">

**New page Apple VoiceOver recording**

https://user-images.githubusercontent.com/95693514/146588218-65d66f46-6c91-4567-9804-c9113d154c99.mov





