### PR TITLE
i18n-check-webpack-plugin: Allow specifying the expected textdomain

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,7 +435,7 @@ importers:
     specifiers:
       '@automattic/babel-plugin-preserve-i18n': 1.0.0
       '@automattic/babel-plugin-replace-textdomain': workspace:^0.1.1-alpha
-      '@automattic/i18n-check-webpack-plugin': workspace:^0.1.1-alpha
+      '@automattic/i18n-check-webpack-plugin': workspace:^0.2.0-alpha
       '@automattic/i18n-loader-webpack-plugin': workspace:^0.1.0-alpha
       '@automattic/webpack-rtl-plugin': 5.1.0
       '@babel/compat-data': 7.16.4

--- a/projects/js-packages/i18n-check-webpack-plugin/README.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/README.md
@@ -26,6 +26,7 @@ Parameters recognized by the plugin are:
 - `filter`: Allows for specifying which source modules to process for i18n strings. The default is to process all files with extensions `js`, `jsx`, `ts`, `tsx`, `cjs`, and `mjs`.
 
   The value may be a function, which will be passed the file path relative to [Webpack's context] and which should return true if the file should be processed, or a string or RegExp to be compared with the relative file path, or an array of such strings, RegExps, and/or functions.
+- `expectDomain`: Set to the expected text domain that should be used in the output assets. If the assets use some other domain, an error will be generated.
 - `warnOnly`: Set true to produce warnings rather than errors when issues are found.
 - `extractorOptions`: Supply options for `GettextExtractor`.
    - `babelOptions`: Supply options for Babel.

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/add-i18n-check-expected-textdomain
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/add-i18n-check-expected-textdomain
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow specifying the expected textdomain to be used in the output assets.

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "0.1.1-alpha",
+	"version": "0.2.0-alpha",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/js-packages/webpack-config/changelog/add-i18n-check-expected-textdomain
+++ b/projects/js-packages/webpack-config/changelog/add-i18n-check-expected-textdomain
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Set i18n-check-webpack-plugin's `expectDomain` based on composer.json.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -19,7 +19,7 @@
 	"dependencies": {
 		"@automattic/babel-plugin-preserve-i18n": "1.0.0",
 		"@automattic/babel-plugin-replace-textdomain": "workspace:^0.1.1-alpha",
-		"@automattic/i18n-check-webpack-plugin": "workspace:^0.1.1-alpha",
+		"@automattic/i18n-check-webpack-plugin": "workspace:^0.2.0-alpha",
 		"@automattic/i18n-loader-webpack-plugin": "workspace:^0.1.0-alpha",
 		"@automattic/webpack-rtl-plugin": "5.1.0",
 		"@babel/compat-data": "7.16.4",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
If the textdomain used is not the expected domain, raise an error.

Then set this in our webpack-config based on the contents of
composer.json, to help ensure that plugins and packages actually use the
expected domain.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit `projects/plugins/backup/babel.config.js` to set the domain to something other than "jetpack-backup", and see if a production build fails with the appropriate error.