### PR TITLE
Fix incorrect syntax for specifying textdomain for WordPress.WP.I18n

### DIFF
--- a/projects/packages/assets/.phpcs.dir.xml
+++ b/projects/packages/assets/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/assets/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/assets/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/backup/.phpcs.dir.xml
+++ b/projects/packages/backup/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/backup/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/backup/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/config/.phpcs.dir.xml
+++ b/projects/packages/config/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/config/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/config/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/connection-ui/.phpcs.dir.xml
+++ b/projects/packages/connection-ui/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/connection-ui/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/connection-ui/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/connection/.phpcs.dir.xml
+++ b/projects/packages/connection/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/connection/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/connection/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/heartbeat/.phpcs.dir.xml
+++ b/projects/packages/heartbeat/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/heartbeat/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/heartbeat/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/identity-crisis/.phpcs.dir.xml
+++ b/projects/packages/identity-crisis/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/identity-crisis/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/identity-crisis/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/jitm/.phpcs.dir.xml
+++ b/projects/packages/jitm/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/jitm/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/jitm/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/lazy-images/.phpcs.dir.xml
+++ b/projects/packages/lazy-images/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/lazy-images/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/lazy-images/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/licensing/.phpcs.dir.xml
+++ b/projects/packages/licensing/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/licensing/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/licensing/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/my-jetpack/.phpcs.dir.xml
+++ b/projects/packages/my-jetpack/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/my-jetpack/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/my-jetpack/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/password-checker/.phpcs.dir.xml
+++ b/projects/packages/password-checker/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/password-checker/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/password-checker/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/post-list/.phpcs.dir.xml
+++ b/projects/packages/post-list/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/post-list/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/post-list/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/search/.phpcs.dir.xml
+++ b/projects/packages/search/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/search/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/search/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/sync/.phpcs.dir.xml
+++ b/projects/packages/sync/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/sync/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/sync/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/packages/tracking/.phpcs.dir.xml
+++ b/projects/packages/tracking/.phpcs.dir.xml
@@ -4,7 +4,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TODO: Change this to something aliasable. -->
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/packages/tracking/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/tracking/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/plugins/backup/.phpcs.dir.xml
+++ b/projects/plugins/backup/.phpcs.dir.xml
@@ -3,7 +3,9 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain">jetpack-backup</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack-backup" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/plugins/backup/changelog/fix-phpcs-textdomain-config
+++ b/projects/plugins/backup/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/plugins/beta/changelog/fix-phpcs-textdomain-config
+++ b/projects/plugins/beta/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/plugins/boost/.phpcs.dir.xml
+++ b/projects/plugins/boost/.phpcs.dir.xml
@@ -3,7 +3,9 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain">jetpack-boost</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack-boost" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/plugins/boost/changelog/fix-phpcs-textdomain-config
+++ b/projects/plugins/boost/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/plugins/jetpack/.phpcs.dir.xml
+++ b/projects/plugins/jetpack/.phpcs.dir.xml
@@ -3,7 +3,9 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain">jetpack</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/plugins/jetpack/changelog/fix-phpcs-textdomain-config
+++ b/projects/plugins/jetpack/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/plugins/search/.phpcs.dir.xml
+++ b/projects/plugins/search/.phpcs.dir.xml
@@ -3,7 +3,9 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain">jetpack-search</property>
+			<property name="text_domain" type="array">
+				<element value="jetpack-search" />
+			</property>
 		</properties>
 	</rule>
 

--- a/projects/plugins/search/changelog/fix-phpcs-textdomain-config
+++ b/projects/plugins/search/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
+
+

--- a/projects/plugins/vaultpress/.phpcs.dir.xml
+++ b/projects/plugins/vaultpress/.phpcs.dir.xml
@@ -4,7 +4,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="jetpack-beta" />
+				<element value="vaultpress" />
 			</property>
 		</properties>
 	</rule>
@@ -12,7 +12,7 @@
 	<rule ref="WordPress.Utils.I18nTextDomainFixer">
 		<properties>
 			<property name="old_text_domain" type="array" />
-			<property name="new_text_domain" value="jetpack-beta" />
+			<property name="new_text_domain" value="vaultpress" />
 		</properties>
 	</rule>
 

--- a/projects/plugins/vaultpress/changelog/fix-phpcs-textdomain-config
+++ b/projects/plugins/vaultpress/changelog/fix-phpcs-textdomain-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Configre textdomain for WordPress.WP.I18n.
+
+

--- a/projects/plugins/vaultpress/changelog/fix-phpcs-textdomain-config
+++ b/projects/plugins/vaultpress/changelog/fix-phpcs-textdomain-config
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Configre textdomain for WordPress.WP.I18n.
+Comment: Configure textdomain for WordPress.WP.I18n.
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The sniff requires an array value, not a string.

Also the syntax for `<property>` was wrong anyway.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try changing a `__()` call in PHP somewhere to use the wrong domain. See if phpcs detects it now.
* Or change the domain in `.phpcs.dir.xml` and see if it reports all the existing calls as wrong.
