### PR TITLE
docker: Fix "fakepot" `wp i18n` command

### DIFF
--- a/tools/docker/bin/fakepot.sh
+++ b/tools/docker/bin/fakepot.sh
@@ -62,7 +62,7 @@ cd "$OLDDIR"
 
 info "Creating POT file"
 mkdir "$TMPDIR/pot"
-php -d memory_limit=2G $(command -v wp) --allow-root --debug i18n make-pot "$TMPDIR/plugin/" "$TMPDIR/pot/$DOMAIN.pot"
+php -d memory_limit=2G $(command -v wp) --allow-root --debug i18n make-pot --slug="$DOMAIN" --ignore-domain "$TMPDIR/plugin/" "$TMPDIR/pot/$DOMAIN.pot"
 
 info "Making translations"
 cat <<EOF > "$TMPDIR/pot/en_piglatin.po"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
WordPress.org's translation infrastructure uses --ignore-domain, we
should too.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try running it in the docker env on `/var/www/html/wp-content/plugins/backup`. Check that the produced files contain strings from packages.
