### PR TITLE
Load the i18n-map in plugins

### DIFF
--- a/projects/plugins/backup/changelog/update-plugins-load-assets-i18n-map
+++ b/projects/plugins/backup/changelog/update-plugins-load-assets-i18n-map
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Load the Composer package assets i18n map.

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -91,6 +91,7 @@ if ( is_wp_error( $jetpack_backup_meets_requirements ) ) {
 $jetpack_autoloader = JETPACK_BACKUP_PLUGIN_DIR . 'vendor/autoload_packages.php';
 if ( is_readable( $jetpack_autoloader ) ) {
 	require_once $jetpack_autoloader;
+	\Automattic\Jetpack\Assets::alias_textdomains_from_file( JETPACK_BACKUP_PLUGIN_DIR . 'jetpack_vendor/i18n-map.php' );
 } else { // Something very unexpected. Error out gently with an admin_notice and exit loading.
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/projects/plugins/boost/changelog/update-plugins-load-assets-i18n-map
+++ b/projects/plugins/boost/changelog/update-plugins-load-assets-i18n-map
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Load the Composer package assets i18n map.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -14,6 +14,7 @@
 	"prefer-stable": true,
 	"require": {
 		"ext-json": "*",
+		"automattic/jetpack-assets": "1.15.x-dev",
 		"automattic/jetpack-admin-ui": "0.2.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
 		"automattic/jetpack-composer-plugin": "0.2.x-dev",

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4b3a2da0b7a9e7838307ad8a8531731",
+    "content-hash": "57de5a0c2e9bfa8c0e593b7a8ad974f3",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -4510,6 +4510,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-assets": 20,
         "automattic/jetpack-admin-ui": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-composer-plugin": 20,

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -62,6 +62,7 @@ if ( ! defined( 'JETPACK__WPCOM_JSON_API_BASE' ) ) {
 $boost_packages_path = JETPACK_BOOST_DIR_PATH . '/vendor/autoload_packages.php';
 if ( is_readable( $boost_packages_path ) ) {
 	require_once $boost_packages_path;
+	\Automattic\Jetpack\Assets::alias_textdomains_from_file( JETPACK_BOOST_DIR_PATH . '/jetpack_vendor/i18n-map.php' );
 } else {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/projects/plugins/jetpack/changelog/update-plugins-load-assets-i18n-map
+++ b/projects/plugins/jetpack/changelog/update-plugins-load-assets-i18n-map
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Load the Composer package assets i18n map.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -139,6 +139,7 @@ $jetpack_autoloader           = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.
 $jetpack_module_headings_file = JETPACK__PLUGIN_DIR . 'modules/module-headings.php'; // This file is loaded later in load-jetpack.php, but let's check here to pause before half-loading Jetpack.
 if ( is_readable( $jetpack_autoloader ) && is_readable( $jetpack_module_headings_file ) ) {
 	require_once $jetpack_autoloader;
+	\Automattic\Jetpack\Assets::alias_textdomains_from_file( JETPACK__PLUGIN_DIR . 'jetpack_vendor/i18n-map.php' );
 } else {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
For Jetpack, this will keep the packages' i18n working once we update
the packages to use aliasable domains instead of "jetpack".

For Backup and Boost, this will make the packages' i18n _start_ working
once we do that update (and once a version with `jetpack_vendor/` is
pushed to wporg svn so the translations exist).

When we add use of jetpack-composer-plugin to other plugins (e.g.
Search), we'll need to remember to do something similar to each of them
too.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
For #21690 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This shouldn't make any visible difference yet.