### PR TITLE
Instant Search: ensure the hidden overlay doesn't add whitespace to printed pages (attempt two)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-overlay-print-css-take2
+++ b/projects/plugins/jetpack/changelog/fix-overlay-print-css-take2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instant Search: ensure the hidden overlay doesn't add whitespace to printed pages

--- a/projects/plugins/jetpack/modules/search/instant-search/components/overlay.scss
+++ b/projects/plugins/jetpack/modules/search/instant-search/components/overlay.scss
@@ -56,3 +56,11 @@ $overlay-horizontal-padding-lg: 3em;
 		box-sizing: inherit;
 	}
 }
+
+// Ensure the hidden overlay doesn't add whitespace to printed pages
+@media print {
+    .jetpack-instant-search__overlay.is-hidden {
+        display: none;
+    }
+}
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/7134.

First attempt was https://github.com/Automattic/jetpack/pull/22134 but I had branched that off the standalone package PR. This one, much more sensibly, branches off master.

The only confirmed theme that this has happened on is 'Field Guide' but there may be others.

#### Changes proposed in this Pull Request:
Ensure the search overlay is completely hidden on printed pages.

On certain themes, the overlay's presence can cause blank pages to be added to the printout.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Open a site with Instant Search installed. Don't start a search.
2. Bring up the print preview for the page.
3. Ensure there are no extra blank pages added by the hidden overlay.
4. Inspect the print styles in the browser and ensure that 'display:none' is applied to '.jetpack-instant-search__overlay'.