### PR TITLE
composer-plugin: Don't output invalid versions in i18n-map

### DIFF
--- a/projects/packages/composer-plugin/changelog/fix-composer-plugin-dev-versions
+++ b/projects/packages/composer-plugin/changelog/fix-composer-plugin-dev-versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix handling of dev versions in i18n-map.php.

--- a/projects/packages/composer-plugin/changelog/fix-composer-plugin-dev-versions#2
+++ b/projects/packages/composer-plugin/changelog/fix-composer-plugin-dev-versions#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix deletion of the i18n-map.php if the plugin isn't configured correctly.

--- a/projects/packages/composer-plugin/src/class-plugin.php
+++ b/projects/packages/composer-plugin/src/class-plugin.php
@@ -92,7 +92,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			$totype   = 'themes';
 		} else {
 			$io->warning( 'Skipping jetpack-library i18n map generation, .extra.wp-plugin-slug / .extra.wp-theme-slug is not set in composer.json' );
-			$filesystem->unlink( 'jetpack_vendor/i18n-map.php' );
+			$filesystem->remove( 'jetpack_vendor/i18n-map.php' );
 			return;
 		}
 
@@ -109,6 +109,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			$ver = $package->getVersion();
 			if ( isset( $extra['branch-alias'][ $ver ] ) ) {
 				$ver = $extra['branch-alias'][ $ver ];
+			}
+			if ( ! preg_match( '/^\d+\.\d+\.\d+(?:-[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$/', $ver ) ) {
+				// Invalid version, skip it.
+				$ver = '0.0.0';
 			}
 
 			$extra = $package->getExtra();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
"1.2.x-dev" is not valid semver. Replace anything that's invalid with
"0.0.0" so plugins with released versions will be preferred as the
source for i18n.

Also fix the attempted deletion of the i18n-map file if the plugin is
misconfigured.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Probably the easiest way to test the version number bit is
  * `rm -rf projects/plugins/jetpack/vendor/ projects/plugins/jetpack/jetpack_vendor/`
  * `composer -d projects/packages/assets config extra.textdomain jetpack-assets`
  * `tools/composer-update-monorepo.sh projects/plugins/jetpack/`
  * Inspect `projects/plugins/jetpack/jetpack_vendor/i18n-map.php`, it should not contain a mapping for "jetpack-assets" version "1.15.x-dev".
* Probably the easiest way to test the i18n-map deletion is to create a temporary directory somewhere, then create this composer.json:
  ```json
  {
      "require": {
          "automattic/jetpack-composer-plugin": "@dev"
      },
      "repositories": [
          {
              "type": "path",
              "url": "/path/to/jetpack-monorepo/projects/packages/*"
          }
      ]
  }
  ```
  then do `composer update`. It should give a warning about skipping the i18n-map update, but it should not error out.
