### PR TITLE
Debug Helper IDC Simulator: Display an admin notice when the module disables Sync

### DIFF
--- a/projects/plugins/debug-helper/changelog/update-notice_when_sync_disabled
+++ b/projects/plugins/debug-helper/changelog/update-notice_when_sync_disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+IDC Simulator: Display an admin notice when the module disables Sync

--- a/projects/plugins/debug-helper/modules/class-idc-simulator.php
+++ b/projects/plugins/debug-helper/modules/class-idc-simulator.php
@@ -61,6 +61,12 @@ class IDC_Simulator {
 		if ( isset( $_GET['idc_notice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			add_action( 'admin_notices', array( $this, 'display_notice' ) );
 		}
+
+		$settings = self::get_stored_settings();
+		if ( ! $settings['idc_sync_status'] ) {
+			// Display a notice when this module disables Sync.
+			add_action( 'admin_notices', array( $this, 'display_sync_disabled_notice' ) );
+		}
 	}
 
 	/**
@@ -439,6 +445,14 @@ class IDC_Simulator {
 			default:
 				return;
 		}
+	}
+
+	/**
+	 * Display a notice when Sync is disabled by this module.
+	 */
+	public function display_sync_disabled_notice() {
+		echo '<div class="notice notice-warning"><p>Sync has been disabled by the Jetpack Debug Helper plugin\'s IDC Simulator module.</p></div>';
+
 	}
 
 	/**


### PR DESCRIPTION


#### Changes proposed in this Pull Request:
Sync can be disabled in the Debug Helper plugin's IDC Simulator module. This allows for easy testing of IDC handling on REST requests. However, if a user disables Sync and forgets to reenable it, it can be hard to track down why Sync isn't working.

To prevent this confusion, let's display an admin notice when the IDC Simulator module has disabled Sync.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* n/a

#### Testing instructions:
1. Install, activate, and connect Jetpack.
2. Install and activate this branch of the Debug Helper plugin.
3. Enable the IDC Simulator module in the Debug Helper plugin.
4. In the IDC Simulator module, disable Sync. An admin notice informing you that Sync is disabled should be displayed.
5. Navigate to other wp-admin pages and confirm that the admin notice is displayed. (Note the admin notices are not displayed on the Jetpack dashboard.)
6. In the IDC Simulator module, enable Sync. The admin notice should no longer be displayed.