### PR TITLE
IDC: remove 'jetpack' slug from Connection\Manager constructor call

### DIFF
--- a/projects/packages/identity-crisis/changelog/update-check_identity_crisis_remove_slug
+++ b/projects/packages/identity-crisis/changelog/update-check_identity_crisis_remove_slug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove the plugin slug from the Connection\Manager constructor call.
+
+

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -285,7 +285,7 @@ class Identity_Crisis {
 	 * @return array|bool Array of options that are in a crisis, or false if everything is OK.
 	 */
 	public static function check_identity_crisis() {
-		$connection = new Connection_Manager( 'jetpack' );
+		$connection = new Connection_Manager();
 
 		if ( ! $connection->is_connected() || ( new Status() )->is_offline_mode() || ! self::validate_sync_error_idc_option() ) {
 			return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Since this call is happening in a package, the `jetpack` slug should not be passed to the `Connection\Manager` constructor.  I'm not aware of this causing any problems.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* tbd
