### PR TITLE
Conditional widgets: Check REQUEST_METHOD set before use

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-widget-visibility-notice
+++ b/projects/plugins/jetpack/changelog/fix-widget-visibility-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Prevent an E_NOTICE when running in non-web context

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -84,7 +84,7 @@ class Jetpack_Widget_Conditions {
 			}
 
 			// Saving widgets via non-batch API. This isn't used within WordPress but could be used by third parties in theory.
-			if ( 'GET' !== $_SERVER['REQUEST_METHOD'] && false !== strpos( $_SERVER['REQUEST_URI'], '/wp/v2/widgets' ) ) {
+			if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] && false !== strpos( $_SERVER['REQUEST_URI'], '/wp/v2/widgets' ) ) {
 				$handle_widget_updates = true;
 				$add_html_to_form      = true;
 			}


### PR DESCRIPTION
Prevents an E_NOTICE being triggered when running in a non-web
environment.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes issue brought up at https://github.com/Automattic/jetpack/pull/20255#issuecomment-998027246

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

 1. Use a theme that supports widgets (you probably are already)
 2.  Go to Jetpack → Settings → Writing, scroll down to the Widgets section, and toggle the switch labelled Enable widget visibility controls to display widgets only on particular posts or pages.
 3. Go to Appearance -> Widgets
 4. Add a widget, you should see a preview of it
 5. Click on one of the blocks you've added
 6. Go to the 'Block' sidebar and expand 'Advanced'
 7. Set a 'visibility' like 'Show this block if page is frontpage'
 8. Press update
 9. Look at the frontpage of the site, it should display the widget
 10. Look at another page of the site, it should not display the widget

