### PR TITLE
Release v1.0.0 of various projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-codesniffer": "2.3.x-dev",
-		"automattic/jetpack-phpcs-filter": "0.1.x-dev",
+		"automattic/jetpack-phpcs-filter": "1.0.x-dev",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
 		"php-parallel-lint/php-parallel-lint": "1.3.1",
 		"sirbrillig/phpcs-changed": "2.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfee2f63170d9b3d349a210cc5f7a06d",
+    "content-hash": "49deada7b9027349f16d0be71667eb51",
     "packages": [],
     "packages-dev": [
         {
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/ignorefile",
-                "reference": "7e383a640adb5bf6bc823f7f829aa5bed4ceb879"
+                "reference": "020dd45a0381ed59e66f91eaf7277582b66f344b"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -28,7 +28,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "0.1.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -123,10 +123,10 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/phpcs-filter",
-                "reference": "b181a57337c0b5834b8ddc249c750c9dcd71d072"
+                "reference": "ffc6b53125ec3aa9c63bdbaf12117f0d9c677bb8"
             },
             "require": {
-                "automattic/ignorefile": "^0.1",
+                "automattic/ignorefile": "^1.0",
                 "squizlabs/php_codesniffer": "^3.6.1"
             },
             "require-dev": {
@@ -136,7 +136,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.1.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,9 +436,9 @@ importers:
   projects/js-packages/webpack-config:
     specifiers:
       '@automattic/babel-plugin-preserve-i18n': 1.0.0
-      '@automattic/babel-plugin-replace-textdomain': workspace:^0.1.1-alpha
-      '@automattic/i18n-check-webpack-plugin': workspace:^0.2.0-alpha
-      '@automattic/i18n-loader-webpack-plugin': workspace:^0.1.0-alpha
+      '@automattic/babel-plugin-replace-textdomain': workspace:^1.0.0
+      '@automattic/i18n-check-webpack-plugin': workspace:^1.0.0
+      '@automattic/i18n-loader-webpack-plugin': workspace:^1.0.0
       '@automattic/webpack-rtl-plugin': 5.1.0
       '@babel/compat-data': 7.16.4
       '@babel/core': 7.16.0
@@ -497,7 +497,7 @@ importers:
     specifiers:
       '@automattic/jetpack-api': workspace:^0.8.1-alpha
       '@automattic/jetpack-connection': workspace:^0.12.0-alpha
-      '@automattic/jetpack-webpack-config': workspace:^0.6.0-alpha
+      '@automattic/jetpack-webpack-config': workspace:^1.0.0
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
@@ -537,7 +537,7 @@ importers:
   projects/packages/identity-crisis:
     specifiers:
       '@automattic/jetpack-idc': workspace:^0.7.1-alpha
-      '@automattic/jetpack-webpack-config': workspace:^0.6.0-alpha
+      '@automattic/jetpack-webpack-config': workspace:^1.0.0
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
@@ -567,7 +567,7 @@ importers:
 
   projects/packages/jitm:
     specifiers:
-      '@automattic/jetpack-webpack-config': workspace:^0.6.0-alpha
+      '@automattic/jetpack-webpack-config': workspace:^1.0.0
       '@wordpress/browserslist-config': 4.1.0
       sass: 1.43.3
       sass-loader: 12.2.0
@@ -583,7 +583,7 @@ importers:
 
   projects/packages/lazy-images:
     specifiers:
-      '@automattic/jetpack-webpack-config': workspace:^0.6.0-alpha
+      '@automattic/jetpack-webpack-config': workspace:^1.0.0
       copy-webpack-plugin: 9.0.1
       intersection-observer: 0.12.0
       webpack: 5.64.1
@@ -598,7 +598,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:^0.1.3-alpha
       '@automattic/jetpack-components': workspace:^0.9.1-alpha
       '@automattic/jetpack-connection': workspace:^0.12.0-alpha
-      '@automattic/jetpack-webpack-config': workspace:^0.6.0-alpha
+      '@automattic/jetpack-webpack-config': workspace:^1.0.0
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
@@ -639,7 +639,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:^0.1.4-alpha
       '@automattic/jetpack-api': workspace:^0.8.1-alpha
       '@automattic/jetpack-components': workspace:^0.9.1-alpha
-      '@automattic/jetpack-webpack-config': workspace:^0.6.0-alpha
+      '@automattic/jetpack-webpack-config': workspace:^1.0.0
       '@babel/core': 7.16.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.0
       '@babel/preset-env': 7.16.4
@@ -731,7 +731,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:^0.1.3-alpha
       '@automattic/jetpack-components': workspace:^0.9.1-alpha
       '@automattic/jetpack-connection': workspace:^0.12.0-alpha
-      '@automattic/jetpack-webpack-config': workspace:^0.6.0-alpha
+      '@automattic/jetpack-webpack-config': workspace:^1.0.0
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
@@ -856,9 +856,9 @@ importers:
       '@automattic/jetpack-connection': workspace:^0.12.0-alpha
       '@automattic/jetpack-licensing': workspace:^0.3.3-alpha
       '@automattic/jetpack-partner-coupon': workspace:^0.1.3-alpha
-      '@automattic/jetpack-webpack-config': workspace:^0.6.0-alpha
+      '@automattic/jetpack-webpack-config': workspace:^1.0.0
       '@automattic/popup-monitor': 1.0.0
-      '@automattic/remove-asset-webpack-plugin': workspace:^0.1.2-alpha
+      '@automattic/remove-asset-webpack-plugin': workspace:^1.0.0
       '@automattic/request-external-access': 1.0.0
       '@automattic/social-previews': 1.1.1
       '@automattic/viewport': 1.0.0

--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2021-12-22
+
+- Initial stable release.
+
 ## 0.1.0 - 2021-12-14
 ### Added
 - Initial release.
 - Replace missing domains too.
+
+[1.0.0]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v0.1.0...v1.0.0

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/update-min-pnpm-version
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/update-min-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version.
-
-

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "0.1.1-alpha",
+	"version": "1.0.0",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2021-12-22
+### Added
+- Allow specifying the expected textdomain to be used in the output assets.
+
+### Fixed
+- Fix a unit test that broke when we added i18n-loader to the webpack config.
+- Fixed a documentation error.
+- Fix use in Node 14.
+
 ## 0.1.0 - 2021-12-14
 ### Added
 - Initial release.
+
+[1.0.0]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v0.1.0...v1.0.0

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/add-i18n-check-expected-textdomain
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/add-i18n-check-expected-textdomain
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Allow specifying the expected textdomain to be used in the output assets.

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-assert-node-14
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-assert-node-14
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix use in Node 14.

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-i18n-check-doc-error
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-i18n-check-doc-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a documentation error.

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-i18n-check-test
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-i18n-check-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix a unit test that broke when we added i18n-loader to the webpack config.

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/update-min-pnpm-version
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/update-min-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version.
-
-

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "0.2.0-alpha",
+	"version": "1.0.0",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 - 2021-12-22
+### Added
+- Initial release.

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/add-i18n-loader-webpack-plugin
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/add-i18n-loader-webpack-plugin
@@ -1,4 +1,0 @@
-Significance: major
-Type: added
-
-Initial release.

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-i18n-loader-webpack-plugin_readme
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-i18n-loader-webpack-plugin_readme
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Fix a typo in the readme file
-
-

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-min-pnpm-version
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-min-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version.
-
-

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-use-bundled-schema-validate
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-use-bundled-schema-validate
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use Webpack's provided `validateSchema` instead of requiring `schema-utils` ourself.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "0.1.0-alpha",
+	"version": "1.0.0",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/js-packages/remove-asset-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/remove-asset-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2021-12-22
+
+- Initial stable release.
+
 ## [0.1.1] - 2021-12-14
 ### Changed
 - Use Webpack's provided `validateSchema` instead of requiring `schema-utils` ourself.
@@ -13,4 +17,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.0.0]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v0.1.1...v1.0.0
 [0.1.1]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v0.1.0...v0.1.1

--- a/projects/js-packages/remove-asset-webpack-plugin/changelog/update-min-pnpm-version
+++ b/projects/js-packages/remove-asset-webpack-plugin/changelog/update-min-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version.
-
-

--- a/projects/js-packages/remove-asset-webpack-plugin/package.json
+++ b/projects/js-packages/remove-asset-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/remove-asset-webpack-plugin",
-	"version": "0.1.2-alpha",
+	"version": "1.0.0",
 	"description": "A Webpack plugin to remove assets from the build.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/remove-asset-webpack-plugin/README.md#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 - 2021-12-22
+### Added
+- Add `@automattic/i18n-loader-webpack-plugin`. This may break some builds.
+- Set i18n-check-webpack-plugin's `expectDomain` based on composer.json.
+
+### Changed
+- Updated package dependencies.
+
 ## 0.5.0 - 2021-12-14
 ### Added
 - Added `@automattic/babel-plugin-replace-textdomain` as an option for the Babel preset.

--- a/projects/js-packages/webpack-config/changelog/add-i18n-check-expected-textdomain
+++ b/projects/js-packages/webpack-config/changelog/add-i18n-check-expected-textdomain
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Set i18n-check-webpack-plugin's `expectDomain` based on composer.json.

--- a/projects/js-packages/webpack-config/changelog/add-use-i18n-loader-webpack-plugin
+++ b/projects/js-packages/webpack-config/changelog/add-use-i18n-loader-webpack-plugin
@@ -1,4 +1,0 @@
-Significance: major
-Type: added
-
-Add `@automattic/i18n-loader-webpack-plugin`. This may break some builds.

--- a/projects/js-packages/webpack-config/changelog/fix-assert-node-14
+++ b/projects/js-packages/webpack-config/changelog/fix-assert-node-14
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/changelog/update-min-pnpm-version
+++ b/projects/js-packages/webpack-config/changelog/update-min-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version.
-
-

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -18,9 +18,9 @@
 	},
 	"dependencies": {
 		"@automattic/babel-plugin-preserve-i18n": "1.0.0",
-		"@automattic/babel-plugin-replace-textdomain": "workspace:^0.1.1-alpha",
-		"@automattic/i18n-check-webpack-plugin": "workspace:^0.2.0-alpha",
-		"@automattic/i18n-loader-webpack-plugin": "workspace:^0.1.0-alpha",
+		"@automattic/babel-plugin-replace-textdomain": "workspace:^1.0.0",
+		"@automattic/i18n-check-webpack-plugin": "workspace:^1.0.0",
+		"@automattic/i18n-loader-webpack-plugin": "workspace:^1.0.0",
 		"@automattic/webpack-rtl-plugin": "5.1.0",
 		"@babel/compat-data": "7.16.4",
 		"@babel/helper-compilation-targets": "7.16.3",

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "0.6.0-alpha",
+	"version": "1.0.0",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/packages/composer-plugin/CHANGELOG.md
+++ b/projects/packages/composer-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2021-12-22
+### Fixed
+- Fix deletion of the i18n-map.php if the plugin isn't configured correctly.
+- Fix handling of dev versions in i18n-map.php.
+
 ## [0.2.0] - 2021-12-20
 ### Added
 - Generate an i18n mapping file for the installed libraries.
@@ -13,4 +18,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the Jetpack Installer package.
 
+[1.0.0]: https://github.com/Automattic/jetpack-composer-plugin/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/Automattic/jetpack-composer-plugin/compare/v0.1.0...v0.2.0

--- a/projects/packages/composer-plugin/changelog/fix-composer-plugin-dev-versions
+++ b/projects/packages/composer-plugin/changelog/fix-composer-plugin-dev-versions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix handling of dev versions in i18n-map.php.

--- a/projects/packages/composer-plugin/changelog/fix-composer-plugin-dev-versions#2
+++ b/projects/packages/composer-plugin/changelog/fix-composer-plugin-dev-versions#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix deletion of the i18n-map.php if the plugin isn't configured correctly.

--- a/projects/packages/composer-plugin/composer.json
+++ b/projects/packages/composer-plugin/composer.json
@@ -48,7 +48,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-master": "0.2.x-dev"
+			"dev-master": "1.0.x-dev"
 		}
 	}
 }

--- a/projects/packages/connection-ui/changelog/add-various-packages-v1.0.0
+++ b/projects/packages/connection-ui/changelog/add-various-packages-v1.0.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -21,7 +21,7 @@
 		"@wordpress/data": "6.1.4"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^0.6.0-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.0.0",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/projects/packages/identity-crisis/changelog/add-various-packages-v1.0.0
+++ b/projects/packages/identity-crisis/changelog/add-various-packages-v1.0.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -20,7 +20,7 @@
 		"@wordpress/data": "6.1.4"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^0.6.0-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.0.0",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/projects/packages/ignorefile/CHANGELOG.md
+++ b/projects/packages/ignorefile/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 - 2021-12-22
+### Added
+- Initial release.

--- a/projects/packages/ignorefile/changelog/add-phpcs-per-director-config
+++ b/projects/packages/ignorefile/changelog/add-phpcs-per-director-config
@@ -1,4 +1,0 @@
-Significance: major
-Type: added
-
-Initial release.

--- a/projects/packages/ignorefile/composer.json
+++ b/projects/packages/ignorefile/composer.json
@@ -45,7 +45,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-master": "0.1.x-dev"
+			"dev-master": "1.0.x-dev"
 		}
 	}
 }

--- a/projects/packages/jitm/changelog/add-various-packages-v1.0.0
+++ b/projects/packages/jitm/changelog/add-various-packages-v1.0.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/jitm/package.json
+++ b/projects/packages/jitm/package.json
@@ -24,7 +24,7 @@
 	},
 	"browserslist": "extends @wordpress/browserslist-config",
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^0.6.0-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.0.0",
 		"@wordpress/browserslist-config": "4.1.0",
 		"sass": "1.43.3",
 		"sass-loader": "12.2.0",

--- a/projects/packages/lazy-images/changelog/add-various-packages-v1.0.0
+++ b/projects/packages/lazy-images/changelog/add-various-packages-v1.0.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/lazy-images/package.json
+++ b/projects/packages/lazy-images/package.json
@@ -25,7 +25,7 @@
 		"validate": "pnpm exec validate-es dist/"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^0.6.0-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.0.0",
 		"copy-webpack-plugin": "9.0.1",
 		"intersection-observer": "0.12.0",
 		"webpack": "5.64.1"

--- a/projects/packages/my-jetpack/changelog/add-various-packages-v1.0.0
+++ b/projects/packages/my-jetpack/changelog/add-various-packages-v1.0.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -32,7 +32,7 @@
 	],
 	"devDependencies": {
 		"@automattic/jetpack-base-styles": "workspace:^0.1.3-alpha",
-		"@automattic/jetpack-webpack-config": "workspace:^0.6.0-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.0.0",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/projects/packages/phpcs-filter/CHANGELOG.md
+++ b/projects/packages/phpcs-filter/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 - 2021-12-22
+### Added
+- Initial release.

--- a/projects/packages/phpcs-filter/changelog/add-phpcs-per-director-config
+++ b/projects/packages/phpcs-filter/changelog/add-phpcs-per-director-config
@@ -1,4 +1,0 @@
-Significance: major
-Type: added
-
-Initial release.

--- a/projects/packages/phpcs-filter/composer.json
+++ b/projects/packages/phpcs-filter/composer.json
@@ -46,7 +46,7 @@
 	"prefer-stable": true,
 	"extra": {
 		"branch-alias": {
-			"dev-master": "0.1.x-dev"
+			"dev-master": "1.0.x-dev"
 		}
 	}
 }

--- a/projects/packages/phpcs-filter/composer.json
+++ b/projects/packages/phpcs-filter/composer.json
@@ -4,7 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/ignorefile": "^0.1",
+		"automattic/ignorefile": "^1.0",
 		"squizlabs/php_codesniffer": "^3.6.1"
 	},
 	"require-dev": {

--- a/projects/packages/search/changelog/add-various-packages-v1.0.0
+++ b/projects/packages/search/changelog/add-various-packages-v1.0.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -65,7 +65,7 @@
 		"tiny-lru": "7.0.6"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^0.6.0-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.0.0",
 		"@babel/core": "7.16.0",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "7.16.0",
 		"@babel/preset-env": "7.16.4",

--- a/projects/plugins/backup/changelog/add-various-packages-v1.0.0
+++ b/projects/plugins/backup/changelog/add-various-packages-v1.0.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-admin-ui": "0.2.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
 		"automattic/jetpack-backup": "1.2.x-dev",
-		"automattic/jetpack-composer-plugin": "0.2.x-dev",
+		"automattic/jetpack-composer-plugin": "1.0.x-dev",
 		"automattic/jetpack-config": "1.6.x-dev",
 		"automattic/jetpack-connection": "1.34.x-dev",
 		"automattic/jetpack-connection-ui": "2.3.x-dev",

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c956cb2383deb6849e248a9a3b1b5a2e",
+    "content-hash": "8d8b6ecfebc8ba4f6991d83e3903e3a8",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -301,7 +301,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "890b8c21a300d3b0ed5022bd3aa9a466d735f273"
+                "reference": "6fdd75c54dcd4e1bf63cd8011243e70eb2759269"
             },
             "require": {
                 "composer-plugin-api": "^2.1.0"
@@ -320,7 +320,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "0.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/backup/package.json
+++ b/projects/plugins/backup/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@automattic/jetpack-base-styles": "workspace:^0.1.3-alpha",
-		"@automattic/jetpack-webpack-config": "workspace:^0.6.0-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.0.0",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/projects/plugins/boost/changelog/add-various-packages-v1.0.0
+++ b/projects/plugins/boost/changelog/add-various-packages-v1.0.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -17,7 +17,7 @@
 		"automattic/jetpack-assets": "1.16.x-dev",
 		"automattic/jetpack-admin-ui": "0.2.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
-		"automattic/jetpack-composer-plugin": "0.2.x-dev",
+		"automattic/jetpack-composer-plugin": "1.0.x-dev",
 		"automattic/jetpack-config": "1.6.x-dev",
 		"automattic/jetpack-connection": "1.34.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51fef6ddc06100bdce8692874eb36372",
+    "content-hash": "e27d7786286229a6dced9245d21cdc9a",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -236,7 +236,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "890b8c21a300d3b0ed5022bd3aa9a466d735f273"
+                "reference": "6fdd75c54dcd4e1bf63cd8011243e70eb2759269"
             },
             "require": {
                 "composer-plugin-api": "^2.1.0"
@@ -255,7 +255,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "0.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-various-packages-v1.0.0
+++ b/projects/plugins/jetpack/changelog/add-various-packages-v1.0.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -18,7 +18,7 @@
 		"automattic/jetpack-backup": "1.2.x-dev",
 		"automattic/jetpack-blocks": "1.4.x-dev",
 		"automattic/jetpack-compat": "1.6.x-dev",
-		"automattic/jetpack-composer-plugin": "0.2.x-dev",
+		"automattic/jetpack-composer-plugin": "1.0.x-dev",
 		"automattic/jetpack-config": "1.6.x-dev",
 		"automattic/jetpack-connection": "1.34.x-dev",
 		"automattic/jetpack-connection-ui": "2.3.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b60a699a8302333d3e09c342e49a45c7",
+    "content-hash": "a9534fba8fab39b8985e84a4cbc181c6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -453,7 +453,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "890b8c21a300d3b0ed5022bd3aa9a466d735f273"
+                "reference": "6fdd75c54dcd4e1bf63cd8011243e70eb2759269"
             },
             "require": {
                 "composer-plugin-api": "^2.1.0"
@@ -472,7 +472,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "0.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -150,8 +150,8 @@
 	"devDependencies": {
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/jetpack-base-styles": "workspace:^0.1.3-alpha",
-		"@automattic/jetpack-webpack-config": "workspace:^0.6.0-alpha",
-		"@automattic/remove-asset-webpack-plugin": "workspace:^0.1.2-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.0.0",
+		"@automattic/remove-asset-webpack-plugin": "workspace:^1.0.0",
 		"@babel/core": "7.16.0",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "7.16.0",
 		"@babel/plugin-transform-react-jsx": "7.16.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Now that all the i18n work is done, time to release the initial stable
versions of all the projects that were created for it.

* js-packages/babel-plugin-replace-textdomain
* js-packages/i18n-check-webpack-plugin
* js-packages/i18n-loader-webpack-plugin
* js-packages/remove-asset-webpack-plugin
* packages/composer-plugin
* packages/ignorefile

And even though they're currently private, may as well do the same for

* js-packages/webpack-config
* packages/phpcs-filter

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just make sure the releases look right.