### PR TITLE
Fix package Assets::register_script() textdomains

### DIFF
--- a/projects/packages/connection-ui/changelog/fix-assets-register-textdomain
+++ b/projects/packages/connection-ui/changelog/fix-assets-register-textdomain
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixup for a just-merged PR: Fix the textdomain passed to Assets::register_script()
+
+

--- a/projects/packages/connection-ui/src/class-admin.php
+++ b/projects/packages/connection-ui/src/class-admin.php
@@ -68,7 +68,7 @@ class Admin {
 				__FILE__,
 				array(
 					'in_footer'  => true,
-					'textdomain' => 'jetpack',
+					'textdomain' => 'jetpack-connection-ui',
 				)
 			);
 			Assets::enqueue_script( 'jetpack_connection_ui' );

--- a/projects/packages/identity-crisis/changelog/fix-assets-register-textdomain
+++ b/projects/packages/identity-crisis/changelog/fix-assets-register-textdomain
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixup for a just-merged PR: Fix the textdomain passed to Assets::register_script()
+
+

--- a/projects/packages/identity-crisis/src/class-ui.php
+++ b/projects/packages/identity-crisis/src/class-ui.php
@@ -54,7 +54,7 @@ class UI {
 				__FILE__,
 				array(
 					'in_footer'  => true,
-					'textdomain' => 'jetpack',
+					'textdomain' => 'jetpack-idc',
 				)
 			);
 			Assets::enqueue_script( 'jp_identity_crisis_banner' );

--- a/projects/packages/my-jetpack/changelog/fix-assets-register-textdomain
+++ b/projects/packages/my-jetpack/changelog/fix-assets-register-textdomain
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixup for a just-merged PR: Fix the textdomain passed to Assets::register_script()
+
+

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -72,7 +72,7 @@ class Initializer {
 			array(
 				'enqueue'    => true,
 				'in_footer'  => true,
-				'textdomain' => 'jetpack',
+				'textdomain' => 'jetpack-my-jetpack',
 			)
 		);
 		wp_localize_script(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When #22151 assigned text domains to the packages, it missed the domains
in calls to Assets::register_script().

We should make a sniff to catch this in the future, but for now let's
just fix it.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ???