### PR TITLE
Docker: Fix fakepot symlink handling

### DIFF
--- a/tools/docker/bin/fakepot.sh
+++ b/tools/docker/bin/fakepot.sh
@@ -45,20 +45,31 @@ trap "do_cleanup" EXIT INT TERM
 
 # This should match similar logic in .github/files/build-all-projects.sh
 info "Copying build files for plugin"
-OLDDIR="$(pwd)";
-cd "$PLUGIN_DIR"
-mkdir "$TMPDIR/plugin"
-{
-	# Include unignored files by default.
-	git -c core.quotepath=off ls-files
-	# Include ignored files that are tagged as production-include.
-	git -c core.quotepath=off ls-files --others --ignored --exclude-standard | git -c core.quotepath=off check-attr --stdin production-include | sed -n 's/: production-include: \(unspecified\|unset\)$//;t;s/: production-include: .*//p'
-} |
-	# Remove all files tagged with production-exclude. This can override production-include.
-	git -c core.quotepath=off check-attr --stdin production-exclude | sed -n 's/: production-exclude: \(unspecified\|unset\)$//p' |
-	# Copy the resulting list of files into the clone.
-	xargs cp -d --parents --target-directory="$TMPDIR/plugin"
-cd "$OLDDIR"
+function docopy {
+	local SRC="$1"
+	local DEST="${2%/}"
+
+	local OLDDIR="$(pwd)";
+	cd "$SRC"
+	mkdir "$DEST"
+	{
+		# Include unignored files by default.
+		git -c core.quotepath=off ls-files
+		# Include ignored files that are tagged as production-include.
+		git -c core.quotepath=off ls-files --others --ignored --exclude-standard | git -c core.quotepath=off check-attr --stdin production-include | sed -n 's/: production-include: \(unspecified\|unset\)$//;t;s/: production-include: .*//p'
+	} |
+		# Remove all files tagged with production-exclude. This can override production-include.
+		git -c core.quotepath=off check-attr --stdin production-exclude | sed -n 's/: production-exclude: \(unspecified\|unset\)$//p' |
+		# Copy the resulting list of files into the clone.
+		xargs cp -d --parents --target-directory="$DEST"
+
+	# Fix any copied symlinks by removing them then docopy-ing from the target.
+	local L T
+	find "$DEST" -type l | while IFS= read -r L; do T="$(realpath "${L#$DEST/}")"; rm "$L"; docopy "$T" "$L"; done
+
+	cd "$OLDDIR"
+}
+docopy "$PLUGIN_DIR" "$TMPDIR/plugin"
 
 info "Creating POT file"
 mkdir "$TMPDIR/pot"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Chances are the plugin will have symlinks to the composer packages. As
it is now, it'll just copy the links without even adjusting their
targets, meaning that any i18n from the packages won't be fake-potted.

We can't just fix the symlinks' targets though, as then `wp i18n
make-pot` will probably wind up descending into various WorDBless copies
of WordPress.

The fix is to check for copied symlinks, and for each one do a recursive
copy from the target package using the same algorithm that handles
.gitignore, production-include, and such.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `rm -rf projects/plugins/backup/vendor projects/plugins/backup/jetpack_vendor`
* `jetpack build packages/identity-crisis`
* `jetpack build plugins/backup`
* `jetpack docker exec /var/scripts/fakepot.sh /var/www/html/wp-content/plugins/backup`
* The file `tools/docker/wordpress/wp-content/languages/plugins/jetpack-backup-en_piglatin-6e3b64de0dc39291801ea2bbc8aaa40e.json` should exist, and should contain translations for the Identity Crisis package's JS.