### PR TITLE
Pay with PayPal: switch to using a unique script tag

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-unique-pay-with-paypal-script-tag
+++ b/projects/plugins/jetpack/changelog/fix-unique-pay-with-paypal-script-tag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Pay with PayPal: update the name of the script enqueued when using the Pay with PayPal button, to avoid conflicts with other plugins that may use a similar script tag.

--- a/projects/plugins/jetpack/modules/simple-payments/paypal-express-checkout.js
+++ b/projects/plugins/jetpack/modules/simple-payments/paypal-express-checkout.js
@@ -1,5 +1,5 @@
 /**
- * This PaypalExpressCheckout global is included by wp_enqueue_script( 'paypal-express-checkout' );
+ * This PaypalExpressCheckout global is included by wp_enqueue_script( 'jetpack-paypal-express-checkout' );
  * It handles communication with Paypal Express checkout and public-api.wordpress.com for the purposes
  * of simple-payments module.
  */

--- a/projects/plugins/jetpack/modules/simple-payments/simple-payments.php
+++ b/projects/plugins/jetpack/modules/simple-payments/simple-payments.php
@@ -42,8 +42,13 @@ class Jetpack_Simple_Payments {
 		 * @see https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/add-paypal-button/
 		 */
 		wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
-		wp_register_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ),
-			array( 'jquery', 'paypal-checkout-js' ), self::$version );
+		wp_register_script(
+			'jetpack-paypal-express-checkout',
+			plugins_url( '/paypal-express-checkout.js', __FILE__ ),
+			array( 'jquery', 'paypal-checkout-js' ),
+			self::$version,
+			false
+		);
 		wp_register_style( 'jetpack-simple-payments', plugins_url( '/simple-payments.css', __FILE__ ), array( 'dashicons' ) );
 	}
 
@@ -76,8 +81,8 @@ class Jetpack_Simple_Payments {
 			wp_enqueue_style( 'jetpack-simple-payments' );
 		}
 
-		if ( ! wp_script_is( 'paypal-express-checkout', 'enqueued' ) ) {
-			wp_enqueue_script( 'paypal-express-checkout' );
+		if ( ! wp_script_is( 'jetpack-paypal-express-checkout', 'enqueued' ) ) {
+			wp_enqueue_script( 'jetpack-paypal-express-checkout' );
 		}
 	}
 
@@ -90,7 +95,7 @@ class Jetpack_Simple_Payments {
 	 */
 	public function setup_paypal_checkout_button( $id, $dom_id, $is_multiple ) {
 		wp_add_inline_script(
-			'paypal-express-checkout',
+			'jetpack-paypal-express-checkout',
 			sprintf(
 				"try{PaypalExpressCheckout.renderButton( '%d', '%d', '%s', '%d' );}catch(e){}",
 				esc_js( $this->get_blog_id() ),


### PR DESCRIPTION
Fixes #22125

#### Changes proposed in this Pull Request:

* This should avoid issues with other plugins that may use a similar script tag for their own asset. This was a bit too generic.

* I've opted to leave the other tag name (for the script loaded directly from PayPal), since a generic name may be a good fit there.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site with a Jetpack plan.
* Go to Posts > Add New
* Add a Pay with PayPal block.
* Publish post.
* Ensure the button is displayed properly on the frontend, and works when clicked.
* Ensure the different assets are loaded properly on the page.
* Go to Plugins > Add New, and install / activate the Classic Widgets plugin.
* Go to Appearance > Customize
* Add a Pay with PayPay widget, with a product.
* Visit your site, ensure the button works.

