### PR TITLE
Stats: do not add tracking pixel to embed views

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-stats-embeds
+++ b/projects/plugins/jetpack/changelog/fix-stats-embeds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Stats: do not trigger views when post is embedded into another site.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -173,7 +173,14 @@ function stats_map_meta_caps( $caps, $cap, $user_id ) {
 function stats_template_redirect() {
 	global $current_user;
 
-	if ( is_feed() || is_robots() || is_trackback() || is_preview() || jetpack_is_dnt_enabled() ) {
+	if (
+		is_feed()
+		|| is_robots()
+		|| is_embed()
+		|| is_trackback()
+		|| is_preview()
+		|| jetpack_is_dnt_enabled()
+	) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #22179

#### Changes proposed in this Pull Request:

* When a post is embedded into another site, it's not really a view of that post; only an excerpt of the post is displayed. As a result, it is best not to count a view when such an embedded post is displayed.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* You'll need 2 sites for this;
    * The Stats module needs to be active on both sites.
    * one of them has to be running this branch (call it Site B).
* On site A, publish a new post. In that post, include (on its own line) a link to a post from Site B.
* In an incognito window (so you're not logged in to those sites), visit the post you just published.
* In your network tab in dev tools, filter for `g.gif`
* Notice that the tracking pixel is called once for the post you are viewing.
* Now, on site B, revert to using latest stable.
* Refresh the post in the incognito window; the bug will now be back. You will see the tracking pixel getting called for both the post you are viewing and the post from site B.


