### PR TITLE
Stats: remove the legacy hide_smile option

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2775,13 +2775,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'stats',
 			),
-			'hide_smile'                           => array(
-				'description'       => esc_html__( 'Hide the stats smiley face image.', 'jetpack' ),
-				'type'              => 'boolean',
-				'default'           => 1,
-				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'jp_group'          => 'stats',
-			),
 			'version'                              => array(
 				'description'       => esc_html__( 'Version.', 'jetpack' ),
 				'type'              => 'integer',

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -826,7 +826,6 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'count_roles':
 				case 'blog_id':
 				case 'do_not_track':
-				case 'hide_smile':
 				case 'version':
 				case 'collapse_nudges':
 					$grouped_options          = $grouped_options_current = (array) get_option( 'stats_options' );

--- a/projects/plugins/jetpack/changelog/rm-stats-hide-smiley-option
+++ b/projects/plugins/jetpack/changelog/rm-stats-hide-smiley-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Stats: remove legacy option to display the Smiley face used for the tracking pixel.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -370,7 +370,6 @@ function stats_upgrade_options( $options ) {
 		'count_roles'  => array(),
 		'blog_id'      => Jetpack_Options::get_option( 'id' ),
 		'do_not_track' => true, // @todo
-		'hide_smile'   => true,
 	);
 
 	if ( isset( $options['reg_users'] ) ) {
@@ -833,18 +832,16 @@ function stats_convert_post_title( $matches ) {
 }
 
 /**
- * Stats Hide Smile.
+ * CSS to hide the tracking pixel smiley.
+ * It is now hidden for everyone (used to be visible if you had set the hide_smile option).
  *
  * @access public
  * @return void
  */
 function stats_hide_smile_css() {
-	$options = stats_get_options();
-	if ( isset( $options['hide_smile'] ) && $options['hide_smile'] ) {
-		?>
+	?>
 <style type='text/css'>img#wpstats{display:none}</style>
-		<?php
-	}
+	<?php
 }
 
 /**


### PR DESCRIPTION
Fixes #22192

#### Changes proposed in this Pull Request:

* The tracking pixel is now always hidden by default, so we do not really need that option, or to check for that option anymore.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site with the Stats feature active, and with this branch.
* Open the site an an incognito window.
* Ensure you see the following in the head: `<style type='text/css'>img#wpstats{display:none}</style>`

