### PR TITLE
Jetpack Connection: Add jetpack_connection_active_plugins fallback when Sync is not present

### DIFF
--- a/projects/packages/connection/changelog/update-jetpack-connection-active-plugins-no-sync
+++ b/projects/packages/connection/changelog/update-jetpack-connection-active-plugins-no-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Connection: Added fallback for keeping `jetpack_connection_active_plugins` consistent on WPCOM when Sync is not present.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1065,6 +1065,8 @@ class Manager {
 		/* This action is documented in src/class-package-version-tracker.php */
 		$package_versions = apply_filters( 'jetpack_package_versions', array() );
 
+		$active_plugins_using_connection = Plugin_Storage::get_all();
+
 		/**
 		 * Filters the request body for additional property addition.
 		 *
@@ -1078,23 +1080,24 @@ class Manager {
 			'jetpack_register_request_body',
 			array_merge(
 				array(
-					'siteurl'            => Urls::site_url(),
-					'home'               => Urls::home_url(),
-					'gmt_offset'         => $gmt_offset,
-					'timezone_string'    => (string) get_option( 'timezone_string' ),
-					'site_name'          => (string) get_option( 'blogname' ),
-					'secret_1'           => $secrets['secret_1'],
-					'secret_2'           => $secrets['secret_2'],
-					'site_lang'          => get_locale(),
-					'timeout'            => $timeout,
-					'stats_id'           => $stats_id,
-					'state'              => get_current_user_id(),
-					'site_created'       => $this->get_assumed_site_creation_date(),
-					'jetpack_version'    => Constants::get_constant( 'JETPACK__VERSION' ),
-					'ABSPATH'            => Constants::get_constant( 'ABSPATH' ),
-					'current_user_email' => wp_get_current_user()->user_email,
-					'connect_plugin'     => $this->get_plugin() ? $this->get_plugin()->get_slug() : null,
-					'package_versions'   => $package_versions,
+					'siteurl'                  => Urls::site_url(),
+					'home'                     => Urls::home_url(),
+					'gmt_offset'               => $gmt_offset,
+					'timezone_string'          => (string) get_option( 'timezone_string' ),
+					'site_name'                => (string) get_option( 'blogname' ),
+					'secret_1'                 => $secrets['secret_1'],
+					'secret_2'                 => $secrets['secret_2'],
+					'site_lang'                => get_locale(),
+					'timeout'                  => $timeout,
+					'stats_id'                 => $stats_id,
+					'state'                    => get_current_user_id(),
+					'site_created'             => $this->get_assumed_site_creation_date(),
+					'jetpack_version'          => Constants::get_constant( 'JETPACK__VERSION' ),
+					'ABSPATH'                  => Constants::get_constant( 'ABSPATH' ),
+					'current_user_email'       => wp_get_current_user()->user_email,
+					'connect_plugin'           => $this->get_plugin() ? $this->get_plugin()->get_slug() : null,
+					'package_versions'         => $package_versions,
+					'active_connected_plugins' => $active_plugins_using_connection,
 				),
 				self::$extra_register_params
 			)

--- a/projects/packages/connection/tests/php/test_plugin_storage.php
+++ b/projects/packages/connection/tests/php/test_plugin_storage.php
@@ -1,0 +1,93 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Unit tests for the Connection Plugin Storage class.
+ *
+ * @package automattic/jetpack-connection
+ * @see \Automattic\Jetpack\Connection\Plugin_Storage
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+
+/**
+ * Unit tests for the Connection Plugin Storage class.
+ *
+ * @see \Automattic\Jetpack\Connection\Plugin_Storage
+ */
+class Test_Plugin_Storage extends TestCase {
+
+	/**
+	 * Whether an http request to the jetpack-active-connected-plugins endoint was attempted.
+	 *
+	 * @var bool
+	 */
+	private $http_request_attempted = false;
+
+	/**
+	 * Setting up the testing environment.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+		$this->http_request_attempted = false;
+		Constants::clear_constants();
+		WorDBless_Options::init()->clear_options();
+	}
+
+	/**
+	 * Unit test for the `Plugin_Storage::update_active_plugins_option()` method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Plugin_Storage::update_active_plugins_option
+	 */
+	public function test_update_active_plugins_option_without_sync_will_trigger_fallback() {
+		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		\Jetpack_Options::update_option( 'id', 1234 );
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10, 3 );
+		Plugin_Storage::update_active_plugins_option();
+		remove_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10 );
+		$this->assertTrue( $this->http_request_attempted );
+	}
+
+	/**
+	 * Unit test for the `Plugin_Storage::update_active_plugins_option()` method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Plugin_Storage::update_active_plugins_option
+	 */
+	public function test_update_active_plugins_option_without_sync_fallback_will_return_early_if_not_connected() {
+		add_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10, 3 );
+		Plugin_Storage::update_active_plugins_option();
+		remove_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10 );
+		$this->assertFalse( $this->http_request_attempted );
+	}
+
+	/**
+	 * Intercept remote HTTP request to WP.com, and mock the response.
+	 * Should be hooked on the `pre_http_request` filter.
+	 *
+	 * @param false  $preempt A preemptive return value of an HTTP request.
+	 * @param array  $args The request arguments.
+	 * @param string $url The request URL.
+	 *
+	 * @return array
+	 */
+	public function intercept_remote_request( $preempt, $args, $url ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$this->http_request_attempted = true;
+
+		return array(
+			'success' => true,
+		);
+	}
+}


### PR DESCRIPTION
The `jetpack_connection_active_plugins` option is Connection specific, however relies on Jetpack Sync to be kept up to date with the Cache site on WPCOM.
This PR ensures that `jetpack_connection_active_plugins` is consistent on both ends of the Connection, even when Sync is not present.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `Jetpack\Connection\Plugin_Storage` class: Added `update_active_plugins_wpcom_no_sync_fallback` method which makes a remote request to WPCOM's `jetpack-active-connected-plugins` endpoint
* `Jetpack\Connection\Plugin_Storage` class: Updated `update_active_plugins_option` method to check if Sync is present and enabled and if not, utilize the introduced `update_active_plugins_wpcom_no_sync_fallback` as fallback.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1201445365181527-as-1201445365181550/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
D71611-code