### PR TITLE
Restore HeaderNav, only show on WoA sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/masthead/header-nav.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/header-nav.jsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React, { useCallback } from 'react';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
+import {
+	getSiteConnectionStatus,
+	hasConnectedOwner as hasConnectedOwnerSelector,
+	isCurrentUserLinked as isCurrentUserLinkedSelector,
+	isSiteRegistered,
+} from 'state/connection';
+import { userCanEditPosts, userCanManageOptions } from 'state/initial-state';
+import { getActiveModules } from 'state/modules';
+
+const HeaderNavComponent = props => {
+	const {
+		activeModules,
+		canEditPosts,
+		canManageOptions,
+		hasConnectedOwner,
+		isCurrentUserLinked,
+		isSiteConnected,
+		location = { pathname: '' },
+		siteConnectionStatus,
+	} = props;
+
+	const { pathname } = location;
+
+	const isDashboardView =
+		[ '/', '/dashboard', '/my-plan', '/plans' ].includes( pathname ) ||
+		pathname.includes( '/recommendations' );
+	const isStatic = '' === pathname;
+
+	const onTrackDashClick = useCallback( () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'masthead',
+			path: 'nav_dashboard',
+		} );
+	}, [] );
+
+	const onTrackSettingsClick = useCallback( () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'masthead',
+			path: 'nav_settings',
+		} );
+	}, [] );
+
+	if ( isStatic ) {
+		return null;
+	}
+
+	if ( ! siteConnectionStatus ) {
+		return null;
+	}
+
+	/**
+	 * Determine whether a user can access the Jetpack Settings page.
+	 *
+	 * Rules are:
+	 * - We're not on the /setup page route
+	 * - user is allowed to see the Jetpack Admin
+	 * - site is connected or in offline mode
+	 * - non-admins only need access to the settings when there are modules they can manage.
+	 */
+	if ( pathname.startsWith( '/setup' ) ) {
+		return null;
+	}
+
+	if ( ! canEditPosts ) {
+		return null;
+	}
+
+	if ( siteConnectionStatus !== 'offline' && ! isSiteConnected ) {
+		return null;
+	}
+
+	if ( siteConnectionStatus !== 'offline' && ! canManageOptions ) {
+		if ( ! hasConnectedOwner ) {
+			return null;
+		}
+
+		if ( ! isCurrentUserLinked ) {
+			return null;
+		}
+
+		// Are there any modules accessible by non-admins active?
+		const activeNonAdminModules = activeModules.some( module =>
+			[ 'post-by-email', 'publicize' ].includes( module )
+		);
+
+		if ( ! activeNonAdminModules ) {
+			return null;
+		}
+	}
+
+	return (
+		<div className="jp-masthead__nav">
+			<ButtonGroup>
+				<Button
+					compact={ true }
+					href="#/dashboard"
+					primary={ isDashboardView && ! isStatic }
+					onClick={ onTrackDashClick }
+				>
+					{ __( 'Dashboard', 'jetpack' ) }
+				</Button>
+				<Button
+					compact={ true }
+					href="#/settings"
+					primary={ ! isDashboardView && ! isStatic }
+					onClick={ onTrackSettingsClick }
+				>
+					{ __( 'Settings', 'jetpack' ) }
+				</Button>
+			</ButtonGroup>
+		</div>
+	);
+};
+
+const HeaderNav = connect( state => {
+	return {
+		canEditPosts: userCanEditPosts( state ),
+		canManageOptions: userCanManageOptions( state ),
+		hasConnectedOwner: hasConnectedOwnerSelector( state ),
+		isCurrentUserLinked: isCurrentUserLinkedSelector( state ),
+		isSiteConnected: isSiteRegistered( state ),
+		activeModules: getActiveModules( state ),
+		siteConnectionStatus: getSiteConnectionStatus( state ),
+	};
+} )( HeaderNavComponent );
+
+export { HeaderNav };

--- a/projects/plugins/jetpack/_inc/client/components/masthead/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/index.jsx
@@ -9,6 +9,8 @@ import { JetpackLogo } from '@automattic/jetpack-components';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { HeaderNav } from './header-nav';
+import { isWoASite as getIsWoASite } from 'state/initial-state';
 import {
 	getSiteConnectionStatus,
 	getSandboxDomain,
@@ -28,7 +30,7 @@ export class Masthead extends React.Component {
 	};
 
 	render() {
-		const { sandboxDomain, siteConnectionStatus } = this.props;
+		const { isWoASite, sandboxDomain, siteConnectionStatus } = this.props;
 
 		const offlineNotice = siteConnectionStatus === 'offline' ? <code>Offline Mode</code> : '',
 			sandboxedBadge = sandboxDomain ? (
@@ -56,6 +58,7 @@ export class Masthead extends React.Component {
 						{ offlineNotice }
 						{ sandboxedBadge }
 					</div>
+					{ isWoASite && <HeaderNav location={ this.props.location } /> }
 				</div>
 			</div>
 		);
@@ -65,6 +68,7 @@ export class Masthead extends React.Component {
 export default connect(
 	state => {
 		return {
+			isWoASite: getIsWoASite( state ),
 			sandboxDomain: getSandboxDomain( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 		};

--- a/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
@@ -58,6 +58,27 @@
 	}
 }
 
+.jp-masthead__nav {
+	display: flex;
+	flex-wrap: nowrap;
+	flex-grow: 1;
+	flex-shrink: 0;
+	text-align: right;
+	margin-top: rem( 6px );
+	padding: rem( 4px ) 0;
+
+	.dops-button-group {
+		flex-grow: 1;
+		align-self: center;
+		/* This fixes an unwanted space between the buttons in the network settings caused by a line break. */
+		/* Fixed here to keep PHP code readable. It's safe: .dops-button and .dops-button.is-compact specify a font size. */
+		font-size: 0;
+	}
+	@include breakpoint( "<480px" ) {
+		text-align: left;
+	}
+}
+
 #sandbox-domain-badge {
 	background: #d63638;
 	text-transform: uppercase;

--- a/projects/plugins/jetpack/changelog/restore-header-nav-for-woa-sites
+++ b/projects/plugins/jetpack/changelog/restore-header-nav-for-woa-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Restore HeaderNav component for WoA sites without easy settings option in the menu.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add back the `Dashboard | Settings` header nav buttons that were removed in #22130. For now, we will show the buttons only on WoA sites since they lack a "Settings" submenu item.

#### Jetpack product discussion

p1HpG7-dHF-p2#comment-51529

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* On a WoA site, using the Jetpack Beta Tester plugin, checkout Bleeding Edge and see that in Calypso for the Jetpack menu item `/wp-admin/admin.php?page=jetpack#/dashboard` you don't see the `Dashboard | Settings` header nav.
* Next, checkout this feature branch and see that the `Dashboard | Settings` nav has returned.
* Checkout this feature branch on a bleeding edge non-WoA site (JN) and see that the `Dashboard | Settings` are not shown.