### PR TITLE
Tests: fix the multisite logic

### DIFF
--- a/projects/plugins/jetpack/changelog/update-multisite_comment
+++ b/projects/plugins/jetpack/changelog/update-multisite_comment
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix the logic which determines whether to display the multisite comments for PHP unit tests.
+
+

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -58,7 +58,7 @@ if ( version_compare( PHP_VERSION, '8.0', '>=' ) &&
 	}
 }
 
-if ( '1' !== getenv( 'WP_MULTISITE' ) && ( defined( 'WP_TESTS_MULTISITE' ) && ! WP_TESTS_MULTISITE ) ) {
+if ( '1' !== getenv( 'WP_MULTISITE' ) && ( ! defined( 'WP_TESTS_MULTISITE' ) || ! WP_TESTS_MULTISITE ) ) {
 	echo 'To run Jetpack multisite, use -c tests/php.multisite.xml' . PHP_EOL;
 	echo "Disregard Core's -c tests/phpunit/multisite.xml notice below." . PHP_EOL;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Fix the logic which determines whether to display the multisite comments for PHP unit tests.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
Test three conditions with the `WP_TESTS_MULTISITE` constant:

##### The constant is defined as true:
1. Add `define( 'WP_TESTS_MULTISITE', true);` before the multisite logic in the `bootstrap.php` file: https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/tests/php/bootstrap.php#L61
2. Run a test: `jetpack docker phpunit -- --filter=test_sends_stats_data_on_heartbeat_on_multisite`
3. Notice that the `To run Jetpack multisite, use -c tests/php.multisite.xml  Disregard Core's -c tests/phpunit/multisite.xml notice below.` comment **is not** displayed.

##### The constant is defined as false:
1. Add `define( 'WP_TESTS_MULTISITE', false);` before the multisite logic in the `bootstrap.php` file: https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/tests/php/bootstrap.php#L61
2. Run a test: `jetpack docker phpunit -- --filter=test_sends_stats_data_on_heartbeat_on_multisite`
3. Notice that the `To run Jetpack multisite, use -c tests/php.multisite.xml  Disregard Core's -c tests/phpunit/multisite.xml notice below.` comment **is** displayed.

##### The constant is not defined:
1. Remove the previously added `define( 'WP_TESTS_MULTISITE', true);` line from the `bootstrap.php` file.
2. Run a test: `jetpack docker phpunit -- --filter=test_sends_stats_data_on_heartbeat_on_multisite`
3. Notice that the `To run Jetpack multisite, use -c tests/php.multisite.xml  Disregard Core's -c tests/phpunit/multisite.xml notice below.` comment **is** displayed.