### PR TITLE
Tests: Fix typos in the failure message in the assertOptionIsSynced method

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sync_option_test_failure_message
+++ b/projects/plugins/jetpack/changelog/update-sync_option_test_failure_message
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix typos in the failure message for assertOptionIsSynced method.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -283,7 +283,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function assertOptionIsSynced( $option_name, $value ) {
-		$this->assertEqualsObject( $value, $this->server_replica_storage->get_option( $option_name ), 'Option ' . $option_name . ' did\'t have the extected value of ' . json_encode( $value ) );
+		$this->assertEqualsObject( $value, $this->server_replica_storage->get_option( $option_name ), 'Option ' . $option_name . ' didn\'t have the expected value of ' . wp_json_encode( $value ) );
 	}
 
 	public function add_jetpack_options_whitelist_filter( $options ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Fix typos in the failure message in the `assertOptionIsSynced` method.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
Testing shouldn't be necessary, but you can manually cause a test failure and verify that the failure message does not contain typos if you'd like. For example:
1. Change `$this->assertEqualsObject` to `$this->assertNotEquals` in this line: https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php#L289
2. Run a test that uses `assertOptionIsSynced`: `jetpack docker phpunit -- --filter=test_sync_default_contentless_options`
3. Confirm that the test failure message doesn't contain typos.