### PR TITLE
Switch back to upstream project automation tool

### DIFF
--- a/.github/workflows/issues-to-projects.yml
+++ b/.github/workflows/issues-to-projects.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       # Jetpack Boost: Push to Boost Maintenance Board if labelled "[Plugin] Boost"
-      - uses: thingalon/project-beta-automations@v1.0.3
+      - uses: leonsteinhaeuser/project-beta-automations@v1.0.3
         if: contains(github.event.issue.labels.*.name, '[Plugin] Boost')
         with:
           gh_token: ${{ secrets.PUSH_ISSUES_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
In #22080, I switched from `leonsteinhaeuser/project-beta-automations@v1.0.2` to my own fork which added support for pushing issues to project boards _without_ specifying a target status / column.

My [change has been accepted upstream](https://github.com/leonsteinhaeuser/project-beta-automations/pull/19) and [released in 1.0.3](https://github.com/leonsteinhaeuser/project-beta-automations/releases/tag/v1.0.3) of the original tool.

Now that the change has been accepted upstream, this PR returns to using the original upstream lib.

#### Changes proposed in this Pull Request:
* Switch back to using upstream version of `leonsteinhaeuser/project-beta-automations` - release 1.0.3

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
I've [tested it in the Boost Hydra repos](https://github.com/Automattic/boost-hydra/commit/f07bfccddff3c82632f369e857d4f950174a9f3b). Beyond that, this will need to be tested after merging.