### PR TITLE
Refactor PluginDashItem Functionally

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
@@ -1,6 +1,6 @@
 # PluginDashItem Component
 
-PluginDashItem component is a React component to display an upsell for another plugin on the Jetpack AAG Dashboard.
+PluginDashItem is used to display an upsell for another plugin on the Jetpack AAG Dashboard.
 
 ## Usage
 

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
@@ -1,0 +1,72 @@
+# PluginDashItem Component
+
+PluginDashItem component is a React component to display an upsell for another plugin on the Jetpack AAG Dashboard.
+
+## Usage
+
+```jsx
+import PluginDashItem from 'components/plugin-dash-item';
+
+export default BoostDashItem = () =>
+	<PluginDashItem
+		pluginName="Boost"
+		pluginFile={ 'jetpack-boost/jetpack-boost.php' }
+		pluginSlug={ 'jetpack-boost' }
+		pluginLink={ this.props.siteAdminUrl + 'admin.php?page=jetpack-boost' }
+		installOrActivatePrompt={ createInterpolateElement(
+			__(
+				'Improve your site’s performance and SEO in a few clicks with the free Jetpack Boost plugin.<br /><ExternalLink>Learn more.</ExternalLink>',
+				'jetpack'
+			),
+			{
+				ExternalLink: <ExternalLink href={ getRedirectUrl( 'stats-nudges-boost-learn' ) } />,
+				br: <br />,
+			}
+		) }
+	/>;
+
+```
+
+## Props
+
+### pluginName
+- **Type:** `String`
+- **Required:** `yes`
+
+The display name for the Plugin. Does not need to match the name of the plugin exactly.
+
+### pluginFile
+- **Type:** `String`
+- **Required:** `yes`
+
+The exact path to the plugin. Used to detect if the plugin is installed.
+
+### pluginSlug
+- **Type:** `String`
+- **Required:** `yes`
+
+The exact slug of the plugin. Used to install and activate the plugin.
+
+### pluginLink
+- **Type:** `String`
+- **Required:** `yes`
+
+Link to an admin page for the plugin. Used in the "manage" link for the card after the plugin is installed.
+
+### installOrActivatePrompt
+- **Type:** `Element`
+- **Required:** `yes`
+
+React prompt to show when Plugin is un-installed or un-activated.
+
+### iconAlt
+- **Type:** `String`
+- **Required:** `no`
+
+Icon alt to use with custom icon for plugin ( see `iconSrc` ).
+
+### iconSrc
+- **Type:** `String`
+- **Required:** `no`
+
+Custom icon for dash item. Is given to `src` of img.

--- a/projects/plugins/jetpack/changelog/update-plugin-dash-item-component
+++ b/projects/plugins/jetpack/changelog/update-plugin-dash-item-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Refactor PluginDashItem component to be functional and add README


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Refactor `PluginDashItem` as a functional component
* Add README for `PluginDashItem`

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/pull/21866#pullrequestreview-843318827

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Should test identically to #21866

1. Navigate to `/wp-admin/admin.php?page=jetpack#/dashboard` on site with branch
2. Test each of the following with both the CRM and Boost Plugins
 a. When the Plugin is not installed it shows the "install" prompt.
 b. Clicking "Install Plugin" correctly installs the plugin.
 c. When the plugin is installed but not activated the "Activate Plugin" prompt is shown.
 d. Clicking "Activate Plugin" correctly activates the plugin.
 e. When the Plugin is installed and activated the "Manage Plugin" prompt is shown
 f. Clicking the "Manage Plugin" plugin navigates to the respective plugin dashboard
