### PR TITLE
Social Menu: remove role navigation attribute from nav item

### DIFF
--- a/projects/plugins/jetpack/changelog/update-social-menu-nav
+++ b/projects/plugins/jetpack/changelog/update-social-menu-nav
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Social Menu: remove role navigation attribute from nav item.

--- a/projects/plugins/jetpack/modules/theme-tools/social-menu.php
+++ b/projects/plugins/jetpack/modules/theme-tools/social-menu.php
@@ -100,7 +100,7 @@ function jetpack_social_menu() {
 		if ( 'svg' === $menu_type ) {
 			$link_after .= jetpack_social_menu_get_svg( array( 'icon' => 'chain' ) );
 		} ?>
-		<nav class="jetpack-social-navigation jetpack-social-navigation-<?php echo esc_attr( $menu_type ); ?>" role="navigation" aria-label="<?php esc_html_e( 'Social Links Menu', 'jetpack' ); ?>">
+		<nav class="jetpack-social-navigation jetpack-social-navigation-<?php echo esc_attr( $menu_type ); ?>" aria-label="<?php esc_html_e( 'Social Links Menu', 'jetpack' ); ?>">
 			<?php
 				wp_nav_menu(
 					array(


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

﻿This is no longer necessary. Read more about it here:
https://core.trac.wordpress.org/ticket/54054

> According to HTML5 documentation, adding role="navigation" to a <nav> element is unnecessary (and not permitted).

#### Jetpack product discussion

* Primary issue: #21322

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here, there should be no functional changes.
