### PR TITLE
Assets: Suppress "doing it wrong" warning for aliases during plugin activation

### DIFF
--- a/projects/packages/assets/changelog/fix-assets-alias_textdomain-during-activation-is-not-_doing_it_wrong
+++ b/projects/packages/assets/changelog/fix-assets-alias_textdomain-during-activation-is-not-_doing_it_wrong
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't issue a "doing it wrong" warning for registering aliases during plugin activation.

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -514,7 +514,11 @@ class Assets {
 			throw new InvalidArgumentException( 'Type must be "plugins", "themes", or "core"' );
 		}
 
-		if ( did_action( 'wp_default_scripts' ) ) {
+		if (
+			did_action( 'wp_default_scripts' ) &&
+			// Don't complain during plugin activation.
+			! defined( 'WP_SANDBOX_SCRAPING' )
+		) {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Plugin activation comes after the wp_default_scripts hook, but that's
expected so don't call `_doing_it_wrong` in that case.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1641335901414900-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Deactivate Jetpack, then activate it again. Check that warnings about "Textdomain aliases should be registered before the `wp_default_scripts` hook" are not produced.
  * If testing this on a JN site, use the Beta Plugin to activate the branch version. Activating it via the Plugins page will activate 10.4 rather than the branch, and 10.4 doesn't have the bug in the first place.