### PR TITLE
[RNMobile] Fix pixelated Tiled Gallery images

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.native.js
@@ -16,8 +16,6 @@ export default function TiledGallerySave( { attributes, innerBlocks } ) {
 		if ( image.attributes ) {
 			return {
 				...image.attributes,
-				width: 100,
-				height: 100,
 			};
 		}
 		return image;


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4306

Related:
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4433

#### Changes proposed in this Pull Request:

This PR addresses the pixelated images we see on Tiled Galleries. The cause was a hard-coded image dimension set in the block's `save` function.

A workaround is to omit the width and height altogether, which allows images to be rendered at full-resolution on the frontend. 

A solution is out of the scope of this PR and this is why: Image blocks, which we used in the Tiled Gallery here, don't expose their width or height via the image's block attributes. I can't find a way to ask an inner image block for its width or height. https://github.com/WordPress/gutenberg/issues/23244 tracks the need to make the image block provide a default width and height, albeit for different reasons. https://github.com/WordPress/gutenberg/issues/35982 explains the issue I'm running into, but I suspect this is a duplicate of the former issue.

For now, the above mentioned workaround seems to bring benefits to the Tiled Gallery and doesn't have any downsides I'm aware of.

#### Screenshots

|  Images were pixelated | Images are now full-resolution  |
| - | - |
| <img width="719" alt="Screen Shot 2022-01-05 at 18 51 08" src="https://user-images.githubusercontent.com/1898325/148295812-b5867b4c-06f8-4e26-9fad-f6415c107903.png"> | <img width="719" alt="Screen Shot 2022-01-05 at 18 55 17" src="https://user-images.githubusercontent.com/1898325/148295836-0c499479-dc10-4425-a9ae-484b82b21d35.png"> |


#### Jetpack product discussion

https://github.com/wordpress-mobile/gutenberg-mobile/issues/4306

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:

<details>
<summary>Setup to test from the main apps</summary>
<p>
<ol>
<li>Run the packager from the <code>add/tiled-gallery-block</code> branch: <code>npm run start:reset</code></li>
<li>Run either of the main apps (WPiOS or WPAndroid)</li>
<li>Open a new post in the main apps and expect the editor to load from the running packager</li>
</details>

1. Add a Tiled Gallery
2. Add a couple of images
3. Switch to the Square layout
4. Preview the post
5. Notice the images appear at their full-resolution