### PR TITLE
Correct mark-up for donations block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-donations-missing-div
+++ b/projects/plugins/jetpack/changelog/fix-donations-missing-div
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add a missing closing div to the front-end rendering of the donations block

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -211,16 +211,17 @@ function render_block( $attr, $content ) {
 		'
 <div class="%1$s">
 	<div class="donations__container">
-	%2$s
-	<div class="donations__content">
-		<div class="donations__tab">
-			%3$s
-			<p>%4$s</p>
-			%5$s
-			%6$s
-			<hr class="donations__separator">
-			%7$s
-			%8$s
+		%2$s
+		<div class="donations__content">
+			<div class="donations__tab">
+				%3$s
+				<p>%4$s</p>
+				%5$s
+				%6$s
+				<hr class="donations__separator">
+				%7$s
+				%8$s
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
The domains block server-side render was missing a closing div tag,
which caused a variety of layout issues.



<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #20309, #19766, #18165

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Ensure you're on a paid wp.com plan (or a jetpack complete plan if testing on jetpack)
2. Create a new post
3. Add a Donations block to the post
4. Insert a full width column block underneath the donations block (you'll need to click on one of the icons to change the column block to full width)
5. Add some content to the columns
6. Gutenberg should display this as full width
7. Save the post
8. View the post - before this change the columns block should not be full width and after it should

Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/148379222-be810feb-af30-4513-8f22-b5d00872447e.png) |  ![image](https://user-images.githubusercontent.com/93301/148379259-e420d1b6-e740-4e0c-ac46-d0512599b9d2.png)

There's a variety of other scenarios too, e.g. placing the donations block inside a cover block and then having cover blocks further down the page.

