### PR TITLE
Fix/videopress allow download property

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -93,8 +93,10 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data extends WPCOM_REST_API_V2_Fie
 	public function get_videopress_data( $attachment_id, $blog_id ) {
 		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id );
 		return array(
-			'guid'   => $info->guid,
-			'rating' => $info->rating,
+			'guid'           => $info->guid,
+			'rating'         => $info->rating,
+			'allow_download' =>
+				isset( $info->allow_download ) && $info->allow_download ? 1 : 0,
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-videopress-allow-download-property
+++ b/projects/plugins/jetpack/changelog/fix-videopress-allow-download-property
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+VideoPress: change allow_download data path from API (wpcom compat)

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -97,7 +97,7 @@ const VideoPressEdit = CoreVideoEdit =>
 			const id = get( this.props, 'attributes.id' );
 			const media = await this.requestMedia( id );
 			let rating = get( media, 'jetpack_videopress.rating' );
-			const allowDownload = get( media, 'media_details.videopress.allow_download' );
+			const allowDownload = get( media, 'jetpack_videopress.allow_download' );
 
 			if ( rating ) {
 				// X-18 was previously supported but is now removed to better comply with our TOS.

--- a/projects/plugins/jetpack/modules/videopress/utility-functions.php
+++ b/projects/plugins/jetpack/modules/videopress/utility-functions.php
@@ -480,8 +480,12 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	$meta             = wp_get_attachment_metadata( $post_id );
 
 	if ( $meta && isset( $meta['videopress'] ) ) {
-		$videopress_meta    = $meta['videopress'];
-		$video_info->rating = $videopress_meta['rating'];
+		$videopress_meta            = $meta['videopress'];
+		$video_info->rating         = $videopress_meta['rating'];
+		$video_info->allow_download =
+			isset( $videopress_meta['allow_download'] )
+			? $videopress_meta['allow_download']
+			: 0;
 	}
 
 	if ( videopress_is_finished_processing( $post_id ) ) {


### PR DESCRIPTION
Fixes Automattic/greenhouse#1076

#### Changes proposed in this Pull Request:

This PR changes the path for allow_download in the Gutenberg block and adds it to the v2 REST API wpcom fields.
It fixes the "allow download" checkbox state in the block editor on wpcom, currently always reporting it as "off".

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* On a Jetpack site with VideoPress enabled 
* Edit or create a new post
* Add a /video block
* Select a VideoPress video from your media library or upload a video on VideoPress
* Select the video block and click on "Allow download" in the video settings (under rating) to turn it on
* Refresh the page and select the video block
* ✅ The "allow download" toggle should be "on"
* Toggle it again and refresh the page
* ✅ The "allow download" toggle should be "off"
