### PR TITLE
Licensing buttons: ensure styles are specific enough

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,7 +854,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:^0.1.3
       '@automattic/jetpack-components': workspace:^0.9.1
       '@automattic/jetpack-connection': workspace:^0.12.0
-      '@automattic/jetpack-licensing': workspace:^0.4.0
+      '@automattic/jetpack-licensing': workspace:^0.4.1-alpha
       '@automattic/jetpack-partner-coupon': workspace:^0.1.3
       '@automattic/jetpack-webpack-config': workspace:^1.0.1
       '@automattic/popup-monitor': 1.0.0

--- a/projects/js-packages/licensing/changelog/fix-license-button-specificity
+++ b/projects/js-packages/licensing/changelog/fix-license-button-specificity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activation buttons: ensure that the styles are specific enough when using Gutenberg

--- a/projects/js-packages/licensing/components/activation-screen-success-info/primary-link/style.scss
+++ b/projects/js-packages/licensing/components/activation-screen-success-info/primary-link/style.scss
@@ -1,46 +1,48 @@
 @import '~@automattic/jetpack-base-styles/style';
 
-.jp-license-activation-screen-success-info--button,
-.jp-license-activation-screen-success-info--button:active,
-.jp-license-activation-screen-success-info--button:visited {
-	background-color: var( --jp-black );
-	border-radius: 4px;
-	color: var( --jp-white );
-	font-size: 16px;
-	font-size: var(--font-body);
-	font-style: normal;
-	font-weight: 600;
-	justify-content: center;
-	line-height: 24px;
-	margin-top: 24px;
-	min-height: 48px;
-	min-width: 158px;
-	padding: 13.5px 45px 13.5px 45px;
-	width: 100%;
-	margin: 0 40px 20px 0;
-
-	@media screen and (min-width: 480px) {
-		width: auto;
-	}
-
-	&:hover {
-		background-color: var( --jp-black-80 );
+.components-button {
+	&.jp-license-activation-screen-success-info--button,
+	&.jp-license-activation-screen-success-info--button:active,
+	&.jp-license-activation-screen-success-info--button:visited {
+		background-color: var( --jp-black );
+		border-radius: 4px;
 		color: var( --jp-white );
-	}
-
-	&:focus {
-		background-color: var( --jp-black-80 );
-		border: 1px solid var( --jp-white );
-		color: var( --jp-white );
-	}
-
-	&[disabled],
-	&:disabled {
-		background-color: var( --jp-gray );
-		color: var( --jp-gray-20 );;
-	}
-
-	.jp-components-spinner {
+		font-size: 16px;
+		font-size: var(--font-body);
+		font-style: normal;
+		font-weight: 600;
+		justify-content: center;
+		line-height: 24px;
+		margin-top: 24px;
+		min-height: 48px;
+		min-width: 158px;
+		padding: 13.5px 45px 13.5px 45px;
 		width: 100%;
+		margin: 0 40px 20px 0;
+
+		@media screen and (min-width: 480px) {
+			width: auto;
+		}
+
+		&:hover {
+			background-color: var( --jp-black-80 );
+			color: var( --jp-white );
+		}
+
+		&:focus {
+			background-color: var( --jp-black-80 );
+			border: 1px solid var( --jp-white );
+			color: var( --jp-white );
+		}
+
+		&[disabled],
+		&:disabled {
+			background-color: var( --jp-gray );
+			color: var( --jp-gray-20 );;
+		}
+
+		.jp-components-spinner {
+			width: 100%;
+		}
 	}
 }

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.4.0",
+	"version": "0.4.1-alpha",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/jetpack/changelog/fix-license-button-specificity
+++ b/projects/plugins/jetpack/changelog/fix-license-button-specificity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -66,7 +66,7 @@
 		"@automattic/jetpack-api": "workspace:^0.8.1",
 		"@automattic/jetpack-components": "workspace:^0.9.1",
 		"@automattic/jetpack-connection": "workspace:^0.12.0",
-		"@automattic/jetpack-licensing": "workspace:^0.4.0",
+		"@automattic/jetpack-licensing": "workspace:^0.4.1-alpha",
 		"@automattic/jetpack-partner-coupon": "workspace:^0.1.3",
 		"@automattic/popup-monitor": "1.0.0",
 		"@automattic/request-external-access": "1.0.0",


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
﻿
When using the Gutenberg plugin, an additional stylesheet is enqueued in the Jetpack React dashboard, with specific styles for `.components-button` that overwrite our existing styles.

By being more specific, we should be able to ensure that our styles will remain.

**Before**

![image](https://user-images.githubusercontent.com/426388/148406939-015aeec5-fab5-4c2a-99b7-0ba4191f384b.png)

**After**

![image](https://user-images.githubusercontent.com/426388/148407136-c57dcee8-0c1c-4d06-abce-fe288bdafe1e.png)


#### Jetpack product discussion

* This was reported in p8oabR-LV-p2#comment-5750

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site running Jetpack and this branch, and the Gutenberg plugin.
* Connect your site to WordPress.com. Do **not** buy any plan yet.
* Go to https://cloud.jetpack.com/pricing and purchase a Backup product.
* Do not attach it to your site just yet.
* Go to https://wordpress.com/me/purchases/ and locate the product you just bought (you can search for "Pending" to locate the purchase if you have a lot on that page).
* On the product page, copy the product code.
* Go back to wp-admin on your site, go to Jetpack > Dashboard > My Plan, and click on the button at the top of the page to activate a product.
* Enter the code you just copied.
* On the new page that loads, the button should look good.

