### PR TITLE
Donations block: Reuse stored plan IDs

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-donations-block-reuse-stored-plan-ids
+++ b/projects/plugins/jetpack/changelog/fix-donations-block-reuse-stored-plan-ids
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Donations block: Fixed an issue which was invalidating existing blocks if they were edited by non-plan owners.

--- a/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
@@ -42,9 +42,15 @@ const Tabs = props => {
 		}
 
 		setAttributes( {
-			oneTimeDonation: { ...oneTimeDonation, planId: products[ 'one-time' ] },
-			monthlyDonation: { ...monthlyDonation, planId: products[ '1 month' ] },
-			annualDonation: { ...annualDonation, planId: products[ '1 year' ] },
+			...( products[ 'one-time' ] && {
+				oneTimeDonation: { ...oneTimeDonation, planId: products[ 'one-time' ] },
+			} ),
+			...( products[ '1 month' ] && {
+				monthlyDonation: { ...monthlyDonation, planId: products[ '1 month' ] },
+			} ),
+			...( products[ '1 year' ] && {
+				annualDonation: { ...annualDonation, planId: products[ '1 year' ] },
+			} ),
 		} );
 	}, [ oneTimeDonation, monthlyDonation, annualDonation, setAttributes, products ] );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/22049

#### Changes proposed in this Pull Request:

There are some cases where the stored plan IDs in the attributes of the Donations block are erased if they are edited by a user who is not the plan owner. To solve that, this PR introduces a safety check to only edit the stored plan IDs if the new ones have a value.

Note that I had a bad time trying to reproduce the issue described in https://github.com/Automattic/jetpack/issues/22049 (only managed to replicate it once), but I suspect this fix should prevent it from happening.

#### Jetpack product discussion
p9MPsk-1iY-p2#comment-12131

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- [Spin up a JN site running changes from this PR](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=fix/donations-block-reuse-stored-plan-ids).
- Set up Jetpack and start for free.
- You need to sandbox the WP.com store now:
  - Edit your `/etc/hosts` file and point `public-api.wordpress.com` and `subscribe.wordpress.com` to your WP.com sandbox IP.
  - Go to WP Admin > Settings > Jetpack Constants and enter your WP.com sandbox address in `JETPACK__SANDBOX_DOMAIN`.
  - Enable incoming HTTP connections in your WP.com sandbox: `sudo global-http enable`.
  - Add the code below to `/wp-content/mu-plugins/0-sandbox.php` in your WP.com sandbox:
```
define( 'USE_STORE_SANDBOX', true );
define( 'USE_BILLING_SANDBOX', true );
define( 'BILLINGDADDY_SANDBOX', rtrim( 'https://' . `hostname` ) );
```
- Purchase a Jetpack Security plan using the fake credit card (PCYsg-IA-p2#paying-by-credit-card).
- Go to WP Admin > Posts > Add new.
- Insert a Donations block.
- Connect to Stripe (you'll have enabled the test mode that allows you to avoid completing a form).
- Publish the post.
- Log in now as a different user.
- Edit the same post.
- Make some edits and update it.
- Activate the code editor.
- Inspect the attributes of the donations block.
- Make sure the plan ID are still there.