### PR TITLE
Admin Page: remove CRM for now

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -14,7 +14,6 @@ import { withModuleSettingsFormHelpers } from 'components/module-settings/with-m
 import DashSectionHeader from 'components/dash-section-header';
 import DashActivity from './activity';
 import DashBoost from './boost';
-import DashCRM from './crm';
 import DashStats from './stats/index.jsx';
 import DashProtect from './protect';
 import DashMonitor from './monitor';
@@ -174,10 +173,7 @@ class AtAGlance extends Component {
 				);
 			}
 
-			performanceCards.push(
-				<DashBoost siteAdminUrl={ this.props.siteAdminUrl } />,
-				<DashCRM siteAdminUrl={ this.props.siteAdminUrl } />
-			);
+			performanceCards.push( <DashBoost siteAdminUrl={ this.props.siteAdminUrl } /> );
 
 			if ( performanceCards.length ) {
 				pairs.push( {

--- a/projects/plugins/jetpack/changelog/rm-crm-aag-card
+++ b/projects/plugins/jetpack/changelog/rm-crm-aag-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin Page: remove CRM card for now.


### PR DESCRIPTION
Follow-up to #21866

#### Changes proposed in this Pull Request:

﻿It's not quite ready for prime time yet.

Let's keep the class in there though, so we can bring it back later.

#### Jetpack product discussion

* Internal reference: p8oabR-LV-p2#comment-5778

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site running this branch, and connected to WordPress.com.
* Go to Jetpack > Dashboard
* You should not see a CRM card towards the bottom of the page.
