### PR TITLE
Donations: Don't display on front-end if stripe disconnected

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-donations-without-stripe
+++ b/projects/plugins/jetpack/changelog/fix-donations-without-stripe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Don't display the donations block to visitors unless Stripe is connected

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -99,10 +99,16 @@ function render_block( $attr, $content ) {
 		return $content;
 	}
 
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+
+	// If stripe isn't connected don't show anything to potential donors - they can't actually make a donation.
+	if ( ! \Jetpack_Memberships::get_connected_account_id() ) {
+		return '';
+	}
+
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME, array( 'thickbox' ) );
 	add_thickbox();
 
-	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	jetpack_require_lib( 'class-jetpack-currencies' );
 
 	$donations = array(


### PR DESCRIPTION
When adding/editing a document with a Donations block that doesn't have
stripe connected it displays a prominent message saying that the block
will be hidden to visitors until stripe is connected. In actual fact it
displays a partial, broken block.

This change does as the message says, and displays nothing on the site
front-end to visitors, unless stripe is connected.

Note that the linked bug proposes that the display on the front-end ought to display a warning rather than nothing at all. I'm open to discuss that, but I decided to display nothing at all because:
 * It's what the existing message says in the editor, so it's clear that Stripe needs connecting already.
 * When a Stripe account becomes disconnected there is an email and a notification explaining that they need connecting, so the site admin ought to be aware
 * I don't like the idea of showing an error to site visitors.

Fixes #17643

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure you're on a paid wp.com plan (or a jetpack complete plan if testing on jetpack)
2. Disconnect stripe if it's connected: https://wordpress.com/earn/payments/SITE-DOMAIN
3. Create a new post
4. Add a donations block
5. Observe warning that nothing will be displayed, like so: ![image](https://user-images.githubusercontent.com/93301/148427072-1ff69a89-0412-41b4-b848-48c5b3f26bc5.png)
6. Save post
7. View front-end of site you should see this:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/148427179-1cd9f5be-41fe-4ef9-b730-db1b433214b3.png) | ![image](https://user-images.githubusercontent.com/93301/148427215-09eb53e0-3bac-4ec6-a2e0-8be1f741b551.png)

8. Reconnect stripe: https://wordpress.com/earn/payments/SITE-DOMAIN
9. Edit the post
10. Save the post
11. View the front-end of the site, you should see the normal donations block, like so: ![image](https://user-images.githubusercontent.com/93301/148379259-e420d1b6-e740-4e0c-ac46-d0512599b9d2.png)


Ideally steps 9 & 10 wouldn't be necessary - the problem is that valid planIDs aren't being saved (it's using fake products with IDs of -1) unless Stripe is connected, but that was the case before this change too.
