### PR TITLE
Admin Page: update AAG links with tracking and correct icon

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/activity.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/activity.jsx
@@ -11,6 +11,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Card from 'components/card';
 import DashItem from 'components/dash-item';
 import { getSitePlan } from 'state/site';
@@ -28,6 +29,14 @@ class DashActivity extends Component {
 		inOfflineMode: false,
 		siteRawUrl: '',
 		sitePlan: '',
+	};
+
+	trackActivityClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			type: 'activity-link',
+			target: 'at-a-glance',
+			feature: 'activity-log',
+		} );
 	};
 
 	render() {
@@ -74,6 +83,9 @@ class DashActivity extends Component {
 					className="jp-dash-item__manage-in-wpcom"
 					compact
 					href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={ this.trackActivityClick }
 				>
 					{ __( 'View site activity', 'jetpack' ) }
 				</Card>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -11,7 +11,6 @@ import { get, noop } from 'lodash';
  */
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { getRedirectUrl } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -80,6 +79,18 @@ class DashAkismet extends Component {
 			} );
 
 		return false;
+	};
+
+	trackModerateClick() {
+		analytics.tracks.recordJetpackClick( {
+			type: 'moderate-link',
+			target: 'at-a-glance',
+			feature: 'anti-spam',
+		} );
+	}
+
+	onModerateClick = () => {
+		this.trackModerateClick();
 	};
 
 	getContent() {
@@ -267,7 +278,8 @@ class DashAkismet extends Component {
 					key="moderate-comments"
 					className="jp-dash-item__manage-in-wpcom"
 					compact
-					href={ getRedirectUrl( 'calypso-comments-all', { site: this.props.siteRawUrl } ) }
+					href={ `${ this.props.siteAdminUrl }edit-comments.php` }
+					onClick={ this.onModerateClick }
 				>
 					{ __( 'Moderate comments', 'jetpack' ) }
 				</Card>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
@@ -16,6 +16,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Card from 'components/card';
 import DashItem from 'components/dash-item';
 import JetpackBanner from 'components/jetpack-banner';
@@ -85,6 +86,14 @@ class DashBackups extends Component {
 		isVaultPressInstalled: false,
 		rewindStatus: '',
 		trackUpgradeButtonView: noop,
+	};
+
+	trackBackupsClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			type: 'backups-link',
+			target: 'at-a-glance',
+			feature: 'backups',
+		} );
 	};
 
 	getVPContent() {
@@ -189,7 +198,15 @@ class DashBackups extends Component {
 	getRewindContent() {
 		const { planClass, rewindStatus, siteRawUrl } = this.props;
 		const buildAction = ( url, message ) => (
-			<Card compact key="manage-backups" className="jp-dash-item__manage-in-wpcom" href={ url }>
+			<Card
+				compact
+				key="manage-backups"
+				className="jp-dash-item__manage-in-wpcom"
+				href={ url }
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={ this.trackBackupsClick }
+			>
 				{ message }
 			</Card>
 		);

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
@@ -111,6 +111,14 @@ class DashScan extends Component {
 		trackUpgradeButtonView: noop,
 	};
 
+	trackScansClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			type: 'scans-link',
+			target: 'at-a-glance',
+			feature: 'scans',
+		} );
+	};
+
 	onActivateVaultPressClick = () => {
 		analytics.tracks.recordJetpackClick( {
 			type: 'activate-link',
@@ -297,6 +305,7 @@ class DashScan extends Component {
 				href={ url }
 				target="_blank"
 				rel="noopener noreferrer"
+				onClick={ this.trackScansClick }
 			>
 				{ message }
 			</Card>

--- a/projects/plugins/jetpack/changelog/update-aag-card-tracks-links
+++ b/projects/plugins/jetpack/changelog/update-aag-card-tracks-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Dashboard: update the links to different Jetpack features in the dashboard.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿* When a link points to an external site, make it open in a new window and change the link icon.
* Add tracking to the links.

#### Jetpack product discussion

* Internal reference: p8oabR-LV-p2#comment-5753

#### Does this pull request change what data or activity we track or use?

* Yes, it adds Tracks links to events in the dashboard.

#### Testing instructions:

* Go to Jetpack > Dashboard.
* In your console, type in `localStorage.setItem( 'debug', 'dops:analytics' );`
* In your console settings, check "Preserve log"
* Refresh the page.
* In the cards appearing below the main graph, try the action links at the bottom of each card.
    * They should trigger a Tracks event you'll see in the console.
    * The icon at the right of each card bottom should reflect whether the link opens an external site or not.
