### PR TITLE
IDC: display resolving errors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,7 @@ importers:
     specifiers:
       '@automattic/jetpack-analytics': workspace:^0.1.4
       '@automattic/jetpack-api': workspace:^0.8.1
+      '@automattic/jetpack-base-styles': workspace:^0.1.3
       '@automattic/jetpack-components': workspace:^0.9.1
       '@wordpress/base-styles': 4.0.4
       '@wordpress/components': 19.1.6
@@ -280,6 +281,7 @@ importers:
     dependencies:
       '@automattic/jetpack-analytics': link:../analytics
       '@automattic/jetpack-api': link:../api
+      '@automattic/jetpack-base-styles': link:../base-styles
       '@automattic/jetpack-components': link:../components
       '@wordpress/base-styles': 4.0.4
       '@wordpress/components': 19.1.6_react-dom@17.0.2+react@17.0.2
@@ -358,7 +360,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:^0.1.3
       '@automattic/jetpack-components': workspace:^0.9.1
       '@automattic/jetpack-connection': workspace:^0.12.0
-      '@automattic/jetpack-idc': workspace:^0.7.1
+      '@automattic/jetpack-idc': workspace:^0.8.0-alpha
       '@babel/core': 7.16.0
       '@babel/plugin-syntax-jsx': 7.16.0
       '@babel/runtime-corejs3': 7.16.3
@@ -536,7 +538,7 @@ importers:
 
   projects/packages/identity-crisis:
     specifiers:
-      '@automattic/jetpack-idc': workspace:^0.7.1
+      '@automattic/jetpack-idc': workspace:^0.8.0-alpha
       '@automattic/jetpack-webpack-config': workspace:^1.0.1
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4

--- a/projects/js-packages/idc/changelog/add-idc-errors
+++ b/projects/js-packages/idc/changelog/add-idc-errors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Display IDC resolution errors.

--- a/projects/js-packages/idc/components/card-fresh/index.jsx
+++ b/projects/js-packages/idc/components/card-fresh/index.jsx
@@ -7,7 +7,7 @@ import { Button, Dashicon } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Spinner } from '@automattic/jetpack-components';
+import { getRedirectUrl, Spinner } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -15,6 +15,31 @@ import { Spinner } from '@automattic/jetpack-components';
 import { STORE_ID } from '../../state/store';
 import extractHostname from '../../tools/extract-hostname';
 import customContentShape from '../../tools/custom-content-shape';
+import ErrorMessage from '../error-message';
+
+/**
+ * Render the error message.
+ *
+ * @returns {React.Component} The error message.
+ */
+const renderError = () => {
+	return (
+		<ErrorMessage>
+			{ createInterpolateElement(
+				__( 'Could not create the connection. Retry or find out more <a>here</a>.', 'jetpack' ),
+				{
+					a: (
+						<a
+							href={ getRedirectUrl( 'jetpack-support-safe-mode' ) }
+							rel="noopener noreferrer"
+							target="_blank"
+						/>
+					),
+				}
+			) }
+		</ErrorMessage>
+	);
+};
 
 /**
  * The "start fresh" card.
@@ -23,7 +48,7 @@ import customContentShape from '../../tools/custom-content-shape';
  * @returns {React.Component} The `ConnectScreen` component.
  */
 const CardFresh = props => {
-	const { isStartingFresh, startFreshCallback, customContent } = props;
+	const { isStartingFresh, startFreshCallback, customContent, hasError } = props;
 
 	const wpcomHostName = extractHostname( props.wpcomHomeUrl );
 	const currentHostName = extractHostname( props.currentUrl );
@@ -33,7 +58,12 @@ const CardFresh = props => {
 	const buttonLabel = __( 'Create a fresh connection', 'jetpack' );
 
 	return (
-		<div className="jp-idc__idc-screen__card-action-base">
+		<div
+			className={
+				'jp-idc__idc-screen__card-action-base' +
+				( hasError ? ' jp-idc__idc-screen__card-action-error' : '' )
+			}
+		>
 			<div className="jp-idc__idc-screen__card-action-top">
 				<h4>
 					{ customContent.startFreshCardTitle ||
@@ -72,6 +102,8 @@ const CardFresh = props => {
 				>
 					{ isStartingFresh ? <Spinner /> : buttonLabel }
 				</Button>
+
+				{ hasError && renderError() }
 			</div>
 		</div>
 	);
@@ -88,12 +120,15 @@ CardFresh.propTypes = {
 	startFreshCallback: PropTypes.func.isRequired,
 	/** Custom text content. */
 	customContent: PropTypes.shape( customContentShape ),
+	/** Whether the component has an error. */
+	hasError: PropTypes.bool.isRequired,
 };
 
 CardFresh.defaultProps = {
 	isStartingFresh: false,
 	startFreshCallback: () => {},
 	customContent: {},
+	hasError: false,
 };
 
 export default CardFresh;

--- a/projects/js-packages/idc/components/card-migrate/index.jsx
+++ b/projects/js-packages/idc/components/card-migrate/index.jsx
@@ -7,7 +7,7 @@ import { Button, Dashicon } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Spinner } from '@automattic/jetpack-components';
+import { getRedirectUrl, Spinner } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -15,6 +15,31 @@ import { Spinner } from '@automattic/jetpack-components';
 import { STORE_ID } from '../../state/store';
 import extractHostname from '../../tools/extract-hostname';
 import customContentShape from '../../tools/custom-content-shape';
+import ErrorMessage from '../error-message';
+
+/**
+ * Render the error message.
+ *
+ * @returns {React.Component} The error message.
+ */
+const renderError = () => {
+	return (
+		<ErrorMessage>
+			{ createInterpolateElement(
+				__( 'Could not move your settings. Retry or find out more <a>here</a>.', 'jetpack' ),
+				{
+					a: (
+						<a
+							href={ getRedirectUrl( 'jetpack-support-safe-mode' ) }
+							rel="noopener noreferrer"
+							target="_blank"
+						/>
+					),
+				}
+			) }
+		</ErrorMessage>
+	);
+};
 
 /**
  * The "migrate" card.
@@ -28,12 +53,17 @@ const CardMigrate = props => {
 
 	const isActionInProgress = useSelect( select => select( STORE_ID ).getIsActionInProgress(), [] );
 
-	const { isMigrating, migrateCallback, customContent } = props;
+	const { isMigrating, migrateCallback, customContent, hasError } = props;
 
 	const buttonLabel = __( 'Move your settings', 'jetpack' );
 
 	return (
-		<div className="jp-idc__idc-screen__card-action-base">
+		<div
+			className={
+				'jp-idc__idc-screen__card-action-base' +
+				( hasError ? ' jp-idc__idc-screen__card-action-error' : '' )
+			}
+		>
 			<div className="jp-idc__idc-screen__card-action-top">
 				<h4>{ customContent.migrateCardTitle || __( 'Move Jetpack data', 'jetpack' ) }</h4>
 
@@ -69,6 +99,8 @@ const CardMigrate = props => {
 				>
 					{ isMigrating ? <Spinner /> : buttonLabel }
 				</Button>
+
+				{ hasError && renderError() }
 			</div>
 		</div>
 	);
@@ -85,12 +117,15 @@ CardMigrate.propTypes = {
 	migrateCallback: PropTypes.func.isRequired,
 	/** Custom text content. */
 	customContent: PropTypes.shape( customContentShape ),
+	/** Whether the component has an error. */
+	hasError: PropTypes.bool.isRequired,
 };
 
 CardMigrate.defaultProps = {
 	isMigrating: false,
 	migrateCallback: () => {},
 	customContent: {},
+	hasError: false,
 };
 
 export default CardMigrate;

--- a/projects/js-packages/idc/components/error-message/error-gridicon.jsx
+++ b/projects/js-packages/idc/components/error-message/error-gridicon.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const ErrorGridicon = () => {
+	return (
+		<svg
+			className="error-gridicon"
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			height={ 24 }
+		>
+			<rect x="0" fill="none" width="24" height="24" />
+			<g>
+				<path d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z" />
+			</g>
+		</svg>
+	);
+};
+
+export default ErrorGridicon;

--- a/projects/js-packages/idc/components/error-message/index.jsx
+++ b/projects/js-packages/idc/components/error-message/index.jsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ErrorGridicon from './error-gridicon';
+import './style.scss';
+
+const ErrorMessage = props => {
+	const { children } = props;
+
+	return (
+		<div className="jp-idc__error-message">
+			<ErrorGridicon />
+			<span>{ children }</span>
+		</div>
+	);
+};
+
+export default ErrorMessage;

--- a/projects/js-packages/idc/components/error-message/style.scss
+++ b/projects/js-packages/idc/components/error-message/style.scss
@@ -1,0 +1,38 @@
+@import '~@automattic/jetpack-base-styles/style';
+
+.jp-idc__idc-screen {
+  .jp-idc__error-message {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	color: var(--jp-red);
+	margin: 15px 0;
+
+	.error-gridicon {
+	  margin-right: 8px;
+	  fill: var(--jp-red);
+	}
+
+	span, a {
+	  font-size: var(--font-body);
+	  color: var(--jp-red);
+	}
+  }
+
+  .jp-idc__safe-mode .jp-idc__error-message {
+	margin-top: 5px;
+  }
+
+  .jp-idc__idc-screen__cards.jp-idc__idc-screen__cards-error .jp-idc__idc-screen__card-action-base {
+	padding-bottom: 75px;
+
+	&.jp-idc__idc-screen__card-action-error {
+	  padding-bottom: 5px;
+	}
+
+	.jp-idc__error-message {
+	  height: 40px;
+	}
+  }
+}

--- a/projects/js-packages/idc/components/idc-screen/index.jsx
+++ b/projects/js-packages/idc/components/idc-screen/index.jsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import analytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import useMigration from '../../hooks/use-migration';
 import useMigrationFinished from '../../hooks/use-migration-finished';
 import useStartFresh from '../../hooks/use-start-fresh';
 import customContentShape from '../../tools/custom-content-shape';
+import { STORE_ID } from '../../state/store';
 
 /**
  * The IDC screen component.
@@ -37,6 +39,8 @@ const IDCScreen = props => {
 	} = props;
 
 	const [ isMigrated, setIsMigrated ] = useState( false );
+
+	const errorType = useSelect( select => select( STORE_ID ).getErrorType(), [] );
 
 	const { isMigrating, migrateCallback } = useMigration(
 		useCallback( () => {
@@ -90,6 +94,9 @@ const IDCScreen = props => {
 			isStartingFresh={ isStartingFresh }
 			startFreshCallback={ startFreshCallback }
 			isAdmin={ isAdmin }
+			hasStaySafeError={ errorType === 'safe-mode' }
+			hasFreshError={ errorType === 'start-fresh' }
+			hasMigrateError={ errorType === 'migrate' }
 		/>
 	);
 };

--- a/projects/js-packages/idc/components/idc-screen/screen-main.jsx
+++ b/projects/js-packages/idc/components/idc-screen/screen-main.jsx
@@ -30,6 +30,9 @@ const ScreenMain = props => {
 		isStartingFresh,
 		startFreshCallback,
 		customContent,
+		hasMigrateError,
+		hasFreshError,
+		hasStaySafeError,
 	} = props;
 
 	return (
@@ -58,13 +61,19 @@ const ScreenMain = props => {
 
 			<h3>{ __( 'Please select an option', 'jetpack' ) }</h3>
 
-			<div className="jp-idc__idc-screen__cards">
+			<div
+				className={
+					'jp-idc__idc-screen__cards' +
+					( hasMigrateError || hasFreshError ? ' jp-idc__idc-screen__cards-error' : '' )
+				}
+			>
 				<CardMigrate
 					wpcomHomeUrl={ wpcomHomeUrl }
 					currentUrl={ currentUrl }
 					isMigrating={ isMigrating }
 					migrateCallback={ migrateCallback }
 					customContent={ customContent }
+					hasError={ hasMigrateError }
 				/>
 				<div className="jp-idc__idc-screen__cards-separator">or</div>
 				<CardFresh
@@ -73,10 +82,11 @@ const ScreenMain = props => {
 					isStartingFresh={ isStartingFresh }
 					startFreshCallback={ startFreshCallback }
 					customContent={ customContent }
+					hasError={ hasFreshError }
 				/>
 			</div>
 
-			<SafeMode />
+			<SafeMode hasError={ hasStaySafeError } />
 		</React.Fragment>
 	);
 };
@@ -96,12 +106,21 @@ ScreenMain.propTypes = {
 	startFreshCallback: PropTypes.func,
 	/** Custom text content. */
 	customContent: PropTypes.shape( customContentShape ),
+	/** Whether the component encountered the migration error. */
+	hasMigrateError: PropTypes.bool.isRequired,
+	/** Whether the component encountered the "Fresh Connection" error. */
+	hasFreshError: PropTypes.bool.isRequired,
+	/** Whether the component encountered the "Stay in Safe Mode" error. */
+	hasStaySafeError: PropTypes.bool.isRequired,
 };
 
 ScreenMain.defaultProps = {
 	isMigrating: false,
 	isStartingFresh: false,
 	customContent: {},
+	hasMigrateError: false,
+	hasFreshError: false,
+	hasStaySafeError: false,
 };
 
 export default ScreenMain;

--- a/projects/js-packages/idc/components/idc-screen/stories/index.jsx
+++ b/projects/js-packages/idc/components/idc-screen/stories/index.jsx
@@ -33,6 +33,9 @@ const DefaultArgs = {
 	isMigrating: false,
 	isStartingFresh: false,
 	isAdmin: true,
+	hasMigrateError: false,
+	hasFreshError: false,
+	hasStaySafeError: false,
 };
 
 export const _default = Template.bind( {} );

--- a/projects/js-packages/idc/components/idc-screen/visual.jsx
+++ b/projects/js-packages/idc/components/idc-screen/visual.jsx
@@ -37,6 +37,9 @@ const IDCScreenVisual = props => {
 		isStartingFresh,
 		startFreshCallback,
 		isAdmin,
+		hasMigrateError,
+		hasFreshError,
+		hasStaySafeError,
 	} = props;
 
 	const nonAdminBody = ! isAdmin ? <ScreenNonAdmin customContent={ customContent } /> : '';
@@ -62,6 +65,9 @@ const IDCScreenVisual = props => {
 				migrateCallback={ migrateCallback }
 				isStartingFresh={ isStartingFresh }
 				startFreshCallback={ startFreshCallback }
+				hasMigrateError={ hasMigrateError }
+				hasFreshError={ hasFreshError }
+				hasStaySafeError={ hasStaySafeError }
 			/>
 		);
 	}
@@ -111,6 +117,12 @@ IDCScreenVisual.propTypes = {
 	startFreshCallback: PropTypes.func,
 	/** Whether to display the "admin" or "non-admin" screen. */
 	isAdmin: PropTypes.bool.isRequired,
+	/** Whether the component encountered the migration error. */
+	hasMigrateError: PropTypes.bool.isRequired,
+	/** Whether the component encountered the "Fresh Connection" error. */
+	hasFreshError: PropTypes.bool.isRequired,
+	/** Whether the component encountered the "Stay in Safe Mode" error. */
+	hasStaySafeError: PropTypes.bool.isRequired,
 };
 
 IDCScreenVisual.defaultProps = {
@@ -120,6 +132,9 @@ IDCScreenVisual.defaultProps = {
 	isMigrating: false,
 	isStartingFresh: false,
 	customContent: {},
+	hasMigrateError: false,
+	hasFreshError: false,
+	hasStaySafeError: false,
 };
 
 export default IDCScreenVisual;

--- a/projects/js-packages/idc/components/safe-mode/index.jsx
+++ b/projects/js-packages/idc/components/safe-mode/index.jsx
@@ -10,13 +10,14 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { removeQueryArgs } from '@wordpress/url';
 import restApi from '@automattic/jetpack-api';
-import { Spinner } from '@automattic/jetpack-components';
+import { getRedirectUrl, Spinner } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
  */
 import { STORE_ID } from '../../state/store';
 import trackAndBumpMCStats from '../../tools/tracking';
+import ErrorMessage from '../error-message';
 import './style.scss';
 
 /**
@@ -56,14 +57,45 @@ const renderStayingSafe = () => {
 	);
 };
 
+/**
+ * Render the error message.
+ *
+ * @returns {React.Component} The error message.
+ */
+const renderError = () => {
+	return (
+		<ErrorMessage>
+			{ createInterpolateElement(
+				__( 'Could not stay in safe mode. Retry or find out more <a>here</a>.', 'jetpack' ),
+				{
+					a: (
+						<a
+							href={ getRedirectUrl( 'jetpack-support-safe-mode' ) }
+							rel="noopener noreferrer"
+							target="_blank"
+						/>
+					),
+				}
+			) }
+		</ErrorMessage>
+	);
+};
+
 const SafeMode = props => {
-	const { isActionInProgress, setIsActionInProgress } = props;
+	const {
+		isActionInProgress,
+		setIsActionInProgress,
+		setErrorType,
+		clearErrorType,
+		hasError,
+	} = props;
 	const [ isStayingSafe, setIsStayingSafe ] = useState( false );
 
 	const staySafeCallback = useCallback( () => {
 		if ( ! isActionInProgress ) {
 			setIsStayingSafe( true );
 			setIsActionInProgress( true );
+			clearErrorType();
 
 			trackAndBumpMCStats( 'confirm_safe_mode' );
 
@@ -79,16 +111,19 @@ const SafeMode = props => {
 				.catch( error => {
 					setIsActionInProgress( false );
 					setIsStayingSafe( false );
+					setErrorType( 'safe-mode' );
 					throw error;
 				} );
 		}
-	}, [ isActionInProgress, setIsActionInProgress ] );
+	}, [ isActionInProgress, setIsActionInProgress, setErrorType, clearErrorType ] );
 
 	return (
 		<div className="jp-idc__safe-mode">
 			{ isStayingSafe
 				? renderStayingSafe()
 				: renderStaySafeButton( staySafeCallback, isActionInProgress ) }
+
+			{ hasError && renderError() }
 		</div>
 	);
 };
@@ -98,6 +133,16 @@ SafeMode.propTypes = {
 	isActionInProgress: PropTypes.bool,
 	/** Function to set the "action in progress" flag. */
 	setIsActionInProgress: PropTypes.func.isRequired,
+	/** Function to set the error type. */
+	setErrorType: PropTypes.func.isRequired,
+	/** Function to clear the error. */
+	clearErrorType: PropTypes.func.isRequired,
+	/** Whether the component has an error. */
+	hasError: PropTypes.bool.isRequired,
+};
+
+SafeMode.defaultProps = {
+	hasError: false,
 };
 
 export default compose( [
@@ -109,6 +154,8 @@ export default compose( [
 	withDispatch( dispatch => {
 		return {
 			setIsActionInProgress: dispatch( STORE_ID ).setIsActionInProgress,
+			setErrorType: dispatch( STORE_ID ).setErrorType,
+			clearErrorType: dispatch( STORE_ID ).clearErrorType,
 		};
 	} ),
 ] )( SafeMode );

--- a/projects/js-packages/idc/hooks/use-migration.jsx
+++ b/projects/js-packages/idc/hooks/use-migration.jsx
@@ -21,7 +21,7 @@ export default onMigrated => {
 	const [ isMigrating, setIsMigrating ] = useState( false );
 
 	const isActionInProgress = useSelect( select => select( STORE_ID ).getIsActionInProgress(), [] );
-	const { setIsActionInProgress } = useDispatch( STORE_ID );
+	const { setIsActionInProgress, setErrorType, clearErrorType } = useDispatch( STORE_ID );
 
 	/**
 	 * Initiate the migration.
@@ -32,6 +32,7 @@ export default onMigrated => {
 
 			setIsActionInProgress( true );
 			setIsMigrating( true );
+			clearErrorType();
 
 			restApi
 				.migrateIDC()
@@ -45,10 +46,19 @@ export default onMigrated => {
 				.catch( error => {
 					setIsActionInProgress( false );
 					setIsMigrating( false );
+					setErrorType( 'migrate' );
+
 					throw error;
 				} );
 		}
-	}, [ setIsMigrating, onMigrated, isActionInProgress, setIsActionInProgress ] );
+	}, [
+		setIsMigrating,
+		onMigrated,
+		isActionInProgress,
+		setIsActionInProgress,
+		setErrorType,
+		clearErrorType,
+	] );
 
 	return {
 		isMigrating,

--- a/projects/js-packages/idc/hooks/use-start-fresh.jsx
+++ b/projects/js-packages/idc/hooks/use-start-fresh.jsx
@@ -21,7 +21,7 @@ export default redirectUri => {
 	const [ isStartingFresh, setIsStartingFresh ] = useState( false );
 
 	const isActionInProgress = useSelect( select => select( STORE_ID ).getIsActionInProgress(), [] );
-	const { setIsActionInProgress } = useDispatch( STORE_ID );
+	const { setIsActionInProgress, setErrorType, clearErrorType } = useDispatch( STORE_ID );
 
 	/**
 	 * Initiate the migration.
@@ -32,6 +32,7 @@ export default redirectUri => {
 
 			setIsActionInProgress( true );
 			setIsStartingFresh( true );
+			clearErrorType();
 
 			restApi
 				.startIDCFresh( redirectUri )
@@ -41,10 +42,19 @@ export default redirectUri => {
 				.catch( error => {
 					setIsActionInProgress( false );
 					setIsStartingFresh( false );
+					setErrorType( 'start-fresh' );
+
 					throw error;
 				} );
 		}
-	}, [ setIsStartingFresh, isActionInProgress, setIsActionInProgress, redirectUri ] );
+	}, [
+		setIsStartingFresh,
+		isActionInProgress,
+		setIsActionInProgress,
+		redirectUri,
+		setErrorType,
+		clearErrorType,
+	] );
 
 	return {
 		isStartingFresh,

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,12 +1,13 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.7.1",
+	"version": "0.8.0-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:^0.1.4",
 		"@automattic/jetpack-api": "workspace:^0.8.1",
+		"@automattic/jetpack-base-styles": "workspace:^0.1.3",
 		"@automattic/jetpack-components": "workspace:^0.9.1",
 		"@wordpress/base-styles": "4.0.4",
 		"@wordpress/components": "19.1.6",

--- a/projects/js-packages/idc/state/actions.jsx
+++ b/projects/js-packages/idc/state/actions.jsx
@@ -1,9 +1,17 @@
 const SET_IS_ACTION_IN_PROGRESS = 'SET_IS_ACTION_IN_PROGRESS';
+const SET_ERROR_TYPE = 'SET_ERROR_TYPE';
+const CLEAR_ERROR_TYPE = 'CLEAR_ERROR_TYPE';
 
 const actions = {
 	setIsActionInProgress: isInProgress => {
 		return { type: SET_IS_ACTION_IN_PROGRESS, isInProgress };
 	},
+	setErrorType: errorType => {
+		return { type: SET_ERROR_TYPE, errorType };
+	},
+	clearErrorType: () => {
+		return { type: CLEAR_ERROR_TYPE };
+	},
 };
 
-export { SET_IS_ACTION_IN_PROGRESS, actions as default };
+export { SET_IS_ACTION_IN_PROGRESS, SET_ERROR_TYPE, CLEAR_ERROR_TYPE, actions as default };

--- a/projects/js-packages/idc/state/reducers.jsx
+++ b/projects/js-packages/idc/state/reducers.jsx
@@ -6,7 +6,7 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { SET_IS_ACTION_IN_PROGRESS } from './actions';
+import { SET_IS_ACTION_IN_PROGRESS, SET_ERROR_TYPE, CLEAR_ERROR_TYPE } from './actions';
 
 const isActionInProgress = ( state = false, action ) => {
 	switch ( action.type ) {
@@ -17,8 +17,20 @@ const isActionInProgress = ( state = false, action ) => {
 	return state;
 };
 
+const errorType = ( state = null, action ) => {
+	switch ( action.type ) {
+		case SET_ERROR_TYPE:
+			return action.errorType;
+		case CLEAR_ERROR_TYPE:
+			return null;
+	}
+
+	return state;
+};
+
 const reducers = combineReducers( {
 	isActionInProgress,
+	errorType,
 } );
 
 export default reducers;

--- a/projects/js-packages/idc/state/selectors.jsx
+++ b/projects/js-packages/idc/state/selectors.jsx
@@ -1,5 +1,6 @@
 const selectors = {
 	getIsActionInProgress: state => state.isActionInProgress || false,
+	getErrorType: state => state.errorType || null,
 };
 
 export default selectors;

--- a/projects/js-packages/storybook/changelog/add-idc-errors
+++ b/projects/js-packages/storybook/changelog/add-idc-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -29,7 +29,7 @@
 		"@automattic/jetpack-components": "workspace:^0.9.1",
 		"@automattic/jetpack-connection": "workspace:^0.12.0",
 		"@automattic/jetpack-base-styles": "workspace:^0.1.3",
-		"@automattic/jetpack-idc": "workspace:^0.7.1",
+		"@automattic/jetpack-idc": "workspace:^0.8.0-alpha",
 		"@babel/core": "7.16.0",
 		"@babel/plugin-syntax-jsx": "7.16.0",
 		"@babel/runtime-corejs3": "7.16.3",

--- a/projects/packages/identity-crisis/changelog/add-idc-errors
+++ b/projects/packages/identity-crisis/changelog/add-idc-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -16,7 +16,7 @@
 	},
 	"browserslist": "extends @wordpress/browserslist-config",
 	"dependencies": {
-		"@automattic/jetpack-idc": "workspace:^0.7.1",
+		"@automattic/jetpack-idc": "workspace:^0.8.0-alpha",
 		"@wordpress/data": "6.1.5"
 	},
 	"devDependencies": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Display error messages if IDC resolution fails.

#### Jetpack product discussion
p9dueE-3pz-p2#comment-6682

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

##### WP-admin area
1. Rebuild the package if testing locally: `jetpack build packages/identity-crisis`
2. Connect Jetpack, go to Jetpack Debug and activate the IDC Simulator.
3. Go to "Jetpack Debug -> IDC Simulator", enable "IDC Simulation" and enter a "Spoof URL".
4. Edit a post and save to make the site sync. Wait a few seconds. Open any WP-admin page, confirm that the IDC screen appears.
5. Switch the browser to offline mode, or disconnect from the internet entirely. Click on "Move your settings", "Create a fresh connection", and "Stay in Safe Mode" buttons. Confirm that the errors show up, and other errors disappear when you click a button.
6. Click on the "Find out more here" link, confirm that the support page opens in a new tab: `https://jetpack.com/support/safe-mode/`

##### Storybook
6. Go to `projects/js-packages/storybook`, run `pnpm install` and `pnpm run storybook:dev`.
7. When the Storybook loads, navigate to "Identity Crisis -> Admin Screen -> Docs", and switch these props to `true`: `hasMigrateError`, `hasFreshError`, `hasStaySafeError`. Confirm that all three error messages show up.

##### Example of an error being displayed
<img width="1137" alt="Screen Shot 2022-01-06 at 4 59 51 PM" src="https://user-images.githubusercontent.com/1341249/148458213-995259c0-fab9-4b94-b203-864733a16315.png">
