### PR TITLE
[RNMobile] Fix Tiled Gallery JS test failure 

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -93,9 +93,9 @@ export default class Mosaic extends Component {
 				: ratiosToMosaicRows( ratios, { isWide: [ 'full', 'wide' ].includes( align ) } );
 
 		const columnWidths = Platform.select( {
-			web: this.props.columnWidths,
-			native: getColumnWidths( rows, renderedImages, 1000 ),
-		} );
+			web: () => this.props.columnWidths,
+			native: () => getColumnWidths( rows, renderedImages, 1000 ),
+		} )();
 
 		let cursor = 0;
 		return (

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
@@ -156,5 +156,5 @@ function applyImgRatio( col, { colHeight, width, rawWidth } ) {
 				item.setAttribute( 'style', `height:${ height }px;width:${ width }px;` );
 			} );
 		},
-	} );
+	} )();
 }


### PR DESCRIPTION
Fixes failing JS test that was introduced by a bug in https://github.com/Automattic/jetpack/pull/21767/files. The failing test is:

```
  FAIL extensions/blocks/tiled-gallery/layout/mosaic/test/index.js
    ● renders as expected
  
      TypeError: row.querySelectorAll is not a function
  
        58 | function getRowCols( row ) {
        59 | 	return Platform.select( {
      > 60 | 		web: () => Array.from( row.querySelectorAll( '.tiled-gallery__col' ) ),
           | 		                           ^
        61 | 		native: () => row,
        62 | 	} )();
        63 | }
```

#### Changes proposed in this Pull Request:
- Bug fix for the Tiled Gallery on the web (this bug isn't on `master`, it's only on our feature branch).

#### Jetpack product discussion
p9ugOq-1Tb-p2

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
Verify that the `JS tests` CI check passes. The "Code coverage" test may fail for different reasons, as long as it doesn't fail due to the above error.