### PR TITLE
Identity Crisis: Do not add IDC query args to requests when in offline or staging mode

### DIFF
--- a/projects/packages/identity-crisis/changelog/fix-idc_query_args_check_staging_offline
+++ b/projects/packages/identity-crisis/changelog/fix-idc_query_args_check_staging_offline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not add IDC query args to authenticated request when in offline or staging mode.

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -190,7 +190,11 @@ class Identity_Crisis {
 	 * @param string $url The remote request url.
 	 */
 	public function add_idc_query_args_to_url( $url ) {
-		if ( ! is_string( $url ) || self::validate_sync_error_idc_option() ) {
+		$status = new Status();
+		if ( ! is_string( $url )
+			|| $status->is_offline_mode()
+			|| $status->is_staging_site()
+			|| self::validate_sync_error_idc_option() ) {
 			return $url;
 		}
 

--- a/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
+++ b/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
@@ -446,6 +446,56 @@ class Test_Identity_Crisis extends BaseTestCase {
 	}
 
 	/**
+	 * Test the add_idc_query_args_to_url method with offline mode.
+	 */
+	public function test_add_idc_query_args_to_url_offline_mode() {
+		$this->set_up_for_test_add_idc_query_args_to_url();
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+		\Jetpack_Options::update_option( 'migrate_for_idc', true );
+
+		$input_url = 'https://www.example.com';
+
+		$result     = Identity_Crisis::init()->add_idc_query_args_to_url( $input_url );
+		$url_parts  = wp_parse_url( $result );
+		$query_args = wp_parse_args( $url_parts['query'] );
+
+		$this->tear_down_for_test_add_idc_query_args_to_url();
+		remove_filter( 'jetpack_offline_mode', '__return_true' );
+		\Jetpack_Options::delete_option( 'migrate_for_idc' );
+
+		$this->assertSame( $input_url, $url_parts['scheme'] . '://' . $url_parts['host'] );
+		$this->assertArrayNotHasKey( 'idc', $query_args );
+		$this->assertArrayNotHasKey( 'migrate_for_idc', $query_args );
+		$this->assertArrayNotHasKey( 'siteurl', $query_args );
+		$this->assertArrayNotHasKey( 'home', $query_args );
+	}
+
+	/**
+	 * Test the add_idc_query_args_to_url method with staging mode.
+	 */
+	public function test_add_idc_query_args_to_url_staging_mode() {
+		$this->set_up_for_test_add_idc_query_args_to_url();
+		add_filter( 'jetpack_is_staging_site', '__return_true' );
+		\Jetpack_Options::update_option( 'migrate_for_idc', true );
+
+		$input_url = 'https://www.example.com';
+
+		$result     = Identity_Crisis::init()->add_idc_query_args_to_url( $input_url );
+		$url_parts  = wp_parse_url( $result );
+		$query_args = wp_parse_args( $url_parts['query'] );
+
+		$this->tear_down_for_test_add_idc_query_args_to_url();
+		remove_filter( 'jetpack_is_staging_site', '__return_true' );
+		\Jetpack_Options::delete_option( 'migrate_for_idc' );
+
+		$this->assertSame( $input_url, $url_parts['scheme'] . '://' . $url_parts['host'] );
+		$this->assertArrayNotHasKey( 'idc', $query_args );
+		$this->assertArrayNotHasKey( 'migrate_for_idc', $query_args );
+		$this->assertArrayNotHasKey( 'siteurl', $query_args );
+		$this->assertArrayNotHasKey( 'home', $query_args );
+	}
+
+	/**
 	 * Set up test_add_idc_query_args_to_url test environment.
 	 */
 	public function set_up_for_test_add_idc_query_args_to_url() {

--- a/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
+++ b/projects/packages/identity-crisis/tests/php/test-identity-crisis.php
@@ -457,7 +457,10 @@ class Test_Identity_Crisis extends BaseTestCase {
 
 		$result     = Identity_Crisis::init()->add_idc_query_args_to_url( $input_url );
 		$url_parts  = wp_parse_url( $result );
-		$query_args = wp_parse_args( $url_parts['query'] );
+		$query_args = array();
+		if ( array_key_exists( 'query', $url_parts ) ) {
+			$query_args = wp_parse_args( $url_parts['query'] );
+		}
 
 		$this->tear_down_for_test_add_idc_query_args_to_url();
 		remove_filter( 'jetpack_offline_mode', '__return_true' );
@@ -482,7 +485,10 @@ class Test_Identity_Crisis extends BaseTestCase {
 
 		$result     = Identity_Crisis::init()->add_idc_query_args_to_url( $input_url );
 		$url_parts  = wp_parse_url( $result );
-		$query_args = wp_parse_args( $url_parts['query'] );
+		$query_args = array();
+		if ( array_key_exists( 'query', $url_parts ) ) {
+			$query_args = wp_parse_args( $url_parts['query'] );
+		}
 
 		$this->tear_down_for_test_add_idc_query_args_to_url();
 		remove_filter( 'jetpack_is_staging_site', '__return_true' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* IDCs should not be detected and the IDC UI should not be displayed when the site is in offline or staging mode. Check whether the site is in offline or staging mode before adding the IDC query arguments to authenticated REST requests.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install and activate this branch of Jetpack.
2. Connect Jetpack.
3. Put the site in staging mode. In the site's `wp-config.php` file, set the `JETPACK_STAGING_MODE` constant to true using this line: `define( 'JETPACK_STAGING_MODE', true );`.
4. Using the Jetpack Debug Helper plugin and its IDC Simulator module, cause an IDC.
5. Confirm that the IDC UI is not displayed. You can also check the request URLs in the IDC Simulator module to confirm that the idc query args (`idc`, `siteurl`, and `home`) have not been added to the request URLs.
6. Remove the `JETPACK_STAGING_MODE` constant definition from `wp-config.php`.
7. Put the site in offline mode. In the site's `wp-config.php` file, set the `JETPACK_DEV_DEBUG` constant to true using this line: `define( 'JETPACK_DEV_DEBUG', true );`.
8. Using the Jetpack Debug Helper plugin and its IDC Simulator module, cause an IDC.
9. Confirm that the IDC UI is not displayed. You can also check the request URLs in the IDC Simulator module to confirm that the idc query args (`idc`, `siteurl`, and `home`) have not been added to the request URLs.
10. Remove the `JETPACK_DEV_DEBUG` constant definition from `wp-config.php`.
11. Using the Jetpack Debug Helper plugin and its IDC Simulator module, cause an IDC.
12. Confirm that the IDC UI is displayed.
