### PR TITLE
Jetpack plugin: check that an Assets package file exists before calling it

### DIFF
--- a/projects/plugins/jetpack/changelog/update-check_for_alias_textdomains_method
+++ b/projects/plugins/jetpack/changelog/update-check_for_alias_textdomains_method
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Check that the Assets::alias_textdomains_from_file method exists before calling it.
+
+

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -139,7 +139,9 @@ $jetpack_autoloader           = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.
 $jetpack_module_headings_file = JETPACK__PLUGIN_DIR . 'modules/module-headings.php'; // This file is loaded later in load-jetpack.php, but let's check here to pause before half-loading Jetpack.
 if ( is_readable( $jetpack_autoloader ) && is_readable( $jetpack_module_headings_file ) ) {
 	require_once $jetpack_autoloader;
-	\Automattic\Jetpack\Assets::alias_textdomains_from_file( JETPACK__PLUGIN_DIR . 'jetpack_vendor/i18n-map.php' );
+	if ( method_exists( '\Automattic\Jetpack\Assets', 'alias_textdomains_from_file' ) ) {
+		\Automattic\Jetpack\Assets::alias_textdomains_from_file( JETPACK__PLUGIN_DIR . 'jetpack_vendor/i18n-map.php' );
+	}
 } else {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Check that the `Assets::alias_textdomains_from_file` method exists before calling it. This could
prevent fatals that would occur if an older version of the Assets package which doesn't have that
method is loaded.


#### Jetpack product discussion
* p1641832336007500-slack-C025MP1Q3HT

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
 I don't think any testing is necessary.