### PR TITLE
Image Compare block: Add `wide` and `full` alignment options

### DIFF
--- a/projects/plugins/jetpack/changelog/add-image-compare-block-align-tool
+++ b/projects/plugins/jetpack/changelog/add-image-compare-block-align-tool
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Image Compare block: Add Align tool
+Image Compare block: Add `wide` and `full` alignment options

--- a/projects/plugins/jetpack/changelog/add-image-compare-block-align-tool
+++ b/projects/plugins/jetpack/changelog/add-image-compare-block-align-tool
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Image Compare block: Add Align tool

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/edit.js
@@ -20,8 +20,7 @@ import './view.js';
 /* global juxtapose */
 
 const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) => {
-	const { imageBefore, imageAfter, caption, orientation } = attributes;
-
+	const { align, imageBefore, imageAfter, caption, orientation } = attributes;
 	// Check for useResizeObserver, not available in older Gutenberg.
 	let resizeListener = null;
 	let sizes = null;
@@ -59,7 +58,7 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 		if ( imageBefore.url && imageAfter.url && typeof juxtapose !== 'undefined' ) {
 			juxtapose.makeSlider( juxtaposeRef?.current );
 		}
-	}, [ imageBefore, imageAfter, orientation ] );
+	}, [ align, imageBefore, imageAfter, orientation ] );
 
 	return (
 		<figure className={ className } id={ clientId }>

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/index.js
@@ -36,6 +36,10 @@ export const settings = {
 		_x( 'slider', 'block search term', 'jetpack' ),
 	],
 
+	supports: {
+		align: [ 'wide', 'full' ],
+	},
+
 	attributes: {
 		imageBefore: {
 			type: 'object',


### PR DESCRIPTION
Fixes #15740 

#### Changes proposed in this Pull Request:

The proposed change adds `wide` and `full` width alignment options to the Image Compare block for better editing experience.

 Before | After |
| ------------- | ------------- |
| ![Markup on 2022-01-11 at 12:48:48](https://user-images.githubusercontent.com/25105483/148937630-9d85af96-50c5-468c-b940-10eeea99ef71.png)  | ![Markup on 2022-01-11 at 12:47:04](https://user-images.githubusercontent.com/25105483/148937622-00a6b95a-a508-4585-92a6-5d774eeab0e4.png)  |

Related issue: https://github.com/Automattic/wp-calypso/issues/47681

#### Jetpack product discussion
This PR is a part of the _Expanding Jetpack Block design tooling for Full Site Editing_ project: pdDOJh-6-p2.

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Create a new post or a page with the Image Compare block
2. There should be a new Align tool in the block toolbar available
3. Change the setting of the Align tool and observe whether the change applies correctly
4. Save the changes and review the block functionality in the front-end as well
5. We can test the change with multiple themes (block-based, classic) and on variety of screen sizes. Not all themes support full / wide width. This means that with some themes, the Align tool won't be visible.