### PR TITLE
Jetpack: port back changelog from 10.5 release branch

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 10.5-beta - 2022-01-04
+## 10.5 - 2022-01-11
 ### Enhancements
 - Print Styles: additional interactive elements are now hidden when printing posts (e.g. Likes, Recommended Posts, Share this).
 - VideoPress: add "allow download" option on videos to allow viewers to download the video.
@@ -23,21 +23,26 @@
 - Jetpack: activate the default modules when the site has already been connected before plugin activation.
 - Jetpack: do not display recommendations during an identity crisis.
 - Search: fix styling conflict for Blank Canvas theme.
+- Security: PDF embeds now only display a link, to avoid issues with malicious PDFss that may run arbitrary code.
 - Settings menu: add Jetpack item for sites with Scan product.
 - Sharing Buttons: rely on official sharing buttons only for Facebook share counts.
 - Stats: do not trigger views when post is embedded into another site.
 - VideoPress: reload embed preview on creation until the video size is known.
 - Vimeo Embeds: support more URL formats, such as videos in playlists.
 - WhatsApp block: fix country code for Cyprus.
+- Widget Visibility: fix "Match All" setting being overwritten on save in the block widget editor.
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AAG upgrade banner: do not display on WoA sites
 - Add get_current_plan() to the WPcom_Admin_Menu.
+- Admin Page: remove CRM card for now.
 - Dashboard: add Jetpack Security Bundle upsell to AAG.
 - Dashboard: add new cards to AAG Dashboard for Boost and CRM plugins.
 - Dashboard: updates the Apps card on the At a Glance page to display links to the Jetpack mobile apps.
 - E2E tests: update readme docs.
 - E2E tests renovate: bump dependencies.
 - Fix a legacy sync test in PHPUnit 9.5.
+- Fix modules using `this` to mean `window`.
 - Hide irrelevant menu items for P2 sites
 - Instant Search: Add missing translator comments and use ordered placeholders in JS sprintf.
 - Janitorial: fix phpcs warnings in multiple widget files.

--- a/projects/plugins/jetpack/changelog/fix-display-bundle-woa
+++ b/projects/plugins/jetpack/changelog/fix-display-bundle-woa
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AAG upgrade banner: do not display on WoA sites

--- a/projects/plugins/jetpack/changelog/fix-install-plugins-aag-multisite
+++ b/projects/plugins/jetpack/changelog/fix-install-plugins-aag-multisite
@@ -1,5 +1,0 @@
-Significance: patch
-Type: bugfix
-Comment: Admin Page: do not show plugin install cards to non-super admins on Multisite network.
-
-

--- a/projects/plugins/jetpack/changelog/fix-jetpack-modules-this-as-window
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-modules-this-as-window
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix modules using `this` to mean `window`.

--- a/projects/plugins/jetpack/changelog/fix-license-button-specificity
+++ b/projects/plugins/jetpack/changelog/fix-license-button-specificity
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/fix-widget-visibility-match-all
+++ b/projects/plugins/jetpack/changelog/fix-widget-visibility-match-all
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Widget Visibility: Fix "Match All" setting being overwritten on save in the block widget editor.

--- a/projects/plugins/jetpack/changelog/jetpack-branch-10.5
+++ b/projects/plugins/jetpack/changelog/jetpack-branch-10.5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/rm-crm-aag-card
+++ b/projects/plugins/jetpack/changelog/rm-crm-aag-card
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Admin Page: remove CRM card for now.

--- a/projects/plugins/jetpack/changelog/update-check_for_alias_textdomains_method
+++ b/projects/plugins/jetpack/changelog/update-check_for_alias_textdomains_method
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Check that the Assets::alias_textdomains_from_file method exists before calling it.
-
-

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -242,13 +242,13 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 4. Promote your newest posts, pages, and products across your social media channels.
 
 == Changelog ==
-### 10.5-beta - 2022-01-04
+### 10.5 - 2022-01-11
 #### Enhancements
 - Print Styles: additional interactive elements are now hidden when printing posts (e.g. Likes, Recommended Posts, Share this).
 - Secure Sign On: add filters for the error text when a local user cannot be found for a given WP.com account and for when SSO is disallowed when on a staging site.
 - Subscription Block: add 'Success Message Text' to the block settings.
 - VideoPress: add "allow download" option on videos to allow viewers to download the video.
-- VideoPress Block: add adaptive progress bar color settings.
+- VideoPress Block: add adaptive progress bar color settings
 - WordAds: add hook for header ad placement, and allow 'leaderboard' size when displaying an ad widget.
 
 #### Improved compatibility
@@ -259,6 +259,7 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 - Pay with PayPal: update the name of the script enqueued when using the Pay with PayPal button as to avoid conflicts with other plugins that may use a similar script tag.
 - Pay with PayPal Widget: hide widget from Legacy Widget block.
 - Stats: remove legacy option to display a Smiley face used for the tracking pixel since the pixel is hidden by default.
+- Twitter Timeline widget: hide widget from the block inserter and Legacy widget block drop-down menu.
 - VideoPress: classic block embeds with old flash URLs can now be properly converted to VideoPress blocks.
 - VideoPress: hide the dedicated VideoPress embed block in favor of Video block.
 
@@ -274,15 +275,16 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 - Jetpack: do not display recommendations during an identity crisis.
 - Milestone widget: fix issue that prevented styles from loading until the widget is saved.
 - Search: fix styling conflict for Blank Canvas theme.
+- Security: PDF embeds now only display a link, to avoid issues with malicious PDFss that may run arbitrary code.
 - Settings menu: add Jetpack item for sites with Scan product.
 - Sharing Buttons: rely on official sharing buttons only for Facebook share counts.
 - Stats: do not trigger views when post is embedded into another site.
-- Twitter Timeline widget: hide widget from the block inserter and Legacy widget block drop-down menu (WPCOM).
 - VideoPress: avoid errors when copying and pasting empty video blocks.
 - VideoPress: reload embed preview on creation until the video size is known.
 - VideoPress Block: maintain the state of different settings panels when reloading the video preview.
 - Vimeo Embeds: support more URL formats, such as videos in playlists.
 - WhatsApp block: fix country code for Cyprus.
+- Widget Visibility: fix "Match All" setting being overwritten on save in the block widget editor.
 
 --------
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, batmoo, barry, beaulebens, biskobe, blobaugh, bjorsch, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, robertbpugh, roccotripaldi, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
-Stable tag: 10.4
+Stable tag: 10.5
 Requires at least: 5.8
 Requires PHP: 5.6
 Tested up to: 5.9


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Ports back changelog & readme changes from the 10.5 release branch.
* Update readme.txt stable tag to match WPorg trunk.

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread changes.
