### PR TITLE
E2E: Fix failing search tests by adjusting E2E build workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,6 +60,7 @@ jobs:
         pnpm install
         pnpx jetpack build packages/search -v --production
         pnpx jetpack build plugins/jetpack -v --production
+        cp -Rfp projects/packages/search/build projects/plugins/jetpack/jetpack_vendor/automattic/jetpack-search
 
     - name: Environment set-up
       working-directory: projects/plugins/jetpack/tests/e2e
@@ -96,37 +97,37 @@ jobs:
         name: test-output-${{ matrix.group }}
         path: projects/plugins/jetpack/tests/e2e/output
 
-    - name: Send Slack notification
-      if: ${{ failure() }}
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      working-directory: projects/plugins/jetpack/tests/e2e
-      run: pnpm slack -- suite $GROUP
+    # - name: Send Slack notification
+    #   if: ${{ failure() }}
+    #   env:
+    #     GITHUB_CONTEXT: ${{ toJson(github) }}
+    #   working-directory: projects/plugins/jetpack/tests/e2e
+    #   run: pnpm slack -- suite $GROUP
 
-  slack-notification:
-    name: "Slack notification"
-    runs-on: ubuntu-latest
-    needs: e2e-tests
-    env:
-      CONFIG_KEY: ${{ secrets.E2E_CONFIG_KEY }}
-      GITHUB_CONTEXT: ${{ toJson(github) }}
+  # slack-notification:
+  #   name: "Slack notification"
+  #   runs-on: ubuntu-latest
+  #   needs: e2e-tests
+  #   env:
+  #     CONFIG_KEY: ${{ secrets.E2E_CONFIG_KEY }}
+  #     GITHUB_CONTEXT: ${{ toJson(github) }}
 
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Setup tools
-        uses: ./.github/actions/tool-setup
-        with:
-          php: false
+  #     - name: Setup tools
+  #       uses: ./.github/actions/tool-setup
+  #       with:
+  #         php: false
 
-      - name: Send Slack notification
-        working-directory: projects/plugins/jetpack/tests/e2e
-        env:
-          RESULT: ${{ needs.e2e-tests.result }}
-        run: |
-          pnpm install
-          pnpm run test-decrypt-all-config
-          pnpm slack -- status $RESULT
+  #     - name: Send Slack notification
+  #       working-directory: projects/plugins/jetpack/tests/e2e
+  #       env:
+  #         RESULT: ${{ needs.e2e-tests.result }}
+  #       run: |
+  #         pnpm install
+  #         pnpm run test-decrypt-all-config
+  #         pnpm slack -- status $RESULT
 
   test-reports:
     name: "Trigger test report workflow"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -54,8 +54,11 @@ jobs:
       uses: ./.github/actions/tool-setup
 
     - name: Build Production Jetpack
+      env:
+        COMPOSER_ROOT_VERSION: "dev-master"
       run: |
         pnpm install
+        pnpx jetpack build packages/search -v --production
         pnpx jetpack build plugins/jetpack -v --production
 
     - name: Environment set-up

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,6 +60,7 @@ jobs:
         pnpm install
         pnpx jetpack build packages/search -v --production
         pnpx jetpack build plugins/jetpack -v --production
+        # composer ingores the build folder when mirroring the package, so we manually copy it.
         cp -Rfp projects/packages/search/build projects/plugins/jetpack/jetpack_vendor/automattic/jetpack-search
 
     - name: Environment set-up

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Run ${{ matrix.group }} tests
       working-directory: projects/plugins/jetpack/tests/e2e
-      run: pnpm run test-e2e -- $TESTS -gv search
+      run: pnpm run test-e2e -- $TESTS
 
     - name: Environment tear-down
       if: ${{ always() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -97,37 +97,37 @@ jobs:
         name: test-output-${{ matrix.group }}
         path: projects/plugins/jetpack/tests/e2e/output
 
-    # - name: Send Slack notification
-    #   if: ${{ failure() }}
-    #   env:
-    #     GITHUB_CONTEXT: ${{ toJson(github) }}
-    #   working-directory: projects/plugins/jetpack/tests/e2e
-    #   run: pnpm slack -- suite $GROUP
+    - name: Send Slack notification
+      if: ${{ failure() }}
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      working-directory: projects/plugins/jetpack/tests/e2e
+      run: pnpm slack -- suite $GROUP
 
-  # slack-notification:
-  #   name: "Slack notification"
-  #   runs-on: ubuntu-latest
-  #   needs: e2e-tests
-  #   env:
-  #     CONFIG_KEY: ${{ secrets.E2E_CONFIG_KEY }}
-  #     GITHUB_CONTEXT: ${{ toJson(github) }}
+  slack-notification:
+    name: "Slack notification"
+    runs-on: ubuntu-latest
+    needs: e2e-tests
+    env:
+      CONFIG_KEY: ${{ secrets.E2E_CONFIG_KEY }}
+      GITHUB_CONTEXT: ${{ toJson(github) }}
 
-  #   steps:
-  #     - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - name: Setup tools
-  #       uses: ./.github/actions/tool-setup
-  #       with:
-  #         php: false
+      - name: Setup tools
+        uses: ./.github/actions/tool-setup
+        with:
+          php: false
 
-  #     - name: Send Slack notification
-  #       working-directory: projects/plugins/jetpack/tests/e2e
-  #       env:
-  #         RESULT: ${{ needs.e2e-tests.result }}
-  #       run: |
-  #         pnpm install
-  #         pnpm run test-decrypt-all-config
-  #         pnpm slack -- status $RESULT
+      - name: Send Slack notification
+        working-directory: projects/plugins/jetpack/tests/e2e
+        env:
+          RESULT: ${{ needs.e2e-tests.result }}
+        run: |
+          pnpm install
+          pnpm run test-decrypt-all-config
+          pnpm slack -- status $RESULT
 
   test-reports:
     name: "Trigger test report workflow"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Adds `packages/search` production build step before running E2E tests. And as `composer` ignores the built search assets ( because they are in `.gitignore` ), we added a step to manually copy them over. @samiff suggests that newer version of `composer` might have addressed the issue, we could possibly remove the copying process in the future.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Ensure that the post-connection E2E tests pass.
- Ensure that the changes look reasonable
