### PR TITLE
My Jetpack: first implementation of plans section

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -15,6 +15,7 @@ import {
 import { ConnectionStatusCard } from '@automattic/jetpack-connection';
 
 import './style.scss';
+import PlanSection from '../plan-section';
 
 /**
  * The My Jetpack App Main Screen.
@@ -45,7 +46,7 @@ export default function MyJetpackScreen() {
 				<AdminSection>
 					<Row>
 						<Col lg={ 6 } sm={ 4 }>
-							<h1>{ __( 'My Plan', 'jetpack-my-jetpack' ) }</h1>
+							<PlanSection />
 						</Col>
 						<Col lg={ 6 } sm={ 4 }>
 							<ConnectionStatusCard

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -15,7 +15,7 @@ import {
 import { ConnectionStatusCard } from '@automattic/jetpack-connection';
 
 import './style.scss';
-import PlanSection from '../plan-section';
+import PlansSection from '../plans-section';
 
 /**
  * The My Jetpack App Main Screen.
@@ -46,7 +46,7 @@ export default function MyJetpackScreen() {
 				<AdminSection>
 					<Row>
 						<Col lg={ 6 } sm={ 4 }>
-							<PlanSection />
+							<PlansSection />
 						</Col>
 						<Col lg={ 6 } sm={ 4 }>
 							<ConnectionStatusCard

--- a/projects/packages/my-jetpack/_inc/components/plan-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plan-section/index.jsx
@@ -9,10 +9,22 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import usePlan from '../../hooks/use-plan';
+
+/**
  * Plan section component.
  *
  * @returns {object} PlanSection React component.
  */
 export default function PlanSection() {
-	return <h1>{ __( 'My Plan', 'jetpack-my-jetpack' ) }</h1>;
+	const { name } = usePlan();
+	return (
+		<div>
+			<h1>{ __( 'Your plan', 'jetpack-my-jetpack' ) }</h1>
+			<p>{ __( 'The extra power you added to your Jetpack.', 'jetpack-my-jetpack' ) }</p>
+			{ name }
+		</div>
+	);
 }

--- a/projects/packages/my-jetpack/_inc/components/plan-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plan-section/index.jsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Plan section component.
+ *
+ * @returns {object} PlanSection React component.
+ */
+export default function PlanSection() {
+	return <h1>{ __( 'My Plan', 'jetpack-my-jetpack' ) }</h1>;
+}

--- a/projects/packages/my-jetpack/_inc/components/plan-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plan-section/index.jsx
@@ -19,12 +19,14 @@ import usePlan from '../../hooks/use-plan';
  * @returns {object} PlanSection React component.
  */
 export default function PlanSection() {
-	const { name } = usePlan();
+	const { name, billingPeriod } = usePlan();
 	return (
 		<div>
 			<h1>{ __( 'Your plan', 'jetpack-my-jetpack' ) }</h1>
 			<p>{ __( 'The extra power you added to your Jetpack.', 'jetpack-my-jetpack' ) }</p>
-			{ name }
+
+			<h2>{ name }</h2>
+			<p>{ billingPeriod }</p>
 		</div>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -22,7 +22,7 @@ export default function PlansSection() {
 	const { name, billingPeriod } = usePlan();
 	return (
 		<div>
-			<h1>{ __( 'Your plan', 'jetpack-my-jetpack' ) }</h1>
+			<h1>{ __( 'My Plan', 'jetpack-my-jetpack' ) }</h1>
 			<p>{ __( 'The extra power you added to your Jetpack.', 'jetpack-my-jetpack' ) }</p>
 
 			<h2>{ name }</h2>

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -16,9 +16,9 @@ import usePlan from '../../hooks/use-plan';
 /**
  * Plan section component.
  *
- * @returns {object} PlanSection React component.
+ * @returns {object} PlansSection React component.
  */
-export default function PlanSection() {
+export default function PlansSection() {
 	const { name, billingPeriod } = usePlan();
 	return (
 		<div>

--- a/projects/packages/my-jetpack/_inc/hooks/use-plan/Readme.md
+++ b/projects/packages/my-jetpack/_inc/hooks/use-plan/Readme.md
@@ -1,0 +1,13 @@
+# usePlan
+
+Simple React custom hook that provides data about the current site plan.
+
+
+```es6
+import usePlan from './hooks/use-plan';
+
+function PlanSection() {
+	const { name } = usePlan();
+	return <h1>{ name ) }</h1>;
+}
+```

--- a/projects/packages/my-jetpack/_inc/hooks/use-plan/Readme.md
+++ b/projects/packages/my-jetpack/_inc/hooks/use-plan/Readme.md
@@ -6,7 +6,7 @@ Simple React custom hook that provides data about the current site plan.
 ```es6
 import usePlan from './hooks/use-plan';
 
-function PlanSection() {
+function PlansSection() {
 	const { name } = usePlan();
 	return <h1>{ name ) }</h1>;
 }

--- a/projects/packages/my-jetpack/_inc/hooks/use-plan/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-plan/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+// Site plan is provided by the `/my-jetpack/v1/site` endpoint response.
+const REST_API_SITE_PLANS_ENDPOINT = 'my-jetpack/v1/site';
+
+/**
+ * Map plan data to a more usable format.
+ *
+ * @param {object} plan - raw plan data.
+ * @returns {object} enriched plan data
+ */
+function mapPlanData( plan = {} ) {
+	return {
+		...plan,
+		name: plan.product_name,
+		shorName: plan.product_name_short,
+	};
+}
+
+/**
+ * React custom hook to get the site plan data.
+ *
+ * @returns {object} site plan data
+ */
+export default function usePlans() {
+	const [ data, setData ] = useState( {} );
+
+	useEffect( () => {
+		apiFetch( { path: REST_API_SITE_PLANS_ENDPOINT } )
+			.then( res => setData( mapPlanData( res?.plan ) ) )
+			.catch( () => setData( {} ) );
+	}, [ setData ] );
+
+	return data;
+}

--- a/projects/packages/my-jetpack/_inc/hooks/use-plan/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-plan/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 // Site plan is provided by the `/my-jetpack/v1/site` endpoint response.
@@ -18,6 +19,11 @@ function mapPlanData( plan = {} ) {
 		...plan,
 		name: plan.product_name,
 		shorName: plan.product_name_short,
+		billingPeriod: sprintf(
+			/* translators: placeholder is the billing period of the plan (e.g. Montly, Annual, ...) */
+			__( '%s subscription', 'jetpack-my-jetpack' ),
+			plan.billing_period
+		),
 	};
 }
 

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-fetch-site-features
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-fetch-site-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: first PlanSection implementation

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "0.3.1",
+	"version": "0.3.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -9,7 +9,9 @@ namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Client as Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 
 /**
  * The main Initializer class that registers the admin menu and eneuque the assets.
@@ -30,6 +32,12 @@ class Initializer {
 		if ( ! defined( 'JETPACK_ENABLE_MY_JETPACK' ) || ! JETPACK_ENABLE_MY_JETPACK ) {
 			return;
 		}
+
+		// Set up the REST authentication hooks.
+		Connection_Rest_Authentication::init();
+
+		// Add custom WP REST API endoints.
+		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
 
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'My Jetpack', 'jetpack-my-jetpack' ),
@@ -97,5 +105,91 @@ class Initializer {
 	 */
 	public static function admin_page() {
 		echo '<div id="my-jetpack-container"></div>';
+	}
+
+	/**
+	 * Register the REST API routes.
+	 *
+	 * @return void
+	 */
+	public static function register_rest_routes() {
+		register_rest_route(
+			'my-jetpack/v1',
+			'/site',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::get_site',
+				'permission_callback' => __CLASS__ . '::permissions_callback',
+			)
+		);
+
+		register_rest_route(
+			'my-jetpack/v1',
+			'/site/plans',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::get_site_plans',
+				'permission_callback' => __CLASS__ . '::permissions_callback',
+			)
+		);
+	}
+
+	/**
+	 * Check user capability to access the endpoint.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function permissions_callback() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Site full-data endpoint.
+	 *
+	 * @return object Site data.
+	 */
+	public static function get_site() {
+		$site_id           = \Jetpack_Options::get_option( 'id' );
+		$wpcom_endpoint    = sprintf( '/sites/%d?force=wpcom', $site_id );
+		$wpcom_api_version = '1.1';
+		$response          = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $wpcom_api_version );
+		$response_code     = wp_remote_retrieve_response_code( $response );
+		$body              = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
+			return new \WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ) );
+		}
+
+		return rest_ensure_response( $body, 200 );
+	}
+
+	/**
+	 * Site plans endpoint.
+	 *
+	 * @return array Site plans.
+	 */
+	public static function get_site_plans() {
+		$wpcom_endpoint    = sprintf( '/plans?_locale=%s?force=wpcom', get_user_locale() );
+		$wpcom_api_version = '2';
+		$response          = Client::wpcom_json_api_request_as_user(
+			$wpcom_endpoint,
+			$wpcom_api_version,
+			array(
+				'headers' => array(
+					'X-Forwarded-For' => \Jetpack::current_user_ip( true ),
+				),
+			)
+		);
+		$response_code     = wp_remote_retrieve_response_code( $response );
+		$body              = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error( 'site_plans_data_fetch_failed', 'Site plans data fetch failed', array( 'status' => $response_code ) );
+		}
+
+		return rest_ensure_response( $body, 200 );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #22288

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR does the first implementation of the Plan section. The most relevant parts of it:

* Data propagation, end to end from wpcom to the client/frontend
* Deal with data adding the `usePlan()`  custom hook
* Pretty basic `<PlansSection />` component.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes
* Go to My Jetpack section
* Confirm you see the pretty basic Plan section there.

<img width="968" alt="Screen Shot 2022-01-12 at 11 40 33 AM" src="https://user-images.githubusercontent.com/746152/149332942-e60e52cb-8b41-41c3-9fbb-5137fcc03d44.png">

* you can take a look at how the client performs the endpoint request
`https://retrowolf.ngrok.io/wp-json/my-jetpack/v1/site`
![image](https://user-images.githubusercontent.com/77539/149166640-3a64beba-bd98-4c75-a676-e7d3fcc6e921.png)

* also, inspect the `<PlansSection />` component.
<img width="822" alt="Screen Shot 2022-01-12 at 12 09 30 PM" src="https://user-images.githubusercontent.com/77539/149166840-6a27da1a-165f-429f-8223-19607b1be5cf.png">


