### PR TITLE
Site Settings: Default to empty array for WooCommerce Onboarding Profile

### DIFF
--- a/projects/plugins/jetpack/changelog/update-settings-default-values
+++ b/projects/plugins/jetpack/changelog/update-settings-default-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Changes the default value of woocommerce_onboarding_profile from array( 0 => false ) to array()

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -416,7 +416,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'date_format'                      => get_option( 'date_format' ),
 						'time_format'                      => get_option( 'time_format' ),
 						'start_of_week'                    => get_option( 'start_of_week' ),
-						'woocommerce_onboarding_profile'   => (array) get_option( 'woocommerce_onboarding_profile' ),
+						'woocommerce_onboarding_profile'   => (array) get_option( 'woocommerce_onboarding_profile', array() ),
 						'woocommerce_store_address'        => (string) get_option( 'woocommerce_store_address' ),
 						'woocommerce_store_address_2'      => (string) get_option( 'woocommerce_store_address_2' ),
 						'woocommerce_store_city'           => (string) get_option( 'woocommerce_store_city' ),

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -289,7 +289,7 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 			'woocommerce_store_city'         => array( 'woocommerce_store_city', '' ),
 			'woocommerce_default_country'    => array( 'woocommerce_default_country', '' ),
 			'woocommerce_store_postcode'     => array( 'woocommerce_store_postcode', '' ),
-			'woocommerce_onboarding_profile' => array( 'woocommerce_onboarding_profile', array( false ) ),
+			'woocommerce_onboarding_profile' => array( 'woocommerce_onboarding_profile', array() ),
 		);
 	}
 


### PR DESCRIPTION
An array with the value of false is not what we're looking for.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes the default value of `woocommerce_onboarding_profile` from `array( 0 => false )` to `array()`.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Run unit tests with the command: `jetpack docker phpunit -- --filter=WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint`


