### PR TITLE
Contact Info block: Add color, typography and spacing features

### DIFF
--- a/projects/plugins/jetpack/changelog/add-contact-info-block-color-typography-spacing-features
+++ b/projects/plugins/jetpack/changelog/add-contact-info-block-color-typography-spacing-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Contact Info block: Add color, typography and spacing features

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/index.js
@@ -51,6 +51,17 @@ export const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
+		color: {
+			link: true,
+			gradients: true,
+		},
+		spacing: {
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+		},
 	},
 	// Transform from classic widget
 	transforms: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The proposed change adds color, typography and spacing (padding) features to the Contact Info block.

 Before | After |
| ------------- | ------------- |
| ![Markup on 2022-01-13 at 14:24:59](https://user-images.githubusercontent.com/25105483/149338638-47728020-7907-4ce9-b562-26deb838b081.png) | ![Markup on 2022-01-13 at 14:26:04](https://user-images.githubusercontent.com/25105483/149338709-38b41f21-ef4b-4b6d-9015-8b8a1b2b6838.png) |

#### Jetpack product discussion
This PR is a part of the _Expanding Jetpack Block design tooling for Full Site Editing_ project: pdDOJh-6-p2.

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Create a new post or a page with the Contact Info block
2. There should be a new set of features (colors, typography and spacing) in the block sidebar.
3. Experiment with the new features and observe whether the change applies correctly in the back-end
4. Save the changes and review if the settings are correctly rendering in the front-end as well
5. We can test the change with multiple themes (block-based, classic). Not all themes support all features. If a theme doesn't support a specific feature, this feature won't be displayed in the block sidebar.

Some of the themes that support all features proposed in this PR: `Geologist`, `Quadrat`, `Seedlet (Blocks)`, `TT1 (Blocks)`.

Please note that the **Link Color** setting is currently broken in at least two themes:
- Twenty Twenty-One: https://github.com/Automattic/themes/issues/5016#issuecomment-1012108530
- Seedlet: https://github.com/Automattic/themes/issues/2566#issuecomment-1012043527