### PR TITLE
composer-plugin: Recognize composer's 4-component versions

### DIFF
--- a/projects/packages/composer-plugin/changelog/fix-composer-plugin-versions
+++ b/projects/packages/composer-plugin/changelog/fix-composer-plugin-versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Composer's `getVersion()` likes to return 4-component versions, while semver wants only 3 components. Strip any extra components instead of considering that invalid.

--- a/projects/packages/composer-plugin/src/class-plugin.php
+++ b/projects/packages/composer-plugin/src/class-plugin.php
@@ -110,6 +110,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			if ( isset( $extra['branch-alias'][ $ver ] ) ) {
 				$ver = $extra['branch-alias'][ $ver ];
 			}
+
+			// Composer's `getVersion()` seems to like to return a 4-component version, while semver wants only 3 components. Strip any extra components.
+			$ver = preg_replace( '/^(\d+\.\d+\.\d+)(?:\.\d+)+/', '$1', $ver );
+
 			if ( ! preg_match( '/^\d+\.\d+\.\d+(?:-[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$/', $ver ) ) {
 				// Invalid version, skip it.
 				$ver = '0.0.0';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Composer's `getVersion()` likes to return 4-component versions, while
semver only allows for three components. Strip the extra component when
generating the i18n map file.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Check out jetpack/branch-10.5
2. Cherry-pick this PR
3. `cd projects/plugins/jetpack`
4. `composer config repositories.0 path ../../packages/composer-plugin/`
5. `composer update automattic/jetpack-composer-plugin`
6. Examine `jetpack_vendor/i18n-map.php`. Packages should have correct version numbers, not "0.0.0".