### PR TITLE
My Jetpack: Janitorial - Fix typo in method name enqueue_scripts

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-typo-my-jetpack-scripts
+++ b/projects/packages/my-jetpack/changelog/fix-typo-my-jetpack-scripts
@@ -1,0 +1,4 @@
+Significance: major
+Type: fixed
+
+Rename method enqueue_scritps to enqueue_scripts

--- a/projects/packages/my-jetpack/changelog/fix-typo-my-jetpack-scripts
+++ b/projects/packages/my-jetpack/changelog/fix-typo-my-jetpack-scripts
@@ -1,4 +1,4 @@
-Significance: major
+Significance: patch
 Type: fixed
 
 Rename method enqueue_scritps to enqueue_scripts

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -64,7 +64,7 @@ class Initializer {
 	 * @return void
 	 */
 	public static function admin_init() {
-		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scritps' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
 	}
 
 	/**
@@ -72,7 +72,7 @@ class Initializer {
 	 *
 	 * @return void
 	 */
-	public static function enqueue_scritps() {
+	public static function enqueue_scripts() {
 		Assets::register_script(
 			'my_jetpack_main_app',
 			'../build/index.js',


### PR DESCRIPTION
Updates `Initializer: enqueue_scritps()` to  `Initializer: enqueue_scripts()` 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Renames the method as it had a typo

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

Incoming
