### PR TITLE
My Jetpack: Update Plans Section style

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -11,6 +11,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import './style.scss';
+
 import usePlan from '../../hooks/use-plan';
 
 /**
@@ -21,11 +23,11 @@ import usePlan from '../../hooks/use-plan';
 export default function PlansSection() {
 	const { name, billingPeriod } = usePlan();
 	return (
-		<div>
-			<h1>{ __( 'My Plan', 'jetpack-my-jetpack' ) }</h1>
+		<div className="jp-plans-section">
+			<h3>{ __( 'My Plan', 'jetpack-my-jetpack' ) }</h3>
 			<p>{ __( 'The extra power you added to your Jetpack.', 'jetpack-my-jetpack' ) }</p>
 
-			<h2>{ name }</h2>
+			<h4>{ name }</h4>
 			<p>{ billingPeriod }</p>
 		</div>
 	);

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.scss
@@ -1,0 +1,34 @@
+@import '@automattic/jetpack-base-styles/style';
+
+.jp-plans-section {
+	h3 {
+		font-size: var(--font-title-large);
+		font-weight: 700;
+		margin-top: 48px;
+		line-height: 1.1;
+		color: var( --jp-black );
+		margin: 0;
+	}
+
+	h4 {
+		font-size: var(--font-title-small);
+		font-weight: 500;
+		line-height: 1;
+		color: var( --jp-black );
+	}
+
+	a, a:active, a:hover {
+		color: var( --jp-black );
+	}
+
+	p {
+		margin: 16px 0;
+		color: var( --jp-black );
+	}
+
+	p, a, li {
+		font-size: var( --font-body );
+		line-height: 24px;
+	}
+
+}

--- a/projects/packages/my-jetpack/changelog/update-plans-section-style
+++ b/projects/packages/my-jetpack/changelog/update-plans-section-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Properly style the Plans Section according to proposed design


### PR DESCRIPTION
Fixes #22330

Updates the style of the Plans Section according to proposed design

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces style.scss for the Plans Section component
* Uses style resembling the proposed one



#### After

![image](https://user-images.githubusercontent.com/746152/149413221-2563ef38-31bd-4a7c-949a-c7383af423e0.png)

#### Before

![image](https://user-images.githubusercontent.com/746152/149413433-fd319c89-e4ff-42fa-afd8-239fc127305f.png)

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Checkout this branch
* Build with `jetpack build packages/my-jetpack`.
* Have Jetpack Backup and a plan for it (either Upgrade to Security or Backup)
* Checkout the My Jetpack page.
* Confirm the styles look updated
* Note the updated styles for the Plans section even though it looks different than the Connection Section
