### PR TITLE
My Jetpack: Add scripts for JS tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,7 @@ importers:
       '@wordpress/i18n': 4.2.4
       enzyme: 3.11.0
       jest: 27.3.1
+      jetpack-js-test-runner: workspace:1.0.0
       react: 17.0.2
       react-dom: 17.0.2
       sass: 1.43.3
@@ -627,6 +628,7 @@ importers:
       '@babel/runtime': 7.16.3
       enzyme: 3.11.0
       jest: 27.3.1
+      jetpack-js-test-runner: link:../../../tools/js-test-runner
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       sass: 1.43.3
@@ -19695,7 +19697,7 @@ packages:
     dependencies:
       array.prototype.flat: 1.2.5
       global-cache: 1.2.1
-      react-with-styles: 3.2.3
+      react-with-styles: 3.2.3_react-dom@17.0.2+react@17.0.2
 
   /react-with-styles/3.2.3:
     resolution: {integrity: sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==}
@@ -20749,7 +20751,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.43.3
-      webpack: 5.65.0_webpack-cli@4.9.1
+      webpack: 5.65.0
     dev: true
 
   /sass-loader/12.4.0_webpack@5.65.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,6 +601,11 @@ importers:
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
       '@babel/runtime': 7.16.3
+      '@testing-library/dom': 8.11.1
+      '@testing-library/jest-dom': 5.14.1
+      '@testing-library/react': 11.2.7
+      '@testing-library/react-hooks': 4.0.1
+      '@testing-library/user-event': 12.8.3
       '@wordpress/components': 19.1.6
       '@wordpress/data': 6.1.5
       '@wordpress/i18n': 4.2.4
@@ -626,6 +631,11 @@ importers:
       '@babel/preset-env': 7.16.4_@babel+core@7.16.0
       '@babel/register': 7.16.0_@babel+core@7.16.0
       '@babel/runtime': 7.16.3
+      '@testing-library/dom': 8.11.1
+      '@testing-library/jest-dom': 5.14.1
+      '@testing-library/react': 11.2.7_react-dom@17.0.2+react@17.0.2
+      '@testing-library/react-hooks': 4.0.1_react@17.0.2
+      '@testing-library/user-event': 12.8.3_@testing-library+dom@8.11.1
       enzyme: 3.11.0
       jest: 27.3.1
       jetpack-js-test-runner: link:../../../tools/js-test-runner
@@ -6171,7 +6181,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.16.7
       '@types/aria-query': 4.2.2
       aria-query: 4.2.2
       chalk: 4.1.2
@@ -6184,14 +6194,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.16.7
       '@types/aria-query': 4.2.2
       aria-query: 5.0.0
       chalk: 4.1.2
       dom-accessibility-api: 0.5.10
       lz-string: 1.4.4
       pretty-format: 27.4.6
-    dev: false
 
   /@testing-library/jest-dom/5.14.1:
     resolution: {integrity: sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==}
@@ -6242,6 +6251,18 @@ packages:
       react-test-renderer: 17.0.2_react@17.0.2
     dev: true
 
+  /@testing-library/react-hooks/4.0.1_react@17.0.2:
+    resolution: {integrity: sha512-DufI8Q2GOM7W2yFEEfz85VNVNaHZL0tPZyBT6ytV7HK+1A4frL1ty+W5NBE0u0K3EFV/Pg5O28HGNEtp9D5EyA==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-test-renderer: '>=16.9.0'
+    dependencies:
+      '@babel/runtime': 7.16.7
+      '@types/react': 17.0.38
+      '@types/react-test-renderer': 17.0.1
+      react: 17.0.2
+    dev: true
+
   /@testing-library/react/11.2.7:
     resolution: {integrity: sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==}
     engines: {node: '>=10'}
@@ -6260,7 +6281,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.16.7
       '@testing-library/dom': 7.31.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -6282,9 +6303,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.16.7
       '@testing-library/dom': 8.11.1
-    dev: false
 
   /@tootallnate/once/1.1.2:
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
@@ -8232,7 +8252,7 @@ packages:
     resolution: {integrity: sha512-5hZDhFwTtKcbJGZdqvIzoLsW/QgBjUjf4ohgDqRlMBX8Zi6/n11O8LDRPOpmJLVSnIx1fgNSGkzXOzzQmbWuqQ==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.16.7
       moment: 2.29.1
       moment-timezone: 0.5.34
 
@@ -8455,7 +8475,7 @@ packages:
     resolution: {integrity: sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.16.7
 
   /@wordpress/html-entities/3.2.3:
     resolution: {integrity: sha512-406VUz8CuKgKGrW/wjRB877soSqGhGDwK4sSuNoIC1FvpfniZ0ijpqfsdhJOOynWdz+RYN1wAsfogBpzuREJOg==}
@@ -9487,7 +9507,6 @@ packages:
   /aria-query/5.0.0:
     resolution: {integrity: sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==}
     engines: {node: '>=6.0'}
-    dev: false
 
   /arr-diff/4.0.0:
     resolution: {integrity: sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=}
@@ -21202,6 +21221,7 @@ packages:
 
   /source-map-resolve/0.6.0:
     resolution: {integrity: sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==}
+    deprecated: See https://github.com/lydell/source-map-resolve#deprecated
     dependencies:
       atob: 2.1.2
       decode-uri-component: 0.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,6 +601,7 @@ importers:
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
       '@babel/runtime': 7.16.3
+      '@storybook/testing-react': 1.2.3
       '@testing-library/dom': 8.11.1
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/react': 11.2.7
@@ -631,6 +632,7 @@ importers:
       '@babel/preset-env': 7.16.4_@babel+core@7.16.0
       '@babel/register': 7.16.0_@babel+core@7.16.0
       '@babel/runtime': 7.16.3
+      '@storybook/testing-react': 1.2.3_react@17.0.2
       '@testing-library/dom': 8.11.1
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/react': 11.2.7_react-dom@17.0.2+react@17.0.2
@@ -6071,6 +6073,20 @@ packages:
       synchronous-promise: 2.0.15
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
+    dev: true
+
+  /@storybook/testing-react/1.2.3_react@17.0.2:
+    resolution: {integrity: sha512-4KK2cdux58bO5NToGdo/Y3HQXL26CsHSo3cqbrowrIZL5JW/gcFFUbYEAwjcn+Cf2vy+FnZAKOXfCZf+j1yRdQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@storybook/addons': '>=6.4.0'
+      '@storybook/client-api': '>=6.4.0'
+      '@storybook/preview-web': '>=6.4.0'
+      '@storybook/react': '>=6.4.0'
+      react: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@storybook/csf': 0.0.2--canary.87bc651.0
+      react: 17.0.2
     dev: true
 
   /@storybook/theming/6.4.10_react-dom@17.0.2+react@17.0.2:

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-unit-tests-scripts
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-unit-tests-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add scripts for JS tests

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -23,11 +23,23 @@
 		],
 		"test-coverage": [
 			"@composer install",
-			"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+			"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\"",
+			"pnpm install",
+			"pnpm run test -- --coverageDirectory=\"$COVERAGE_DIR\" --coverage"
 		],
 		"test-php": [
 			"@composer install",
 			"@composer phpunit"
+		],
+		"test-js": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm install",
+			"pnpm run test"
+		],
+		"test-js-watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm install",
+			"pnpm run test -- --watch"
 		],
 		"build-development": [
 			"Composer\\Config::disableProcessTimeout",

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -23,9 +23,9 @@
 		],
 		"test-coverage": [
 			"@composer install",
-			"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\"",
+			"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/coverage.xml\"",
 			"pnpm install",
-			"pnpm run test -- --coverageDirectory=\"$COVERAGE_DIR\" --coverage"
+			"pnpm run test -- --coverageDirectory=\"$COVERAGE_DIR\" --coverage --coverageReporters=clover"
 		],
 		"test-php": [
 			"@composer install",

--- a/projects/packages/my-jetpack/jest.setup.js
+++ b/projects/packages/my-jetpack/jest.setup.js
@@ -1,0 +1,4 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -19,7 +19,7 @@
 		"clean": "rm -rf build/",
 		"install-if-deps-outdated": "pnpm install --no-prod --frozen-lockfile",
 		"watch": "pnpm run build && pnpm webpack watch",
-		"test": "js-test-runner jest"
+		"test": "js-test-runner jest --passWithNoTests"
 	},
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:^0.10.1-alpha",

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -19,7 +19,7 @@
 		"clean": "rm -rf build/",
 		"install-if-deps-outdated": "pnpm install --no-prod --frozen-lockfile",
 		"watch": "pnpm run build && pnpm webpack watch",
-		"test": "js-test-runner jest --passWithNoTests"
+		"test": "js-test-runner jest --passWithNoTests --setupFilesAfterEnv ./jest.setup.js"
 	},
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:^0.10.1-alpha",
@@ -39,6 +39,11 @@
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",
 		"@babel/runtime": "7.16.3",
+		"@testing-library/dom": "8.11.1",
+		"@testing-library/jest-dom": "5.14.1",
+		"@testing-library/react": "11.2.7",
+		"@testing-library/react-hooks": "4.0.1",
+		"@testing-library/user-event": "12.8.3",
 		"enzyme": "3.11.0",
 		"jest": "27.3.1",
 		"jetpack-js-test-runner": "workspace:1.0.0",

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -18,7 +18,8 @@
 		"build-client": "pnpm webpack --config webpack.config.js",
 		"clean": "rm -rf build/",
 		"install-if-deps-outdated": "pnpm install --no-prod --frozen-lockfile",
-		"watch": "pnpm run build && pnpm webpack watch"
+		"watch": "pnpm run build && pnpm webpack watch",
+		"test": "js-test-runner jest"
 	},
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:^0.10.1-alpha",
@@ -40,6 +41,7 @@
 		"@babel/runtime": "7.16.3",
 		"enzyme": "3.11.0",
 		"jest": "27.3.1",
+		"jetpack-js-test-runner": "workspace:1.0.0",
 		"react": "17.0.2",
 		"react-dom": "17.0.2",
 		"sass": "1.43.3",

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -39,6 +39,7 @@
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",
 		"@babel/runtime": "7.16.3",
+		"@storybook/testing-react": "1.2.3",
 		"@testing-library/dom": "8.11.1",
 		"@testing-library/jest-dom": "5.14.1",
 		"@testing-library/react": "11.2.7",

--- a/projects/plugins/backup/changelog/update-my-jetpack-unit-tests-scripts
+++ b/projects/plugins/backup/changelog/update-my-jetpack-unit-tests-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer.lock

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -793,7 +793,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "eb74cc3b7a6ca1038ed138d62a49a70ac90c0e2f"
+                "reference": "33da255534e1873fd121712cb488b38ebd3e930e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -827,11 +827,23 @@
                 ],
                 "test-coverage": [
                     "@composer install",
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/coverage.xml\"",
+                    "pnpm install",
+                    "pnpm run test -- --coverageDirectory=\"$COVERAGE_DIR\" --coverage --coverageReporters=clover"
                 ],
                 "test-php": [
                     "@composer install",
                     "@composer phpunit"
+                ],
+                "test-js": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm install",
+                    "pnpm run test"
+                ],
+                "test-js-watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm install",
+                    "pnpm run test -- --watch"
                 ],
                 "build-development": [
                     "Composer\\Config::disableProcessTimeout",

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-unit-tests-scripts
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-unit-tests-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update composer.lock

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1196,7 +1196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "eb74cc3b7a6ca1038ed138d62a49a70ac90c0e2f"
+                "reference": "33da255534e1873fd121712cb488b38ebd3e930e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1230,11 +1230,23 @@
                 ],
                 "test-coverage": [
                     "@composer install",
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/coverage.xml\"",
+                    "pnpm install",
+                    "pnpm run test -- --coverageDirectory=\"$COVERAGE_DIR\" --coverage --coverageReporters=clover"
                 ],
                 "test-php": [
                     "@composer install",
                     "@composer phpunit"
+                ],
+                "test-js": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm install",
+                    "pnpm run test"
+                ],
+                "test-js-watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm install",
+                    "pnpm run test -- --watch"
                 ],
                 "build-development": [
                     "Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Include scripts for `test`, `watch` and `coverage` related with JS files.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `test` script into `package.json`.
* Add `test-js`, `test-js-watch` into `composer.json`.
* Add JS coverage into `test-coverage`.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

_To run general all tests_

* Run `jetpack test packages/my-jetpack js`
* Tests will run

_To enter watch mode_

* Run `jetpack test packages/my-jetpack js-watch`
* It will enter into watch mode.

_To run coverage_

* Run `jetpack test packages/my-jetpack coverage`
* Tests will run and `coverage` folder will be created.

_To run with COVERAGE_DIR_

* Run `COVERAGE_DIR=agora jetpack test packages/my-jetpack coverage`
* Tests will run and `agora` folder will be created.