### PR TITLE
[JS-package: Connection] Fixed style for button on Required Plan screen

### DIFF
--- a/projects/js-packages/connection/changelog/update-connect-plan-button
+++ b/projects/js-packages/connection/changelog/update-connect-plan-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed styling on Required Plan button

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -25,7 +25,7 @@
 			left: 62%;
 		}
 
-		.components-button  {
+		.jp-action-button--button.components-button  {
 			width: 100%;
 			height: auto;
 			font-size: 18px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixed the style overrides for the Get Jetpack Backup button

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start a JN site with the Backup Plugin
* Visit the connection screen and ensure the Required Plan connection screen matches Storybook
Storybook: https://automattic.github.io/jetpack-storybook/?path=/docs/connection-connect-screen-with-required-plan--default
