### PR TITLE
Assets: Handle `WP_CONTENT_DIR` not in `ABSPATH`

### DIFF
--- a/projects/packages/assets/changelog/fix-assets-contentdir-not-in-abspath
+++ b/projects/packages/assets/changelog/fix-assets-contentdir-not-in-abspath
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Handle the case where `WP_LANG_DIR` is in `WP_CONTENT_DIR`, but `WP_CONTENT_DIR` is not in `ABSPATH`.

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -443,10 +443,13 @@ class Assets {
 			'domainMap' => array(),
 		);
 
-		$lang_dir = Jetpack_Constants::get_constant( 'WP_LANG_DIR' );
-		$abspath  = Jetpack_Constants::get_constant( 'ABSPATH' );
+		$lang_dir    = Jetpack_Constants::get_constant( 'WP_LANG_DIR' );
+		$content_dir = Jetpack_Constants::get_constant( 'WP_CONTENT_DIR' );
+		$abspath     = Jetpack_Constants::get_constant( 'ABSPATH' );
 
-		if ( strpos( $lang_dir, $abspath ) === 0 ) {
+		if ( strpos( $lang_dir, $content_dir ) === 0 ) {
+			$data['baseUrl'] = content_url( substr( trailingslashit( $lang_dir ), strlen( trailingslashit( $content_dir ) ) ) );
+		} elseif ( strpos( $lang_dir, $abspath ) === 0 ) {
 			$data['baseUrl'] = site_url( substr( trailingslashit( $lang_dir ), strlen( untrailingslashit( $abspath ) ) ) );
 		}
 

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -642,8 +642,9 @@ class AssetsTest extends TestCase {
 		);
 
 		$constants = $options['constants'] + array(
-			'ABSPATH'     => '/path/to/wordpress/',
-			'WP_LANG_DIR' => '/path/to/wordpress/wp-content/languages',
+			'ABSPATH'        => '/path/to/wordpress/',
+			'WP_CONTENT_DIR' => '/path/to/wordpress/wp-content',
+			'WP_LANG_DIR'    => '/path/to/wordpress/wp-content/languages',
 		);
 		foreach ( $constants as $k => $v ) {
 			Jetpack_Constants::set_constant( $k, $v );
@@ -655,6 +656,11 @@ class AssetsTest extends TestCase {
 		Functions\expect( 'site_url' )->andReturnUsing(
 			function ( $v ) {
 				return "http://example.com$v";
+			}
+		);
+		Functions\expect( 'content_url' )->andReturnUsing(
+			function ( $v ) {
+				return "http://example.com/wp-content/$v";
 			}
 		);
 
@@ -713,6 +719,24 @@ class AssetsTest extends TestCase {
 				'console.warn( "Failed to determine languages base URL. Is WP_LANG_DIR in the WordPress root?" );',
 				array(
 					'constants' => array( 'WP_LANG_DIR' => '/not/path/to/wordpress/wp-content/languages' ),
+				),
+			),
+			'WP_LANG_DIR in wp-includes'       => array(
+				array( 'baseUrl' => 'http://example.com/wp-includes/languages/' ) + $expect_filter,
+				'wp.jpI18nState = {"baseUrl":"http://example.com/wp-includes/languages/","locale":"en_US","domainMap":{}};',
+				array(
+					'constants' => array( 'WP_LANG_DIR' => '/path/to/wordpress/wp-includes/languages' ),
+				),
+			),
+			'WP_CONTENT_DIR not in ABSPATH'    => array(
+				array( 'baseUrl' => 'http://example.com/wp-content/languages/' ) + $expect_filter,
+				'wp.jpI18nState = {"baseUrl":"http://example.com/wp-content/languages/","locale":"en_US","domainMap":{}};',
+				array(
+					'constants' => array(
+						'ABSPATH'        => '/srv/htdocs/__wp__/',
+						'WP_CONTENT_DIR' => '/srv/htdocs/wp-content',
+						'WP_LANG_DIR'    => '/srv/htdocs/wp-content/languages',
+					),
 				),
 			),
 			'Filter'                           => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When generating the base URL from `WP_LANG_DIR`, handle the case where
`WP_LANG_DIR` is in `WP_CONTENT_DIR` but `WP_CONTENT_DIR` is not in
`ABSPATH`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1642416715007500/1639739679.124300-slack-C82FZ5T4G

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a site where `WP_CONTENT_DIR` is not in `ABSPATH` (e.g. an Atomic Ephemeral site). Then set a non-English locale and try out Instant Search.
  * If it fails, at least make sure it tried to fetch a correct URL and got a 404 because the language pack hasn't been updated for changed Instant Search script paths in 10.6-a.1 yet.