### PR TITLE
Docs: monorepo now uses Composer v2.2.x

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -110,7 +110,7 @@ You'll need all the tools below to work in the Jetpack monorepo.
 
 	Composer is a PHP package manager and it's used to install packages that are required to run development tools and build projects.
 
-	The monorepo requires version 2.1.x.
+	The monorepo requires version 2.2.x.
 
 	 * ##### Installing Composer on macOS
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Update dev docs with new Composer version that the monorepo uses, was updated in #22373

#### Jetpack product discussion

#22373

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.
