### PR TITLE
My Jetpack: Update Plans section component to use css module

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -10,8 +10,7 @@ import { ExternalLink } from '@wordpress/components';
  */
 import usePurchases from '../../hooks/use-purchases';
 import getManageYourPlanUrl from '../../utils/get-manage-your-plan-url';
-
-import './style.scss';
+import styles from './style.module.scss';
 
 /**
  * Basic plan section component.
@@ -66,7 +65,7 @@ export default function PlansSection() {
 	const purchases = usePurchases();
 
 	return (
-		<div className="jp-plans-section">
+		<div className={ styles.container }>
 			<PlanSectionHeader purchases={ purchases } />
 
 			<div className="jp-plans-section__purchases-section">

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
@@ -1,0 +1,32 @@
+.container {
+	h3 {
+		font-size: var(--font-title-large);
+		font-weight: 700;
+		margin-top: 48px;
+		line-height: 1.1;
+		color: var( --jp-black );
+		margin: 0;
+	}
+
+	h4 {
+		font-size: var(--font-title-small);
+		font-weight: 500;
+		line-height: 1;
+		color: var( --jp-black );
+	}
+
+	a, a:active, a:hover {
+		color: var( --jp-black );
+	}
+
+	p {
+		margin: 16px 0;
+		color: var( --jp-black );
+	}
+
+	p, a, li {
+		font-size: var( --font-body );
+		line-height: 24px;
+	}
+
+}

--- a/projects/packages/my-jetpack/changelog/update-css-module-plans-section
+++ b/projects/packages/my-jetpack/changelog/update-css-module-plans-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added css module for My Jetpack Plans Section


### PR DESCRIPTION
Introducess css module for the Plans Section component

Follow-up to #22345

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds styles.module.scss file under `components/plans-section`.



#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
#### Testing instructions:

* Checkout this branch
* Build with `jetpack build packages/my-jetpack`.
* Have Jetpack Backup and a plan for it (either Upgrade to Security or Backup)
* Checkout the My Jetpack page.
* Confirm the styles look as before

![image](https://user-images.githubusercontent.com/746152/149413221-2563ef38-31bd-4a7c-949a-c7383af423e0.png)
