### PR TITLE
My Jetpack build: do not ship raw files in production bundle

### DIFF
--- a/projects/packages/my-jetpack/.gitattributes
+++ b/projects/packages/my-jetpack/.gitattributes
@@ -10,6 +10,7 @@ package.json      export-ignore
 # Remember to end all directories with `/**` to properly tag every file.
 .gitignore          production-exclude
 .phpcs.dir.xml      production-exclude
+_inc/**             production-exclude
 changelog/**        production-exclude
 phpunit.xml.dist    production-exclude
 tests/**            production-exclude

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-do-not-ship-raw-files
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-do-not-ship-raw-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: do not ship raw files in production bundle.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿We ship the build directory:
https://github.com/Automattic/jetpack-my-jetpack/tree/v0.3.3/build

We consequently do not need raw files.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here I'm afraid. Does it make sense? 
* You can check the generated zip for that package in the build GitHub action; it should not include the `_inc` dir.
