### PR TITLE
Fix prop type warning in UserLicenseActivationNotice component.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
@@ -127,11 +127,18 @@ const UserLicenseActivationNotice = props => {
 UserLicenseActivationNotice.propTypes = {
 	detachedLicensesCount: PropTypes.number.isRequired,
 	activationNoticeDismissInfo: PropTypes.shape( {
-		last_detached_count: PropTypes.number.isRequired,
-		last_dismiss_time: PropTypes.string.isRequired,
+		last_detached_count: PropTypes.number,
+		last_dismiss_time: PropTypes.string,
 	} ),
 	pathname: PropTypes.string.isRequired,
 	siteAdminUrl: PropTypes.string.isRequired,
+};
+
+UserLicenseActivationNotice.defaultProps = {
+	activationNoticeDismissInfo: {
+		last_detached_count: null,
+		last_dismiss_time: null,
+	},
 };
 
 export default connect(

--- a/projects/plugins/jetpack/changelog/fix-activation-notice-proptypes
+++ b/projects/plugins/jetpack/changelog/fix-activation-notice-proptypes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed development mode prop type warning in UserLicenseActivationNotice component.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #22382

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR fixes issue #22382 where in development mode, a prop type warning was being output to the console originating from the `UserLicenseActivationNotice` component.

**Implementation notes:**
- `activationNoticeDismissInfo.last_detached_count` was set as a "required" prop and this was throwing a prop type warning because by default the value will be `null`.
- To fix this, I removed the requirement for the prop to be "required", and instead set the default value to `null` via React `defaultProps`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#22382

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Spin up a local development version of Jetpack (localhost docker env for example). Connect Jetpack and visit the Jetpack dashboard.
2. Open the dev console.
3. Verify you **DO NOT** see a warning in the console that says: ```Warning: Failed prop type: The prop `activationNoticeDismissInfo.last_detached_count` is marked as required in `UserLicenseActivationNotice`, but its value is `null`.
  in UserLicenseActivationNotice (created by Context.Consumer)
  in Connect(UserLicenseActivationNotice) (created by JetpackNotices)```, like shown in this image:

![149918005-769ff52a-60fd-4698-843b-7a0ea7cbc9cd](https://user-images.githubusercontent.com/11078128/150007227-c9bc0d3a-6493-49dc-a8ca-e1723339b9e0.png)

