### PR TITLE
Backup: Correct wrong use of className prop

### DIFF
--- a/projects/plugins/backup/changelog/fix-classname-use-prop
+++ b/projects/plugins/backup/changelog/fix-classname-use-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Correct wrong use of class instead of className prop.

--- a/projects/plugins/backup/src/js/components/Backups.js
+++ b/projects/plugins/backup/src/js/components/Backups.js
@@ -116,16 +116,19 @@ const Backups = () => {
 
 	const renderInProgressBackup = ( showProgressBar = true ) => {
 		return (
-			<div class="jp-row">
-				<div class="lg-col-span-5 md-col-span-8 sm-col-span-4">
+			<div className="jp-row">
+				<div className="lg-col-span-5 md-col-span-8 sm-col-span-4">
 					{ showProgressBar && (
-						<div class="backup__progress">
-							<div class="backup__progress-info">
+						<div className="backup__progress">
+							<div className="backup__progress-info">
 								<p>{ __( 'Backing up Your Groovy Site…', 'jetpack-backup' ) }</p>
-								<p class="backup__progress-info-percentage">{ progress }%</p>
+								<p className="backup__progress-info-percentage">{ progress }%</p>
 							</div>
-							<div class="backup__progress-bar">
-								<div class="backup__progress-bar-actual" style={ { width: progress + '%' } }></div>
+							<div className="backup__progress-bar">
+								<div
+									className="backup__progress-bar-actual"
+									style={ { width: progress + '%' } }
+								></div>
 							</div>
 						</div>
 					) }
@@ -154,8 +157,8 @@ const Backups = () => {
 						) }
 					</p>
 				</div>
-				<div class="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
-				<div class="backup__animation lg-col-span-6 md-col-span-2 sm-col-span-2">
+				<div className="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
+				<div className="backup__animation lg-col-span-6 md-col-span-2 sm-col-span-2">
 					<img className="backup__animation-el-1" src={ BackupAnim1 } alt="" />
 					<img className="backup__animation-el-2" src={ BackupAnim2 } alt="" />
 					<img className="backup__animation-el-3" src={ BackupAnim3 } alt="" />
@@ -186,7 +189,7 @@ const Backups = () => {
 					</div>
 					<h1>{ formatDateString( latestTime ) }</h1>
 					<a
-						class="button is-full-width"
+						className="button is-full-width"
 						href={ getRedirectUrl( 'jetpack-backup', { site: domain } ) }
 						target="_blank"
 						rel="noreferrer"
@@ -229,8 +232,8 @@ const Backups = () => {
 
 	const renderNoGoodBackups = () => {
 		return (
-			<div class="jp-row">
-				<div class="lg-col-span-5 md-col-span-4 sm-col-span-4">
+			<div className="jp-row">
+				<div className="lg-col-span-5 md-col-span-4 sm-col-span-4">
 					<img src={ CloudAlertIcon } alt="" />
 					<h1>{ __( "We're having trouble backing up your site", 'jetpack-backup' ) }</h1>
 					<p>
@@ -252,14 +255,14 @@ const Backups = () => {
 						) }
 					</p>
 				</div>
-				<div class="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
-				<div class="lg-col-span-6 md-col-span-2 sm-col-span-2"></div>
+				<div className="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
+				<div className="lg-col-span-6 md-col-span-2 sm-col-span-2"></div>
 			</div>
 		);
 	};
 
 	const renderLoading = () => {
-		return <div class="jp-row"></div>;
+		return <div className="jp-row"></div>;
 	};
 
 	return (


### PR DESCRIPTION
Correct occurrencies where `class` is used instead o `className`.

<!--- Provide a general summary of your changes in the Title above -->
In React the class property must be named className.

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/22378
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change class to ClassName, as it should be on React. 


#### Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
1- Start your Jetpack local environment
2- On the `wp-config.php` of your site, add `define( SCRIPT_DEBUG, true );` so the React warnings are shown. If you're running JP on Docker, the wp-config should be in `tools/docker/wordpress/wp-config.php`
3- Make sure your site has a plan and visit the Backup wp-admin page
4- Open the dev console
Confirm you see no messages with this Warning: Invalid DOM property class. Did you mean className?
![image](https://user-images.githubusercontent.com/16329583/150038699-0e2923d2-6c1b-4755-afe4-68a1a8582e69.png)

