### PR TITLE
Fix warning on Scan module

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-scan-warning
+++ b/projects/plugins/jetpack/changelog/fix-scan-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+bugfix Fix warning for non admin users

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -93,6 +93,11 @@ class Admin_Sidebar_Link {
 	private function get_link_offset() {
 		global $submenu;
 		$offset = 0;
+
+		if ( ! array_key_exists( 'jetpack', $submenu ) ) {
+			return $offset;
+		}
+
 		foreach ( $submenu['jetpack'] as $link ) {
 			if ( 'jetpack_admin_page' !== $link[1] ) {
 				break;
@@ -193,5 +198,3 @@ class Admin_Sidebar_Link {
 		$this->schedule_refresh_checked = true;
 	}
 }
-
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Fixes 7219-gh-Automattic/jpop-issues

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes a warning that happens when a non admin users open wp-admin:

```
[19-Jan-2022 03:29:36 UTC] PHP Notice:  Undefined index: jetpack in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php on line 101
[19-Jan-2022 03:29:36 UTC] PHP Warning:  Invalid argument supplied for foreach() in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php on line 101
```

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect your jetpack and make sure that the scan submenu is showing.
* Create a non admin user.
* Open wp-admin using that user and verify your logs to make sure the warning doesn't occur.