### PR TITLE
Connection: Make redirectUri not be required in ConnectionStatusCard

### DIFF
--- a/projects/js-packages/connection/changelog/fix-redirectUri-connection-status-card
+++ b/projects/js-packages/connection/changelog/fix-redirectUri-connection-status-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make redirectUri property not be required in ConnectionStatusCard

--- a/projects/js-packages/connection/components/connection-status-card/index.jsx
+++ b/projects/js-packages/connection/components/connection-status-card/index.jsx
@@ -180,7 +180,7 @@ ConnectionStatusCard.propTypes = {
 	/** API Nonce, required. */
 	apiNonce: PropTypes.string.isRequired,
 	/** The redirect admin URI after the user has connected their WordPress.com account. */
-	redirectUri: PropTypes.string.isRequired,
+	redirectUri: PropTypes.string,
 	/** An object of the plugins currently using the Jetpack connection. */
 	connectedPlugins: PropTypes.object,
 	/** ID of the currently connected site. */
@@ -201,6 +201,7 @@ ConnectionStatusCard.defaultProps = {
 		'Leverages the Jetpack Cloud for more features on your side.',
 		'jetpack'
 	),
+	redirectUri: null,
 };
 
 export default ConnectionStatusCard;


### PR DESCRIPTION
Makes the redirectUri property to be `isRequired` and sets it to null by default

Fixes some Warning shown when loading my Jetpack 

#### Changes proposed in this Pull Request:

<!--- Explain what functional changes your PR includes -->
* Adds default prop  `isRequired` value set to `null`
* makes `redrectUri` not be required


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Checkout this branch
* Run `jetpack build packages/my-jetpack`.
* Your site has to have `SCRIPT_DEBUG` constant set to true
* Make sure you can see the My Jetpack page.
* Visit My Jetpack with the browser console open.
* Confirm you don't see an error like this:
  `Warning: Failed prop type: The prop `redirectUri` is marked as required in `ConnectionStatusCard`, but its value is `null`.`
  
![image](https://user-images.githubusercontent.com/746152/150113351-7963d4f7-75da-4442-bed3-0225081689f4.png)
