### PR TITLE
Search: Set correct path for I18nLoaderWebpackPlugin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -683,6 +683,7 @@ importers:
       '@babel/preset-env': 7.16.4
       '@babel/preset-react': 7.16.0
       '@babel/preset-typescript': 7.16.0
+      '@babel/runtime': 7.16.3
       '@size-limit/preset-app': 6.0.3
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/preact': 2.0.1
@@ -754,6 +755,7 @@ importers:
       '@babel/preset-env': 7.16.4_@babel+core@7.16.0
       '@babel/preset-react': 7.16.0_@babel+core@7.16.0
       '@babel/preset-typescript': 7.16.0_@babel+core@7.16.0
+      '@babel/runtime': 7.16.3
       '@size-limit/preset-app': 6.0.3_size-limit@6.0.3
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/preact': 2.0.1_preact@10.5.15

--- a/projects/packages/search/changelog/fix-search-pkg-i18n-loader-path
+++ b/projects/packages/search/changelog/fix-search-pkg-i18n-loader-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set correct path in Webpack I18nLoaderPlugin config.

--- a/projects/packages/search/changelog/fix-search-pkg-i18n-loader-path#2
+++ b/projects/packages/search/changelog/fix-search-pkg-i18n-loader-path#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add missing JS peer dependency.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -70,6 +70,7 @@
 		"@babel/preset-env": "7.16.4",
 		"@babel/preset-react": "7.16.0",
 		"@babel/preset-typescript": "7.16.0",
+		"@babel/runtime": "7.16.3",
 		"@size-limit/preset-app": "6.0.3",
 		"@testing-library/jest-dom": "5.14.1",
 		"@testing-library/preact": "2.0.1",

--- a/projects/packages/search/tools/webpack.customberg.config.js
+++ b/projects/packages/search/tools/webpack.customberg.config.js
@@ -34,7 +34,11 @@ module.exports = {
 	plugins: [
 		...jetpackWebpackConfig.StandardPlugins( {
 			DependencyExtractionPlugin: { injectPolyfill: true },
-			I18nLoaderPlugin: { textdomain: 'jetpack-search-pkg' },
+			I18nLoaderPlugin: {
+				textdomain: 'jetpack-search-pkg',
+				// When installed in a plugin, this is where it will be.
+				path: 'jetpack_vendor/automattic/jetpack-search/build/customberg',
+			},
 		} ),
 		definePaletteColorsAsStaticVariables(),
 	],

--- a/projects/packages/search/tools/webpack.instant.config.js
+++ b/projects/packages/search/tools/webpack.instant.config.js
@@ -67,7 +67,11 @@ module.exports = {
 				requestToExternal,
 				requestToHandle: defaultRequestToHandle,
 			},
-			I18nLoaderPlugin: { textdomain: 'jetpack-search-pkg' },
+			I18nLoaderPlugin: {
+				textdomain: 'jetpack-search-pkg',
+				// When installed in a plugin, this is where it will be.
+				path: 'jetpack_vendor/automattic/jetpack-search/build/instant-search',
+			},
 		} ),
 		// Replace 'debug' module with a dummy implementation in production
 		...( jetpackWebpackConfig.isDevelopment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When installed in a plugin with automattic/jetpack-composer-plugin, the
built files will wind up at `jetpack_vendor/automattic/jetpack-search/build/`
rather than `build/`. I18nLoaderWebpackPlugin needs to be configured
accordingly.

Also, there was a missing peer dependency which was making
eslint-changed fail in the pre-commit hook. Added that so the commit
could be committed.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1642603817021400/1639739679.124300-slack-C82FZ5T4G

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an updated language pack (e.g. in the docker env with /var/scripts/fakepot.sh) and try Instant Search.