### PR TITLE
My Jetpack: implement first approach of data handling

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -643,6 +643,7 @@ importers:
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2
+      refx: 3.1.1
       sass: 1.43.3
       sass-loader: 12.4.0
       storybook-addon-mock: 2.0.2
@@ -655,6 +656,7 @@ importers:
       '@wordpress/i18n': 4.2.4
       classnames: 2.3.1
       prop-types: 15.8.1
+      refx: 3.1.1
     devDependencies:
       '@automattic/jetpack-base-styles': link:../../js-packages/base-styles
       '@automattic/jetpack-webpack-config': link:../../js-packages/webpack-config

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -3,7 +3,8 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, Button } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import usePurchases from '../../hooks/use-purchases';
 import getManageYourPlanUrl from '../../utils/get-manage-your-plan-url';
 
 import './style.scss';
+import { useProducts } from '../../hooks/use-products';
 
 /**
  * Basic plan section component.
@@ -38,6 +40,17 @@ function PlanSection( { purchase = {} } ) {
  * @returns {object} PlanSectionHeader react component.
  */
 function PlanSectionHeader( { purchases } ) {
+	const { list: productsList, activate, deactivate } = useProducts();
+
+	/**
+	 * Set product state handler
+	 */
+	const setProductStateHandler = useCallback(
+		() =>
+			productsList?.backup.status !== 'active' ? activate( 'backup' ) : deactivate( 'backup' ),
+		[ productsList, activate, deactivate ]
+	);
+
 	return (
 		<>
 			<h3>
@@ -52,6 +65,12 @@ function PlanSectionHeader( { purchases } ) {
 						? __( 'Manage your plan', 'jetpack-my-jetpack' )
 						: __( 'Manage your plans', 'jetpack-my-jetpack' ) }
 				</ExternalLink>
+
+				<Button primary onClick={ setProductStateHandler }>
+					{ productsList.backup.status !== 'active'
+						? __( 'Activate Backup', 'jetpack-my-jetpack' )
+						: __( 'Deactivate Backup', 'jetpack-my-jetpack' ) }
+				</Button>
 			</p>
 		</>
 	);

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -45,6 +45,7 @@ function PlanSectionHeader( { purchases } ) {
 	/**
 	 * Set product state handler
 	 */
+	// @todo: remove this testing code
 	const setProductStateHandler = useCallback(
 		() =>
 			productsList?.backup.status !== 'active' ? activate( 'backup' ) : deactivate( 'backup' ),

--- a/projects/packages/my-jetpack/_inc/hooks/use-products/Readme.md
+++ b/projects/packages/my-jetpack/_inc/hooks/use-products/Readme.md
@@ -5,7 +5,7 @@ Simple React custom hook that provides data and helpers to deal with site produc
 ## API
 
 ```es6
-const { list: productsList, enable, disable } = useProducts();
+const { list: productsList, activate, deactivate } = useProducts();
 ```
 
 The `useProducts()` hooks returns an object with the following properties:
@@ -14,17 +14,17 @@ The `useProducts()` hooks returns an object with the following properties:
 
 An array with the products list.
 
-### enable( <slug> )
-A helper function to enable a product.
+### activate( <slug> )
+A helper function to activate a product.
 
-### disnable( <slug> )
+### deactivate( <slug> )
 A helper function to disable a product.
 
 ```es6
 import usePlan from './hooks/use-products';
 
 function PlansSection() {
-	const { list: productsList, enable, disable } = useProducts();
+	const { list: productsList, activate, deactivate } = useProducts();
 
 	return (
 		<div className="products">
@@ -32,8 +32,8 @@ function PlansSection() {
 				<>
 					<h4>{ name }</h4>
 					<p>{ description }</p>
-					<Button onClick={ () => enable( slug ) }>Enable</Button>
-					<Button onClick={ () => disable( slug ) }>Disable</Button>
+					<Button onClick={ () => activate( slug ) }>Enable</Button>
+					<Button onClick={ () => deactivate( slug ) }>Disable</Button>
 				</>
 			) ) }
 		</div>

--- a/projects/packages/my-jetpack/_inc/hooks/use-products/Readme.md
+++ b/projects/packages/my-jetpack/_inc/hooks/use-products/Readme.md
@@ -1,0 +1,42 @@
+# useProducts
+
+Simple React custom hook that provides data and helpers to deal with site products.
+
+## API
+
+```es6
+const { list: productsList, enable, disable } = useProducts();
+```
+
+The `useProducts()` hooks returns an object with the following properties:
+
+### list
+
+An array with the products list.
+
+### enable( <slug> )
+A helper function to enable a product.
+
+### disnable( <slug> )
+A helper function to disable a product.
+
+```es6
+import usePlan from './hooks/use-products';
+
+function PlansSection() {
+	const { list: productsList, enable, disable } = useProducts();
+
+	return (
+		<div className="products">
+			{ productsList.map( ( { name, description, slug } ) => (
+				<>
+					<h4>{ name }</h4>
+					<p>{ description }</p>
+					<Button onClick={ () => enable( slug ) }>Enable</Button>
+					<Button onClick={ () => disable( slug ) }>Disable</Button>
+				</>
+			) ) }
+		</div>
+	)
+}
+```

--- a/projects/packages/my-jetpack/_inc/hooks/use-products/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-products/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,9 +14,11 @@ import { STORE_ID } from '../../state/store';
  * @returns {object} site products data
  */
 export function useProducts() {
+	const { activateProduct: activate } = useDispatch( STORE_ID );
+
 	return {
 		list: useSelect( select => select( STORE_ID ).getProducts() ),
-		enable: () => {},
+		activate,
 		disable: () => {},
 	};
 }

--- a/projects/packages/my-jetpack/_inc/hooks/use-products/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-products/index.js
@@ -14,11 +14,11 @@ import { STORE_ID } from '../../state/store';
  * @returns {object} site products data
  */
 export function useProducts() {
-	const { activateProduct: activate } = useDispatch( STORE_ID );
+	const { activateProduct: activate, deactivateProduct: deactivate } = useDispatch( STORE_ID );
 
 	return {
 		list: useSelect( select => select( STORE_ID ).getProducts() ),
 		activate,
-		disable: () => {},
+		deactivate,
 	};
 }

--- a/projects/packages/my-jetpack/_inc/hooks/use-products/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-products/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_ID } from '../../state/store';
+
+/**
+ * React custom hook to deal with the site products.
+ *
+ * @returns {object} site products data
+ */
+export function useProducts() {
+	return {
+		list: useSelect( select => select( STORE_ID ).getProducts() ),
+		enable: () => {},
+		disable: () => {},
+	};
+}

--- a/projects/packages/my-jetpack/_inc/state/README.md
+++ b/projects/packages/my-jetpack/_inc/state/README.md
@@ -1,0 +1,74 @@
+# State
+
+## Selectors
+
+### Products
+
+#### getProducts
+
+#### getProductNames
+
+#### isValidProduct
+
+## Side Effects
+
+Side effects are useful to handle data asynchronously. By default, Redux actions do it synchronously.
+The following is an example of how to handle async data with the data My Jetpack approach:
+
+Let's suppose you need to implement an action to activate a product, let's say `backup`.
+
+## 1st
+So, the first step is defining a simple action that will start to take over it.
+
+```es6
+export function requestActivateProduct( productId ) {
+	return {
+		type: 'ACTIVATE_PRODUCT',
+		productId,
+	};
+}
+```
+
+So far pretty simple. When the action runs it dispatches the `ACTIVATE_PRODUCT` action, passing the productId in the action object to be consumed by the reducer. But...
+
+### 2do
+
+... this action requires async handling by its nature. We need to link the client with the backend in order to propagate these changes to the system. In other words, hit an endpoint, wait for its response and update the data locally. We call it a side effect.
+
+Since the reducer expects an action object, and only an action object, we need to catch the action to implement this especial async behavior in between, and (maybe) dispatch other actions. This is the middleware.
+
+To add the side effect to _observe_ the `ACTIVATE_PRODUCT` action , let's add a key to the [effects.js](./effects.js) object with its respective handler.
+
+```es6
+function requestActivateProduct( action, store ) {
+	const { productId } = action;
+	const { getState, dispatch } = store;
+
+	// Check valid product.
+	const isValid = isValidProduct( getState(), productId );
+	if ( ! isValid ) {
+		return dispatch(
+			setProductActionError( {
+				code: 'invalid_product',
+				message: __( 'Invalid product name', 'jetpack-my-jetpack' ),
+			} )
+		);
+	}
+
+	apiFetch( {
+		path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
+		method: 'POST',
+		data: {
+			action: 'activate',
+		}
+	} )
+	.then( ( res ) => dispatch( activateProduct( res ) ) )
+	.catch( error => dispatch( setProductActionError( error ) ) );
+};
+
+export default {
+	'ACTIVATE_PRODUCT': requestActivateProduct,
+};
+```
+
+The middleware provides the `action` and the `store` to the side-effect handler, all that we need to handle the action from there.

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -3,7 +3,8 @@ const FETCH_PURCHASES = 'FETCH_PURCHASES';
 const SET_PURCHASES = 'SET_PURCHASES';
 const SET_PRODUCT_ACTION_ERROR = 'SET_PRODUCT_ACTION_ERROR';
 const ACTIVATE_PRODUCT = 'ACTIVATE_PRODUCT';
-const SET_PRODUCT_ACTIVATED = 'SET_PRODUCT_ACTIVATED';
+const DEACTIVATE_PRODUCT = 'DEACTIVATE_PRODUCT';
+const SET_PRODUCT_STATUS = 'SET_PRODUCT_STATUS';
 
 const setPurchasesIsFetching = isFetching => {
 	return { type: SET_PURCHASES_IS_FETCHING, isFetching };
@@ -21,8 +22,12 @@ const activateProduct = productId => {
 	return { type: ACTIVATE_PRODUCT, productId };
 };
 
-export const setProductActivated = productId => {
-	return { type: SET_PRODUCT_ACTIVATED, productId };
+const deactivateProduct = productId => {
+	return { type: DEACTIVATE_PRODUCT, productId };
+};
+
+export const setProductStatus = ( productId, status ) => {
+	return { type: SET_PRODUCT_STATUS, productId, status };
 };
 
 export const setProductActionError = error => {
@@ -31,7 +36,8 @@ export const setProductActionError = error => {
 
 const productActions = {
 	activateProduct,
-	setProductActivated,
+	deactivateProduct,
+	setProductStatus,
 	setProductActionError,
 };
 
@@ -48,6 +54,7 @@ export {
 	SET_PURCHASES,
 	SET_PRODUCT_ACTION_ERROR,
 	ACTIVATE_PRODUCT,
-	SET_PRODUCT_ACTIVATED,
+	DEACTIVATE_PRODUCT,
+	SET_PRODUCT_STATUS,
 	actions as default,
 };

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -1,6 +1,7 @@
 const SET_PURCHASES_IS_FETCHING = 'SET_PURCHASES_IS_FETCHING';
 const FETCH_PURCHASES = 'FETCH_PURCHASES';
 const SET_PURCHASES = 'SET_PURCHASES';
+const ACTIVATE_PRODUCT = 'ACTIVATE_PRODUCT';
 
 const setPurchasesIsFetching = isFetching => {
 	return { type: SET_PURCHASES_IS_FETCHING, isFetching };
@@ -14,10 +15,25 @@ const setPurchases = purchases => {
 	return { type: SET_PURCHASES, purchases };
 };
 
-const actions = {
-	setPurchasesIsFetching, // Purchases -> is fetching
-	fetchPurchases, // Purchases -> fecth
-	setPurchases, // Purchases -> set
+const activateProduct = productId => {
+	return { type: ACTIVATE_PRODUCT, productId };
 };
 
-export { SET_PURCHASES_IS_FETCHING, FETCH_PURCHASES, SET_PURCHASES, actions as default };
+const productActions = {
+	activateProduct,
+};
+
+const actions = {
+	setPurchasesIsFetching,
+	fetchPurchases,
+	setPurchases,
+	...productActions,
+};
+
+export {
+	SET_PURCHASES_IS_FETCHING,
+	FETCH_PURCHASES,
+	SET_PURCHASES,
+	ACTIVATE_PRODUCT,
+	actions as default,
+};

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -1,7 +1,9 @@
 const SET_PURCHASES_IS_FETCHING = 'SET_PURCHASES_IS_FETCHING';
 const FETCH_PURCHASES = 'FETCH_PURCHASES';
 const SET_PURCHASES = 'SET_PURCHASES';
+const SET_PRODUCT_ACTION_ERROR = 'SET_PRODUCT_ACTION_ERROR';
 const ACTIVATE_PRODUCT = 'ACTIVATE_PRODUCT';
+const SET_PRODUCT_ACTIVATED = 'SET_PRODUCT_ACTIVATED';
 
 const setPurchasesIsFetching = isFetching => {
 	return { type: SET_PURCHASES_IS_FETCHING, isFetching };
@@ -19,8 +21,18 @@ const activateProduct = productId => {
 	return { type: ACTIVATE_PRODUCT, productId };
 };
 
+export const setProductActivated = productId => {
+	return { type: SET_PRODUCT_ACTIVATED, productId };
+};
+
+export const setProductActionError = error => {
+	return { type: SET_PRODUCT_ACTION_ERROR, error };
+};
+
 const productActions = {
 	activateProduct,
+	setProductActivated,
+	setProductActionError,
 };
 
 const actions = {
@@ -34,6 +46,8 @@ export {
 	SET_PURCHASES_IS_FETCHING,
 	FETCH_PURCHASES,
 	SET_PURCHASES,
+	SET_PRODUCT_ACTION_ERROR,
 	ACTIVATE_PRODUCT,
+	SET_PRODUCT_ACTIVATED,
 	actions as default,
 };

--- a/projects/packages/my-jetpack/_inc/state/constants.js
+++ b/projects/packages/my-jetpack/_inc/state/constants.js
@@ -1,0 +1,3 @@
+const REST_API_NAMESPACE = 'my-jetpack/v1';
+export const REST_API_SITE_PURCHASES_ENDPOINT = `${ REST_API_NAMESPACE }/site/purchases`;
+export const REST_API_SITE_PRODUCTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/products`;

--- a/projects/packages/my-jetpack/_inc/state/controls.js
+++ b/projects/packages/my-jetpack/_inc/state/controls.js
@@ -3,7 +3,10 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 
-const REST_API_SITE_PURCHASES_ENDPOINT = 'my-jetpack/v1/site/purchases';
+/**
+ * Internal dependencies
+ */
+import { REST_API_SITE_PURCHASES_ENDPOINT } from './constants';
 
 const FETCH_PURCHASES = () => {
 	return new Promise( ( resolve, reject ) => {

--- a/projects/packages/my-jetpack/_inc/state/effects.js
+++ b/projects/packages/my-jetpack/_inc/state/effects.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { setProductActionError, setProductActivated } from './actions';
+import { REST_API_SITE_PRODUCTS_ENDPOINT } from './constants';
+import { isValidProduct } from './selectors';
+
+/**
+ * Effect handler which will sync
+ * the product `actuve` status with the server.
+ *
+ * @param {object} action  - Action which had initiated the effect handler.
+ * @param {object} store   - Store instance.
+ */
+function activateProduct( action, store ) {
+	const { productId } = action;
+	const { getState, dispatch } = store;
+
+	// Check valid product.
+	const isValid = isValidProduct( getState(), productId );
+	if ( ! isValid ) {
+		dispatch(
+			setProductActionError( {
+				code: 'invalid_product',
+				message: __( 'Invalid product name', 'jetpack-my-jetpack' ),
+			} )
+		);
+		return;
+	}
+
+	apiFetch( {
+		path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
+		method: 'POST',
+		data: {
+			action: 'activate',
+		},
+	} )
+		.then( () => dispatch( setProductActivated( productId ) ) )
+		.catch( error => dispatch( setProductActionError( error ) ) );
+}
+
+export default {
+	ACTIVATE_PRODUCT: activateProduct,
+};

--- a/projects/packages/my-jetpack/_inc/state/effects.js
+++ b/projects/packages/my-jetpack/_inc/state/effects.js
@@ -7,7 +7,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { setProductActionError, setProductActivated } from './actions';
+import {
+	ACTIVATE_PRODUCT,
+	DEACTIVATE_PRODUCT,
+	setProductActionError,
+	setProductStatus,
+} from './actions';
 import { REST_API_SITE_PRODUCTS_ENDPOINT } from './constants';
 import { isValidProduct } from './selectors';
 
@@ -18,8 +23,8 @@ import { isValidProduct } from './selectors';
  * @param {object} action  - Action which had initiated the effect handler.
  * @param {object} store   - Store instance.
  */
-function activateProduct( action, store ) {
-	const { productId } = action;
+function requestProductStatus( action, store ) {
+	const { productId, type } = action;
 	const { getState, dispatch } = store;
 
 	// Check valid product.
@@ -34,17 +39,19 @@ function activateProduct( action, store ) {
 		return;
 	}
 
+	// Body request.
+	const data = { activate: type === ACTIVATE_PRODUCT };
+
 	apiFetch( {
 		path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
 		method: 'POST',
-		data: {
-			action: 'activate',
-		},
+		data,
 	} )
-		.then( () => dispatch( setProductActivated( productId ) ) )
+		.then( status => dispatch( setProductStatus( productId, status ) ) )
 		.catch( error => dispatch( setProductActionError( error ) ) );
 }
 
 export default {
-	ACTIVATE_PRODUCT: activateProduct,
+	[ ACTIVATE_PRODUCT ]: requestProductStatus,
+	[ DEACTIVATE_PRODUCT ]: requestProductStatus,
 };

--- a/projects/packages/my-jetpack/_inc/state/middlewares.js
+++ b/projects/packages/my-jetpack/_inc/state/middlewares.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import refx from 'refx';
+import { flowRight } from 'lodash';
+
+/**
+ * Applies the middlewares to the given store.
+ *
+ * @param {object} store   - Store Object.
+ * @param {object} effects - Effects Object.
+ * @returns {object} Update Store Object.
+ */
+export default function applyMiddlewares( store, effects ) {
+	// Convert side-effect handler to middleware.
+	const middlewares = [ refx( effects ) ];
+	let enhancedDispatch = () => {
+		throw new Error(
+			'Dispatching while constructing your middleware is not allowed. ' +
+				'Other middleware would not be applied to this dispatch.'
+		);
+	};
+	let chain = [];
+
+	const middlewareAPI = {
+		getState: store.getState,
+		dispatch: ( ...args ) => enhancedDispatch( ...args ),
+	};
+	chain = middlewares.map( middleware => middleware( middlewareAPI ) );
+	enhancedDispatch = flowRight( ...chain )( store.dispatch );
+
+	store.dispatch = enhancedDispatch;
+
+	return store;
+}

--- a/projects/packages/my-jetpack/_inc/state/reducers.js
+++ b/projects/packages/my-jetpack/_inc/state/reducers.js
@@ -6,10 +6,38 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { SET_PURCHASES, SET_PURCHASES_IS_FETCHING } from './actions';
+import {
+	SET_PURCHASES,
+	SET_PURCHASES_IS_FETCHING,
+	SET_PRODUCT_ACTION_ERROR,
+	SET_PRODUCT_ACTIVATED,
+} from './actions';
 
-const products = ( state = {} ) => {
-	return state;
+const products = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SET_PRODUCT_ACTIVATED: {
+			const { productId } = action;
+			return {
+				...state,
+				items: {
+					...state.items,
+					[ productId ]: {
+						...state.items[ productId ],
+						status: 'active',
+					},
+				},
+			};
+		}
+
+		case SET_PRODUCT_ACTION_ERROR:
+			return {
+				...state,
+				error: action.error,
+			};
+
+		default:
+			return state;
+	}
 };
 
 const purchases = ( state = {}, action ) => {

--- a/projects/packages/my-jetpack/_inc/state/reducers.js
+++ b/projects/packages/my-jetpack/_inc/state/reducers.js
@@ -10,20 +10,20 @@ import {
 	SET_PURCHASES,
 	SET_PURCHASES_IS_FETCHING,
 	SET_PRODUCT_ACTION_ERROR,
-	SET_PRODUCT_ACTIVATED,
+	SET_PRODUCT_STATUS,
 } from './actions';
 
 const products = ( state = {}, action ) => {
 	switch ( action.type ) {
-		case SET_PRODUCT_ACTIVATED: {
-			const { productId } = action;
+		case SET_PRODUCT_STATUS: {
+			const { productId, status } = action;
 			return {
 				...state,
 				items: {
 					...state.items,
 					[ productId ]: {
 						...state.items[ productId ],
-						status: 'active',
+						...status,
 					},
 				},
 			};

--- a/projects/packages/my-jetpack/_inc/state/reducers.js
+++ b/projects/packages/my-jetpack/_inc/state/reducers.js
@@ -26,6 +26,7 @@ const products = ( state = {}, action ) => {
 						...status,
 					},
 				},
+				error: {},
 			};
 		}
 

--- a/projects/packages/my-jetpack/_inc/state/selectors.js
+++ b/projects/packages/my-jetpack/_inc/state/selectors.js
@@ -1,5 +1,11 @@
+export const getProducts = state => state.products?.items || {};
+export const getProductNames = state => Object.keys( getProducts( state ) );
+export const isValidProduct = ( state, product ) => getProductNames( state ).includes( product );
+
 const productSelectors = {
-	getProducts: state => state.products || {},
+	getProducts,
+	getProductNames,
+	isValidProduct,
 };
 
 const purchasesSelectors = {

--- a/projects/packages/my-jetpack/_inc/state/store-holder.js
+++ b/projects/packages/my-jetpack/_inc/state/store-holder.js
@@ -1,15 +1,25 @@
 /**
  * External dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
+import applyMiddlewares from './middlewares';
 
+/**
+ * Internal dependencies
+ */
+import effects from './effects';
 class storeHolder {
 	static store = null;
 
 	static mayBeInit( storeId, storeConfig ) {
 		if ( null === storeHolder.store ) {
-			storeHolder.store = createReduxStore( storeId, storeConfig );
-			register( storeHolder.store );
+			// Register `my-jetpack` store.
+			const store = registerStore( storeId, storeConfig );
+
+			// Apply side effects to the store.
+			const storeWithEffects = applyMiddlewares( store, effects );
+
+			storeHolder.store = storeWithEffects;
 		}
 	}
 }

--- a/projects/packages/my-jetpack/_inc/state/store.js
+++ b/projects/packages/my-jetpack/_inc/state/store.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import actions from './actions';
 import reducer from './reducers';
 import selectors from './selectors';
 import storeHolder from './store-holder';
@@ -15,7 +16,7 @@ const STORE_ID = 'my-jetpack';
 function initStore() {
 	storeHolder.mayBeInit( STORE_ID, {
 		reducer,
-		actions: {},
+		actions,
 		selectors,
 		resolvers,
 		controls,

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-reduxify-products
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-reduxify-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Implement data handling for enable/disable products

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -27,7 +27,8 @@
 		"@wordpress/data": "6.1.5",
 		"@wordpress/i18n": "4.2.4",
 		"classnames": "2.3.1",
-		"prop-types": "15.8.1"
+		"prop-types": "15.8.1",
+		"refx": "3.1.1"
 	},
 	"sideEffects": [
 		"*.css",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -90,8 +90,12 @@ class Initializer {
 			array(
 				'apiRoot'               => esc_url_raw( rest_url() ),
 				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-				'products'              => Products::get_products(),
-				'purchases'             => array(),
+				'products'              => array(
+					'items' => Products::get_products(),
+				),
+				'purchases'             => array(
+					'items' => array(),
+				),
 				'redirectUrl'           => admin_url( '?page=my-jetpack' ),
 				'topJetpackMenuItemUrl' => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'            => ( new Status() )->get_site_suffix(),

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -53,9 +53,9 @@ class Products {
 	}
 
 	/**
-	 * Enable Backup product
+	 * Activate Backup product
 	 */
-	public static function enable_backup_product() {
+	public static function activate_backup_product() {
 		/*
 		 * @todo: implement
 		 * suggestion: when it enables, return an success array:
@@ -63,7 +63,19 @@ class Products {
 		 * Otherwise, an WP_Error instance will be nice.
 		 */
 		return array(
-			'status' => 'activated',
+			'status' => 'active',
+		);
+	}
+
+	/**
+	 * Deactivate Backup product
+	 */
+	public static function deactivate_backup_product() {
+		/*
+		 * @todo: implement
+		 */
+		return array(
+			'status' => 'inactive',
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -53,6 +53,21 @@ class Products {
 	}
 
 	/**
+	 * Enable Backup product
+	 */
+	public static function enable_backup_product() {
+		/*
+		 * @todo: implement
+		 * suggestion: when it enables, return an success array:
+		 * array( 'status' => 'activated' );
+		 * Otherwise, an WP_Error instance will be nice.
+		 */
+		return array(
+			'status' => 'activated',
+		);
+	}
+
+	/**
 	 * Returns information about the Backup product
 	 *
 	 * @return array Object with infromation about the product.

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -43,6 +43,32 @@ class REST_Products {
 				),
 			)
 		);
+
+		register_rest_route(
+			'my-jetpack/v1/',
+			'/site/products/(?P<product>[a-z\-]+)',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => __CLASS__ . '::enable_product',
+				'permission_callback' => __CLASS__ . '::permissions_callback',
+				'args'                => array(
+					'product' => array(
+						'description'       => __( 'Product slug', 'jetpack-my-jetpack' ),
+						'type'              => 'string',
+						'enum'              => Products::get_product_names(),
+						'required'          => false,
+						'validate_callback' => __CLASS__ . '::check_product_argument',
+					),
+					'action'  => array(
+						'description'       => __( 'Production action to execute', 'jetpack-my-jetpack' ),
+						'type'              => 'string',
+						'enum'              => array( 'activate', 'deactivate' ),
+						'required'          => false,
+						'validate_callback' => __CLASS__ . '::check_product_argument',
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -97,5 +123,16 @@ class REST_Products {
 		$product_slug = $request->get_param( 'product' );
 		$products     = Products::get_products();
 		return rest_ensure_response( $products[ $product_slug ], 200 );
+	}
+
+	/**
+	 * Enable a site product.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return array of site products list.
+	 */
+	public static function enable_product( $request ) {
+		$product_slug = $request->get_param( 'product' );
+		return Products::enable_backup_product( $product_slug );
 	}
 }

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -49,7 +49,7 @@ class REST_Products {
 			'/site/products/(?P<product>[a-z\-]+)',
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
-				'callback'            => __CLASS__ . '::enable_product',
+				'callback'            => __CLASS__ . '::set_product_state',
 				'permission_callback' => __CLASS__ . '::permissions_callback',
 				'args'                => array(
 					'product' => array(
@@ -126,13 +126,19 @@ class REST_Products {
 	}
 
 	/**
-	 * Enable a site product.
+	 * Set site product state.
 	 *
 	 * @param \WP_REST_Request $request The request object.
 	 * @return array of site products list.
 	 */
-	public static function enable_product( $request ) {
+	public static function set_product_state( $request ) {
 		$product_slug = $request->get_param( 'product' );
-		return Products::enable_backup_product( $product_slug );
+		$activate     = $request->get_param( 'activate' );
+
+		if ( $activate ) {
+			return Products::activate_backup_product( $product_slug );
+		}
+
+		return Products::deactivate_backup_product( $product_slug );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the initial approach for data handling of My Jetpack app. As an implementation real use case, it introduces a custom hook, redux changes, and also backend code to make the communication end to end work.

The most important change introduced here is the side effect handling. PR adds a [Readme file](https://github.com/Automattic/jetpack/blob/00f964889aed067d232e82789367bd0ffea3db20/projects/packages/my-jetpack/_inc/state/README.md) that we can keep documenting.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: implement first approach of data handling

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I added a simple Button in the dashboard in order to test the communication, end to end.

<img width="388" alt="Screen Shot 2022-01-20 at 3 22 07 PM" src="https://user-images.githubusercontent.com/77539/150398690-aebe5cc6-7fdc-4606-a9c3-7c641f7cc1a0.png">

That is as ugly as it is useful, just like me 😅 

### Check Actions

* Open the redux tool
* Select `my-jetpack` store
* Click on the button.
* Confirm you see the actions there.

https://user-images.githubusercontent.com/77539/150399727-c08d9d06-5448-4083-995f-c8737dd02f45.mov

### Check side effects
The activate/deactivate actions are observed by the middleware. You can see how the client performs the request:

https://user-images.githubusercontent.com/77539/150400253-174f2bc3-faba-4edd-b32c-9b1930f77387.mov

In short, the actions triggered from the UI are `ACTIVATE_PRODUCT` and `DEACTIVATE_PRODUCT`. Both are caught by the middleware, processed to finally dispatch the `setProductStatus()` action (`SET_PRODUCT_STATUS`) if everything is fine. Otherwise, it will dispatch `setProductActionError()`, storing the error into the state tree. 

For now, the backend responses with hardcoded data.