### PR TITLE
lazy js i18n: Move package→plugin path mapping into Assets

### DIFF
--- a/projects/js-packages/i18n-loader-webpack-plugin/README.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/README.md
@@ -31,7 +31,7 @@ Parameters recognized by the plugin are:
 - `loaderModule`: The name of a module supplying the i18n loader. See [Loader module](#loader-module) below for details.
 - `loaderMethod`: The name of the function from `loaderModule` to download the i18n. See [Loader module](#loader-module) below for details.
 - `target`: The target of the build: 'plugin' (the default), 'theme', or 'core'. This is used to determine where in WordPress's languages directory to look for the translation files.
-- `path`: See [Webpack context](#webpack-context) and [Use in Composer packages](#use-in-composer-packages) below for details.
+- `path`: See [Webpack context](#webpack-context) below for details.
 - `ignoreModules`: If some bundles in your build depend on [@wordpress/i18n] for purposes other than translating strings, i18n-loader-webpack-plugin will none the less count them as "using @wordpress/i18n" which may result in it trying to load translations for bundles that do not need it. This option may be used to ignore the relevant source files when examining the bundles.
 
   The value may be a function, which will be passed the file path relative to [Webpack's context] and the Webpack Module object and which should return true if the file should be ignored, or a string or RegExp to be compared with the relative file path, or an array of such strings, RegExps, and/or functions.
@@ -76,7 +76,7 @@ Most likely the method will separate any query part from the path, hash it, buil
 
 WordPress's translation infrastructure generates a file for each JS script named like "_textdomain_-_locale_-_hash_.json". The _hash_ is an MD5 hash of the path of the script file relative to the plugin's root.
 
-I18n-loader-webpack-plugin assumes that [Webpack's context] is the base of the WordPress plugin in which the bundles will be included.
+I18n-loader-webpack-plugin assumes that [Webpack's context] is the base of the WordPress package or plugin in which the bundles will be included, and that the [loader module](#loader-module) will handle mapping from package root to plugin root.
 If this is not the case, you'll need to set the plugin's `path` parameter to the relative path from the plugin's root to Webpack's `output.path`.
 
 ### Other useful Webpack configuration
@@ -97,8 +97,6 @@ Composer packages are useful for holding shared code, but when it comes to WordP
 WordPress's plugin infrastructure doesn't natively support Composer packages, so the usual thing to do is to include the `vendor/` directory in the push to the WordPress.org SVN.
 That won't work for packages needing translation, though, as WordPress's translation infrastructure ignores the `vendor/` directory when looking for strings to be translated.
 You'll need to use something like [automattic/jetpack-composer-plugin] so that the composer packages with translated strings are installed to a different path.
-
-Then, for Webpack builds in the Composer package, you'll need to set i18n-loader-webpack-plugin's `path` option to the path relative to the _plugin's_ root directory. For example, if your Composer package is named "automattic/foobar", will be used with [automattic/jetpack-composer-plugin] which will install the package to `jetpack_vendor/` rather than `vendor/`, and Webpack is building to a `build/` directory within the package, you'd need to set `path` to `jetpack_vendor/automattic/foobar/build/` as that's where the built files will end up relative to the plugin.
 
 Also, as the translation file will be named using the plugin's textdomain rather than the Composer package's, the consuming plugin will also need to arrange for the [loader module](#loader-module) to fetch the proper file.
 This may be done using [automattic/jetpack-assets] along with [automattic/jetpack-composer-plugin], as described in the latter's documentation.

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-move-i18n-loader-pkg-path-into-assets
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-move-i18n-loader-pkg-path-into-assets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update documentation for moving of the handling of package→plugin path mapping into jetpack-composer-plugin and jetpack-assets.

--- a/projects/js-packages/i18n-loader-webpack-plugin/src/I18nLoaderPlugin.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/src/I18nLoaderPlugin.js
@@ -48,7 +48,7 @@ const schema = {
 			enum: [ 'plugin', 'theme', 'core' ],
 		},
 		path: {
-			description: 'Path (relative to the plugin) to locate the output assets.',
+			description: 'Path (relative to the package or plugin) to locate the output assets.',
 			type: 'string',
 		},
 		ignoreModules: {

--- a/projects/packages/assets/changelog/update-move-i18n-loader-pkg-path-into-assets
+++ b/projects/packages/assets/changelog/update-move-i18n-loader-pkg-path-into-assets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Accept package path prefixes from jetpack-composer-plugin and use them when lazy-loading JS translations.

--- a/projects/packages/assets/src/js/i18n-loader.js
+++ b/projects/packages/assets/src/js/i18n-loader.js
@@ -14,6 +14,7 @@ module.exports = {
 		baseUrl: null,
 		locale: null,
 		domainMap: {},
+		domainPaths: {},
 	},
 
 	/**
@@ -41,13 +42,14 @@ module.exports = {
 		}
 
 		// Extract any query part and hash the script name like WordPress does.
+		const pathPrefix = hasOwn( state.domainPaths, domain ) ? state.domainPaths[ domain ] : '';
 		let hash, query;
 		const i = path.indexOf( '?' );
 		if ( i >= 0 ) {
-			hash = md5.hash( path.substring( 0, i ) );
+			hash = md5.hash( pathPrefix + path.substring( 0, i ) );
 			query = path.substring( i );
 		} else {
-			hash = md5.hash( path );
+			hash = md5.hash( pathPrefix + path );
 			query = '';
 		}
 

--- a/projects/packages/assets/tests/js/i18n-loader.test.js
+++ b/projects/packages/assets/tests/js/i18n-loader.test.js
@@ -49,6 +49,7 @@ beforeEach( () => {
 		baseUrl: 'http://example.com/wp-content/languages/',
 		locale: 'en_piglatin',
 		domainMap: {},
+		domainPaths: {},
 	};
 } );
 
@@ -152,6 +153,31 @@ test( 'Fetch with query part and domain map', async () => {
 	expect( global.fetch ).toHaveBeenCalledTimes( 1 );
 	expect( global.fetch ).toHaveBeenCalledWith(
 		'http://example.com/wp-content/languages/themes/mytheme-en_piglatin-1648792a465228e857cd166c292e2e4a.json?ver=12345?6789'
+	);
+	expect( mockSetLocaleData ).toHaveBeenCalledTimes( 1 );
+	expect( mockSetLocaleData ).toHaveBeenCalledWith(
+		{
+			'': {
+				domain: 'bar',
+				lang: 'en',
+				'plural-forms': 'nplurals=2; plural=(n != 1);',
+			},
+			'This is translated': [ 'is-Thay is-way anslated-tray' ],
+		},
+		'bar'
+	);
+} );
+
+test( 'Fetch with query part and domain map and path', async () => {
+	loader.state.domainMap.bar = 'themes/mytheme';
+	loader.state.domainPaths.bar = 'path/to/bar/';
+	fetch.mockFetchResponse( translations );
+	await expect(
+		loader.downloadI18n( 'dist/foo.js?ver=12345?6789', 'bar', 'plugin' )
+	).resolves.not.toThrow();
+	expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+	expect( global.fetch ).toHaveBeenCalledWith(
+		'http://example.com/wp-content/languages/themes/mytheme-en_piglatin-fe1568906ebfe6b7e22d422cba956f83.json?ver=12345?6789'
 	);
 	expect( mockSetLocaleData ).toHaveBeenCalledTimes( 1 );
 	expect( mockSetLocaleData ).toHaveBeenCalledWith(

--- a/projects/packages/assets/tests/php/test-assets-files/i18n-map.php
+++ b/projects/packages/assets/tests/php/test-assets-files/i18n-map.php
@@ -3,7 +3,10 @@ return array(
 	'domain' => 'target',
 	'type' => 'plugins',
 	'packages' => array(
-		'foo' => '1.2.3',
+		'foo' => array(
+			'path' => 'path/to/foo',
+			'ver' => '1.2.3',
+		),
 		'bar' => '4.5.6',
 	),
 );

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -697,54 +697,58 @@ class AssetsTest extends TestCase {
 	/** Data provider for test_wp_default_scripts_hook. */
 	public function provide_wp_default_scripts_hook() {
 		$expect_filter = array(
-			'baseUrl'   => 'http://example.com/wp-content/languages/',
-			'locale'    => 'en_US',
-			'domainMap' => array(),
+			'baseUrl'     => 'http://example.com/wp-content/languages/',
+			'locale'      => 'en_US',
+			'domainMap'   => array(),
+			'domainPaths' => array(),
 		);
 
 		return array(
-			'Basic test'                       => array(
+			'Basic test'                         => array(
 				$expect_filter,
-				'wp.jpI18nLoader.state = {"baseUrl":"http://example.com/wp-content/languages/","locale":"en_US","domainMap":{}};',
+				'wp.jpI18nLoader.state = {"baseUrl":"http://example.com/wp-content/languages/","locale":"en_US","domainMap":{},"domainPaths":{}};',
 			),
-			'Basic test (2)'                   => array(
+			'Basic test (2)'                     => array(
 				array(
-					'baseUrl'   => 'http://example.com/wp-includes/languages/',
-					'locale'    => 'de_DE',
-					'domainMap' => array(
+					'baseUrl'     => 'http://example.com/wp-includes/languages/',
+					'locale'      => 'de_DE',
+					'domainMap'   => array(
 						'jetpack-foo' => 'plugins/jetpack',
 						'jetpack-bar' => 'themes/sometheme',
 						'core'        => 'default',
 					),
+					'domainPaths' => array(
+						'jetpack-foo' => 'path/to/foo/',
+					),
 				),
-				'wp.jpI18nLoader.state = {"baseUrl":"http://example.com/wp-includes/languages/","locale":"de_DE","domainMap":{"jetpack-foo":"plugins/jetpack","jetpack-bar":"themes/sometheme","core":"default"}};',
+				'wp.jpI18nLoader.state = {"baseUrl":"http://example.com/wp-includes/languages/","locale":"de_DE","domainMap":{"jetpack-foo":"plugins/jetpack","jetpack-bar":"themes/sometheme","core":"default"},"domainPaths":{"jetpack-foo":"path/to/foo/"}};',
 				array(
 					'constants'  => array( 'WP_LANG_DIR' => '/path/to/wordpress/wp-includes/languages' ),
 					'locale'     => 'de_DE',
 					'domain_map' => array(
-						'jetpack-foo' => array( 'jetpack', 'plugins', '1.2.3' ),
-						'jetpack-bar' => array( 'sometheme', 'themes', '1.2.3' ),
-						'core'        => array( 'default', 'core', '1.2.3' ),
+						'jetpack-foo' => array( 'jetpack', 'plugins', '1.2.3', 'path/to/foo' ),
+						'jetpack-bar' => array( 'sometheme', 'themes', '1.2.3', '' ),
+						'core'        => array( 'default', 'core', '1.2.3', '' ),
 					),
 				),
 			),
-			'Bad WP_LANG_DIR'                  => array(
+			'Bad WP_LANG_DIR'                    => array(
 				array( 'baseUrl' => false ) + $expect_filter,
 				'console.warn( "Failed to determine languages base URL. Is WP_LANG_DIR in the WordPress root?" );',
 				array(
 					'constants' => array( 'WP_LANG_DIR' => '/not/path/to/wordpress/wp-content/languages' ),
 				),
 			),
-			'WP_LANG_DIR in wp-includes'       => array(
+			'WP_LANG_DIR in wp-includes'         => array(
 				array( 'baseUrl' => 'http://example.com/wp-includes/languages/' ) + $expect_filter,
-				'wp.jpI18nLoader.state = {"baseUrl":"http://example.com/wp-includes/languages/","locale":"en_US","domainMap":{}};',
+				'wp.jpI18nLoader.state = {"baseUrl":"http://example.com/wp-includes/languages/","locale":"en_US","domainMap":{},"domainPaths":{}};',
 				array(
 					'constants' => array( 'WP_LANG_DIR' => '/path/to/wordpress/wp-includes/languages' ),
 				),
 			),
-			'WP_CONTENT_DIR not in ABSPATH'    => array(
+			'WP_CONTENT_DIR not in ABSPATH'      => array(
 				array( 'baseUrl' => 'http://example.com/wp-content/languages/' ) + $expect_filter,
-				'wp.jpI18nLoader.state = {"baseUrl":"http://example.com/wp-content/languages/","locale":"en_US","domainMap":{}};',
+				'wp.jpI18nLoader.state = {"baseUrl":"http://example.com/wp-content/languages/","locale":"en_US","domainMap":{},"domainPaths":{}};',
 				array(
 					'constants' => array(
 						'ABSPATH'        => '/srv/htdocs/__wp__/',
@@ -753,72 +757,101 @@ class AssetsTest extends TestCase {
 					),
 				),
 			),
-			'Filter'                           => array(
+			'Filter'                             => array(
 				array( 'baseUrl' => false ) + $expect_filter,
-				'wp.jpI18nLoader.state = {"baseUrl":"http://example.org/languages/","locale":"klingon","domainMap":{"foo":"plugins/bar"}};',
+				'wp.jpI18nLoader.state = {"baseUrl":"http://example.org/languages/","locale":"klingon","domainMap":{"foo":"plugins/bar"},"domainPaths":{"foo":"path/to/bar/"}};',
 				array(
 					'constants' => array( 'WP_LANG_DIR' => '/not/path/to/wordpress/wp-content/languages' ),
 					'filter'    => array(
-						'baseUrl'   => 'http://example.org/languages/',
-						'locale'    => 'klingon',
-						'domainMap' => array( 'foo' => 'plugins/bar' ),
+						'baseUrl'     => 'http://example.org/languages/',
+						'locale'      => 'klingon',
+						'domainMap'   => array( 'foo' => 'plugins/bar' ),
+						'domainPaths' => array( 'foo' => 'path/to/bar/' ),
 					),
 				),
 			),
-			'Bad filter: not array'            => array(
+			'Bad filter: not array'              => array(
 				$expect_filter,
 				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
 				array( 'filter' => null ),
 			),
-			'Bad filter: baseUrl is not set'   => array(
+			'Bad filter: baseUrl is not set'     => array(
 				$expect_filter,
 				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
 				array(
 					'filter' => array(
+						'locale'      => 'en_US',
+						'domainMap'   => array(),
+						'domainPaths' => array(),
+					),
+				),
+			),
+			'Bad filter: locale is not set'      => array(
+				$expect_filter,
+				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
+				array(
+					'filter' => array(
+						'baseUrl'     => 'http://example.com/wp-content/languages/',
+						'domainMap'   => array(),
+						'domainPaths' => array(),
+					),
+				),
+			),
+			'Bad filter: locale is bad'          => array(
+				$expect_filter,
+				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
+				array(
+					'filter' => array(
+						'baseUrl'     => 'http://example.com/wp-content/languages/',
+						'locale'      => false,
+						'domainMap'   => array(),
+						'domainPaths' => array(),
+					),
+				),
+			),
+			'Bad filter: domainMap is not set'   => array(
+				$expect_filter,
+				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
+				array(
+					'filter' => array(
+						'baseUrl'     => 'http://example.com/wp-content/languages/',
+						'locale'      => 'en_US',
+						'domainPaths' => array(),
+					),
+				),
+			),
+			'Bad filter: domainMap is bad'       => array(
+				$expect_filter,
+				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
+				array(
+					'filter' => array(
+						'baseUrl'     => 'http://example.com/wp-content/languages/',
+						'locale'      => 'en_US',
+						'domainMap'   => (object) array(),
+						'domainPaths' => array(),
+					),
+				),
+			),
+			'Bad filter: domainPaths is not set' => array(
+				$expect_filter,
+				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
+				array(
+					'filter' => array(
+						'baseUrl'   => 'http://example.com/wp-content/languages/',
 						'locale'    => 'en_US',
 						'domainMap' => array(),
 					),
 				),
 			),
-			'Bad filter: locale is not set'    => array(
+			'Bad filter: domainPaths is bad'     => array(
 				$expect_filter,
 				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
 				array(
 					'filter' => array(
-						'baseUrl'   => 'http://example.com/wp-content/languages/',
-						'domainMap' => array(),
-					),
-				),
-			),
-			'Bad filter: locale is bad'        => array(
-				$expect_filter,
-				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
-				array(
-					'filter' => array(
-						'baseUrl'   => 'http://example.com/wp-content/languages/',
-						'locale'    => false,
-						'domainMap' => array(),
-					),
-				),
-			),
-			'Bad filter: domainMap is not set' => array(
-				$expect_filter,
-				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
-				array(
-					'filter' => array(
-						'baseUrl' => 'http://example.com/wp-content/languages/',
-						'locale'  => 'en_US',
-					),
-				),
-			),
-			'Bad filter: domainMap is bad'     => array(
-				$expect_filter,
-				'console.warn( "I18n state deleted by jetpack_i18n_state hook" );',
-				array(
-					'filter' => array(
-						'baseUrl'   => 'http://example.com/wp-content/languages/',
-						'locale'    => 'en_US',
-						'domainMap' => (object) array(),
+						'baseUrl'     => 'http://example.com/wp-content/languages/',
+						'locale'      => 'en_US',
+						'domainMap'   => array(),
+						'domainPaths' => (object) array(),
 					),
 				),
 			),
@@ -837,15 +870,15 @@ class AssetsTest extends TestCase {
 		Filters\expectAdded( 'ngettext_with_context_bar' )->once()->with( array( Assets::class, 'filter_ngettext_with_context' ), 10, 6 );
 		Filters\expectAdded( 'load_script_translation_file' )->once()->with( array( Assets::class, 'filter_load_script_translation_file' ), 10, 3 );
 
-		Assets::alias_textdomain( 'foo', 'one', 'plugins', '1.2.3' );
-		Assets::alias_textdomain( 'foo', 'two', 'plugins', '1.2.4' );
-		Assets::alias_textdomain( 'bar', 'one', 'themes', '1.2.3' );
-		Assets::alias_textdomain( 'bar', 'two', 'themes', '1.2.2' );
+		Assets::alias_textdomain( 'foo', 'one', 'plugins', '1.2.3', 'path/to/foo/1.2.3' );
+		Assets::alias_textdomain( 'foo', 'two', 'plugins', '1.2.4', 'path/to/foo/1.2.4' );
+		Assets::alias_textdomain( 'bar', 'one', 'themes', '1.2.3', 'path/to/bar/1.2.3' );
+		Assets::alias_textdomain( 'bar', 'two', 'themes', '1.2.2', 'path/to/bar/1.2.2' );
 
 		$this->assertEquals(
 			array(
-				'foo' => array( 'two', 'plugins', '1.2.4' ),
-				'bar' => array( 'one', 'themes', '1.2.3' ),
+				'foo' => array( 'two', 'plugins', '1.2.4', 'path/to/foo/1.2.4' ),
+				'bar' => array( 'one', 'themes', '1.2.3', 'path/to/bar/1.2.3' ),
 			),
 			TestingAccessWrapper::newFromClass( Assets::class )->domain_map
 		);
@@ -863,8 +896,8 @@ class AssetsTest extends TestCase {
 		Assets::alias_textdomains_from_file( __DIR__ . '/test-assets-files/i18n-map.php' );
 		$this->assertEquals(
 			array(
-				'foo' => array( 'target', 'plugins', '1.2.3' ),
-				'bar' => array( 'target', 'plugins', '4.5.6' ),
+				'foo' => array( 'target', 'plugins', '1.2.3', 'path/to/foo' ),
+				'bar' => array( 'target', 'plugins', '4.5.6', '' ),
 			),
 			TestingAccessWrapper::newFromClass( Assets::class )->domain_map
 		);
@@ -883,7 +916,7 @@ class AssetsTest extends TestCase {
 
 	/** Test filter_gettext. */
 	public function test_filter_gettext() {
-		TestingAccessWrapper::newFromClass( Assets::class )->domain_map = array( 'olddomain' => array( 'newdomain', 'plugins', '1.2.3' ) );
+		TestingAccessWrapper::newFromClass( Assets::class )->domain_map = array( 'olddomain' => array( 'newdomain', 'plugins', '1.2.3', '' ) );
 
 		Functions\expect( '__' )->once()->with( 'foo', 'newdomain' )->andReturn( 'oo-fay' );
 		Functions\expect( '__' )->never()->with( 'bar', 'newdomain' );
@@ -895,7 +928,7 @@ class AssetsTest extends TestCase {
 
 	/** Test filter_ngettext. */
 	public function test_filter_ngettext() {
-		TestingAccessWrapper::newFromClass( Assets::class )->domain_map = array( 'olddomain' => array( 'newdomain', 'plugins', '1.2.3' ) );
+		TestingAccessWrapper::newFromClass( Assets::class )->domain_map = array( 'olddomain' => array( 'newdomain', 'plugins', '1.2.3', '' ) );
 
 		Functions\expect( '_n' )->once()->with( 'foo', 'foos', 10, 'newdomain' )->andReturn( 'oos-fay' );
 		Functions\expect( '_n' )->never()->with( 'bar', 'bars', 42, 'newdomain' );
@@ -907,7 +940,7 @@ class AssetsTest extends TestCase {
 
 	/** Test filter_gettext_with_context. */
 	public function test_filter_gettext_with_context() {
-		TestingAccessWrapper::newFromClass( Assets::class )->domain_map = array( 'olddomain' => array( 'newdomain', 'plugins', '1.2.3' ) );
+		TestingAccessWrapper::newFromClass( Assets::class )->domain_map = array( 'olddomain' => array( 'newdomain', 'plugins', '1.2.3', '' ) );
 
 		Functions\expect( '_x' )->once()->with( 'foo', 'context', 'newdomain' )->andReturn( 'oo-fay' );
 		Functions\expect( '_x' )->never()->with( 'bar', 'context', 'newdomain' );
@@ -919,7 +952,7 @@ class AssetsTest extends TestCase {
 
 	/** Test filter_ngettext_with_context. */
 	public function test_filter_ngettext_with_context() {
-		TestingAccessWrapper::newFromClass( Assets::class )->domain_map = array( 'olddomain' => array( 'newdomain', 'plugins', '1.2.3' ) );
+		TestingAccessWrapper::newFromClass( Assets::class )->domain_map = array( 'olddomain' => array( 'newdomain', 'plugins', '1.2.3', '' ) );
 
 		Functions\expect( '_nx' )->once()->with( 'foo', 'foos', 10, 'context', 'newdomain' )->andReturn( 'oos-fay' );
 		Functions\expect( '_nx' )->never()->with( 'bar', 'bars', 42, 'context', 'newdomain' );
@@ -940,9 +973,9 @@ class AssetsTest extends TestCase {
 	public function test_filter_load_script_translation_file( $args, $is_readable, $expect ) {
 		Jetpack_Constants::set_constant( 'WP_LANG_DIR', '/path/to/wordpress/wp-content/languages' );
 		TestingAccessWrapper::newFromClass( Assets::class )->domain_map = array(
-			'one'   => array( 'new1', 'plugins', '1.2.3' ),
-			'two'   => array( 'new2', 'themes', '1.2.3' ),
-			'three' => array( 'new3', 'core', '1.2.3' ),
+			'one'   => array( 'new1', 'plugins', '1.2.3', 'path/to/one' ),
+			'two'   => array( 'new2', 'themes', '1.2.3', '' ),
+			'three' => array( 'new3', 'core', '1.2.3', '' ),
 		);
 		Functions\when( 'is_readable' )->alias(
 			function ( $file ) use ( $is_readable ) {

--- a/projects/packages/composer-plugin/changelog/update-move-i18n-loader-pkg-path-into-assets
+++ b/projects/packages/composer-plugin/changelog/update-move-i18n-loader-pkg-path-into-assets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Include package path prefixes in `i18n-map.php` so Assets can map them when lazy-loading.

--- a/projects/packages/composer-plugin/composer.json
+++ b/projects/packages/composer-plugin/composer.json
@@ -46,7 +46,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-master": "1.0.x-dev"
+			"dev-master": "1.1.x-dev"
 		}
 	}
 }

--- a/projects/packages/composer-plugin/src/class-plugin.php
+++ b/projects/packages/composer-plugin/src/class-plugin.php
@@ -123,8 +123,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			if ( empty( $extra['textdomain'] ) ) {
 				$io->info( "  {$package->getName()} ($ver): no textdomain set" );
 			} else {
-				$data['packages'][ $extra['textdomain'] ] = $ver;
-				$io->info( "  {$package->getName()} ($ver): textdomain is {$extra['textdomain']}" );
+				$data['packages'][ $extra['textdomain'] ] = array(
+					'path' => 'jetpack_vendor/' . $package->getPrettyName(),
+					'ver'  => $ver,
+				);
+				$io->info( "  {$package->getName()} ($ver): textdomain is {$extra['textdomain']}, path is jetpack_vendor/{$package->getPrettyName()}" );
 			}
 		}
 

--- a/projects/plugins/backup/changelog/update-move-i18n-loader-pkg-path-into-assets
+++ b/projects/plugins/backup/changelog/update-move-i18n-loader-pkg-path-into-assets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-admin-ui": "0.2.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
 		"automattic/jetpack-backup": "1.2.x-dev",
-		"automattic/jetpack-composer-plugin": "1.0.x-dev",
+		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.6.x-dev",
 		"automattic/jetpack-connection": "1.36.x-dev",
 		"automattic/jetpack-connection-ui": "2.3.x-dev",

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35df913a69cfe4028637421890372f9e",
+    "content-hash": "f7489e34a8fa938c0d9663c10b2ac755",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -301,7 +301,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "d9a79b97dbf363bdffb2f748e0dbed8216753c36"
+                "reference": "c3fc0e4cf179c619f896174a6c9db8e70cff74c3"
             },
             "require": {
                 "composer-plugin-api": "^2.1.0"
@@ -320,7 +320,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/update-move-i18n-loader-pkg-path-into-assets
+++ b/projects/plugins/boost/changelog/update-move-i18n-loader-pkg-path-into-assets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -17,7 +17,7 @@
 		"automattic/jetpack-assets": "1.17.x-dev",
 		"automattic/jetpack-admin-ui": "0.2.x-dev",
 		"automattic/jetpack-autoloader": "2.10.x-dev",
-		"automattic/jetpack-composer-plugin": "1.0.x-dev",
+		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.6.x-dev",
 		"automattic/jetpack-connection": "1.36.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b184d7476a787247ac9c9d18216e5976",
+    "content-hash": "bf84051ff242fd51a306b1a6eed5ce99",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -238,7 +238,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "d9a79b97dbf363bdffb2f748e0dbed8216753c36"
+                "reference": "c3fc0e4cf179c619f896174a6c9db8e70cff74c3"
             },
             "require": {
                 "composer-plugin-api": "^2.1.0"
@@ -257,7 +257,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-move-i18n-loader-pkg-path-into-assets
+++ b/projects/plugins/jetpack/changelog/update-move-i18n-loader-pkg-path-into-assets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -18,7 +18,7 @@
 		"automattic/jetpack-backup": "1.2.x-dev",
 		"automattic/jetpack-blocks": "1.4.x-dev",
 		"automattic/jetpack-compat": "1.6.x-dev",
-		"automattic/jetpack-composer-plugin": "1.0.x-dev",
+		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.6.x-dev",
 		"automattic/jetpack-connection": "1.36.x-dev",
 		"automattic/jetpack-connection-ui": "2.3.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e0657836c2a099f253a650fac6abf39",
+    "content-hash": "1d4c429182c3873ea4bae518a3d4d268",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -449,7 +449,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "d9a79b97dbf363bdffb2f748e0dbed8216753c36"
+                "reference": "c3fc0e4cf179c619f896174a6c9db8e70cff74c3"
             },
             "require": {
                 "composer-plugin-api": "^2.1.0"
@@ -468,7 +468,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Instead of having to have every package know where it will end up in the
plugin, we can have jetpack-composer-plugin pass the paths to
jetpack-assets and let the latter's JS prepend that when hashing the
script path.

This is an alternative to #22407.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1642603817021400/1639739679.124300-slack-C82FZ5T4G

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an updated language pack (e.g. in the docker env with /var/scripts/fakepot.sh) and try Instant Search.