### PR TITLE
[Plugin] Backup: Updated default of prices from null to 0

### DIFF
--- a/projects/plugins/backup/changelog/fix-backup-connect-properties
+++ b/projects/plugins/backup/changelog/fix-backup-connect-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Changed price default to null from 0 to fix prop warnings.

--- a/projects/plugins/backup/src/js/components/Admin.js
+++ b/projects/plugins/backup/src/js/components/Admin.js
@@ -33,8 +33,8 @@ const Admin = () => {
 	const [ connectionLoaded, setConnectionLoaded ] = useState( false );
 	const [ capabilitiesLoaded, setCapabilitiesLoaded ] = useState( false );
 	const [ showHeaderFooter, setShowHeaderFooter ] = useState( true );
-	const [ price, setPrice ] = useState( null );
-	const [ priceAfter, setPriceAfter ] = useState( null );
+	const [ price, setPrice ] = useState( 0 );
+	const [ priceAfter, setPriceAfter ] = useState( 0 );
 
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
 

--- a/projects/plugins/backup/src/js/hooks/useConnection.js
+++ b/projects/plugins/backup/src/js/hooks/useConnection.js
@@ -32,8 +32,8 @@ export default function useConnection() {
 		select => select( CONNECTION_STORE_ID ).getConnectionStatus(),
 		[]
 	);
-	const [ price, setPrice ] = useState( null );
-	const [ priceAfter, setPriceAfter ] = useState( null );
+	const [ price, setPrice ] = useState( 0 );
+	const [ priceAfter, setPriceAfter ] = useState( 0 );
 
 	useEffect( () => {
 		apiFetch( { path: '/jetpack/v4/backup-promoted-product-info' } ).then( res => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #22380

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changed the default for prices from null to 0


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On the local environment, run jetpack watch plugins/backup standing on master
* Visit the connection screen for Backup, disconnect first if necessary
* Open the dev console
* Confirm you do not see warnings related to `priceBefore` and `priceAfter`
* Connect, and without a plan, visit the Backup page
* Confirm again no warnings in the dev console related to `priceBefore` and `priceAfter`