### PR TITLE
Add support for Beta Plugins to PluginDashItem

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -15,7 +15,10 @@ import boostSvgUrl from './boost.svg';
 import PluginDashItem from 'components/plugin-dash-item';
 
 const BOOST_PLUGIN_DASH = 'admin.php?page=jetpack-boost';
-const BOOST_PLUGIN_FILE = 'jetpack-boost/jetpack-boost.php';
+const BOOST_PLUGIN_FILES = [
+	'jetpack-boost/jetpack-boost.php',
+	'jetpack-boost-dev/jetpack-boost.php',
+];
 const BOOST_PLUGIN_SLUG = 'jetpack-boost';
 
 class DashBoost extends Component {
@@ -33,7 +36,7 @@ class DashBoost extends Component {
 					'The Jetpack Boost product name, without the Jetpack prefix',
 					'jetpack'
 				) }
-				pluginFile={ BOOST_PLUGIN_FILE }
+				pluginFiles={ BOOST_PLUGIN_FILES }
 				pluginSlug={ BOOST_PLUGIN_SLUG }
 				pluginLink={ this.props.siteAdminUrl + BOOST_PLUGIN_DASH }
 				installOrActivatePrompt={ createInterpolateElement(

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/crm/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/crm/index.jsx
@@ -15,7 +15,7 @@ import peopleSvgUrl from './people.svg';
 import PluginDashItem from 'components/plugin-dash-item';
 
 const CRM_PLUGIN_DASH = 'admin.php?page=zerobscrm-dash';
-const CRM_PLUGIN_FILE = 'zero-bs-crm/ZeroBSCRM.php';
+const CRM_PLUGIN_FILES = [ 'zero-bs-crm/ZeroBSCRM.php' ];
 const CRM_PLUGIN_SLUG = 'zero-bs-crm';
 
 class DashCRM extends Component {
@@ -33,7 +33,7 @@ class DashCRM extends Component {
 					'The Jetpack CRM product name, without the Jetpack prefix',
 					'jetpack'
 				) }
-				pluginFile={ CRM_PLUGIN_FILE }
+				pluginFiles={ CRM_PLUGIN_FILES }
 				pluginSlug={ CRM_PLUGIN_SLUG }
 				pluginLink={ this.props.siteAdminUrl + CRM_PLUGIN_DASH }
 				installOrActivatePrompt={ createInterpolateElement(

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
@@ -10,7 +10,7 @@ import PluginDashItem from 'components/plugin-dash-item';
 export default BoostDashItem = () =>
 	<PluginDashItem
 		pluginName="Boost"
-		pluginFile={ 'jetpack-boost/jetpack-boost.php' }
+		pluginFiles={ [ 'jetpack-boost/jetpack-boost.php' ] }
 		pluginSlug={ 'jetpack-boost' }
 		pluginLink={ this.props.siteAdminUrl + 'admin.php?page=jetpack-boost' }
 		installOrActivatePrompt={ createInterpolateElement(
@@ -35,11 +35,11 @@ export default BoostDashItem = () =>
 
 The display name for the Plugin. Does not need to match the name of the plugin exactly.
 
-### pluginFile
-- **Type:** `String`
+### pluginFiles
+- **Type:** `String[]`
 - **Required:** `yes`
 
-The exact path to the plugin. Used to detect if the plugin is installed.
+The exact path to the plugin(s). Used to detect if the plugin is installed. Can contain multiple paths, in which case each is checked.
 
 ### pluginSlug
 - **Type:** `String`

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/index.jsx
@@ -37,8 +37,8 @@ export const PluginDashItem = ( {
 	iconSrc,
 	installOrActivatePrompt,
 	isFetchingPluginsData,
-	pluginIsActive,
-	pluginIsInstalled,
+	aPluginIsActive,
+	aPluginIsInstalled,
 	pluginLink,
 	pluginName,
 	pluginSlug,
@@ -47,17 +47,17 @@ export const PluginDashItem = ( {
 	const [ isInstalling, setIsInstalling ] = useState( false );
 
 	const activateOrInstallPlugin = useCallback( () => {
-		if ( ! pluginIsInstalled ) {
+		if ( ! aPluginIsInstalled ) {
 			setIsInstalling( true );
-		} else if ( ! pluginIsActive ) {
+		} else if ( ! aPluginIsActive ) {
 			setIsActivating( true );
-		} else if ( pluginIsInstalled && pluginIsActive ) {
+		} else if ( aPluginIsInstalled && aPluginIsActive ) {
 			// do not try to do anything to an installed, active plugin
 			return Promise.resolve();
 		}
 		analytics.tracks.recordJetpackClick( {
 			target: 'plugin_dash_item',
-			type: pluginIsInstalled ? 'install' : 'activate',
+			type: aPluginIsInstalled ? 'install' : 'activate',
 			feature: pluginSlug,
 		} );
 		return (
@@ -73,7 +73,7 @@ export const PluginDashItem = ( {
 					setIsInstalling( false );
 				} )
 		);
-	}, [ fetchPluginsData, pluginIsActive, pluginIsInstalled, pluginSlug ] );
+	}, [ fetchPluginsData, aPluginIsActive, aPluginIsInstalled, pluginSlug ] );
 
 	const renderContent = () => {
 		if ( isFetchingPluginsData ) {
@@ -108,7 +108,7 @@ export const PluginDashItem = ( {
 					</p>
 				</Card>
 			);
-		} else if ( ! pluginIsInstalled ) {
+		} else if ( ! aPluginIsInstalled ) {
 			return (
 				<JetpackBanner
 					callToAction={ sprintf(
@@ -123,7 +123,7 @@ export const PluginDashItem = ( {
 					onClick={ activateOrInstallPlugin }
 				/>
 			);
-		} else if ( ! pluginIsActive ) {
+		} else if ( ! aPluginIsActive ) {
 			return (
 				<JetpackBanner
 					callToAction={ sprintf(
@@ -174,15 +174,15 @@ PluginDashItem.propTypes = {
 
 	// connected properties
 	isFetchingPluginsData: PropTypes.bool,
-	pluginIsActive: PropTypes.bool,
-	pluginIsInstalled: PropTypes.bool,
+	aPluginIsActive: PropTypes.bool,
+	aPluginIsInstalled: PropTypes.bool,
 };
 
 export default connect(
-	( state, { pluginFile } ) => ( {
+	( state, { pluginFiles } ) => ( {
 		isFetchingPluginsData: getIsFetchingPluginsData( state ),
-		pluginIsInstalled: isPluginInstalled( state, pluginFile ),
-		pluginIsActive: isPluginActive( state, pluginFile ),
+		aPluginIsInstalled: pluginFiles.some( pluginFile => isPluginInstalled( state, pluginFile ) ),
+		aPluginIsActive: pluginFiles.some( pluginFile => isPluginActive( state, pluginFile ) ),
 	} ),
 	dispatch => ( { fetchPluginsData: () => dispatch( dispatchFetchPluginsData() ) } )
 )( PluginDashItem );

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/index.jsx
@@ -165,7 +165,7 @@ export const PluginDashItem = ( {
 
 PluginDashItem.propTypes = {
 	pluginName: PropTypes.string.isRequired,
-	pluginFile: PropTypes.string.isRequired,
+	pluginFiles: PropTypes.arrayOf( PropTypes.string ).isRequired,
 	pluginSlug: PropTypes.string.isRequired,
 	pluginLink: PropTypes.string.isRequired,
 	installOrActivatePrompt: PropTypes.element.isRequired,

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/test/component.js
@@ -15,13 +15,13 @@ describe( 'PluginDashItem', () => {
 
 	const testProps = {
 		pluginName: 'Test',
-		pluginFile: 'test/test.php',
+		pluginFiles: [ 'test/test.php' ],
 		pluginSlug: 'test',
 		pluginLink: '/',
 		installOrActivatePrompt: <p>{ 'Install the test plugin.' }</p>,
 		isFetchingPluginsData: false,
-		pluginIsActive: false,
-		pluginIsInstalled: false
+		aPluginIsActive: false,
+		aPluginIsInstalled: false
 	};
 
 	it( 'should render loading while isFetching', () => {
@@ -42,7 +42,7 @@ describe( 'PluginDashItem', () => {
 	} );
 
 	it( 'should render activate prompt if plugin is installed but not active ', () => {
-		const localTestProps = { ...testProps, pluginIsInstalled: true };
+		const localTestProps = { ...testProps, aPluginIsInstalled: true };
 		const wrapper = shallow( <PluginDashItem { ...localTestProps } /> );
 		const content = wrapper.find( JetpackBanner );
 
@@ -51,7 +51,7 @@ describe( 'PluginDashItem', () => {
 	} );
 
 	it( 'should render manage prompt if plugin is installed and active ', () => {
-		const localTestProps = { ...testProps, pluginIsInstalled: true, pluginIsActive: true };
+		const localTestProps = { ...testProps, aPluginIsInstalled: true, aPluginIsActive: true };
 		const wrapper = shallow( <PluginDashItem { ...localTestProps } /> );
 		const content = wrapper.find( JetpackBanner );
 

--- a/projects/plugins/jetpack/changelog/add-plugin-dash-multi-plugin-support
+++ b/projects/plugins/jetpack/changelog/add-plugin-dash-multi-plugin-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for Beta Plugins to PluginDashItem


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Currently, the `PluginDashItem` component accepts a single `pluginFile` prop, and checks to see if the provided plugin is installed and active when rendering the dash item's content.

This PR adds support to `PluginDashItem` to accept *multiple* plugin files, and then consider the plugin installed or active if *any one* of the provided plugin files are installed or active.

This is then implemented in the existing use of `PluginDashItem` in `DashBoost` to consider both the release and beta plugins, which have differing paths (`jetpack-boost` and `jetpack-boost-dev` respectively).

This ensures a consistent behaviour from `PluginDashItem` whether the user has the release or beta version of Jetpack Boost installed.

Fixes 1164141197617539-as-1201689448751944

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Converts `PluginDashItem`'s `pluginFile` string prop to a `pluginFiles` array of strings, so that multiple plugin files can be validated.
* Converts `PluginDashItem`'s `pluginIsActive` and `pluginIsInstalled` props to `aPluginIsActive` and `aPluginIsInstalled`, which are truthy when any single one of the provided plugin file paths is installed or active.
* Updates implementations and tests of `PluginDashItem` to use the new array format for `pluginFiles`, and adds the beta plugin file path in `DashBoost`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p8oabR-LV-p2#comment-5745

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
For all references to the Jetpack dashboard in these instructions, refer to this path in your WordPress installation: 
`/wp-admin/admin.php?page=jetpack#/dashboard`
1. Install and activate [Jetpack Boost](https://wordpress.org/plugins/jetpack-boost/) from the WordPress plugin repository.
2. Visit the Jetpack dashboard and validate that the Jetpack Boost dash item is displayed like so:
<img width="1064" alt="active" src="https://user-images.githubusercontent.com/10933065/150230186-144ff3f5-f678-460d-b79a-30d1bd67bb88.png">

3. Deactivate the Jetpack Boost plugin, but keep it installed.
4. Visit the Jetpack dashboard and validate that the Jetpack Boost dash item is displayed like so:

<img width="1070" alt="installed" src="https://user-images.githubusercontent.com/10933065/150230259-64f36b90-341d-485c-823b-400745e89691.png">

5. Delete the Jetpack Boost plugin. This can also be simulated by renaming the plugin's directory, i.e. `_jetpack-boost`.
6. Visit the Jetpack dashboard and validate that the Jetpack Boost dash item is displayed like so:

<img width="1069" alt="uninstalled" src="https://user-images.githubusercontent.com/10933065/150230516-9cf64f21-d445-459a-83e4-a53cf7fe411a.png">

7. Install [Jetpack Beta](https://jetpack.com/download-jetpack-beta/) and activate the Release Candidate version of Jetpack Boost. You can find the controls for this here: `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack-boost`.
8. **Repeat steps 2-4.**

