### PR TITLE
Connection: Use helper function instead of direct call to option

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-handle_post_authorization_actions
+++ b/projects/plugins/jetpack/changelog/fix-handle_post_authorization_actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Connection: correctly request list of active modules so they can be activated on a reconnection

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -7039,7 +7039,7 @@ endif;
 			: array();
 
 		if ( Jetpack_Options::get_option( 'active_modules_initialized' ) ) {
-			$active_modules = Jetpack_Options::get_option( 'active_modules' );
+			$active_modules = self::get_active_modules();
 			self::delete_active_modules();
 
 			self::activate_default_modules( 999, 1, array_merge( $active_modules, $other_modules ), $redirect_on_activation_error, $send_state_messages );


### PR DESCRIPTION
- Use the helper function instead of direct call to the option
- changelog

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Reported by VIP. If a site uses a filter like:
```
add_filter(
	'jetpack_active_modules',
	function ( $modules ) {
		$modules[] = 'search';

		return array_unique( $modules );
	}
);
```
it appears that `search` would not be included in the `handle_post_authorization_actions` work because that module may not be in the active_modules option. We use helper functions elsewhere.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use helper function instead of direct call to the active_modules option.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Slack

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect Jetpack. Do not manually enable Search.
* Add snippet like the above.
* Add snippet that's something like `add_action( 'jetpack_before_activate_default_modules', function( $min_ver, $max_ver, $other ) { error_log( $other ); }, 10, 5 );` so we can see the output of the "other modules".
* Cycle the connection.
* Check error log. See if `search` is included.
