### PR TITLE
Markdown block: Add Align and Spacing features

### DIFF
--- a/projects/plugins/jetpack/changelog/add-markdown-block-align-and-spacing-feature
+++ b/projects/plugins/jetpack/changelog/add-markdown-block-align-and-spacing-feature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Markdown block: Add Align and Spacing features

--- a/projects/plugins/jetpack/extensions/blocks/markdown/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/index.js
@@ -77,16 +77,8 @@ export const settings = {
 	},
 
 	supports: {
-		color: {
-			link: true,
-			gradients: true,
-		},
 		spacing: {
 			padding: true,
-		},
-		typography: {
-			fontSize: true,
-			lineHeight: true,
 		},
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/projects/plugins/jetpack/extensions/blocks/markdown/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/index.js
@@ -77,6 +77,18 @@ export const settings = {
 	},
 
 	supports: {
+		color: {
+			link: true,
+			gradients: true,
+		},
+		spacing: {
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+		},
+		align: [ 'wide', 'full' ],
 		html: false,
 	},
 

--- a/projects/plugins/jetpack/extensions/blocks/markdown/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/index.js
@@ -77,11 +77,11 @@ export const settings = {
 	},
 
 	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
 		spacing: {
 			padding: true,
 		},
-		align: [ 'wide', 'full' ],
-		html: false,
 	},
 
 	edit,

--- a/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
@@ -22,10 +22,7 @@ const handleLinkClick = event => {
 	}
 };
 
-const getStyles = attributes => {
-	if ( ! attributes ) {
-		return null;
-	}
+const getStyles = ( attributes = {} ) => {
 	const spacingProps = getSpacingClassesAndStyles( attributes );
 	return spacingProps.style;
 };

--- a/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import MarkdownIt from 'markdown-it';
 import { RawHTML } from '@wordpress/element';
+import { __experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
  * Module variables
@@ -21,8 +22,13 @@ const handleLinkClick = event => {
 	}
 };
 
-export default ( { className, source = '' } ) => (
-	<RawHTML className={ className } onClick={ handleLinkClick }>
+const getStyles = attributes => {
+	const spacingProps = getSpacingClassesAndStyles( attributes );
+	return spacingProps.style;
+};
+
+export default ( { className, source = '', attributes = '' } ) => (
+	<RawHTML className={ className } onClick={ handleLinkClick } style={ getStyles( attributes ) }>
 		{ source.length ? markdownConverter.render( source ) : '' }
 	</RawHTML>
 );

--- a/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
@@ -23,11 +23,14 @@ const handleLinkClick = event => {
 };
 
 const getStyles = attributes => {
+	if ( ! attributes ) {
+		return null;
+	}
 	const spacingProps = getSpacingClassesAndStyles( attributes );
 	return spacingProps.style;
 };
 
-export default ( { className, source = '', attributes = '' } ) => (
+export default ( { className, source = '', attributes } ) => (
 	<RawHTML className={ className } onClick={ handleLinkClick } style={ getStyles( attributes ) }>
 		{ source.length ? markdownConverter.render( source ) : '' }
 	</RawHTML>

--- a/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
@@ -23,8 +23,8 @@ const handleLinkClick = event => {
 };
 
 const getStyles = ( attributes = {} ) => {
-	const spacingProps = getSpacingClassesAndStyles( attributes );
-	return spacingProps.style;
+	const spacingProps = getSpacingClassesAndStyles?.( attributes );
+	return spacingProps?.style ? spacingProps.style : {};
 };
 
 export default ( { className, source = '', attributes } ) => (

--- a/projects/plugins/jetpack/extensions/blocks/markdown/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/save.js
@@ -4,5 +4,9 @@
 import MarkdownRenderer from './renderer';
 
 export default ( { attributes, className } ) => (
-	<MarkdownRenderer className={ className } source={ attributes.source } />
+	<MarkdownRenderer
+		className={ className }
+		source={ attributes.source }
+		attributes={ attributes }
+	/>
 );

--- a/projects/plugins/jetpack/extensions/blocks/markdown/test/__snapshots__/markdown-renderer.js.snap
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/test/__snapshots__/markdown-renderer.js.snap
@@ -4,6 +4,7 @@ exports[`MarkdownRenderer renders markdown to HTML as expected 1`] = `
 <RawHTML
   className="markdown"
   onClick={[Function]}
+  style={Object {}}
 >
   &lt;h1&gt;Heading&lt;/h1&gt;
 &lt;h2&gt;2nd Heading&lt;/h2&gt;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The proposed change adds Align (Wide & Full Width) and Dimensions (Padding) features to the Markdown block.

 Before | After |
| ------------- | ------------- |
| ![Markup on 2022-01-20 at 16:12:13](https://user-images.githubusercontent.com/25105483/150366471-449e098b-7413-4deb-b5cc-77d36350af58.png) | ![Markup on 2022-01-20 at 16:09:17](https://user-images.githubusercontent.com/25105483/150366566-1999d578-a7d0-498e-8e3f-1041898ae593.png) |
![Markup on 2022-01-20 at 16:12:46](https://user-images.githubusercontent.com/25105483/150366815-a5c6734f-d273-4931-94ee-5c61eeff07e9.png) | ![Markup on 2022-01-20 at 16:10:01](https://user-images.githubusercontent.com/25105483/150366914-f9191867-9be3-4bc8-ad50-172b74acbb41.png) |

#### Jetpack product discussion

This PR is a part of the _Expanding Jetpack Block design tooling for Full Site Editing_ project: pdDOJh-6-p2.

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Create a new post or a page with the Markdown block
2. There should be a new set of features: Align (in the block toolbar) and Dimensions / Padding (in the block sidebar).
3. Experiment with the new features and observe whether the change applies correctly in the back-end
4. Save the changes and review if the settings are correctly rendering in the front-end as well
5. We can test the change with multiple themes (block-based, classic). Not all themes support all features. If a theme doesn't support a specific feature, this feature won't be displayed in the block sidebar.

For example, themes like Storefront and Dara doesn't support block Dimensions / Padding and therefore it won't display in the block sidebar. Theme like Hever, Maywood or Geologist support both Align and Dimensions / Padding.

**Example markdown text you can use in your tests:**

```
# Heading 1
## Heading 2
### Heading 3

Text text text

- bullet point 1
- bullet point 2
- bullet point 3

1. ordered 1
2. ordered 2
3. ordered 3

**bold** *italic*

> blockquote

Horizontal line:

---

This should be a link: [I am a link](https://wordpress.com "I am a link").

Image:

![image](https://via.placeholder.com/150/0000FF/808080?Text=Test)
```
