### PR TITLE
Build: copy files from the new vendor dir to previous location

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -178,7 +178,7 @@ for SLUG in "${SLUGS[@]}"; do
 	# Copy SECURITY.md
 	cp "$BASE/SECURITY.md" "$BUILD_DIR/SECURITY.md"
 
-	if [ $SLUG === "plugins/jetpack" ]; then
+	if [[ "$SLUG" == "plugins/jetpack" ]]; then
 		echo "Copying Jetpack files for backward compatibility."
 
 		OLD_VENDOR_DIR="$BUILD_DIR/vendor"

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -197,7 +197,7 @@ for SLUG in "${SLUGS[@]}"; do
 		)
 
 		for file in "${FILES_TO_COPY[@]}"; do
-			if [[ -f "$file" ]]; then
+			if [[ -f "$NEW_VENDOR_DIR/$file" ]]; then
 				dir_name=$(dirname "$file")
 
 				mkdir -pm 644 "$OLD_VENDOR_DIR/$dir_name"

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -198,7 +198,7 @@ for SLUG in "${SLUGS[@]}"; do
 
 		for file in "${FILES_TO_COPY[@]}"; do
 			if [[ -f "$file" ]]; then
-				cp "$NEW_VENDOR_DIR/$file" "$OLD_VENDOR_DIR/$file"
+				install -D -m 644 "$NEW_VENDOR_DIR/$file" "$OLD_VENDOR_DIR/$file"
 			fi
 		done
 	fi

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -178,27 +178,30 @@ for SLUG in "${SLUGS[@]}"; do
 	# Copy SECURITY.md
 	cp "$BASE/SECURITY.md" "$BUILD_DIR/SECURITY.md"
 
-	# Copy files for backward compatibility.
-	OLD_VENDOR_DIR="$BUILD_DIR/vendor"
-	NEW_VENDOR_DIR="$BUILD_DIR/jetpack_vendor"
-	FILES_TO_MOVE=(
-		"automattic/jetpack-roles/src/class-roles.php",
-		"automattic/jetpack-backup/src/class-package-version.php",
-		"automattic/jetpack-sync/src/class-package-version.php",
-		"automattic/jetpack-connection/src/class-package-version.php",
-		"automattic/jetpack-connection/src/class-urls.php",
-		"automattic/jetpack-sync/src/class-queue-buffer.php",
-		"automattic/jetpack-sync/src/class-utils.php",
-		"automattic/jetpack-connection/legacy/class-jetpack-ixr-client.php",
-		"automattic/jetpack-connection/src/class-client.php",
-		"automattic/jetpack-connection/legacy/class-jetpack-signature.php"
-	)
+	if [ $SLUG === "plugins/jetpack" ]; then
+		echo "Copying Jetpack files for backward compatibility."
 
-	for file in "${FILES_TO_MOVE[@]}"; do
-		if [[ -f "$file" ]]; then
-			cp "$NEW_VENDOR_DIR$file" "$OLD_VENDOR_DIR$file"
-		fi
-	done
+		OLD_VENDOR_DIR="$BUILD_DIR/vendor"
+		NEW_VENDOR_DIR="$BUILD_DIR/jetpack_vendor"
+		FILES_TO_COPY=(
+			"automattic/jetpack-roles/src/class-roles.php",
+			"automattic/jetpack-backup/src/class-package-version.php",
+			"automattic/jetpack-sync/src/class-package-version.php",
+			"automattic/jetpack-connection/src/class-package-version.php",
+			"automattic/jetpack-connection/src/class-urls.php",
+			"automattic/jetpack-sync/src/class-queue-buffer.php",
+			"automattic/jetpack-sync/src/class-utils.php",
+			"automattic/jetpack-connection/legacy/class-jetpack-ixr-client.php",
+			"automattic/jetpack-connection/src/class-client.php",
+			"automattic/jetpack-connection/legacy/class-jetpack-signature.php"
+		)
+
+		for file in "${FILES_TO_COPY[@]}"; do
+			if [[ -f "$file" ]]; then
+				cp "$NEW_VENDOR_DIR/$file" "$OLD_VENDOR_DIR/$file"
+			fi
+		done
+	fi
 
 
 	# Copy only wanted files, based on .gitignore and .gitattributes.

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -220,6 +220,7 @@ for SLUG in "${SLUGS[@]}"; do
 
 			fi
 		done
+		echo "::endgroup::"
 	fi
 
 	# Remove monorepo repos from composer.json

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -179,7 +179,7 @@ for SLUG in "${SLUGS[@]}"; do
 	cp "$BASE/SECURITY.md" "$BUILD_DIR/SECURITY.md"
 
 	if [[ "$SLUG" == "plugins/jetpack" ]]; then
-		echo "Copying Jetpack files for backward compatibility."
+		echo "::group::Copying Jetpack files for backward compatibility."
 
 		OLD_VENDOR_DIR="$BUILD_DIR/vendor"
 		NEW_VENDOR_DIR="$BUILD_DIR/jetpack_vendor"

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -184,15 +184,15 @@ for SLUG in "${SLUGS[@]}"; do
 		OLD_VENDOR_DIR="$BUILD_DIR/vendor"
 		NEW_VENDOR_DIR="$BUILD_DIR/jetpack_vendor"
 		FILES_TO_COPY=(
-			"automattic/jetpack-roles/src/class-roles.php",
-			"automattic/jetpack-backup/src/class-package-version.php",
-			"automattic/jetpack-sync/src/class-package-version.php",
-			"automattic/jetpack-connection/src/class-package-version.php",
-			"automattic/jetpack-connection/src/class-urls.php",
-			"automattic/jetpack-sync/src/class-queue-buffer.php",
-			"automattic/jetpack-sync/src/class-utils.php",
-			"automattic/jetpack-connection/legacy/class-jetpack-ixr-client.php",
-			"automattic/jetpack-connection/src/class-client.php",
+			"automattic/jetpack-roles/src/class-roles.php"
+			"automattic/jetpack-backup/src/class-package-version.php"
+			"automattic/jetpack-sync/src/class-package-version.php"
+			"automattic/jetpack-connection/src/class-package-version.php"
+			"automattic/jetpack-connection/src/class-urls.php"
+			"automattic/jetpack-sync/src/class-queue-buffer.php"
+			"automattic/jetpack-sync/src/class-utils.php"
+			"automattic/jetpack-connection/legacy/class-jetpack-ixr-client.php"
+			"automattic/jetpack-connection/src/class-client.php"
 			"automattic/jetpack-connection/legacy/class-jetpack-signature.php"
 		)
 

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -198,7 +198,10 @@ for SLUG in "${SLUGS[@]}"; do
 
 		for file in "${FILES_TO_COPY[@]}"; do
 			if [[ -f "$file" ]]; then
-				install -D -m 644 "$NEW_VENDOR_DIR/$file" "$OLD_VENDOR_DIR/$file"
+				dir_name=$(dirname "$file")
+
+				mkdir -pm 644 "$OLD_VENDOR_DIR/$dir_name"
+				cp "$NEW_VENDOR_DIR/$file" "$OLD_VENDOR_DIR/$file"
 			fi
 		done
 	fi

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -201,6 +201,7 @@ for SLUG in "${SLUGS[@]}"; do
 			"automattic/jetpack-sync/src/class-package-version.php"
 			"automattic/jetpack-connection/src/class-package-version.php"
 			"automattic/jetpack-connection/src/class-urls.php"
+			"automattic/jetpack-sync/src/class-functions.php"
 			"automattic/jetpack-sync/src/class-queue-buffer.php"
 			"automattic/jetpack-sync/src/class-utils.php"
 			"automattic/jetpack-connection/legacy/class-jetpack-ixr-client.php"

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -178,6 +178,29 @@ for SLUG in "${SLUGS[@]}"; do
 	# Copy SECURITY.md
 	cp "$BASE/SECURITY.md" "$BUILD_DIR/SECURITY.md"
 
+	# Copy files for backward compatibility.
+	OLD_VENDOR_DIR="$BUILD_DIR/vendor"
+	NEW_VENDOR_DIR="$BUILD_DIR/jetpack_vendor"
+	FILES_TO_MOVE=(
+		"automattic/jetpack-roles/src/class-roles.php",
+		"automattic/jetpack-backup/src/class-package-version.php",
+		"automattic/jetpack-sync/src/class-package-version.php",
+		"automattic/jetpack-connection/src/class-package-version.php",
+		"automattic/jetpack-connection/src/class-urls.php",
+		"automattic/jetpack-sync/src/class-queue-buffer.php",
+		"automattic/jetpack-sync/src/class-utils.php",
+		"automattic/jetpack-connection/legacy/class-jetpack-ixr-client.php",
+		"automattic/jetpack-connection/src/class-client.php",
+		"automattic/jetpack-connection/legacy/class-jetpack-signature.php"
+	)
+
+	for file in "${FILES_TO_MOVE[@]}"; do
+		if [[ -f "$file" ]]; then
+			cp "$NEW_VENDOR_DIR$file" "$OLD_VENDOR_DIR$file"
+		fi
+	done
+
+
 	# Copy only wanted files, based on .gitignore and .gitattributes.
 	{
 		# Include unignored files by default.

--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -200,7 +200,7 @@ for SLUG in "${SLUGS[@]}"; do
 			if [[ -f "$NEW_VENDOR_DIR/$file" ]]; then
 				dir_name=$(dirname "$file")
 
-				mkdir -pm 644 "$OLD_VENDOR_DIR/$dir_name"
+				mkdir -p "$OLD_VENDOR_DIR/$dir_name"
 				cp "$NEW_VENDOR_DIR/$file" "$OLD_VENDOR_DIR/$file"
 			fi
 		done


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Let's attempt, when building a production version of Jetpack, to copy some files to their previous location pre-10.5.

#### Jetpack product discussion

﻿Internal references:
- p9dueE-4fc-p2
- p1642671449497200-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Click on the Build check below, and in the summary view click to download "jetpack-build"
* Uncompress the downloaded archive, navigate to the Jetpack plugin (`jetpack-production`), and check that the files can be found at the old location (`vendor/automattic/...`)
* Zip just the Jetpack plugin (make sure the folder is named just `jetpack` before zipping).
* Create a new JN site with Jetpack and the WP Rollback plugin.
* SSH into the site, and tail the debug.log.
* Using the WP Rollback plugin, rollback to Jetpack version 10.4
* Connect your site to WordPress.com.
* Go to Plugins > Add New > Upload plugin, and upload the zip you've just created.
* It should offer you to update from Jetpack 10.4 to Jetpack 10.6-a.4 (if you don't see the "this plugin is already installed..." prompt then a step was likely missed).
* Run the update; you should see no issues on the site or in the log.
