### PR TITLE
My Jetpack: Remove superseded endpoint my-jetpack/v1/site/plans

### DIFF
--- a/projects/packages/my-jetpack/changelog/remove-plans-endpoints-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/remove-plans-endpoints-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Removed endpoint plans superseded by purchases

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -13,7 +13,6 @@ use Automattic\Jetpack\Connection\Client as Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Status as Status;
-use Automattic\Jetpack\Status\Visitor;
 
 /**
  * The main Initializer class that registers the admin menu and eneuque the assets.
@@ -130,16 +129,6 @@ class Initializer {
 				'permission_callback' => __CLASS__ . '::permissions_callback',
 			)
 		);
-
-		register_rest_route(
-			'my-jetpack/v1',
-			'/site/plans',
-			array(
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => __CLASS__ . '::get_site_plans',
-				'permission_callback' => __CLASS__ . '::permissions_callback',
-			)
-		);
 	}
 
 	/**
@@ -174,30 +163,4 @@ class Initializer {
 		return rest_ensure_response( $body, 200 );
 	}
 
-	/**
-	 * Site plans endpoint.
-	 *
-	 * @return array Site plans.
-	 */
-	public static function get_site_plans() {
-		$wpcom_endpoint    = sprintf( '/plans?_locale=%s?force=wpcom', get_user_locale() );
-		$wpcom_api_version = '2';
-		$response          = Client::wpcom_json_api_request_as_user(
-			$wpcom_endpoint,
-			$wpcom_api_version,
-			array(
-				'headers' => array(
-					'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
-				),
-			)
-		);
-		$response_code     = wp_remote_retrieve_response_code( $response );
-		$body              = json_decode( wp_remote_retrieve_body( $response ) );
-
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'site_plans_data_fetch_failed', 'Site plans data fetch failed', array( 'status' => $response_code ) );
-		}
-
-		return rest_ensure_response( $body, 200 );
-	}
 }


### PR DESCRIPTION
Removes an endpoint that was replaced by the purchases endpoint

Fixes #22430


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes registration of `my-jetpack/v1/site/plans` as an endpoint.

#### Does this pull request change what data or activity we track or use?
none

#### Testing instructions:

None