### PR TITLE
Connection, Components, My Jetpack: Do not style header elements from AdminSection component an update ConnectionStatusCard header style

### DIFF
--- a/projects/js-packages/components/changelog/update-connection-section-my-jetpack-styles
+++ b/projects/js-packages/components/changelog/update-connection-section-my-jetpack-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Do not style header elements from AdminSection component

--- a/projects/js-packages/components/components/admin-section/basic/style.module.scss
+++ b/projects/js-packages/components/components/admin-section/basic/style.module.scss
@@ -3,8 +3,4 @@
 	padding: 64px 0px;
 	background-color: white;
 
-	h1, h2, h3, h4, h5, h6 {
-		margin-top: 0px;
-		line-height: 1.2;
-	}
 }

--- a/projects/js-packages/connection/changelog/update-connection-section-my-jetpack-styles
+++ b/projects/js-packages/connection/changelog/update-connection-section-my-jetpack-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update h3 style for connection status card

--- a/projects/js-packages/connection/components/connection-status-card/style.scss
+++ b/projects/js-packages/connection/components/connection-status-card/style.scss
@@ -2,9 +2,10 @@
 
 .jp-connection-status-card {
 	h3 {
-		font-size: 36px;
-		line-height: 40px;
-		font-weight: 400;
+		font-size: var(--font-title-large);
+		font-weight: 700;
+		margin-top: 48px;
+		line-height: 1.1;
 		color: var( --jp-black );
 		margin: 0;
 	}
@@ -19,7 +20,7 @@
 	}
 
 	p, a, li {
-		font-size: 16px;
+		font-size: var( --font-body );
 		line-height: 24px;
 	}
 


### PR DESCRIPTION
Fixes style for Connection Status Card when shown in My Jetpack

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes CSS rules affecting headers in AdminSection's css module file.
* Update ConnectionStatusCard header style to compy with latest design's

#### Jetpack product discussion

p1HpG7-dFw-p2

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### After

![image](https://user-images.githubusercontent.com/746152/150400211-721e4b51-2340-4320-91e8-ad0ba321f180.png)

#### Before

![Uploading image.png…]()
