### PR TITLE
My Jetpack: Make the ProductCard component accept an actions property

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -89,7 +89,7 @@ const renderActionButton = ( {
 };
 
 const ProductCard = props => {
-	const { name, admin, description, icon, status, onDeactivate } = props;
+	const { actions, name, admin, description, icon, status, onDeactivate } = props;
 	const isActive = status === PRODUCT_STATUSES.ACTIVE;
 	const isError = status === PRODUCT_STATUSES.ERROR;
 	const isInactive = status === PRODUCT_STATUSES.INACTIVE;
@@ -107,6 +107,14 @@ const ProductCard = props => {
 		[ styles.error ]: isError,
 	} );
 
+	const defaultActions = [
+		{
+			title: __( 'Deactivate', 'jetpack-my-jetpack' ),
+			icon: null,
+			onClick: onDeactivate,
+		},
+	];
+
 	return (
 		<div className={ containerClassName }>
 			<div className={ styles.name }>
@@ -123,13 +131,7 @@ const ProductCard = props => {
 							toggleProps={ { isPressed: true } }
 							popoverProps={ { noArrow: false } }
 							icon={ DownIcon }
-							controls={ [
-								{
-									title: __( 'Deactivate', 'jetpack-my-jetpack' ),
-									icon: null,
-									onClick: onDeactivate,
-								},
-							] }
+							controls={ actions || defaultActions }
 						/>
 					</ButtonGroup>
 				) : (
@@ -142,6 +144,7 @@ const ProductCard = props => {
 };
 
 ProductCard.propTypes = {
+	actions: PropTypes.array,
 	name: PropTypes.string.isRequired,
 	description: PropTypes.string.isRequired,
 	icon: PropTypes.element,

--- a/projects/packages/my-jetpack/changelog/update-allow-product-controls-extensibility
+++ b/projects/packages/my-jetpack/changelog/update-allow-product-controls-extensibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Make the ProductCard My Jetpack component accept an actions property


### PR DESCRIPTION
Adds an `actions` property accepting an array of objects. The format for this objects is the same as DropdownMenu's [controls](https://developer.wordpress.org/block-editor/reference-guides/components/dropdown-menu/#controls). 


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds an `actions` property accepting an array of objects. The format for this objects is the same as DropdownMenu's [controls](https://developer.wordpress.org/block-editor/reference-guides/components/dropdown-menu/#controls). 


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:

