### PR TITLE
My Jetpack: Add analytics hook

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,6 +619,7 @@ importers:
 
   projects/packages/my-jetpack:
     specifiers:
+      '@automattic/jetpack-analytics': workspace:^0.1.7-alpha
       '@automattic/jetpack-base-styles': workspace:^0.1.7-alpha
       '@automattic/jetpack-components': workspace:^0.10.3-alpha
       '@automattic/jetpack-connection': workspace:^0.14.0-alpha
@@ -648,6 +649,7 @@ importers:
       storybook-addon-mock: 2.0.2
       webpack: 5.65.0
     dependencies:
+      '@automattic/jetpack-analytics': link:../../js-packages/analytics
       '@automattic/jetpack-components': link:../../js-packages/components
       '@automattic/jetpack-connection': link:../../js-packages/connection
       '@wordpress/components': 19.1.6_aae888dfa296766acacf1a733aa50b3a

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
 import {
 	AdminSection,
@@ -11,10 +11,14 @@ import {
 	Col,
 } from '@automattic/jetpack-components';
 
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 import ConnectionsSection from '../connections-section';
 import PlansSection from '../plans-section';
 import ProductCardsSection from '../product-cards-section';
+import useAnalytics from '../../hooks/use-analytics';
 
 /**
  * The My Jetpack App Main Screen.
@@ -22,6 +26,12 @@ import ProductCardsSection from '../product-cards-section';
  * @returns {object} The MyJetpackScreen component.
  */
 export default function MyJetpackScreen() {
+	const {
+		tracks: { recordEvent },
+	} = useAnalytics();
+	useEffect( () => {
+		recordEvent( 'jetpack_myjetpack_page_view' );
+	}, [ recordEvent ] );
 	return (
 		<div className="jp-my-jetpack-screen">
 			<AdminPage>

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/README.md
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/README.md
@@ -1,0 +1,22 @@
+# useAnalytics
+
+React hook that provides access to the functions exported by @automattic/jetpack-analytics by almost autoinitializing it. 
+Depends on the connection package @automattic/jetpack-connection
+
+
+```es6
+import useAnalytics from './hooks/use-analyticis';
+
+function PlansSection() {
+	const analytics = useAnalytics();
+	const doit = () => {
+		analytics.tracks.recordEvent( 'jetpack_doit_click' );
+		alert( 'do something' );
+	}
+	return (
+		<div>
+			<Button onClick={ doit }>Do it!</Button>
+		</div>
+	)
+}
+```

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
@@ -1,0 +1,51 @@
+/* global myJetpackInitialState */
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { useConnection } from '@automattic/jetpack-connection';
+
+const useAnalytics = () => {
+	const { apiRoot, apiNonce } = myJetpackInitialState;
+
+	const { isUserConnected, userConnectionData } = useConnection( {
+		apiRoot,
+		apiNonce,
+	} );
+
+	const { login, ID } = userConnectionData.currentUser.wpcomUser;
+	/**
+	 * Initialize tracks with user data.
+	 * Should run when we have a connected user.
+	 */
+	useEffect( () => {
+		if ( isUserConnected ) {
+			jetpackAnalytics.initialize( ID, login );
+		}
+	} );
+	const {
+		clearedIdentity,
+		ga,
+		mc,
+		pageView,
+		purchase,
+		setGoogleAnalyticsEnabled,
+		setMcAnalyticsEnabled,
+		setProperties,
+		tracks,
+	} = jetpackAnalytics;
+	return {
+		clearedIdentity,
+		ga,
+		mc,
+		pageView,
+		purchase,
+		setGoogleAnalyticsEnabled,
+		setMcAnalyticsEnabled,
+		setProperties,
+		tracks,
+	};
+};
+
+export default useAnalytics;

--- a/projects/packages/my-jetpack/changelog/add-analytics-to-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-analytics-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added useAnalytics hook

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -6,7 +6,9 @@
 	"require": {
 		"automattic/jetpack-admin-ui": "^0.2",
 		"automattic/jetpack-assets": "^1.16",
-		"automattic/jetpack-connection": "^1.36"
+		"automattic/jetpack-connection": "^1.36",
+		"automattic/jetpack-terms-of-service": "^1.9",
+		"automattic/jetpack-tracking": "^1.14"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -21,6 +21,7 @@
 		"test": "js-test-runner jest --passWithNoTests --setupFilesAfterEnv ./jest.setup.js"
 	},
 	"dependencies": {
+		"@automattic/jetpack-analytics": "workspace:^0.1.7-alpha",
 		"@automattic/jetpack-components": "workspace:^0.10.3-alpha",
 		"@automattic/jetpack-connection": "workspace:^0.14.0-alpha",
 		"@wordpress/components": "19.1.6",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -11,8 +11,11 @@ use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Client as Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Status as Status;
+use Automattic\Jetpack\Terms_Of_Service;
+use Automattic\Jetpack\Tracking;
 
 /**
  * The main Initializer class that registers the admin menu and eneuque the assets.
@@ -69,6 +72,17 @@ class Initializer {
 	}
 
 	/**
+	 * Returns whether we are in condition to track to use
+	 * Analytics functionality like Tracks, MC, or GA.
+	 */
+	public static function can_use_analytics() {
+		$status     = new Status();
+		$connection = new Connection_Manager();
+		$tracking   = new Tracking( 'jetpack', $connection );
+
+		return $tracking->should_enable_tracking( new Terms_Of_Service(), $status );
+	}
+	/**
 	 * Enqueue admin page assets.
 	 *
 	 * @return void
@@ -100,6 +114,11 @@ class Initializer {
 
 		// Connection Initial State.
 		wp_add_inline_script( 'my_jetpack_main_app', Connection_Initial_State::render(), 'before' );
+
+		// Required for Analytics.
+		if ( self::can_use_analytics() ) {
+			Tracking::register_tracks_functions_scripts( true );
+		}
 	}
 
 	/**

--- a/projects/plugins/backup/changelog/add-analytics-to-my-jetpack
+++ b/projects/plugins/backup/changelog/add-analytics-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Update root reqs for Jetpack

--- a/projects/plugins/backup/changelog/add-analytics-to-my-jetpack
+++ b/projects/plugins/backup/changelog/add-analytics-to-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Update root reqs for Jetpack

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -767,12 +767,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "873d6eefa75c3545c18297c962702a6324df65e2"
+                "reference": "a5d7c6f0f3652d649cac7b11dfe35db034634fb7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
                 "automattic/jetpack-assets": "^1.16",
-                "automattic/jetpack-connection": "^1.36"
+                "automattic/jetpack-connection": "^1.36",
+                "automattic/jetpack-terms-of-service": "^1.9",
+                "automattic/jetpack-tracking": "^1.14"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",

--- a/projects/plugins/jetpack/changelog/add-analytics-to-my-jetpack
+++ b/projects/plugins/jetpack/changelog/add-analytics-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Update root reqs for Jetpack

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1154,12 +1154,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "873d6eefa75c3545c18297c962702a6324df65e2"
+                "reference": "a5d7c6f0f3652d649cac7b11dfe35db034634fb7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
                 "automattic/jetpack-assets": "^1.16",
-                "automattic/jetpack-connection": "^1.36"
+                "automattic/jetpack-connection": "^1.36",
+                "automattic/jetpack-terms-of-service": "^1.9",
+                "automattic/jetpack-tracking": "^1.14"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",


### PR DESCRIPTION
Introduces an `useAnalytics` hook. 

The hook utilizes the connection initial state to `initialize` the jetpack analyticis lib.


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces `my-jetpack/hooks/use-analytics`.
* Adds firing of `jetpack_myjetpack_page_view` event when the My Jetpack page is viewed.
* Adds conditional loading of Tracks Js on the My Jetpack initializer class.
* Adds dependency on `terms-of-service` 
* Adds dependency on `tracking`.
* **The script is only loaded if the User is connected**

#### Does this pull request change what data or activity we track or use?

Well... yes.

#### Testing instructions:

* Checkout this branch...
* Open the browser.
* Open the developer console, execute the following code: `localStorage.debug='dops:analyitics*`
* Connect Jetpack.
* Go to "Jetpack -> My Jetpack", Confirm that the developer console displays the events `jetpack_wpa_click` and `jetpack_myjetpack_page_view`.


https://user-images.githubusercontent.com/746152/150571491-8d4f62ad-f527-4392-ab06-41e642298e2d.mov


