### PR TITLE
Build - Add plugins/backup to previous vendor copy logic

### DIFF
--- a/.github/files/build-all-projects.sh
+++ b/.github/files/build-all-projects.sh
@@ -190,7 +190,7 @@ for SLUG in "${SLUGS[@]}"; do
 		# Copy the resulting list of files into the clone.
 		xargs cp --parents --target-directory="$BUILD_DIR"
 
-	if [[ "$SLUG" == "plugins/jetpack" ]]; then
+	if [[ "$SLUG" == "plugins/jetpack" || "$SLUG" == "plugins/backup" ]]; then
 		echo "::group::Copying Jetpack files for backward compatibility."
 
 		OLD_VENDOR_DIR="$BUILD_DIR/vendor"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds plugins/backup to have vendor files copied to avoid conflicts when upgrading from 1.0.1 to 1.1.0

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Internal references:

p9dueE-4fc-p2
p1642671449497200-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Click on the Build check below, and in the summary view click to download "jetpack-build"
* Uncompress the downloaded archive, navigate to the Jetpack Backup plugin (jetpack-backup-plugin), and check that the files can be found at the old location (vendor/automattic/...)
* Zip just the Jetpack Backup plugin (make sure the folder is named just jetpack-backup before zipping).
* Create a new JN site without any plugins
* SSH into the site, and tail the debug.log.
* Go to Plugins > Add New > Search for Jetpack Backup and install from .org (v1.0.1) - Activate
* Connect your site to WordPress.com from Jetpack > Backup
* Go to Plugins > Add New > Upload plugin, and upload the zip you've just created.
* It should offer you to update from Jetpack Backup 1.0.1 to Jetpack Backup 1.1.1-alpha (if you don't see the "this plugin is already installed..." prompt then a step was likely missed).
* Run the update; you should see no issues on the site or in the log.