### PR TITLE
My Jetpack: Update name and description props to use i18n in product cards

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,8 +25,8 @@ const AntiSpamCard = ( { admin } ) => {
 	// @todo: implement action handlers
 	return (
 		<ProductCard
-			name="Anti-spam"
-			description="Stop comment and form spam"
+			name={ __( 'Anti-spam', 'jetpack-my-jetpack' ) }
+			description={ __( 'Stop comment and form spam', 'jetpack-my-jetpack' ) }
 			status={ PRODUCT_STATUSES.ABSENT }
 			icon={ <AntiSpamIcon /> }
 			admin={ admin }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,8 +25,8 @@ const BackupCard = ( { admin } ) => {
 	// @todo: implement action handlers
 	return (
 		<ProductCard
-			name="Backup"
-			description="Save every change"
+			name={ __( 'Backup', 'jetpack-my-jetpack' ) }
+			description={ __( 'Save every change', 'jetpack-my-jetpack' ) }
 			status={ PRODUCT_STATUSES.ACTIVE }
 			icon={ <BackupIcon /> }
 			admin={ admin }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -19,8 +20,8 @@ const BoostCard = ( { admin } ) => {
 	// @todo: implement action handlers
 	return (
 		<ProductCard
-			name="Boost"
-			description="Instant speed and SEO"
+			name={ __( 'Boost', 'jetpack-my-jetpack' ) }
+			description={ __( 'Instant speed and SEO', 'jetpack-my-jetpack' ) }
 			status={ PRODUCT_STATUSES.ABSENT }
 			icon={ <BoostIcon /> }
 			admin={ admin }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,8 +27,8 @@ const CrmCard = ( { admin } ) => {
 	// @todo: implement action handlers
 	return (
 		<ProductCard
-			name="CRM"
-			description="Connect with your people"
+			name={ __( 'CRM', 'jetpack-my-jetpack' ) }
+			description={ __( 'Connect with your people', 'jetpack-my-jetpack' ) }
 			status={ PRODUCT_STATUSES.ABSENT }
 			icon={ <CrmIcon /> }
 			admin={ admin }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,8 +25,8 @@ const ExtrasCard = ( { admin } ) => {
 	// @todo: implement action handlers
 	return (
 		<ProductCard
-			name="Extras"
-			description="Basic tools for a successful site"
+			name={ __( 'Extras', 'jetpack-my-jetpack' ) }
+			description={ __( 'Basic tools for a successful site', 'jetpack-my-jetpack' ) }
 			status={ PRODUCT_STATUSES.ABSENT }
 			icon={ <ExtrasIcon /> }
 			admin={ admin }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,8 +25,8 @@ const ScanCard = ( { admin } ) => {
 	// @todo: implement action handlers
 	return (
 		<ProductCard
-			name="Scan"
-			description="Stay one step ahead of threats"
+			name={ __( 'Scan', 'jetpack-my-jetpack' ) }
+			description={ __( 'Stay one step ahead of threats', 'jetpack-my-jetpack' ) }
 			status={ PRODUCT_STATUSES.ABSENT }
 			icon={ <ScanIcon /> }
 			admin={ admin }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,8 +21,8 @@ const SearchCard = ( { admin } ) => {
 	// @todo: implement action handlers
 	return (
 		<ProductCard
-			name="Search"
-			description="Help them find what they need"
+			name={ __( 'Search', 'jetpack-my-jetpack' ) }
+			description={ __( 'Help them find what they need', 'jetpack-my-jetpack' ) }
 			status={ PRODUCT_STATUSES.ABSENT }
 			icon={ <SearchIcon /> }
 			admin={ admin }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -28,8 +29,8 @@ const VideopressCard = ( { admin } ) => {
 	// @todo: implement action handlers
 	return (
 		<ProductCard
-			name="VideoPress"
-			description="High-quality, ad-free video"
+			name={ __( 'VideoPress', 'jetpack-my-jetpack' ) }
+			description={ __( 'High-quality, ad-free video', 'jetpack-my-jetpack' ) }
 			status={ PRODUCT_STATUSES.ABSENT }
 			icon={ <VideopressIcon /> }
 			admin={ admin }

--- a/projects/packages/my-jetpack/changelog/update-product-cards-i18n
+++ b/projects/packages/my-jetpack/changelog/update-product-cards-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replaced fixed strings for translated one


### PR DESCRIPTION
Replaces string literals in props `name` and `description` for Product Cards

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Replaces string literals in props `name` and `description` for Product Cards




#### Does this pull request change what data or activity we track or use?
none

#### Testing instructions:

Check visually that the changes make sense