### PR TITLE
widget-conditions: fix regression introduced in #22414

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-yoavf-r238742-wpcom-1642953249
+++ b/projects/plugins/jetpack/changelog/fusion-sync-yoavf-r238742-wpcom-1642953249
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Widget Visibility: ensure it remains possible to edit visibility for legacy widgets in the block-based widget editor.

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -892,11 +892,11 @@ class Jetpack_Widget_Conditions {
 									$condition_result = $wp_query->is_posts_page;
 								} else {
 									// $rule['minor'] is a page ID
-									$condition_result = is_page() && ( get_the_ID() === $rule['minor'] );
+									$condition_result = is_page() && ( get_the_ID() === (int) $rule['minor'] );
 
 									// Check if $rule['minor'] is parent of page ID.
 									if ( ! $condition_result && isset( $rule['has_children'] ) && $rule['has_children'] ) {
-										$condition_result = wp_get_post_parent_id( get_the_ID() ) === $rule['minor'];
+										$condition_result = wp_get_post_parent_id( get_the_ID() ) === (int) $rule['minor'];
 									}
 								}
 								break;


### PR DESCRIPTION
Fixes #22460.

This commit syncs r238742-wpcom.

In #22414, a couple of the changes switched to strict equality when the actual data compared had different types.
This meant that if a legacy widget was saved with visibility on a specific page, it would never show on that page (or any other page).
This was documented in https://github.com/Automattic/wp-calypso/issues/60352 and https://github.com/Automattic/wp-calypso/issues/60355

#### Changes proposed in this Pull Request:
* Fixes regression by casting the page ID data from the visiblity rule to int

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:
* Add a legacy widget to a theme with a widget area
* Set the widget to be visible on a specific page
* Update
* Visit that page, widget should be visible