### PR TITLE
cli: Add missing `nyc` dep when creating JS packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,10 @@ importers:
   projects/js-packages/config:
     specifiers:
       jetpack-js-test-runner: workspace:*
+      nyc: 15.1.0
     devDependencies:
       jetpack-js-test-runner: link:../../../tools/js-test-runner
+      nyc: 15.1.0
 
   projects/js-packages/connection:
     specifiers:
@@ -326,6 +328,7 @@ importers:
       '@wordpress/i18n': 4.2.4
       '@wordpress/icons': 6.1.1
       jetpack-js-test-runner: workspace:*
+      nyc: 15.1.0
       prop-types: 15.7.2
       react: 17.0.2
       react-test-renderer: 17.0.2
@@ -342,6 +345,7 @@ importers:
       '@babel/core': 7.16.0
       '@babel/preset-react': 7.16.0_@babel+core@7.16.0
       jetpack-js-test-runner: link:../../../tools/js-test-runner
+      nyc: 15.1.0
       react: 17.0.2
       react-test-renderer: 17.0.2_react@17.0.2
 
@@ -354,6 +358,7 @@ importers:
       '@wordpress/i18n': 4.2.4
       classnames: 2.3.1
       jetpack-js-test-runner: workspace:*
+      nyc: 15.1.0
       prop-types: 15.7.2
       react: 17.0.2
     dependencies:
@@ -366,6 +371,7 @@ importers:
       '@babel/core': 7.16.0
       '@babel/preset-react': 7.16.0_@babel+core@7.16.0
       jetpack-js-test-runner: link:../../../tools/js-test-runner
+      nyc: 15.1.0
       react: 17.0.2
 
   projects/js-packages/remove-asset-webpack-plugin:
@@ -479,6 +485,7 @@ importers:
       css-minimizer-webpack-plugin: 3.1.4
       duplicate-package-checker-webpack-plugin: 3.0.0
       mini-css-extract-plugin: 2.4.5
+      nyc: 15.1.0
       terser-webpack-plugin: 5.2.5
       thread-loader: 3.0.4
       webpack: 5.65.0
@@ -509,6 +516,7 @@ importers:
     devDependencies:
       '@babel/core': 7.16.0
       '@babel/runtime': 7.16.3
+      nyc: 15.1.0
       webpack: 5.65.0_webpack-cli@4.9.1
       webpack-cli: 4.9.1_webpack@5.65.0
 
@@ -1219,6 +1227,7 @@ importers:
       path-name: 1.0.0
       pluralize: 8.0.0
       process: 0.11.10
+      semver: 7.3.5
       simple-git: 2.37.0
       sinon: 9.2.4
       yargs: 16.2.0
@@ -1239,6 +1248,7 @@ importers:
       path-name: 1.0.0
       pluralize: 8.0.0
       process: 0.11.10
+      semver: 7.3.5
       simple-git: 2.37.0
       yargs: 16.2.0
     devDependencies:

--- a/projects/js-packages/config/changelog/add-missing-nyc-deps
+++ b/projects/js-packages/config/changelog/add-missing-nyc-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add missing dev dependency on `nyc` for code coverage.

--- a/projects/js-packages/config/package.json
+++ b/projects/js-packages/config/package.json
@@ -17,7 +17,8 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom 'glob:./!(node_modules)/**/test/*.@(jsx|js)'"
 	},
 	"devDependencies": {
-		"jetpack-js-test-runner": "workspace:*"
+		"jetpack-js-test-runner": "workspace:*",
+		"nyc": "15.1.0"
 	},
 	"engines": {
 		"node": "^14.18.3 || ^16.13.2",

--- a/projects/js-packages/licensing/changelog/add-missing-nyc-deps
+++ b/projects/js-packages/licensing/changelog/add-missing-nyc-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add missing dev dependency on `nyc` for code coverage.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -20,6 +20,7 @@
 		"@babel/core": "7.16.0",
 		"@babel/preset-react": "7.16.0",
 		"jetpack-js-test-runner": "workspace:*",
+		"nyc": "15.1.0",
 		"react": "17.0.2",
 		"react-test-renderer": "17.0.2",
 		"@automattic/jetpack-base-styles": "workspace:^0.1.7-alpha"

--- a/projects/js-packages/partner-coupon/changelog/add-missing-nyc-deps
+++ b/projects/js-packages/partner-coupon/changelog/add-missing-nyc-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add missing dev dependency on `nyc` for code coverage.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -20,6 +20,7 @@
 		"@babel/core": "7.16.0",
 		"@babel/preset-react": "7.16.0",
 		"jetpack-js-test-runner": "workspace:*",
+		"nyc": "15.1.0",
 		"react": "17.0.2"
 	},
 	"peerDependencies": {

--- a/projects/js-packages/webpack-config/changelog/add-missing-nyc-deps
+++ b/projects/js-packages/webpack-config/changelog/add-missing-nyc-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add missing dev dependency on `nyc` for code coverage.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -43,6 +43,7 @@
 	"devDependencies": {
 		"@babel/core": "7.16.0",
 		"@babel/runtime": "7.16.3",
+		"nyc": "15.1.0",
 		"webpack": "5.65.0",
 		"webpack-cli": "4.9.1"
 	},

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -36,6 +36,7 @@
 		"path-name": "1.0.0",
 		"pluralize": "8.0.0",
 		"process": "0.11.10",
+		"semver": "7.3.5",
 		"simple-git": "2.37.0",
 		"yargs": "16.2.0"
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When creating a JS package, the CLI is pre-filling the test-coverage
script with a call to `nyc`. But it wasn't also pre-adding a dependency
on nyc, resulting in coverage not working for several packages.

Also, add the missing dep to those packages.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that the coverage job isn't failing to run for these packages (e.g. not [this](https://github.com/Automattic/jetpack/runs/4923504024?check_suite_focus=true#step:9:501)).
  * :heavy_check_mark: https://github.com/Automattic/jetpack/runs/4926248885?check_suite_focus=true#step:9:505
  * :heavy_check_mark: https://github.com/Automattic/jetpack/runs/4926248885?check_suite_focus=true#step:9:1126
  * :heavy_check_mark: https://github.com/Automattic/jetpack/runs/4926248885?check_suite_focus=true#step:9:1212
  * :heavy_check_mark: https://github.com/Automattic/jetpack/runs/4926248885?check_suite_focus=true#step:9:1320
