### PR TITLE
js-test-runner: Add WorDBless dir to jest collectCoverageFrom

### DIFF
--- a/tools/js-test-runner/jest-config/default.config.js
+++ b/tools/js-test-runner/jest-config/default.config.js
@@ -32,6 +32,8 @@ const defaultConfig = {
 		'**/*.{js,jsx}',
 		'!**/node_modules/**',
 		'!**/vendor/**',
+		'!**/jetpack_vendor/**',
+		'!**/wordpress/**', // WorDBless.
 		'!**/__tests__/**',
 		'!**/coverage/**',
 		'!test-main.{js,jsx}',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The coverage report started taking an extra 10 minutes after
packages/my-jetpack added JS tests because it was reporting coverage for
all of WordPress that was brought in via WorDBless. Exclude that by
default.

Also exclude the `jetpack_vendor/` directory from
packages/composer-plugin for good measure.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In the "Tests / Code coverage" job, check that the JS tests for packages/my-jetpack take closer to 5 seconds than 580.
  * :heavy_check_mark: [5.738s](https://github.com/Automattic/jetpack/runs/4925842664?check_suite_focus=true#step:9:4180)