### PR TITLE
My Jetpack: check user connectivity before hitting wpcom side

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-check-connectivity-when-requesting
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-check-connectivity-when-requesting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: check user connectivity before to hit wpcom side

--- a/projects/packages/my-jetpack/src/class-rest-purchases.php
+++ b/projects/packages/my-jetpack/src/class-rest-purchases.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\Connection\Client as Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 /**
  * Registers the REST routes for Purchases.
@@ -37,6 +38,19 @@ class REST_Purchases {
 	 * @return true|WP_Error
 	 */
 	public static function permissions_callback() {
+		$connection        = new Connection_Manager();
+		$is_user_connected = $connection->is_connected();
+
+		if ( ! $is_user_connected ) {
+			return new \WP_Error(
+				'not_connected',
+				__( 'You are not connected to Jetpack.', 'jetpack-my-jetpack' ),
+				array(
+					'status' => 400,
+				)
+			);
+		}
+
 		return current_user_can( 'manage_options' );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: check user connectivity before hitting wpcom side

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack dashboard
* With a user connected, confirm no issues in there
* Disconnect the user

**Without these changes**,
* App got broken. White screen.
<img src="https://user-images.githubusercontent.com/77539/150958906-901ec5f7-ee26-4573-b932-59de15d56439.png" width="600px" />

* Confirm you get an error in the client. 
<img src="https://user-images.githubusercontent.com/77539/150958942-8ced1720-3670-4c22-b858-ce70b4afb16f.png" width="600px" />

* Check the `site/purchases` endpoint. Get an error without error status:
<img src="https://user-images.githubusercontent.com/77539/150959011-9f00c4e8-e364-496e-8ac7-7a408cb22baa.png" width="600px" />

** With these changes**
* Confirm you see the error in the dev console
<img src="https://user-images.githubusercontent.com/77539/150958588-96462f43-0161-431a-b402-cd3c63bcdc97.png" width="600px" />

* App is not broken. You still see the products list and My Plan section
<img src="https://user-images.githubusercontent.com/77539/150959432-b5b6ca32-248e-441e-8cdd-22a2096fe300.png" width="600px" />

* You'd like to take a look at the network tab, too.
<img src="https://user-images.githubusercontent.com/77539/150958786-0af64387-f825-4246-92df-05c2bd48d792.png" width="600px" />

