### PR TITLE
Connection: Fix misspelling of propTypes in ConnectedPlugins component from connection js-package

### DIFF
--- a/projects/js-packages/connection/changelog/fix-proptypes-connected-plugins
+++ b/projects/js-packages/connection/changelog/fix-proptypes-connected-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Wrong spelling of propTypes in ConnectedPlugins

--- a/projects/js-packages/connection/components/connected-plugins/index.jsx
+++ b/projects/js-packages/connection/components/connected-plugins/index.jsx
@@ -64,7 +64,7 @@ const ConnectedPlugins = props => {
 	return null;
 };
 
-ConnectedPlugins.PropTypes = {
+ConnectedPlugins.propTypes = {
 	/** Plugins that are using the Jetpack connection. */
 	connectedPlugins: PropTypes.object,
 	/** Slug of the plugin that has initiated the disconnect. */


### PR DESCRIPTION
Fixes #22479

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes typo in ConnectedPlugins propTypes.


#### Does this pull request change what data or activity we track or use?
none


#### Testing instructions

1. On a connected site, visit the My Jetpack page
2. Run `jetpack build packages/my-jetpack`.
2. build with 
1. Have `SCRIPT_DEBUG` on as a constant in wp-config.php
2. open the browser console
2. Attempt to disconnect site by clicking Disconnect from the Connection Status card
3. Confirm you don't see an error like this:
  ```
  Warning: Component ConnectedPlugins declared PropTypes instead of propTypes. Did you misspell the property assignment?
    in StepDisconnect (created by DisconnectDialog)
   ```

![image](https://user-images.githubusercontent.com/746152/150978348-ceb49675-80f8-40a9-b6f4-a791e4de8bd4.png)


