### PR TITLE
My Jetpack: Fire Tracks events for product activation and deactivation clicks

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -39,10 +39,10 @@ const DownIcon = () => (
 
 const renderActionButton = ( {
 	status,
-	activateHandler,
 	admin,
 	name,
 	onLearn,
+	onActivate,
 	onAdd,
 	onManage,
 	onFixConnection,
@@ -88,7 +88,7 @@ const renderActionButton = ( {
 			);
 		case PRODUCT_STATUSES.INACTIVE:
 			return (
-				<Button { ...buttonState } onClick={ activateHandler }>
+				<Button { ...buttonState } onClick={ onActivate }>
 					{ __( 'Activate', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
@@ -149,7 +149,7 @@ const ProductCard = props => {
 			<div className={ styles.actions }>
 				{ canDeactivate ? (
 					<ButtonGroup>
-						{ renderActionButton( { ...props, activateHandler } ) }
+						{ renderActionButton( { ...props, onActivate: activateHandler } ) }
 						<DropdownMenu
 							className={ styles.dropdown }
 							toggleProps={ { isPressed: true, disabled: isFetching } }

--- a/projects/packages/my-jetpack/changelog/add-tracks-events-my-jetpack-product-card
+++ b/projects/packages/my-jetpack/changelog/add-tracks-events-my-jetpack-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds Tracks events for activating and deactivating products from the product cards

--- a/projects/packages/my-jetpack/jest.setup.js
+++ b/projects/packages/my-jetpack/jest.setup.js
@@ -2,3 +2,11 @@
  * External dependencies
  */
 import '@testing-library/jest-dom';
+window.JP_CONNECTION_INITIAL_STATE = {
+	userConnectionData: {
+		currentUser: {
+			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacrmaneto' },
+		},
+	},
+};
+window.myJetpackInitialState = {};


### PR DESCRIPTION

Adds tracking for clicks on activate/deactivate links for product cards.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces functions `activateHandler` and `deactivateHandler` that will call the passed props `onActivate`, and `onDeactivate` after firing Tracks events.
* Renames the prop that `renderActionButton` recevies from 'onActivate` to 'activateHandler'

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?

Introduces 2 new events:
*  `jetpack_myjetpack_product_card_activate_click` fired when the user clicks on a product card activate link
* `jetpack_myjetpack_product_card_activate_click` fired when the user clicks on a product card deactivate link

#### Testing instructions:
* Checkout this branch on a site with Jetpack connected the Backup plugin active, and the `JETPACK_ENABLE_MY_JETPACK` constant set to `true`.
* Open the browser and visit the site's wp-admin.
* Open the developer console, execute the following code: `localStorage.debug='dops:analyitics*`
* Go to "Jetpack -> My Jetpack", Confirm that the developer console displays the events `jetpack_myjetpack_product_card_activate_click` and `jetpack_myjetpack_product_card_activate_click` when clicking such items from the Boost product card for example.

