### PR TITLE
My Jetpack: Implement first approach for global notice

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -229,20 +229,6 @@
                 "issues": "https://github.com/composer/semver/issues",
                 "source": "https://github.com/composer/semver/tree/3.2.7"
             },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2022-01-04T09:57:54+00:00"
         },
         {
@@ -309,20 +295,6 @@
                 "issues": "https://github.com/composer/spdx-licenses/issues",
                 "source": "https://github.com/composer/spdx-licenses/tree/1.5.6"
             },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-11-18T10:14:14+00:00"
         },
         {
@@ -900,6 +872,5 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -872,5 +872,6 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,6 +655,7 @@ importers:
       '@wordpress/components': 19.1.6
       '@wordpress/data': 6.1.5
       '@wordpress/i18n': 4.2.4
+      '@wordpress/icons': 6.1.1
       classnames: 2.3.1
       enzyme: 3.11.0
       jest: 27.3.1
@@ -673,6 +674,7 @@ importers:
       '@wordpress/components': 19.1.6_aae888dfa296766acacf1a733aa50b3a
       '@wordpress/data': 6.1.5_react@17.0.2
       '@wordpress/i18n': 4.2.4
+      '@wordpress/icons': 6.1.1
       classnames: 2.3.1
       prop-types: 15.8.1
     devDependencies:
@@ -19676,7 +19678,7 @@ packages:
     dependencies:
       array.prototype.flat: 1.2.5
       global-cache: 1.2.1
-      react-with-styles: 3.2.3
+      react-with-styles: 3.2.3_react-dom@17.0.2+react@17.0.2
 
   /react-with-styles/3.2.3:
     resolution: {integrity: sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==}
@@ -20730,7 +20732,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.43.3
-      webpack: 5.65.0_webpack-cli@4.9.1
+      webpack: 5.65.0
     dev: true
 
   /sass-loader/12.4.0_webpack@5.65.0:

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -3,6 +3,8 @@
  */
 import React, { useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { Icon, warning, info } from '@wordpress/icons';
 import {
 	AdminSection,
 	AdminSectionHero,
@@ -14,11 +16,43 @@ import {
 /**
  * Internal dependencies
  */
-import './style.scss';
 import ConnectionsSection from '../connections-section';
 import PlansSection from '../plans-section';
 import ProductCardsSection from '../product-cards-section';
 import useAnalytics from '../../hooks/use-analytics';
+import useNoticeWatcher, { useGlobalNotice } from '../../hooks/use-notice';
+import './style.scss';
+
+/**
+ * Component that renders the My Jetpack global notices.
+ *
+ * @returns {object} The GlobalNotice component.
+ */
+function GlobalNotice() {
+	// Watch global events.
+	useNoticeWatcher();
+
+	/*
+	 * Map Notice statuses with Icons.
+	 * `success`, `info`, `warning`, `error`
+	 */
+	const iconMap = {
+		error: warning,
+		info,
+	};
+
+	const { message, options, clean } = useGlobalNotice();
+	if ( ! message ) {
+		return null;
+	}
+
+	return (
+		<Notice { ...options } onRemove={ clean }>
+			{ iconMap?.[ options.status ] && <Icon icon={ iconMap[ options.status ] } /> }
+			<div className="components-notice__message-content">{ message }</div>
+		</Notice>
+	);
+}
 
 /**
  * The My Jetpack App Main Screen.
@@ -32,6 +66,7 @@ export default function MyJetpackScreen() {
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_page_view' );
 	}, [ recordEvent ] );
+
 	return (
 		<div className="jp-my-jetpack-screen">
 			<AdminPage>
@@ -44,6 +79,11 @@ export default function MyJetpackScreen() {
 									'jetpack-my-jetpack'
 								) }
 							</h1>
+							<GlobalNotice />
+						</Col>
+					</Row>
+					<Row>
+						<Col lg={ 12 } md={ 8 } sm={ 4 }>
 							<ProductCardsSection />
 						</Col>
 					</Row>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/style.scss
@@ -1,1 +1,20 @@
 @import '@automattic/jetpack-base-styles/style';
+
+.components-notice {
+	margin: 20px 0;
+
+	.components-notice__content {
+		display: flex;
+
+		.components-notice__message-content {
+			height: 24px;
+			line-height: 24px;
+			margin-left: 10px;
+		}
+	}
+
+	.components-notice__action.components-button.is-link {
+		color: var( --jp-black );
+		font-weight: 600;
+	}
+}

--- a/projects/packages/my-jetpack/_inc/hooks/use-notice/Readme.md
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notice/Readme.md
@@ -1,0 +1,20 @@
+# useNotice custom hooks 
+
+## useNoticeWatcher
+
+## useGlobalNotice
+
+```es6
+import { useGlobalNotice } from './hooks/use-notice';
+
+function PlansSection() {
+	const global = useGlobalNotice();
+	if ( ! global ) {
+		return null;
+	}
+
+	return (
+		<Notice>{ global.message }</Notice>;
+	)
+}
+```

--- a/projects/packages/my-jetpack/_inc/hooks/use-notice/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notice/index.js
@@ -1,0 +1,64 @@
+/* global myJetpackInitialState */
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useConnection } from '@automattic/jetpack-connection';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_ID } from '../../state/store';
+
+/**
+ * React custom hook to get global notices.
+ *
+ * @returns {object} Global notices data
+ */
+export function useGlobalNotice() {
+	const dispatch = useDispatch();
+
+	const { message, options } = useSelect( select => select( STORE_ID ).getGlobalNotice() );
+	return {
+		message,
+		options: options || {},
+		clean: () => dispatch( STORE_ID ).cleanGlobalNotice(),
+	};
+}
+
+/**
+ * React custom hook to watch global events.
+ * For instance, when the user is not connected,
+ * the hook dispatches an action to populate the global notice.
+ */
+export default function useNoticeWatcher() {
+	const { apiRoot, apiNonce } = myJetpackInitialState;
+	const dispatch = useDispatch();
+
+	const { isUserConnected } = useConnection( {
+		apiRoot,
+		apiNonce,
+	} );
+
+	useEffect( () => {
+		if ( ! isUserConnected ) {
+			return dispatch( STORE_ID ).setGlobalNotice(
+				__(
+					'Jetpack is currently not connected and some products might not work until the connection is reestablished.',
+					'jetpack-my-jetpack'
+				),
+				{
+					status: 'error',
+					actions: [
+						{
+							label: __( 'Connect Jetpack now.', 'jetpack-my-jetpack' ),
+							url: '#',
+						},
+					],
+				}
+			);
+		}
+	}, [ isUserConnected, dispatch ] );
+}

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -22,6 +22,9 @@ const ACTIVATE_PRODUCT = 'ACTIVATE_PRODUCT';
 const DEACTIVATE_PRODUCT = 'DEACTIVATE_PRODUCT';
 const SET_PRODUCT_STATUS = 'SET_PRODUCT_STATUS';
 
+const SET_GLOBAL_NOTICE = 'SET_GLOBAL_NOTICE';
+const CLEAN_GLOBAL_NOTICE = 'CLEAN_GLOBAL_NOTICE';
+
 const setPurchasesIsFetching = isFetching => {
 	return { type: SET_PURCHASES_IS_FETCHING, isFetching };
 };
@@ -140,10 +143,20 @@ const productActions = {
 	setRequestProductError,
 };
 
+const noticeActions = {
+	setGlobalNotice: ( message, options ) => ( {
+		type: 'SET_GLOBAL_NOTICE',
+		message,
+		options,
+	} ),
+	cleanGlobalNotice: () => ( { type: 'CLEAN_GLOBAL_NOTICE' } ),
+};
+
 const actions = {
 	setPurchasesIsFetching,
 	fetchPurchases,
 	setPurchases,
+	...noticeActions,
 	...productActions,
 };
 
@@ -157,5 +170,7 @@ export {
 	DEACTIVATE_PRODUCT,
 	SET_IS_FETCHING_PRODUCT,
 	SET_PRODUCT_STATUS,
+	SET_GLOBAL_NOTICE,
+	CLEAN_GLOBAL_NOTICE,
 	actions as default,
 };

--- a/projects/packages/my-jetpack/_inc/state/reducers.js
+++ b/projects/packages/my-jetpack/_inc/state/reducers.js
@@ -13,6 +13,8 @@ import {
 	SET_PRODUCT_STATUS,
 	SET_IS_FETCHING_PRODUCT,
 	SET_PRODUCT_REQUEST_ERROR,
+	SET_GLOBAL_NOTICE,
+	CLEAN_GLOBAL_NOTICE,
 } from './actions';
 
 const products = ( state = {}, action ) => {
@@ -93,9 +95,35 @@ const purchases = ( state = {}, action ) => {
 	}
 };
 
+const notices = ( state = { global: {} }, action ) => {
+	switch ( action.type ) {
+		case SET_GLOBAL_NOTICE: {
+			const { message, options } = action;
+			return {
+				...state,
+				global: {
+					message,
+					options,
+				},
+			};
+		}
+
+		case CLEAN_GLOBAL_NOTICE: {
+			return {
+				...state,
+				global: {},
+			};
+		}
+
+		default:
+			return state;
+	}
+};
+
 const reducers = combineReducers( {
 	products,
 	purchases,
+	notices,
 } );
 
 export default reducers;

--- a/projects/packages/my-jetpack/_inc/state/selectors.js
+++ b/projects/packages/my-jetpack/_inc/state/selectors.js
@@ -17,9 +17,14 @@ const purchasesSelectors = {
 	isRequestingPurchases: state => state.isRequestingPurchases || false,
 };
 
+const noticeSelectors = {
+	getGlobalNotice: state => state.notices?.global,
+};
+
 const selectors = {
 	...productSelectors,
 	...purchasesSelectors,
+	...noticeSelectors,
 };
 
 export default selectors;

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-implement-global-error
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-implement-global-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Initial approach to handle global notice

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -27,6 +27,7 @@
 		"@wordpress/components": "19.1.6",
 		"@wordpress/data": "6.1.5",
 		"@wordpress/i18n": "4.2.4",
+		"@wordpress/icons": "6.1.1",
 		"classnames": "2.3.1",
 		"prop-types": "15.8.1"
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implement the first approach to deal with global notice. For this purpose:

* Add global notice to redux store
* Add custom hooks
* Connect primary component to show errors in the UI

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Implement first approach for global notice

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* My Jetpack Implement first approach for global notice

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Dispatching actions:**
* Go to My Jetpack dashboard
* Open the dev console
* Dispatch `my-jetpack` actions to show/clean global notice:

```
wp.data.dispatch( 'my-jetpack' ).setGlobalNotice( 'Testing an info notice', { status: 'info' } )
```

```
wp.data.dispatch( 'my-jetpack' ).setGlobalNotice( 'This is an error', { status: 'error' } )
```

https://user-images.githubusercontent.com/77539/150998618-cac7687d-9132-47fb-a876-d9909e21a69c.mov

**Disconnect the user**
Once you disconnect the user, it should show a global error. It's handled by the `useNoticeWatcher()` hook.

<img src="https://user-images.githubusercontent.com/77539/150998926-7d94bc12-6908-4a4f-a880-b7bfb05887e4.png" width="600px" />