### PR TITLE
Reduced Sync Search test data sample.

### DIFF
--- a/projects/plugins/jetpack/changelog/try-reduce-sync-search-test-data
+++ b/projects/plugins/jetpack/changelog/try-reduce-sync-search-test-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Reduced the data set for the Search Sync tests to speed up the process.

--- a/projects/plugins/jetpack/tests/php/sync/class-test-jetpack-sync-search.php
+++ b/projects/plugins/jetpack/tests/php/sync/class-test-jetpack-sync-search.php
@@ -70,11 +70,11 @@ class Test_Jetpack_Sync_Search extends WP_Test_Jetpack_Sync_Base {
 	 *
 	 * @return string[][]
 	 */
-	public function get_allowed_postmeta_keys() {
+	public function get_random_allowed_postmeta_keys() {
 		$params = array();
 		$keys   = Modules\Search::get_all_postmeta_keys();
-		foreach ( $keys as $k ) {
-			$params[] = array( $k );
+		foreach ( array_rand( $keys, 10 ) as $k ) {
+			$params[] = array( $keys[ $k ] );
 		}
 
 		return $params;
@@ -85,11 +85,11 @@ class Test_Jetpack_Sync_Search extends WP_Test_Jetpack_Sync_Base {
 	 *
 	 * @return string[][]
 	 */
-	public function get_allowed_taxonomies() {
+	public function get_random_allowed_taxonomies() {
 		$params = array();
 		$keys   = Modules\Search::get_all_taxonomies();
-		foreach ( $keys as $k ) {
-			$params[] = array( $k );
+		foreach ( array_rand( $keys, 10 ) as $k ) {
+			$params[] = array( $keys[ $k ] );
 		}
 
 		return $params;
@@ -167,7 +167,7 @@ class Test_Jetpack_Sync_Search extends WP_Test_Jetpack_Sync_Base {
 	 * Important that we double check the specification format since
 	 * this will often get added to.
 	 *
-	 * @dataProvider get_allowed_postmeta_keys
+	 * @dataProvider get_random_allowed_postmeta_keys
 	 * @param string $key Meta Key.
 	 */
 	public function test_check_postmeta_spec( $key ) {
@@ -201,7 +201,7 @@ class Test_Jetpack_Sync_Search extends WP_Test_Jetpack_Sync_Base {
 	/**
 	 * Verify that allowed taxonomies are synced.
 	 *
-	 * @dataProvider get_allowed_taxonomies
+	 * @dataProvider get_random_allowed_taxonomies
 	 * @param string $taxonomy Taxonomy Name.
 	 */
 	public function test_add_taxonomy( $taxonomy ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a follow up to #19674 . This is a pretty crude change, designed to show at least one way we can speed up the tests from 9 minutes to 11 seconds. I realize that this might be too harsh for this test, since we may want to be sure that every allowed key is tested with the filters/include/exclude lists. Let me know what you think of that approach. Maybe there is a different way how we can narrow down the data set instead of doing a random selection?

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This change reduces the data set that the tests run on.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the Sync Search test suite from the Jetpack project folder: `WP_DEVELOP_DIR=/home/zinigor/workspace/wordpress-develop ./vendor/bin/phpunit --filter=Test_Jetpack_Sync_Search`
* Observe that tests take more than 8 minutes.
* Use this PR.
* Observe that tests run in less than a minute.
