### PR TITLE
E2E tests: force theme to fix broken tests

### DIFF
--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -53,6 +53,7 @@ configure_wp_env() {
 	fi
 	$BASE_CMD wp option set permalink_structure ""
 	$BASE_CMD wp jetpack module deactivate sso
+	$BASE_CMD wp theme activate twentytwentyone
 
 	echo
 	echo "WordPress is ready!"


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
The new Twenty Twenty-Two theme breaks some of the e2e tests. 
This is a quick fix, by activating twentytwentyone in the setup phase.
A more complex solution that supports any theme should be considered.

#### Jetpack product discussion
p1643195257206500-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- E2E tests pass in CI?