### PR TITLE
My Jetpack: Update plugin absent status consistently

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -16,7 +16,7 @@ export const PRODUCT_STATUSES = {
 	ACTIVE: 'active',
 	INACTIVE: 'inactive',
 	ERROR: 'error',
-	ABSENT: 'absent',
+	ABSENT: 'plugin_absent',
 };
 
 const PRODUCT_STATUSES_LABELS = {
@@ -104,7 +104,7 @@ const ProductCard = props => {
 	const canDeactivate = ( isActive || isError ) && admin;
 
 	const containerClassName = classNames( styles.container, {
-		[ styles.absent ]: isAbsent,
+		[ styles.plugin_absent ]: isAbsent,
 	} );
 
 	const statusClassName = classNames( styles.status, {

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -70,7 +70,7 @@
     border-radius: 50%;
   }
 
-  // in pluing absent case, there's not status flag
+  // in plugin absent case, there's not status flag
   $statuses: active, inactive, error;
 
   @each $status in $statuses {

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -13,7 +13,7 @@
   --status-active: #008710;
   --status-inactive: #646970;
   --status-error: #B32D2E;
-  --status-absent: #C3C4C7;
+  --status-plugin_absent: #C3C4C7;
 
   padding: 24px;
   background: var( --jp-white );
@@ -24,10 +24,10 @@
   flex-direction: column;
   justify-content: space-between;
 
-  &.absent {
+  &.plugin_absent {
     background: none;
     box-shadow: none;
-    box-shadow: 0 0 0 1px var( --status-absent ) inset;
+    box-shadow: 0 0 0 1px var( --status-plugin_absent ) inset;
   }
 }
 
@@ -70,7 +70,7 @@
     border-radius: 50%;
   }
 
-  // in absent case, there's not status flag
+  // in pluing absent case, there's not status flag
   $statuses: active, inactive, error;
 
   @each $status in $statuses {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -7,7 +7,8 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import ProductCard, { PRODUCT_STATUSES } from '../product-card';
+import ProductCard from '../product-card';
+import { useProduct } from '../../hooks/use-product';
 
 const CrmIcon = () => (
 	<svg width="18" height="11" viewBox="0 0 18 11" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -23,14 +24,19 @@ const CrmIcon = () => (
 );
 
 const CrmCard = ( { admin } ) => {
-	// @todo: implement action handlers
+	const { status, activate, deactivate, detail, isFetching } = useProduct( 'crm' );
+	const { name, description } = detail;
+
 	return (
 		<ProductCard
-			name="CRM"
-			description="Connect with your people"
-			status={ PRODUCT_STATUSES.ABSENT }
+			name={ name }
+			description={ description }
+			status={ status }
 			icon={ <CrmIcon /> }
+			isFetching={ isFetching }
 			admin={ admin }
+			onDeactivate={ deactivate }
+			onActivate={ activate }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-plugin-absent-status
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-plugin-absent-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update plugin absent status consistently


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR updates the status name when the status of the products is _plugin absent_. If fixes validation prop issue that happens since the status provided by the server is not the same that the expected values by the client: `plugin_absent` vs `absent`

![image](https://user-images.githubusercontent.com/77539/151169343-519d5ae0-5e26-481a-8f88-d5d3c297a43c.png)


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to my jetpack dashboard. You should see the following error:
```
Warning: Failed prop type: Invalid prop `status` of value `plugin_absent` supplied to `ProductCard`,
expected one of ["active","inactive","error","absent"].
```
* Confirm with these changes the issue is addressed.
