### PR TITLE
My Jetpack: Introduce @wordpress/element library

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -662,6 +662,7 @@ importers:
       '@testing-library/user-event': 12.8.3
       '@wordpress/components': 19.1.6
       '@wordpress/data': 6.1.5
+      '@wordpress/element': 4.0.4
       '@wordpress/i18n': 4.2.4
       '@wordpress/icons': 6.1.1
       classnames: 2.3.1
@@ -681,6 +682,7 @@ importers:
       '@automattic/jetpack-connection': link:../../js-packages/connection
       '@wordpress/components': 19.1.6_aae888dfa296766acacf1a733aa50b3a
       '@wordpress/data': 6.1.5_react@17.0.2
+      '@wordpress/element': 4.0.4
       '@wordpress/i18n': 4.2.4
       '@wordpress/icons': 6.1.1
       classnames: 2.3.1

--- a/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
+import { useCallback } from '@wordpress/element';
 import { ConnectionStatusCard } from '@automattic/jetpack-connection';
 
 /**
@@ -16,6 +17,7 @@ export default function ConnectionsSection() {
 	const redirectAfterDisconnect = useCallback( () => {
 		window.location = myJetpackInitialState.topJetpackMenuItemUrl;
 	}, [] );
+
 	return (
 		<ConnectionStatusCard
 			apiRoot={ apiRoot }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React from 'react';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import { Icon, warning, info } from '@wordpress/icons';

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { useEffect } from 'react';
+import { useEffect } from '@wordpress/element';
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useConnection } from '@automattic/jetpack-connection';
 

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-introduce-wordpress-element
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-introduce-wordpress-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Introduce @wordpress/element library

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -26,6 +26,7 @@
 		"@automattic/jetpack-connection": "workspace:^0.14.1-alpha",
 		"@wordpress/components": "19.1.6",
 		"@wordpress/data": "6.1.5",
+		"@wordpress/element": "4.0.4",
 		"@wordpress/i18n": "4.2.4",
 		"@wordpress/icons": "6.1.1",
 		"classnames": "2.3.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR introduces the `@wordpress/element` library into the My Jetpack client app and consumes some of the helpers that usually were imported from React.

### Why

* The whole My Jetpack implementation is `@wordpress` friendly. Instead of `redux`, the data approach is built over `@wordpress/data`. `@wordpress/i18n` for internationalization, `@wordpress.componenents` for the UI, and so on...

* It's encouraged by core:

> You may find yourself asking, “Why an abstraction layer?”. For a few reasons:
>
> In many applications, especially those extended by a rich plugin ecosystem as is the case with WordPress, it’s wise to create interfaces to underlying third-party code. The thinking is that if ever a need arises to change or even replace the underlying implementation, it can be done without catastrophic rippling effects to dependent code, so long as the interface stays the same.
> It provides a mechanism to shield implementers by omitting features with uncertain futures (createClass, PropTypes).
> It helps avoid incompatibilities between versions by ensuring that every plugin operates on a single centralized version of the code.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Introduce @wordpress/element library

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes
* Compile
* Check it's working as expected. `<ConnectionsSection />` component and `useAnalytics()` are functions affected for these changes. You could start from there.
