### PR TITLE
Dashboard: Replace renderPairs logic for a more declarative approach

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { __ } from '@wordpress/i18n';
 import { chunk, get } from 'lodash';
@@ -39,18 +39,6 @@ import { isOfflineMode, hasConnectedOwner } from 'state/connection';
 import { getModuleOverride } from 'state/modules';
 import { getScanStatus, isFetchingScanStatus } from 'state/scan';
 
-const renderPairs = layout =>
-	layout.map( ( item, layoutIndex ) => [
-		item.header,
-		item.pinnedBundle,
-		chunk( item.cards, 2 ).map( ( [ left, right ], cardIndex ) => (
-			<div className="jp-at-a-glance__item-grid" key={ `card-${ layoutIndex }-${ cardIndex }` }>
-				<div className="jp-at-a-glance__left">{ left }</div>
-				<div className="jp-at-a-glance__right">{ right }</div>
-			</div>
-		) ),
-	] );
-
 class AtAGlance extends Component {
 	trackSecurityClick = () => analytics.tracks.recordJetpackClick( 'aag_manage_security_wpcom' );
 
@@ -71,7 +59,6 @@ class AtAGlance extends Component {
 		};
 		const securityHeader = (
 			<DashSectionHeader
-				key="securityHeader"
 				label={ __( 'Security', 'jetpack' ) }
 				settingsPath={ this.props.userCanManageModules ? '#security' : undefined }
 				externalLink={
@@ -145,14 +132,6 @@ class AtAGlance extends Component {
 		if ( this.props.userCanManageModules ) {
 			const canDisplaybundleCard =
 				! this.props.multisite && ! this.props.isOfflineMode && this.props.hasConnectedOwner;
-			const pairs = [
-				{
-					header: securityHeader,
-					cards: securityCards,
-					pinnedBundle: canDisplaybundleCard ? <DashSecurityBundle /> : null,
-				},
-			];
-
 			const performanceCards = [];
 			if ( 'inactive' !== this.props.getModuleOverride( 'photon' ) ) {
 				performanceCards.push( <DashPhoton { ...settingsProps } /> );
@@ -178,25 +157,21 @@ class AtAGlance extends Component {
 				performanceCards.push( <DashBoost siteAdminUrl={ this.props.siteAdminUrl } /> );
 			}
 
-			if ( performanceCards.length ) {
-				pairs.push( {
-					header: (
-						<DashSectionHeader
-							key="performanceHeader"
-							label={ __( 'Performance and Growth', 'jetpack' ) }
-						/>
-					),
-					cards: performanceCards,
-				} );
-			}
-
 			return (
 				<div className="jp-at-a-glance">
 					<QuerySitePlugins />
 					<QuerySite />
 					<QueryScanStatus />
 					<DashStats { ...settingsProps } { ...urls } />
-					{ renderPairs( pairs ) }
+					<Section
+						header={ securityHeader }
+						cards={ securityCards }
+						pinnedBundle={ canDisplaybundleCard ? <DashSecurityBundle /> : null }
+					/>
+					<Section
+						header={ <DashSectionHeader label={ __( 'Performance and Growth', 'jetpack' ) } /> }
+						cards={ performanceCards }
+					/>
 					{ connections }
 				</div>
 			);
@@ -243,3 +218,21 @@ export default connect( state => {
 		hasConnectedOwner: hasConnectedOwner( state ),
 	};
 } )( withModuleSettingsFormHelpers( AtAGlance ) );
+
+const Section = ( { cards = [], header, pinnedBundle } ) => {
+	if ( ! cards.length ) {
+		return null;
+	}
+	return (
+		<>
+			{ header }
+			{ pinnedBundle }
+			{ chunk( cards, 2 ).map( ( [ left, right ], cardIndex ) => (
+				<div className="jp-at-a-glance__item-grid" key={ `card-${ cardIndex }` }>
+					<div className="jp-at-a-glance__left">{ left }</div>
+					<div className="jp-at-a-glance__right">{ right }</div>
+				</div>
+			) ) }
+		</>
+	);
+};

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { __ } from '@wordpress/i18n';
 import { chunk, get } from 'lodash';

--- a/projects/plugins/jetpack/changelog/update-render-pair-logic-at-a-glance-jetpack
+++ b/projects/plugins/jetpack/changelog/update-render-pair-logic-at-a-glance-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update internal logic for rendering Dashboard sections


### PR DESCRIPTION
Updates an imperative logic for rendering pairs of cards inside sections

Fixes annoying warning of missing `key` prop when visiting the Dashboard.
We were looping through items before rendering them and React demanded unique key props. 



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Replaces logic of gathering `pair` for rendering afterwards with `renderPairs`. Introduces local Section component and we use it more declaratively


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Check this branch out.
* Enable SCRIPT_DEBUG
* build Jetpack with `jetpack build plugins/jetpack`
* Visit the admin page .
* Open the console
* Confirm you no longer see the warning about lack of unique key in AtAGlance component.
  ![image](https://user-images.githubusercontent.com/746152/151350135-828b4bed-e992-4648-ab33-957fc6fd9d0f.png)
* Confirm that the sections with their cards render the same.