### PR TITLE
My Jetpack: change global error severity when no user connection 

### DIFF
--- a/projects/packages/my-jetpack/_inc/hooks/use-notice/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notice/index.js
@@ -50,7 +50,7 @@ export default function useNoticeWatcher() {
 					'jetpack-my-jetpack'
 				),
 				{
-					status: 'error',
+					status: 'warning',
 					actions: [
 						{
 							label: __( 'Connect Jetpack now.', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-change-no-user-connection-error-severity
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-change-no-user-connection-error-severity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Change the global error severity when no user connection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Simple PR that changes the error severity when the user is not connected.


Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: change global error severity when no user connection 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disconnect the user
* Go to My jetpack

**before**
![image](https://user-images.githubusercontent.com/77539/151360226-5b30b2dc-438d-423e-bb3c-338d01553e96.png)

**after**
![image](https://user-images.githubusercontent.com/77539/151360123-388f382a-aeb8-44cf-b72a-98ad042c7a9a.png)

