### PR TITLE
My Jetpack: Handle when site is not connected

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
@@ -16,6 +16,7 @@ export default function ConnectionsSection() {
 	const redirectAfterDisconnect = useCallback( () => {
 		window.location = myJetpackInitialState.topJetpackMenuItemUrl;
 	}, [] );
+
 	return (
 		<ConnectionStatusCard
 			apiRoot={ apiRoot }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -68,7 +68,7 @@ export default function MyJetpackScreen() {
 		recordEvent( 'jetpack_myjetpack_page_view' );
 	}, [ recordEvent ] );
 
-	const { isSiteConnected } = useMyJetpackConnection();
+	const { isSiteConnected } = useMyJetpackConnection( { redirect: true } );
 	if ( ! isSiteConnected ) {
 		return null;
 	}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -21,6 +21,7 @@ import PlansSection from '../plans-section';
 import ProductCardsSection from '../product-cards-section';
 import useAnalytics from '../../hooks/use-analytics';
 import useNoticeWatcher, { useGlobalNotice } from '../../hooks/use-notice';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import './style.scss';
 
 /**
@@ -66,6 +67,11 @@ export default function MyJetpackScreen() {
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_page_view' );
 	}, [ recordEvent ] );
+
+	const { isSiteConnected } = useMyJetpackConnection();
+	if ( ! isSiteConnected ) {
+		return null;
+	}
 
 	return (
 		<div className="jp-my-jetpack-screen">

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
@@ -1,20 +1,14 @@
-/* global myJetpackRest */
 /**
  * External dependencies
  */
 import { useEffect } from 'react';
 import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { useConnection } from '@automattic/jetpack-connection';
+import useMyJetpackConnection from '../use-my-jetpack-connection';
 
 const useAnalytics = () => {
-	const { apiRoot, apiNonce } = myJetpackRest;
-
-	const { isUserConnected, userConnectionData } = useConnection( {
-		apiRoot,
-		apiNonce,
-	} );
-
+	const { isUserConnected, userConnectionData } = useMyJetpackConnection();
 	const { login, ID } = userConnectionData.currentUser.wpcomUser;
+
 	/**
 	 * Initialize tracks with user data.
 	 * Should run when we have a connected user.

--- a/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
@@ -10,10 +10,13 @@ import { useEffect } from 'react';
 /**
  * React custom hook to get the site purchases data.
  *
+ * @param   {object} options           - Options to pass to the hook.
+ * @param   {boolean} options.reditect - Perform a redirect when no connection is found.
  * @returns {object} site purchases data
  */
-export default function useMyJetpackConnection() {
+export default function useMyJetpackConnection( options = { redirect: false } ) {
 	const { apiRoot, apiNonce } = myJetpackRest;
+	const { redirect } = options;
 	const connectionData = useConnection( { apiRoot, apiNonce } );
 
 	// Alias: https://github.com/Automattic/jetpack/blob/master/projects/packages/connection/src/class-rest-connector.php/#L315
@@ -21,14 +24,22 @@ export default function useMyJetpackConnection() {
 
 	/*
 	 * When the site is not connect,
+	 * and the `redirect` option is set to `true`,
 	 * redirect to the Jetpack dashboard.
 	 */
 	useEffect( () => {
+		// Bail early when redirect mode is disabled.
+		if ( ! redirect ) {
+			return;
+		}
+
+		// When site is connected, bail early.
 		if ( isSiteConnected ) {
 			return;
 		}
+
 		window.location = myJetpackInitialState.topJetpackMenuItemUrl;
-	}, [ isSiteConnected ] );
+	}, [ isSiteConnected, redirect ] );
 
 	return {
 		...connectionData,

--- a/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
@@ -1,8 +1,10 @@
 /* global myJetpackInitialState */
+
 /**
  * WordPress dependencies
  */
 import { useConnection } from '@automattic/jetpack-connection';
+import { useEffect } from 'react';
 
 /**
  * React custom hook to get the site purchases data.
@@ -11,5 +13,24 @@ import { useConnection } from '@automattic/jetpack-connection';
  */
 export default function useMyJetpackConnection() {
 	const { apiRoot, apiNonce } = myJetpackInitialState;
-	return useConnection( { apiRoot, apiNonce } );
+	const connectionData = useConnection( { apiRoot, apiNonce } );
+
+	// Alias: https://github.com/Automattic/jetpack/blob/master/projects/packages/connection/src/class-rest-connector.php/#L315
+	const isSiteConnected = connectionData.isRegistered;
+
+	/*
+	 * When the site is not connect,
+	 * redirect to the Jetpack dashboard.
+	 */
+	useEffect( () => {
+		if ( isSiteConnected ) {
+			return;
+		}
+		window.location = myJetpackInitialState.topJetpackMenuItemUrl;
+	}, [ isSiteConnected ] );
+
+	return {
+		...connectionData,
+		isSiteConnected,
+	};
 }

--- a/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
@@ -1,0 +1,15 @@
+/* global myJetpackInitialState */
+/**
+ * WordPress dependencies
+ */
+import { useConnection } from '@automattic/jetpack-connection';
+
+/**
+ * React custom hook to get the site purchases data.
+ *
+ * @returns {object} site purchases data
+ */
+export default function useMyJetpackConnection() {
+	const { apiRoot, apiNonce } = myJetpackInitialState;
+	return useConnection( { apiRoot, apiNonce } );
+}

--- a/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
@@ -1,5 +1,6 @@
 /* global myJetpackInitialState */
 
+/* global myJetpackRest */
 /**
  * WordPress dependencies
  */
@@ -12,7 +13,7 @@ import { useEffect } from 'react';
  * @returns {object} site purchases data
  */
 export default function useMyJetpackConnection() {
-	const { apiRoot, apiNonce } = myJetpackInitialState;
+	const { apiRoot, apiNonce } = myJetpackRest;
 	const connectionData = useConnection( { apiRoot, apiNonce } );
 
 	// Alias: https://github.com/Automattic/jetpack/blob/master/projects/packages/connection/src/class-rest-connector.php/#L315

--- a/projects/packages/my-jetpack/_inc/hooks/use-notice/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notice/index.js
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
-/* global myJetpackRest */
-=======
->>>>>>> ac91b94a08 ([not verified] my-jetpack: use custom hook to deal with connection)
 /**
  * WordPress dependencies
  */
@@ -37,10 +33,6 @@ export function useGlobalNotice() {
  * the hook dispatches an action to populate the global notice.
  */
 export default function useNoticeWatcher() {
-<<<<<<< HEAD
-	const { apiRoot, apiNonce } = myJetpackRest;
-=======
->>>>>>> ac91b94a08 ([not verified] my-jetpack: use custom hook to deal with connection)
 	const dispatch = useDispatch();
 
 	const { isUserConnected } = useMyJetpackConnection();

--- a/projects/packages/my-jetpack/_inc/hooks/use-notice/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notice/index.js
@@ -1,16 +1,19 @@
+<<<<<<< HEAD
 /* global myJetpackRest */
+=======
+>>>>>>> ac91b94a08 ([not verified] my-jetpack: use custom hook to deal with connection)
 /**
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useConnection } from '@automattic/jetpack-connection';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { STORE_ID } from '../../state/store';
+import useMyJetpackConnection from '../use-my-jetpack-connection';
 
 /**
  * React custom hook to get global notices.
@@ -34,13 +37,13 @@ export function useGlobalNotice() {
  * the hook dispatches an action to populate the global notice.
  */
 export default function useNoticeWatcher() {
+<<<<<<< HEAD
 	const { apiRoot, apiNonce } = myJetpackRest;
+=======
+>>>>>>> ac91b94a08 ([not verified] my-jetpack: use custom hook to deal with connection)
 	const dispatch = useDispatch();
 
-	const { isUserConnected } = useConnection( {
-		apiRoot,
-		apiNonce,
-	} );
+	const { isUserConnected } = useMyJetpackConnection();
 
 	useEffect( () => {
 		if ( ! isUserConnected ) {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-handle-when-no-site-connected
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-handle-when-no-site-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Handle when site is not connected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR handles the issue when there is no connection to wpcom, performing a client redirect to the main Jetpack dashboard. Currently, under this situation, it produces a Fatal Error showing a classical white screen page.

Fixes https://github.com/Automattic/jetpack/issues/22481

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Handle when site is not connected

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test the breaking bug when no connected site
* Disconnect the site. You can use the Jetpack Debug plugin -> `Clean blog token `
* Go to My Jetpack dashboard
* Confirm you get a white screen
* Confirm the errors in the console
![image](https://user-images.githubusercontent.com/77539/151383797-c24093ca-14b1-4095-983e-f091ce369944.png)

* With these changes, confirm the there is no errors in the console
* The client performs a redirect to the Jetpack dashboard
