### PR TITLE
My Community widget: widget deprecation

### DIFF
--- a/projects/plugins/jetpack/changelog/update-my-community-widget-deprecate
+++ b/projects/plugins/jetpack/changelog/update-my-community-widget-deprecate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+My Community widget: Hide widget from the block inserter and Legacy widget block drop-down menu

--- a/projects/plugins/jetpack/modules/widgets/my-community.php
+++ b/projects/plugins/jetpack/modules/widgets/my-community.php
@@ -49,6 +49,19 @@ class Jetpack_My_Community_Widget extends WP_Widget {
 		}
 
 		$this->default_title = esc_html__( 'Community', 'jetpack' );
+
+		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+	}
+
+	/**
+	 * Remove the "My Community" widget from the Legacy Widget block
+	 *
+	 * @param array $widget_types List of widgets that are currently removed from the Legacy Widget block.
+	 * @return array $widget_types New list of widgets that will be removed.
+	 */
+	public function hide_widget_in_block_editor( $widget_types ) {
+		$widget_types[] = 'jetpack_my_community';
+		return $widget_types;
 	}
 
 	/**


### PR DESCRIPTION
This commit hides the My Community widget from the block inserter and Legacy widget block drop-down menu.

**Before**

  Block inserter  |  Legacy Widget block
:-------------------------:|:-------------------------:
![Markup on 2022-01-27 at 10:19:36](https://user-images.githubusercontent.com/25105483/151392389-c7c88356-cae1-463c-83b2-7b0afe6afc6f.png) | ![Markup on 2022-01-27 at 10:18:48](https://user-images.githubusercontent.com/25105483/151392433-f2677491-7877-4328-af4a-2757102ded80.png)

**After**

  Block inserter  |  Legacy Widget block
:-------------------------:|:-------------------------:
![Markup on 2022-01-27 at 10:25:16](https://user-images.githubusercontent.com/25105483/151392513-6b143783-9efb-4ecb-87a8-a7d216e34eb8.png) | ![Markup on 2022-01-27 at 10:27:08](https://user-images.githubusercontent.com/25105483/151392542-8340b84b-0535-4fcf-9248-4f06884a2479.png)

The My Community widget on WPCOM will have a dedicated deprecation patch as the My Community widget in Jetpack and My Community widget on WPCOM are not synced.

#### Changes proposed in this Pull Request:
- Add filter to deprecate the My Community widget

#### Jetpack product discussion
- this PR is part of the Legacy Widgets Migration project: pdf5j4-4C-p2
- more info can be found in pdf5j4-7f-p2

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Navigate to Customizer → Widgets
2. Add the Legacy block and take a look at the dropdown menu. The My Community widget should not be available.
3. Try to search for the widget in the block inserter in Customizer as well. It should not come up.