### PR TITLE
Dashboard: Update Apps Badge to not require utm_source prop

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/apps-badge/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/apps-badge/index.jsx
@@ -64,7 +64,7 @@ class AppsBadge extends PureComponent {
 		storeName: PropTypes.oneOf( [ 'ios', 'android' ] ).isRequired,
 		titleText: PropTypes.string,
 		onBadgeClick: PropTypes.func,
-		utm_source: PropTypes.string.isRequired,
+		utm_source: PropTypes.string,
 		utm_campaign: PropTypes.string,
 		utm_medium: PropTypes.string,
 	};

--- a/projects/plugins/jetpack/changelog/fix-card-badge-required-utm_source
+++ b/projects/plugins/jetpack/changelog/fix-card-badge-required-utm_source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+


### PR DESCRIPTION
Removes `required` requirement for prop `utm_source`

Confirned with @IanRamosC that it does not need to be required.

Fixes #22516


#### Does this pull request change what data or activity we track or use?
no
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Check this branch out.
* Enable SCRIPT_DEBUG
* build Jetpack  with `jetpack build plugins/jetpack`.
* Visit the admin page . 
* Open the console
* Confirm you only see this red warning:
  *  About usage of `javascript:void(0)` in `href` props for an `a`. Will handle this on another PR
