### PR TITLE
Fix breaking unit tests

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-breaking-unit-tests
+++ b/projects/packages/my-jetpack/changelog/fix-breaking-unit-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+added unit test mock for new global variable myJetpackRest

--- a/projects/packages/my-jetpack/jest.setup.js
+++ b/projects/packages/my-jetpack/jest.setup.js
@@ -10,3 +10,4 @@ window.JP_CONNECTION_INITIAL_STATE = {
 	},
 };
 window.myJetpackInitialState = {};
+window.myJetpackRest = {};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix failing unit tests in packages/my-jetpack - myJetpackRest is undefined.

Added a  basic mock object on the window to allow the test to proceed - and passes as before.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Change to the `projects/packages/my-jetpack` from the project root and run `pnpm t`

Tests should now pass

