### PR TITLE
Search: Allow unconnected admins to manage settings

### DIFF
--- a/projects/packages/search/changelog/fix-search-plan-fetch-for-nonconnected-admins
+++ b/projects/packages/search/changelog/fix-search-plan-fetch-for-nonconnected-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Fetch plan info as blog, not as user, to allow nonconnected admins to use dashboard

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -43,9 +43,12 @@ class Plan {
 	 */
 	public function get_plan_info_from_wpcom() {
 		$blog_id  = Jetpack_Options::get_option( 'id' );
-		$response = Client::wpcom_json_api_request_as_user(
+		$response = Client::wpcom_json_api_request_as_blog(
 			'/sites/' . $blog_id . '/jetpack-search/plan',
-			'2'
+			'2',
+			array(),
+			null,
+			'wpcom'
 		);
 
 		// store plan in options.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Requires D74015-code!

#### Changes proposed in this Pull Request:
Fixes a bug that prevented non-connected admins on Jetpack sites from managing Jetpack Search settings. We now query Search plan information as a blog, not as a user.

#### Jetpack product discussion
p8oabR-Nm-p2#comment-5924

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Ensure D74015-code has been applied and public-api sandboxed.
* Apply this change to your site with an active Jetpack Search subscription.
* Log into your wp-admin using an admin user that hasn't been connected to WPCOM.
* Navigate to the Search Dashboard (`/wp-admin/admin.php?page=jetpack-search`).
* Ensure that the dashboard works as expected.
* Click on the "Customize search results" button; ensure that the search configurator works as expected.
