### PR TITLE
My Jetpack: tweak dims of the Product card status

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -15,7 +15,6 @@
   --status-inactive: #646970;
   --status-error: #B32D2E;
   --status-plugin_absent: #C3C4C7;
-  --status-label-height: 36px;
 
   padding: 24px;
   background: var( --jp-white );

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -68,8 +68,8 @@
 .status {
   margin-left: var(--product-card-margin-base);
   white-space: nowrap;
-  height: --product-card-actions-size;
-  line-height: --product-card-actions-size;
+  height: var(--product-card-actions-size);
+  line-height: var(--product-card-actions-size);
 
   &:before {
     content: "";

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -67,6 +67,8 @@
 .status {
   margin-left: var(--product-card-margin-base);
   white-space: nowrap;
+  height: 36px;
+  line-height: 36px;
 
   &:before {
     content: "";

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -15,6 +15,7 @@
   --status-inactive: #646970;
   --status-error: #B32D2E;
   --status-plugin_absent: #C3C4C7;
+  --status-label-height: 36px;
 
   padding: 24px;
   background: var( --jp-white );
@@ -67,8 +68,8 @@
 .status {
   margin-left: var(--product-card-margin-base);
   white-space: nowrap;
-  height: 36px;
-  line-height: 36px;
+  height: --product-card-actions-size;
+  line-height: --product-card-actions-size;
 
   &:before {
     content: "";

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-tweak-status-cmp-dims
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-tweak-status-cmp-dims
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Tweak dimms of the Product card status


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

It tweaks the status component of the Product card, aligning it with the action button:

<img src="https://user-images.githubusercontent.com/77539/151790156-84d83eaf-70a9-4202-a1a5-1b33f4bb3f16.png" width="500px" />

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: tweak dims of the Product card status

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My jetpack dashboard

before | after
-------|------
![image](https://user-images.githubusercontent.com/77539/151789959-a37121a1-2bd6-4df9-ae9e-7967bc15f39a.png) | ![image](https://user-images.githubusercontent.com/77539/151789892-de5ee797-ee28-4d22-899a-77145a989687.png)

*
