### PR TITLE
Search: set default value when saving widget instance

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-warning-search-instance
+++ b/projects/plugins/jetpack/changelog/fix-warning-search-instance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: avoid PHP warning when using Search widget.

--- a/projects/plugins/jetpack/modules/widgets/search.php
+++ b/projects/plugins/jetpack/modules/widgets/search.php
@@ -660,7 +660,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		$instance['title']              = sanitize_text_field( $new_instance['title'] );
 		$instance['search_box_enabled'] = empty( $new_instance['search_box_enabled'] ) ? '0' : '1';
 		$instance['user_sort_enabled']  = empty( $new_instance['user_sort_enabled'] ) ? '0' : '1';
-		$instance['sort']               = $new_instance['sort'];
+		$instance['sort']               = empty( $new_instance['sort'] ) ? self::DEFAULT_SORT : $new_instance['sort'];
 		$instance['post_types']         = empty( $new_instance['post_types'] ) || empty( $instance['search_box_enabled'] )
 			? array()
 			: array_map( 'sanitize_key', $new_instance['post_types'] );


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

﻿This should avoid PHP warnings such as this one:
```
PHP Warning:  Undefined array key "sort" in /wp-content/plugins/jetpack-dev/modules/widgets/search.php on line 663
```

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Set up a new site, using a non-block theme like Twenty Twenty, buy a Jetpack Search plan.
* Go to Appearance > Widgets
* Ensure you can use the Jetpack Search widget
* Ensure that there are no issues in your error log.

