### PR TITLE
My Jetpack: Fix stories for ProductCard component

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/stories/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/stories/index.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/react-in-jsx-scope */
+
 /**
  * External dependencies
  */
@@ -9,6 +10,9 @@ import React from 'react';
  */
 import ProductCard, { PRODUCT_STATUSES } from '../index.jsx';
 import { initStore } from '../../../state/store';
+
+// Set myJetpackRest global var.
+window.myJetpackRest = {};
 
 initStore();
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
@@ -6,15 +6,15 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 
 const useAnalytics = () => {
-	const { isUserConnected, userConnectionData } = useMyJetpackConnection();
-	const { login, ID } = userConnectionData.currentUser.wpcomUser;
+	const { isUserConnected, userConnectionData = {} } = useMyJetpackConnection();
+	const { login, ID } = userConnectionData.currentUser?.wpcomUser || {};
 
 	/**
 	 * Initialize tracks with user data.
 	 * Should run when we have a connected user.
 	 */
 	useEffect( () => {
-		if ( isUserConnected ) {
+		if ( isUserConnected && ID && login ) {
 			jetpackAnalytics.initialize( ID, login );
 		}
 	} );

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-stories-for-product-card
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-stories-for-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fixes stories for ProductCard component


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The stories for ProductCard are broken since they expect a connected user to when trying to track events. To fix this issue, the PR defines a fake empty object, and also tweaks the `useAnalitics()` hook, checking the data before initializing the analytics. 

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Fix stories for ProductCard component

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start js-packages storybook

```
cd ./jetpack/projects/js-packages/storybook
```

```
pnpm install & pnpm storybook:dev
```

*before*
<img src="https://user-images.githubusercontent.com/77539/151852511-8b66280f-c512-48da-9b76-fb6ca5c3d1c4.png" width="600px" />


*after*
<img src="https://user-images.githubusercontent.com/77539/151852421-b24b241c-03b8-44e6-9068-cd2596148f5f.png" width="600px" />

* Confirm it keeps tracking event, when:
  * My Jetpack dashboard is rendered
![image](https://user-images.githubusercontent.com/77539/151852705-2c300706-fe2f-49ff-aea3-37940feb454b.png)

  * Activating/Deactivating a product
![image](https://user-images.githubusercontent.com/77539/151852734-750e9f7b-225c-4830-a9c7-d28e244b0620.png)


