### PR TITLE
My Jetpack: fix tracking event when activating product

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -166,7 +166,7 @@ const ProductCard = props => {
 						/>
 					</ButtonGroup>
 				) : (
-					renderActionButton( props )
+					renderActionButton( { ...props, onActivate: activateHandler } )
 				) }
 				{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
 			</div>

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-tracking-activating-product-event
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-tracking-activating-product-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+my-jetpack: fix tracking event when activating product


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR fixes an issue when tracking the activate event when the user clicks on the `Activate` button.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, when the user clicks on the Activate/Deactivate button.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Reproduce the issue
* Go to My Jetpack
* Set the debug  with localStorage
```cli
localStorage.setItem( 'debug', 'dops:analytics*' );
```
* Confirm you see a log when deactivating the product, but it doesn't happen when activating it.

![image](https://user-images.githubusercontent.com/77539/151854456-d0fbe3e5-ac32-4bc6-9d78-cf4b506f24f9.png)

After these changes...

* Confirm you see the log events either when deactivating as well as when activating the product.
![image](https://user-images.githubusercontent.com/77539/151854635-81d3f315-b509-415d-a2fe-5ec1b22f7d41.png)

