### PR TITLE
Sharing: Add an AMP-compatible version of the email share button

### DIFF
--- a/projects/plugins/jetpack/changelog/add-email-share-amp-support
+++ b/projects/plugins/jetpack/changelog/add-email-share-amp-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add an AMP-compatible version of the email share button.

--- a/projects/plugins/jetpack/modules/sharedaddy/amp-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/amp-sharing.css
@@ -37,6 +37,15 @@ amp-social-share::before,
 	color: #656565;
 }
 
+amp-social-share[type='email'] {
+	background: #e9e9e9;
+	color: #656565;
+}
+
+amp-social-share[type='email']::before {
+	content: '\f410';
+}
+
 amp-social-share[type='tumblr'] {
 	background: #2c4762;
 }

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -658,12 +658,17 @@ class Share_Email extends Sharing_Source {
 	}
 
 	/**
-	 * No AMP display for email.
+	 * AMP display for email.
 	 *
 	 * @param \WP_Post $post The current post being viewed.
 	 */
-	public function get_amp_display( $post ) { // phpcs:ignore
-		return false;
+	public function get_amp_display( $post ) {
+		$attrs = array(
+			// Prevents an empty window from opening on desktop: https://github.com/ampproject/amphtml/issues/9157.
+			'data-target' => '_self',
+		);
+
+		return $this->build_amp_markup( $attrs );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -662,7 +662,7 @@ class Share_Email extends Sharing_Source {
 	 *
 	 * @param \WP_Post $post The current post being viewed.
 	 */
-	public function get_amp_display( $post ) {
+	public function get_amp_display( $post ) { // phpcs:ignore
 		$attrs = array(
 			// Prevents an empty window from opening on desktop: https://github.com/ampproject/amphtml/issues/9157.
 			'data-target' => '_self',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See #9730

#### Changes proposed in this Pull Request:
This PR adds an AMP-compatible version of the email share button, to go with the other supported sharing services. 

#### Jetpack product discussion
* N/A.

#### Does this pull request change what data or activity we track or use?
* No.

#### Testing instructions:
* If it's not already running one, switch your test site to an AMP compatible theme -- this can include any of the default themes.
* If your site isn't already running it, install and activate the [AMP plugin](https://wordpress.org/plugins/amp/).
* Navigate to WP Admin > AMP; switch your site to 'Standard' under 'Template Mode', and click Save.
* If your site isn't already running it, install and activate the [Akismet plugin](https://wordpress.org/plugins/akismet/); this is required to add the Email Share button to your site. 
* Navigate to WP Admin > Jetpack > Settings > Sharing, and enable sharing on your site; click 'Configure Share buttons', and add a couple share options, including the Email share button. 
* To compare the AMP and non-AMP appearance, switch the buttons to use the 'Icon only' button style.
* View a single post on the front-end of your site; by default in AMP Standard, you will see the AMP version of the post on all devices: 

![image](https://user-images.githubusercontent.com/177561/151873254-035a48b8-7118-4720-8d6d-a67aadaecb87.png)

* Hover over the AMP menu item in the Admin Toolbar, and click 'View with AMP disabled' to view the non-AMP version of the page (right clicking and opening in a new tab will let you switch between the two views):

![image](https://user-images.githubusercontent.com/177561/151873322-b0938c58-81ec-4140-82fd-013e8b30f95f.png)

* Compare the non-AMP version of the buttons to the AMP version above -- the email button is getting stripped out. 

![image](https://user-images.githubusercontent.com/177561/151873565-739fafc6-66e2-4162-8011-5f269430c93d.png)

* Apply and build the PR.
* Confirm that the email button is now displaying on the AMP version of your post:

![image](https://user-images.githubusercontent.com/177561/151874099-bbd4811c-2194-4542-9f2e-736c39113f85.png)

* Click on the button and confirm it opens your email program; it should add your post title as the subject line, and a link to the post in the email body.
* Repeat the above step on a mobile device, and confirm that it's working as expected.
* Compare the AMP version of the email button to the non-AMP version of the icon-only email button, and confirm they look the same. 