### PR TITLE
My Jetpack: Add react-router for route handling

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -672,6 +672,7 @@ importers:
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2
+      react-router-dom: '6'
       sass: 1.43.3
       sass-loader: 12.4.0
       storybook-addon-mock: 2.0.2
@@ -687,6 +688,7 @@ importers:
       '@wordpress/icons': 6.1.1
       classnames: 2.3.1
       prop-types: 15.8.1
+      react-router-dom: 6.2.1_react-dom@17.0.2+react@17.0.2
     devDependencies:
       '@automattic/jetpack-base-styles': link:../../js-packages/base-styles
       '@automattic/jetpack-webpack-config': link:../../js-packages/webpack-config
@@ -14531,7 +14533,6 @@ packages:
     resolution: {integrity: sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==}
     dependencies:
       '@babel/runtime': 7.16.7
-    dev: true
 
   /hmac-drbg/1.0.1:
     resolution: {integrity: sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=}
@@ -19523,7 +19524,6 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-router: 6.2.1_react@17.0.2
-    dev: true
 
   /react-router-dom/6.2.1_react@17.0.2:
     resolution: {integrity: sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==}
@@ -19561,7 +19561,6 @@ packages:
     dependencies:
       history: 5.2.0
       react: 17.0.2
-    dev: true
 
   /react-shallow-renderer/16.14.1:
     resolution: {integrity: sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==}

--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -3,14 +3,22 @@
  */
 import ReactDOM from 'react-dom';
 import React from 'react';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import MyJetpackScreen from './components/my-jetpack-screen';
 import { initStore } from './state/store';
+import useRouteBlocker from './hooks/use-route-blocker';
 
 initStore();
+
+// @TODO Remove as soon new routes arrives
+const New = () => {
+	useRouteBlocker();
+	return <div>New</div>;
+};
 
 /**
  * The initial renderer function.
@@ -22,7 +30,15 @@ function render() {
 		return;
 	}
 
-	ReactDOM.render( <MyJetpackScreen />, container );
+	ReactDOM.render(
+		<HashRouter>
+			<Routes>
+				<Route path="/" element={ <MyJetpackScreen /> } />
+				<Route path="/new" element={ <New /> } />
+			</Routes>
+		</HashRouter>,
+		container
+	);
 }
 
 render();

--- a/projects/packages/my-jetpack/_inc/hooks/use-route-blocker/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-route-blocker/index.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import { useNavigationType, useNavigate } from 'react-router-dom';
+
+export default () => {
+	const type = useNavigationType();
+	const navigate = useNavigate();
+
+	useEffect( () => {
+		if ( type === 'POP' ) {
+			navigate( '/', { replace: true } );
+		}
+	}, [ type, navigate ] );
+};

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-routes
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-routes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add route handling

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -30,7 +30,8 @@
 		"@wordpress/i18n": "4.2.4",
 		"@wordpress/icons": "6.1.1",
 		"classnames": "2.3.1",
-		"prop-types": "15.8.1"
+		"prop-types": "15.8.1",
+		"react-router-dom": "6"
 	},
 	"sideEffects": [
 		"*.css",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Implement the route system inside My Jetpack, with a hook to block direct navigation to the component.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Setup `HashRouter` and `Routes`.
* Include `useRouteBlocker` that blocks direct route access for some component, it will only be allowed if coming from other router.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1643660572899069-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Goes into `MyJetpackScreen` component
* Insert a `Link` component from `react-router-dom` any place, and set the `to` for `/new` route.
* Build `My Jetpack` (`jetpack build packages/my-jetpack`).
* Navigate to `My Jetpack`.
* Click in the `Link`.
* It should load the `New` screen.
* Go back and try to go forward.
* It will redirect you back to the `My Jetpack` screen.
* Click on the link again.
* Refresh the page.
* It will redirect you back to the `My Jetpack` screen.

#### Demo


https://user-images.githubusercontent.com/1663717/151889564-403695d0-3208-445d-bb04-e1dc45842f50.mp4

