### PR TITLE
Premium Content Block: Don't offer transform to self

### DIFF
--- a/projects/plugins/jetpack/changelog/update-premium-content-transformations
+++ b/projects/plugins/jetpack/changelog/update-premium-content-transformations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Don't offer to transform a premium content block to a premium content block

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
@@ -75,6 +75,12 @@ export const settings = {
 				type: 'block',
 				isMultiBlock: true,
 				blocks: [ '*' ],
+				isMatch: fromAttributes => {
+					if ( fromAttributes.some( attributes => attributes.isPremiumContentChild ) ) {
+						return false;
+					}
+					return true;
+				},
 				__experimentalConvert( blocks ) {
 					// Avoid transforming any premium-content block.
 					if ( blocks.some( blockContainsPremiumBlock ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
@@ -12,6 +12,30 @@ import save from './save';
 import icon from './_inc/icon';
 import { blockContainsPremiumBlock, blockHasParentPremiumBlock } from './_inc/premium';
 
+/**
+ * Check if the given blocks are transformable to premium-content block
+ *
+ * This is because transforming blocks that are already premium content blocks, or have one as a descendant or ancestor
+ * doesn't make sense and is likely to lead to confusion.
+ *
+ * @param {Array} blocks - The blocks that could be transformed
+ * @returns {boolean} Whether the blocks should be allowed to be transformed to a premium content block
+ */
+const blocksCanBeTransformed = blocks => {
+	// Avoid transforming any premium-content block.
+	if ( blocks.some( blockContainsPremiumBlock ) ) {
+		return false;
+	}
+
+	// Avoid transforming if any parent is a premium-content block. Blocks share same parents since they
+	// are siblings, so checking the first one is enough.
+	if ( blockHasParentPremiumBlock( blocks[ 0 ] ) ) {
+		return false;
+	}
+
+	return true;
+};
+
 export const name = 'premium-content/container';
 export const settings = {
 	title: __( 'Premium Content', 'jetpack' ),
@@ -75,21 +99,18 @@ export const settings = {
 				type: 'block',
 				isMultiBlock: true,
 				blocks: [ '*' ],
-				isMatch: fromAttributes => {
+				isMatch: ( fromAttributes, fromBlocks ) => {
 					if ( fromAttributes.some( attributes => attributes.isPremiumContentChild ) ) {
 						return false;
 					}
-					return true;
+					// The fromBlocks parameter doesn't exist in Gutenberg < 11.1.0, so if it isn't passed, allow the
+					// match, fallback code in the convert method will handle it.
+					return fromBlocks === undefined || blocksCanBeTransformed( fromBlocks );
 				},
 				__experimentalConvert( blocks ) {
-					// Avoid transforming any premium-content block.
-					if ( blocks.some( blockContainsPremiumBlock ) ) {
-						return;
-					}
-
-					// Avoid transforming if any parent is a premium-content block. Blocks share same parents since they
-					// are siblings, so checking the first one is enough.
-					if ( blockHasParentPremiumBlock( blocks[ 0 ] ) ) {
+					// This is checked here as well as in isMatch because the isMatch function isn't fully compatible
+					// with gutenberg < 11.1.0
+					if ( ! blocksCanBeTransformed( blocks ) ) {
 						return;
 					}
 


### PR DESCRIPTION
Premium content blocks currently offer a transformation from any source
block, including existing premium content blocks. When the user tries to
transform a premium content block to a premium content block it is
detected and nothing happens.

This change doesn't offer the transformation in the first place, which
reduces confusion and menu clutter.

Partly fixes #22423

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
 1. Apply patch
 2. Build extension with `pnpm run build-extensions` from `projects/plugins/jetpack/extensions`
 3. Open the add new post screen
 4. Add a premium content block
 5. Click the premium content block (not it's children)
 6. See it doesn't offer a transformation to a premium content block

Before | After
-------|------
 ![image](https://user-images.githubusercontent.com/93301/151957318-76c35fcb-6e73-4019-8fe6-d1aedad76e1f.png) | ![image](https://user-images.githubusercontent.com/93301/151957437-5d1248e0-d721-4e68-9c17-65080df6aa4b.png)
