### PR TITLE
Janitorial: update orphan projects

### DIFF
--- a/projects/github-actions/repo-gardening/CHANGELOG.md
+++ b/projects/github-actions/repo-gardening/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022-02-01
+### Changed
+- General: update required node version to v16.13.2
+- Updated package dependencies
+
 ## [2.0.0] - 2021-11-02
 ### Added
 - Automatically add the RNA label to PRs.
@@ -74,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[2.0.1]: https://github.com/Automattic/action-repo-gardening/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/action-repo-gardening/compare/v1.4.0...v2.0.0
 [1.4.0]: https://github.com/Automattic/action-repo-gardening/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/Automattic/action-repo-gardening/compare/v1.2.2...v1.3.0

--- a/projects/github-actions/repo-gardening/changelog/renovate-node-fetch-2.x
+++ b/projects/github-actions/repo-gardening/changelog/renovate-node-fetch-2.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/github-actions/repo-gardening/changelog/update-min-pnpm-version
+++ b/projects/github-actions/repo-gardening/changelog/update-min-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version.
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-node-version-16132
+++ b/projects/github-actions/repo-gardening/changelog/update-node-version-16132
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: update required node version to v16.13.2

--- a/projects/github-actions/repo-gardening/changelog/update-project-scripts-no-install
+++ b/projects/github-actions/repo-gardening/changelog/update-project-scripts-no-install
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Tooling only: Build and test scripts no longer call `composer install` or `pnpm install`.
-
-

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "2.0.1-alpha",
+	"version": "2.0.1",
 	"description": "Manage PR and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/eslint-config-target-es/CHANGELOG.md
+++ b/projects/js-packages/eslint-config-target-es/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2022-02-01
+### Changed
+- General: update required node version to v16.13.2
+- Updated package dependencies
+
 ## 1.0.0 - 2021-11-16
 ### Added
 - Initial release.
+
+[1.0.1]: https://github.com/Automattic/eslint-config-target-es/compare/1.0.0...1.0.1

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x#2
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/eslint-config-target-es/changelog/update-min-pnpm-version
+++ b/projects/js-packages/eslint-config-target-es/changelog/update-min-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version.
-
-

--- a/projects/js-packages/eslint-config-target-es/changelog/update-node-version-16132
+++ b/projects/js-packages/eslint-config-target-es/changelog/update-node-version-16132
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: update required node version to v16.13.2

--- a/projects/js-packages/eslint-config-target-es/changelog/update-project-scripts-no-install
+++ b/projects/js-packages/eslint-config-target-es/changelog/update-project-scripts-no-install
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Tooling only: Build and test scripts no longer call `composer install` or `pnpm install`.
-
-

--- a/projects/js-packages/eslint-config-target-es/package.json
+++ b/projects/js-packages/eslint-config-target-es/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/eslint-config-target-es",
-	"version": "1.0.1-alpha",
+	"version": "1.0.1",
 	"description": "ESLint sharable config to activate eslint-plugin-es checks based on browserslist targets.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/eslint-config-target-es/README.md#readme",
 	"bugs": {

--- a/projects/js-packages/storybook/CHANGELOG.md
+++ b/projects/js-packages/storybook/CHANGELOG.md
@@ -5,3 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2022-02-01
+### Added
+- Added addons-essentials to the dependencies
+- Added storybook package for generating component previews
+- Add Gutenberg components tree to the storybook
+- Add jetpack-connection package to Storybook config.
+- Add support for base-style stories
+- Add support for the IDC package stories.
+- Storybook: Expose my-jetpack components
+
+### Changed
+- Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.
+- General: update required node version to v16.13.2
+- Publish to a mirror repo rather than the `gh-pages` branch.
+- Tests: update PHPUnit polyfills dependency (yoast/phpunit-polyfills).
+- Updated package dependencies.
+- Update webpack version to match other monorepo packages
+- Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
+
+### Removed
+- removed knobs dependency
+- Remove use of deprecated `~` in sass-loader imports.
+
+### Fixed
+- fixed babel/preset-react dependency
+- GH only allows pages to be in `/` or `/docs`, so build to `/docs`.

--- a/projects/js-packages/storybook/changelog/2021-09-28-16-11-44-715508
+++ b/projects/js-packages/storybook/changelog/2021-09-28-16-11-44-715508
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2021-10-13-15-55-37-502807
+++ b/projects/js-packages/storybook/changelog/2021-10-13-15-55-37-502807
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2021-10-26-11-37-27-239390
+++ b/projects/js-packages/storybook/changelog/2021-10-26-11-37-27-239390
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2021-11-02-12-22-14-382297
+++ b/projects/js-packages/storybook/changelog/2021-11-02-12-22-14-382297
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2021-11-09-14-35-04-196965
+++ b/projects/js-packages/storybook/changelog/2021-11-09-14-35-04-196965
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2021-11-16-15-55-31-535583
+++ b/projects/js-packages/storybook/changelog/2021-11-16-15-55-31-535583
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2021-11-23-12-49-57-152426
+++ b/projects/js-packages/storybook/changelog/2021-11-23-12-49-57-152426
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2021-11-30-15-13-01-232780
+++ b/projects/js-packages/storybook/changelog/2021-11-30-15-13-01-232780
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2021-12-07-15-51-02-511843
+++ b/projects/js-packages/storybook/changelog/2021-12-07-15-51-02-511843
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2021-12-14-15-28-06-798680
+++ b/projects/js-packages/storybook/changelog/2021-12-14-15-28-06-798680
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2022-01-04-19-50-37-326407
+++ b/projects/js-packages/storybook/changelog/2022-01-04-19-50-37-326407
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2022-01-11-19-07-56-905220
+++ b/projects/js-packages/storybook/changelog/2022-01-11-19-07-56-905220
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2022-01-18-09-57-37-701551
+++ b/projects/js-packages/storybook/changelog/2022-01-18-09-57-37-701551
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2022-01-25-15-57-55-469586
+++ b/projects/js-packages/storybook/changelog/2022-01-25-15-57-55-469586
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-10.1-changelog
+++ b/projects/js-packages/storybook/changelog/add-10.1-changelog
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-@wordpress-eslint-plugin
+++ b/projects/js-packages/storybook/changelog/add-@wordpress-eslint-plugin
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update eslint configuration.
-
-

--- a/projects/js-packages/storybook/changelog/add-changelogger-squash-command
+++ b/projects/js-packages/storybook/changelog/add-changelogger-squash-command
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-connection-button-spinner
+++ b/projects/js-packages/storybook/changelog/add-connection-button-spinner
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Package version bump.
-
-

--- a/projects/js-packages/storybook/changelog/add-fancy-eslint-ignore
+++ b/projects/js-packages/storybook/changelog/add-fancy-eslint-ignore
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Hack eslint config to use `.gitignore` and per-dir `.eslintignore`.
-
-

--- a/projects/js-packages/storybook/changelog/add-gutenberg-components
+++ b/projects/js-packages/storybook/changelog/add-gutenberg-components
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Gutenberg components tree to the storybook

--- a/projects/js-packages/storybook/changelog/add-idc-errors
+++ b/projects/js-packages/storybook/changelog/add-idc-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-idc-non-admin
+++ b/projects/js-packages/storybook/changelog/add-idc-non-admin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-jetpack-spinner-to-storybook
+++ b/projects/js-packages/storybook/changelog/add-jetpack-spinner-to-storybook
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-js-packages-exports
+++ b/projects/js-packages/storybook/changelog/add-js-packages-exports
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-my-jetpack-sections
+++ b/projects/js-packages/storybook/changelog/add-my-jetpack-sections
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-new-attach-license-method
+++ b/projects/js-packages/storybook/changelog/add-new-attach-license-method
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-rna-connect-screen-required-plan
+++ b/projects/js-packages/storybook/changelog/add-rna-connect-screen-required-plan
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add jetpack-connection package to Storybook config.

--- a/projects/js-packages/storybook/changelog/add-rna-connect-screen-required-plan#2
+++ b/projects/js-packages/storybook/changelog/add-rna-connect-screen-required-plan#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-storybook
+++ b/projects/js-packages/storybook/changelog/add-storybook
@@ -1,4 +1,0 @@
-Significance: major
-Type: added
-
-Added storybook package for generating component previews

--- a/projects/js-packages/storybook/changelog/add-user-license-activate-notice-2
+++ b/projects/js-packages/storybook/changelog/add-user-license-activate-notice-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-user-license-activate-notice-2#2
+++ b/projects/js-packages/storybook/changelog/add-user-license-activate-notice-2#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/backup-branch-1.1.0
+++ b/projects/js-packages/storybook/changelog/backup-branch-1.1.0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/fix-babel-react-preset-dep
+++ b/projects/js-packages/storybook/changelog/fix-babel-react-preset-dep
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-fixed babel/preset-react dependency

--- a/projects/js-packages/storybook/changelog/fix-base-style-color
+++ b/projects/js-packages/storybook/changelog/fix-base-style-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/fix-changelogger-prerelease-version-next
+++ b/projects/js-packages/storybook/changelog/fix-changelogger-prerelease-version-next
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/fix-plain-permalinks-authorization-url
+++ b/projects/js-packages/storybook/changelog/fix-plain-permalinks-authorization-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/fix-rm-deprecated-sass-tilde
+++ b/projects/js-packages/storybook/changelog/fix-rm-deprecated-sass-tilde
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Remove use of deprecated `~` in sass-loader imports.

--- a/projects/js-packages/storybook/changelog/fix-storybook-in-mirror-repo
+++ b/projects/js-packages/storybook/changelog/fix-storybook-in-mirror-repo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-GH only allows pages to be in `/` or `/docs`, so build to `/docs`.

--- a/projects/js-packages/storybook/changelog/fix-storybook-stories-tab
+++ b/projects/js-packages/storybook/changelog/fix-storybook-stories-tab
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Changed related to storybook, not a product feature
-
-

--- a/projects/js-packages/storybook/changelog/fix-style-inconsistencies-in-action-button
+++ b/projects/js-packages/storybook/changelog/fix-style-inconsistencies-in-action-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/jetpack-branch-10.4
+++ b/projects/js-packages/storybook/changelog/jetpack-branch-10.4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/jetpack-branch-10.5
+++ b/projects/js-packages/storybook/changelog/jetpack-branch-10.5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/js-redirects-add-docs-and-tests
+++ b/projects/js-packages/storybook/changelog/js-redirects-add-docs-and-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/prepare-10.4.a.7-release
+++ b/projects/js-packages/storybook/changelog/prepare-10.4.a.7-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/remove-es5-skeleton
+++ b/projects/js-packages/storybook/changelog/remove-es5-skeleton
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Removed unused ES5 validation command
-
-

--- a/projects/js-packages/storybook/changelog/remove-knobs-from-stories
+++ b/projects/js-packages/storybook/changelog/remove-knobs-from-stories
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-removed knobs dependency

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-css-loader-6.x
+++ b/projects/js-packages/storybook/changelog/renovate-css-loader-6.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-css-loader-6.x#2
+++ b/projects/js-packages/storybook/changelog/renovate-css-loader-6.x#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-emotion-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-emotion-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-pin-dependencies
+++ b/projects/js-packages/storybook/changelog/renovate-pin-dependencies
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-sass-loader-12.x
+++ b/projects/js-packages/storybook/changelog/renovate-sass-loader-12.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-storybook-addon-knobs-6.x
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-addon-knobs-6.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#4
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#5
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#6
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#7
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-webpack-5.x
+++ b/projects/js-packages/storybook/changelog/renovate-webpack-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-webpack-5.x#2
+++ b/projects/js-packages/storybook/changelog/renovate-webpack-5.x#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#4
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#5
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#6
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#7
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#8
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#9
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/js-packages/storybook/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Tests: update PHPUnit polyfills dependency (yoast/phpunit-polyfills).

--- a/projects/js-packages/storybook/changelog/renovate-yoast-phpunit-polyfills-1.x#2
+++ b/projects/js-packages/storybook/changelog/renovate-yoast-phpunit-polyfills-1.x#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/renovate-yoast-phpunit-polyfills-1.x#3
+++ b/projects/js-packages/storybook/changelog/renovate-yoast-phpunit-polyfills-1.x#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/js-packages/storybook/changelog/try-allow-node-14
+++ b/projects/js-packages/storybook/changelog/try-allow-node-14
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Allow Node ^14.17.6 to be used in this project. This shouldn't change the behavior of the code itself.

--- a/projects/js-packages/storybook/changelog/try-html-only-stories
+++ b/projects/js-packages/storybook/changelog/try-html-only-stories
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add support for base-style stories

--- a/projects/js-packages/storybook/changelog/try-rna-connection-store-export
+++ b/projects/js-packages/storybook/changelog/try-rna-connection-store-export
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/try-update-to-node-16
+++ b/projects/js-packages/storybook/changelog/try-update-to-node-16
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.

--- a/projects/js-packages/storybook/changelog/try-update-webpack-globally
+++ b/projects/js-packages/storybook/changelog/try-update-webpack-globally
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update webpack version to match other monorepo packages

--- a/projects/js-packages/storybook/changelog/update-backport-connection-package
+++ b/projects/js-packages/storybook/changelog/update-backport-connection-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-changelog-cherry-pick
+++ b/projects/js-packages/storybook/changelog/update-changelog-cherry-pick
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-connect-button-visual-component
+++ b/projects/js-packages/storybook/changelog/update-connect-button-visual-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added addons-essentials to the dependencies

--- a/projects/js-packages/storybook/changelog/update-css-modules
+++ b/projects/js-packages/storybook/changelog/update-css-modules
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-extend-disconnect-dialog-component
+++ b/projects/js-packages/storybook/changelog/update-extend-disconnect-dialog-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-idc-storybook
+++ b/projects/js-packages/storybook/changelog/update-idc-storybook
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add support for the IDC package stories.

--- a/projects/js-packages/storybook/changelog/update-idc_text
+++ b/projects/js-packages/storybook/changelog/update-idc_text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-jetpack-base-styles
+++ b/projects/js-packages/storybook/changelog/update-jetpack-base-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-jetpack-color-primary
+++ b/projects/js-packages/storybook/changelog/update-jetpack-color-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-js-pkg-idc-v0.8.0
+++ b/projects/js-packages/storybook/changelog/update-js-pkg-idc-v0.8.0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-min-pnpm-version
+++ b/projects/js-packages/storybook/changelog/update-min-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version.
-
-

--- a/projects/js-packages/storybook/changelog/update-my-jetpack-storybook
+++ b/projects/js-packages/storybook/changelog/update-my-jetpack-storybook
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Storybook: Expose my-jetpack components

--- a/projects/js-packages/storybook/changelog/update-node-version-16132
+++ b/projects/js-packages/storybook/changelog/update-node-version-16132
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: update required node version to v16.13.2

--- a/projects/js-packages/storybook/changelog/update-project-scripts-no-install
+++ b/projects/js-packages/storybook/changelog/update-project-scripts-no-install
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Tooling only: Build and test scripts no longer call `composer install` or `pnpm install`.
-
-

--- a/projects/js-packages/storybook/changelog/update-public-base-styles
+++ b/projects/js-packages/storybook/changelog/update-public-base-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-refactor-connection-button
+++ b/projects/js-packages/storybook/changelog/update-refactor-connection-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-refactor-number-format-location
+++ b/projects/js-packages/storybook/changelog/update-refactor-number-format-location
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-rna-connection-move-register-to-store
+++ b/projects/js-packages/storybook/changelog/update-rna-connection-move-register-to-store
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-rna-pricing-card-same-price
+++ b/projects/js-packages/storybook/changelog/update-rna-pricing-card-same-price
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-storybook-in-mirror-repo
+++ b/projects/js-packages/storybook/changelog/update-storybook-in-mirror-repo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Publish to a mirror repo rather than the `gh-pages` branch.

--- a/projects/js-packages/storybook/changelog/update-user-data-on-initial-state
+++ b/projects/js-packages/storybook/changelog/update-user-data-on-initial-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-storybook",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "Jetpack components storybook",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.2] - 2022-02-01
+### Changed
+- Build: remove unneeded files from production build.
+
 ## [1.17.1] - 2022-01-27
 ### Changed
 - Updated package dependencies.
@@ -182,6 +186,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[1.17.2]: https://github.com/Automattic/jetpack-assets/compare/v1.17.1...v1.17.2
 [1.17.1]: https://github.com/Automattic/jetpack-assets/compare/v1.17.0...v1.17.1
 [1.17.0]: https://github.com/Automattic/jetpack-assets/compare/v1.16.2...v1.17.0
 [1.16.2]: https://github.com/Automattic/jetpack-assets/compare/v1.16.1...v1.16.2

--- a/projects/packages/assets/changelog/update-ignored-files-packages
+++ b/projects/packages/assets/changelog/update-ignored-files-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Build: remove unneeded files from production build.

--- a/projects/packages/codesniffer/CHANGELOG.md
+++ b/projects/packages/codesniffer/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2022-02-01
+### Added
+- Add a sniff to check the textdomain passed to `Assets::register_script()`.
+
+### Changed
+- Disable CI tests on 8.1, PHPCompatibility raises deprecation warnings.
+- Reconfigure phpcs so we don't need so many `phpcs:ignore` comments.
+- Switch to pcov for code coverage.
+- Updated package dependencies
+
 ## [2.3.0] - 2021-11-02
 ### Changed
 - Set `convertDeprecationsToExceptions` true in PHPUnit config.
@@ -63,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Codesniffer: Add a package to hold our coding standard
 
+[2.4.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.1.1...v2.2.0

--- a/projects/packages/codesniffer/changelog/add-phpcs-per-director-config
+++ b/projects/packages/codesniffer/changelog/add-phpcs-per-director-config
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Reconfigure phpcs so we don't need so many `phpcs:ignore` comments.

--- a/projects/packages/codesniffer/changelog/add-phpcs-sniff-for-assets-register_script-textdomain
+++ b/projects/packages/codesniffer/changelog/add-phpcs-sniff-for-assets-register_script-textdomain
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a sniff to check the textdomain passed to `Assets::register_script()`.

--- a/projects/packages/codesniffer/changelog/fix-disable-codesniffer-tests-on-8.1
+++ b/projects/packages/codesniffer/changelog/fix-disable-codesniffer-tests-on-8.1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Disable CI tests on 8.1, PHPCompatibility raises deprecation warnings.

--- a/projects/packages/codesniffer/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/packages/codesniffer/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/packages/codesniffer/changelog/try-pcov
+++ b/projects/packages/codesniffer/changelog/try-pcov
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Switch to pcov for code coverage.

--- a/projects/packages/codesniffer/changelog/update-composer
+++ b/projects/packages/codesniffer/changelog/update-composer
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Tooling update: Use composer 2.2.
-
-

--- a/projects/packages/codesniffer/changelog/update-project-scripts-no-install
+++ b/projects/packages/codesniffer/changelog/update-project-scripts-no-install
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Tooling only: Build and test scripts no longer call `composer install` or `pnpm install`.
-
-

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2022-02-01
+### Changed
+- Build: remove unneeded files from production build.
+- Switch to pcov for code coverage.
+- Updated package dependencies.
+- Updated package textdomain from `jetpack` to `jetpack-post-list`.
+
 ## [0.2.4] - 2021-11-19
 ### Fixed
 - Fixed the stretched thumbnails when using a non-square image.
@@ -44,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default columns displayed on the post and page list screens
 - Refactored thumbnail preview to function server side. All javascript removed.
 
+[0.3.0]: https://github.com/automattic/jetpack-post-list/compare/v0.2.4...v0.3.0
 [0.2.4]: https://github.com/automattic/jetpack-post-list/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/automattic/jetpack-post-list/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/automattic/jetpack-post-list/compare/v0.2.1...v0.2.2

--- a/projects/packages/post-list/changelog/add-assets-support-for-i18n-loader
+++ b/projects/packages/post-list/changelog/add-assets-support-for-i18n-loader
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/post-list/changelog/add-assets-textdomain-aliasing
+++ b/projects/packages/post-list/changelog/add-assets-textdomain-aliasing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/post-list/changelog/add-phpcs-per-director-config#2
+++ b/projects/packages/post-list/changelog/add-phpcs-per-director-config#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Added project-specific phpcs configuration (for i18n textdomain).
-
-

--- a/projects/packages/post-list/changelog/add-phpcs-sniff-for-assets-register_script-textdomain
+++ b/projects/packages/post-list/changelog/add-phpcs-sniff-for-assets-register_script-textdomain
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Configure Jetpack.Functions.I18n
-
-

--- a/projects/packages/post-list/changelog/add-register_script-textdomain
+++ b/projects/packages/post-list/changelog/add-register_script-textdomain
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/post-list/changelog/fix-phpcs-textdomain-config
+++ b/projects/packages/post-list/changelog/fix-phpcs-textdomain-config
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed incorrect syntax for specifying textdomain for WordPress.WP.I18n.
-
-

--- a/projects/packages/post-list/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/packages/post-list/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/packages/post-list/changelog/try-pcov
+++ b/projects/packages/post-list/changelog/try-pcov
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Switch to pcov for code coverage.

--- a/projects/packages/post-list/changelog/update-better-structure-for-i18n-loader
+++ b/projects/packages/post-list/changelog/update-better-structure-for-i18n-loader
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/post-list/changelog/update-composer
+++ b/projects/packages/post-list/changelog/update-composer
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Tooling update: Use composer 2.2.
-
-

--- a/projects/packages/post-list/changelog/update-composer_package_types
+++ b/projects/packages/post-list/changelog/update-composer_package_types
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Change package type to jetpack-library
-
-

--- a/projects/packages/post-list/changelog/update-ignored-files-packages
+++ b/projects/packages/post-list/changelog/update-ignored-files-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Build: remove unneeded files from production build.

--- a/projects/packages/post-list/changelog/update-package-textdomains
+++ b/projects/packages/post-list/changelog/update-package-textdomains
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated package textdomain from `jetpack` to `jetpack-post-list`.

--- a/projects/packages/post-list/changelog/update-project-scripts-no-install
+++ b/projects/packages/post-list/changelog/update-project-scripts-no-install
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Tooling only: Build and test scripts no longer call `composer install` or `pnpm install`.
-
-

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Post_List;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.3.0-alpha';
+	const PACKAGE_VERSION = '0.3.0';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,26 +2,28 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 10.6-beta - 2022-01-25
+## 10.6 - 2022-02-01
 ### Enhancements
-- Dashboard: support Beta versions of Automattic plugins in plugin cards.
 - Contact Info and Markdown Blocks: add color, typography and spacing features.
-- Tiled Gallery Block: improve the block so it can be used within the mobile applications.
+- Dashboard: support Beta versions of Automattic plugins in plugin cards.
 - Search: improve accessibility via headings hierarchy and aria roles.
+- Tiled Gallery Block: improve the block so it can be used within the mobile applications.
 
 ### Improved compatibility
-- Sharing / AMP plugin: avoid adding sharing's CSS on AMP pages when the sharing feature is not active.
 - Instant Search: synchronize more meta data so the search feature can be used with more third-party plugins.
+- Sharing / AMP plugin: avoid adding sharing's CSS on AMP pages when the sharing feature is not active.
 
 ### Bug fixes
 - Backups: hide backup preparation message for sites without backup.
 - Connection: correctly request list of active features so they can be activated on a reconnection.
 - Pay with Paypal Block: properly display the card icons below the button.
 - Scan: avoid PHP notice when non-admin users access the dashboard.
+- Search: Initialize debug bar using correct class
 - Widget Visibility: ensure it remains possible to edit visibility for legacy widgets in the block-based widget editor.
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Add a comment to explain the reasoning behind an empty scss file.
+- Change usage of filter_var to filter_input in markdown file.
 - Comment: phpcs linting cleanup.
 - Cover block: avoid the block's placeholder rendering on top of other blocks.
 - Dashboard: update CTAs (wording, layout) in the At A Glance section.

--- a/projects/plugins/jetpack/changelog/2022-01-27-11-15-47-053708
+++ b/projects/plugins/jetpack/changelog/2022-01-27-11-15-47-053708
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/fix-easy-markdown-filter-var
+++ b/projects/plugins/jetpack/changelog/fix-easy-markdown-filter-var
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Change usage of filter_var to filter_input in markdown file.

--- a/projects/plugins/jetpack/changelog/fix-search-debug-bar-init
+++ b/projects/plugins/jetpack/changelog/fix-search-debug-bar-init
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Search: Initialize debug bar using correct class

--- a/projects/plugins/jetpack/changelog/jetpack-branch-10.6
+++ b/projects/plugins/jetpack/changelog/jetpack-branch-10.6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-changelog-release-106
+++ b/projects/plugins/jetpack/changelog/update-changelog-release-106
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Janitorial: upddate changelog with latest entries from 10.6 release
+
+

--- a/projects/plugins/jetpack/changelog/update-plans-security-slugs
+++ b/projects/plugins/jetpack/changelog/update-plans-security-slugs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Plans: add more variations of the security plan slugs.
-
-

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -242,7 +242,7 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 4. Promote your newest posts, pages, and products across your social media channels.
 
 == Changelog ==
-### 10.6-beta - 2022-01-25
+### 10.6 - 2022-02-01
 #### Enhancements
 - Contact Info and Markdown Blocks: add color, typography and spacing features.
 - Dashboard: support Beta versions of Automattic plugins in plugin cards.
@@ -268,6 +268,7 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 - Pay with Paypal Block: properly display the card icons below the button.
 - Protect: fixed math fallback's input accessibility and display.
 - Scan: avoid PHP notice when non-admin users access the dashboard.
+- Search: Initialize debug bar using correct class
 - Subscription form: adding a default line-height to avoid differences using different font-faces on input and button elements
 - Widget Visibility: ensure it remains possible to edit visibility for legacy widgets in the block-based widget editor.
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, batmoo, barry, beaulebens, biskobe, blobaugh, bjorsch, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, robertbpugh, roccotripaldi, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
-Stable tag: 10.5.1
+Stable tag: 10.6
 Requires at least: 5.8
 Requires PHP: 5.6
 Tested up to: 5.9

--- a/projects/plugins/vaultpress/CHANGELOG.md
+++ b/projects/plugins/vaultpress/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.1 - 2022-02-01
+### Changed
+- Colors: update colors to match the latest iterations of our brand.
+- General: update WordPress tested up to version, since the plugin works with WordPress 5.9.
+- Set `convertDeprecationsToExceptions` true in PHPUnit config.
+- Switch to pcov for code coverage.
+- Updated package dependencies.
+
+
 ## 2.2.0 - 2021-10-11
 ### Changed
 - Tests: update PHPUnit polyfills dependency (yoast/phpunit-polyfills).

--- a/projects/plugins/vaultpress/changelog/add-custom-composer-installer
+++ b/projects/plugins/vaultpress/changelog/add-custom-composer-installer
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Added support for the jetpack_vendor directory
-
-

--- a/projects/plugins/vaultpress/changelog/add-idc-customizate-labels
+++ b/projects/plugins/vaultpress/changelog/add-idc-customizate-labels
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/add-idc-customizer-tags
+++ b/projects/plugins/vaultpress/changelog/add-idc-customizer-tags
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/add-phpcs-sniff-for-assets-register_script-textdomain
+++ b/projects/plugins/vaultpress/changelog/add-phpcs-sniff-for-assets-register_script-textdomain
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Configure Jetpack.Functions.I18n
-
-

--- a/projects/plugins/vaultpress/changelog/add-rna-connect-screen-required-plan
+++ b/projects/plugins/vaultpress/changelog/add-rna-connect-screen-required-plan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/add-test-with-php-8.1
+++ b/projects/plugins/vaultpress/changelog/add-test-with-php-8.1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Set `convertDeprecationsToExceptions` true in PHPUnit config.

--- a/projects/plugins/vaultpress/changelog/add-user-license-activate-notice-2
+++ b/projects/plugins/vaultpress/changelog/add-user-license-activate-notice-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/feature-sync-error-capture
+++ b/projects/plugins/vaultpress/changelog/feature-sync-error-capture
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/fix-changelogger-prerelease-version-next
+++ b/projects/plugins/vaultpress/changelog/fix-changelogger-prerelease-version-next
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/fix-phpcs-textdomain-config
+++ b/projects/plugins/vaultpress/changelog/fix-phpcs-textdomain-config
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Configure textdomain for WordPress.WP.I18n.
-
-

--- a/projects/plugins/vaultpress/changelog/remove-special-cases-for-changelogger-in-changelogger
+++ b/projects/plugins/vaultpress/changelog/remove-special-cases-for-changelogger-in-changelogger
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/plugins/vaultpress/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies

--- a/projects/plugins/vaultpress/changelog/renovate-yoast-phpunit-polyfills-1.x#2
+++ b/projects/plugins/vaultpress/changelog/renovate-yoast-phpunit-polyfills-1.x#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/try-pcov
+++ b/projects/plugins/vaultpress/changelog/try-pcov
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Switch to pcov for code coverage.

--- a/projects/plugins/vaultpress/changelog/update-composer
+++ b/projects/plugins/vaultpress/changelog/update-composer
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Tooling update: Use composer 2.2.
-
-

--- a/projects/plugins/vaultpress/changelog/update-composer_package_types
+++ b/projects/plugins/vaultpress/changelog/update-composer_package_types
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/update-contributor-lists
+++ b/projects/plugins/vaultpress/changelog/update-contributor-lists
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Readme: update contributor list.
-
-

--- a/projects/plugins/vaultpress/changelog/update-jetpack-color-primary
+++ b/projects/plugins/vaultpress/changelog/update-jetpack-color-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Colors: update Jetpack Primary color to match latest brand book.

--- a/projects/plugins/vaultpress/changelog/update-project-scripts-no-install
+++ b/projects/plugins/vaultpress/changelog/update-project-scripts-no-install
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Tooling only: Build and test scripts no longer call `composer install` or `pnpm install`.
-
-

--- a/projects/plugins/vaultpress/changelog/update-vaultpress-requirements
+++ b/projects/plugins/vaultpress/changelog/update-vaultpress-requirements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: update WordPress tested up to version, since the plugin works with WordPress 5.9.

--- a/projects/plugins/vaultpress/changelog/update-vaultpress-tested-version
+++ b/projects/plugins/vaultpress/changelog/update-vaultpress-tested-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Tested against WordPress 5.8

--- a/projects/plugins/vaultpress/changelog/vaultpress-update-changelog-2.2.0
+++ b/projects/plugins/vaultpress/changelog/vaultpress-update-changelog-2.2.0
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Backporting the changelog changes from the feature branch into master
-
-

--- a/projects/plugins/vaultpress/composer.json
+++ b/projects/plugins/vaultpress/composer.json
@@ -38,7 +38,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ2_2_1_alpha",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ2_2_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true
 		}

--- a/projects/plugins/vaultpress/vaultpress.php
+++ b/projects/plugins/vaultpress/vaultpress.php
@@ -1287,9 +1287,32 @@ class VaultPress {
 		$this->block_change_handler( 'woocommerce_tax_rate_locations', array( 'tax_rate_id' => $id ) );
 	}
 
-	function woocommerce_order_item_handler( $id )      { $this->generic_change_handler( 'woocommerce_order_items',          array( 'order_item_id' => $id ) ); }
-	function woocommerce_order_item_meta_handler( $id ) { $this->generic_change_handler( 'woocommerce_order_itemmeta',       array( 'meta_id' => $id ) ); }
-	function woocommerce_attribute_handler( $id )       { $this->generic_change_handler( 'woocommerce_attribute_taxonomies', array( 'attribute_id' => $id ) ); }
+	/**
+	 * Monitor for changes to a Woo order (creation, update, or deletion).
+	 *
+	 * @param int $id Item ID.
+	 */
+	public function woocommerce_order_item_handler( $id ) {
+		$this->generic_change_handler( 'woocommerce_order_items', array( 'order_item_id' => $id ) );
+	}
+
+	/**
+	 * Monitor for changes to a Woo order meta (creation, update, or deletion).
+	 *
+	 * @param int $id Item ID.
+	 */
+	public function woocommerce_order_item_meta_handler( $id ) {
+		$this->generic_change_handler( 'woocommerce_order_itemmeta', array( 'meta_id' => $id ) );
+	}
+
+	/**
+	 * Monitor for changes to a Woo attribute (creation, update, or deletion).
+	 *
+	 * @param int $id Item ID.
+	 */
+	public function woocommerce_attribute_handler( $id ) {
+		$this->generic_change_handler( 'woocommerce_attribute_taxonomies', array( 'attribute_id' => $id ) );
+	}
 
 	function generic_change_handler( $table, $key ) {
 		$this->add_ping( 'db', array( $table => $key ) );

--- a/projects/plugins/vaultpress/vaultpress.php
+++ b/projects/plugins/vaultpress/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>. Activate, enter your registration key, and never worry again. <a href="http://vaultpress.com/help/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">Need some help?</a>
- * Version: 2.2.1-alpha
+ * Version: 2.2.1
  * Author: Automattic
  * Author URI: http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+
@@ -17,7 +17,7 @@
 defined( 'ABSPATH' ) || die();
 
 define( 'VAULTPRESS__MINIMUM_PHP_VERSION', '5.6' );
-define( 'VAULTPRESS__VERSION', '2.2.1-alpha' );
+define( 'VAULTPRESS__VERSION', '2.2.1' );
 define( 'VAULTPRESS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Release projects that have not been updated in a while: `packages/post-list`, `packages/codesniffer`, `js-packages/storybook`,  `js-packages/eslint-config-target-es`, `github-actions/repo-gardening`, and `plugins/vaultpress`
* Bring back Jetpack 10.6 changelog changes from the release branch.
    * This was already committed to the release branch.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Does everything look in the right place?
* Check for typos.
