### PR TITLE
My Jetpack: My Jetpack: connect Backup product class with Product class

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-backup-product-class
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-backup-product-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: connect Backup product class with Product class. Add long description and features fields.

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -122,12 +122,7 @@ class Products {
 	 * @return array Object with infromation about the product.
 	 */
 	public static function get_backup_data() {
-		return array(
-			'slug'        => 'backup',
-			'description' => __( 'Save every change', 'jetpack-my-jetpack' ),
-			'name'        => __( 'Backup', 'jetpack-my-jetpack' ),
-			'status'      => 'active',
-		);
+		return Products\Backup::get_info();
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -53,4 +53,27 @@ class Backup extends Hybrid_Product {
 		return __( 'Save every change', 'jetpack-my-jetpack' );
 	}
 
+	/**
+	 * Get the internationalized product long description
+	 *
+	 * @return string
+	 */
+	public static function get_long_description() {
+		return __( 'Real-time backups save every change and one-click restores get you back online quickly.', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized features list
+	 *
+	 * @return array Backup features list
+	 */
+	public static function get_features() {
+		return array(
+			_x( 'Real-time cloud backups', 'Backup Product Feature', 'jetpack-my-jetpack' ),
+			_x( '10GB of backup storage', 'Backup Product Feature', 'jetpack-my-jetpack' ),
+			_x( '30-day archive & activity log', 'Backup Product Feature', 'jetpack-my-jetpack' ),
+			_x( 'One-click restores', 'Backup Product Feature', 'jetpack-my-jetpack' ),
+		);
+	}
+
 }

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -53,4 +53,21 @@ class Boost extends Product {
 		return __( 'Instant speed and SEO', 'jetpack-my-jetpack' );
 	}
 
+	/**
+	 * Get the internationalized product long description
+	 *
+	 * @return string
+	 */
+	public static function get_long_description() {
+		return ''; // @todo Add long description
+	}
+
+	/**
+	 * Get the internationalized features list
+	 *
+	 * @return array Boost features list
+	 */
+	public static function get_features() {
+		return array();
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-crm.php
+++ b/projects/packages/my-jetpack/src/products/class-crm.php
@@ -53,4 +53,21 @@ class Crm extends Product {
 		return __( 'Connect with your people', 'jetpack-my-jetpack' );
 	}
 
+	/**
+	 * Get the internationalized product long description
+	 *
+	 * @return string
+	 */
+	public static function get_long_description() {
+		return ''; // @todo Add long description
+	}
+
+	/**
+	 * Get the internationalized features list
+	 *
+	 * @return array CRM features list
+	 */
+	public static function get_features() {
+		return array();
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -60,11 +60,13 @@ abstract class Product {
 			throw new \Exception( 'Product classes must declare the $slug attribute.' );
 		}
 		return array(
-			'slug'        => static::$slug,
-			'name'        => static::get_name(),
-			'description' => static::get_description(),
-			'status'      => static::get_status(),
-			'class'       => get_called_class(),
+			'slug'             => static::$slug,
+			'name'             => static::get_name(),
+			'description'      => static::get_description(),
+			'long_description' => static::get_long_description(),
+			'features'         => static::get_features(),
+			'status'           => static::get_status(),
+			'class'            => get_called_class(),
 		);
 	}
 
@@ -81,6 +83,20 @@ abstract class Product {
 	 * @return string
 	 */
 	abstract public static function get_description();
+
+	/**
+	 * Get the internationalized product long description
+	 *
+	 * @return string
+	 */
+	abstract public static function get_long_description();
+
+	/**
+	 * Get the internationalized features list
+	 *
+	 * @return array
+	 */
+	abstract public static function get_features();
 
 	/**
 	 * Undocumented function


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR:

* Connects the Backup product class to the Product class when providing product info e5828c6615d0b6387e0fb7b7f297f628382a9daa
* And also adds the `long_description` and `features` fields.
* 
Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: connect Backup product class with Product class. Add long_description and features fields.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1643719015043149-slack-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* My Jetpack dashboard
* Take a look at the Products Data. You can expose it in the dev console:
```
myJetpackInitialState.products.items.backup
```
* Confirm you see the backup product detail, wth the long description and features files populated.

<img src="https://user-images.githubusercontent.com/77539/151983192-84f1f7bb-a51c-4b5b-8035-cdaed122e1a4.png" width="800px" />

