### PR TITLE
VaultPress: do not ship PHPCS config file in production

### DIFF
--- a/projects/plugins/vaultpress/.gitattributes
+++ b/projects/plugins/vaultpress/.gitattributes
@@ -18,6 +18,7 @@ changelog/**                                production-exclude
 composer.lock                               production-exclude
 package.json                                production-exclude
 phpunit.xml.dist                            production-exclude
+.phpcs.dir.xml                              production-exclude
 tests/**                                    production-exclude
 /vendor/automattic/jetpack-autoloader/**    production-exclude
 /vendor/automattic/jetpack-changelogger/**  production-exclude

--- a/projects/plugins/vaultpress/changelog/update-vaultpress-excluded-file
+++ b/projects/plugins/vaultpress/changelog/update-vaultpress-excluded-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: do not ship PHPCS configuration file


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Avoid shipping a file that is not needed on production installs.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here.
