### PR TITLE
My Jetpack: avoid performing a request for each product

### DIFF
--- a/projects/packages/my-jetpack/_inc/state/resolvers.js
+++ b/projects/packages/my-jetpack/_inc/state/resolvers.js
@@ -6,29 +6,9 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { REST_API_SITE_PURCHASES_ENDPOINT, REST_API_SITE_PRODUCTS_ENDPOINT } from './constants';
+import { REST_API_SITE_PURCHASES_ENDPOINT } from './constants';
 
 const myJetpackResolvers = {
-	getProduct: productId => async ( { dispatch } ) => {
-		dispatch.setIsFetchingProduct( productId, true );
-		try {
-			dispatch.setProduct(
-				await apiFetch( {
-					path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
-				} )
-			);
-			dispatch.setIsFetchingProduct( productId, false );
-		} catch ( error ) {
-			dispatch.setIsFetchingProduct( productId, false );
-
-			// Pick error from the response body.
-			if ( error?.code && error?.message ) {
-				dispatch.setRequestProductError( productId, error );
-			} else {
-				throw new Error( error );
-			}
-		}
-	},
 	getPurchases: () => async ( { dispatch } ) => {
 		dispatch.setPurchasesIsFetching( true );
 

--- a/projects/packages/my-jetpack/changelog/udpate-my-jetpack-avoid-product-resolver
+++ b/projects/packages/my-jetpack/changelog/udpate-my-jetpack-avoid-product-resolver
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Remove getProduct() resolver


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR avoids performing a request for each product. We consider it unneeded since the products list is already populated and exposed to the client via the `myJetpackInitialState` global var.

Fixes https://github.com/Automattic/jetpack/issues/22598

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: avoid performing a request for each product

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to my Jetpack dashboard
* Confirm the client does not perform additional requests for each product. For instance:
<img src="https://user-images.githubusercontent.com/77539/152027687-ea1ec50b-c3df-4373-a7e1-fd23d9ce506d.png" width="400px" />
* Confirm the app keeps working as expected. Activate/Deactivate `Boost` and `VideoPress` for instance.
* Confirm the activation state is consistent after a hard-refresh
