### PR TITLE
add user connection requirement to product info

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-user-connection-requirement
+++ b/projects/packages/my-jetpack/changelog/add-user-connection-requirement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+User connection requirement to product info

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -164,12 +164,13 @@ class REST_Products {
 			return new \WP_Error(
 				'not_implemented',
 				esc_html__( 'The product class handler is not implemented', 'jetpack-my-jetpack' ),
-				array( 'status' => 400 )
+				array( 'status' => 501 )
 			);
 		}
 
 		$activate_product_result = call_user_func( array( $product['class'], 'activate' ) );
 		if ( is_wp_error( $activate_product_result ) ) {
+			$activate_product_result->add_data( array( 'status' => 400 ) );
 			return $activate_product_result;
 		}
 
@@ -189,12 +190,13 @@ class REST_Products {
 			return new \WP_Error(
 				'not_implemented',
 				esc_html__( 'The product class handler is not implemented', 'jetpack-my-jetpack' ),
-				array( 'status' => 400 )
+				array( 'status' => 501 )
 			);
 		}
 
 		$deactivate_product_result = call_user_func( array( $product['class'], 'deactivate' ) );
 		if ( is_wp_error( $deactivate_product_result ) ) {
+			$deactivate_product_result->add_data( array( 'status' => 400 ) );
 			return $deactivate_product_result;
 		}
 

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -36,6 +36,13 @@ class Boost extends Product {
 	public static $plugin_slug = 'jetpack-boost';
 
 	/**
+	 * Whether this product requires a user connection
+	 *
+	 * @var string
+	 */
+	public static $requires_user_connection = false;
+
+	/**
 	 * Get the internationalized product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-crm.php
+++ b/projects/packages/my-jetpack/src/products/class-crm.php
@@ -36,6 +36,13 @@ class Crm extends Product {
 	public static $plugin_slug = 'zero-bs-crm';
 
 	/**
+	 * Whether this product requires a user connection
+	 *
+	 * @var string
+	 */
+	public static $requires_user_connection = false;
+
+	/**
 	 * Get the internationalized product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -51,6 +51,13 @@ abstract class Product {
 	const JETPACK_PLUGIN_FILENAME = 'jetpack/jetpack.php';
 
 	/**
+	 * Whether this product requires a user connection
+	 *
+	 * @var string
+	 */
+	public static $requires_user_connection = true;
+
+	/**
 	 * Get the plugin slug
 	 *
 	 * @return ?string
@@ -79,13 +86,14 @@ abstract class Product {
 			throw new \Exception( 'Product classes must declare the $slug attribute.' );
 		}
 		return array(
-			'slug'             => static::$slug,
-			'name'             => static::get_name(),
-			'description'      => static::get_description(),
-			'long_description' => static::get_long_description(),
-			'features'         => static::get_features(),
-			'status'           => static::get_status(),
-			'class'            => get_called_class(),
+			'slug'                     => static::$slug,
+			'name'                     => static::get_name(),
+			'description'              => static::get_description(),
+			'long_description'         => static::get_long_description(),
+			'features'                 => static::get_features(),
+			'status'                   => static::get_status(),
+			'requires_user_connection' => static::$requires_user_connection,
+			'class'                    => get_called_class(),
 		);
 	}
 

--- a/projects/packages/my-jetpack/tests/php/test-products-rest.php
+++ b/projects/packages/my-jetpack/tests/php/test-products-rest.php
@@ -246,7 +246,7 @@ class Test_Products_Rest extends TestCase {
 		$response = $this->server->dispatch( $this->request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 500, $response->get_status() );
+		$this->assertEquals( 400, $response->get_status() );
 		$this->assertEquals( 'plugin_php_incompatible', $data['code'] );
 		$this->assertFalse( is_plugin_active( $this->boost_mock_filename ) );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add user connection requirement to product info
* Improve error codes on REST API

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Open the console and check `myJetpackInitialState` global var
* Check that the products include a `requires_user_connection` key
* Try to activate Scan and see that the response code is 400
