### PR TITLE
[wip] VideoPress: Change the default for the "usesAverageColor" setting to True

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-default-progress-colour-option
+++ b/projects/plugins/jetpack/changelog/update-videopress-default-progress-colour-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Changes the default for the `Match video` setting to `true` for VideoPress videos.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/deprecated/v4/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/deprecated/v4/index.js
@@ -1,0 +1,90 @@
+/**
+ * Internal dependencies
+ */
+import save from './save';
+
+// This deprecation is a result of:
+// - changing the default of `useAverageColor` resulting in old blocks not passing validation.
+export default {
+	attributes: {
+		autoplay: {
+			type: 'boolean',
+		},
+		caption: {
+			type: 'string',
+			source: 'html',
+			selector: 'figcaption',
+		},
+		controls: {
+			type: 'boolean',
+			default: true,
+		},
+		maxWidth: {
+			type: 'string',
+			default: '100%',
+		},
+		guid: {
+			type: 'string',
+		},
+		id: {
+			type: 'number',
+		},
+		loop: {
+			type: 'boolean',
+		},
+		isVideoPressExample: {
+			type: 'boolean',
+			default: false,
+		},
+		muted: {
+			type: 'boolean',
+		},
+		playsinline: {
+			type: 'boolean',
+		},
+		poster: {
+			type: 'string',
+		},
+		preload: {
+			type: 'string',
+			default: 'metadata',
+		},
+		seekbarPlayedColor: {
+			type: 'string',
+			default: '',
+		},
+		seekbarLoadingColor: {
+			type: 'string',
+			default: '',
+		},
+		seekbarColor: {
+			type: 'string',
+			default: '',
+		},
+		src: {
+			type: 'string',
+		},
+		useAverageColor: {
+			type: 'boolean',
+			default: false, // forcing false here to be explicit about what is changing even though thats the default.
+		},
+		videoPressTracks: {
+			type: 'array',
+			items: {
+				type: 'object',
+			},
+			default: [],
+		},
+		videoPressClassNames: {
+			type: 'string',
+		},
+	},
+	support: {
+		reusable: false,
+	},
+	isEligible: attrs => {
+		return attrs.guid;
+	},
+	save,
+	isDeprecation: true,
+};

--- a/projects/plugins/jetpack/extensions/blocks/videopress/deprecated/v4/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/deprecated/v4/save.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { getVideoPressUrl } from './url';
+
+const VideoPressSave = CoreVideoSave => props => {
+	const {
+		attributes: {
+			autoplay,
+			caption,
+			controls,
+			guid,
+			loop,
+			muted,
+			playsinline,
+			poster,
+			preload,
+			videoPressClassNames,
+			className,
+			align,
+			seekbarColor,
+			seekbarPlayedColor,
+			seekbarLoadingColor,
+			useAverageColor,
+			maxWidth,
+		} = {},
+	} = props;
+
+	const blockProps = useBlockProps.save( {
+		className: classnames( 'wp-block-video', className, videoPressClassNames, {
+			[ `align${ align }` ]: align,
+		} ),
+	} );
+
+	if ( ! guid ) {
+		/**
+		 * We return the element produced by the render so Gutenberg can add the block class when cloning the element.
+		 * This is due to the fact that `React.cloneElement` ignores the class name when we clone a component to be
+		 * rendered (i.e. `React.cloneElement( <CoreVideoSave { ...props } />, { className: 'wp-block-video' } )`).
+		 *
+		 * @see https://github.com/WordPress/gutenberg/blob/3f1324b53cc8bb45d08d12d5321d6f88510bed09/packages/blocks/src/api/serializer.js#L78-L96
+		 * @see https://github.com/WordPress/gutenberg/blob/c5f9bd88125282a0c35f887cc8d835f065893112/packages/editor/src/hooks/generated-class-name.js#L42
+		 * @see https://github.com/Automattic/wp-calypso/pull/30546#issuecomment-463637946
+		 */
+		return CoreVideoSave( props );
+	}
+
+	const url = getVideoPressUrl( guid, {
+		autoplay,
+		controls,
+		loop,
+		muted,
+		playsinline,
+		poster,
+		preload,
+		seekbarColor,
+		seekbarPlayedColor,
+		seekbarLoadingColor,
+		useAverageColor,
+	} );
+
+	let embedWrapperStyle = {};
+	if ( maxWidth && maxWidth.length > 0 && '100%' !== maxWidth ) {
+		embedWrapperStyle = {
+			maxWidth,
+			margin: 'auto',
+		};
+	}
+
+	return (
+		<figure { ...blockProps }>
+			<div className="wp-block-embed__wrapper" style={ embedWrapperStyle }>
+				{ `\n${ url }\n` /* URL needs to be on its own line. */ }
+			</div>
+			{ ! RichText.isEmpty( caption ) && (
+				<RichText.Content tagName="figcaption" value={ caption } />
+			) }
+		</figure>
+	);
+};
+
+export default createHigherOrderComponent( VideoPressSave, 'withVideoPressSave' );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/deprecated/v4/url.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/deprecated/v4/url.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+export const getVideoPressUrl = (
+	guid,
+	{
+		autoplay,
+		controls,
+		loop,
+		muted,
+		playsinline,
+		poster,
+		preload,
+		seekbarColor,
+		seekbarPlayedColor,
+		seekbarLoadingColor,
+		useAverageColor,
+	}
+) => {
+	if ( ! guid ) {
+		return null;
+	}
+
+	// In order to have a cleaner URL, we only set the options differing from the default VideoPress player settings:
+	// - Autoplay: Turned off by default.
+	// - Controls: Turned on by default.
+	// - Loop: Turned off by default.
+	// - Muted: Turned off by default.
+	// - Plays Inline: Turned off by default.
+	// - Poster: No image by default.
+	// - Preload: None by default.
+	const options = {
+		resizeToParent: true,
+		cover: true,
+		...( autoplay && { autoPlay: true } ),
+		...( ! controls && { controls: false } ),
+		...( loop && { loop: true } ),
+		...( muted && { muted: true, persistVolume: false } ),
+		...( playsinline && { playsinline: true } ),
+		...( poster && { posterUrl: poster } ),
+		...( preload !== 'none' && { preloadContent: preload } ),
+		...( seekbarColor !== '' && { sbc: seekbarColor } ),
+		...( seekbarPlayedColor !== '' && { sbpc: seekbarPlayedColor } ),
+		...( seekbarLoadingColor !== '' && { sblc: seekbarLoadingColor } ),
+		...( useAverageColor && { useAverageColor: true } ),
+	};
+	return addQueryArgs( `https://videopress.com/v/${ guid }`, options );
+};

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -20,6 +20,7 @@ import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-
 import deprecatedV1 from './deprecated/v1';
 import deprecatedV2 from './deprecated/v2';
 import deprecatedV3 from './deprecated/v3';
+import deprecatedV4 from './deprecated/v4';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import withHasWarningIsInteractiveClassNames from '../../shared/with-has-warning-is-interactive-class-names';
 import './editor.scss';
@@ -230,6 +231,7 @@ const addVideoPressSupport = ( settings, name ) => {
 			},
 			useAverageColor: {
 				type: 'boolean',
+				default: true,
 			},
 			videoPressTracks: {
 				type: 'array',
@@ -303,6 +305,7 @@ const addVideoPressSupport = ( settings, name ) => {
 
 			deprecated: [
 				...( deprecated || [] ),
+				deprecatedV4,
 				deprecatedV3,
 				{
 					attributes: attributesDefinition,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

This PR changes the default value for the "usesAverageColor" setting (appears as "Match video" under the Progress Bar Colors menu) to `true` from `false` since now that its been tested manually for a while we want to make the default behaviour.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Default value for the `usesAverageColor` changed to `true`
* Deprecation created since this changes the url of the video embed that gets created

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Don't apply the PR yet
* ensure jetpack is built `jetpack build plugins/jetpack`
* Create a new `/video` block and ensure the Progress Bar Colors -> Match video setting is disabled
* Create another new `/video` block and turn on the Progress Bar Colors -> Match video setting
* Publish the page
* Checkout this branch
* rebuild jetpack `jetpack build plugins/jetpack`
* reload the page
* Both players should render correctly without any errors
* Create a new `/video` block, the Progress Bar Colors -> Match video setting should be on be default
