### PR TITLE
cli: Fix friendly error for missing modules

### DIFF
--- a/tools/cli/bin/jetpack.js
+++ b/tools/cli/bin/jetpack.js
@@ -7,27 +7,36 @@ import process from 'process';
 import { fileURLToPath } from 'url';
 
 /**
- * Internal dependencies
- */
-import * as cliRouter from '../cliRouter.js';
-
-/**
  * Standardizes the cwd for the process. Allows `jetpack` cli to run correctly from any location in the repo.
  */
 
 process.chdir( fileURLToPath( new URL( '../../..', import.meta.url ) ) );
 
 try {
+	const cliRouter = await import( '../cliRouter.js' );
 	cliRouter.cli();
 } catch ( error ) {
-	if ( error.code === 'MODULE_NOT_FOUND' ) {
-		// if pnpm install hasn't been run, esm require will fail here.
+	const identity = v => v;
+	const chalk = await import( 'chalk' ).then(
+		m => m.default,
+		() => ( {} )
+	);
+
+	if ( error.code === 'ERR_MODULE_NOT_FOUND' ) {
+		// if pnpm install hasn't been run, the import() will fail here.
 		console.error(
 			'Something is missing from your install. Please run `pnpm install` and try again.'
 		);
+
+		// Print the original error's message too, as sometimes the error isn't fixed by `pnpm install`.
+		console.error(
+			( chalk.grey || identity )( `The original error message was ${ error.message }` )
+		);
 	} else {
 		console.error( error );
-		console.error( 'Something unexpected happened. See error above.' );
+		console.error(
+			( chalk.bold || identity )( 'Something unexpected happened. See error above.' )
+		);
 	}
 	process.exit( 1 );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The CLI used to print a friendly error message when modules were
missing, but that was broken in #22395. This restores it.

Also, this adds output of the original error message for cases where the
problem isn't fixed by `pnpm install`. And since I'm doing it anyway, it
also tries to bold the final line on other errors.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1643811770635859/1643811292.937799-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test that the CLI works normally, e.g. `jetpack` with no command outputs some help text.
* `rm tools/cli/node_modules/listr-silent-renderer`. Test that the CLI outputs the "Something is missing from your install. Please run \`pnpm install\` and try again" message. It should also output a "The original error message was" line, probably in grey.
* `rm tools/cli/node_modules/chalk`. Test that the CLI still outputs the "Something is missing from your install. Please run \`pnpm install\` and try again" message. It should also output a "The original error message was" line, but not grey this time.