### PR TITLE
Add anti spam into my jetpack

### DIFF
--- a/projects/packages/admin-ui/.phpcs.dir.xml
+++ b/projects/packages/admin-ui/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-admin-ui" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-admin-ui" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-admin-ui" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/admin-ui/changelog/add-anti-spam-my-jetpack
+++ b/projects/packages/admin-ui/changelog/add-anti-spam-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Support for akismet menu with stand-alone plugins

--- a/projects/packages/admin-ui/composer.json
+++ b/projects/packages/admin-ui/composer.json
@@ -40,6 +40,7 @@
 	"extra": {
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-admin-ui",
+		"textdomain": "jetpack-admin-ui",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
 		},

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -37,7 +37,31 @@ class Admin_Menu {
 	public static function init() {
 		if ( ! self::$initialized ) {
 			self::$initialized = true;
+			self::handle_akismet_menu();
 			add_action( 'admin_menu', array( __CLASS__, 'admin_menu_hook_callback' ), 1000 ); // Jetpack uses 998.
+		}
+	}
+
+	/**
+	 * Handles the Akismet menu item when used alongside other stand-alone plugins
+	 *
+	 * When Jetpack plugin is present, Akismet menu item is moved under the Jetpack top level menu, but if Akismet is active alongside other stand-alone plugins,
+	 * we use this method to move the menu item.
+	 */
+	private static function handle_akismet_menu() {
+		if ( class_exists( 'Akismet_Admin' ) ) {
+			// Prevent Akismet from adding a menu item.
+			add_action(
+				'admin_menu',
+				function () {
+					remove_action( 'admin_menu', array( 'Akismet_Admin', 'admin_menu' ), 5 );
+				},
+				4
+			);
+
+			// Add an Anti-spam menu item for Jetpack.
+			self::add_menu( __( 'Anti-Spam', 'jetpack-admin-ui' ), __( 'Anti-Spam', 'jetpack-admin-ui' ), 'manage_options', 'akismet-key-config', array( 'Akismet_Admin', 'display_page' ) );
+
 		}
 	}
 

--- a/projects/packages/my-jetpack/changelog/add-anti-spam-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-anti-spam-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+anti spam product class

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -108,12 +108,7 @@ class Products {
 	 * @return array Object with infromation about the product.
 	 */
 	public static function get_anti_spam_data() {
-		return array(
-			'slug'        => 'anti-spam',
-			'description' => __( 'Stop comment and form spam', 'jetpack-my-jetpack' ),
-			'name'        => __( 'Anti-spam', 'jetpack-my-jetpack' ),
-			'status'      => 'inactive',
-		);
+		return Products\Anti_Spam::get_info();
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Anti_Spam product
+ *
+ * @package my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack\Products;
+
+use Automattic\Jetpack\My_Jetpack\Product;
+
+/**
+ * Class responsible for handling the Anti_Spam product
+ */
+class Anti_Spam extends Product {
+
+	/**
+	 * The product slug
+	 *
+	 * @var string
+	 */
+	public static $slug = 'anti-spam';
+
+	/**
+	 * The filename (id) of the plugin associated with this product. If not defined, it will default to the Jetpack plugin
+	 *
+	 * @var string
+	 */
+	public static $plugin_filename = 'akismet/akismet.php';
+
+	/**
+	 * The slug of the plugin associated with this product. If not defined, it will default to the Jetpack plugin
+	 *
+	 * @var string
+	 */
+	public static $plugin_slug = 'akismet';
+
+	/**
+	 * Whether this product requires a user connection
+	 *
+	 * @var string
+	 */
+	public static $requires_user_connection = false;
+
+	/**
+	 * Get the internationalized product name
+	 *
+	 * @return string
+	 */
+	public static function get_name() {
+		return __( 'Anti-Spam', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product description
+	 *
+	 * @return string
+	 */
+	public static function get_description() {
+		return __( 'Stop comment and form spam', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product long description
+	 *
+	 * @return string
+	 */
+	public static function get_long_description() {
+		return ''; // @todo Add long description
+	}
+
+	/**
+	 * Get the internationalized features list
+	 *
+	 * @return array Boost features list
+	 */
+	public static function get_features() {
+		return array();
+	}
+}

--- a/projects/plugins/backup/changelog/add-anti-spam-my-jetpack
+++ b/projects/plugins/backup/changelog/add-anti-spam-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -60,7 +60,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "e9c471e1ac68c4dd7cf656fd17a4b96fdc4c6ff1"
+                "reference": "bbb92b9b9852760e84b7aaee877ee081616efcb3"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -71,6 +71,7 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-admin-ui",
+                "textdomain": "jetpack-admin-ui",
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },

--- a/projects/plugins/boost/changelog/add-anti-spam-my-jetpack
+++ b/projects/plugins/boost/changelog/add-anti-spam-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -60,7 +60,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "e9c471e1ac68c4dd7cf656fd17a4b96fdc4c6ff1"
+                "reference": "bbb92b9b9852760e84b7aaee877ee081616efcb3"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -71,6 +71,7 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-admin-ui",
+                "textdomain": "jetpack-admin-ui",
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },

--- a/projects/plugins/jetpack/changelog/add-anti-spam-my-jetpack
+++ b/projects/plugins/jetpack/changelog/add-anti-spam-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -116,7 +116,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "e9c471e1ac68c4dd7cf656fd17a4b96fdc4c6ff1"
+                "reference": "bbb92b9b9852760e84b7aaee877ee081616efcb3"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -127,6 +127,7 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-admin-ui",
+                "textdomain": "jetpack-admin-ui",
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR does 2 things

1. It adds the Anti Spam product associated to the akismet plugin into My Jetpack

2. Handles the Akismet menu item when used alongside other stand-alone plugins -> When Jetpack plugin is present, Akismet menu item is moved under the Jetpack top level menu, but if Akismet is active alongside other stand-alone plugins, it wasn't. This PR changes the Admin_Menu class to handle this.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Creates the Anti Spam product class
* Makes Admin UI package handle the askismet menu when Jetpack plugin is not present

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate a stand-alone plugin like boost or backup (and NOT Jetpack)
* Go to My Jetpack
* Activate Anti Spam
* Confirm Akismet plugin was activated
* Confirm Anti-Spam menu item was added to the Jetpack menu and it links to the Akismet admin page
* Activate Jetpack and make sure the menu still works fine
