### PR TITLE
My Jetpack: Fire Tracks events for click on product add link

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -96,7 +96,17 @@ const renderActionButton = ( {
 };
 
 const ProductCard = props => {
-	const { name, admin, description, icon, status, onActivate, onDeactivate, isFetching } = props;
+	const {
+		name,
+		admin,
+		description,
+		icon,
+		status,
+		onActivate,
+		onAdd,
+		onDeactivate,
+		isFetching,
+	} = props;
 	const isActive = status === PRODUCT_STATUSES.ACTIVE;
 	const isError = status === PRODUCT_STATUSES.ERROR;
 	const isInactive = status === PRODUCT_STATUSES.INACTIVE;
@@ -139,6 +149,16 @@ const ProductCard = props => {
 		onActivate();
 	};
 
+	/**
+	 * Calls the passed function onAdd after firing Tracks event
+	 */
+	const addHandler = () => {
+		recordEvent( 'jetpack_myjetpack_product_card_add_click', {
+			product: name,
+		} );
+		onAdd();
+	};
+
 	return (
 		<div className={ containerClassName }>
 			<div className={ styles.name }>
@@ -166,7 +186,7 @@ const ProductCard = props => {
 						/>
 					</ButtonGroup>
 				) : (
-					renderActionButton( { ...props, onActivate: activateHandler } )
+					renderActionButton( { ...props, onActivate: activateHandler, onAdd: addHandler } )
 				) }
 				{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
 			</div>

--- a/projects/packages/my-jetpack/changelog/add-record-event-for-on-add
+++ b/projects/packages/my-jetpack/changelog/add-record-event-for-on-add
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fire Tracks event when clickn Add link on My Jetpack product card


### PR DESCRIPTION
Adds tracking for clicks on add links for product cards.



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces function `addHandler`  that will call the passed prop `onAdd` after firing Tracks event.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?

Introduces 1 new event:
*  `jetpack_myjetpack_product_card_add_click` fired when the user clicks on a product card add link


#### Testing instructions:
* Checkout this branch on a site with Jetpack connected the Backup plugin active, and the `JETPACK_ENABLE_MY_JETPACK` constant set to `true`.
* Open the browser and visit the site's wp-admin.
* Open the developer console, execute the following code: `localStorage.debug='dops:analyitics*`
* Go to "Jetpack -> My Jetpack", Confirm that the developer console displays the events `jetpack_myjetpack_product_card_add_click` ` when clicking such link from the CRM product card for example.
