### PR TITLE
My Jetpack: expose pricing product data

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-add-pricing-harcoded-product-data
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-add-pricing-harcoded-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Product princign harcoded data

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -77,4 +77,18 @@ class Anti_Spam extends Product {
 	public static function get_features() {
 		return array();
 	}
+
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing_for_ui() {
+		return array(
+			'available'            => true,
+			'currency_code'        => 'EUR',
+			'full_price'           => '9',
+			'promotion_percentage' => '50',
+		);
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -76,4 +76,18 @@ class Backup extends Hybrid_Product {
 		);
 	}
 
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing() {
+		return array(
+			'available'            => true,
+			'currency_code'        => 'USD',
+			'full_price'           => '108',
+			'promotion_percentage' => '50',
+		);
+	}
+
 }

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -81,7 +81,7 @@ class Backup extends Hybrid_Product {
 	 *
 	 * @return array Pricing details
 	 */
-	public static function get_pricing() {
+	public static function get_pricing_for_ui() {
 		return array(
 			'available'            => true,
 			'currency_code'        => 'USD',

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -84,8 +84,8 @@ class Backup extends Hybrid_Product {
 	public static function get_pricing_for_ui() {
 		return array(
 			'available'            => true,
-			'currency_code'        => 'USD',
-			'full_price'           => '108',
+			'currency_code'        => 'EUR',
+			'full_price'           => '9',
 			'promotion_percentage' => '50',
 		);
 	}

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -83,7 +83,7 @@ class Boost extends Product {
 	 *
 	 * @return array Pricing details
 	 */
-	public static function get_pricing() {
+	public static function get_pricing_for_ui() {
 		return array(
 			'available' => true,
 			'is_free'   => true,

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -77,4 +77,16 @@ class Boost extends Product {
 	public static function get_features() {
 		return array();
 	}
+
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing() {
+		return array(
+			'available' => true,
+			'is_free'   => true,
+		);
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-crm.php
+++ b/projects/packages/my-jetpack/src/products/class-crm.php
@@ -83,7 +83,7 @@ class Crm extends Product {
 	 *
 	 * @return array Pricing details
 	 */
-	public static function get_pricing() {
+	public static function get_pricing_for_ui() {
 		return array(
 			'available' => true,
 			'is_free'   => true,

--- a/projects/packages/my-jetpack/src/products/class-crm.php
+++ b/projects/packages/my-jetpack/src/products/class-crm.php
@@ -77,4 +77,16 @@ class Crm extends Product {
 	public static function get_features() {
 		return array();
 	}
+
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing() {
+		return array(
+			'available' => true,
+			'is_free'   => true,
+		);
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -92,6 +92,7 @@ abstract class Product {
 			'long_description'         => static::get_long_description(),
 			'features'                 => static::get_features(),
 			'status'                   => static::get_status(),
+			'pricing'                  => static::get_pricing(),
 			'requires_user_connection' => static::$requires_user_connection,
 			'class'                    => get_called_class(),
 		);
@@ -124,6 +125,13 @@ abstract class Product {
 	 * @return array
 	 */
 	abstract public static function get_features();
+
+	/**
+	 * Get the product pricing
+	 *
+	 * @return array
+	 */
+	abstract public static function get_pricing();
 
 	/**
 	 * Undocumented function

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -92,7 +92,7 @@ abstract class Product {
 			'long_description'         => static::get_long_description(),
 			'features'                 => static::get_features(),
 			'status'                   => static::get_status(),
-			'pricing'                  => static::get_pricing(),
+			'pricing_for_ui'           => static::get_pricing_for_ui(),
 			'requires_user_connection' => static::$requires_user_connection,
 			'class'                    => get_called_class(),
 		);
@@ -131,7 +131,7 @@ abstract class Product {
 	 *
 	 * @return array
 	 */
-	abstract public static function get_pricing();
+	abstract public static function get_pricing_for_ui();
 
 	/**
 	 * Undocumented function

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -69,7 +69,7 @@ class Scan extends Module_Product {
 	 *
 	 * @return array Pricing details
 	 */
-	public static function get_pricing() {
+	public static function get_pricing_for_ui() {
 		return array(
 			'available' => true,
 			'is_free'   => true,

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -64,4 +64,16 @@ class Scan extends Module_Product {
 		return array();
 	}
 
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing() {
+		return array(
+			'available' => true,
+			'is_free'   => true,
+		);
+	}
+
 }

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -69,7 +69,7 @@ class Search extends Module_Product {
 	 *
 	 * @return array Pricing details
 	 */
-	public static function get_pricing() {
+	public static function get_pricing_for_ui() {
 		return array(
 			'available' => true,
 			'is_free'   => true,

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -64,4 +64,15 @@ class Search extends Module_Product {
 		return array();
 	}
 
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing() {
+		return array(
+			'available' => true,
+			'is_free'   => true,
+		);
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -71,8 +71,10 @@ class Search extends Module_Product {
 	 */
 	public static function get_pricing_for_ui() {
 		return array(
-			'available' => true,
-			'is_free'   => true,
+			'available'            => true,
+			'currency_code'        => 'EUR',
+			'full_price'           => '4.50',
+			'promotion_percentage' => '50',
 		);
 	}
 }

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -64,4 +64,15 @@ class Videopress extends Module_Product {
 		return array();
 	}
 
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing() {
+		return array(
+			'available' => true,
+			'is_free'   => true,
+		);
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -69,7 +69,7 @@ class Videopress extends Module_Product {
 	 *
 	 * @return array Pricing details
 	 */
-	public static function get_pricing() {
+	public static function get_pricing_for_ui() {
 		return array(
 			'available' => true,
 			'is_free'   => true,

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -71,8 +71,10 @@ class Videopress extends Module_Product {
 	 */
 	public static function get_pricing_for_ui() {
 		return array(
-			'available' => true,
-			'is_free'   => true,
+			'available'            => true,
+			'currency_code'        => 'EUR',
+			'full_price'           => '9',
+			'promotion_percentage' => '50',
 		);
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/class-broken-product.php
+++ b/projects/packages/my-jetpack/tests/php/class-broken-product.php
@@ -53,4 +53,14 @@ class Broken_Product extends Module_Product {
 	public static function get_features() {
 		return array();
 	}
+
+	/**
+	 * Get the product pricing
+	 *
+	 * @return array
+	 */
+	public static function get_pricing_for_ui() {
+		return array();
+	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR exposes the pricing data for each product, adding the `get_pricing_for_ui()` static method to the Product class. We can define the way that we are going to get and propagate these data. Hardcoding vs pulling from wpcom.
The data provided should be enough to show the following price section of the Product card:

<img width="397" alt="Screen Shot 2022-02-02 at 6 18 01 PM" src="https://user-images.githubusercontent.com/77539/152239020-7ce6ca1e-992a-40c2-8b7f-a9b71fe340e2.png">


Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: expose pricing product data

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack page
* Check the Product items taking a look at the items:
```
myJetpackInitialState.products.items
```

![image](https://user-images.githubusercontent.com/77539/152336020-2b5876a1-1368-4ba5-aa82-af2a5cd91157.png)


