### PR TITLE
Jetpack plugin: add Jetpack partner coupon banner on My Page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/index.jsx
@@ -20,6 +20,7 @@ import { getSiteConnectionStatus } from 'state/connection';
 
 import MyPlanHeader from './my-plan-header';
 import MyPlanBody from './my-plan-body';
+import MyPlanPartnerCoupon from './my-plan-partner-coupon';
 
 export function MyPlan( props ) {
 	let sitePlan = props.sitePlan.product_slug || '',
@@ -34,6 +35,7 @@ export function MyPlan( props ) {
 	return (
 		<React.Fragment>
 			<QuerySite />
+			<MyPlanPartnerCoupon siteAdminUrl={ props.siteAdminUrl } />
 			<MyPlanHeader
 				activeProducts={ props.activeProducts }
 				plan={ sitePlan }

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-banner/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-banner/index.jsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React, { useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import MyPlanCard from '../my-plan-card';
+import { imagePath } from 'constants/urls';
+
+/**
+ * Import styles
+ */
+import './style.scss';
+
+const MyPlanBanner = props => {
+	const { productSlug, action, title, tagLine, trackingId } = props;
+
+	useEffect( () => {
+		analytics.tracks.recordEvent( 'jetpack_my_plan_banner_view', {
+			type: trackingId,
+		} );
+	}, [ trackingId ] );
+
+	const trackActionClick = useCallback( () => {
+		analytics.tracks.recordJetpackClick( {
+			target: trackingId,
+			feature: 'my-plan-banner',
+			page: 'my-plan',
+		} );
+	}, [ trackingId ] );
+
+	return (
+		<div className="jp-my-plan-banner">
+			<div
+				className="jp-my-plan-banner__card dops-card"
+				style={ { backgroundImage: `url(${ imagePath }jetpack-banner-gradient.svg)` } }
+			>
+				<MyPlanCard
+					productSlug={ productSlug }
+					action={ React.cloneElement( action, { onClick: trackActionClick } ) }
+					title={ title }
+					tagLine={ tagLine }
+				/>
+			</div>
+		</div>
+	);
+};
+
+MyPlanBanner.propTypes = {
+	productSlug: PropTypes.string.isRequired,
+	trackingId: PropTypes.string.isRequired,
+	action: PropTypes.element.isRequired,
+	tagLine: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
+	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
+};
+
+export default MyPlanBanner;

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-banner/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-banner/style.scss
@@ -1,0 +1,17 @@
+@import '../../scss/calypso-colors';
+
+.jp-my-plan-banner__card {
+	background-color: $white;
+	background-position: 100%;
+	background-size: 50% 100%;
+	background-repeat: no-repeat;
+}
+
+.jp-my-plan-banner .my-plan-card__icon {
+	margin-top: 8px;
+	margin-bottom: 8px;
+}
+
+.jp-my-plan-banner .my-plan-card__header {
+	align-self: center;
+}

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-partner-coupon/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-partner-coupon/index.jsx
@@ -14,8 +14,8 @@ import MyPlanBanner from '../my-plan-banner';
 import { getPartnerCoupon } from 'state/initial-state';
 
 const MyPlanPartnerCoupon = ( { siteAdminUrl, partnerCoupon } ) => {
-	if ( ! partnerCoupon ) {
-		return;
+	if ( 'object' !== typeof partnerCoupon ) {
+		return null;
 	}
 
 	const redeemButton = (
@@ -48,7 +48,7 @@ const MyPlanPartnerCoupon = ( { siteAdminUrl, partnerCoupon } ) => {
 };
 
 MyPlanPartnerCoupon.propTypes = {
-	partnerCoupon: PropTypes.object.isRequired,
+	partnerCoupon: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	siteAdminUrl: PropTypes.string.isRequired,
 };
 

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-partner-coupon/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-partner-coupon/index.jsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import MyPlanBanner from '../my-plan-banner';
+import { getPartnerCoupon } from 'state/initial-state';
+
+const MyPlanPartnerCoupon = ( { siteAdminUrl, partnerCoupon } ) => {
+	if ( ! partnerCoupon ) {
+		return;
+	}
+
+	const redeemButton = (
+		<Button primary href={ `${ siteAdminUrl }admin.php?page=jetpack&showCouponRedemption=1` }>
+			{ __( 'Redeem', 'jetpack' ) }
+		</Button>
+	);
+
+	return (
+		<MyPlanBanner
+			productSlug={ partnerCoupon.product.slug }
+			action={ redeemButton }
+			title={ sprintf(
+				/* translators: %s: Jetpack product or plan name. */
+				__( 'Get %s free for one year!', 'jetpack' ),
+				partnerCoupon.product.title
+			) }
+			tagLine={ sprintf(
+				/* translators: %1$s: the name of a Jetpack partner, %2$s: the name of a Jetpack product or plan. */
+				__(
+					'Redeem your %1$s coupon to get started with %2$s for free the first year!',
+					'jetpack'
+				),
+				partnerCoupon.partner.name,
+				partnerCoupon.product.title
+			) }
+			trackingId="jetpack-partner-coupon"
+		/>
+	);
+};
+
+MyPlanPartnerCoupon.propTypes = {
+	partnerCoupon: PropTypes.object.isRequired,
+	siteAdminUrl: PropTypes.string.isRequired,
+};
+
+export default connect( state => ( {
+	partnerCoupon: getPartnerCoupon( state ),
+} ) )( MyPlanPartnerCoupon );

--- a/projects/plugins/jetpack/changelog/add-my-plans-partner-coupon-component
+++ b/projects/plugins/jetpack/changelog/add-my-plans-partner-coupon-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added Jetpack Partner Coupon banner on My Plan page

--- a/projects/plugins/jetpack/images/jetpack-banner-gradient.svg
+++ b/projects/plugins/jetpack/images/jetpack-banner-gradient.svg
@@ -1,0 +1,33 @@
+<svg width="547" height="138" viewBox="0 0 547 138" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.7" filter="url(#filter0_f_1903_11097)">
+<ellipse cx="467.316" cy="-12.1619" rx="204.367" ry="206.457" transform="rotate(-105 467.316 -12.1619)" fill="#CED9F2"/>
+</g>
+<g opacity="0.7" filter="url(#filter1_f_1903_11097)">
+<ellipse cx="537.635" cy="148.748" rx="138.334" ry="139.588" transform="rotate(-105 537.635 148.748)" fill="#F5E6B3"/>
+</g>
+<g filter="url(#filter2_f_1903_11097)">
+<ellipse cx="272.261" cy="228.172" rx="188.068" ry="179.709" transform="rotate(-105 272.261 228.172)" fill="#069E08" fill-opacity="0.11"/>
+</g>
+<mask id="mask0_1903_11097" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="50" y="0" width="497" height="138">
+<rect x="50" width="497" height="138" fill="#C4C4C4"/>
+</mask>
+<g mask="url(#mask0_1903_11097)">
+</g>
+<defs>
+<filter id="filter0_f_1903_11097" x="96.9519" y="-380.717" width="740.728" height="737.109" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="81.9979" result="effect1_foregroundBlur_1903_11097"/>
+</filter>
+<filter id="filter1_f_1903_11097" x="234.1" y="-153.7" width="607.069" height="604.898" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="81.9979" result="effect1_foregroundBlur_1903_11097"/>
+</filter>
+<filter id="filter2_f_1903_11097" x="0.0963745" y="-51.2308" width="544.33" height="558.805" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="45.9189" result="effect1_foregroundBlur_1903_11097"/>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
### Summary

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR will add a banner to the `My Plan` page, informing users about unredeemed Jetpack partner coupons (if they have any).

The banner will redirect to a "Redeem coupon" component that gives the user greater detail about the product they are about to claim (`/wp-admin/admin.php?page=jetpack&showCouponRedemption=1`).

**Heads up**: this PR adds the component to `plugins/jetpack` instead of `js-packages/partner-coupon`. The main reason for this decision is because it's almost a 1:1 copy of `<MyPlanCard>` (except positioning and a background), so I've created a `<MyPlanBanner>` component that can be re-used on the My Plan page instead.

If we wanted to implement `<MyPlanPartnerCoupon>` as a RNA component, we wouldn't be able to use any of the font sizes etc. that exists in @automattic/jetpack-base-styles anyway and would have to hardcode old style values.

### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Add a new `<MyPlanBanner>` component to highlight efforts/opportunities relevant for users plans/products on the "My Plan" page.
* Add a `<MyPlanPartnerCoupon>` that uses `<MyPlanBanner>` to inform users about available Jetpack Partner coupons.

### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* 1201265858818217-as-1201673004210759
* pdpAdu-1U-p2

### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

This PR introduced one (and a half) new events:

* `jetpack_wpa_click`: we trigger a WPA click event when the banner button is clicked. The event itself isn't new, but the situation it's triggered is new and will add the following event properties:
  * `target`: jetpack-partner-coupon
  * `feature`: my-plan-banner
  * `page`: my-plan
* `jetpack_my_plan_banner_view`: will be trigger each time a My Plan banner is viewed. The event is new and shares the following event properties:
  * `type`: jetpack-partner-coupon

### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* Add the following coupon to the URL: 2b922-pb
*

### Screenshots

**"Desktop"**
![Screenshot 2022-02-03 at 04 15 59](https://user-images.githubusercontent.com/3846700/152278425-206e79ed-7c4b-425e-8c9e-bd8b8f34e805.png)

**"Tablet"**

![Screenshot 2022-02-03 at 04 52 53](https://user-images.githubusercontent.com/3846700/152278602-a60e6db0-92c2-4083-84a4-bee3cfd8c1a7.png)

**"Phone"**

![Screenshot 2022-02-03 at 04 53 08](https://user-images.githubusercontent.com/3846700/152278623-f81e28f6-b8df-4310-8344-35cca9bbf58f.png)
