### PR TITLE
WAF: do not ship .phpcs.dir.xml in production build

### DIFF
--- a/projects/packages/waf/.gitattributes
+++ b/projects/packages/waf/.gitattributes
@@ -12,4 +12,5 @@ package.json      export-ignore
 .gitignore        production-exclude
 changelog/**      production-exclude
 phpunit.xml.dist  production-exclude
+.phpcs.dir.xml    production-exclude
 tests/**          production-exclude

--- a/projects/packages/waf/changelog/update-ignored-config-waf
+++ b/projects/packages/waf/changelog/update-ignored-config-waf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Core: do not ship .phpcs.dir.xml in production builds.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* We do not need that file in production builds.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here.
