### PR TITLE
E2E tests: fix unsupported GITHUB_EVENT_NAME for schedule runs

### DIFF
--- a/.github/files/create-e2e-projects-matrix.sh
+++ b/.github/files/create-e2e-projects-matrix.sh
@@ -6,21 +6,21 @@ PROJECTS=('{"project":"Jetpack","path":"projects/plugins/jetpack/tests/e2e","tes
 PROJECTS_MATRIX=()
 RUN_NAME=''
 
+if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "push" ]]; then
+	CHANGED_PROJECTS="$(.github/files/list-changed-projects.sh)"
+fi
+
 # gutenberg scheduled run
 if [ "$CRON" == "0 */12 * * *" ]; then
   PROJECTS_MATRIX+=('{"project":"Jetpack with Gutenberg","path":"projects/plugins/jetpack/tests/e2e","testArgs":["blocks"],"slackArgs":["--report", "gutenberg"]}')
   RUN_NAME='gutenberg'
-  exit 0
 fi
 
 # atomic scheduled run
 if [ "$CRON" == "0 */4 * * *" ]; then
   PROJECTS_MATRIX+=('{"project":"Jetpack on Atomic","path":"projects/plugins/jetpack/tests/e2e","testArgs":["blocks", "--grep-invert", "wordads"],"slackArgs":["--report", "atomic"]}')
   RUN_NAME='atomic'
-  exit 0
 fi
-
-CHANGED_PROJECTS="$(.github/files/list-changed-projects.sh)"
 
 for PROJECT in "${PROJECTS[@]}"; do
 	PROJECT_PATH=$(jq -r ".path" <<<"$PROJECT")

--- a/.github/files/create-e2e-projects-matrix.sh
+++ b/.github/files/create-e2e-projects-matrix.sh
@@ -6,19 +6,21 @@ PROJECTS=('{"project":"Jetpack","path":"projects/plugins/jetpack/tests/e2e","tes
 PROJECTS_MATRIX=()
 RUN_NAME=''
 
-CHANGED_PROJECTS="$(.github/files/list-changed-projects.sh)"
-
 # gutenberg scheduled run
 if [ "$CRON" == "0 */12 * * *" ]; then
   PROJECTS_MATRIX+=('{"project":"Jetpack with Gutenberg","path":"projects/plugins/jetpack/tests/e2e","testArgs":["blocks"],"slackArgs":["--report", "gutenberg"]}')
   RUN_NAME='gutenberg'
+  exit 0
 fi
 
 # atomic scheduled run
 if [ "$CRON" == "0 */4 * * *" ]; then
   PROJECTS_MATRIX+=('{"project":"Jetpack on Atomic","path":"projects/plugins/jetpack/tests/e2e","testArgs":["blocks", "--grep-invert", "wordads"],"slackArgs":["--report", "atomic"]}')
   RUN_NAME='atomic'
+  exit 0
 fi
+
+CHANGED_PROJECTS="$(.github/files/list-changed-projects.sh)"
 
 for PROJECT in "${PROJECTS[@]}"; do
 	PROJECT_PATH=$(jq -r ".path" <<<"$PROJECT")


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
*  After merging #22318 the scheduled e2e test runs are failing. Apparently `list-changed-projects.sh` only supports GITHUB_EVENT_NAME pull_request or push, resulting in an `unsupported GITHUB_EVENT_NAME` error for scheduled runs.
* With this fix `list-changed-projects.sh` is only called for pull_request or push events

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Run `./.github/files/create-e2e-projects-matrix.sh` with different GITHUB_EVENT_NAME and CRON values