### PR TITLE
My Jetpack: Fix reducer for SET_PRODUCT_STATUS

### DIFF
--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -81,7 +81,7 @@ function requestProductStatus( productId, data, { select, dispatch } ) {
 		// Check valid product.
 		const isValid = select.isValidProduct( productId );
 		if ( ! isValid ) {
-			dispatch( setProductStatus( productId, { status: 'error' } ) );
+			dispatch( setProductStatus( productId, 'error' ) );
 			return dispatch(
 				setRequestProductError( productId, {
 					code: 'invalid_product',
@@ -105,7 +105,7 @@ function requestProductStatus( productId, data, { select, dispatch } ) {
 				resolve( status );
 			} )
 			.catch( error => {
-				dispatch( setProductStatus( productId, { status: 'error' } ) );
+				dispatch( setProductStatus( productId, 'error' ) );
 				dispatch( setRequestProductError( productId, error ) );
 				reject( error );
 				dispatch( setIsFetchingProduct( productId, false ) );

--- a/projects/packages/my-jetpack/_inc/state/reducers.js
+++ b/projects/packages/my-jetpack/_inc/state/reducers.js
@@ -42,7 +42,7 @@ const products = ( state = {}, action ) => {
 					...state.items,
 					[ productId ]: {
 						...state.items[ productId ],
-						...status,
+						status,
 					},
 				},
 			};

--- a/projects/packages/my-jetpack/changelog/fix-set-product-status-reducer-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/fix-set-product-status-reducer-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix My Jetpack's reducer for SET_PRODUCT_STATUS


### PR DESCRIPTION
We were attempting to destructure a string value (`status`)
...Thus attempting to upate the state like this: 

![image](https://user-images.githubusercontent.com/746152/152367846-6f481feb-254f-495a-8253-fa0dca581773.png)

Fixes SET_PRODUCT_STATUS action

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes destructuring operator. 
 
#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
#### Testing instructions:
Just confirm it makes sense
