### PR TITLE
Create new Plans package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,6 +58,7 @@
 				"automattic/jetpack-partner",
 				"automattic/jetpack-password-checker",
 				"automattic/jetpack-phpcs-filter",
+				"automattic/jetpack-plans",
 				"automattic/jetpack-plugins-installer",
 				"automattic/jetpack-post-list",
 				"automattic/jetpack-redirect",

--- a/projects/packages/plans/.gitattributes
+++ b/projects/packages/plans/.gitattributes
@@ -1,0 +1,15 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+package.json      export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+.gitignore        production-exclude
+changelog/**      production-exclude
+phpunit.xml.dist  production-exclude
+tests/**          production-exclude

--- a/projects/packages/plans/.gitignore
+++ b/projects/packages/plans/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+node_modules/
+wordpress

--- a/projects/packages/plans/CHANGELOG.md
+++ b/projects/packages/plans/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/packages/plans/README.md
+++ b/projects/packages/plans/README.md
@@ -1,0 +1,20 @@
+# plans
+
+Fetch information about Jetpack Plans from wpcom
+
+## How to install plans
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+plans is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/packages/plans/changelog/extract-jetpack-plans
+++ b/projects/packages/plans/changelog/extract-jetpack-plans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Package created

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -1,0 +1,56 @@
+{
+	"name": "automattic/jetpack-plans",
+	"description": "Fetch information about Jetpack Plans from wpcom",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"automattic/jetpack-connection": "^1.36"
+	},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "1.0.3",
+		"automattic/jetpack-changelogger": "^3.0",
+		"automattic/jetpack-options": "^1.14",
+		"automattic/jetpack-status": "^1.10",
+		"automattic/wordbless": "@dev"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		],
+		"test-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+		],
+		"test-php": [
+			"@composer phpunit"
+		],
+		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\"",
+		"build-production": "echo 'Add your build step to composer.json, please!'",
+		"build-development": "echo 'Add your build step to composer.json, please!'"
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"branch-alias": {
+			"dev-master": "0.1.x-dev"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"roots/wordpress-core-installer": true
+		}
+	}
+}

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,0 +1,29 @@
+{
+	"private": true,
+	"name": "@automattic/jetpack-plans",
+	"version": "0.1.0-alpha",
+	"description": "Fetch information about Jetpack Plans from wpcom",
+	"homepage": "https://jetpack.com",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "echo 'Not implemented.",
+		"build-js": "echo 'Not implemented.",
+		"build-production": "echo 'Not implemented.",
+		"build-production-js": "echo 'Not implemented.",
+		"clean": "true"
+	},
+	"devDependencies": {},
+	"engines": {
+		"node": "^14.18.3 || ^16.13.2",
+		"pnpm": "^6.23.6",
+		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	}
+}

--- a/projects/packages/plans/phpunit.xml.dist
+++ b/projects/packages/plans/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * Handles fetching of the site's plan and products from WordPress.com and caching values locally.
+ *
+ * This file was copied and adapted from the Jetpack plugin on Jan 2022
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Provides methods methods for fetching the site's plan and products from WordPress.com.
+ */
+class Current_Plan {
+	/**
+	 * A cache variable to hold the active plan for the current request.
+	 *
+	 * @var array
+	 */
+	private static $active_plan_cache;
+
+	/**
+	 * The name of the option that will store the site's plan.
+	 *
+	 * @var string
+	 */
+	const PLAN_OPTION = 'jetpack_active_plan';
+
+	/**
+	 * The name of the option that will store the site's products.
+	 *
+	 * @var string
+	 */
+	const SITE_PRODUCTS_OPTION = 'jetpack_site_products';
+
+	const PLAN_DATA = array(
+		'free'     => array(
+			'plans'    => array(
+				'jetpack_free',
+			),
+			'supports' => array(
+				'opentable',
+				'calendly',
+				'send-a-message',
+				'whatsapp-button',
+				'social-previews',
+				'videopress',
+
+				'core/video',
+				'core/cover',
+				'core/audio',
+			),
+		),
+		'personal' => array(
+			'plans'    => array(
+				'jetpack_personal',
+				'jetpack_personal_monthly',
+				'personal-bundle',
+				'personal-bundle-monthly',
+				'personal-bundle-2y',
+			),
+			'supports' => array(
+				'akismet',
+				'recurring-payments',
+				'premium-content/container',
+				'videopress',
+			),
+		),
+		'premium'  => array(
+			'plans'    => array(
+				'jetpack_premium',
+				'jetpack_premium_monthly',
+				'value_bundle',
+				'value_bundle-monthly',
+				'value_bundle-2y',
+			),
+			'supports' => array(
+				'donations',
+				'simple-payments',
+				'vaultpress',
+				'videopress',
+				'republicize',
+			),
+		),
+		'security' => array(
+			'plans'    => array(
+				'jetpack_security_daily',
+				'jetpack_security_daily_monthly',
+				'jetpack_security_realtime',
+				'jetpack_security_realtime_monthly',
+				'jetpack_security_t1_yearly',
+				'jetpack_security_t1_monthly',
+				'jetpack_security_t2_yearly',
+				'jetpack_security_t2_monthly',
+			),
+			'supports' => array(),
+		),
+		'business' => array(
+			'plans'    => array(
+				'jetpack_business',
+				'jetpack_business_monthly',
+				'business-bundle',
+				'business-bundle-monthly',
+				'business-bundle-2y',
+				'ecommerce-bundle',
+				'ecommerce-bundle-monthly',
+				'ecommerce-bundle-2y',
+			),
+			'supports' => array(),
+		),
+
+		'complete' => array(
+			'plans'    => array(
+				'jetpack_complete',
+				'jetpack_complete_monthly',
+				'vip',
+			),
+			'supports' => array(),
+		),
+	);
+
+	/**
+	 * Given a response to the `/sites/%d` endpoint, will parse the response and attempt to set the
+	 * site's plan and products from the response.
+	 *
+	 * @param array $response The response from `/sites/%d`.
+	 * @return bool Was the plan successfully updated?
+	 */
+	public static function update_from_sites_response( $response ) {
+		// Bail if there was an error or malformed response.
+		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
+			return false;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( is_wp_error( $body ) ) {
+			return false;
+		}
+
+		// Decode the results.
+		$results = json_decode( $body, true );
+
+		if ( ! is_array( $results ) ) {
+			return false;
+		}
+
+		if ( isset( $results['products'] ) ) {
+			// Store the site's products in an option and return true if updated.
+			self::store_data_in_option( self::SITE_PRODUCTS_OPTION, $results['products'] );
+		}
+
+		if ( ! isset( $results['plan'] ) ) {
+			return false;
+		}
+
+		$current_plan = get_option( self::PLAN_OPTION, array() );
+
+		if ( ! empty( $current_plan ) && $current_plan === $results['plan'] ) {
+			// Bail if the plans array hasn't changed.
+			return false;
+		}
+
+		// Store the new plan in an option and return true if updated.
+		$result = self::store_data_in_option( self::PLAN_OPTION, $results['plan'] );
+
+		if ( $result ) {
+			// Reset the cache since we've just updated the plan.
+			self::$active_plan_cache = null;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Store data in an option.
+	 *
+	 * @param string $option The name of the option that will store the data.
+	 * @param array  $data Data to be store in an option.
+	 * @return bool Were the subscriptions successfully updated?
+	 */
+	private static function store_data_in_option( $option, $data ) {
+		$result = update_option( $option, $data, true );
+
+		// If something goes wrong with the update, so delete the current option and then update it.
+		if ( ! $result ) {
+			delete_option( $option );
+			$result = update_option( $option, $data, true );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Make an API call to WordPress.com for plan status
+	 *
+	 * @uses Jetpack_Options::get_option()
+	 * @uses Client::wpcom_json_api_request_as_blog()
+	 * @uses update_option()
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return bool True if plan is updated, false if no update
+	 */
+	public static function refresh_from_wpcom() {
+		// Make the API request.
+		$request  = sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) );
+		$response = Client::wpcom_json_api_request_as_blog( $request, '1.1' );
+
+		return self::update_from_sites_response( $response );
+	}
+
+	/**
+	 * Get the plan that this Jetpack site is currently using.
+	 *
+	 * @uses get_option()
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return array Active Jetpack plan details
+	 */
+	public static function get() {
+		// this can be expensive to compute so we cache for the duration of a request.
+		if ( is_array( self::$active_plan_cache ) && ! empty( self::$active_plan_cache ) ) {
+			return self::$active_plan_cache;
+		}
+
+		$plan = get_option( self::PLAN_OPTION, array() );
+
+		// Set the default options.
+		$plan = wp_parse_args(
+			$plan,
+			array(
+				'product_slug' => 'jetpack_free',
+				'class'        => 'free',
+				'features'     => array(
+					'active' => array(),
+				),
+			)
+		);
+
+		list( $plan['class'], $supports ) = self::get_class_and_features( $plan['product_slug'] );
+
+		// get available features if Jetpack is active.
+		if ( class_exists( 'Jetpack' ) ) {
+			foreach ( Jetpack::get_available_modules() as $module_slug ) {
+				$module = Jetpack::get_module( $module_slug );
+				if ( ! isset( $module ) || ! is_array( $module ) ) {
+					continue;
+				}
+				if ( in_array( 'free', $module['plan_classes'], true ) || in_array( $plan['class'], $module['plan_classes'], true ) ) {
+					$supports[] = $module_slug;
+				}
+			}
+		}
+
+		$plan['supports'] = $supports;
+
+		self::$active_plan_cache = $plan;
+
+		return $plan;
+	}
+
+	/**
+	 * Get the site's products.
+	 *
+	 * @uses get_option()
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return array Active Jetpack products
+	 */
+	public static function get_products() {
+		return get_option( self::SITE_PRODUCTS_OPTION, array() );
+	}
+
+	/**
+	 * Get the class of plan and a list of features it supports
+	 *
+	 * @param string $plan_slug The plan that we're interested in.
+	 * @return array Two item array, the plan class and the an array of features.
+	 */
+	private static function get_class_and_features( $plan_slug ) {
+		$features = array();
+		foreach ( self::PLAN_DATA as $class => $details ) {
+			$features = array_merge( $features, $details['supports'] );
+			if ( in_array( $plan_slug, $details['plans'], true ) ) {
+				return array( $class, $features );
+			}
+		}
+		return array( 'free', self::PLAN_DATA['free']['supports'] );
+	}
+
+	/**
+	 * Gets the minimum plan slug that supports the given feature
+	 *
+	 * @param string $feature The name of the feature.
+	 * @return string|bool The slug for the minimum plan that supports.
+	 *  the feature or false if not found
+	 */
+	public static function get_minimum_plan_for_feature( $feature ) {
+		foreach ( self::PLAN_DATA as $details ) {
+			if ( in_array( $feature, $details['supports'], true ) ) {
+				return $details['plans'][0];
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Determine whether the active plan supports a particular feature
+	 *
+	 * @uses Jetpack_Plan::get()
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param string $feature The module or feature to check.
+	 *
+	 * @return bool True if plan supports feature, false if not
+	 */
+	public static function supports( $feature ) {
+		// Search product bypasses plan feature check.
+		if ( 'search' === $feature && (bool) get_option( 'has_jetpack_search_product' ) ) {
+			return true;
+		}
+
+		// As of Q3 2021 - a videopress free tier is available to all plans.
+		if ( 'videopress' === $feature ) {
+			return true;
+		}
+
+		$plan = self::get();
+
+		// Manually mapping WordPress.com features to Jetpack module slugs.
+		foreach ( $plan['features']['active'] as $wpcom_feature ) {
+			switch ( $wpcom_feature ) {
+				case 'wordads-jetpack':
+					// WordAds are supported for this site.
+					if ( 'wordads' === $feature ) {
+						return true;
+					}
+					break;
+			}
+		}
+
+		if (
+			in_array( $feature, $plan['supports'], true )
+			|| in_array( $feature, $plan['features']['active'], true )
+		) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/projects/packages/plans/src/class-plans.php
+++ b/projects/packages/plans/src/class-plans.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Plans Library
+ *
+ * Fetch plans data from WordPress.com.
+ *
+ * This file was copied and adapted from the Jetpack plugin on Jan 2022.
+ *
+ * @package automattic/jetpack-plans
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Fetch data about available Plans from WordPress.com
+ */
+class Plans {
+	/**
+	 * Get a list of all available plans from WordPress.com
+	 *
+	 * @since-jetpack 7.7.0
+	 *
+	 * @return array The plans list
+	 */
+	public static function get_plans() {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			if ( ! class_exists( 'Store_Product_List' ) ) {
+				require WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/store-product-list.php';
+			}
+
+			return Store_Product_List::api_only_get_active_plans_v1_4();
+		}
+
+		// We're on Jetpack, so it's safe to use this namespace.
+		$request = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+			'/plans?_locale=' . get_user_locale(),
+			// We're using version 1.5 of the endpoint rather than the default version 2
+			// since the latter only returns Jetpack Plans, but we're also interested in
+			// WordPress.com plans, for consumers of this method that run on WP.com.
+			'1.5',
+			array(
+				'method'  => 'GET',
+				'headers' => array(
+					'X-Forwarded-For' => ( new Automattic\Jetpack\Status\Visitor() )->get_ip( true ),
+				),
+			),
+			null,
+			'rest'
+		);
+
+		$body = wp_remote_retrieve_body( $request );
+		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
+			return json_decode( $body );
+		} else {
+			return $body;
+		}
+	}
+
+	/**
+	 * Get plan information for a plan given its slug
+	 *
+	 * @since-jetpack 7.7.0
+	 *
+	 * @param string $plan_slug Plan slug.
+	 *
+	 * @return object The plan object
+	 */
+	public static function get_plan( $plan_slug ) {
+		$plans = self::get_plans();
+		if ( ! is_array( $plans ) ) {
+			return;
+		}
+
+		foreach ( $plans as $plan ) {
+			if ( $plan_slug === $plan->product_slug ) {
+				return $plan;
+			}
+		}
+	}
+}

--- a/projects/packages/plans/src/example.php
+++ b/projects/packages/plans/src/example.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Put your classes in this `src` folder!
+ *
+ * @package automattic/PACKAGE-NAME
+ */
+
+// Start your code here!

--- a/projects/packages/plans/tests/php/bootstrap.php
+++ b/projects/packages/plans/tests/php/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+define( 'WP_DEBUG', true );
+
+\WorDBless\Load::load();

--- a/projects/packages/plans/tests/php/test-current-plan.php
+++ b/projects/packages/plans/tests/php/test-current-plan.php
@@ -1,0 +1,307 @@
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * This file was copied and adapted from the Jetpack plugin on Jan 2022
+ */
+// phpcs:disable Squiz.Commenting, Generic.Commenting  -- Tests should be self documenting
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
+use Jetpack_Options;
+use PHPUnit\Framework\TestCase;
+use WP_Error;
+
+/**
+ * Contains the tests for the Jetpack_Plan class.
+ */
+class WP_Test_Jetpack_Plan extends TestCase {
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		delete_option( 'jetpack_active_plan' );
+	}
+
+	public function test_update_from_sites_response_failure_to_update() {
+		update_option( 'jetpack_active_plan', $this->get_free_plan(), true );
+
+		$option = get_option( 'jetpack_active_plan' );
+		$this->assertSame( 'jetpack_free', $option['product_slug'] );
+
+		// Set up an issue where the value in cache does not match the DB, so the DB update fails.
+		Jetpack_Options::update_raw_option( 'jetpack_active_plan', $this->get_personal_plan(), true );
+
+		$this->assertTrue( Jetpack_Plan::update_from_sites_response( $this->get_response_personal_plan() ) );
+	}
+
+	/**
+	 * @dataProvider get_update_from_sites_response_data
+	 */
+	public function test_update_from_sites_response( $response, $expected_plan_slug_after, $expected_return, $initial_option = null ) {
+
+		if ( ! is_null( $initial_option ) ) {
+			update_option( 'jetpack_active_plan', $initial_option, true );
+		}
+
+		$this->assertSame( $expected_return, Jetpack_Plan::update_from_sites_response( $response ) );
+
+		$plan = Jetpack_Plan::get();
+		$this->assertSame( $expected_plan_slug_after, $plan['product_slug'] );
+	}
+
+	public function get_update_from_sites_response_data() {
+		return array(
+			'is_errored_response'                    => array(
+				$this->get_errored_sites_response(),
+				'jetpack_free',
+				false,
+			),
+			'response_is_empty'                      => array(
+				$this->get_mocked_response( 200, '' ),
+				'jetpack_free',
+				false,
+			),
+			'response_does_not_have_body'            => array(
+				array( 'code' => 400 ),
+				'jetpack_free',
+				false,
+			),
+			'response_does_not_have_plan'            => array(
+				array(
+					'code' => 200,
+					array(),
+				),
+				'jetpack_free',
+				false,
+			),
+			'initially_empty_option_to_free'         => array(
+				$this->get_response_free_plan(),
+				'jetpack_free',
+				true,
+			),
+			'initially_empty_to_personal'            => array(
+				$this->get_response_personal_plan(),
+				'jetpack_personal',
+				true,
+			),
+			'initially_free_to_personal'             => array(
+				$this->get_response_personal_plan(),
+				'jetpack_personal',
+				true,
+				$this->get_free_plan(),
+			),
+			'initially_personal_to_free'             => array(
+				$this->get_response_free_plan(),
+				'jetpack_free',
+				true,
+				$this->get_personal_plan(),
+			),
+			'initially_free_no_change'               => array(
+				$this->get_response_free_plan(),
+				'jetpack_free',
+				false,
+				$this->get_free_plan(),
+			),
+			'initially_personal_to_changed_personal' => array(
+				$this->get_response_changed_personal_plan(),
+				'jetpack_personal',
+				true,
+				$this->get_response_personal_plan(),
+			),
+		);
+	}
+
+	private function get_response_free_plan() {
+		return $this->get_successful_plan_response( $this->get_free_plan() );
+	}
+
+	private function get_response_personal_plan() {
+		return $this->get_successful_plan_response( $this->get_personal_plan() );
+	}
+
+	private function get_response_changed_personal_plan() {
+		return $this->get_successful_plan_response( $this->get_changed_personal_plan() );
+	}
+
+	private function get_successful_plan_response( $plan_response ) {
+		$body = wp_json_encode(
+			array(
+				'plan' => $plan_response,
+			)
+		);
+		return $this->get_mocked_response( 200, $body );
+	}
+
+	private function get_errored_sites_response() {
+		return $this->get_mocked_response( 400, new WP_Error() );
+	}
+
+	private function get_mocked_response( $code, $body ) {
+		return array(
+			'code' => $code,
+			'body' => $body,
+		);
+	}
+
+	private function get_free_plan() {
+		return array(
+			'product_id'         => 2002,
+			'product_slug'       => 'jetpack_free',
+			'product_name_short' => 'Free',
+			'expired'            => false,
+			'user_is_owner'      => false,
+			'is_free'            => true,
+			'features'           => array(
+				'active'    => array(
+					'akismet',
+					'support',
+				),
+				'available' => array(
+					'akismet'                       => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'vaultpress-backups'            => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'vaultpress-backup-archive'     => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'vaultpress-storage-space'      => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'vaultpress-automated-restores' => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'simple-payments'               => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'support'                       => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_personal',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+						'jetpack_personal_monthly',
+					),
+					'premium-themes'                => array(
+						'jetpack_business',
+						'jetpack_business_monthly',
+					),
+					'vaultpress-security-scanning'  => array(
+						'jetpack_business',
+						'jetpack_business_monthly',
+					),
+					'polldaddy'                     => array(
+						'jetpack_business',
+						'jetpack_business_monthly',
+					),
+				),
+			),
+		);
+	}
+
+	private function get_changed_personal_plan() {
+		$changed_personal_plan = $this->get_personal_plan();
+
+		$changed_personal_plan['features']['available']['test_feature'] = array( 'jetpack_free' );
+		return $changed_personal_plan;
+	}
+
+	private function get_personal_plan() {
+		return array(
+			'product_id'         => 2005,
+			'product_slug'       => 'jetpack_personal',
+			'product_name_short' => 'Personal',
+			'expired'            => false,
+			'user_is_owner'      => false,
+			'is_free'            => false,
+			'features'           => array(
+				'active'    => array(
+					'support',
+				),
+				'available' => array(
+					'akismet'                       => array(
+						'jetpack_free',
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'support'                       => array(
+						'jetpack_free',
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+						'jetpack_personal_monthly',
+					),
+					'vaultpress-backups'            => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'vaultpress-backup-archive'     => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'vaultpress-storage-space'      => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'vaultpress-automated-restores' => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'simple-payments'               => array(
+						'jetpack_premium',
+						'jetpack_business',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					),
+					'premium-themes'                => array(
+						'jetpack_business',
+						'jetpack_business_monthly',
+					),
+					'vaultpress-security-scanning'  => array(
+						'jetpack_business',
+						'jetpack_business_monthly',
+					),
+					'polldaddy'                     => array(
+						'jetpack_business',
+						'jetpack_business_monthly',
+					),
+				),
+			),
+		);
+	}
+}
+
+// phpcs:enable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR creates a new package with functionality to fetch Plans data from WPCOM.

For now, it copies the classes from the Jetpack plugin. Usage in the Jetpack plugin will be replaced in subsequent PRs as this must be synced with changes in WPCOM as well.

We need this to move the work on the My Jetpack feature.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Create new Plans package

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing for now, the package is not used
* Let's see if the tests pass
