### PR TITLE
My Jetpack: Connect Boost card with the interstitial

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -11,6 +11,7 @@ import { HashRouter, Routes, Route } from 'react-router-dom';
 import MyJetpackScreen from './components/my-jetpack-screen';
 import ConnectionScreen from './components/connection-screen';
 import { initStore } from './state/store';
+import { BoostInterstitial } from './components/product-interstitial';
 
 initStore();
 
@@ -29,6 +30,7 @@ function render() {
 			<Routes>
 				<Route path="/" element={ <MyJetpackScreen /> } />
 				<Route path="/connection" element={ <ConnectionScreen /> } />
+				<Route path="/add-boost" element={ <BoostInterstitial /> } />
 			</Routes>
 		</HashRouter>,
 		container

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -19,6 +20,11 @@ export const BoostIcon = () => (
 const BoostCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
 	const { name, description } = detail;
+	const navigate = useNavigate();
+
+	const onAddHandler = useCallback( () => {
+		navigate( '/add-boost' );
+	}, [ navigate ] );
 
 	return (
 		<ProductCard
@@ -30,6 +36,7 @@ const BoostCard = ( { admin } ) => {
 			isFetching={ isFetching }
 			onDeactivate={ deactivate }
 			onActivate={ activate }
+			onAdd={ onAddHandler }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-open-boost-interstitial
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-open-boost-interstitial
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Connect Boost card with the interstitial page via /add-boost root


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR register a new `/add-boost` route tied to the `<BoostInterstitial />` component. Also, Adds a handler to the `onAdd()` BoostCard property to lead the user to the interstitial page by clicking on the `Add Boost` link

Note: We are going to add the `Go back link` in a follow-up.

Fixes https://github.com/Automattic/jetpack/issues/22655

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Connect Boost card with the interstitial page via /add-boost root

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Set up in order to do not have `Boost` available in your dashboard. You can hardcode the [get_status()](https://github.com/Automattic/jetpack/blob/56b5e9d2be8d4cfd0f2cb3c716308e74abb9af76/projects/packages/my-jetpack/src/products/class-product.php#L149-L158) method forcing this `plugin_absent` status.
* Confirm you see the interstitial page by clicking on `Add Boost` link.

https://user-images.githubusercontent.com/77539/152508127-e83d9047-595a-464c-af65-47ce3e637936.mov