### PR TITLE
Twitter Gather: make endpoint restricted to contributors

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
@@ -56,7 +56,9 @@ class WPCOM_REST_API_V2_Endpoint_Tweetstorm_Gather extends WP_REST_Controller {
 				'private_site_security_settings' => array(
 					'allow_blog_token_access' => true,
 				),
-				'permission_callback'            => '__return_true',
+				'permission_callback'            => function () {
+					return current_user_can( 'edit_posts' );
+				},
 			)
 		);
 	}

--- a/projects/plugins/jetpack/changelog/update-twitter-unroll-endpoint
+++ b/projects/plugins/jetpack/changelog/update-twitter-unroll-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Unroll Twitter Threads: ensure that only contributors can access the endpoint to unroll threads.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿Until now, the endpoint was available to anyone, and one could pass any Twitter Thread to that endpoint to make a blog-authenticated request to WordPress.com, and then, in turn, an authenticated request to the Twitter API using our app credentials.

Here is an example:
https://jeremy.hu/wp-json/wpcom/v2/tweetstorm/gather?url=https://twitter.com/KieranBinchy/status/1488812175372267526

That endpoint is currently used in the block editor (so only by folks with contributing capabilities on a given site) to "unroll" a Twitter Thread, i.e. pull all tweets from a thread based off a single tweet.

I think it would be fine to limit that endpoint to contributors.

- This merges r239582-wpcom from WordPress.com (D74346-code).

#### Jetpack product discussion

- Related post: p3btAN-1Fc-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Posts > Add New
* Paste in the following URL: `https://twitter.com/KieranBinchy/status/1488812175372267526`
* Click on the "Unroll" button above the Twitter embed block that appears.
* The thread should unroll.

