### PR TITLE
Plans: update to support mirror repo.

### DIFF
--- a/projects/packages/plans/changelog/update-plans-mirror-repo
+++ b/projects/packages/plans/changelog/update-plans-mirror-repo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Core: update composer info to support mirror repo.

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -44,6 +44,11 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-plans",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
+		},
 		"branch-alias": {
 			"dev-master": "0.1.x-dev"
 		}

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Connection\Client;
+use Jetpack_Options;
 
 /**
  * Provides methods methods for fetching the site's plan and products from WordPress.com.


### PR DESCRIPTION
Follow-up from #22650

#### Changes proposed in this Pull Request:

﻿* [x] Plans: update composer info to support mirror repo.
* [x] The class uses `Jetpack_Options`, let's clear that up.
* [ ] The class also uses the `Jetpack` class, so we'll most likely have to get rid of that dependency.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here since the package isn't being used yet.
