### PR TITLE
My Jetpack: useCallback for track functions that are bound to onEvents

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
@@ -132,32 +132,32 @@ const ProductCard = props => {
 	/**
 	 * Calls the passed function onDeactivate after firing Tracks event
 	 */
-	const deactivateHandler = () => {
+	const deactivateHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_card_deactivate_click', {
 			product: name,
 		} );
 		onDeactivate();
-	};
+	}, [ name, onDeactivate, recordEvent ] );
 
 	/**
 	 * Calls the passed function onActivate after firing Tracks event
 	 */
-	const activateHandler = () => {
+	const activateHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_card_activate_click', {
 			product: name,
 		} );
 		onActivate();
-	};
+	}, [ name, onActivate, recordEvent ] );
 
 	/**
 	 * Calls the passed function onAdd after firing Tracks event
 	 */
-	const addHandler = () => {
+	const addHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_card_add_click', {
 			product: name,
 		} );
 		onAdd();
-	};
+	}, [ name, onAdd, recordEvent ] );
 
 	return (
 		<div className={ containerClassName }>

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
@@ -17,7 +17,8 @@ const useAnalytics = () => {
 		if ( isUserConnected && ID && login ) {
 			jetpackAnalytics.initialize( ID, login );
 		}
-	} );
+	}, [ ID, isUserConnected, login ] );
+
 	const {
 		clearedIdentity,
 		ga,

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-tracking-events-handler
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-tracking-events-handler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+useCallback for functions that are bound to onEvents


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

My Jetpack: useCallback for track functions that are bound to onEvents

Fixes https://github.com/Automattic/jetpack/issues/22660

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: useCallback for track functions that are bound to onEvents

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Check events are properly working after these changes
```
localStorage.setItem( 'debug', 'dops:analytics*' );
```
  * When the My Jetpack shows up
  * Activating/Deactivating a product

![image](https://user-images.githubusercontent.com/77539/152529031-6b75d335-e192-4dbb-87f4-365178b2fff5.png)

