### PR TITLE
My Jetpack: Fire Tracks event when showing product Interstitial page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Container, Col } from '@automattic/jetpack-components';
 
 /**
@@ -10,6 +10,7 @@ import { Container, Col } from '@automattic/jetpack-components';
 import { ProductDetail } from '../product-detail-card';
 import styles from './style.module.scss';
 import boostImage from './boost.png';
+import useAnalytics from '../../hooks/use-analytics';
 
 /**
  * Product Interstitial component.
@@ -20,6 +21,13 @@ import boostImage from './boost.png';
  * @returns {object}                ProductInterstitial react component.
  */
 export default function ProductInterstitial( { slug, children = null } ) {
+	const {
+		tracks: { recordEvent },
+	} = useAnalytics();
+
+	useEffect( () => {
+		recordEvent( 'jetpack_myjetpack_product_interstitial_view', { slug } );
+	}, [ recordEvent, slug ] );
 	return (
 		<Container className={ styles.container } horizontalSpacing={ 0 } horizontalGap={ 0 }>
 			<Col sm={ 4 } md={ 4 } lg={ 5 }>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -26,7 +26,7 @@ export default function ProductInterstitial( { slug, children = null } ) {
 	} = useAnalytics();
 
 	useEffect( () => {
-		recordEvent( 'jetpack_myjetpack_product_interstitial_view', { slug } );
+		recordEvent( 'jetpack_myjetpack_product_interstitial_view', { product: slug } );
 	}, [ recordEvent, slug ] );
 	return (
 		<Container className={ styles.container } horizontalSpacing={ 0 } horizontalGap={ 0 }>

--- a/projects/packages/my-jetpack/changelog/add-event-interstitial-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-event-interstitial-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fire Tracks event when showing the Interstitial page


### PR DESCRIPTION
Adds tracking for views on product interstitial pages

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces side effect for firing `jetpack_myjetpack_product_interstitial_view`.
#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?

Introduces 1 new event:
*  `jetpack_myjetpack_product_interstitial_view` fired when the user views the interstitial page

#### Testing instructions:
* Checkout this branch on a site with Jetpack connected the Backup plugin active, and the `JETPACK_ENABLE_MY_JETPACK` constant set to `true`.
* Open the browser and visit the site's wp-admin.
* Open the developer console, execute the following code: `localStorage.debug='dops:analyitics*`
* Go to this patch `wp-admin/admin.php?page=my-jetpack#/add-boost`. |
* Confirm that the developer console displays the events `jetpack_myjetpack_product_interstitial_view` 