### PR TITLE
My Jetpack: Fire Tracks event when clicking CTA button on product Interstitial page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -66,7 +66,7 @@ function Price( { value, currency, isOld } ) {
  * @param {object} props                    - Component props.
  * @param {string} props.slug               - Product slug
  * @param {Function} props.trackButtonClick - Function to call for tracking clicks on Call To Action button
- * @returns {object}                        ProductDetailCard react component.
+ * @returns {object}                          ProductDetailCard react component.
  */
 const ProductDetail = ( { slug, trackButtonClick } ) => {
 	const { detail } = useProduct( slug );

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -63,11 +63,12 @@ function Price( { value, currency, isOld } ) {
 /**
  * Product Detail component.
  *
- * @param {object} props          - Component props.
- * @param {string} props.slug     - Product slug
- * @returns {object}                ProductDetailCard react component.
+ * @param {object} props                    - Component props.
+ * @param {string} props.slug               - Product slug
+ * @param {Function} props.trackButtonClick - Function to call for tracking clicks on Call To Action button
+ * @returns {object}                        ProductDetailCard react component.
  */
-export function ProductDetail( { slug } ) {
+const ProductDetail = ( { slug, trackButtonClick } ) => {
 	const { detail } = useProduct( slug );
 	const { title, longDescription, features } = detail;
 	const price = 9;
@@ -95,7 +96,13 @@ export function ProductDetail( { slug } ) {
 				</div>
 			</div>
 
-			<Button isLink isPrimary href="#" className={ styles[ 'checkout-button' ] }>
+			<Button
+				onClick={ trackButtonClick }
+				isLink
+				isPrimary
+				href="#"
+				className={ styles[ 'checkout-button' ] }
+			>
 				{
 					/* translators: placeholder is product name. */
 					sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), title )
@@ -103,7 +110,13 @@ export function ProductDetail( { slug } ) {
 			</Button>
 		</div>
 	);
-}
+};
+
+ProductDetail.defaultProps = {
+	trackButtonClick: () => {},
+};
+
+export { ProductDetail };
 
 /**
  * ProductDetailCard component.

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Container, Col } from '@automattic/jetpack-components';
 
 /**
@@ -28,10 +28,14 @@ export default function ProductInterstitial( { slug, children = null } ) {
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_product_interstitial_view', { product: slug } );
 	}, [ recordEvent, slug ] );
+
+	const trackProductClick = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', { product: slug } );
+	}, [ recordEvent, slug ] );
 	return (
 		<Container className={ styles.container } horizontalSpacing={ 0 } horizontalGap={ 0 }>
 			<Col sm={ 4 } md={ 4 } lg={ 5 }>
-				<ProductDetail slug={ slug } />
+				<ProductDetail slug={ slug } trackButtonClick={ trackProductClick } />
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 7 } className={ styles.imageContainer }>
 				{ children }

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-tracks-event-interstitial-click
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-tracks-event-interstitial-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fire Tracks event when clicking CTA button on product Interstitial page


### PR DESCRIPTION
Adds tracking for click on product interstitial pages CTA buttons

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces firing of  `jetpack_myjetpack_product_interstitial_add_link_click`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?

Introduces 1 new event:
*  `jetpack_myjetpack_product_interstitial_add_link_click` fired when the user views the interstitial page

#### Testing instructions:
* Checkout this branch on a site with Jetpack connected the Backup plugin active, and the `JETPACK_ENABLE_MY_JETPACK` constant set to `true`.
* Open the browser and visit the site's wp-admin.
* Open the developer console, execute the following code: `localStorage.debug='dops:analyitics*`
* Go to this patch `wp-admin/admin.php?page=my-jetpack#/add-boost`. 
* Click the Add... button
* Confirm that the developer console displays the events `jetpack_myjetpack_product_interstitial_add_link_click` 