### PR TITLE
Connection: authorize URL doesn't forward Calypso env param

### DIFF
--- a/projects/packages/connection/changelog/fix-authorize-url-missing-env-query-param
+++ b/projects/packages/connection/changelog/fix-authorize-url-missing-env-query-param
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Unify how connection register and authorize url works with local environments
+
+

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -721,14 +721,18 @@ class REST_Connector {
 	public function connection_authorize_url( $request ) {
 		$redirect_uri = $request->get_param( 'redirect_uri' ) ? admin_url( $request->get_param( 'redirect_uri' ) ) : null;
 
-		if ( ! $request->get_param( 'no_iframe' ) ) {
-			add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
-		}
+		if ( class_exists( 'Jetpack' ) ) {
+			$authorize_url = \Jetpack::build_authorize_url( $redirect_uri, ! $request->get_param( 'no_iframe' ) );
+		} else {
+			if ( ! $request->get_param( 'no_iframe' ) ) {
+				add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
+			}
 
-		$authorize_url = $this->connection->get_authorization_url( null, $redirect_uri );
+			$authorize_url = $this->connection->get_authorization_url( null, $redirect_uri );
 
-		if ( ! $request->get_param( 'no_iframe' ) ) {
-			remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
+			if ( ! $request->get_param( 'no_iframe' ) ) {
+				remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
+			}
 		}
 
 		return rest_ensure_response(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Connecting a user account to your local environment doesn't forward the Calypso environment which means that it will always send you to `wordpress.com` instead of `calypso.localhost:3000`.

Looking at `connection_register` vs `connection_authorize_url`, then it works when registering the site because it allows the Jetpack plugin to implement its own authorize URL logic.

The suggestion implementation is probably not the most optimal since it doens't allow e.g. Jetpack Backup or any other plugins outside the Jetpack plugin to forward the Calypso environment, but it's a direct copy so it at least works the same way between the two connection methods.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

None.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up this branch.
* Add `define( 'CALYPSO_ENV', 'development' );` to `wp-config.php` or `0-sandbox.php`.
* Start connecting Jetpack (but leave before connecting your WPCOM user to the site / said another way: leave Calypso when it asks you to `Approve`).
* Go to `/wp-admin/admin.php?page=jetpack#/connect-user`.
* Click the `Connect your user account` button.
* You should now be redirected to `calypso.localhost:3000` instead of `wordpress.com`.

![Screenshot 2022-02-04 at 14 57 54](https://user-images.githubusercontent.com/3846700/152541187-be1f7b13-6cb8-4697-a9ca-51b119db8a07.png)
