### PR TITLE
Internet Defense League widget: Widget deprecation

### DIFF
--- a/projects/plugins/jetpack/changelog/update-internet-defense-league-widget-deprecate
+++ b/projects/plugins/jetpack/changelog/update-internet-defense-league-widget-deprecate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Internet Defense League widget: Widget deprecation

--- a/projects/plugins/jetpack/modules/widgets/internet-defense-league.php
+++ b/projects/plugins/jetpack/modules/widgets/internet-defense-league.php
@@ -51,6 +51,19 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			'variant'  => key( $this->variants ),
 			'badge'    => key( $this->badges ),
 		);
+
+		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+	}
+
+	/**
+	 * Remove the "Internet Defense League" widget from the Legacy Widget block
+	 *
+	 * @param array $widget_types List of widgets that are currently removed from the Legacy Widget block.
+	 * @return array $widget_types New list of widgets that will be removed.
+	 */
+	public function hide_widget_in_block_editor( $widget_types ) {
+		$widget_types[] = 'internet_defense_league_widget';
+		return $widget_types;
 	}
 
 	public function widget( $args, $instance ) {


### PR DESCRIPTION
The proposed change hides the _Internet Defense League_ widget from the block inserter and _Legacy widget_ block drop-down menu.

**Before**

  Block inserter  |  Legacy Widget block
:-------------------------:|:-------------------------:
![Markup on 2022-02-04 at 17:31:30](https://user-images.githubusercontent.com/25105483/152566665-418fb384-871e-4e30-a595-b8cf7ac98f22.png) | ![Markup on 2022-02-04 at 17:32:10](https://user-images.githubusercontent.com/25105483/152566718-9cb046a7-d0e0-42b1-88f1-250a8e38f1ba.png)

**After**

  Block inserter  |  Legacy Widget block
:-------------------------:|:-------------------------:
![Markup on 2022-02-04 at 17:32:58](https://user-images.githubusercontent.com/25105483/152566781-f0cf3ede-1957-4e46-aa34-1e73e715a3c7.png) | ![Markup on 2022-02-04 at 17:33:54](https://user-images.githubusercontent.com/25105483/152566822-a33c1555-3ace-487d-9b6b-74ed0cfb5057.png)

#### Changes proposed in this Pull Request:
- Add filter to deprecate the _Internet Defense League_ widget

WPCOM version of this widget is out of sync with the Jetpack version and will be deprecated in a related patch: D74186-code.

#### Jetpack product discussion
- this PR is part of the Legacy Widgets Migration project: pdf5j4-4C-p2
- more info can be found in pdf5j4-7f-p2

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Navigate to Customizer → Widgets
2. Add the _Legacy widget_ block and take a look at the dropdown menu. The _Internet Defense League_ widget should not be available.
3. Try to search for the widget in the block inserter in Customizer as well. It should not come up.