### PR TITLE
cli: Split PrefixStream into a generic FilterStream

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,6 +714,12 @@ importers:
       storybook-addon-mock: 2.0.2_react-dom@17.0.2+react@17.0.2
       webpack: 5.65.0
 
+  projects/packages/plans:
+    specifiers: {}
+
+  projects/packages/publicize:
+    specifiers: {}
+
   projects/packages/search:
     specifiers:
       '@automattic/calypso-color-schemes': 2.1.1
@@ -1239,6 +1245,7 @@ importers:
       '@octokit/auth-token': 2.4.5
       '@octokit/rest': 18.6.7
       chai: 4.3.4
+      chai-as-promised: 7.1.1
       chalk: 4.1.2
       configstore: 5.0.1
       envfile: 6.17.0
@@ -1287,6 +1294,7 @@ importers:
       yargs: 16.2.0
     devDependencies:
       chai: 4.3.4
+      chai-as-promised: 7.1.1_chai@4.3.4
       mocha: 8.4.0
       sinon: 9.2.4
       yargs-parser: 20.2.4
@@ -10879,6 +10887,15 @@ packages:
 
   /ccount/1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
+    dev: true
+
+  /chai-as-promised/7.1.1_chai@4.3.4:
+    resolution: {integrity: sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==}
+    peerDependencies:
+      chai: '>= 2.1.2 < 5'
+    dependencies:
+      chai: 4.3.4
+      check-error: 1.0.2
     dev: true
 
   /chai-dom/1.11.0_chai@4.3.4+mocha@8.4.0:

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -21,7 +21,7 @@ import promptForProject from '../helpers/promptForProject.js';
 import { readComposerJson } from '../helpers/json.js';
 import { getInstallArgs, projectDir } from '../helpers/install.js';
 import { allProjects, allProjectsByType } from '../helpers/projectHelpers.js';
-import PrefixTransformStream from '../helpers/prefix-stream.js';
+import PrefixStream from '../helpers/prefix-stream.js';
 
 export const command = 'build [project...]';
 export const describe = 'Builds one or more monorepo projects';
@@ -268,8 +268,8 @@ function createBuildTask( project, argv, title, build ) {
 					const t = {};
 					if ( argv.v ) {
 						const streamArgs = { prefix: ctx.concurrent ? project : null, time: !! argv.timing };
-						const stdout = new PrefixTransformStream( streamArgs );
-						const stderr = new PrefixTransformStream( streamArgs );
+						const stdout = new PrefixStream( streamArgs );
+						const stderr = new PrefixStream( streamArgs );
 						stdout.pipe( process.stdout, { end: false } );
 						stderr.pipe( process.stderr, { end: false } );
 

--- a/tools/cli/helpers/filter-stream.js
+++ b/tools/cli/helpers/filter-stream.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { Buffer } from 'buffer';
+import * as stream from 'stream';
+
+/**
+ * A Transform stream to filter each line.
+ */
+export default class FilterStream extends stream.Transform {
+	#filter;
+	#rest;
+	#onDrain;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param {Function} filter - Function taking a line (without trailing newline) as a parameter and returning a string (replacement line) or null/undefined (to skip the line).
+	 * @param {object} options - Options for stream constructors.
+	 */
+	constructor( filter, options = {} ) {
+		super( options );
+		this.#filter = filter;
+		this.#rest = null;
+	}
+
+	_transform( chunk, encoding, callback ) {
+		this.#rest = this.#rest ? Buffer.concat( [ this.#rest, chunk ] ) : chunk;
+		const func = () => {
+			let s = 0,
+				e,
+				ok = true;
+			while ( ok && ( e = this.#rest.indexOf( '\n', s ) ) >= 0 ) {
+				let line = this.#rest.slice( s, e ).toString();
+				try {
+					line = this.#filter( line );
+				} catch ( err ) {
+					this.#rest = null;
+					callback( err );
+					return false;
+				}
+				s = e + 1;
+				if ( line || line === '' ) {
+					ok = this.push( Buffer.from( line + '\n' ) );
+				}
+			}
+			if ( ok ) {
+				this.#rest = s < this.#rest.length ? this.#rest.slice( s ) : null;
+				callback();
+			} else {
+				this.#rest = this.#rest.slice( s );
+				this.#onDrain = func;
+			}
+			return ok;
+		};
+		func();
+	}
+
+	_flush( callback ) {
+		if ( this.#rest ) {
+			let line = this.#rest.toString();
+			this.#rest = null;
+			try {
+				line = this.#filter( line );
+			} catch ( err ) {
+				callback( err );
+				return;
+			}
+			if ( line || line === '' ) {
+				this.push( Buffer.from( line ) );
+			}
+		}
+		callback();
+	}
+
+	_read( size ) {
+		if ( this.#onDrain ) {
+			const onDrain = this.#onDrain;
+			this.#onDrain = null;
+			if ( onDrain() ) {
+				super._read( size );
+			}
+		} else {
+			super._read( size );
+		}
+	}
+}

--- a/tools/cli/helpers/prefix-stream.js
+++ b/tools/cli/helpers/prefix-stream.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { Buffer } from 'buffer';
-import * as stream from 'stream';
 
 /**
  * Internal dependencies
  */
+import FilterStream from './filter-stream.js';
 import formatDuration from './format-duration.js';
 
 /**
@@ -14,15 +14,9 @@ import formatDuration from './format-duration.js';
  *
  * The data is line buffered to try to avoid interleaved output.
  */
-export default class PrefixTransformStream extends stream.Transform {
-	static #openBracket = Buffer.from( '[' );
-	static #sep = Buffer.from( ' ' );
-	static #closeBracket = Buffer.from( '] ' );
-
+export default class PrefixStream extends FilterStream {
 	#prefix;
 	#startTime;
-	#rest;
-	#onDrain;
 
 	/**
 	 * Constructor.
@@ -34,10 +28,9 @@ export default class PrefixTransformStream extends stream.Transform {
 	constructor( options = {} ) {
 		const opts = { ...options };
 		delete opts.prefix, opts.time;
-		super( opts );
+		super( s => this.#addPrefix( s ), opts );
 
-		this.#prefix = Buffer.from( options.prefix || '' );
-		this.#rest = Buffer.alloc( 0 );
+		this.#prefix = options.prefix || '';
 		if ( options.time === true ) {
 			this.#startTime = Date.now();
 		} else if ( options.time ) {
@@ -46,66 +39,20 @@ export default class PrefixTransformStream extends stream.Transform {
 	}
 
 	/**
-	 * Push a line to the stream.
+	 * Prefixer.
 	 *
-	 * @param {Buffer} line - Line to push.
-	 * @returns {boolean} Whether the push succeeded.
+	 * @param {string} line - Line to prefix.
+	 * @returns {string} Prefixed line.
 	 */
-	#doPush( line ) {
-		if ( ! this.#prefix.length && ! this.#startTime ) {
-			return this.push( line );
-		}
-
-		// Push to the stream as a single buffer to try to avoid split writes.
-		const bufs = [ PrefixTransformStream.#openBracket ];
-		if ( this.#prefix.length > 0 ) {
-			bufs.push( this.#prefix );
+	#addPrefix( line ) {
+		const parts = [];
+		if ( this.#prefix.length ) {
+			parts.push( this.#prefix );
 		}
 		if ( this.#startTime ) {
-			if ( bufs.length > 1 ) {
-				bufs.push( PrefixTransformStream.#sep );
-			}
-			bufs.push( Buffer.from( formatDuration( Date.now() - this.#startTime ) ) );
+			parts.push( formatDuration( Date.now() - this.#startTime ) );
 		}
-		bufs.push( PrefixTransformStream.#closeBracket, line );
 
-		return this.push( Buffer.concat( bufs ) );
-	}
-
-	_transform( chunk, encoding, callback ) {
-		this.#rest = Buffer.concat( [ this.#rest, chunk ] );
-		const func = () => {
-			let i;
-			while ( ( i = this.#rest.indexOf( '\n' ) ) >= 0 ) {
-				const line = this.#rest.slice( 0, ++i );
-				this.#rest = this.#rest.slice( i );
-				if ( ! this.#doPush( line ) ) {
-					this.#onDrain = func;
-					return false;
-				}
-			}
-			callback();
-			return true;
-		};
-		func();
-	}
-
-	_flush( callback ) {
-		if ( this.#rest.length ) {
-			this.#doPush( this.#rest );
-		}
-		callback();
-	}
-
-	_read( size ) {
-		if ( this.#onDrain ) {
-			const onDrain = this.#onDrain;
-			this.#onDrain = null;
-			if ( onDrain() ) {
-				super._read( size );
-			}
-		} else {
-			super._read( size );
-		}
+		return parts.length ? '[' + parts.join( ' ' ) + '] ' + line : line;
 	}
 }

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -46,6 +46,7 @@
 	},
 	"devDependencies": {
 		"chai": "4.3.4",
+		"chai-as-promised": "7.1.1",
 		"mocha": "8.4.0",
 		"sinon": "9.2.4",
 		"yargs-parser": "20.2.4"

--- a/tools/cli/tests/unit/helpers/filter-stream.test.js
+++ b/tools/cli/tests/unit/helpers/filter-stream.test.js
@@ -1,0 +1,170 @@
+/**
+ * External dependencies
+ */
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { once } from 'events';
+import { promisify } from 'util';
+
+/**
+ * Internal dependencies
+ */
+import FilterStream from '../../../helpers/filter-stream.js';
+
+chai.use( chaiAsPromised );
+
+describe( 'FilterStream', () => {
+	it( 'transforms', async () => {
+		const ts = new FilterStream( s => s.toUpperCase(), { encoding: 'utf8' } );
+		ts.pwrite = promisify( ts.write );
+		ts.pend = promisify( ts.end );
+
+		await ts.pwrite( 'line 1\n' );
+		chai.expect( ts.read() ).to.equal( 'LINE 1\n' );
+		await ts.pwrite( 'line 2...' );
+		chai.expect( ts.read() ).to.equal( null );
+		await ts.pwrite( ' ... done\n' );
+		chai.expect( ts.read() ).to.equal( 'LINE 2... ... DONE\n' );
+		await ts.pwrite( 'line 3\nline 4\n\nline 5\n' );
+		chai.expect( ts.read() ).to.equal( 'LINE 3\nLINE 4\n\nLINE 5\n' );
+		await ts.pwrite( '\nline 6\n' );
+		chai.expect( ts.read() ).to.equal( '\nLINE 6\n' );
+		await ts.pwrite( 'line 7\nline 8' );
+		chai.expect( ts.read() ).to.equal( 'LINE 7\n' );
+		await ts.pwrite( '...\nline 9' );
+		chai.expect( ts.read() ).to.equal( 'LINE 8...\n' );
+		await ts.pend();
+		chai.expect( ts.read() ).to.equal( 'LINE 9' );
+	} );
+
+	it( 'filters', async () => {
+		const ts = new FilterStream( s => ( s.match( /\d/ ) ? s : null ), { encoding: 'utf8' } );
+		ts.pwrite = promisify( ts.write );
+		ts.pend = promisify( ts.end );
+
+		await ts.pwrite( 'line 1\nnope\nno\nline 2\nline 3' );
+		await ts.pend();
+		chai.expect( ts.read() ).to.equal( 'line 1\nline 2\nline 3' );
+	} );
+
+	it( 'filters (2)', async () => {
+		const ts = new FilterStream( s => ( s.match( /\d/ ) ? s : null ), { encoding: 'utf8' } );
+		ts.pwrite = promisify( ts.write );
+		ts.pend = promisify( ts.end );
+
+		await ts.pwrite( 'nope\nno\nnot this either' );
+		await ts.pend();
+		chai.expect( ts.read() ).to.equal( null );
+	} );
+
+	it( "doesn't produce a stray line if EOF is a newline", async () => {
+		const ts = new FilterStream( s => `<${ s }>`, { encoding: 'utf8' } );
+		ts.pwrite = promisify( ts.write );
+		ts.pend = promisify( ts.end );
+
+		await ts.pwrite( 'line 1\n' );
+		await ts.pend();
+		chai.expect( ts.read() ).to.equal( '<line 1>\n' );
+	} );
+
+	it( "doesn't produce a stray line if nothing was written", async () => {
+		const ts = new FilterStream( s => `<${ s }>`, { encoding: 'utf8' } );
+		ts.pwrite = promisify( ts.write );
+		ts.pend = promisify( ts.end );
+
+		await ts.pend();
+		chai.expect( ts.read() ).to.equal( null );
+	} );
+
+	it( "doesn't die from backpressure", async () => {
+		const ts = new FilterStream( s => s.toUpperCase(), {
+			encoding: 'utf8',
+			highWaterMark: 100,
+		} );
+
+		let drains = 0;
+		let n = 0;
+		let expect = '';
+		let actual = '';
+		while ( drains < 2 ) {
+			expect += `LINE ${ ++n }...\n`;
+			if ( ts.write( `line ${ n }...\n` ) === false ) {
+				drains++;
+				actual += ts.read();
+			}
+		}
+		ts.end();
+		let chunk;
+		while ( ( chunk = ts.read() ) !== null ) {
+			actual += chunk;
+		}
+		chai.expect( actual ).to.equal( expect );
+	} );
+
+	it( "doesn't die from backpressure (2)", async () => {
+		const ts = new FilterStream( s => s.toUpperCase(), {
+			encoding: 'utf8',
+			highWaterMark: 100,
+		} );
+
+		let n = 0;
+		let expect = '';
+		do {
+			expect += `LINE ${ ++n }...\n`;
+		} while ( ts.write( `line ${ n }...\n` ) !== false );
+		ts.end( 'end' );
+		expect += `END`;
+
+		let actual = '';
+		let chunk;
+		while ( ( chunk = ts.read() ) !== null ) {
+			actual += chunk;
+		}
+		chai.expect( actual ).to.equal( expect );
+	} );
+
+	it( 'handles filter errors', async () => {
+		const ts = new FilterStream(
+			() => {
+				throw new Error( 'nope!' );
+			},
+			{ encoding: 'utf8' }
+		);
+		ts.pwrite = promisify( ts.write );
+		ts.pend = promisify( ts.end );
+
+		const errorEvent = once( ts, 'error' );
+
+		await chai.expect( ts.pwrite( 'line 1\n' ) ).to.eventually.be.rejectedWith( 'nope!' );
+		await chai
+			.expect( errorEvent )
+			.to.eventually.be.an( 'array' )
+			.with.lengthOf( 1 )
+			.with.property( 0 )
+			.is.an( 'error' )
+			.with.property( 'message', 'nope!' );
+	} );
+
+	it( 'handles filter errors (2)', async () => {
+		const ts = new FilterStream(
+			() => {
+				throw new Error( 'nope!' );
+			},
+			{ encoding: 'utf8' }
+		);
+		ts.pwrite = promisify( ts.write );
+		ts.pend = promisify( ts.end );
+
+		const errorEvent = once( ts, 'error' );
+		await ts.pwrite( 'line 1' );
+		// For some reason the end() callback is never called when there's an error. Only the error event.
+		ts.end( () => chai.expect.fail( 'Expected end callback to never be called' ) );
+		await chai
+			.expect( errorEvent )
+			.to.eventually.be.an( 'array' )
+			.with.lengthOf( 1 )
+			.with.property( 0 )
+			.is.an( 'error' )
+			.with.property( 'message', 'nope!' );
+	} );
+} );

--- a/tools/cli/tests/unit/helpers/format-duration.test.js
+++ b/tools/cli/tests/unit/helpers/format-duration.test.js
@@ -25,8 +25,10 @@ const tests = {
 	'0.0000000005': '0.000',
 };
 
-for ( const [ k, v ] of Object.entries( tests ) ) {
-	it( `formats ${ k }`, () => {
-		chai.expect( formatDuration( Number( k ) ) ).to.equal( v );
-	} );
-}
+describe( 'format-duration', () => {
+	for ( const [ k, v ] of Object.entries( tests ) ) {
+		it( `formats ${ k }`, () => {
+			chai.expect( formatDuration( Number( k ) ) ).to.equal( v );
+		} );
+	}
+} );

--- a/tools/cli/tests/unit/helpers/prefix-stream.test.js
+++ b/tools/cli/tests/unit/helpers/prefix-stream.test.js
@@ -6,110 +6,41 @@ import chai from 'chai';
 /**
  * Internal dependencies
  */
-import PrefixTransformStream from '../../../helpers/prefix-stream.js';
+import PrefixStream from '../../../helpers/prefix-stream.js';
 
-it( 'prefixes', async () => {
-	const ts = new PrefixTransformStream( { prefix: 'foobar', encoding: 'utf8' } );
+describe( 'PrefixStream', () => {
+	it( 'prefixes', async () => {
+		const ts = new PrefixStream( { prefix: 'foobar', encoding: 'utf8' } );
 
-	ts.write( 'line 1\n' );
-	chai.expect( ts.read() ).to.equal( '[foobar] line 1\n' );
-	ts.write( 'line 2...' );
-	chai.expect( ts.read() ).to.equal( null );
-	ts.write( ' ... done\n' );
-	chai.expect( ts.read() ).to.equal( '[foobar] line 2... ... done\n' );
-	ts.write( 'line 3\nline 4\nline 5\n' );
-	chai.expect( ts.read() ).to.equal( '[foobar] line 3\n[foobar] line 4\n[foobar] line 5\n' );
-	ts.write( 'line 6\nline 7' );
-	chai.expect( ts.read() ).to.equal( '[foobar] line 6\n' );
-	ts.write( '...\nline 8' );
-	chai.expect( ts.read() ).to.equal( '[foobar] line 7...\n' );
-	ts.end();
-	chai.expect( ts.read() ).to.equal( '[foobar] line 8' );
-} );
-
-it( "doesn't produce a stray prefix if EOF is a newline", async () => {
-	const ts = new PrefixTransformStream( { prefix: 'foobar', encoding: 'utf8' } );
-
-	ts.write( 'line 1\n' );
-	ts.end();
-	chai.expect( ts.read() ).to.equal( '[foobar] line 1\n' );
-} );
-
-it( "doesn't produce a stray prefix if nothing was written", async () => {
-	const ts = new PrefixTransformStream( { prefix: 'foobar', encoding: 'utf8' } );
-
-	ts.end();
-	chai.expect( ts.read() ).to.equal( null );
-} );
-
-it( 'prefixes with timing info', async () => {
-	const ts = new PrefixTransformStream( { prefix: 'foobar', encoding: 'utf8', time: true } );
-
-	ts.write( 'line 1\nline 2' );
-	chai.expect( ts.read() ).to.match( /^\[foobar 0\.0\d\d\] line 1\n$/ );
-	await new Promise( r => {
-		setTimeout( r, 100 );
-	} );
-	ts.end();
-	chai.expect( ts.read() ).to.match( /^\[foobar 0\.1\d\d\] line 2$/ );
-} );
-
-it( 'prefixes with timing info but no prefix', async () => {
-	const ts = new PrefixTransformStream( { encoding: 'utf8', time: Date.now() - 3723000 } );
-
-	ts.write( 'line 1\n' );
-	chai.expect( ts.read() ).to.match( /^\[1:02:03\.0\d\d\] line 1\n$/ );
-} );
-
-it( "doesn't prefix with no timing info and no prefix", async () => {
-	const ts = new PrefixTransformStream( { encoding: 'utf8' } );
-
-	ts.write( 'line 1\n' );
-	chai.expect( ts.read() ).to.equal( 'line 1\n' );
-} );
-
-it( "doesn't die from backpressure", async () => {
-	const ts = new PrefixTransformStream( {
-		prefix: 'foobar',
-		encoding: 'utf8',
-		highWaterMark: 100,
+		ts.write( 'line 1\n\nline 2' );
+		chai.expect( ts.read() ).to.equal( '[foobar] line 1\n[foobar] \n' );
+		ts.end();
+		chai.expect( ts.read() ).to.equal( '[foobar] line 2' );
 	} );
 
-	let drains = 0;
-	let n = 0;
-	let expect = '';
-	let actual = '';
-	while ( drains < 2 ) {
-		expect += `[foobar] line ${ ++n }...\n`;
-		if ( ts.write( `line ${ n }...\n` ) === false ) {
-			drains++;
-			actual += ts.read();
-		}
-	}
-	ts.end();
-	actual += ts.read();
-	chai.expect( actual ).to.equal( expect );
-} );
+	it( 'prefixes with timing info', async () => {
+		const ts = new PrefixStream( { prefix: 'foobar', encoding: 'utf8', time: true } );
 
-it( "doesn't die from backpressure (2)", async () => {
-	const ts = new PrefixTransformStream( {
-		prefix: 'foobar',
-		encoding: 'utf8',
-		highWaterMark: 100,
+		ts.write( 'line 1\nline 2' );
+		chai.expect( ts.read() ).to.match( /^\[foobar 0\.0\d\d\] line 1\n$/ );
+		await new Promise( r => {
+			setTimeout( r, 100 );
+		} );
+		ts.end();
+		chai.expect( ts.read() ).to.match( /^\[foobar 0\.1\d\d\] line 2$/ );
 	} );
 
-	let n = 0;
-	let expect = '';
-	do {
-		expect += `[foobar] line ${ ++n }...\n`;
-	} while ( ts.write( `line ${ n }...\n` ) !== false );
-	ts.end( 'end' );
-	expect += `[foobar] end`;
+	it( 'prefixes with timing info but no prefix', async () => {
+		const ts = new PrefixStream( { encoding: 'utf8', time: Date.now() - 3723000 } );
 
-	let actual = '';
-	let chunk;
-	while ( ( chunk = ts.read() ) !== null ) {
-		actual += chunk;
-	}
-	chai.expect( actual ).to.equal( expect );
+		ts.write( 'line 1\n' );
+		chai.expect( ts.read() ).to.match( /^\[1:02:03\.0\d\d\] line 1\n$/ );
+	} );
+
+	it( "doesn't prefix with no timing info and no prefix", async () => {
+		const ts = new PrefixStream( { encoding: 'utf8' } );
+
+		ts.write( 'line 1\n' );
+		chai.expect( ts.read() ).to.equal( 'line 1\n' );
+	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
I found I'm going to need the "process each line" logic elsewhere too,
so let's split that out from the prefixing.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The CLI build command should continue to work the same, no changes.