### PR TITLE
PHPCS: Ignore rule by file for WP.com

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -7,11 +7,6 @@
 	<!-- Default ruleset. -->
 	<rule ref="Jetpack" />
 
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
-		<!-- Template files use extracted variables. -->
-		<exclude-pattern>/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/*</exclude-pattern>
-	</rule>
-
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">

--- a/projects/plugins/jetpack/changelog/update-phpcs-remove-global-exemption
+++ b/projects/plugins/jetpack/changelog/update-phpcs-remove-global-exemption
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Move PHPCS ignore to pass WP.com linting
+
+

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- This file expects $template_props set outside the file.
+
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+//phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- This file expects $template_props set outside the file.
+
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 /**
@@ -43,7 +45,11 @@ $track_link = empty( $template_props['track']['link'] ) ? $template_props['track
 		<?php endif; // phpcs:enable ?>
 	</span>
 
-	<?php if ( ! empty( $template_props['title'] ) ) : ?>
+	<?php
+	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- This file expects $template_props set outside the file.
+
+	if ( ! empty( $template_props['title'] ) ) :
+		?>
 		<span class="jetpack-podcast-player--visually-hidden"> - </span>
 
 		<?php

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- This file expects $template_props set outside the file.
+
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/podcast-title.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/podcast-title.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- This file expects $template_props set outside the file.
+
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The Jetpack ruleset is not used on WP.com, so our rule excluding the podcast template files from the undeclared variable sniff does not apply. We can remove that to disable by file so it'll work on WP.com.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves PHPCS ignore.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
