### PR TITLE
Removed duplicate docblock for jetpack_relatedposts_returned_results filter

### DIFF
--- a/projects/plugins/jetpack/changelog/rm-duplicate-docblock-related-posts
+++ b/projects/plugins/jetpack/changelog/rm-duplicate-docblock-related-posts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Removed duplicate docblock for jetpack_relatedposts_returned_results filter and updated $post_id type to int

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -859,7 +859,7 @@ EOT;
 		 * @since 2.8.0
 		 *
 		 * @param array $results Array of related posts matched by Elasticsearch.
-		 * @param string $post_id Post ID of the post for which we are retrieving Related Posts.
+		 * @param int $post_id Post ID of the post for which we are retrieving Related Posts.
 		 */
 		return apply_filters( 'jetpack_relatedposts_returned_results', $results, $post_id );
 	}
@@ -1255,16 +1255,7 @@ EOT;
 			),
 		);
 
-		/**
-		 * Filter the array of related posts.
-		 *
-		 * @module related-posts
-		 *
-		 * @since 2.8.0
-		 *
-		 * @param array $results Array of related posts.
-		 * @param int $post_id Post ID of the post for which we are retrieving Related Posts.
-		 */
+		/** This filter is already documented in modules/related-posts/jetpack-related-posts.php */
 		return apply_filters( 'jetpack_relatedposts_returned_results', $related_posts, $post_id );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
https://github.com/Automattic/jetpack/pull/22270#issuecomment-1024368342

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removed duplicate `jetpack_relatedposts_returned_results` filter docblock 
* Updated `$post_id` type to int

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
NA

* Go to '..'
*
