### PR TITLE
Always show the Activate a Product button

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -314,7 +314,7 @@ class MyPlanHeader extends React.Component {
 	renderPlan() {
 		return (
 			<>
-				{ this.props.hasDetachedUserLicenses && this.renderLicensingActions() }
+				{ this.renderLicensingActions() }
 				<Card compact>
 					{ this.renderHeader( __( 'My Plan', 'jetpack' ) ) }
 					<MyPlanCard { ...this.getProductProps( this.props.plan ) } />
@@ -342,7 +342,13 @@ class MyPlanHeader extends React.Component {
 		return <h3 className="jp-landing__card-header">{ title }</h3>;
 	}
 
-	renderLicensingActions = () => {
+	/**
+	 * Renders license related actions
+	 *
+	 * @param {'header'|'footer'} position - Whether the actions are for header or footer
+	 * @returns {React.ReactElement} The licence actions
+	 */
+	renderLicensingActions = ( position = 'header' ) => {
 		const {
 			hasDetachedUserLicenses,
 			showRecommendations: showRecommendationsButton,
@@ -354,12 +360,12 @@ class MyPlanHeader extends React.Component {
 			return null;
 		}
 
-		const showPurchasesLink = !! purchases?.length || hasDetachedUserLicenses;
+		const showPurchasesLink = !! purchases?.length && 'header' === position;
 
 		return (
 			<Card compact>
 				<div className="jp-landing__licensing-actions">
-					{ hasDetachedUserLicenses && (
+					{ 'header' === position && (
 						<span>{ __( 'Got a license key? Activate it here.', 'jetpack' ) }</span>
 					) }
 					<div
@@ -379,7 +385,7 @@ class MyPlanHeader extends React.Component {
 								{ __( 'View all purchases', 'jetpack' ) }
 							</ExternalLink>
 						) }
-						{ hasDetachedUserLicenses ? (
+						{ 'header' === position ? (
 							<Button
 								href={ siteAdminUrl + 'admin.php?page=jetpack#/license/activation' }
 								onClick={ this.trackLicenseActivationClick }
@@ -426,7 +432,7 @@ class MyPlanHeader extends React.Component {
 		return (
 			// The activation label should be displayed in the footer only if
 			// there is no product to be activated.
-			! this.props.hasDetachedUserLicenses && this.renderLicensingActions()
+			! this.props.hasDetachedUserLicenses && this.renderLicensingActions( 'footer' )
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/update-always-show-activate-a-product
+++ b/projects/plugins/jetpack/changelog/update-always-show-activate-a-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Updated the logic for "Activate a Product" button in "My Plan" to be always visible.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1164141197617539-as-1201757324416015/f

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the logic for "Activate a Product" button in "My Plan" to be always visible.
* Previously it was visible only if the user had at least one detached purchase.

#### Jetpack product discussion
pbNhbs-1dQ-p2
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure that your WPCOM account doesn't have any detached Jetpack purchases
* Boot up this PR and fire it up
* Go to wp-admin > Jetpack > My Plan
* Confirm that "Activate a Product" button is visible
* Now add a detached license to your WPCOM account
* To do that, goto to [cloud.jetpack.com/pricing](https://cloud.jetpack.com/pricing) and purchase any plan and don't attach it to any site.
* Now goto My Plan page again
* Confirm that you see the notice above the navigation about an available product license key.
* Confirm that "Activate a Product" button is visible


#### Screenshots

##### Without detached license (See the Activate a Product button)
| BEFORE | AFTER |
|-|-|
| <img width="1006" alt="Screenshot 2022-02-07 at 2 55 30 PM" src="https://user-images.githubusercontent.com/18226415/152769329-bafdc8c4-9aa9-4bef-86ed-ddcb9a47c491.png"> | <img width="1010" alt="Screenshot 2022-02-07 at 2 55 50 PM" src="https://user-images.githubusercontent.com/18226415/152769377-1c48dc45-cdf0-4e64-bb8a-0ee2eef00cf1.png"> |

##### With detached license (No difference)
| BEFORE | AFTER |
|-|-|
| <img width="1015" alt="Screenshot 2022-02-07 at 2 57 25 PM" src="https://user-images.githubusercontent.com/18226415/152769641-a1036d0c-5c11-4a98-b144-d9dcd96e8dbd.png"> | <img width="1007" alt="Screenshot 2022-02-07 at 3 03 18 PM" src="https://user-images.githubusercontent.com/18226415/152769673-e1467173-189f-4b71-a5ee-fab40633ef01.png"> |
