### PR TITLE
My Jetpack: Set checkout URL for the Product

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/plans-section/stories/mock-data.js
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/stories/mock-data.js
@@ -1,5 +1,6 @@
 window.myJetpackInitialState = {
 	siteSuffix: 'my-jetpack-mock-site.com',
+	redirectUrl: 'https://my-jetpack-mock-site.com/wp-admin/?page=my-jetpack',
 };
 
 export const siteWithSecurityPlanResponseBody = {

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -15,6 +15,7 @@ import { useProduct } from '../../hooks/use-product';
 import { BackupIcon } from '../product-cards-section/backup-card';
 import styles from './style.module.scss';
 import { BoostIcon } from '../product-cards-section/boost-card';
+import getProductCheckoutUrl from '../../utils/get-product-checkout-url';
 
 /**
  * Simple react component to render the product icon,
@@ -72,6 +73,7 @@ const ProductDetail = ( { slug, trackButtonClick } ) => {
 	const { detail } = useProduct( slug );
 	const { title, longDescription, features, pricingForUi = {} } = detail;
 	const { isFree, fullPrice, currencyCode } = pricingForUi;
+	const addProductUrl = getProductCheckoutUrl( `jetpack_${ slug }` ); // @ToDo: Remove this when we have a new product structure.
 
 	return (
 		<div className={ styles.container }>
@@ -106,7 +108,7 @@ const ProductDetail = ( { slug, trackButtonClick } ) => {
 				onClick={ trackButtonClick }
 				isLink
 				isPrimary
-				href="#"
+				href={ addProductUrl }
 				className={ styles[ 'checkout-button' ] }
 			>
 				{

--- a/projects/packages/my-jetpack/_inc/constants.js
+++ b/projects/packages/my-jetpack/_inc/constants.js
@@ -1,1 +1,2 @@
 export const MY_JETPACK_MY_PLANS_MANAGE_SOURCE = 'my-jetpack-my-plans-manage';
+export const MY_JETPACK_PRODUCT_CHECKOUT = 'my-jetpack-product-checkout';

--- a/projects/packages/my-jetpack/_inc/utils/get-product-checkout-url.js
+++ b/projects/packages/my-jetpack/_inc/utils/get-product-checkout-url.js
@@ -1,0 +1,30 @@
+// eslint-disable-next-line no-unused-vars
+/* global myJetpackInitialState */
+
+/**
+ * External dependencies
+ */
+import { getRedirectUrl } from '@automattic/jetpack-components';
+
+/**
+ * Internal dependencies
+ */
+import { MY_JETPACK_PRODUCT_CHECKOUT } from '../constants';
+
+/**
+ * Return the product redirect URL, according to
+ * the Jetpack redirect source, site, path, and redirect_to params.
+ *
+ * @param {string} product - Checkout product name
+ * @returns {string} the redirect URL
+ */
+export default function getProductCheckoutUrl( product ) {
+	const { siteSuffix: site, redirectUrl } = window?.myJetpackInitialState || {};
+	const redirect_to = `${ redirectUrl }&product=${ product }`;
+
+	return getRedirectUrl( MY_JETPACK_PRODUCT_CHECKOUT, {
+		site,
+		path: 'jetpack_search',
+		query: `redirect_to=${ redirect_to }`,
+	} );
+}

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-add-product-checkout-link
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-add-product-checkout-link
@@ -1,0 +1,4 @@
+Significance: major
+Type: added
+
+Set the checkout URL for the Product detail component

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -73,7 +73,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-master": "0.5.x-dev"
+			"dev-master": "0.6.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "0.5.1-alpha",
+	"version": "0.6.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/backup/changelog/update-my-jetpack-add-product-checkout-link
+++ b/projects/plugins/backup/changelog/update-my-jetpack-add-product-checkout-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-connection": "1.36.x-dev",
 		"automattic/jetpack-connection-ui": "2.3.x-dev",
 		"automattic/jetpack-identity-crisis": "0.7.x-dev",
-		"automattic/jetpack-my-jetpack": "0.5.x-dev",
+		"automattic/jetpack-my-jetpack": "0.6.x-dev",
 		"automattic/jetpack-sync": "1.29.x-dev",
 		"automattic/jetpack-status": "1.10.x-dev"
 	},

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3a6891977d5f9e3a9b540f58682effe",
+    "content-hash": "ef796c5e5c9fde0ef9033b11e358a684",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -778,7 +778,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0a4354d247242a1fbc56373c2ddd4ccacab62d52"
+                "reference": "a441de113bf2be6a47891d1fabb0d9377c8bb17c"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -804,7 +804,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.5.x-dev"
+                    "dev-master": "0.6.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-add-product-checkout-link
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-add-product-checkout-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -31,7 +31,7 @@
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"automattic/jetpack-licensing": "1.6.x-dev",
 		"automattic/jetpack-logo": "1.5.x-dev",
-		"automattic/jetpack-my-jetpack": "0.5.x-dev",
+		"automattic/jetpack-my-jetpack": "0.6.x-dev",
 		"automattic/jetpack-options": "1.14.x-dev",
 		"automattic/jetpack-partner": "1.6.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3ad0f7d5068bf5c2b3d734da62195d8",
+    "content-hash": "dcf84356c024c6e9724c897287cc9f85",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1165,7 +1165,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "0a4354d247242a1fbc56373c2ddd4ccacab62d52"
+                "reference": "a441de113bf2be6a47891d1fabb0d9377c8bb17c"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1191,7 +1191,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.5.x-dev"
+                    "dev-master": "0.6.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR sets the checkout URL for the `Add Product` button, on the product detail page. The URL is based on the redirects Jetpack system.

### Follow-up tasks

* Keep working on the action post buying the product. We'd like to be able to redirect wherever we want, activate the product, and so on.

Fixes https://github.com/Automattic/jetpack/issues/22701

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Set checkout URL for the Product

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a site without the Search product
* Go to My Jetpack dashboard
* You should see the `Add Search` link in the product card
* It should redirect to the checkout page by clicking on the Add product button
* Once you buy the product, it should go back to the My Jetpack dashboard
* Now, you should be able to activate/deactivate the Search product.


https://user-images.githubusercontent.com/77539/152866560-71deeab4-6a1a-4bc8-b539-bc39ceb657d0.mov

* Confirm visually you see the Free text there

**Using Storybook**

* Build My Jetpack

```bash
> jetpack build packages/my-jetpack
```

* Run storybook

```bash
cd ./jetpack/projects/js-packages/storybook
```

```bash
> pnpm install & pnpm storybook:dev
```

* Take a look at the URL defined in the `Add product` button. It should be something like...
```
https://jetpack.com/redirect/?source=my-jetpack-product-checkout&site=my-jetpack-mock-site.com&path=jetpack_search&query=redirect_to%3Dhttps%3A%2F%2Fmy-jetpack-mock-site.com%2Fwp-admin%2F%3Fpage%3Dmy-jetpack%26product%3Djetpack_boost
```

The parts of the URL contains `source`, `path`, and `query`.