### PR TITLE
My Jetpack: Support multiple folder for each plugin

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-support-multiple-folders-for-plugin
+++ b/projects/packages/my-jetpack/changelog/update-support-multiple-folders-for-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Support multiple possible folder for each plugin

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -25,14 +25,18 @@ class Backup extends Hybrid_Product {
 	public static $slug = 'backup';
 
 	/**
-	 * The filename (id) of the plugin associated with this product. If not defined, it will default to the Jetpack plugin
+	 * The filename (id) of the plugin associated with this product.
 	 *
 	 * @var string
 	 */
-	public static $plugin_filename = 'jetpack-backup/jetpack-backup.php';
+	public static $plugin_filename = array(
+		'jetpack-backup/jetpack-backup.php',
+		'backup/jetpack-backup.php',
+		'jetpack-backup-dev/jetpack-backup.php',
+	);
 
 	/**
-	 * The slug of the plugin associated with this product. If not defined, it will default to the Jetpack plugin
+	 * The slug of the plugin associated with this product.
 	 *
 	 * @var string
 	 */

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -22,14 +22,17 @@ class Boost extends Product {
 	public static $slug = 'boost';
 
 	/**
-	 * The filename (id) of the plugin associated with this product. If not defined, it will default to the Jetpack plugin
+	 * The filename (id) of the plugin associated with this product.
 	 *
 	 * @var string
 	 */
-	public static $plugin_filename = 'boost/jetpack-boost.php';
-
+	public static $plugin_filename = array(
+		'jetpack-boost/jetpack-boost.php',
+		'boost/jetpack-boost.php',
+		'jetpack-boost-dev/jetpack-boost.php',
+	);
 	/**
-	 * The slug of the plugin associated with this product. If not defined, it will default to the Jetpack plugin
+	 * The slug of the plugin associated with this product.
 	 *
 	 * @var string
 	 */

--- a/projects/packages/my-jetpack/tests/php/test-hybrid-product.php
+++ b/projects/packages/my-jetpack/tests/php/test-hybrid-product.php
@@ -57,7 +57,7 @@ class Test_Hybrid_Product extends TestCase {
 		if ( ! file_exists( WP_PLUGIN_DIR . '/jetpack' ) ) {
 			mkdir( WP_PLUGIN_DIR . '/jetpack', 0777, true );
 		}
-		copy( __DIR__ . '/assets/backup-mock-plugin.txt', WP_PLUGIN_DIR . '/' . Backup::$plugin_filename );
+		copy( __DIR__ . '/assets/backup-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack-backup/jetpack-backup.php' );
 		copy( __DIR__ . '/assets/jetpack-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack/jetpack.php' );
 	}
 
@@ -85,7 +85,7 @@ class Test_Hybrid_Product extends TestCase {
 	 */
 	public function test_if_jetpack_inactive_and_backup_active_return_true() {
 		deactivate_plugins( 'jetpack/jetpack.php' );
-		activate_plugins( Backup::$plugin_filename );
+		activate_plugins( Backup::get_installed_plugin_filename() );
 		$this->assertTrue( Backup::is_active() );
 	}
 
@@ -94,7 +94,7 @@ class Test_Hybrid_Product extends TestCase {
 	 */
 	public function test_if_jetpack_inactive_and_backup_inactive_return_false() {
 		deactivate_plugins( 'jetpack/jetpack.php' );
-		deactivate_plugins( Backup::$plugin_filename );
+		deactivate_plugins( Backup::get_installed_plugin_filename() );
 		$this->assertFalse( Backup::is_active() );
 	}
 

--- a/projects/packages/my-jetpack/tests/php/test-product-multiple-filenames.php
+++ b/projects/packages/my-jetpack/tests/php/test-product-multiple-filenames.php
@@ -1,0 +1,170 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\My_Jetpack\Products\Backup;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+
+/**
+ * Unit tests for the REST API endpoints.
+ *
+ * @package automattic/my-jetpack
+ * @see \Automattic\Jetpack\My_Jetpack\Rest_Products
+ */
+class Test_Product_Multiple_Filenames extends TestCase {
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * The secondary user id.
+	 *
+	 * @var int
+	 */
+	private static $secondary_user_id;
+
+	/**
+	 * The possible folders for the Backup plugin
+	 *
+	 * @var int
+	 */
+	private static $possible_folders = array(
+		'backup',
+		'jetpack-backup',
+		'jetpack-backup-dev',
+	);
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+
+		if ( version_compare( phpversion(), '5.7', '<=' ) ) {
+			$this->markTestSkipped( 'avoid bug in PHP 5.6 that throws strict mode warnings for abstract static methods.' );
+		}
+
+	}
+
+	/**
+	 * Installs the mock plugin present in the test assets folder as if it was the Boost plugin
+	 *
+	 * @param string $dest_folder The folder destination for the mock backup plugin.
+	 *
+	 * @return void
+	 */
+	public function install_mock_plugin( $dest_folder ) {
+		$plugin_dir = WP_PLUGIN_DIR . '/' . $dest_folder;
+		if ( ! file_exists( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0777, true );
+		}
+
+		copy( __DIR__ . '/assets/backup-mock-plugin.txt', WP_PLUGIN_DIR . '/' . $dest_folder . '/jetpack-backup.php' );
+
+	}
+
+	/**
+	 * Uninstalls the Backup mock plugin
+	 *
+	 * @return void
+	 */
+	public function uninstall_mock_plugins() {
+		foreach ( self::$possible_folders as $folder ) {
+			if ( file_exists( WP_PLUGIN_DIR . '/' . $folder . '/jetpack-backup.php' ) ) {
+				unlink( WP_PLUGIN_DIR . '/' . $folder . '/jetpack-backup.php' );
+				rmdir( WP_PLUGIN_DIR . '/' . $folder );
+			}
+		}
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+
+		WorDBless_Options::init()->clear_options();
+
+	}
+
+	/**
+	 * Data provider for test_installed_plugin_filename
+	 *
+	 * @return array
+	 */
+	public function installed_plugin_filename_data() {
+		$data = array();
+		foreach ( self::$possible_folders as $folder ) {
+			$data[ $folder ] = array( $folder );
+		}
+		$data['invalid'] = array(
+			'invalid_folder',
+			false,
+		);
+		return $data;
+	}
+
+	/**
+	 * Data provider for test_activate
+	 *
+	 * @return array
+	 */
+	public function activate_data() {
+		$data = array();
+		foreach ( self::$possible_folders as $folder ) {
+			$data[ $folder ] = array( $folder );
+		}
+		return $data;
+	}
+
+	/**
+	 * Tests multiple folders for a plugin
+	 *
+	 * @param string $folder The folder of the Backup plugin.
+	 * @param bool   $success whether we expect to find the plugin or not.
+	 *
+	 * @dataProvider installed_plugin_filename_data
+	 */
+	public function test_installed_plugin_filename( $folder, $success = true ) {
+		$this->uninstall_mock_plugins();
+		$this->install_mock_plugin( $folder );
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		$this->assertSame( $success, Backup::is_plugin_installed() );
+		$expected_file = $success ? $folder . '/jetpack-backup.php' : null;
+		$this->assertSame( $expected_file, Backup::get_installed_plugin_filename() );
+
+	}
+
+	/**
+	 * Tests multiple folders for a plugin - activation
+	 *
+	 * @param string $folder The folder of the Backup plugin.
+	 *
+	 * @dataProvider activate_data
+	 */
+	public function test_activate( $folder ) {
+		$this->uninstall_mock_plugins();
+		$this->install_mock_plugin( $folder );
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		$filename = Backup::get_installed_plugin_filename();
+
+		$this->assertFalse( Backup::is_active() );
+		$this->assertFalse( is_plugin_active( $filename ) );
+
+		Backup::activate();
+
+		$this->assertTrue( Backup::is_active() );
+		$this->assertTrue( is_plugin_active( $filename ) );
+
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Plugins developed in the monorepo might run in different folder names depending on the context.

For example, the backup main file can be:

* `backup/jetpack-backup.php` in the monorepo
* `jetpack-backup/jetpack-backup.php` in the distributed plugin
* `jetpack-backup-dev/jetpack-backup.php` when used via Jetpack Beta plugin

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Support multiple folder for each plugin

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Plugin status and activation should work in the local environment, in Jurassic Ninja and in Jurassic Ninja with Jetpack Beta.

Let's try this with Boost.

In your local dev environment:

* Install and connect Backup just so you have access to the My Jetpack page
* Check that Boost is not active
* Activate Boost plugin
* Go back to My Jetpack and see that Boost is now active

Now spin up a Jurassic Ninja site and do the same

Now let's try with Jetpack Beta
* Remove installed Boost
* Activate Jetpack Beta
* Activate Jetpack Boost bleeding edge
* Go to My Jetpack page and verify that My Jetpack is able to correctly determine Boost status and activate/deactivate it
