### PR TITLE
Related Posts Block: Add color, spacing, typography & align design tools.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-related-posts-block-design-tools
+++ b/projects/plugins/jetpack/changelog/add-related-posts-block-design-tools
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add design tools for related posts block.

--- a/projects/plugins/jetpack/changelog/add-related-posts-block-design-tools
+++ b/projects/plugins/jetpack/changelog/add-related-posts-block-design-tools
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Add design tools for related posts block.
+Related Posts block: Add design tools (align, color, typography & spacing)

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/index.js
@@ -64,6 +64,18 @@ export const settings = {
 		html: false,
 		multiple: false,
 		reusable: false,
+		color: {
+			gradients: true,
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+		},
+		align: [ 'wide', 'full' ],
 	},
 
 	transforms: {

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/index.js
@@ -66,6 +66,7 @@ export const settings = {
 		reusable: false,
 		color: {
 			gradients: true,
+			link: true,
 		},
 		spacing: {
 			margin: true,

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -80,7 +80,7 @@ class Jetpack_RelatedPosts {
 				'supports'        => array(
 					'color'      => array(
 						'gradients' => true,
-						'links'     => true,
+						'link'      => true,
 					),
 					'spacing'    => array(
 						'margin'  => true,

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -77,6 +77,21 @@ class Jetpack_RelatedPosts {
 			'jetpack/related-posts',
 			array(
 				'render_callback' => array( $this, 'render_block' ),
+				'supports'        => array(
+					'color'      => array(
+						'gradients' => true,
+						'links'     => true,
+					),
+					'spacing'    => array(
+						'margin'  => true,
+						'padding' => true,
+					),
+					'typography' => array(
+						'fontSize'   => true,
+						'lineHeight' => true,
+					),
+					'align'      => array( 'wide', 'full' ),
+				),
 			)
 		);
 	}
@@ -409,8 +424,12 @@ EOT;
 			$rows_markup .= $this->render_block_row( $lower_row_posts, $block_attributes );
 		}
 
+		$wrapper_attributes = \WP_Block_Supports::get_instance()->apply_block_supports();
+
 		$display_markup = sprintf(
-			'<nav class="jp-relatedposts-i2" data-layout="%1$s">%2$s%3$s</nav>',
+			'<nav class="jp-relatedposts-i2%1$s"%2$s data-layout="%3$s">%4$s%5$s</nav>',
+			! empty( $wrapper_attributes['class'] ) ? ' ' . esc_attr( $wrapper_attributes['class'] ) : '',
+			! empty( $wrapper_attributes['style'] ) ? ' style="' . esc_attr( $wrapper_attributes['style'] ) . '"' : '',
 			esc_attr( $block_attributes['layout'] ),
 			$block_attributes['headline'],
 			$rows_markup


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add color, spacing, typography & align (wide & full) design tools to the Related Posts block.

![image](https://user-images.githubusercontent.com/1287077/153438860-a172a381-3e24-479e-aced-30c3373f393e.png)

![image](https://user-images.githubusercontent.com/1287077/153438876-1972634f-8fbc-4d4a-8aed-c60ce8524445.png)

#### Jetpack product discussion
This PR is a part of the Expanding Jetpack Block design tooling for Full Site Editing project: pdDOJh-1P-p2 & pdDOJh-6-p2

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:

I recommend testing this on a sandboxed existing WPCOM site using D74562-code as you'll need data for Related Posts.

1. Add Related Post block.
2. On the **Block Inspector** sidebar, you should see:
    - Color (Text, Background, Link option)
    - Typography (Size & Line Height option)
    - Dimensions (Padding & Margin option)
3. On the **Block Toolbar**, you should see:
    - Align (Full & Wide align option)
4. Check that they render fine both on the editor and the post page itself.

Note: Different themes may support different style attributes. Some theme suggestions to test on: Quadrat (Quadrat White is great), Geologist, TT1 (Blocks), Seedlet (Blocks).