### PR TITLE
Premium content: Switch view

### DIFF
--- a/projects/plugins/jetpack/changelog/try-payment-selects
+++ b/projects/plugins/jetpack/changelog/try-payment-selects
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+When content within a premium-content view is selected in the editor, switch to that view

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -6,7 +6,7 @@ import { Disabled, Placeholder, Spinner, ToolbarButton, ToolbarGroup } from '@wo
 import { BlockControls } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
-import { select, withSelect, withDispatch } from '@wordpress/data';
+import { select, useSelect, withSelect, withDispatch } from '@wordpress/data';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import formatCurrency from '@automattic/format-currency';
 import apiFetch from '@wordpress/api-fetch';
@@ -218,12 +218,13 @@ function Edit( props ) {
 
 	const { isSelected, className } = props;
 
+	const selectedBlock = useSelect( selector => selector( 'core/block-editor' ).getSelectedBlock() );
+
 	useEffect( () => {
 		if ( isSelected ) {
 			return; // If this block is selected then leave the focused tab as it was.
 		}
 
-		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
 		if ( ! selectedBlock ) {
 			return; // Sometimes there isn't a block selected, e.g. on page load.
 		}
@@ -254,7 +255,7 @@ function Edit( props ) {
 			selectTab( tabs[ 0 ] );
 			return;
 		}
-	}, [ clientId, isSelected ] );
+	}, [ clientId, isSelected, selectedBlock ] );
 
 	useEffect( () => {
 		if ( isPreview ) {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -244,16 +244,8 @@ function Edit( props ) {
 			).length
 		) {
 			selectTab( tabs[ 1 ] );
-			return;
-		} else if (
-			'premium-content/subscriber-view' === selectedBlock.name ||
-			select( 'core/block-editor' ).getBlockParentsByBlockName(
-				selectedBlock.clientId,
-				'premium-content/subscriber-view'
-			).length
-		) {
+		} else {
 			selectTab( tabs[ 0 ] );
-			return;
 		}
 	}, [ clientId, isSelected, selectedBlock ] );
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -229,16 +229,16 @@ function Edit( props ) {
 			return; // Sometimes there isn't a block selected, e.g. on page load.
 		}
 
+		const editorStore = select( 'core/block-editor' );
+
 		// Confirm that the selected block is a descendant of this one.
-		if (
-			! select( 'core/block-editor' ).getBlockParents( selectedBlock.clientId ).includes( clientId )
-		) {
+		if ( ! editorStore.getBlockParents( selectedBlock.clientId ).includes( clientId ) ) {
 			return;
 		}
 
 		if (
 			'premium-content/logged-out-view' === selectedBlock.name ||
-			select( 'core/block-editor' ).getBlockParentsByBlockName(
+			editorStore.getBlockParentsByBlockName(
 				selectedBlock.clientId,
 				'premium-content/logged-out-view'
 			).length

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -30,6 +30,10 @@ import InvalidSubscriptionWarning from './_inc/invalid-subscription-warning';
  */
 
 /**
+ * Tab definitions
+ *
+ * If changing or adding tabs, the _TAB constants below might need changing too.
+ *
  * @typedef { import('./tabs').Tab } Tab
  * @type { Tab[] }
  */
@@ -45,6 +49,9 @@ const tabs = [
 		className: 'wp-premium-content-logged-out-view',
 	},
 ];
+
+const CONTENT_TAB = 0;
+const WALL_TAB = 1;
 
 const API_STATE_LOADING = 0;
 const API_STATE_CONNECTED = 1;
@@ -82,7 +89,7 @@ const defaultString = null;
  */
 
 function Edit( props ) {
-	const [ selectedTab, selectTab ] = useState( tabs[ 1 ] );
+	const [ selectedTab, selectTab ] = useState( tabs[ WALL_TAB ] );
 	const [ selectedInnerBlock, hasSelectedInnerBlock ] = useState( false );
 	const [ products, setProducts ] = useState( emptyProducts );
 	const [ connectURL, setConnectURL ] = useState( defaultString );
@@ -243,9 +250,9 @@ function Edit( props ) {
 				'premium-content/logged-out-view'
 			).length
 		) {
-			selectTab( tabs[ 1 ] );
+			selectTab( tabs[ WALL_TAB ] );
 		} else {
-			selectTab( tabs[ 0 ] );
+			selectTab( tabs[ CONTENT_TAB ] );
 		}
 	}, [ clientId, isSelected, selectedBlock ] );
 
@@ -364,7 +371,7 @@ function Edit( props ) {
 				<ToolbarGroup>
 					<ToolbarButton
 						onClick={ () => {
-							selectTab( tabs[ 1 ] );
+							selectTab( tabs[ WALL_TAB ] );
 						} }
 						className="components-tab-button"
 						isPressed={ selectedTab.className === 'wp-premium-content-logged-out-view' }
@@ -373,7 +380,7 @@ function Edit( props ) {
 					</ToolbarButton>
 					<ToolbarButton
 						onClick={ () => {
-							selectTab( tabs[ 0 ] );
+							selectTab( tabs[ CONTENT_TAB ] );
 						} }
 						className="components-tab-button"
 						isPressed={ selectedTab.className !== 'wp-premium-content-logged-out-view' }

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/edit.js
@@ -3,26 +3,13 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useDispatch, withSelect } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Context from '../_inc/context';
 
-function Edit( { parentClientId, isSelected } ) {
-	const { selectBlock } = useDispatch( 'core/block-editor' );
-
-	useEffect( () => {
-		if ( isSelected ) {
-			// The logged-out view is managed by the parent premium-content/container block,
-			// so here we ensure that the parent block is selected instead.
-			selectBlock( parentClientId );
-		}
-	}, [ selectBlock, isSelected, parentClientId ] );
-
+export default function Edit() {
 	return (
 		<Context.Consumer>
 			{ ( { selectedTab, stripeNudge } ) => (
@@ -49,17 +36,3 @@ function Edit( { parentClientId, isSelected } ) {
 		</Context.Consumer>
 	);
 }
-
-export default compose(
-	withSelect( select => {
-		const { getBlockParents, getSelectedBlockClientId } = select( 'core/block-editor' );
-
-		const selectedBlockClientId = getSelectedBlockClientId();
-		const parents = getBlockParents( selectedBlockClientId );
-		const parentClientId = parents.length ? parents[ parents.length - 1 ] : undefined;
-
-		return {
-			parentClientId,
-		};
-	} )
-)( Edit );

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/edit.js
@@ -3,26 +3,15 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useDispatch, withSelect } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Context from '../_inc/context';
 
-function Edit( { hasInnerBlocks, parentClientId, isSelected } ) {
-	const { selectBlock } = useDispatch( 'core/block-editor' );
-
-	useEffect( () => {
-		if ( isSelected ) {
-			// The subscriber view is managed by the parent premium-content/container block,
-			// so here we ensure that the parent block is selected instead.
-			selectBlock( parentClientId );
-		}
-	}, [ selectBlock, isSelected, parentClientId ] );
-
+function Edit( { hasInnerBlocks } ) {
 	return (
 		<Context.Consumer>
 			{ ( { selectedTab, stripeNudge } ) => (
@@ -55,14 +44,7 @@ function Edit( { hasInnerBlocks, parentClientId, isSelected } ) {
 
 export default compose( [
 	withSelect( ( select, props ) => {
-		const { getBlockParents, getSelectedBlockClientId } = select( 'core/block-editor' );
-
-		const selectedBlockClientId = getSelectedBlockClientId();
-		const parents = getBlockParents( selectedBlockClientId );
-		const parentClientId = parents.length ? parents[ parents.length - 1 ] : undefined;
-
 		return {
-			parentClientId,
 			// @ts-ignore difficult to type with JSDoc
 			hasInnerBlocks: !! select( 'core/block-editor' ).getBlocksByClientId( props.clientId )[ 0 ]
 				.innerBlocks.length,


### PR DESCRIPTION
When a block inside a premium content block is selected using the block list view tree, switch premium content to display the Subscriber/Guest view that contains it

Fixes #22426
#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply patch
2. If on a JP site then enable beta blocks
3. Ensure you have a paid plan
4. Create a post
5. Add a premium-content block
6. Open the list view sidebar
7. Select one of the children of the subscriber view or the subscriber view itself
8. You should see the guest view blocks in the content area disappear and the subscriber view blocks appear.
9. Select one of the children in the guest view or the guest view itself and the opposite should happen
