### PR TITLE
Update Free plan description based upon active products

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -23,7 +23,7 @@ import Card from 'components/card';
 import ExternalLink from 'components/external-link';
 import ProductExpiration from 'components/product-expiration';
 import UpgradeLink from 'components/upgrade-link';
-import { getPlanClass } from 'lib/plans/constants';
+import { getPlanClass, JETPACK_BACKUP_PRODUCTS, JETPACK_SCAN_PRODUCTS } from 'lib/plans/constants';
 import {
 	getUpgradeUrl,
 	getDateFormat,
@@ -40,7 +40,7 @@ const TIER_1_BACKUP_STORAGE_GB = 10;
 const TIER_2_BACKUP_STORAGE_TB = 1;
 
 class MyPlanHeader extends React.Component {
-	getProductProps( productSlug ) {
+	getProductProps( productSlug, activeProducts = [] ) {
 		const { displayBackups, dateFormat, purchases } = this.props;
 
 		const productProps = {
@@ -60,6 +60,8 @@ class MyPlanHeader extends React.Component {
 		if ( purchase ) {
 			expiration = (
 				<ProductExpiration
+					// Add key because this goes to `details` as array.
+					key="product-expiration"
 					dateFormat={ dateFormat }
 					expiryDate={ purchase.expiry_date }
 					purchaseDate={ purchase.subscribed_date }
@@ -67,30 +69,62 @@ class MyPlanHeader extends React.Component {
 				/>
 			);
 
-			activation = purchase.active === '1' ? <ProductActivated /> : null;
+			activation = purchase.active === '1' ? <ProductActivated key="product-activated" /> : null;
 		}
 
 		switch ( getPlanClass( productSlug ) ) {
-			case 'is-free-plan':
+			case 'is-free-plan': {
+				// Default tagline
+				let tagLineText = __(
+					'Worried about security? Get backups, automated security fixes and more.',
+					'jetpack'
+				);
+
+				if ( activeProducts.length ) {
+					const hasSiteJetpackBackup = activeProducts.some( ( { product_slug } ) =>
+						JETPACK_BACKUP_PRODUCTS.includes( product_slug )
+					);
+
+					const hasSiteJetpackScan = activeProducts.some( ( { product_slug } ) =>
+						JETPACK_SCAN_PRODUCTS.includes( product_slug )
+					);
+
+					if ( hasSiteJetpackBackup && hasSiteJetpackScan ) {
+						tagLineText = __(
+							'Upgrade your site to access additional features, including spam protection and priority support.',
+							'jetpack'
+						);
+					} else if ( hasSiteJetpackBackup ) {
+						tagLineText = __(
+							'Upgrade your site to access additional features, including spam protection, security scanning, and priority support.',
+							'jetpack'
+						);
+					} else if ( hasSiteJetpackScan ) {
+						tagLineText = __(
+							'Upgrade your site to access additional features, including spam protection, backups, and priority support.',
+							'jetpack'
+						);
+					}
+				}
+
 				return {
 					...productProps,
-					tagLine: createInterpolateElement(
-						__(
-							'Worried about security? Get backups, automated security fixes and more: <a>Upgrade now</a>',
-							'jetpack'
-						),
-						{
-							a: (
-								<UpgradeLink
-									source="my-plan-header-free-plan-text-link"
-									target="upgrade-now"
-									feature="my-plan-header-free-upgrade"
-								/>
-							),
-						}
+					tagLine: (
+						<>
+							{ tagLineText }
+							&nbsp;
+							<UpgradeLink
+								source="my-plan-header-free-plan-text-link"
+								target="upgrade-now"
+								feature="my-plan-header-free-upgrade"
+							>
+								{ __( 'Upgrade now', 'jetpack' ) }
+							</UpgradeLink>
+						</>
 					),
 					title: __( 'Jetpack Free', 'jetpack' ),
 				};
+			}
 
 			case 'is-personal-plan':
 				return {
@@ -317,7 +351,7 @@ class MyPlanHeader extends React.Component {
 				{ this.renderLicensingActions() }
 				<Card compact>
 					{ this.renderHeader( __( 'My Plan', 'jetpack' ) ) }
-					<MyPlanCard { ...this.getProductProps( this.props.plan ) } />
+					<MyPlanCard { ...this.getProductProps( this.props.plan, this.props.activeProducts ) } />
 				</Card>
 			</>
 		);

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -76,7 +76,7 @@ class MyPlanHeader extends React.Component {
 			case 'is-free-plan': {
 				// Default tagline
 				let tagLineText = __(
-					'Worried about security? Get backups, automated security fixes and more.',
+					'Worried about security? Get backups, automated security fixes and more: <a>Upgrade now</a>',
 					'jetpack'
 				);
 
@@ -91,17 +91,17 @@ class MyPlanHeader extends React.Component {
 
 					if ( hasSiteJetpackBackup && hasSiteJetpackScan ) {
 						tagLineText = __(
-							'Upgrade your site to access additional features, including spam protection and priority support.',
+							'Upgrade your site to access additional features, including spam protection and priority support: <a>Upgrade now</a>',
 							'jetpack'
 						);
 					} else if ( hasSiteJetpackBackup ) {
 						tagLineText = __(
-							'Upgrade your site to access additional features, including spam protection, security scanning, and priority support.',
+							'Upgrade your site to access additional features, including spam protection, security scanning, and priority support: <a>Upgrade now</a>',
 							'jetpack'
 						);
 					} else if ( hasSiteJetpackScan ) {
 						tagLineText = __(
-							'Upgrade your site to access additional features, including spam protection, backups, and priority support.',
+							'Upgrade your site to access additional features, including spam protection, backups, and priority support: <a>Upgrade now</a>',
 							'jetpack'
 						);
 					}
@@ -109,19 +109,15 @@ class MyPlanHeader extends React.Component {
 
 				return {
 					...productProps,
-					tagLine: (
-						<>
-							{ tagLineText }
-							&nbsp;
+					tagLine: createInterpolateElement( tagLineText, {
+						a: (
 							<UpgradeLink
 								source="my-plan-header-free-plan-text-link"
 								target="upgrade-now"
 								feature="my-plan-header-free-upgrade"
-							>
-								{ __( 'Upgrade now', 'jetpack' ) }
-							</UpgradeLink>
-						</>
-					),
+							/>
+						),
+					} ),
 					title: __( 'Jetpack Free', 'jetpack' ),
 				};
 			}

--- a/projects/plugins/jetpack/changelog/update-free-plan-description
+++ b/projects/plugins/jetpack/changelog/update-free-plan-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Updated the Free plan description to consider the currently active products


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1164141197617539-as-1201340609889764/f

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the description of Jetpack Free plan in My Plan tab to not include the active standalone products which are already active for the site 
* The logic is copied from Calypso from [here](https://github.com/Automattic/wp-calypso/blob/bbe31df69fea04abd0b7d3df71aabb4fa597d693/packages/calypso-products/src/plans-list.tsx#L1302-L1334).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-dpL-p2#comment-50044

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Boot up this PR and 🔥  it.
* Go to wp-admin > Jetpack > My Plan
* Check the free plan description
* Now add a Backup plan to the site
* Confirm that the Free plan description does not include "backup"
* Add Scan plan to the site.
* Confirm that the Free plan description does not include "scan"


Screenshots

BEFORE

<img width="1007" alt="Screenshot 2022-02-08 at 3 54 56 PM" src="https://user-images.githubusercontent.com/18226415/152972442-76e2d54b-04db-4060-8b0b-bf8ad10ef2eb.png">

AFTER

- When there is both Backup and Scan
<img width="1011" alt="Screenshot 2022-02-08 at 3 53 20 PM" src="https://user-images.githubusercontent.com/18226415/152972430-5433a850-e6df-49b4-b2de-64946046e9b3.png">

- When there is just Backup but not Scan
<img width="1004" alt="Screenshot 2022-02-08 at 4 05 17 PM" src="https://user-images.githubusercontent.com/18226415/152972446-e9770b8b-2316-4f5d-a808-d2f4b21a0b76.png">

- When there is no plan purchased
<img width="1009" alt="Screenshot 2022-02-08 at 4 06 02 PM" src="https://user-images.githubusercontent.com/18226415/152972450-d1039c7b-ab9e-47d4-95c1-e5c0eaa38a44.png">
