### PR TITLE
Docs: Adding working link and explanation for Jetpack unit tests to the Coding Guidelines page

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -14,7 +14,7 @@ These are some things to keep in mind when writing code for Jetpack plugin. Plea
 - Install PHP Code Sniffer [Code Sniffer rules for Jetpack Coding Standards.](https://github.com/Automattic/jetpack-codesniffer#usage) They will make it easier for you to notice any missing documentation or coding standards you should respect. Most IDEs display warnings and notices inside the editor, making it easy to inspect your code.
 - If coding a module, make sure you declare the module in the inline doc, [like this](https://github.com/Automattic/jetpack/blob/16bc2fce3ace760ff402f656dcf05255888f23f4/modules/sitemaps/sitemaps.php#L92-L101). The same applies for filters or actions, [as shown here](https://github.com/Automattic/jetpack/blob/16bc2fce3ace760ff402f656dcf05255888f23f4/modules/sitemaps/sitemaps.php#L143-L151).
 - Sanitize URLs, attributes, everything. WordPress.com VIP has this nice [article about the topic](https://wpvip.com/documentation/vip-go/validating-sanitizing-and-escaping/).
-- Create [unit tests](https://github.com/Automattic/jetpack/tree/master/tests) if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
+- Create unit tests if you can ([here are the Jetpack plugin tests for reference](https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/tests)). If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
 
 ## Deprecating code
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Adding working link and explanation to Jetpack unit tests on the [Coding Guidelines markdown page](https://github.com/Automattic/jetpack/blob/master/docs/coding-guidelines.md)

#### Does this pull request change what data or activity we track or use?

* n/a

#### Testing instructions:

* Testing the link to the Jetpack unit tests should work, and the brief explanation should make it clear what you are clicking on
