### PR TITLE
Widget Visibility: switch to using shared js package utility

### DIFF
--- a/projects/plugins/jetpack/changelog/update-widget-visibility-site-type-dep
+++ b/projects/plugins/jetpack/changelog/update-widget-visibility-site-type-dep
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Widget Visibility: switch to using shared js package utility instead of built-in site type check.

--- a/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
+++ b/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { Fragment, useCallback, useMemo } from '@wordpress/element';
 import { BaseControl, Button, SelectControl, ToggleControl } from '@wordpress/components';
@@ -7,6 +7,11 @@ import { __, _x } from '@wordpress/i18n';
 import { InspectorAdvancedControls } from '@wordpress/block-editor'; // eslint-disable-line import/no-unresolved
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
+import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+
+/**
+ * Internal dependencies
+ */
 import analytics from '../../../_inc/client/lib/analytics';
 
 /* global widget_conditions_data */
@@ -124,17 +129,6 @@ const buildOptions = ( options, level = 0 ) =>
 		return acc.concat( [ newItem ] );
 	}, [] );
 
-/**
- * Get the site type.
- *
- * @return {string} - jetpack, atomic, or simple.
- */
-const getSiteType = () => {
-	return 'object' === typeof window && typeof window._currentSiteType === 'string'
-		? window._currentSiteType
-		: 'jetpack';
-};
-
 const VisibilityRule = props => {
 	const { rule, onDelete, setMajor, setMinor } = props;
 
@@ -158,7 +152,7 @@ const VisibilityRule = props => {
 		{ label: __( 'Category', 'jetpack' ), value: 'category' },
 		{ label: __( 'Author', 'jetpack' ), value: 'author' },
 	]
-		.concat( 'simple' === getSiteType() ? [] : optionsDisabledOnWpcom )
+		.concat( isSimpleSite() ? [] : optionsDisabledOnWpcom )
 		.concat( [
 			{ label: __( 'Tag', 'jetpack' ), value: 'tag' },
 			{ label: __( 'Date', 'jetpack' ), value: 'date' },


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* ﻿In #22527, I copied over a utility function that we used in the block bundle to use in the Widget visibility bundle. However, starting in #22733, that utility function is now part of an external js package that we can use in the Widget visiblity bundle. Let's do that and save some duplication!

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* You'll want to test this on wpcom simple as well as Jetpack
* In Jetpack > settings, ensure the Widget visibility feature is active.
* go to Appearance > Widgets
* Add a block
* in the right block sidebar, scroll down and open the "Advanced" panel.
* Add a visibility rule
* in the options, you should see the option to filter by user role, or to check whether the user is logged in or not.
    * On WordPress.com, those options should not appear.
