### PR TITLE
Search: add tier maximum records for use by Record Meter

### DIFF
--- a/projects/packages/search/changelog/add-jp-search-record-meter-max-tier-records
+++ b/projects/packages/search/changelog/add-jp-search-record-meter-max-tier-records
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: add tier maximum records for Record Meter

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -5,8 +5,15 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
+import { STORE_ID } from 'store';
+
 import './style.scss';
 
 /**
@@ -15,11 +22,18 @@ import './style.scss';
  * @returns {React.Component} RecordMeter React component
  */
 export default function RecordMeter() {
+	const tierMaximumRecords = useSelect( select => select( STORE_ID ).getTierMaximumRecords() );
+
 	return (
 		<div className="jp-search-record-meter jp-search-dashboard-wrap">
 			<div className="jp-search-dashboard-row">
 				<div className="jp-search-record-meter__title lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<h2>{ __( 'Your search records', 'jetpack-search-pkg' ) }</h2>
+					{ tierMaximumRecords && (
+						<p>
+							Tier maximum records: <strong>{ tierMaximumRecords }</strong>
+						</p>
+					) }
 				</div>
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 			</div>

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -7,6 +7,7 @@ const sitePlanSelectors = {
 	getUpgradeBillPeriod: state => state.sitePlan?.default_upgrade_bill_period,
 	supportsSearch: state =>
 		state.sitePlan.supports_instant_search || state.sitePlan.supports_only_classic_search,
+	getTierMaximumRecords: state => state.sitePlan.tier_maximum_records,
 };
 
 export default sitePlanSelectors;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
One piece of data needed by the new Record Meter feature in Jetpack Search's wp-admin dashboard is the maximum number of records allowed by the user's current tier.

This PR adds a new selector to retrieve it from the API response and outputs the value in the Record Meter component.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
On a test site with a Jetpack Search plan, navigate to `/wp-admin/admin.php?page=jetpack-search&features=record-meter`.

The maximum records for the current tier should be displayed as below:

<img width="253" alt="Screen Shot 2022-02-09 at 16 45 19" src="https://user-images.githubusercontent.com/17325/153119344-4d15a19e-f48f-49ba-8576-540625ffc5b4.png">
